### PR TITLE
Chore: Cleaning up tutorials

### DIFF
--- a/app/_tutorials/add-rate-limiting-for-a-consumer-with-kong-gateway.md
+++ b/app/_tutorials/add-rate-limiting-for-a-consumer-with-kong-gateway.md
@@ -30,7 +30,7 @@ tags:
 content_type: tutorial
 
 tldr:
-    q: How do I add Rate Limiting to a consumer with Kong Gateway?
+    q: How do I rate limit a consumer with Kong Gateway?
     a: Install the Rate Limiting plugin and enable it for the consumer.
 
 tools:

--- a/app/_tutorials/add-rate-limiting-tiers-with-kong-gateway.md
+++ b/app/_tutorials/add-rate-limiting-tiers-with-kong-gateway.md
@@ -115,8 +115,10 @@ To use consumer groups for rate limiting, you need to:
     data:
       name: rate-limiting-advanced
       config:
-        limit: 5
-        window_size: 30
+        limit: 
+          - 5
+        window_size: 
+          - 30
         window_type: sliding
         retry_after_jitter_max: 0
  

--- a/app/_tutorials/add-rate-limiting-to-a-service-with-kong-gateway.md
+++ b/app/_tutorials/add-rate-limiting-to-a-service-with-kong-gateway.md
@@ -44,7 +44,7 @@ prereqs:
 
 ## Steps
 
-1. Enable the Rate Limiting Plugin on the Service
+1. Enable the Rate Limiting plugin on a service:
 
 {% capture step %}
 {% entity_example %}

--- a/app/_tutorials/enable-key-authentication-on-a-service-with-kong-gateway.md
+++ b/app/_tutorials/enable-key-authentication-on-a-service-with-kong-gateway.md
@@ -24,12 +24,15 @@ prereqs:
         - example-service
     routes:
         - example-route
+tldr:
+    q: How do I secure a service with key authentication?
+    a: Enable the Key Authentication plugin on the service. This plugin will require all requests made to this service to have a valid API key.
 
 ---
 
 ## Steps
 
-1. Enable the Key Authentication plugin on the Service
+1. Enable the Key Authentication plugin on the service:
 
 {% capture step %}
 {% entity_example %}
@@ -62,7 +65,7 @@ data:
 
 1. Validate
 
