### PR TITLE
Track changed docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Team Docs own all the things, should be tagged in PRs
+*    @Kong/docs-maintainers

--- a/.github/workflows/check-for-changes-in-docs-repo.yml
+++ b/.github/workflows/check-for-changes-in-docs-repo.yml
@@ -1,0 +1,28 @@
+name: Check for Changes in the docs repo
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check out docs repo
+        uses: actions/checkout@master
+        with:
+          repository: Kong/docs.konghq.com
+          token: ${{ secrets.PAT }}
+          path: './docs'
+
+      - name: Run docs changes tracker
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DAYS_TO_CHECK_FOR_DOCS_CHANGES: ${{ vars.DAYS_TO_CHECK_FOR_DOCS_CHANGES }}
+          DOCS_PATH: './docs'
+        run: |
+          npm ci --prefix ./tools/track-docs-changes
+          node tools/track-docs-changes/index.js

--- a/tools/track-docs-changes/README.md
+++ b/tools/track-docs-changes/README.md
@@ -1,0 +1,20 @@
+# track-docs-changes
+
+A tool to track  changes made to files in https://github.com/Kong/docs.konghq.com, which are used as the source for dev site pages.
+
+## How it works
+
+1. Read `./config/sources.yml` to build a mapping of the files in the docs repo that serve as the source for dev site pages.
+2. Check for changes made to the source files in the docs repository (specify the relative path to the docs repository using the environment variable `DOCS_PATH`) over the past `DAYS_TO_CHECK_FOR_DOCS_CHANGES` days.
+3. For each dev site page specified in `./config/sources.yml`, it outputs:
+   * The file path corresponding to each source in the docs repository.
+   * For each source, a link to the pull requests (PRs) that modified it within the specified date range.
+
+## How to run it
+
+In the current directory:
+
+``` bash
+npm ci
+DOCS_PATH='<relative path to docs repo>' node index.js
+```

--- a/tools/track-docs-changes/index.js
+++ b/tools/track-docs-changes/index.js
@@ -1,0 +1,109 @@
+import { Octokit } from "@octokit/rest";
+import simpleGit from 'simple-git';
+import fs from 'node:fs/promises';
+import YAML from 'yaml';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const octokit = new Octokit({ auth: process.env.GITHUB_TOKEN });
+const docsPath = process.env.DOCS_PATH;
+const numberOfDays = process.env.DAYS_TO_CHECK_FOR_DOCS_CHANGES || 7;
+
+async function getPullRequestsForCommit(commitSha) {
+  try {
+    const { data: pulls } = await octokit.rest.repos.listPullRequestsAssociatedWithCommit({
+      owner: 'Kong',
+      repo: 'docs.konghq.com',
+      commit_sha: commitSha,
+    });
+
+    return pulls;
+  } catch (error) {
+    console.error('Error fetching pull requests:', error);
+    return [];
+  }
+}
+
+async function getRecentCommits(repoPath, file) {
+  const git = simpleGit(repoPath);
+  const commits = [];
+
+  try {
+    const now = new Date();
+    const since = new Date(now);
+    since.setUTCDate(now.getUTCDate() - numberOfDays);
+    since.setUTCHours(0, 0, 0, 0);
+    const filePath = path.join(repoPath, file);
+
+    try {
+      await fs.access(filePath);
+    } catch {
+      console.log(`File ${file} does not exist in the repository.`);
+      return [];
+    }
+
+    const log = await git.log({ file, '--since': `${since.toISOString()}` });
+
+    if (log.total > 0) {
+      for (const commit of log.all) {
+        const prList = await getPullRequestsForCommit(commit.hash);
+        commits.push({ commit, prList });
+      }
+    }
+  } catch (error) {
+    console.error('Error:', error);
+  }
+
+  return commits;
+}
+
+async function main() {
+  try {
+    console.log('Checking for changes...');
+    const config = await fs.readFile(path.join(__dirname, './config/sources.yml'), { encoding: 'utf8' });
+    if (config === '') {
+      console.log('config/sources.yml is empty.')
+      return;
+    }
+    const files = YAML.parse(config);
+    const uniqueSources = new Set();
+    let prsForSource = {};
+
+    for (const sources of Object.values(files)) {
+      sources.forEach(source => uniqueSources.add(source));
+    }
+    const sourcesArray = Array.from(uniqueSources);
+
+    for (const source of sourcesArray) {
+      const commits = await getRecentCommits(docsPath, source);
+      const allPRs = commits.reduce((acc, { prList }) => {
+        return acc.concat(prList);
+      }, []);
+      prsForSource[source] = [...new Map(allPRs.map(pr => [pr.number, pr])).values()];
+    }
+
+    for(const [file, sources] of Object.entries(files)) {
+      console.log('----------------------------------------');
+      console.log(`Dev Site file: ${file}`);
+      console.log('Sources in docs.konghq.com:');
+      for (const source of sources) {
+        const prs = prsForSource[source];
+        if (prs.length > 0) {
+          console.log(` ${source}:`)
+          console.log(prs.map(pr => `   #${pr.number} - ${pr.title} - ${pr.html_url}`).join('\n'));
+        } else {
+          console.log(` ${source}: No changes.`);
+        }
+      }
+    }
+    console.log('----------------------------------------');
+    console.log('Done!');
+  } catch (err) {
+    console.error('Error reading or parsing YAML:', err);
+  }
+}
+
+main();

