### PR TITLE
Add entity example block

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ group :development do
   gem 'puma'
   gem 'rubocop'
   gem 'foreman'
+  gem 'byebug'
 end
 
 group :jekyll_plugins do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,6 +4,7 @@ GEM
     addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
+    byebug (11.1.3)
     coderay (1.1.3)
     colorator (1.1.0)
     concurrent-ruby (1.2.3)
@@ -124,6 +125,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  byebug
   foreman
   jekyll
   jekyll-contentblocks

--- a/app/_assets/entrypoints/application.js
+++ b/app/_assets/entrypoints/application.js
@@ -2,8 +2,13 @@
 //
 // When using a plain API, perhaps it's better to generate an HTML entrypoint
 // and link to the scripts and stylesheets, and let Vite transform it.
-console.log('Vite ⚡️ Ruby')
 
 // Example: Import a stylesheet in <sourceCodeDir>/index.css
 import '~/stylesheets/index.css'
 import '~/stylesheets/core.css'
+
+import EntityExample from '@/javascripts/components/entity_example';
+
+document.addEventListener('DOMContentLoaded', function () {
+  new EntityExample();
+});

--- a/app/_assets/javascripts/components/entity_example.js
+++ b/app/_assets/javascripts/components/entity_example.js
@@ -1,0 +1,64 @@
+class EntityExampleComponent {
+  constructor(elem) {
+    this.elem = elem;
+    this.formatSelect = this.elem.querySelector('.select-format');
+    this.targetSelect = this.elem.querySelector('.select-target');
+
+    this.addEventListeners();
+    this.initializeSelects();
+  }
+
+  initializeSelects() {
+    if (this.targetSelect) {
+      this.targetSelect.dispatchEvent(new Event('change'));
+    } else {
+      this.elem.querySelector('.entity-example-format-panel').classList.remove('hidden');
+    }
+    if (this.formatSelect) {
+      this.formatSelect.dispatchEvent(new Event('change'));
+    }
+  }
+
+  addEventListeners() {
+    if (this.targetSelect) {
+      this.targetSelect.addEventListener('change', this.selectTarget.bind(this));
+    }
+    if (this.formatSelect) {
+      this.formatSelect.addEventListener('change', this.selectFormat.bind(this));
+    }
+  }
+
+  selectFormat(event) {
+    event.stopPropagation();
+    const select = event.currentTarget;
+
+    this.elem.querySelectorAll('.entity-example-format-panel').forEach((panel) => {
+      if (panel.dataset.format === select.value) {
+        panel.classList.remove('hidden');
+      } else {
+        panel.classList.add('hidden');
+      }
+    })
+  }
+
+  selectTarget(event) {
+    event.stopPropagation();
+    const select = event.currentTarget;
+
+    this.elem.querySelectorAll('.entity-example-target-panel').forEach((panel) => {
+      if (panel.dataset.target === select.value) {
+        panel.classList.remove('hidden');
+      } else {
+        panel.classList.add('hidden');
+      }
+    })
+  }
+}
+
+export default class EntityExample {
+  constructor() {
+    document.querySelectorAll('.entity-example').forEach((elem) => {
+      new EntityExampleComponent(elem);
+    });
+  }
+}

--- a/app/_includes/components/entity_example.html
+++ b/app/_includes/components/entity_example.html
@@ -1,0 +1,49 @@
+{% assign entity_example = include.entity_example %}
+{% assign targets_dropdown = entity_example.targets_dropdown %}
+{% assign formats_dropdown = entity_example.formats_dropdown %}
+
+<div id="{{ entity_example.id }}" class="mt-8 entity-example">
+  <div class="p-2 flex justify-end">
+    <div>
+      {% if targets_dropdown %}
+        {% if targets_dropdown.options.size > 1 %}
+          <label for="select-target-{{ entity_example.id }}" class="sr-only">Select an entity</label>
+          <select id="select-target-{{ entity_example.id }}" class="ml-1 w-36 select-target border border-gray-300 ">
+            {% for option in targets_dropdown.options %}
+              <option value="{{ option.value }}">{{ option.text }}</option>
+            {% endfor %}
+          </select>
+        {% endif %}
+      {% endif %}
+
+      {% if formats_dropdown.options.size > 1 %}
+        <label for="select-format-{{ entity_example.id }}" class="sr-only">Select a format</label>
+        <select id="select-format-{{ entity_example.id }}" class="ml-1 w-36 select-format border border-gray-300 ">
+          {% for option in formats_dropdown.options %}
+            <option value="{{ option.value }}">{{ option.text }}</option>
+          {% endfor %}
+        </select>
+      {% endif %}
+    </div>
+  </div>
+
+  {% if targets_dropdown %}
+    {% for target_with_examples in entity_example.formatted_eamples_by_target %}
+     {% assign target = target_with_examples[0] %}
+     {% assign formatted_examples = target_with_examples[1] %}
+      <div tabindex="0" class="entity-example-target-panel hidden overflow-auto" aria-labelledby="select-target-{{ entity_example.id }}" data-target="{{ target }}">
+        {% for formatted_example in formatted_examples %}
+          <div tabindex="0" class="entity-example-format-panel hidden overflow-auto" aria-labelledby="select-format-{{ entity_example.id }}" data-format="{{ formatted_example.format }}">
+            {% include {{ formatted_example.template_file }} presenter=formatted_example.presenter %}
+          </div>
+        {% endfor %}
+      </div>
+    {% endfor %}
+  {% else %}
+    {% for formatted_example in entity_example.formatted_examples %}
+      <div tabindex="0" class="entity-example-format-panel hidden overflow-auto" aria-labelledby="select-format-{{ entity_example.id }}" data-format="{{ formatted_example.format }}">
+        {% include {{ formatted_example.template_file }} presenter=formatted_example.presenter %}
+      </div>
+    {% endfor %}
+  {% endif %}
+</div>

