### PR TITLE
UI examples for entities

### DIFF
--- a/app/_includes/components/entity_example/format/ui/consumer.html
+++ b/app/_includes/components/entity_example/format/ui/consumer.html
@@ -1,8 +1,8 @@
 <div markdown="1">
 The following creates a new consumer called **{{ include.presenter.data['username'] }}**:
 
-1. In Kong Manager or Gateway Manager, go to **API Gateway** > **Consumers**.
+1. In Kong Manager or Gateway Manager, go to **Consumers**.
 2. Click **New Consumer**.
 3. Enter the **Username** `{{ include.presenter.data['username'] }}` and **Custom ID** `{{ include.presenter.data['custom_id'] }}`.
-4. Click **Create**.
+4. Click **Save**.
 </div>

--- a/app/_includes/components/entity_example/format/ui/plugin.html
+++ b/app/_includes/components/entity_example/format/ui/plugin.html
@@ -1,0 +1,12 @@
+<div markdown="1">
+1. In Kong Manager or Gateway Manager, go to **Plugins**.
+2. Click **New Plugin**.
+3. Choose a scope for the plugin: 
+    * **Global**, which applies the plugin to all services, routes, consumers, and consumer groups in the workspace (Kong Manager) or control plane (Gateway Manager).
+    * **Scoped**, which lets you choose a specific Gateway service, route, consumer, or consumer group to apply the plugin to. 
+    The types of entities you have available here depend on the plugin you picked.
+
+4. Configure your plugin. The configuration options will depend on which plugin you picked.
+5. Click **Save**.
+</div>
+    

--- a/app/_includes/components/entity_example/format/ui/route.html
+++ b/app/_includes/components/entity_example/format/ui/route.html
@@ -1,0 +1,10 @@
+<div markdown="1">
+The following creates a new route called **{{ include.presenter.data['name'] }}** with basic configuration:
+
+1. In Kong Manager or Gateway Manager, go to **Routes**.
+2. Click **New Route**.
+3. Enter a unique name and select a service to assign it to. In this example, the route is named `{{ include.presenter.data['name'] }}`.
+4. Set a path or define routing rules. For example, the path can be `{{ include.presenter.data['paths']}}`.
+5. Click **Save**.
+</div>
+    

--- a/app/_includes/components/entity_example/format/ui/service.html
+++ b/app/_includes/components/entity_example/format/ui/service.html
@@ -1,0 +1,10 @@
+<div markdown="1">
+The following creates a new service called **{{ include.presenter.data['name'] }}** with basic configuration:
+
+1. In Kong Manager or Gateway Manager, go to **Gateway Services**.
+2. Click **New Gateway Service**.
+3. Enter a unique name for the service. In this example, it's `{{ include.presenter.data['name'] }}`.
+4. Define the endpoint for this service by specifying the full URL or by its separate elements. In this example, the full upstream URL is `{{ include.presenter.data['url'] }}`.
+5. Click **Save**.
+</div>
+    

--- a/app/_plugins/drops/entity_example/format/deck.rb
+++ b/app/_plugins/drops/entity_example/format/deck.rb
@@ -24,7 +24,7 @@ module Jekyll
           end
 
           def to_option
-            'Deck'
+            'decK'
           end
         end
       end


### PR DESCRIPTION
Tested UIs and added examples for all the existing entities.

Switch to the Kong Manager/Gateway Manager tab on one of these entity pages:
https://deploy-preview-26--kongdeveloper.netlify.app/kong-entities/consumer/
https://deploy-preview-26--kongdeveloper.netlify.app/kong-entities/service/
https://deploy-preview-26--kongdeveloper.netlify.app/kong-entities/route/

For routes: would it be more helpful to do a `traditional_compat` example and an `expressions` example?