### PR TITLE
Add entity_examples tag

### DIFF
--- a/app/_includes/components/entity_example.html
+++ b/app/_includes/components/entity_example.html
@@ -1,5 +1,1 @@
-{% if page.plugin? %}
-  {% include components/entity_example/dropdowns.html entity_example=entity_example content_type=page.content_type %}
-{% else %}
-  {% include components/entity_example/tabs.html entity_example=entity_example example_index=example_index content_type=page.content_type %}
-{% endif %}
+{% include components/entity_example/tabs.html entity_example=entity_example %}

--- a/app/_includes/components/entity_example/format/deck.md
+++ b/app/_includes/components/entity_example/format/deck.md
@@ -1,11 +1,5 @@
-{%- assign render_format_version = true %}
-{%- if include.content_type == 'tutorial' and include.example_index != 1 %}
-{% assign render_format_version = false %}
-{%- endif %}
 {: data-file="kong.yaml" }
 ```yaml
-{%- if render_format_version %}
 _format_version: '3.0'
-{%- endif %}
 {{ include.presenter.data }}
 ```

--- a/app/_includes/components/entity_example/tabs.html
+++ b/app/_includes/components/entity_example/tabs.html
@@ -4,11 +4,11 @@
 {% navtabs %}
 {% for formatted_example in entity_example.formatted_examples %}
 {% navtab {{ formatted_example.format.to_option }} slug={{ formatted_example.format.value }} %}
-  {% include {{ formatted_example.template_file }} presenter=formatted_example.presenter example_index=include.example_index content_type=include.content_type %}
+  {% include {{ formatted_example.template_file }} presenter=formatted_example.presenter %}
 {% endnavtab %}
 {% endfor %}
 {% endnavtabs %}
 {% else %}
   {% assign formatted_example = entity_example.formatted_examples | first %}
-  {% include {{ formatted_example.template_file }} presenter=formatted_example.presenter example_index=include.example_index content_type=include.content_type %}
+  {% include {{ formatted_example.template_file }} presenter=formatted_example.presenter %}
 {% endif %}

--- a/app/_includes/components/entity_examples.html
+++ b/app/_includes/components/entity_examples.html
@@ -1,0 +1,12 @@
+{%- assign render_format_version = true %}
+{%- if page.content_type == 'tutorial' and example_index != 1 %}
+{% assign render_format_version = false %}
+{%- endif %}
+{: data-file="kong.yaml" }
+```yaml
+{%- if render_format_version %}
+_format_version: '3.0'
+{%- endif %}
+{{ entity_examples.data }}
+```
+

--- a/app/_includes/components/entity_examples.html
+++ b/app/_includes/components/entity_examples.html
@@ -2,6 +2,9 @@
 {%- if page.content_type == 'tutorial' and example_index != 1 %}
 {% assign render_format_version = false %}
 {%- endif %}
