### PR TITLE
Display badges in landing pages under the h1

### DIFF
--- a/app/_includes/landing_pages/header.md
+++ b/app/_includes/landing_pages/header.md
@@ -1,5 +1,11 @@
 {% capture header %}
 <{{ include.config.type }} id="{{ include.config.text | slugify }}" class="{% if include.config.align %}self-{{ include.config.align }}{% endif %}">{{ include.config.text }}</{{ include.config.type }}>
+
+    {% if include.config.type == 'h1' and page.tier %}
+        <div class="flex gap-2 items-center">
+            {% include tier.html products=page.products tier=page.tier %}
+        </div>
+    {% endif %}
 {% endcapture %}
 
 {% if include.config.sub_text %}

--- a/app/_includes/tier.html
+++ b/app/_includes/tier.html
@@ -1,0 +1,5 @@
+{% if include.products and include.products.size > 1 %}
+{% raise "tier.html include called with a tier and more than one product." %}
+{% endif %}
+{% assign tier = site.data.products[include.products.first].tiers[include.tier] %}
+{% include badge.html url=tier.url text=tier.text %}

--- a/app/_includes/uses.html
+++ b/app/_includes/uses.html
@@ -1,11 +1,7 @@
 {% if include.products or include.tools or include.tier %}
 <div class="flex gap-2 items-center">
     {% if include.tier %}
-        {% if include.products and include.products.size > 1 %}
-            {% raise "uses.html include called with a tier and more than one product." %}
-        {% endif %}
-        {% assign tier = site.data.products[include.products.first].tiers[include.tier] %}
-        {% include badge.html url=tier.url text=tier.text %}
+        {% include tier.html products=include.products tier=include.tier %}
     {% endif %}
 
     {% if include.tier %}


### PR DESCRIPTION
Render tier badges on landing pages under the h1.

For it work, the page must have the product and the tier specified in the metadata, e.g.:
```
products:
  - insomnia

tier: team
``` 

```
products:
  - gateway

tier: enterprise
``` 

The tier should match the corresponding key defined in the product metadata files, e.g [insomnia](https://github.com/Kong/developer.konghq.com/blob/main/app/_data/products/insomnia.yml#L2-L11), [gateway](https://github.com/Kong/developer.konghq.com/blob/main/app/_data/products/gateway.yml#L8-L11).