### PR TITLE
[don't merge yet] feat: Rate Limiting Plugin Reference Page

### DIFF
--- a/app/_kong_plugins/rate-limiting/reference.md
+++ b/app/_kong_plugins/rate-limiting/reference.md
@@ -1,0 +1,54 @@
+---
+title: Rate Limiting configuration
+content_type: reference
+entities: 
+    - service
+    - route
+    - consumer
+    - consumer_group
+    - plugin
+faqs:
+  - q: What is the Rate Limiting plugin used for?
+    a: The Rate Limiting plugin is used to control the rate of requests that clients can make to your services. It helps prevent abuse and ensures fair usage by limiting the number of requests a client can make in a given time period.
+  - q: Can I set different rate limits for different endpoints or services?
+    a: Yes, you can configure rate limits on a per-service or per-route basis by applying the Rate Limiting plugin to specific services or routes in Kong.
+  - q: "How does the `policy` option affect rate limiting?"
+    a: |
+      The `policy` option determines how rate limits are stored and enforced. The `local` policy uses Kong’s in-memory storage, while the `redis` policy uses Redis, which is useful for distributed setups where rate limiting needs to be consistent across multiple Kong data plane nodes.
+related_resources:
+  - text: How to create rate limiting tiers with Rate Limiting Advanced
+    url: https://docs.konghq.com/hub/kong-inc/rate-limiting-advanced/how-to/
+  - text: Rate Limiting Advanced plugin overview
+    url: https://docs.konghq.com/hub/kong-inc/rate-limiting-advanced/
+---
+
+This page provides a reference for the Rate Limiting plugin configuration.
+
+## schema goes here
+
+<!-- example plugin schema renderer below, ideally this will render on the left of the config examples -->
+
+
+{% contentfor config_examples %}
+{% entity_example %}
+type: plugin
+data:
+  name: rate-limiting
+  config:
+    second: 5
+    hour: 1000
+    policy: local
+targets:
+  - consumer
+  - service
+  - route
+  - global
+  - consumer_group
+formats:
+  - admin-api
+  - konnect
+  - kic
+  - deck
+  - terraform
+{% endentity_example %}
+{% endcontentfor %}

--- a/app/_kong_plugins/rate-limiting/reference.md
+++ b/app/_kong_plugins/rate-limiting/reference.md
@@ -7,6 +7,8 @@ entities:
     - consumer
     - consumer_group
     - plugin
+tools:
+    - deck
 faqs:
   - q: What is the Rate Limiting plugin used for?
     a: The Rate Limiting plugin is used to control the rate of requests that clients can make to your services. It helps prevent abuse and ensures fair usage by limiting the number of requests a client can make in a given time period.


### PR DESCRIPTION
- I added more front matter to the existing Rate Limiting reference page
- I also added an example plugin schema block in Liquid to see if something like that would work (I didn't do any of the backend work to make the schema render because I have no idea what would be done to make that work)
- I can't help but wonder if reference pages like this (that are primarily schema-driven) should be yaml files instead with the `row` and `column` formatting instead. I don't think people other than the docs team will be editing these pages, so I wonder if yaml files would work or be better than markdown since there's less text content.