+{% if entity_examples.append_to_existing_section %}
+Add the following to your existing `{{ entity_examples.append_to }}` section in `kong.yaml`
+{% endif %}
 {: data-file="kong.yaml" }
 ```yaml
 {%- if render_format_version %}

--- a/app/_plugins/blocks/entity_example.rb
+++ b/app/_plugins/blocks/entity_example.rb
@@ -19,7 +19,6 @@ module Jekyll
         raise ArgumentError, "Missing key `tools` in metadata, or `formats` in entity_example block on page #{@page['path']}"
       end
 
-
       entity_example = EntityExampleBlock::Base.make_for(example: example)
       entity_example_drop = entity_example.to_drop
 
@@ -27,7 +26,6 @@ module Jekyll
 
       context.stack do
         context['entity_example'] = entity_example_drop
-        context['example_index'] = example_index(@page, environment)
         Liquid::Template.parse(template).render(context)
       end
     rescue Psych::SyntaxError => e
@@ -37,14 +35,6 @@ module Jekyll
       #{e.message}
       STRING
       raise ArgumentError.new(message)
-    end
-
-    def example_index(page, environment)
-      if page['content_type'] == 'tutorial'
-        environment[page['id']] ||= {}
-        environment[page['id']]['examples'] ||= 0
-        environment[page['id']]['examples'] += 1
-      end
     end
   end
 end

--- a/app/_plugins/blocks/entity_example_block/base.rb
+++ b/app/_plugins/blocks/entity_example_block/base.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jekyll
-  module EntityExamples
+  module EntityExampleBlock
     class Base
       MAPPINGS = {
         'consumer'       => 'Consumer',
@@ -18,7 +18,7 @@ module Jekyll
 
         raise ArgumentError, "Unsupported entity example type: #{example['type']}. Available types: #{MAPPINGS.keys.join(', ')}" unless klass
 
-        Object.const_get("Jekyll::EntityExamples::#{klass}").new(example:)
+        Object.const_get("Jekyll::EntityExampleBlock::#{klass}").new(example:)
       end
 
       def initialize(example:)
@@ -41,7 +41,7 @@ module Jekyll
 
       def formats
         @formats ||= @example.fetch('formats').sort.map do |f|
-          Jekyll::EntityExamples::Format::Base.make_for(format: f)
+          Jekyll::EntityExampleBlock::Format::Base.make_for(format: f)
         end
       end
 

--- a/app/_plugins/blocks/entity_example_block/consumer.rb
+++ b/app/_plugins/blocks/entity_example_block/consumer.rb
@@ -3,8 +3,8 @@
 require_relative './base'
 
 module Jekyll
-  module EntityExamples
-    class Route < Base
+  module EntityExampleBlock
+    class Consumer < Base
     end
   end
 end

--- a/app/_plugins/blocks/entity_example_block/consumer_group.rb
+++ b/app/_plugins/blocks/entity_example_block/consumer_group.rb
@@ -3,10 +3,8 @@
 require_relative './base'
 
 module Jekyll
-  module EntityExamples
-    module Format
-      class Deck < Base
-      end
+  module EntityExampleBlock
+    class ConsumerGroup < Base
     end
   end
 end

--- a/app/_plugins/blocks/entity_example_block/format/admin-api.rb
+++ b/app/_plugins/blocks/entity_example_block/format/admin-api.rb
@@ -3,8 +3,10 @@
 require_relative './base'
 
 module Jekyll
-  module EntityExamples
-    class Consumer < Base
+  module EntityExampleBlock
+    module Format
+      class AdminAPI < Base
+      end
     end
   end
 end

--- a/app/_plugins/blocks/entity_example_block/format/base.rb
+++ b/app/_plugins/blocks/entity_example_block/format/base.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jekyll
-  module EntityExamples
+  module EntityExampleBlock
     module Format
       class Base
         MAPPINGS = {
@@ -18,7 +18,7 @@ module Jekyll
 
           raise ArgumentError, "Unsupported `format`: #{format}. Available formats: #{MAPPINGS.keys.join(', ')}" unless klass
 
-          Object.const_get("Jekyll::EntityExamples::Format::#{klass}").new(format:)
+          Object.const_get("Jekyll::EntityExampleBlock::Format::#{klass}").new(format:)
         end
 
         def initialize(format:)

--- a/app/_plugins/blocks/entity_example_block/format/deck.rb
+++ b/app/_plugins/blocks/entity_example_block/format/deck.rb
@@ -3,9 +3,9 @@
 require_relative './base'
 
 module Jekyll
-  module EntityExamples
+  module EntityExampleBlock
     module Format
-      class UI < Base
+      class Deck < Base
       end
     end
   end

--- a/app/_plugins/blocks/entity_example_block/format/kic.rb
+++ b/app/_plugins/blocks/entity_example_block/format/kic.rb
@@ -3,9 +3,9 @@
 require_relative './base'
 
 module Jekyll
-  module EntityExamples
-    module Target
-      class Global < Base
+  module EntityExampleBlock
+    module Format
+      class KIC < Base
       end
     end
   end

--- a/app/_plugins/blocks/entity_example_block/format/konnect-api.rb
+++ b/app/_plugins/blocks/entity_example_block/format/konnect-api.rb
@@ -3,7 +3,7 @@
 require_relative './base'
 
 module Jekyll
-  module EntityExamples
+  module EntityExampleBlock
     module Format
       class KonnectAPI < Base
       end

--- a/app/_plugins/blocks/entity_example_block/format/terraform.rb
+++ b/app/_plugins/blocks/entity_example_block/format/terraform.rb
@@ -3,9 +3,9 @@
 require_relative './base'
 
 module Jekyll
-  module EntityExamples
-    module Target
-      class Route < Base
+  module EntityExampleBlock
+    module Format
+      class Terraform < Base
       end
     end
   end

--- a/app/_plugins/blocks/entity_example_block/format/ui.rb
+++ b/app/_plugins/blocks/entity_example_block/format/ui.rb
@@ -3,9 +3,9 @@
 require_relative './base'
 
 module Jekyll
-  module EntityExamples
-    module Target
-      class Service < Base
+  module EntityExampleBlock
+    module Format
+      class UI < Base
       end
     end
   end

--- a/app/_plugins/blocks/entity_example_block/plugin.rb
+++ b/app/_plugins/blocks/entity_example_block/plugin.rb
@@ -3,7 +3,7 @@
 require_relative './base'
 
 module Jekyll
-  module EntityExamples
+  module EntityExampleBlock
     class Plugin < Base
       def targets
         @targets ||= @example.fetch('targets').sort.map do |t|

--- a/app/_plugins/blocks/entity_example_block/route.rb
+++ b/app/_plugins/blocks/entity_example_block/route.rb
@@ -3,10 +3,8 @@
 require_relative './base'
 
 module Jekyll
-  module EntityExamples
-    module Format
-      class KIC < Base
-      end
+  module EntityExampleBlock
+    class Route < Base
     end
   end
 end

--- a/app/_plugins/blocks/entity_example_block/service.rb
+++ b/app/_plugins/blocks/entity_example_block/service.rb
@@ -3,10 +3,8 @@
 require_relative './base'
 
 module Jekyll
-  module EntityExamples
-    module Format
-      class AdminAPI < Base
-      end
+  module EntityExampleBlock
+    class Service < Base
     end
   end
 end

--- a/app/_plugins/blocks/entity_example_block/target/base.rb
+++ b/app/_plugins/blocks/entity_example_block/target/base.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module Jekyll
-  module EntityExamples
+  module EntityExampleBlock
     module Target
       class Base
         MAPPINGS = {
@@ -17,7 +17,7 @@ module Jekyll
 
           raise ArgumentError, "Unsupported `target`: #{target}. Available targets: #{MAPPINGS.keys.join(', ')}" unless klass
 
-          Object.const_get("Jekyll::EntityExamples::Target::#{klass}").new(target:)
+          Object.const_get("Jekyll::EntityExampleBlock::Target::#{klass}").new(target:)
         end
 
         def initialize(target:)

--- a/app/_plugins/blocks/entity_example_block/target/consumer.rb
+++ b/app/_plugins/blocks/entity_example_block/target/consumer.rb
@@ -3,7 +3,7 @@
 require_relative './base'
 
 module Jekyll
-  module EntityExamples
+  module EntityExampleBlock
     module Target
       class Consumer < Base
       end

--- a/app/_plugins/blocks/entity_example_block/target/consumer_group.rb
+++ b/app/_plugins/blocks/entity_example_block/target/consumer_group.rb
@@ -3,7 +3,7 @@
 require_relative './base'
 
 module Jekyll
-  module EntityExamples
+  module EntityExampleBlock
     module Target
       class ConsumerGroup < Base
       end

--- a/app/_plugins/blocks/entity_example_block/target/global.rb
+++ b/app/_plugins/blocks/entity_example_block/target/global.rb
@@ -3,8 +3,10 @@
 require_relative './base'
 
 module Jekyll
-  module EntityExamples
-    class Service < Base
+  module EntityExampleBlock
+    module Target
+      class Global < Base
+      end
     end
   end
 end

--- a/app/_plugins/blocks/entity_example_block/target/route.rb
+++ b/app/_plugins/blocks/entity_example_block/target/route.rb
@@ -3,8 +3,10 @@
 require_relative './base'
 
 module Jekyll
-  module EntityExamples
-    class ConsumerGroup < Base
+  module EntityExampleBlock
+    module Target
+      class Route < Base
+      end
     end
   end
 end

--- a/app/_plugins/blocks/entity_example_block/target/service.rb
+++ b/app/_plugins/blocks/entity_example_block/target/service.rb
@@ -3,9 +3,9 @@
 require_relative './base'
 
 module Jekyll
-  module EntityExamples
-    module Format
-      class Terraform < Base
+  module EntityExampleBlock
+    module Target
+      class Service < Base
       end
     end
   end

--- a/app/_plugins/drops/entity_example/base.rb
+++ b/app/_plugins/drops/entity_example/base.rb
@@ -22,7 +22,7 @@ module Jekyll
           @formatted_examples ||= formats.map do |f|
             Drops::EntityExample::FormattedExample.new(
               format: f,
-              target: Jekyll::EntityExamples::Target::Base.make_for(target: @example.type).to_drop,
+              target: Jekyll::EntityExampleBlock::Target::Base.make_for(target: @example.type).to_drop,
               data: @example.data,
               presenter_class: 'Base',
               variables: @example.variables,

--- a/app/_plugins/drops/entity_examples.rb
+++ b/app/_plugins/drops/entity_examples.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Drops
+    class EntityExamples < Liquid::Drop
+      def initialize(config:)
+        @config = config
+      end
+
+      def entities
+        @entities ||= @config.fetch('entities')
+      end
+
+      def data
+        @data ||= Jekyll::Utils::HashToYAML.new(entities).convert
+      end
+
+      def template
+        @template ||= File.expand_path('app/_includes/components/entity_examples.html')
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_examples.rb
+++ b/app/_plugins/drops/entity_examples.rb
@@ -5,18 +5,40 @@ module Jekyll
     class EntityExamples < Liquid::Drop
       def initialize(config:)
         @config = config
+
+        validate!
       end
 
       def entities
         @entities ||= @config.fetch('entities')
       end
 
+      def append_to_existing_section
+        @config['append_to_existing_section']
+      end
+
+      def append_to
+        @append_to ||= entities.keys.first
+      end
+
       def data
-        @data ||= Jekyll::Utils::HashToYAML.new(entities).convert
+        @data ||= if append_to_existing_section
+                    Jekyll::Utils::HashToYAML.new(entities[append_to]).convert
+                  else
+                    Jekyll::Utils::HashToYAML.new(entities).convert
+                  end
       end
 
       def template
         @template ||= File.expand_path('app/_includes/components/entity_examples.html')
+      end
+
+      private
+
+      def validate!
+        if append_to_existing_section && entities.size > 1
+          raise ArgumentError, "Invalid config for entity_examples. If `append_to_existing_section` is set, only one type of entity can be specified."
+        end
       end
     end
   end

--- a/app/_tutorials/add-rate-limiting-for-a-consumer-with-kong-gateway.md
+++ b/app/_tutorials/add-rate-limiting-for-a-consumer-with-kong-gateway.md
@@ -90,6 +90,7 @@ entities:
       config:
         second: 5
         hour: 1000
+append_to_existing_section: true
 {% endentity_examples %}
 {% endcapture %}
 {{ plugin | indent: 3 }}

--- a/app/_tutorials/add-rate-limiting-for-a-consumer-with-kong-gateway.md
+++ b/app/_tutorials/add-rate-limiting-for-a-consumer-with-kong-gateway.md
@@ -55,47 +55,42 @@ cleanup:
 1. Add the following content to `kong.yaml` to enable the Key Authentication plugin. You need [authentication](/authentication/) to identify the consumer and apply rate limiting.
 
 {% capture plugin %}
-{% entity_example %}
-type: plugin
-data:
-  name: key-auth
-  config:
-    key_names:
-    - apikey
-targets:
-  - global
-{% endentity_example %}
+{% entity_examples %}
+entities:
+  plugins:
+    - name: key-auth
+      config:
+        key_names:
+          - apikey
+{% endentity_examples %}
 {% endcapture %}
 {{ plugin | indent: 3 }}
 
 1. Create a [consumer](/gateway/entities/consumer/) with a key.
 
 {% capture consumer %}
-{% entity_example %}
-type: consumer
-data:
-  username: jsmith
-  keyauth_credentials:
-      - key: example-key
-{% endentity_example %}
+{% entity_examples %}
+entities:
+  consumers:
+    - username: jsmith
+      keyauth_credentials:
+        - key: example-key
+{% endentity_examples %}
 {% endcapture %}
 {{ consumer | indent: 3 }}
 
 1. Enable the [Rate Limiting plugin](/plugins/rate-limiting/) for the consumer. In this example, the limit is 5 requests per second and 1000 requests per hour.
 
 {% capture plugin %}
-{% entity_example %}
-type: plugin
-data:
-  name: rate-limiting
-  config:
-    second: 5
-    hour: 1000
-targets:
-  - consumer 
-variables:
-    consumerName|Id: jsmith
-{% endentity_example %}
+{% entity_examples %}
+entities:
+  plugins:
+    - name: rate-limiting
+      consumer: jsmith
+      config:
+        second: 5
+        hour: 1000
+{% endentity_examples %}
 {% endcapture %}
 {{ plugin | indent: 3 }}
 
@@ -113,7 +108,7 @@ variables:
 
     You can run the following command to test the rate limiting as the consumer:
     ```bash
