### PR TITLE
Tutorial: Rate Limiting a service with Kong Gateway

### DIFF
--- a/app/_gateway_entities/service.md
+++ b/app/_gateway_entities/service.md
@@ -10,6 +10,8 @@ description: In Kong Gateway, a service is an abstraction of an existing upstrea
 related_resources:
   - text: Routes entity
     url: /gateway/entities/route/
+  - text: Enable rate limiting on a service with Kong Gateway
+    url: /tutorials/add-rate-limiting-to-a-service-with-kong-gateway/
 
 tools:
     - admin-api

--- a/app/_includes/tutorials/prereqs.html
+++ b/app/_includes/tutorials/prereqs.html
@@ -1,0 +1,8 @@
+<h2>Prerequisites</h2>
+<div>
+    <button>{{ prereqs.title }}</button>
+    <div>
+        <p>{{ prereqs.content }}</p>
+    </div>
+</div>
+

--- a/app/_includes/tutorials/prereqs/kong-quickstart.yaml
+++ b/app/_includes/tutorials/prereqs/kong-quickstart.yaml
@@ -1,0 +1,12 @@
+text: Kong Gateway running
+content: | 
+  If you don't already have Kong Gateway running, you can use the quickstart script to get up and running quickly:
+  ```bash
+  curl -Ls https://get.konghq.com/quickstart | bash -s
+  ```
+
+  Once the Kong Gateway is ready, you will see the following message:
+
+  ```bash
+  Kong Gateway Ready 
+  ```

--- a/app/_includes/tutorials/prereqs/route.yaml
+++ b/app/_includes/tutorials/prereqs/route.yaml
@@ -1,0 +1,8 @@
+text: Create a route
+content: | 
+  {% highlight yaml %}
+  _format_version: "3.0"
+  {{ include.presenter.entity }}:
+    -
+  {{ include.presenter.data | indent: 2 }}
+  {% endhighlight %}

--- a/app/_includes/tutorials/prereqs/service.yaml
+++ b/app/_includes/tutorials/prereqs/service.yaml
@@ -1,0 +1,8 @@
+text: Create a service
+content: | 
+  {% highlight yaml %}
+  _format_version: "3.0"
+  {{ include.presenter.entity }}:
+    -
+  {{ include.presenter.data | indent: 2 }}
+  {% endhighlight %}

--- a/app/_layouts/plugin.html
+++ b/app/_layouts/plugin.html
@@ -85,6 +85,9 @@ layout: default
               <a href="#" class="text-blue-500 hover:underline">Rate Limiting with consumer groups</a>
             </li>
             <li>
+              <a href="/tutorials/add-rate-limiting-to-a-service-with-kong-gateway/" class="text-blue-500 hover:underline">Enable rate limiting on a service with Kong Gateway</a>
+            </li>
+            <li>
               <a href="#" class="text-blue-500 hover:underline">See more tutorials &raquo;</a>
             </li>
           </ul>

--- a/app/_tutorials/add-rate-limiting-to-a-service-with-kong-gateway.md
+++ b/app/_tutorials/add-rate-limiting-to-a-service-with-kong-gateway.md
@@ -32,61 +32,27 @@ tags:
 content_type: tutorial
 
 tldr:
-    q: How do I add Rate Limiting to a Service with Kong Gateway?
+    q: How do I rate limit a service with Kong Gateway?
     a: Install the Rate Limiting plugin and enable it on the service.
 
 tools:
     - deck
+
+prereqs:
+  - type: kong-quickstart
+  - type: service
+    data:
+      name: example_service
+  - type: route
+    data:
+      name: example_route
+      service:
+        name: example_service
 ---
-
-## Prerequisites 
-
-place holder for prerendered prereq instructions that contains: 
-
-* Docker: Docker is used to run a temporary Kong Gateway and database to allow you to run this tutorial
-* curl: curl is used to send requests to Kong Gateway . 
-* Kong Gateway
 
 ## Steps
 
-1. Get Kong
-
-    Run Kong Gateway with the quickstart script:
-    ```bash
-    curl -Ls https://get.konghq.com/quickstart | bash -s
-    ```
-
-    Once the Kong Gateway is ready, you will see the following message:
-
-    ```bash
-    Kong Gateway Ready 
-    ```
-
-1. Create a service 
-
-{% capture step %}
-{% entity_example %}
- type: service
- data:
-   name: example_service
-{% endentity_example %}
-{% endcapture %}
-{{ step | indent: 3}}
-
-1. Create a route 
-
-{% capture step %}
-{% entity_example %}
-type: route
-data:
-  name: example_route
-  service:
-    name: example_service
-{% endentity_example %}
-{% endcapture %}
-{{ step | indent: 3 }}
-
-1. Enable the Rate Limiting Plugin on the Service
+1. Enable the Rate Limiting Plugin on the service:
 
 {% capture step %}
 {% entity_example %}
@@ -105,9 +71,8 @@ variables:
 {% endcapture %}
 {{ step | indent: 3 }}
 
-1. Validate
+1. Verify that the Rate Limiting plugin was configured correctly by sending more requests then allowed in the configured time limit:
 
-   After configuring the Rate Limiting plugin, you can verify that it was configured correctly and is working, by sending more requests then allowed in the configured time limit.
    ```bash
    for _ in {1..6}
    do
@@ -118,12 +83,4 @@ variables:
 
    ```bash
    { "message": "API rate limit exceeded" }
-   ```
-
-1. Teardown
-
-   Destroy the Kong Gateway container.
-
-   ```bash
-   curl -Ls https://get.konghq.com/quickstart | bash -s -- -d
    ```

--- a/app/_tutorials/add-rate-limiting-to-a-service-with-kong-gateway.md
+++ b/app/_tutorials/add-rate-limiting-to-a-service-with-kong-gateway.md
@@ -52,7 +52,7 @@ prereqs:
 
 ## Steps
 
-1. Enable the Rate Limiting Plugin on the service:
+1. Enable the Rate Limiting Plugin on the service by adding the following to your `kong.yaml` file:
 
 {% capture step %}
 {% entity_example %}
@@ -71,13 +71,6 @@ variables:
 {% endcapture %}
 {{ step | indent: 3 }}
 
-1. Run the diff command:
-
-  ```bash
-  deck gateway diff kong.yaml
-  ```
-
-  You should see decK reporting that the properties you had changed in the file are going to be changed by decK in Kong Gateway’s database.
 
 1. Apply the changes:
 

--- a/app/_tutorials/add-rate-limiting-to-a-service-with-kong-gateway.md
+++ b/app/_tutorials/add-rate-limiting-to-a-service-with-kong-gateway.md
@@ -71,6 +71,20 @@ variables:
 {% endcapture %}
 {{ step | indent: 3 }}
 
+1. Run the diff command:
+
+  ```bash
+  deck gateway diff kong.yaml
+  ```
+
+  You should see decK reporting that the properties you had changed in the file are going to be changed by decK in Kong Gateway’s database.
+
+1. Apply the changes:
+
+  ```bash
+  deck gateway sync kong.yaml
+  ```
+
 1. Verify that the Rate Limiting plugin was configured correctly by sending more requests then allowed in the configured time limit:
 
    ```bash


### PR DESCRIPTION
Preview URL: https://deploy-preview-43--kongdeveloper.netlify.app/tutorials/add-rate-limiting-to-a-service-with-kong-gateway/

- Revised the existing RL service tutorial to clean up the prereqs
- Made some metadata for prereqs, it doesn't work and I'm not sure how to fix it, but hopefully that gives a starting point for what we could do
- Added links to relevant pages to create a better user journey to find this content