--- a/app/_includes/components/entity_example.html
+++ b/app/_includes/components/entity_example.html
@@ -2,7 +2,7 @@
 {% assign targets_dropdown = entity_example.targets_dropdown %}
 {% assign formats_dropdown = entity_example.formats_dropdown %}
 
-<div id="{{ entity_example.id }}" class="mt-8 entity-example">
+<div id="{{ entity_example.id }}" class="entity-example">
   <div class="p-2 flex justify-end">
     <div>
       {% if targets_dropdown %}

--- a/app/_includes/components/entity_example/format/admin-api.html
+++ b/app/_includes/components/entity_example/format/admin-api.html
@@ -1,0 +1,8 @@
+{% highlight bash %}
+curl -X POST {{ include.presenter.url }} \
+    --header "accept: application/json" \
+    --header "Content-Type: application/json" \
+    --data '
+{{ include.presenter.data | json_prettify | indent | indent }}
+    '
+{% endhighlight %}

--- a/app/_includes/components/entity_example/format/deck.html
+++ b/app/_includes/components/entity_example/format/deck.html
@@ -1,0 +1,6 @@
+{% highlight yaml %}
+_format_version: "3.0"
+{{ include.presenter.entity }}:
+  -
+{{ include.presenter.data | indent }}
+{% endhighlight %}

--- a/app/_includes/components/entity_example/format/konnect.html
+++ b/app/_includes/components/entity_example/format/konnect.html
@@ -1,0 +1,8 @@
+{% highlight bash %}
+curl -X POST {{ include.presenter.url }} \
+    --header "accept: application/json" \
+    --header "Content-Type: application/json" \
+    --data '
+{{ include.presenter.data | json_prettify | indent | indent }}
+    '
+{% endhighlight %}

--- a/app/_includes/components/entity_example/format/ui/consumer.html
+++ b/app/_includes/components/entity_example/format/ui/consumer.html
@@ -1,0 +1,8 @@
+<div markdown="1">
+The following creates a new consumer called **{{ include.presenter.data['username'] }}**:
+
+1. In Kong Manager or Gateway Manager, go to **API Gateway** > **Consumers**.
+2. Click **New Consumer**.
+3. Enter the **Username** `{{ include.presenter.data['username'] }}` and **Custom ID** `{{ include.presenter.data['custom_id'] }}`.
+4. Click **Create**.
+</div>

--- a/app/_kong_entities/consumer.md
+++ b/app/_kong_entities/consumer.md
@@ -1,5 +1,7 @@
 ---
 title: Consumers
+kong_entity: Consumer # we could use this to pull the schema too
+
 related_resources:
   - text: Authentication reference
     url: https://docs.konghq.com/gateway/latest/kong-plugins/authentication/reference/
@@ -60,7 +62,7 @@ faqs:
       which can easily grow into hundreds of thousands or millions of records.
 ---
 
-## What is a consumer?
+## What is a Consumer?
 
 A consumer typically refers to an entity that consumes or uses the APIs managed by {{site.base_gateway}}. 
 Consumers can be applications, services, or users who interact with your APIs. 
@@ -92,7 +94,7 @@ end
 B-->C
 {% endmermaid %}
 
-## Use cases for consumers
+## Use cases for Consumers
 
 The following are examples of common use cases for consumers:
 
@@ -102,7 +104,7 @@ The following are examples of common use cases for consumers:
 |Consumer groups | Group consumers by sets of criteria and apply certain rules to them.|
 |Rate limiting | Rate limit specific consumers based on tiers.|
 
-{% contentfor manage_entity %}
+{% contentfor setup_entity %}
 {% entity_example %}
 type: consumer
 data:

--- a/app/_kong_entities/consumer.md
+++ b/app/_kong_entities/consumer.md
@@ -103,4 +103,36 @@ The following are examples of common use cases for consumers:
 |Rate limiting | Rate limit specific consumers based on tiers.|
 
 {% contentfor manage_entity %}
+{% entity_example %}
+type: consumer
+data:
+  custom_id: example-consumer-id
+  username: example-consumer
+  tags:
+    - silver-tier
+
+formats:
+  - admin-api
+  - konnect
+  - kic
+  - deck
+  - ui
+{% endentity_example %}
+
+{% entity_example %}
+type: plugin 
+data:
+  name: rate-limiting
+  config:
+    second: 5
+    hour: 1000
+    policy: local
+target: consumer
+formats:
+  - admin-api
+  - konnect
+  - kic
+  - deck
+  - ui
+{% endentity_example %}
 {% endcontentfor %}

