### PR TITLE
Add breadcrumbs

### DIFF
--- a/app/_includes/breadcrumbs.html
+++ b/app/_includes/breadcrumbs.html
@@ -1,6 +1,6 @@
 <div class="flex gap-1 justify-start text-xs items-center">
   {% for breadcrumb in page.breadcrumbs %}
     <a class="text-terciary" href="{{ breadcrumb.url }}">{{ breadcrumb.title }}</a>
-    <span>/</span>
+  {% unless forloop.last %}<span>/</span>{% endunless %}
   {% endfor %}
 </div>

--- a/app/_includes/breadcrumbs.html
+++ b/app/_includes/breadcrumbs.html
@@ -1,6 +1,6 @@
 <div class="flex gap-1 justify-start text-xs items-center">
   {% for breadcrumb in page.breadcrumbs %}
     <a class="text-terciary" href="{{ breadcrumb.url }}">{{ breadcrumb.title }}</a>
-  {% unless forloop.last %}<span>/</span>{% endunless %}
+    <span>/</span>
   {% endfor %}
 </div>

--- a/app/_includes/breadcrumbs.html
+++ b/app/_includes/breadcrumbs.html
@@ -1,0 +1,6 @@
+<div class="flex gap-1 justify-start text-xs items-center">
+  {% for breadcrumb in page.breadcrumbs %}
+    <a class="text-terciary" href="{{ breadcrumb.url }}">{{ breadcrumb.title }}</a>
+    <span>/</span>
+  {% endfor %}
+</div>

--- a/app/_includes/index_link.html
+++ b/app/_includes/index_link.html
@@ -1,1 +1,0 @@
-<a class="py-0.5 pr-2 text-terciary text-xs w-fit" href="{{ include.url }}">&larr; {{ include.text }}</a>

--- a/app/_includes/structured_data.html
+++ b/app/_includes/structured_data.html
@@ -1,0 +1,26 @@
+{% if page.breadcrumbs %}
+{% assign breadcrumbs_length = page.breadcrumbs.size %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "BreadcrumbList",
+  "itemListElement": [
+{%- for breadcrumb in page.breadcrumbs -%}
+  {
+    "@type": "ListItem",
+    "position": {{ forloop.index }},
+    "name": "{{ breadcrumb.title }}",
+    "item": "{{ site.links.web | append: breadcrumb.url }}"
+  },
+{%- endfor -%}
+{%- assign current_page_url = page.url | prepend: '/' | append: '/' | replace: '//', '/' -%}
+  {
+    "@type": "ListItem",
+    "position": {{ breadcrumbs_length | plus: 1 }},
+    "name": "{{ page.title }}",
+    "item": "{{ site.links.web | append: current_page_url }}"
+  }
+  ]
+}
+</script>
+{% endif %}

--- a/app/_landing_pages/gateway/enterprise-vs-oss.yaml
+++ b/app/_landing_pages/gateway/enterprise-vs-oss.yaml
@@ -1,5 +1,7 @@
 metadata:
   title: Kong Gateway Open Source vs Enterprise
+  breadcrumbs:
+  - /gateway/
 rows:
   - header:
       type: h1

--- a/app/_landing_pages/gateway/entities.yaml
+++ b/app/_landing_pages/gateway/entities.yaml
@@ -1,5 +1,7 @@
 metadata:
   title: Gateway Entities
+  breadcrumbs:
+    - /gateway/
 rows:
   -  header:
         type: h1

--- a/app/_landing_pages/gateway/rate-limiting.yaml
+++ b/app/_landing_pages/gateway/rate-limiting.yaml
@@ -1,5 +1,8 @@
 metadata:
   title: Gateway Rate Limiting
+  breadcrumbs:
+    - /rate-limiting/
+
 rows:
   - header:
       type: h1

--- a/app/_landing_pages/inso-cli.yaml
+++ b/app/_landing_pages/inso-cli.yaml
@@ -1,5 +1,7 @@
 metadata:
   title: Inso CLI
+  breadcrumbs:
+    - /insomnia/
 rows:
   - header:
       type: h1

--- a/app/_landing_pages/insomnia/debug.yaml
+++ b/app/_landing_pages/insomnia/debug.yaml
@@ -1,5 +1,7 @@
 metadata:
   title: Debug APIs
+  breadcrumbs:
+    - /insomnia/
 rows:
   - header:
       type: h1

--- a/app/_landing_pages/insomnia/design.yaml
+++ b/app/_landing_pages/insomnia/design.yaml
@@ -1,5 +1,7 @@
 metadata:
   title: Design APIs
+  breadcrumbs:
+    - /insomnia/
 rows:
   - header:
       type: h1