-    for _ in {1..6}; do curl -i http://localhost:8000/example_route -H 'apikey:example_key'; echo; done
+    for _ in {1..6}; do curl -i http://localhost:8000/example-route -H 'apikey:example_key'; echo; done
     ```
 
     This command sends six consecutive requests to the route. On the last one you should get a `429` error with the message `API rate limit exceeded`.

--- a/app/_tutorials/add-rate-limiting-tiers-with-kong-gateway.md
+++ b/app/_tutorials/add-rate-limiting-tiers-with-kong-gateway.md
@@ -180,12 +180,11 @@ entities:
        window_type: sliding
        retry_after_jitter_max: 0
        namespace: premium
+append_to_existing_section: true
 {% endentity_examples %}
 {% endcapture %}
 {{ groups | indent: 3 }}
    
-   Append this to the existing `plugin` configuration in your `kong.yaml` file.
-
    This configures the different tiers like the following:
    * **Free:** Allows six requests per second. This configuration sets the rate limit to three requests (`config.limit`) for every 30 seconds (`config.window_size`).
    * **Basic:** Allows 10 requests per second. This configuration sets the rate limit to five requests (`config.limit`) for every 30 seconds (`config.window_size`).

--- a/app/_tutorials/add-rate-limiting-tiers-with-kong-gateway.md
+++ b/app/_tutorials/add-rate-limiting-tiers-with-kong-gateway.md
@@ -67,28 +67,30 @@ cleanup:
 1. Add the following content to `kong.yaml` to enable the Key Authentication plugin. You need [authentication](/authentication/) to identify the consumer and apply rate limiting.
 
 {% capture plugin %}
-{% entity_example %}
-type: plugin
-data:
-  name: key-auth
-  config:
-    key_names:
-    - apikey
-targets:
-  - global
-{% endentity_example %}
+{% entity_examples %}
+entities:
+  plugins:
+    - name: key-auth
+      config:
+        key_names:
+          - apikey
+{% endentity_examples %}
 {% endcapture %}
 {{ plugin | indent: 3 }}
 
 1. Create the Free, Basic, and Premium tier consumer groups:
 
-    ```yaml
-    _format_version: '3.0'
-    consumer_groups:
+{% capture groups %}
+{% entity_examples %}
+entities:
+  consumer_groups:
     - name: Free
     - name: Basic
     - name: Premium
