### PR TITLE
WIP: Add inso-cli reference docs generated from source

### DIFF
--- a/app/inso-cli/reference/export.md
+++ b/app/inso-cli/reference/export.md
@@ -1,0 +1,27 @@
+---
+title: inso export
+auto_generated: true
+layout: reference
+content_type: reference
+---
+
+## Command Description
+
+Export data from insomnia models
+
+## Syntax
+
+`inso export [options] [command]`
+
+## Global Flags
+
+* `-v, --version`: output the version number
+* `-w, --workingDir <dir>`: set working directory/file: .insomnia folder, *.db.json, export.yaml
+* `--verbose`: show additional logs while running the command
+* `--ci`: run in CI, disables all prompts, defaults to false
+* `--config <path>`: path to configuration file containing above options (.insorc)
+* `--printOptions`: print the loaded options
+
+## inso export Commands
+
+* [inso export spec](/inso-cli/reference/export_spec/): Export an API Specification to a file, identifier can be an API Spec id

--- a/app/inso-cli/reference/export_spec.md
+++ b/app/inso-cli/reference/export_spec.md
@@ -1,0 +1,28 @@
+---
+title: inso export spec
+auto_generated: true
+layout: reference
+content_type: reference
+---
+
+## Command Description
+
+Export an API Specification to a file, identifier can be an API Spec id
+
+## Syntax
+
+`inso export spec [options] [identifier]`
+
+## Local Flags
+
+* `-o, --output <path>`: save the generated config to a file
+* `-s, --skipAnnotations`: remove all "x-kong-" annotations, defaults to false
+
+## Global Flags
+
+* `-v, --version`: output the version number
+* `-w, --workingDir <dir>`: set working directory/file: .insomnia folder, *.db.json, export.yaml
+* `--verbose`: show additional logs while running the command
+* `--ci`: run in CI, disables all prompts, defaults to false
+* `--config <path>`: path to configuration file containing above options (.insorc)
+* `--printOptions`: print the loaded options

--- a/app/inso-cli/reference/index.md
+++ b/app/inso-cli/reference/index.md
@@ -1,0 +1,36 @@
+---
+title: Inso CLI
+auto_generated: true
+content_type: reference
+layout: reference
+---
+
+
+## Global Flags
+
+* `-v, --version`: output the version number
+* `-w, --workingDir <dir>`: set working directory/file: .insomnia folder, *.db.json, export.yaml
+* `--verbose`: show additional logs while running the command
+* `--ci`: run in CI, disables all prompts, defaults to false
+* `--config <path>`: path to configuration file containing above options (.insorc)
+* `--printOptions`: print the loaded options
+
+## Commands
+
+* [inso run](/inso-cli/reference/run/): Execution utilities
+* [inso lint](/inso-cli/reference/lint/): Lint a yaml file in the workingDir or the provided file path (with  .spectral.yml) or a spec in an Insomnia database directory
+* [inso export](/inso-cli/reference/export/): Export data from insomnia models
+* [inso script](/inso-cli/reference/script/): Run scripts defined in .insorc
+
+## inso run Commands
+
+* [inso run test](/inso-cli/reference/run_test/): Run Insomnia unit test suites, identifier can be a test suite id or a API Spec id
+* [inso run collection](/inso-cli/reference/run_collection/): Run Insomnia request collection, identifier can be a workspace id
+
+## inso lint Commands
+
+* [inso lint spec](/inso-cli/reference/lint_spec/): Lint an API Specification, identifier can be an API Spec id or a file path
+
+## inso export Commands
+
+* [inso export spec](/inso-cli/reference/export_spec/): Export an API Specification to a file, identifier can be an API Spec id

--- a/app/inso-cli/reference/lint.md
+++ b/app/inso-cli/reference/lint.md
@@ -1,0 +1,27 @@
+---
+title: inso lint
+auto_generated: true
+layout: reference
+content_type: reference
+---
+
+## Command Description
+
+Lint a yaml file in the workingDir or the provided file path (with  .spectral.yml) or a spec in an Insomnia database directory
+
+## Syntax
+
+`inso lint [options] [command]`
+
+## Global Flags
+
+* `-v, --version`: output the version number
+* `-w, --workingDir <dir>`: set working directory/file: .insomnia folder, *.db.json, export.yaml
+* `--verbose`: show additional logs while running the command
+* `--ci`: run in CI, disables all prompts, defaults to false
+* `--config <path>`: path to configuration file containing above options (.insorc)
+* `--printOptions`: print the loaded options
+
+## inso lint Commands
+
+* [inso lint spec](/inso-cli/reference/lint_spec/): Lint an API Specification, identifier can be an API Spec id or a file path

--- a/app/inso-cli/reference/lint_spec.md
+++ b/app/inso-cli/reference/lint_spec.md
@@ -1,0 +1,23 @@
+---
+title: inso lint spec
+auto_generated: true
+layout: reference
+content_type: reference
+---
+
+## Command Description
+
+Lint an API Specification, identifier can be an API Spec id or a file path
+
+## Syntax
+
+`inso lint spec [options] [identifier]`
+
+## Global Flags
+
+* `-v, --version`: output the version number
+* `-w, --workingDir <dir>`: set working directory/file: .insomnia folder, *.db.json, export.yaml
+* `--verbose`: show additional logs while running the command
+* `--ci`: run in CI, disables all prompts, defaults to false
+* `--config <path>`: path to configuration file containing above options (.insorc)
+* `--printOptions`: print the loaded options