--- a/app/_landing_pages/insomnia/documents.yaml
+++ b/app/_landing_pages/insomnia/documents.yaml
@@ -1,5 +1,7 @@
 metadata:
   title: Documents
+  breadcrumbs:
+    - /insomnia/
 rows:
   - header:
       type: h1

--- a/app/_landing_pages/insomnia/inso-cli.yaml
+++ b/app/_landing_pages/insomnia/inso-cli.yaml
@@ -1,5 +1,7 @@
 metadata:
   title: Inso CLI
+  breadcrumbs:
+    - /insomnia/
 rows:
   - header:
       type: h1

--- a/app/_landing_pages/insomnia/test.yaml
+++ b/app/_landing_pages/insomnia/test.yaml
@@ -1,5 +1,7 @@
 metadata:
   title: Test APIs
+  breadcrumbs:
+    - /insomnia/
 rows:
   - header:
       type: h1

--- a/app/_landing_pages/kic/rate-limiting.yaml
+++ b/app/_landing_pages/kic/rate-limiting.yaml
@@ -1,5 +1,7 @@
 metadata:
   title: KIC Rate Limiting
+  breadcrumbs:
+    - /rate-limiting/
 rows:
   - header:
       type: h1

--- a/app/_landing_pages/mesh/rate-limiting.yaml
+++ b/app/_landing_pages/mesh/rate-limiting.yaml
@@ -1,5 +1,7 @@
 metadata:
   title: Mesh Rate Limiting
+  breadcrumbs:
+    - /rate-limiting/
 rows:
   - header:
       type: h1

--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -15,6 +15,9 @@
           document.documentElement.classList.remove('dark');
         }
     </script>
+
+    {% include structured_data.html %}
+
     {% vite_client_tag %}
     {% vite_javascript_tag application %}
 

--- a/app/_layouts/gateway_entity.html
+++ b/app/_layouts/gateway_entity.html
@@ -3,10 +3,6 @@ layout: with_aside
 entity_schema: true
 ---
 
-{% contentfor index_link %}
-  {% include index_link.html text="Gateway Entities" url="/gateway/entities/" %}
-{% endcontentfor %}
-
 {{ content }}
 
 {% if page.schema %}

--- a/app/_layouts/how-to.html
+++ b/app/_layouts/how-to.html
@@ -1,10 +1,6 @@
 ---
 layout: with_aside
 ---
-{% contentfor index_link %}
-  {% include index_link.html text="How-to Guides" url="/how-to/" %}
-{% endcontentfor %}
-
 {% include how-tos/tldr.html %}
 
 <div class="flex flex-col gap-8 accordion" data-all-expanded="true">

--- a/app/_layouts/landing_page.html
+++ b/app/_layouts/landing_page.html
@@ -2,24 +2,16 @@
 layout: default
 ---
 
-{% capture edit_links %}
-<div class="flex gap-3 justify-end">
-  {% include edit_and_issue_links.html edit_link=page.edit_link %}
-</div>
-{% endcapture %}
-
 <main class="flex flex-col gap-3 py-12 w-full">
-  {% if page.url == '/gateway/rate-limiting/' %}
-  <div class="flex justify-between">
-    <div class="flex gap-1 justify-start text-xs">
-      <a class="text-terciary" href="/rate-limiting/">Rate Limiting</a><span>/</span>
-      <a class="text-terciary" href="/gateway/rate-limiting/">Kong Gateway</a>
+
+  <div class="grid {% if page.breadcrumbs %}sm:grid-cols-2{% endif %}">
+    {% if page.breadcrumbs %}
+      {% include breadcrumbs.html %}
+    {% endif %}
+    <div class="hidden sm:flex gap-3 justify-end items-end">
+      {% include edit_and_issue_links.html edit_link=page.edit_link %}
     </div>
-    {{edit_links}}
   </div>
-  {% else %}
-    {{edit_links}}
-  {% endif %}
 
   <div class="flex flex-col gap-12">
     {% for row in page.rows %}

--- a/app/_layouts/plugins/base.html
+++ b/app/_layouts/plugins/base.html
@@ -3,10 +3,6 @@ layout: with_aside
 uses: false
 ---
 
-{% contentfor index_link %}
-  {% include index_link.html text="Plugins" url="/plugins/" %}
-{% endcontentfor %}
-
 {% contentfor nav_header %}
 <header class="w-full">
   <div class="flex items-end">

--- a/app/_layouts/with_aside.html
+++ b/app/_layouts/with_aside.html
@@ -5,10 +5,9 @@ layout: default
 <div class="flex gap-16 w-full">
     <main class="flex flex-col basis-3/4 py-12 gap-12 {{ page.content_type | slugify }}">
         <div class="flex flex-col gap-3">