--- a/app/_kong_entities/consumer.md
+++ b/app/_kong_entities/consumer.md
@@ -118,21 +118,4 @@ formats:
   - deck
   - ui
 {% endentity_example %}
-
-{% entity_example %}
-type: plugin 
-data:
-  name: rate-limiting
-  config:
-    second: 5
-    hour: 1000
-    policy: local
-target: consumer
-formats:
-  - admin-api
-  - konnect
-  - kic
-  - deck
-  - ui
-{% endentity_example %}
 {% endcontentfor %}

--- a/app/_kong_plugins/rate-limiting.md
+++ b/app/_kong_plugins/rate-limiting.md
@@ -31,11 +31,13 @@ targets:
   - consumer
   - service
   - route
+  - global
+  - consumer_group
 formats:
   - admin-api
   - konnect
   - kic
   - deck
-  - ui
+  - terraform
 {% endentity_example %}
 {% endcontentfor %}

--- a/app/_kong_plugins/rate-limiting.md
+++ b/app/_kong_plugins/rate-limiting.md
@@ -16,3 +16,26 @@ faqs:
 Rate limit how many HTTP requests can be made in a given period of seconds, minutes, hours, days,
 months, or years. If the underlying service or route has no authentication layer, the Client IP address is
 used. Otherwise, the consumer is used if an authentication plugin has been configured
+
+
+{% contentfor config_examples %}
+{% entity_example %}
+type: plugin
+data:
+  name: rate-limiting
+  config:
+    second: 5
+    hour: 1000
+    policy: local
+targets:
+  - consumer
+  - service
+  - route
+formats:
+  - admin-api
+  - konnect
+  - kic
+  - deck
+  - ui
+{% endentity_example %}
+{% endcontentfor %}

--- a/app/_layouts/kong_entity.html
+++ b/app/_layouts/kong_entity.html
@@ -23,11 +23,12 @@ layout: default
         </div>
       {% endifhascontent schema %}
 
-      {% ifhascontent manage_entity %}
-        <div id="manage-entity" class="mt-4">
-          {% contentblock manage_entity %}
+      {% ifhascontent setup_entity %}
+        <div id="setup-entity" class="mt-4">
+          <h2>Set up a {{ page.kong_entity }}</h2>
+          {% contentblock setup_entity %}
         </div>
-      {% endifhascontent manage_entity %}
+      {% endifhascontent setup_entity %}
 
       {% if page.faqs %}
         <div id="faq" class="mt-4">

--- a/app/_layouts/plugin.html
+++ b/app/_layouts/plugin.html
@@ -91,36 +91,11 @@ layout: default
         </div>
       </div>
 
-      <div id="config-examples" class="mt-8">
-        <div class="bg-blue-600 p-2 flex justify-between">
-          <span class="font-bold text-white">Configuration</span>
-          <div>
-            <select class="w-36">
-              <option>Service</option>
-              <option>Route</option>
-              <option>Consumer</option>
-            </select>
-            <select class="ml-1 w-36">
-              <option>deck YAML</option>
-              <option>Terraform</option>
-            </select>
-            <span class="ml-2 text-white">&copy;</span>
-          </div>
+      {% ifhascontent config_examples %}
+        <div id="config-examples" class="mt-8 border">
+        {% contentblock config_examples %}
         </div>
-        <code class="block bg-gray-100 p-4">
-          <span class="text-gray-500"># Example configuration</span>
-          <br>
-          <span class="text-gray-500">config:</span>
-          <br>
-          <span class="text-gray-500">  limits:</span>
-          <br>
-          <span class="text-gray-500">  - second: 5</span>
-          <br>
-          <span class="text-gray-500">    minute: 10</span>
-          <br>
-          <span class="text-gray-500">    hour: 100</span>
-        </code>
-      </div>
+      {% endifhascontent %}
     </div>
   </div>
 </div>

--- a/app/_plugins/blocks/entity_example.rb
+++ b/app/_plugins/blocks/entity_example.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module Jekyll
+  class EntityExample < Liquid::Block
+    def render(context) # rubocop:disable Metrics/MethodLength
+      @context = context
+      @site = context.registers[:site]
+      @page = context.environments.first['page']
+
+      contents = super
+
+      entity_example = EntityExamples::Base.make_for(example: YAML.load(contents))
+      entity_example_drop = entity_example.to_drop
+
+      Liquid::Template
+        .parse(File.read(entity_example_drop.template))
+        .render(
+          { 'site' => @site.config, 'page' => @page, 'include' => { 'entity_example' => entity_example_drop } },
+          { registers: @context.registers, context: @context }
+        )
+    end
+  end
+end
+
+Liquid::Template.register_tag('entity_example', Jekyll::EntityExample)

--- a/app/_plugins/blocks/entity_examples/base.rb
+++ b/app/_plugins/blocks/entity_examples/base.rb
@@ -35,7 +35,7 @@ module Jekyll
       end
 
       def formats