--- a/app/inso-cli/reference/run.md
+++ b/app/inso-cli/reference/run.md
@@ -1,0 +1,28 @@
+---
+title: inso run
+auto_generated: true
+layout: reference
+content_type: reference
+---
+
+## Command Description
+
+Execution utilities
+
+## Syntax
+
+`inso run [options] [command]`
+
+## Global Flags
+
+* `-v, --version`: output the version number
+* `-w, --workingDir <dir>`: set working directory/file: .insomnia folder, *.db.json, export.yaml
+* `--verbose`: show additional logs while running the command
+* `--ci`: run in CI, disables all prompts, defaults to false
+* `--config <path>`: path to configuration file containing above options (.insorc)
+* `--printOptions`: print the loaded options
+
+## inso run Commands
+
+* [inso run test](/inso-cli/reference/run_test/): Run Insomnia unit test suites, identifier can be a test suite id or a API Spec id
+* [inso run collection](/inso-cli/reference/run_collection/): Run Insomnia request collection, identifier can be a workspace id

--- a/app/inso-cli/reference/run_collection.md
+++ b/app/inso-cli/reference/run_collection.md
@@ -1,0 +1,37 @@
+---
+title: inso run collection
+auto_generated: true
+layout: reference
+content_type: reference
+---
+
+## Command Description
+
+Run Insomnia request collection, identifier can be a workspace id
+
+## Syntax
+
+`inso run collection [options] [identifier]`
+
+## Local Flags
+
+* `-t, --requestNamePattern <regex>`: run requests that match the regex
+* `-i, --item <requestid>`: request or folder id to run
+* `-e, --env <identifier>`: environment to use
+* `-g, --globals <identifier>`: global environment to use (filepath or id)
+* `--delay-request <duration>`: milliseconds to delay between requests
+* `--env-var <key=value>`: override environment variables
+* `-n, --iteration-count <count>`: number of times to repeat
+* `-d, --iteration-data <path/url>`: file path or url (JSON or CSV)
+* `-r, --reporter <reporter>`: reporter to use, options are [dot, list, min, progress, spec, tap]
+* `-b, --bail`: abort ("bail") after first non-200 response
+* `--disableCertValidation`: disable certificate validation for requests with SSL
+
+## Global Flags
+
+* `-v, --version`: output the version number
+* `-w, --workingDir <dir>`: set working directory/file: .insomnia folder, *.db.json, export.yaml
+* `--verbose`: show additional logs while running the command
+* `--ci`: run in CI, disables all prompts, defaults to false
+* `--config <path>`: path to configuration file containing above options (.insorc)
+* `--printOptions`: print the loaded options

--- a/app/inso-cli/reference/run_test.md
+++ b/app/inso-cli/reference/run_test.md
@@ -1,0 +1,32 @@
+---
+title: inso run test
+auto_generated: true
+layout: reference
+content_type: reference
+---
+
+## Command Description
+
+Run Insomnia unit test suites, identifier can be a test suite id or a API Spec id
+
+## Syntax
+
+`inso run test [options] [identifier]`
+
+## Local Flags
+
+* `-e, --env <identifier>`: environment to use
+* `-t, --testNamePattern <regex>`: run tests that match the regex
+* `-r, --reporter <reporter>`: reporter to use, options are [dot, list, min, progress, spec, tap]
+* `-b, --bail`: abort ("bail") after first test failure
+* `--keepFile`: do not delete the generated test file
+* `-k, --disableCertValidation`: disable certificate validation for requests with SSL
+
+## Global Flags
+
+* `-v, --version`: output the version number
+* `-w, --workingDir <dir>`: set working directory/file: .insomnia folder, *.db.json, export.yaml
+* `--verbose`: show additional logs while running the command
+* `--ci`: run in CI, disables all prompts, defaults to false
+* `--config <path>`: path to configuration file containing above options (.insorc)
+* `--printOptions`: print the loaded options

--- a/app/inso-cli/reference/script.md
+++ b/app/inso-cli/reference/script.md
@@ -1,0 +1,23 @@
+---
+title: inso script
+auto_generated: true
+layout: reference
+content_type: reference
+---
+
+## Command Description
+
+Run scripts defined in .insorc
+
+## Syntax
+
+`inso script [options] <script-name>`
+
+## Global Flags
+
+* `-v, --version`: output the version number
+* `-w, --workingDir <dir>`: set working directory/file: .insomnia folder, *.db.json, export.yaml
+* `--verbose`: show additional logs while running the command
+* `--ci`: run in CI, disables all prompts, defaults to false
+* `--config <path>`: path to configuration file containing above options (.insorc)
+* `--printOptions`: print the loaded options


### PR DESCRIPTION
Add Inso-cli reference docs generated from source, not final but at least it gives us an idea of what we can expect to get.

[Inso-reference preview link](https://deploy-preview-124--kongdeveloper.netlify.app/inso-cli/reference/)

**Notes:**

* This is a WIP.
* The work in insomnia that generates these files hasn't been completed yet.
* We need to define the metadata, URL structure,  links structure, formatting, etc.
* How would we handle different versions of these docs with each release?
* Is there anything else we would like the content to have? e.g. examples, we can work with the insomnia to get those included.