-            {% ifhascontent index_link %}
-                {% capture index_link_include %}{% contentblock index_link %}{% endcapture %}
-                {{ index_link_include | markdown }}
-            {% endifhascontent %}
+            {% if page.breadcrumbs %}
+                {% include breadcrumbs.html %}
+            {% endif %}
 
             <h1>{{ page.title }}</h1>
 

--- a/app/_plugins/generators/data/breadcrumbs.rb
+++ b/app/_plugins/generators/data/breadcrumbs.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Data
+    class Breadcrumbs
+      attr_reader :site, :page
+
+      def initialize(site:, page:)
+        @site = site
+        @page = page
+      end
+
+      def process
+        return unless @page.data['breadcrumbs']
+
+        @page.data['breadcrumbs'] = build_breadcrumbs
+      end
+
+      private
+
+      def build_breadcrumbs
+        @page.data['breadcrumbs'].map do |url|
+          normalized_url = Utils::URL.normalize_path(url)
+          breadcrumb = find_page_by_url(normalized_url)
+          { 'url' => normalized_url, 'title' => breadcrumb.data['title'] }
+        end
+      end
+
+      def find_page_by_url(url)
+        site.pages.detect { |p| p.url == url } ||
+          site.documents.detect { |d| d.url == url }
+      end
+    end
+  end
+end

--- a/app/_plugins/generators/page_data.rb
+++ b/app/_plugins/generators/page_data.rb
@@ -7,11 +7,13 @@ module Jekyll
     def generate(site)
       site.pages.each do |page|
         Data::EditLink::Base.new(site:, page:).process
+        Data::Breadcrumbs.new(site:, page:).process
       end
 
       site.documents.each do |doc|
         Data::EditLink::Base.new(site:, page: doc).process
         Data::Prerequisites.new(site:, page: doc).process
+        Data::Breadcrumbs.new(site:, page: doc).process
       end
     end
   end

--- a/app/_plugins/generators/plugins/pages/base.rb
+++ b/app/_plugins/generators/plugins/pages/base.rb
@@ -26,7 +26,8 @@ module Jekyll
             'plugin?' => true,
             'layout' => layout,
             'examples' => examples,
-            'tools' => @plugin.formats
+            'tools' => @plugin.formats,
+            'breadcrumbs' => ['/plugins/']
           )
         end
 

--- a/app/_plugins/generators/utils/url.rb
+++ b/app/_plugins/generators/utils/url.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Utils
+    class URL
+      def self.normalize_path(path)
+        path.dup.prepend('/').concat('/').gsub(%r{\/+}, '/')
+      end
+    end
+  end
+end

--- a/app/deck/distributed-config.md
+++ b/app/deck/distributed-config.md
@@ -13,6 +13,9 @@ productss:
 
 tools:
   - deck
+
+breadcrumbs:
+  - /deck/
 ---
 
 decK can operate on a subset of configuration instead of

--- a/app/deck/environment-variables.md
+++ b/app/deck/environment-variables.md
@@ -13,6 +13,9 @@ products:
 
 tools:
   - deck
+
+breadcrumbs:
+  - /deck/
 ---
 
 To manage any values in decK files with environment varaibles, you can create environment variables 

--- a/app/deck/manage-deck-with-docker.md
+++ b/app/deck/manage-deck-with-docker.md
@@ -16,6 +16,9 @@ tags:
 
 products:
   - api-ops