-    ```
+{% endentity_examples %}
+{% endcapture %}
+{{ groups | indent: 3 }}
+
    Add this configuration to a `kong.yaml` file in a `deck_files` directory.
 
 1. Synchronize your configuration
@@ -105,24 +107,28 @@ targets:
 
 1. Create three consumers, one for each tier:
   
-   ```yaml
-   consumers:
-   - username: Amal
-     groups:
-     - name: Free
-     keyauth_credentials:
-     - key: amal
-   - username: Dana
-     groups:
-     - name: Basic
-     keyauth_credentials:
-     - key: dana
-   - username: Mahan
-     groups:
-     - name: Premium
-     keyauth_credentials:
-     - key: mahan
-   ```
+{% capture consumers %}
+{% entity_examples %}
+entities:
+  consumers:
+    - username: Amal
+      groups:
+        - name: Free
+      keyauth_credentials:
+        - key: amal
+    - username: Dana
+      groups:
+        - name: Basic
+      keyauth_credentials:
+        - key: dana
+    - username: Mahan
+      groups:
+        - name: Premium
+      keyauth_credentials:
+        - key: mahan
+{% endentity_examples %}
+{% endcapture %}
+{{ consumers | indent: 3 }}
 
    Append this to your `kong.yaml` file. By adding key auth credentials here you can test later that rate limiting was correctly configured for the different tiers.
 
@@ -140,7 +146,9 @@ targets:
 
 1. Enable the Rate Limiting Advanced plugins for each tier:
 
-   ```yaml
+{% capture groups %}
+{% entity_examples %}
+entities:
    plugins:
    - name: rate-limiting-advanced
      consumer_group: Free
