### PR TITLE
Add tabs

### DIFF
--- a/app/_assets/entrypoints/application.js
+++ b/app/_assets/entrypoints/application.js
@@ -8,7 +8,9 @@ import '~/stylesheets/index.css'
 import '~/stylesheets/core.css'
 
 import EntityExample from '@/javascripts/components/entity_example';
+import Tabs from '@/javascripts/components/tabs';
 
 document.addEventListener('DOMContentLoaded', function () {
   new EntityExample();
+  new Tabs();
 });

--- a/app/_assets/javascripts/components/tabs.js
+++ b/app/_assets/javascripts/components/tabs.js
@@ -1,0 +1,108 @@
+class TabsComponent {
+  constructor(elem) {
+    this.elem = elem;
+    this.tablistNode = this.elem.querySelector('[role=tablist]');
+    this.activeTabClasses = ['text-blue-600', 'border-blue-600'];
+    this.inactiveTabClasses = ['hover:text-gray-600', 'hover:border-gray-600'];
+
+    this.tabs = Array.from(this.tablistNode.querySelectorAll('[role=tab]'));
+    this.firstTab = this.tabs[0];
+    this.lastTab = this.tabs[this.tabs.length - 1];
+
+    this.tabs.forEach((tab) => {
+      tab.addEventListener('keydown', this.onKeydown.bind(this));
+      tab.addEventListener('click', this.onClick.bind(this));
+    });
+
+    this.setSelectedTab(this.firstTab, false);
+  }
+
+  onKeydown(event) {
+    const tgt = event.currentTarget;
+    let flag = false;
+
+    switch (event.key) {
+      case 'ArrowLeft':
+        this.setSelectedToPreviousTab(tgt);
+        flag = true;
+        break;
+
+      case 'ArrowRight':
+        this.setSelectedToNextTab(tgt);
+        flag = true;
+        break;
+
+      case 'Home':
+        this.setSelectedTab(this.firstTab);
+        flag = true;
+        break;
+
+      case 'End':
+        this.setSelectedTab(this.lastTab);
+        flag = true;
+        break;
+
+      default:
+        break;
+    }
+    if (flag) {
+      event.stopPropagation();
+      event.preventDefault();
+    }
+  }
+
+  onClick(event) {
+    this.setSelectedTab(event.currentTarget);
+  }
+
+  setSelectedTab(currentTab, setFocus) {
+    if (typeof setFocus !== 'boolean') {
+      setFocus = true;
+    }
+    this.tabs.forEach((tab) => {
+      const tabPanel = document.getElementById(tab.getAttribute('aria-controls'));
+      if (currentTab === tab) {
+        tab.setAttribute('aria-selected', 'true');
+        tab.tabIndex = 0;
+        tab.classList.add(...this.activeTabClasses);
+        tab.classList.remove(...this.inactiveTabClasses);
+        tabPanel.classList.remove('hidden');
+        if (setFocus) {
+          tab.focus();
+        }
+      } else {
+        tab.setAttribute('aria-selected', 'false');
+        tab.tabIndex = -1;
+        tab.classList.add(...this.inactiveTabClasses);
+        tab.classList.remove(...this.activeTabClasses);
+        tabPanel.classList.add('hidden');
+      }
+    });
+  }
+
+  setSelectedToPreviousTab(currentTab) {
+    if (currentTab === this.firstTab) {
+      this.setSelectedTab(this.lastTab);
+    } else {
+      const index = this.tabs.indexOf(currentTab);
+      this.setSelectedTab(this.tabs[index - 1]);
+    }
+  }
+
+  setSelectedToNextTab(currentTab) {
+    if (currentTab === this.lastTab) {
+      this.setSelectedTab(this.firstTab);
+    } else {
+      const index = this.tabs.indexOf(currentTab);
+      this.setSelectedTab(this.tabs[index + 1]);
+    }
+  }
+}
+
+export default class Tabs {
+  constructor() {
+    document.querySelectorAll('.tabs').forEach((elem) => {
+      new TabsComponent(elem);
+    });
+  }
+}

