### PR TITLE
Add landing page index (temporary)

### DIFF
--- a/app/_landing_pages/custom-plugins.yaml
+++ b/app/_landing_pages/custom-plugins.yaml
@@ -1,3 +1,5 @@
+metadata:
+  title: Custom Plugins
 content:
   - row:
       - column:

--- a/app/_landing_pages/gateway.yaml
+++ b/app/_landing_pages/gateway.yaml
@@ -1,3 +1,5 @@
+metadata:
+  title: Kong Gateway
 content:
   - row:
       - column:

--- a/app/_landing_pages/gateway/entities.yaml
+++ b/app/_landing_pages/gateway/entities.yaml
@@ -1,3 +1,5 @@
+metadata:
+  title: Gateway Entities
 content:
   - row:
       - column:

--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -36,6 +36,9 @@
           <li class='border-gray-300 max-lg:py-3 px-3'>
             <a href='/gateway/entities/' class='text-white hover:text-red-200'>Gateway Entities</a>
           </li>
+          <li class='border-gray-300 max-lg:py-3 px-3'>
+            <a href='/landing-pages/' class='text-white hover:text-red-200'>All Landing Pages</a>
+          </li>
         </li>
       </ul>
 

--- a/app/_plugins/generators/landing_page/page.rb
+++ b/app/_plugins/generators/landing_page/page.rb
@@ -24,6 +24,10 @@ module Jekyll
         @data['layout'] = 'landing_page'
       end
 
+      def url
+        @dir.sub(@site.dest, '')
+      end
+
       private
 
       def output_path(file)

--- a/app/landing-pages.html
+++ b/app/landing-pages.html
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Landing Page Index
+---
+
+<div class="mx-16">
+  <h1 class="text-3xl my-4">Landing Page Index</h1>
+  <ul class="list-disc list-inside">
+    {% assign all_pages = site.pages | sort: 'dir' %}
+    {% for page in all_pages %}
+    {% if page.layout == "landing_page" %}
+      <li>
+        <a href="{{ page.url }}" class="text-blue-500 hover:underline">{{ page.title | default: "MISSING TITLE" }}</a> ({{ page.dir }})
+      </li>
+    {% endif %}
+    {% endfor %}
+  </ul>
+</div>


### PR DESCRIPTION
Temporary index page to help us keep track of landing pages that exist without looking in `_landing_pages` and typing the URL manually