@@ -172,7 +180,9 @@ targets:
        window_type: sliding
        retry_after_jitter_max: 0
        namespace: premium
-   ```
+{% endentity_examples %}
+{% endcapture %}
+{{ groups | indent: 3 }}
    
    Append this to the existing `plugin` configuration in your `kong.yaml` file.
 

--- a/app/_tutorials/add-rate-limiting-to-a-service-with-kong-gateway.md
+++ b/app/_tutorials/add-rate-limiting-to-a-service-with-kong-gateway.md
@@ -48,19 +48,16 @@ prereqs:
 1. Enable the Rate Limiting plugin on a service:
 
 {% capture step %}
-{% entity_example %}
-type: plugin
-data:
-  name: rate-limiting
-  config:
-    second: 5
-    hour: 1000
-    policy: local
-targets:
-  - service
-variables: 
-    serviceName|Id: example-service
-{% endentity_example %}
+{% entity_examples %}
+entities:
+  plugins:
+    - name: rate-limiting
+      service: example-service
+      config:
+        second: 5
+        hour: 1000
+        policy: local
+{% endentity_examples %}
 {% endcapture %}
 {{ step | indent: 3 }}
 

--- a/app/_tutorials/enable-key-authentication-on-a-service-with-kong-gateway.md
+++ b/app/_tutorials/enable-key-authentication-on-a-service-with-kong-gateway.md
@@ -36,31 +36,28 @@ tldr:
 1. Enable the Key Authentication plugin on the service:
 
 {% capture step %}
-{% entity_example %}
-type: plugin
-data:
-  name: key-auth
-  config:
-    key_names:
-    - apikey
-targets:
-- service
-variables: 
-    serviceName|Id: example-service
-{% endentity_example %}
+{% entity_examples %}
+entities:
+  plugins:
+    - name: key-auth
+      service: example-service
+      config:
+        key_names:
+        - apikey
+{% endentity_examples %}
 {% endcapture %}
 {{ step | indent: 3 }}
 
 1. Create a consumer
 
 {% capture step %}
-{% entity_example %}
-type: consumer
-data:
-  username: alex
-  keyauth_credentials:
-  - key: hello_world
-{% endentity_example %}
+{% entity_examples %}
+entities:
+  consumers:
+    - username: alex
+      keyauth_credentials:
+        - key: hello_world
+{% endentity_examples %}
 {% endcapture %}
 {{ step | indent: 3 }}
 
@@ -71,7 +68,7 @@ data:
    This request should be successful:
    ```bash
    curl --request GET \