--- a/tools/track-docs-changes/package-lock.json
+++ b/tools/track-docs-changes/package-lock.json
@@ -1,0 +1,248 @@
+{
+  "name": "track-docs-changes",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "track-docs-changes",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@octokit/rest": "^21.0.2",
+        "simple-git": "^3.27.0",
+        "yaml": "^2.5.1"
+      }
+    },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/auth-token": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.1.tgz",
+      "integrity": "sha512-rh3G3wDO8J9wSjfI436JUKzHIxq8NaiL0tVeB2aXmG6p/9859aUOAjA9pmSPNGGZxfwmaJ9ozOJImuNVJdpvbA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/core": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.2.tgz",
+      "integrity": "sha512-hEb7Ma4cGJGEUNOAVmyfdB/3WirWMg5hDuNFVejGEDFqupeOysLc2sG6HJxY2etBp5YQu5Wtxwi020jS9xlUwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/auth-token": "^5.0.0",
+        "@octokit/graphql": "^8.0.0",
+        "@octokit/request": "^9.0.0",
+        "@octokit/request-error": "^6.0.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^3.0.2",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/endpoint": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.1.tgz",
+      "integrity": "sha512-JYjh5rMOwXMJyUpj028cu0Gbp7qe/ihxfJMLc8VZBMMqSwLgOxDI1911gV4Enl1QSavAQNJcwmwBF9M0VvLh6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/graphql": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.1.1.tgz",
+      "integrity": "sha512-ukiRmuHTi6ebQx/HFRCXKbDlOh/7xEV6QUXaE7MJEKGNAncGI/STSbOkl12qVXZrfZdpXctx5O9X1AIaebiDBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/request": "^9.0.0",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^7.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/openapi-types": {
+      "version": "22.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-22.2.0.tgz",
+      "integrity": "sha512-QBhVjcUa9W7Wwhm6DBFu6ZZ+1/t/oYxqc2tp81Pi41YNuJinbFRx8B133qVOrAaBbF7D/m0Et6f9/pZt9Rc+tg==",
+      "license": "MIT"
+    },
+    "node_modules/@octokit/plugin-paginate-rest": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.5.tgz",
+      "integrity": "sha512-cgwIRtKrpwhLoBi0CUNuY83DPGRMaWVjqVI/bGKsLJ4PzyWZNaEmhHroI2xlrVXkk6nFv0IsZpOp+ZWSWUS2AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.6.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-request-log": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-5.3.1.tgz",
+      "integrity": "sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/plugin-rest-endpoint-methods": {
+      "version": "13.2.6",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.2.6.tgz",
+      "integrity": "sha512-wMsdyHMjSfKjGINkdGKki06VEkgdEldIGstIEyGX0wbYHGByOwN/KiM+hAAlUwAtPkP3gvXtVQA9L3ITdV2tVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.6.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "@octokit/core": ">=6"
+      }
+    },
+    "node_modules/@octokit/request": {
+      "version": "9.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.1.3.tgz",
+      "integrity": "sha512-V+TFhu5fdF3K58rs1pGUJIDH5RZLbZm5BI+MNF+6o/ssFNT4vWlCh/tVpF3NxGtP15HUxTTMUbsG5llAuU2CZA==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/endpoint": "^10.0.0",
+        "@octokit/request-error": "^6.0.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^7.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/request-error": {
+      "version": "6.1.5",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.5.tgz",
+      "integrity": "sha512-IlBTfGX8Yn/oFPMwSfvugfncK2EwRLjzbrpifNaMY8o/HTEAFqCA1FZxjD9cWvSKBHgrIhc4CSBIzMxiLsbzFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/types": "^13.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/rest": {
+      "version": "21.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-21.0.2.tgz",
+      "integrity": "sha512-+CiLisCoyWmYicH25y1cDfCrv41kRSvTq6pPWtRroRJzhsCZWZyCqGyI8foJT5LmScADSwRAnr/xo+eewL04wQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/core": "^6.1.2",
+        "@octokit/plugin-paginate-rest": "^11.0.0",
+        "@octokit/plugin-request-log": "^5.3.1",
+        "@octokit/plugin-rest-endpoint-methods": "^13.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@octokit/types": {
+      "version": "13.6.1",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.6.1.tgz",
+      "integrity": "sha512-PHZE9Z+kWXb23Ndik8MKPirBPziOc0D2/3KH1P+6jK5nGWe96kadZuE4jev2/Jq7FvIfTlT2Ltg8Fv2x1v0a5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@octokit/openapi-types": "^22.2.0"
+      }
+    },
+    "node_modules/before-after-hook": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
+      "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/simple-git": {
+      "version": "3.27.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.27.0.tgz",
+      "integrity": "sha512-ivHoFS9Yi9GY49ogc6/YAi3Fl9ROnF4VyubNylgCkA+RVqLaKWnDSzXOVzya8csELIaWaYNutsEuAhZrtOjozA==",
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.3.5"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
+    "node_modules/universal-user-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
+      "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
+      "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.5.1.tgz",
+      "integrity": "sha512-bLQOjaX/ADgQ20isPJRvF0iRUHIxVhYvr53Of7wGcWlO2jvtUlH5m87DsmulFVxRpNLOnI4tB6p/oh8D7kpn9Q==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    }
+  }
+}

--- a/tools/track-docs-changes/package.json
+++ b/tools/track-docs-changes/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "track-docs-changes",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@octokit/rest": "^21.0.2",
+    "simple-git": "^3.27.0",
+    "yaml": "^2.5.1"
+  }
+}


### PR DESCRIPTION
 Add tool that check for changes in files in the docs repo that are used as sources for dev site pages.

## Example config file

```
app/_gateway_entities/consumer.md:
  - app/_src/gateway/key-concepts/consumers.md

app/_gateway_entities/service.md:
  - app/_src/gateway/key-concepts/services.md
  - app/_src/gateway/get-started/index.md
```

## How it works

1. Read `./config/sources.yml` to build a mapping of the files in the docs repo that serve as the source for dev site pages.
2. Check for changes made to the source files in the docs repository (specify the relative path to the docs repository using the environment variable `DOCS_PATH`) over the past `DAYS_TO_CHECK_FOR_DOCS_CHANGES` days.
3. For each dev site page specified in `./config/sources.yml`, it outputs:
   * The file path corresponding to each source in the docs repository.
   * For each source, a link to the pull requests (PRs) that modified it within the specified date range.

## How to run it

In the current directory:

``` bash
npm ci
DOCS_PATH='<relative path to docs repo>' node index.js
```