-   After configuring the Key Authentication plugin, you can verify that it was configured correctly and is working, by sending requests with and without the api key you created for your consumer.
+   After configuring the Key Authentication plugin, you can verify that it was configured correctly and is working, by sending requests with and without the API key you created for your consumer.
 
    This request should be successful:
    ```bash

--- a/app/_tutorials/konnect-oidc.md
+++ b/app/_tutorials/konnect-oidc.md
@@ -1,9 +1,8 @@
 ---
-title: Configure OIDC in Konnect
+title: Configure Generic SSO in Konnect
 related_resources:
   - text: Authentication
     url: /authentication
-
 
 works_on:
     - konnect
@@ -11,17 +10,30 @@ works_on:
 tags:
   - authentication
   - oidc
+  - saml
   - sso
 
 content_type: tutorial
 
+
+tldr: 
+  q: How do I configure SSO?
+  a: As an alternative to Kong Konnect’s native authentication, you can set up single sign-on (SSO) access to Konnect using OpenID Connect or SAML. This authentication method allows your users to log in to Kong Konnect using their IdP credentials, without needing a separate login. This topic covers configuring SSO for use with various identity providers.
+
 ---
 
-You can configure rate-limiting based on peak or non-peak times by using the Pre-function and the Rate Limiting Advanced plugins together. This tutorial creates two Kong Gateway routes, one to handle peak traffic, and one to handle off-peak traffic. Each route has a different rate limiting configuration. The Pre-function plugin runs a Lua function to ship traffic to either of the routes based on the time. 
+## Prerequisites
 
-## Configure Konnect
+* {{site.konnect_short_name}} must be added to your IdP as an application
+* Claims are set up in your IdP
 
-1. In [Konnect](https://cloud.konghq.com/login), click **Organization**, and then **Auth Settings**.
+## Set up SSO in {{site.konnect_short_name}}
+
+{% navtabs %}
+{% navtab "OIDC" %}
+
+1. In [{{site.konnect_saas}}](https://cloud.konghq.com/login), click **Organization**, and then **Auth Settings**.
+
 1. Click **Configure provider** for **OIDC**.
 
 1. Paste the issuer URI from your IdP in the **Issuer URI** box. 
@@ -32,20 +44,153 @@ You can configure rate-limiting based on peak or non-peak times by using the Pre
 
 1. In the **Organization Login Path** box, enter a unique string. For example: `examplepath`.
 
+    {{site.konnect_short_name}} uses this string to generate a custom login
+    URL for your organization.
+
+    Requirements:
+    * The path must be unique *across all {{site.konnect_short_name}} organizations*.
+    If your desired path is already taken, you must to choose another one.
+    * The path can be any alphanumeric string.
+    * The path does not require a slash (`/`).
+
 1. After clicking Save, close the configuration dialog and click Enable on your OIDC provider.
 
+{% endnavtab %}
+{% navtab "SAML" %}
+
+The {{site.konnect_short_name}} SAML integration allows you to configure various identity providers. While technically any SAML-compliant provider can be used, the following have been verified:
+
+* Okta 
+* Azure Active Directory
+* Oracle Identity Cloud Service 
+* Keycloak
+
+1. Log in to {{site.konnect_saas}}, click **Organization**, and then select **Auth Settings**.
+
+1. Click **Configure provider** under **SAML**. 
+
+1. Enter the **Metadata URL** from your IdP in the **IDP Metadata URL** field.
+
+1. In the **Login Path** field, enter the unique string that matches the one in Okta. For example: `examplepath`.
+
+   {{site.konnect_short_name}} uses this string to generate a custom login
+   URL for your organization.
+
+   Requirements:
+    * The path must be unique across all {{site.konnect_short_name}} organizations.
+    * The path can be any alphanumeric string.
+    * The path does not require a slash (`/`).
+
+1. After clicking **Save**, configure the SP Entity ID and Login URL on your SAML IdP.
+{% endnavtab %}
+{% endnavtabs %}
+
+## Test and apply the configuration
+
+{% navtabs %}
+{% navtab "OIDC" %}
+
+{:.important}
+> **Important:** Keep built-in authentication enabled while you are testing IdP authentication. Only disable built-in authentication after successfully testing IdP authentication.
+
 You can test the SSO configuration by navigating to the login URI based on the organization login path you set earlier. For example: `https://cloud.konghq.com/login/examplepath`, where `examplepath` is the unique login path string set in the steps above. 
+
 If your configuration is set up correctly, you will see the IdP sign-in page.
 
-## Advanced configuration
+You can now manage your organization's user permissions entirely from the IdP
+application.
+
+{% endnavtab %}
+{% navtab "SAML" %}
+
+{:.important}
+> **Important:** Keep built-in authentication enabled while you are testing IdP authentication. Only disable built-in authentication after successfully testing IdP authentication.
+
+Test the SSO configuration by navigating to the login URI based on the organization login path you set earlier. For example: `https://cloud.konghq.com/login/examplepath`, where `examplepath` is the unique login path string set in the previous steps.
+
+If the configuration is correct, you will see the IdP sign-in page. You can now manage your organization's user permissions entirely from the IdP application.
+
+{% endnavtab %}
+{% endnavtabs %}
+
+## Reference
+
+### Provider specific SAML configuration
+
+The following section contains provider specific information and attribute mapping tables necessary for configuring SSO. 
+
+{% navtabs %}
+{% navtab "Azure" %}
+
+* When adding an enterprise application, note that OIDC uses app registration.
+* Remove the namespace from the claim name in Azure. You can do this by checking **Customize** on the group claim.
+* Using groups maps to the Group ID by default.
+
+Attribute mapping for Azure configuration:
+
+| Azure                                       | Konnect                  |
+|---------------------------------------------|--------------------------|
+| Identifier (Entity ID)                      | `sp_entity_id`           |
+| Reply URL (Assertion Consumer Service URL)  | `callback_url`           |
+| App Federation Metadata Url                 | `idp_metadata_url`       |
+| `email`                                       | `user.email`             |
+| `firstname`                                   | `user.givenname`         |
+| `lastname`                                    | `user.surname`           |
+| `groups`                                      | `user.groups`            |
+| Unique user identifier                      | `user.principalname`     |
+
+
+{% endnavtab %}
+{% navtab "Oracle Cloud" %}
+
+* When configuring the Name ID format in Oracle Cloud, make sure to set it to `transient`.
+* You will need to manually upload the signing certificate from `sp_metadata_url`.
+   - `cert.pem` must use the `X509Certificate` value for signing.
+
+Attribute mapping for Oracle Cloud configuration:
+
+| Oracle Cloud                                | Konnect                  |
+|---------------------------------------------|--------------------------|
+| Entity ID                                   | `sp_entity_id`           |
+| Assertion consumer URL                      | `callback_url`           |
+| App Federation Metadata Url                 | `idp_metadata_url`       |
+
+{% endnavtab %}
+{% navtab "KeyCloak" %}
+
+* You will need to manually upload the signing certificate from `sp_metadata_url`.
+   - `cert.pem` must use the `X509Certificate` value for signing.
+* Go to **Realm Settings** in Keycloak to locate your metadata endpoint. The `sp_metadata_url` for {{site.konnect_short_name}} will be:`http://<keycloak-url>/realms/konnect/protocol/saml/descriptor`
+
+Attribute mapping for KeyCloak configuration:
+
+| KeyCloak                                    | Konnect                  |
+|---------------------------------------------|--------------------------|
+| Client ID                                   | `sp_entity_id`           |
+| Valid redirect URI                          | `callback_url`           |
+| App Federation Metadata Url                 | `idp_metadata_url`       |
+
+{% endnavtab %}
+{% endnavtabs %}
+
 
 ### Advanced OIDC settings
 
 You can configure custom IdP-specific behaviors in the **Advanced Settings** of the OIDC configuration form. The following options are available:
 