-        @formats ||= @example.fetch('formats').map do |f|
+        @formats ||= @example.fetch('formats').sort.map do |f|
           Jekyll::EntityExamples::Format::Base.make_for(format: f)
         end
       end

--- a/app/_plugins/blocks/entity_examples/base.rb
+++ b/app/_plugins/blocks/entity_examples/base.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module EntityExamples
+    class Base
+      MAPPINGS = {
+        'consumer' => 'Consumer',
+        'plugin'   => 'Plugin',
+        'service'  => 'Service',
+        'route'    => 'Route',
+      }
+
+      def self.make_for(example:)
+        raise ArgumentError, "Missing `type` for entity_example. Available types: #{MAPPINGS.keys.join(', ')}" unless example['type']
+
+        klass = MAPPINGS[example['type']]
+
+        raise ArgumentError, "Unsupported entity example type: #{example['type']}. Available types: #{MAPPINGS.keys.join(', ')}" unless klass
+
+        Object.const_get("Jekyll::EntityExamples::#{klass}").new(example:)
+      end
+
+      def initialize(example:)
+        @example = example
+
+        validate!
+      end
+
+      def type
+        @type ||= @example.fetch('type')
+      end
+
+      def data
+        @data ||= @example.fetch('data')
+      end
+
+      def formats
+        @formats ||= @example.fetch('formats').map do |f|
+          Jekyll::EntityExamples::Format::Base.make_for(format: f)
+        end
+      end
+
+      def to_drop
+        Object.const_get(
+          "Jekyll::Drops::EntityExample::#{self.class.name.split('::').last}"
+        ).new(example: self)
+      end
+
+      def validate!
+        raise ArgumentError, "Missing `data` for entity_type `#{@example['type']}`." unless @example['data']
+        raise ArgumentError, "Missing `formats` for entity_type `#{@example['type']}`. Available formats: #{Format::Base::MAPPINGS.keys.join(', ')}." unless @example['formats']
+
+        formats.map(&:validate!)
+      end
+    end
+  end
+end

--- a/app/_plugins/blocks/entity_examples/consumer.rb
+++ b/app/_plugins/blocks/entity_examples/consumer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module EntityExamples
+    class Consumer < Base
+    end
+  end
+end

--- a/app/_plugins/blocks/entity_examples/format/admin_api.rb
+++ b/app/_plugins/blocks/entity_examples/format/admin_api.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module EntityExamples
+    module Format
+      class AdminAPI < Base
+      end
+    end
+  end
+end

--- a/app/_plugins/blocks/entity_examples/format/base.rb
+++ b/app/_plugins/blocks/entity_examples/format/base.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module EntityExamples
+    module Format
+      class Base
+        MAPPINGS = {
+          'admin-api' => 'AdminAPI',
+          'deck'      => 'Deck',
+          'konnect'   => 'Konnect',
+          'kic'       => 'KIC',
+          'ui'        => 'UI',
+          'terraform' => 'Terraform'
+        }
+
+        def self.make_for(format:)
+          klass = MAPPINGS[format]
+
+          raise ArgumentError, "Unsupported `format`: #{format}. Available formats: #{MAPPINGS.keys.join(', ')}" unless klass
+
+          Object.const_get("Jekyll::EntityExamples::Format::#{klass}").new(format:)
+        end
+
+        def initialize(format:)
+          @format = format
+        end
+
+        def value
+          @value ||= @format
+        end
+
+        def validate!; end
+
+        def to_drop
+          Object.const_get(
+            "Jekyll::Drops::EntityExample::Format::#{self.class.name.split('::').last}"
+          ).new(format: self)
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/blocks/entity_examples/format/deck.rb
+++ b/app/_plugins/blocks/entity_examples/format/deck.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module EntityExamples
+    module Format
+      class Deck < Base
+      end
+    end
+  end
+end

--- a/app/_plugins/blocks/entity_examples/format/kic.rb
+++ b/app/_plugins/blocks/entity_examples/format/kic.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module EntityExamples
+    module Format
+      class KIC < Base
+      end
+    end
+  end
+end

--- a/app/_plugins/blocks/entity_examples/format/konnect.rb
+++ b/app/_plugins/blocks/entity_examples/format/konnect.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module EntityExamples
+    module Format
+      class Konnect < Base
+      end
+    end
+  end
+end

--- a/app/_plugins/blocks/entity_examples/format/terraform.rb
+++ b/app/_plugins/blocks/entity_examples/format/terraform.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module EntityExamples
+    module Format
+      class Terraform < Base
+      end
+    end
+  end
+end

--- a/app/_plugins/blocks/entity_examples/format/ui.rb
+++ b/app/_plugins/blocks/entity_examples/format/ui.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module EntityExamples
+    module Format
+      class UI < Base
+      end
+    end
+  end
+end

--- a/app/_plugins/blocks/entity_examples/plugin.rb
+++ b/app/_plugins/blocks/entity_examples/plugin.rb
@@ -6,7 +6,7 @@ module Jekyll
   module EntityExamples
     class Plugin < Base
       def targets