+
+breadcrumbs:
+  - /deck/
 ---
 
 If you used the [kong/deck](https://hub.docker.com/r/kong/deck) Docker image to 

--- a/app/deck/object-defaults.md
+++ b/app/deck/object-defaults.md
@@ -17,6 +17,9 @@ tools:
 related_resources:
   - text: Customize decK object defaults
     url:  /how-to/custom-deck-object-defaults
+
+breadcrumbs:
+  - /deck/
 ---
 
 Kong Gateway sets some default values for most objects, including Kong

--- a/app/gateway/rate-limiting/strategies.md
+++ b/app/gateway/rate-limiting/strategies.md
@@ -10,6 +10,10 @@ plugins:
   - rate-limiting-advanced
   - ai-rate-limiting-advanced
   - graphql-rate-limiting-advanced
+
+breadcrumbs:
+  - /gateway/
+  - /gateway/rate-limiting/
 ---
 
 All rate limiting plugins support some subset of the following strategies:

--- a/app/gateway/rate-limiting/window-types.md
+++ b/app/gateway/rate-limiting/window-types.md
@@ -14,6 +14,10 @@ plugins:
   - graphql-rate-limiting-advanced
 
 tier: enterprise
+
+breadcrumbs:
+  - /gateway/
+  - /gateway/rate-limiting/
 ---
 
 The Rate Limiting Advanced, AI Rate Limiting Advanced, and GraphQL Rate Limiting Advanced plugins support the following window types:

--- a/app/gateway/routing/expressions.md
+++ b/app/gateway/routing/expressions.md
@@ -12,6 +12,9 @@ related_resources:
   - text: Expressions repository
     url: https://github.com/Kong/atc-router
 
+breadcrumbs:
+  - /gateway/
+  - /gateway/routing/
 ---
 
 {{site.base_gateway}} includes a rule-based engine using a domain-specific expressions language. Expressions can be used to perform tasks such as defining

--- a/app/gateway/routing/index.md
+++ b/app/gateway/routing/index.md
@@ -9,6 +9,9 @@ related_resources:
     url: /gateway/entities/route/
   - text: Expressions router
     url: /gateway/routing/expressions/
+
+breadcrumbs:
+  - /gateway/
 ---
 
 ## How requests are routed

--- a/app/how-to.html
+++ b/app/how-to.html
@@ -1,4 +1,5 @@
 ---
+title: How-to Guides
 layout: default
 ---
 

--- a/app/insomnia/api-specs.md
+++ b/app/insomnia/api-specs.md
@@ -41,6 +41,9 @@ faqs:
     a: Yes. For Insomnia to autodetect that your spec is in GraphQL format, the path must be `/graphql`, the method must be `POST`, the request body must be application/json and must contain a property query with the type string, and the response body must be application/json.
   - q: Can I create a spec in a collection?
     a: No, you can import an existing spec into a collection, but you can only create a new API spec in a document.
+
+breadcrumbs:
+  - /insomnia/
 ---
 
 ## What are API specs?

--- a/app/insomnia/env-variables.md
+++ b/app/insomnia/env-variables.md
@@ -6,6 +6,9 @@ layout: reference
 
 products:
     - insomnia
+
+breadcrumbs:
+  - /insomnia/
 ---
 
 content

--- a/app/insomnia/test-examples-insomnia.md
+++ b/app/insomnia/test-examples-insomnia.md
@@ -6,6 +6,9 @@ layout: reference
 
 products:
     - insomnia
+
+breadcrumbs:
+  - /insomnia/
 ---
 
 content

--- a/app/plugins.html
+++ b/app/plugins.html
@@ -1,4 +1,5 @@
 ---
+title: Plugins
 layout: default
 ---
 

--- a/app/plugins/deployment-options.md
+++ b/app/plugins/deployment-options.md
@@ -9,7 +9,8 @@ related_resources:
   - text: Kong Plugins
     url: /plugins/
 
-
+breadcrumbs:
+  - /gateway/
 ---
 
 ## Plugin compatibility with deployment types

--- a/app/plugins/precedence.md
+++ b/app/plugins/precedence.md
@@ -8,6 +8,9 @@ layout: reference
 related_resources:
   - text: Kong Plugins
     url: /plugins/
+
+breadcrumbs:
+  - /gateway/
 ---
 
 A single plugin instance always runs _once_ per request. The

--- a/app/plugins/protocols.md
+++ b/app/plugins/protocols.md
@@ -7,4 +7,7 @@ layout: reference
 related_resources:
   - text: Kong Plugins
     url: /plugins/
+
+breadcrumbs:
+  - /gateway/
 ---

--- a/app/plugins/scopes.md
+++ b/app/plugins/scopes.md
@@ -8,6 +8,9 @@ layout: reference
 related_resources:
   - text: Kong Plugins
     url: /plugins/
+
+breadcrumbs:
+  - /gateway/
 ---
 
 ## Scoping plugins

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -41,6 +41,8 @@ defaults:
       layout: "how-to"
       permalink: "/how-to/:path/"
       content_type: "how-to"
+      breadcrumbs:
+        - "/how-to/"
   - scope:
       path: "_gateway_entities"
       type: "gateway_entities"
@@ -50,6 +52,9 @@ defaults:
       content_type: "reference"
       products:
         - gateway
+      breadcrumbs:
+        - "/gateway/"
+        - "/gateway/entities/"
 
 
 


### PR DESCRIPTION
Add breadcrumbs and structured data.

**Implementation details:**
Breadcrumbs are rendered based on the `breadcrumbs` key in the metadata, which should be an array of urls.
The text of each crumb is the title of the page matching the corresponding url.

**Notes:**

* Breadcrumbs don't include Home and current page
* The structured data does contain the current page as the last item
* I replaced the links to index pages in how-tos, plugins and gateway entities with breadcrumbs
