### PR TITLE
Run frontmatter validations on run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,14 @@ install-prerequisites:
 install: ruby-version-check
 	npm ci
 	bundle install
+	cd tools/frontmatter-validator
+	npm ci
+
+validate-frontmatters:
+	npm --prefix tools/frontmatter-validator run validate
 
 # Using local dependencies, starts a doc site instance on http://localhost:4000.
-run: ruby-version-check
+run: ruby-version-check validate-frontmatters
 	netlify dev
 
 run-debug: ruby-version-check
@@ -43,3 +48,4 @@ kill-ports:
 
 vale:
 	-git diff --name-only --diff-filter=d HEAD | grep '\.md$$' | xargs vale
+

--- a/tools/frontmatter-validator/index.js
+++ b/tools/frontmatter-validator/index.js
@@ -7,7 +7,7 @@ const YAML = require("yaml");
 const Ajv = require("ajv");
 const addFormats = require("ajv-formats");
 
-const ajv = new Ajv({ allErrors: true });
+const ajv = new Ajv({ allErrors: true, strict: false });
 addFormats(ajv);
 
 async function validateFrontmatters() {

--- a/tools/frontmatter-validator/package.json
+++ b/tools/frontmatter-validator/package.json
@@ -4,7 +4,8 @@
     "description": "",
     "main": "index.js",
     "scripts": {
-        "test": "echo \"Error: no test specified\" && exit 1"
+      "validate": "node index.js",
+      "test": "echo \"Error: no test specified\" && exit 1"
     },
     "keywords": [],
     "author": "",


### PR DESCRIPTION
Add `make validate-frontmatters` and run it as part of `make run`, it takes less than 0.38s.
Its dependencies are installed as part of `make install`.