### PR TITLE
Add 'text' block for landing pages

### DIFF
--- a/app/_includes/landing_pages/text.md
+++ b/app/_includes/landing_pages/text.md
@@ -1,0 +1,1 @@
+{{ include.config }}

--- a/app/_landing_pages/deck.yaml
+++ b/app/_landing_pages/deck.yaml
@@ -7,15 +7,12 @@ content:
             config:
               type: h1
               text: "decK"
-  - row: 
+  - row:
     - column:
-      - type: structured_text
-        config: 
-          blocks: 
-            - type: text
-              text: | 
-                decK is a command line tool that facilitates API Lifecycle Automation (APIOps) by offering a comprehensive toolkit of commands designed to orchestrate and automate the entire process of API delivery. APIOps involves leveraging automation frameworks to streamline and enforce best practices throughout the API lifecycle. This enables developers and operations teams to manage APIs from development through deployment, ensuring consistency, reliability, and speed in API integrations. 
-                decK is one of the many supported tools used to interact with Kong, to learn about other tools review our [tools page](/tools)
+      - type: text
+        config:
+          decK is a command line tool that facilitates API Lifecycle Automation (APIOps) by offering a comprehensive toolkit of commands designed to orchestrate and automate the entire process of API delivery. APIOps involves leveraging automation frameworks to streamline and enforce best practices throughout the API lifecycle. This enables developers and operations teams to manage APIs from development through deployment, ensuring consistency, reliability, and speed in API integrations.
+          decK is one of the many supported tools used to interact with Kong, to learn about other tools review our [tools page](/tools)
 
   - row:
     - column:
@@ -38,63 +35,51 @@ content:
           align: center
   - row:
     - column:
-      - type: structured_text
+      - type: text
         config:
-          blocks:
-            - type: text
-              text: | 
-                1.  `brew tap kong/deck`
-                2. `brew install deck`
-    - column: 
-      - type: structured_text
-        config: 
-          blocks:
-            - type: text
-              text: |
-                1. `curl -sL https://github.com/kong/deck/releases/download/v1.38.1/deck_1.38.1_windows_amd64.tar.gz -o deck.tar.gz`
-                2. `tar -xf deck.tar.gz -C /tmp`
-                3. `sudo cp /tmp/deck /usr/local/bin/`
-    - column: 
-      - type: structured_text
-        config: 
-          blocks:
-            - type: text
-              text: |
-                If you are on Windows, you can either use the compressed archive from the [Github release page](https://github.com/kong/deck/releases) or install using CMD by entering the target installation folder and downloading a compressed archive, which contains the binary.
-                1. `curl -sL https://github.com/kong/deck/releases/download/v1.38.1/deck_1.38.1_windows_amd64.tar.gz -o deck.tar.gz`
-                2. `mkdir deck`
-                2. `tar -xf deck.tar.gz -C deck`
-                3. `powershell -command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + [IO.Path]::PathSeparator + [System.IO.Directory]::GetCurrentDirectory() + '\deck', 'User')"`
-  - row: 
-    - column: 
+          1.  `brew tap kong/deck`
+          2. `brew install deck`
+    - column:
+      - type: text
+        config:
+          1. `curl -sL https://github.com/kong/deck/releases/download/v1.38.1/deck_1.38.1_windows_amd64.tar.gz -o deck.tar.gz`
+          2. `tar -xf deck.tar.gz -C /tmp`
+          3. `sudo cp /tmp/deck /usr/local/bin/`
+    - column:
+      - type: text
+        config:
+          If you are on Windows, you can either use the compressed archive from the [Github release page](https://github.com/kong/deck/releases) or install using CMD by entering the target installation folder and downloading a compressed archive, which contains the binary.
+          1. `curl -sL https://github.com/kong/deck/releases/download/v1.38.1/deck_1.38.1_windows_amd64.tar.gz -o deck.tar.gz`
+          2. `mkdir deck`
+          2. `tar -xf deck.tar.gz -C deck`
+          3. `powershell -command "[Environment]::SetEnvironmentVariable('Path', [Environment]::GetEnvironmentVariable('Path', 'User') + [IO.Path]::PathSeparator + [System.IO.Directory]::GetCurrentDirectory() + '\deck', 'User')"`
+  - row:
+    - column:
       - type: header
-        config: 
+        config:
           type: h2
           text: "How does decK work?"
-  - row: 
-    - column: 
-      - type: structured_text
-        config: 
-          blocks:  
-            - type: text
-              text: | 
-                decK operates on state files. 
-                decK state files describe the configuration of Kong Gateway. 
-                State files store Kong Gateway configuration in a declarative format, letting you manage services, routes, plugins, consumers, and other entities that define how requests are processed and routed through Kong Gateway.
+  - row:
+    - column:
+      - type: text
+        config:
+          decK operates on state files.
+          decK state files describe the configuration of Kong Gateway.
+          State files store Kong Gateway configuration in a declarative format, letting you manage services, routes, plugins, consumers, and other entities that define how requests are processed and routed through Kong Gateway.
 
-                In the background, decK communicates to your Kong Gateways via the Admin API.
-  
-  
-  - row: 
+          In the background, decK communicates to your Kong Gateways via the Admin API.
+
+
+  - row:
     - column:
       - type: x_with_y
-        config: 
+        config:
             type: h2
             headers:
               - What can decK do?
 
             items:
-              - text: | 
+              - text: |
                   Export your current settings from Kong Gateway
                 action:
                   type: command
@@ -104,7 +89,7 @@ content:
                       - gateway
                       - sync
                       - /path/to/file.json
-              - text: | 
+              - text: |
                   Sync configs between Gateway and Konnect
                 action:
                   type: command
@@ -113,8 +98,8 @@ content:
                     args:
                       - gateway
                       - ping
-                  
-              - text: | 
+
+              - text: |
                   Self-validate it's own configuration
                 action:
                   type: command
@@ -124,9 +109,9 @@ content:
                       - deck
                       - gateway
                       - validate
-                  
 
-  
+
+
   - row:
     - column:
       - type: card
@@ -143,7 +128,7 @@ content:
         config:
           title: Changelog
           cta: https://github.com/kong/deck/blob/main/CHANGELOG.md/
-  - row: 
+  - row:
     - column:
       - type: header
         config:
@@ -157,7 +142,7 @@ content:
           - q: I use Terraform to configure Kong, why should I care about decK?
             a: |
               If you are using Terraform and are happy with it, you should continue to use it. decK covers all the problems that Terraform solves and goes beyond it:
-              
+
               * With Terraform, you have to track and maintain Terraform files (*.tf) and the Terraform state (likely using a cloud storage solution). With decK, the entire configuration is stored in the YAML/JSON file(s) only. There is no separate state that needs to be tracked.
               * decK can export and back up your existing Kong’s configuration, meaning, you can take an existing Kong installation, and have a backup, as well as a declarative configuration for it. With Terraform, you will have to import each and every entity in Kong into Terraform’s state.
               * decK can check if a configuration file is valid or not (validate sub-command).
@@ -225,7 +210,7 @@ content:
               * decK is read-intensive for most parts, meaning it will perform read-intensive queries on your Cassandra cluster, so make sure you tune your Cassandra cluster accordingly.
               * decK talks to the same Kong node that talks to the same Cassandra node in your cluster.
               Use the `--parallelism 1` flag to ensure that there is only request being processed at a time. This will slow down sync process and should be used as a last resort.
-  - row: 
+  - row:
     - column:
       - type: faqs
         config:
@@ -233,10 +218,10 @@ content:
             a:  |
                Yes. The decK team maintains a JSON schema that you can use to validate YAML files on Github. You can use the schema with a text editor to provide JIT YAML validation. For example, to use the JSON schema with VS Code:
                1. Install the Red Hat YAML extension:
-                
+
                       code --install-extension redhat.vscode-yaml
                2. Edit the plugin settings in VS Code:
-                       
+
                       "yaml.schemas": {
                         "https://json.schemastore.org/kong_json_schema.json": [
                             "kong.yml",
@@ -244,23 +229,23 @@ content:
                         ]
                     }
                3. Verify that it works by opening your existing `kong.yml` or `kong.yaml` file.
-  - row: 
+  - row:
     - column:
       - type: faqs
         config:
           - q: What endpoints does decK use?
             a:  |
 
-              decK uses Kong's Admin API to communicate with {{site.base_gateway}}. 
-              If you have RBAC enabled, you need to give decK permissions to perform operations, or use an admin account that has these permissions. 
+              decK uses Kong's Admin API to communicate with {{site.base_gateway}}.
+              If you have RBAC enabled, you need to give decK permissions to perform operations, or use an admin account that has these permissions.
 
               Here are some common endpoints hit by decK for normal operations:
 
               * `GET, POST, PATCH, PUT, DELETE /{entityType}` or `GET, POST, PATCH, PUT, DELETE /{workspace}/{entityType}`: Perform read and write operations on entities.
 
-                If you are running {{site.ee_product_name}}, then decK interacts with entities inside workspaces. 
+                If you are running {{site.ee_product_name}}, then decK interacts with entities inside workspaces.
                 See the [Entities managed by decK](/deck/{{page.release}}/reference/entities/) reference for the full list.
-                
+
                 Note that decK also performs operations on entities enabled by plugins, such as `/basic-auths`, `/jwts`, and so on.
               * `GET /`: Get the {{site.base_gateway}} version.
               * `GET /{workspace}/kong`: Get entities in a workspace.
@@ -269,6 +254,6 @@ content:
               * `GET /{workspace}/schemas/plugins/{pluginName}`: Retrieves the schema for a specified plugin within a workspace and applies default settings.
               * `POST /workspaces`: Create missing workspaces.
 
-              To find out which endpoints your instance of decK is hitting, execute any decK command with the `--verbose 1` flag. 
+              To find out which endpoints your instance of decK is hitting, execute any decK command with the `--verbose 1` flag.
               This outputs all of the queries being made. For example, here's a snippet from `deck gateway dump --verbose 1`:
 

--- a/app/_landing_pages/gateway/entities.yaml
+++ b/app/_landing_pages/gateway/entities.yaml
@@ -11,12 +11,9 @@ content:
 
   - row:
       - column:
-          - type: structured_text
+          - type: text
             config:
-              blocks:
-                - type: text
-                  text: |
-                    Kong entities refer to the various components and objects that make up the Kong API Gateway and its ecosystem.
+              Kong entities refer to the various components and objects that make up the Kong API Gateway and its ecosystem.
           - type: image
             config:
               url: "https://raw.githubusercontent.com/Kong/docs.konghq.com/main/app/assets/images/products/konnect/getting-started/konnect-gateway-entities.png"
@@ -72,14 +69,8 @@ content:
         config:
           entity: workspace
     - column: 
-      - type: structured_text
-        config:
-          blocks:
-            type: text 
-            text: "&nbsp;"
+      - type: text
+        config: "&nbsp;"
     - column: 
-      - type: structured_text
-        config:
-          blocks:
-            type: text 
-            text: "&nbsp;"
+      - type: text
+        config: "&nbsp;"


### PR DESCRIPTION
Enough people are using `structured_text` with a single text block that it makes sense to add a `text` type.

`structured_text` is intended for showing header + text (plus other types as needed` in a single block