-        @targets ||= @example.fetch('targets').map do |t|
+        @targets ||= @example.fetch('targets').sort.map do |t|
           Jekyll::EntityExamples::Target::Base.make_for(target: t)
         end
       end

--- a/app/_plugins/blocks/entity_examples/plugin.rb
+++ b/app/_plugins/blocks/entity_examples/plugin.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module EntityExamples
+    class Plugin < Base
+      def targets
+        @targets ||= @example.fetch('targets').map do |t|
+          Jekyll::EntityExamples::Target::Base.make_for(target: t)
+        end
+      end
+
+      def validate!
+        super
+
+        raise ArgumentError, "Missing `targets` for entity_type `plugin`. Available targets: #{Target::Base::MAPPINGS.keys.join(', ')}." unless @example['targets']
+
+        targets.map(&:validate!)
+      end
+    end
+  end
+end

--- a/app/_plugins/blocks/entity_examples/route.rb
+++ b/app/_plugins/blocks/entity_examples/route.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module EntityExamples
+    class Route < Base
+    end
+  end
+end

--- a/app/_plugins/blocks/entity_examples/service.rb
+++ b/app/_plugins/blocks/entity_examples/service.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module EntityExamples
+    class Service < Base
+    end
+  end
+end

--- a/app/_plugins/blocks/entity_examples/target/base.rb
+++ b/app/_plugins/blocks/entity_examples/target/base.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module EntityExamples
+    module Target
+      class Base
+        MAPPINGS = {
+          'consumer'       => 'Consumer',
+          'consumer_group' => 'ConsumerGroup',
+          'global'         => 'Global',
+          'route'          => 'Route',
+          'service'        => 'Service',
+        }.freeze
+
+        def self.make_for(target:)
+          klass = MAPPINGS[target]
+
+          raise ArgumentError, "Unsupported `target`: #{target}. Available targets: #{MAPPINGS.keys.join(', ')}" unless klass
+
+          Object.const_get("Jekyll::EntityExamples::Target::#{klass}").new(target:)
+        end
+
+        def initialize(target:)
+          @target = target
+        end
+
+        def value
+          @value ||= @target
+        end
+
+        def validate!; end
+
+        def to_drop
+          Object.const_get(
+            "Jekyll::Drops::EntityExample::Target::#{self.class.name.split('::').last}"
+          ).new(target: self)
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/blocks/entity_examples/target/consumer.rb
+++ b/app/_plugins/blocks/entity_examples/target/consumer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module EntityExamples
+    module Target
+      class Consumer < Base
+      end
+    end
+  end
+end

--- a/app/_plugins/blocks/entity_examples/target/consumer_group.rb
+++ b/app/_plugins/blocks/entity_examples/target/consumer_group.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module EntityExamples
+    module Target
+      class ConsumerGroup < Base
+      end
+    end
+  end
+end

--- a/app/_plugins/blocks/entity_examples/target/global.rb
+++ b/app/_plugins/blocks/entity_examples/target/global.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module EntityExamples
+    module Target
+      class Global < Base
+      end
+    end
+  end
+end

--- a/app/_plugins/blocks/entity_examples/target/route.rb
+++ b/app/_plugins/blocks/entity_examples/target/route.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module EntityExamples
+    module Target
+      class Route < Base
+      end
+    end
+  end
+end