-    --url http://localhost:8000/example_route/anything \
+    --url http://localhost:8000/example-route/anything \
     --header 'apikey: hello_world'
    ```
 
@@ -79,7 +76,7 @@ data:
 
    ```bash
    curl --request GET \
-    --url http://localhost:8000/example_route/anything \
+    --url http://localhost:8000/example-route/anything \
     --header 'apikey: another_key'
    ```
 

--- a/app/_tutorials/multiple-rate-limits-window-sizes.md
+++ b/app/_tutorials/multiple-rate-limits-window-sizes.md
@@ -52,24 +52,19 @@ faqs:
 1. Enable the Rate Limiting Advanced plugin on a service:
 
 {% capture step %}
-{% entity_example %}
-type: plugin
-data:
-  name: rate-limiting-advanced
-  config:
-    limit:
-    - 10
-    - 100
-    window_size:
-    - 60
-    - 3600
-tools:
-  - deck
-targets:
-  - service
-variables: 
-    serviceName|Id: example_service
-{% endentity_example %}
+{% entity_examples %}
+entities:
+  plugins:
+    - name: rate-limiting-advanced
+      service: example-service
+      config:
+        limit:
+        - 10
+        - 100
+        window_size:
+        - 60
+        - 3600
+{% endentity_examples %}
 {% endcapture %}
 {{ step | indent: 3 }}
 


### PR DESCRIPTION
It should be used in tutorials to generate deck snippets, even for just one entity.

I've added an optional flag, `append_to_existing_section: true` (suggestions welcome) in case the entities were already defined in the tutorial and we need to append to it.

`append_to_existing_section: true` behaviour:
* It only renders the list of entities and not their key, e.g. `plugins`
* Renders `Add the following to your existing {{ entity_name_plural_form }} section in kong.yaml` before the snippet
* Raises an error if `append_to_existing_section: true` and more that one entity type is provided.

Example usage:

<details>
  <summary>One entity type, multiple instances</summary>

```
{% entity_examples %}
entities:
   plugins:
   - name: rate-limiting-advanced
     consumer_group: Free
     config:
       limit: 
       - 3
       window_size: 
       - 30
       window_type: fixed
       retry_after_jitter_max: 0
       namespace: free
   - name: rate-limiting-advanced
     consumer_group: Basic
     config:
       limit: 
       - 5
       window_size: 
       - 30
       window_type: sliding
       retry_after_jitter_max: 0
       namespace: basic
   - name: rate-limiting-advanced
     consumer_group: Premium
     config:
       limit: 
       - 500
       window_size: 
       - 30
       window_type: sliding
       retry_after_jitter_max: 0
       namespace: premium
{% endentity_examples %}
```

</details>


<details>
  <summary>Multiple entity types</summary>

```
{% entity_examples %}
entities:
   plugins:
   - name: rate-limiting-advanced
     consumer_group: Free
     config:
       limit: 
       - 3
       window_size: 
       - 30
       window_type: fixed
       retry_after_jitter_max: 0
       namespace: free
  consumers:
    - username: Amal
      groups:
        - name: Free
      keyauth_credentials:
        - key: amal

{% endentity_examples %}
</details>