-1. **Scopes**: Specify the list of scopes Konnect requests from the IdP. By default, Konnect requests the `openid`, `email`, and `profile` scopes. The `openid` scope is required and cannot be removed.
-2. **Claim Mappings**: Customize the mapping of required attributes to a different claim in the `id_token` Konnect receives from the IdP. By default, Konnect requires three attributes: Name, Email, and Groups. The values in these attributes are mapped as follows:
-    - `name`: Used as the Konnect account's `full_name`.
-    - `email`: Used as the Konnect account's `email`.
+1. **Scopes**: Specify the list of scopes {{site.konnect_short_name}} requests from the IdP. By default, {{site.konnect_short_name}} requests the `openid`, `email`, and `profile` scopes. The `openid` scope is required and cannot be removed.
+2. **Claim Mappings**: Customize the mapping of required attributes to a different claim in the `id_token` {{site.konnect_short_name}} receives from the IdP. By default, {{site.konnect_short_name}} requires three attributes: Name, Email, and Groups. The values in these attributes are mapped as follows:
+    - `name`: Used as the {{site.konnect_short_name}} account's `full_name`.
+    - `email`: Used as the {{site.konnect_short_name}} account's `email`.
     - `groups`: Used to map users to teams defined in the team mappings upon login.
 
+### Authentication issues with large numbers of groups
+
+If users are assigned a very large number of groups (over 150 in most cases), the IdP may send the groups claim in a non-standard manner, causing authentication issues. 
+
+To work around this limitation in the IdP, we recommend using group filtering functions provided by the IdP for this purpose. 
+Here are some quick reference guides for common IdPs:
+* [Azure group filtering](https://learn.microsoft.com/en-us/azure/active-directory/hybrid/connect/how-to-connect-fed-group-claims#group-filtering) 
+* [Okta group filtering](https://support.okta.com/help/s/article/How-to-send-certain-groups-that-the-user-is-assigned-to-in-one-Group-attribute-statement)
+
+You may need to contact the support team of your identity provider in order to learn how to filter groups emitted for the application.

--- a/app/_tutorials/konnect-oidc.md
+++ b/app/_tutorials/konnect-oidc.md
@@ -15,7 +15,6 @@ tags:
 
 content_type: tutorial
 
-
 tldr: 
   q: How do I configure SSO?
   a: As an alternative to Kong Konnect’s native authentication, you can set up single sign-on (SSO) access to Konnect using OpenID Connect or SAML. This authentication method allows your users to log in to Kong Konnect using their IdP credentials, without needing a separate login. This topic covers configuring SSO for use with various identity providers.


### PR DESCRIPTION
Fixing a broken tutorial, switching the OIDC tutorial (which doesn't exist on our docs site anymore) with the SSO content that replaced it, and various minor cleanup for tutorials.

The SSO tutorial has prereqs that are unique to it. I added them in as manually for now, didn't want to fail the build. How do we want to handle those?