--- a/app/_plugins/blocks/entity_examples/target/service.rb
+++ b/app/_plugins/blocks/entity_examples/target/service.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module EntityExamples
+    module Target
+      class Service < Base
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/dropdowns/option.rb
+++ b/app/_plugins/drops/dropdowns/option.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Drops
+    module Dropdowns
+      class Option < Liquid::Drop
+        def initialize(value:, text:)
+          @value = value
+          @text  = text
+        end
+
+        def value
+          @value
+        end
+
+        def text
+          @text
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/dropdowns/select.rb
+++ b/app/_plugins/drops/dropdowns/select.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require_relative './option'
+
+module Jekyll
+  module Drops
+    module Dropdowns
+      class Select < Liquid::Drop
+        def initialize(options)
+          @options = options
+        end
+
+        def options
+          @options
+        end
+
+        def any?
+          options.any?
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/base.rb
+++ b/app/_plugins/drops/entity_example/base.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+
+module Jekyll
+  module Drops
+    module EntityExample
+      class Base < Liquid::Drop
+        def initialize(example:)
+          @example = example
+        end
+
+        def template
+          @template ||= File.expand_path('app/_includes/components/entity_example.html')
+        end
+
+        def id
+          @id ||= SecureRandom.hex(10)
+        end
+
+        def formatted_examples
+          @formatted_examples ||= formats.map do |f|
+            Drops::EntityExample::FormattedExample.new(
+              format: f,
+              target: Jekyll::EntityExamples::Target::Base.make_for(target: @example.type).to_drop,
+              data: @example.data,
+              presenter_class: 'Base',
+              entity_type: @example.type
+            )
+          end
+        end
+
+        def formats
+          @formats ||= @example.formats.map(&:to_drop)
+        end
+
+        def formats_dropdown
+          @formats_dropdown ||= begin
+            options = formats.map do |f|
+              Drops::Dropdowns::Option.new(text: f.to_option, value: f.value)
+            end
+            Drops::Dropdowns::Select.new(options)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/consumer.rb
+++ b/app/_plugins/drops/entity_example/consumer.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Drops
+    module EntityExample
+      class Consumer < Base
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/format/admin-api.rb
+++ b/app/_plugins/drops/entity_example/format/admin-api.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module Drops
+    module EntityExample
+      module Format
+        class AdminAPI < Base
+          def template_file(_type)
+            @template_file ||= '/components/entity_example/format/admin-api.html'
+          end
+
+          def to_option
+            'Admin API'
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/format/base.rb
+++ b/app/_plugins/drops/entity_example/format/base.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Drops
+    module EntityExample
+      module Format
+        class Base < Liquid::Drop
+          def initialize(format:)
+            @format = format
+          end
+
+          def value
+            @value ||= @format.value
+          end
+
+          def template_file(_type)
+            raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+          end
+
+          def to_option
+            raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/format/deck.rb
+++ b/app/_plugins/drops/entity_example/format/deck.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module Drops
+    module EntityExample
+      module Format
+        class Deck < Base
+          def entity
+            @entity ||= Formatters::Deck::Base
+              .make_for(type: @type, target: @target, data: @data)
+              .entity
+          end
+
+          def data
+            @_data ||= Formatters::Deck::Base
+              .make_for(type: @type, target: @target, data: @data)
+              .data
+          end
+
+          def template_file(_type)
+            @template_file ||= '/components/entity_example/format/deck.html'
+          end
+
+          def to_option
+            'Deck'
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/format/kic.rb
+++ b/app/_plugins/drops/entity_example/format/kic.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module Drops
+    module EntityExample
+      module Format
+        class KIC < Base
+          def template_file(_type)
+            @template_file ||= '/components/entity_example/format/kic.html'
+          end
+
+          def to_option
+            'KIC'
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/format/konnect.rb
+++ b/app/_plugins/drops/entity_example/format/konnect.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module Drops
+    module EntityExample
+      module Format
+        class Konnect < Base
+          def template_file(_type)
+            @template_file ||= '/components/entity_example/format/konnect.html'
+          end
+
+          def to_option
+            'Konnect'
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/format/terraform.rb
+++ b/app/_plugins/drops/entity_example/format/terraform.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module Drops
+    module EntityExample
+      module Format
+        class Terraform < Base
+          def template_file(_type)
+            @template_file ||= '/components/entity_example/format/terraform.html'
+          end
+
+          def to_option
+            'Terraform'
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/format/ui.rb
+++ b/app/_plugins/drops/entity_example/format/ui.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module Drops
+    module EntityExample
+      module Format
+        class UI < Base
+          def template_file(type)
+            @template_file ||= "/components/entity_example/format/ui/#{type}.html"
+          end
+
+          def to_option
+            'Kong Manager/Gateway Manager'
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/formatted_example.rb
+++ b/app/_plugins/drops/entity_example/formatted_example.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Drops
+    module EntityExample
+      class FormattedExample < Liquid::Drop
+        def initialize(format:, data:, target:, presenter_class:, entity_type:)
+          @format          = format
+          @data            = data
+          @target          = target
+          @presenter_class = presenter_class
+          @entity_type     = entity_type
+        end
+
+        def presenter
+          @presenter ||= Object.const_get(
+            "Jekyll::Drops::EntityExample::Presenters::#{@format.class.name.split('::').last}::#{@presenter_class}"
+          ).new(target: target, data: @data, entity_type: @entity_type)
+        end
+
+        def format
+          @format.value
+        end
+
+        def target
+          @target.value
+        end
+
+        def template_file
+          @template_file ||= @format.template_file(@entity_type)
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/plugin.rb
+++ b/app/_plugins/drops/entity_example/plugin.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Drops
+    module EntityExample
+      class Plugin < Base
+        def targets_dropdown
+          @targets_dropdown ||= Drops::Dropdowns::Select.new(
+            [Drops::Dropdowns::Option.new(text: target.to_option, value: target.value)]
+            )
+        end
+
+        def targets
+          @targets ||= @example.targets.map(&:to_drop)
+        end
+
+        def targets_dropdown
+          @targets_dropdown ||= begin
+            options = targets.map do |t|
+              Drops::Dropdowns::Option.new(text: t.to_option, value: t.value)
+            end
+            Drops::Dropdowns::Select.new(options)
+          end
+        end
+
+        def formatted_examples
+          @formatted_examples ||= targets.map do |t|
+            formats.map do |f|
+              Drops::EntityExample::FormattedExample.new(
+                format: f,
+                target: t,
+                data: @example.data,
+                presenter_class: 'Plugin',
+                entity_type: @example.type
+              )
+            end
+          end.flatten
+        end
+
+        def formatted_eamples_by_target
+          @formatted_eamples_by_target ||= formatted_examples.group_by { |fe| fe.target }
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/presenters/admin-api.rb
+++ b/app/_plugins/drops/entity_example/presenters/admin-api.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Drops
+    module EntityExample
+      module Presenters
+        module AdminAPI
+          class Base < Liquid::Drop
+            BASE_URL = 'http://localhost:8001'.freeze
+
+            URLS = {
+              'consumer' => "#{BASE_URL}/consumers/",
+              'route'    => "#{BASE_URL}/routes/",
+              'service'  => "#{BASE_URL}/services/"
+            }.freeze
+
+            def initialize(target:, data:, entity_type:)
+              @target      = target
+              @data        = data
+              @entity_type = entity_type
+            end
+
+            def url
+              @url ||= self.class::URLS.fetch(@entity_type)
+            end
+
+            def data
+              @data
+            end
+          end
+
+          class Plugin < Base
+            URLS = {
+              'consumer' => "#{BASE_URL}/consumers/{consumerName|Id}/plugins",
+              'route'    => "#{BASE_URL}/routes/{routeName|Id}/plugins",
+              'service'  => "#{BASE_URL}/services/{serviceName|Id}/plugins"
+            }.freeze
+
+            def url
+              @url ||= self.class::URLS.fetch(@target)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/presenters/admin-api.rb
+++ b/app/_plugins/drops/entity_example/presenters/admin-api.rb
@@ -31,9 +31,11 @@ module Jekyll
 
           class Plugin < Base
             URLS = {
-              'consumer' => "#{BASE_URL}/consumers/{consumerName|Id}/plugins",
-              'route'    => "#{BASE_URL}/routes/{routeName|Id}/plugins",
-              'service'  => "#{BASE_URL}/services/{serviceName|Id}/plugins"
+              'consumer'       => "#{BASE_URL}/consumers/{consumerName|Id}/plugins/",
+              'consumer_group' => "#{BASE_URL}/consumer_groups/{consumerGroupName|Id}/plugins/",
+              'route'          => "#{BASE_URL}/routes/{routeName|Id}/plugins/",
+              'service'        => "#{BASE_URL}/services/{serviceName|Id}/plugins/",
+              'global'         => "#{BASE_URL}/plugins/"
             }.freeze
 
             def url