--- a/app/_includes/components/tabs.html
+++ b/app/_includes/components/tabs.html
@@ -1,0 +1,41 @@
+{% assign tabs = 'navtabs-' | append: navtabs_id %}
+
+<div class="tabs {{ class }} {{ environment['additional_classes'] }}">
+  <ul class="tablist" role="tablist">
+    {% for tab in environment[tabs] %}
+      {% assign slug = tab[0] | slugify %}
+      {% if forloop.first %}
+        {% assign aria_selected = true %}
+      {% else %}
+        {% assign aria_selected = false %}
+      {% endif %}
+      <button
+        id="navtab-{{ navtabs_id }}-tab-{{ forloop.index }}"
+        class="p-4 border-b-2"
+        aria-controls="navtab-{{ navtabs_id }}-tabpanel-{{ forloop.index }}"
+        role="tab"
+        aria-selected="{{ aria_selected }}"
+        {% if forloop.first %} tabindex="0" {% else %} tabindex="-1" {% endif %}
+        data-slug="{{ slug }}"
+      >
+        {{ tab[0] }}
+      </button>
+    {% endfor %}
+  </ul>
+
+  <div class="navtab-contents">
+    {% for tab in environment[tabs] %}
+      {% assign slug = tab[0] | slugify %}
+      <div
+        class="navtab-content {% unless forloop.first %} hidden {% endunless %}"
+        role="tabpanel"
+        id="navtab-{{ navtabs_id }}-tabpanel-{{ forloop.index }}"
+        tabindex="0"
+        aria-labelledby="navtab-{{ navtabs_id }}-tab-{{ forloop.index }}"
+        data-panel="{{ slug }}"
+      >
+        {{ tab[1] }}
+      </div>
+    {% endfor %}
+  </div>
+</div>

--- a/app/_plugins/blocks/navtabs.rb
+++ b/app/_plugins/blocks/navtabs.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'erb'
+require 'securerandom'
+
+module Jekyll
+  module NavTabs
+    class NavTabsBlock < Liquid::Block
+      def initialize(tag_name, markup, tokens)
+        super
+        @class = markup.strip
+      end
+
+      def render(context) # rubocop:disable Metrics/MethodLength
+        navtabs_id = SecureRandom.uuid
+        environment = context.environments.first
+        @site = context.registers[:site]
+
+        environment["navtabs-#{navtabs_id}"] = {}
+        environment['navtabs-stack'] ||= []
+        environment['navtabs-stack'].push(navtabs_id)
+
+        super
+
+        environment['navtabs-stack'].pop
+        environment['additional_classes'] = ''
+
+        Liquid::Template
+          .parse(File.read('app/_includes/components/tabs.html'))
+          .render(
+            {
+              'site' => @site.config, 'page' => @page,
+              'class' => @class, 'environment' => environment, 'navtabs_id' => navtabs_id,
+            },
+            { registers: context.registers, context: @context }
+          )
+      end
+    end
+
+    class NavTabBlock < Liquid::Block
+      alias render_block render
+
+      def initialize(tag_name, markup, tokens)
+        super
+        raise SyntaxError, "No toggle name given in #{tag_name} tag" if markup == ''
+
+        @title = markup.strip
+      end
+
+      def render(context) # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+        # Add support for variable titles
+        path = @title.split('.')
+        # 0 is the page scope, 1 is the local scope
+        [0, 1].each do |k|
+          next unless context.scopes[k]
+
+          ref = context.scopes[k].dig(*path)
+          @title = ref if ref
+        end
+
+        site = context.registers[:site]
+        converter = site.find_converter_instance(::Jekyll::Converters::Markdown)
+        environment = context.environments.first
+
+        navtabs_id = environment['navtabs-stack'].last
+        environment["navtabs-#{navtabs_id}"][@title] = converter.convert(render_block(context))
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag('navtab', Jekyll::NavTabs::NavTabBlock)
+Liquid::Template.register_tag('navtabs', Jekyll::NavTabs::NavTabsBlock)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,6 +7,7 @@ module.exports = {
     "app/_landing_pagees/**/*.yaml",
     "app/_tutorials/**/*.md",
     "app/_plugins/**/*.rb",
+    "app/_assets/javascripts/**"
   ],
   safelist: [
     {


### PR DESCRIPTION
Add support for tabs.

They work in the same way as in docs.konghq.com

```
{% navtabs %}
{% navtab Tab title goes here %}
Content goes here
{% endnavtab %}

{% navtab Tab title 2 goes here %}
Content goes here
{% endnavtab %}
{% endnavtabs %}
```

Example with some dummy content

https://github.com/user-attachments/assets/f5b04d48-908a-4ce0-aa63-d381ffd413f1

