### PR TITLE
Fix auth landing page and add plugin stubs

### DIFF
--- a/app/_kong_plugins/basic-auth/index.md
+++ b/app/_kong_plugins/basic-auth/index.md
@@ -1,0 +1,14 @@
+---
+title: Basic Auth plugin
+
+name: Basic Auth
+publisher: kong-inc
+content_type: plugin
+description: Secure services and routes with Basic Authentication
+tags:
+    - authentication
+---
+
+Add Basic Authentication to a service or a route with username and password protection. The plugin checks for valid credentials in the Proxy-Authorization and Authorization headers (in that order).
+
+

--- a/app/_kong_plugins/jwt/index.md
+++ b/app/_kong_plugins/jwt/index.md
@@ -1,0 +1,20 @@
+---
+title: JWT plugin
+
+name: JWT
+publisher: kong-inc
+content_type: plugin
+description: Verify and authenticate JSON Web Tokens
+tags:
+    - authentication
+---
+
+The JWT plugin lets you verify requests containing HS256 or RS256 signed JSON Web Tokens, as specified in [RFC 7519](https://tools.ietf.org/html/rfc7519).
+
+When you enable this plugin, it grants JWT credentials (public and secret keys) to each of your consumers, which must be used to sign their JWTs. You can then pass a token through any of the following:
+
+* A query string parameter
+* A cookie
+* HTTP request headers
+
+Kong will either proxy the request to your upstream services if the token’s signature is verified, or discard the request if not. Kong can also perform verifications on some of the registered claims of RFC 7519 (exp and nbf). If Kong finds multiple tokens that differ - even if they are valid - the request will be rejected to prevent JWT smuggling.

--- a/app/_kong_plugins/key-auth/index.md
+++ b/app/_kong_plugins/key-auth/index.md
@@ -1,0 +1,14 @@
+---
+title: Key Auth plugin
+
+name: Key Auth
+publisher: kong-inc
+content_type: plugin
+description: Secure services and routes with key authetication
+tags:
+    - authentication
+---
+
+This plugin lets you add API key authentication to a service or a route. Consumers then add their API key either in a query string parameter, a header, or a request body to authenticate their requests.
+
+This plugin also comes in an enterprise version: Key Authentication Encrypted, which provides the ability to encrypt keys. Keys are encrypted at rest in the API gateway datastore.

--- a/app/_landing_pages/authentication.yaml
+++ b/app/_landing_pages/authentication.yaml
@@ -160,12 +160,12 @@ content:
     - column:
         - type: plugin
           config:
-            name: basic-auth
+            slug: basic-auth
     - column:
         - type: plugin
           config:
-            name: jwt
+             slug: jwt
     - column:
         - type: plugin
           config:
-            name: key-auth
+            slug: key-auth


### PR DESCRIPTION
Fixing the authentication landing page to unblock any new dev work. Right now, main is broken and all builds are failing with

```
Liquid Exception: Error rendering {% plugin %} on page: /opt/build/repo/app/_landing_pages/authentication.yaml. The plugin `` doesn't exist. in /opt/build/repo/app/_layouts/landing_page.html"
```