--- a/app/_plugins/drops/entity_example/presenters/deck.rb
+++ b/app/_plugins/drops/entity_example/presenters/deck.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module Jekyll
+  module Drops
+    module EntityExample
+      module Presenters
+        module Deck
+          class Base < Liquid::Drop
+            def initialize(target:, data:, entity_type:)
+              @target      = target
+              @data        = data
+              @entity_type = entity_type
+            end
+
+            def entity
+              @entity ||= "#{@entity_type}s"
+            end
+
+            def data
+              YAML.dump(@data).delete_prefix("---\n")
+            end
+          end
+
+          class Plugin < Base
+            TARGETS = {
+              'consumer'       => 'CONSUMER_NAME|ID',
+              'consumer_group' => 'CONSUMER_GROUP_NAME|ID',
+              'global'         => nil,
+              'route'          => 'ROUTE_NAME|ID',
+              'service'        => 'SERVICE_NAME|ID'
+            }.freeze
+
+            def data
+              YAML.dump(
+                {
+                  'name' => @data.fetch('name'),
+                  @target => TARGETS.fetch(@target)
+                }.merge('config' => @data.fetch('config'))
+              ).delete_prefix("---\n")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/presenters/kic.rb
+++ b/app/_plugins/drops/entity_example/presenters/kic.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Drops
+    module EntityExample
+      module Presenters
+        module KIC
+          class Base < Liquid::Drop
+            def initialize(data:, target:, entity_type:)
+              @data        = data
+              @target      = target
+              @entity_type = entity_type
+            end
+
+            def data
+              @data
+            end
+          end
+
+          class Plugin < Base
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/presenters/konnect.rb
+++ b/app/_plugins/drops/entity_example/presenters/konnect.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Drops
+    module EntityExample
+      module Presenters
+        module Konnect
+          class Base < Liquid::Drop
+            BASE_URL = 'https://{us|eu}.api.konghq.com/v2/control-planes/{controlPlaneId}/core-entities'.freeze
+
+            URLS = {
+              'consumer' => "#{BASE_URL}/consumers/",
+              'route'    => "#{BASE_URL}/routes/",
+              'service'  => "#{BASE_URL}/services/"
+            }.freeze
+
+            def initialize(data:, target:, entity_type:)
+              @data        = data
+              @target      = target
+              @entity_type = entity_type
+            end
+
+            def url
+              @url ||= self.class::URLS.fetch(@entity_type)
+            end
+
+            def data
+              @data
+            end
+          end
+
+          class Plugin < Base
+            URLS = {
+              'consumer'       => "#{BASE_URL}/consumers/{consumerId}/plugins/",
+              'consumer_group' => "#{BASE_URL}/consumer_groups/{consumerGroupId}/plugins/",
+              'global'         => "#{BASE_URL}/plugins/",
+              'route'          => "#{BASE_URL}/routes/{routeId}/plugins/",
+              'service'        => "#{BASE_URL}/services/{serviceId}/plugins/"
+            }.freeze
+
+            def url
+              @url ||= self.class::URLS.fetch(@target)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/presenters/terraform.rb
+++ b/app/_plugins/drops/entity_example/presenters/terraform.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Drops
+    module EntityExample
+      module Presenters
+        module Terraform
+          class Base < Liquid::Drop
+            def initialize(data:, target:, entity_type:)
+              @data        = data
+              @target      = target
+              @entity_type = entity_type
+            end
+
+            def data
+              @data
+            end
+          end
+
+          class Plugin < Base
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/presenters/ui.rb
+++ b/app/_plugins/drops/entity_example/presenters/ui.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Drops
+    module EntityExample
+      module Presenters
+        module UI
+          class Base < Liquid::Drop
+            def initialize(data:, target:, entity_type:)
+              @data        = data
+              @target      = target
+              @entity_type = entity_type
+            end
+
+            def data
+              @data
+            end
+          end
+
+          class Plugin < Base
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/route.rb
+++ b/app/_plugins/drops/entity_example/route.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Drops
+    module EntityExample
+      class Route < Base
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/service.rb
+++ b/app/_plugins/drops/entity_example/service.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Drops
+    module EntityExample
+      class Service < Base
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/target/base.rb
+++ b/app/_plugins/drops/entity_example/target/base.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Drops
+    module EntityExample
+      module Target
+        class Base < Liquid::Drop
+          def initialize(target:)
+            @target = target
+          end
+
+          def value
+            @value ||= @target.value
+          end
+
+          def to_option
+            raise NotImplementedError, "#{self.class} has not implemented method '#{__method__}'"
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/target/consumer.rb
+++ b/app/_plugins/drops/entity_example/target/consumer.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module Drops
+    module EntityExample
+      module Target
+        class Consumer < Base
+          def to_option
+            'Consumer'
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/target/consumer_group.rb
+++ b/app/_plugins/drops/entity_example/target/consumer_group.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module Drops
+    module EntityExample
+      module Target
+        class ConsumerGroup < Base
+          def to_option
+            'Consumer Group'
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/target/global.rb
+++ b/app/_plugins/drops/entity_example/target/global.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module Drops
+    module EntityExample
+      module Target
+        class Global < Base
+          def to_option
+            'Global'
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/target/route.rb
+++ b/app/_plugins/drops/entity_example/target/route.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module Drops
+    module EntityExample
+      module Target
+        class Route < Base
+          def to_option
+            'Route'
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/target/service.rb
+++ b/app/_plugins/drops/entity_example/target/service.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module Drops
+    module EntityExample
+      module Target
+        class Service < Base
+          def to_option
+            'Service'
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/filters/indent.rb
+++ b/app/_plugins/filters/indent.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module IndentFilter
+  def indent(input)
+    input
+      .gsub("\n</code>", '</code>')
+      .split("\n")
+      .map { |l| l.prepend('   ') }
+      .join("\n")
+  end
+end
+
+Liquid::Template.register_filter(IndentFilter)

