### PR TITLE
Add variable support to Terraform examples

### DIFF
--- a/app/_includes/components/entity_example/format/snippets/terraform.md
+++ b/app/_includes/components/entity_example/format/snippets/terraform.md
@@ -28,3 +28,16 @@ resource "{{ include.presenter.resource_name }}" "my_{{ include.presenter.entity
 }
 ```
 {% endif %}
+
+{% if include.presenter.variable_names.size > 0 %}
+
+This example requires the following variables to be added to your manifest. You can specify values at runtime by setting `TF_VAR_name=value`.
+
+```
+{% for variable in include.presenter.variable_names -%}
+variable "{{ variable }}" {
+  type = string
+}
+{% endfor -%}
+```
+{% endif %}

--- a/app/_plugins/drops/entity_example/utils/variable_replacer.rb
+++ b/app/_plugins/drops/entity_example/utils/variable_replacer.rb
@@ -61,6 +61,18 @@ module Jekyll
               "${{ env \"#{env_variable}\" }}"
             end
           end
+
+          class TerraformData < Data
+            def replace_variable(variable)
+              value = super
+
+              return nil unless value
+
+              env_variable = value.gsub('$', '').downcase
+              "var.#{env_variable}"
+            end
+          end
+
         end
       end
     end


### PR DESCRIPTION
Renders as:

```
header_value = var.anthropic_api_key
```

```
This example requires the following variables to be added to your manifest. You can specify values at runtime by setting TF_VAR_name=value.

variable "anthropic_api_key" {
  type = string
}
```

### Preview Links

/plugins/ai-proxy/examples/anthropic-chat-route/