--- a/app/_plugins/filters/json_prettify.rb
+++ b/app/_plugins/filters/json_prettify.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Jekyll
+  module JSONPrettifyFilter
+    def json_prettify(input)
+      JSON.pretty_generate(input)
+    end
+  end
+end
+
+Liquid::Template.register_filter(Jekyll::JSONPrettifyFilter)

--- a/app/_plugins/utils/hash_to_yaml.rb
+++ b/app/_plugins/utils/hash_to_yaml.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module Jekyll
+  module Utils
+    class HashToYAML
+      def self.run(hash)
+        YAML.dump(hash).delete_prefix("---\n")
+      end
+    end
+  end
+end

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -9,6 +9,8 @@ kramdown:
     css_class: "highlight"
     guess_lang: true
 incremental: true
+liquid:
+  error_mode: strict
 
 keep_files:
   - assets


### PR DESCRIPTION
  Add basic support for `{% entity_example %}` block

  It takes the following param in yaml format:
  * type: consumer, service, route (for now)
  * data: the entity's data to render
  * formats: admin-api, konnect, kick, deck, ui

  and renders how to create that particular entity in the provided
  formats. Example usage:

```
  {% entity_example %}
  type: consumer
  data:
    custom_id: example-consumer-id
    username: example-consumer
    tags:
      - silver-tier

  formats:
    - admin-api
    - konnect
    - kic
    - deck
    - ui
  {% endentity_example %}
```

There's a liquid drop for each type and format, and the templates live in:
```
components/
  entity_example.html
  entity_example/
    format/
      admin-api.html
      deck.html
      kic.html
      konnect.html
      ui/
        consumer.html
        route.html
        service.html
```

Notes:
* It works just for consumers for now, I need to add the templates for services and routes
* It renders everything in one block, the dropdown doesn't toggle blocks
* Variables are not supported for now

TODO:
* Add missing templates for `types`
  * [ ] service
  * [ ] route
* Add missing templates for `formats`
  *  [ ] kic
  *  [ ] terraform
  *  [ ] ui
    *  [ ] service
    *  [ ] route
* [ ] Add support for plugins and other types of entities
* [ ] Make the dropdown work