### PR TITLE
Add {% feature_table %} block

### DIFF
--- a/app/_includes/components/feature_table.html
+++ b/app/_includes/components/feature_table.html
@@ -1,7 +1,7 @@
 <table class="{% if include.sticky %}table__sticky{% endif %}">
     <thead>
         <tr>
-        <th></th>
+        <th>{% if include.item_title %}{{ include.item_title }}{% endif %}</th>
         {% for column in include.columns %}
             <th class="text-center">
             <span class="font-semibold text-primary">{{ column.title | liquify }}</span>

--- a/app/_includes/landing_pages/feature_table.md
+++ b/app/_includes/landing_pages/feature_table.md
@@ -1,1 +1,1 @@
-{% include components/feature_table.html columns=include.config.columns rows=include.config.features %}
+{% include components/feature_table.html columns=include.config.columns rows=include.config.features item_title=include.config.item_title %}

--- a/app/_includes/plugins/table.html
+++ b/app/_includes/plugins/table.html
@@ -1,3 +1,3 @@
 <div class="max-h-[50vh] overflow-y-auto rounded-lg">
-    {% include components/feature_table.html columns=columns rows=rows sticky=true %}
+    {% include components/feature_table.html columns=columns rows=rows sticky=true item_title="Plugin" %}
 </div>

--- a/app/_plugins/blocks/feature_table.rb
+++ b/app/_plugins/blocks/feature_table.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module Jekyll
+  class FeatureTable < Liquid::Block
+    def render(context)
+      @context = context
+      @site = context.registers[:site]
+      @page = context.environments.first['page']
+
+      contents = super
+
+      config = YAML.load(contents)
+
+      context.stack do
+        context['include'] =
+          { 'columns' => config['columns'], 'rows' => config['features'], 'item_title' => config['item_title'] }
+        Liquid::Template.parse(template).render(context)
+      end
+    rescue Psych::SyntaxError => e
+      message = <<~STRING
+        On `#{@page['path']}`, the following {% feature_table %} block contains a malformed yaml:
+        #{contents.strip.split("\n").each_with_index.map { |l, i| "#{i}: #{l}" }.join("\n")}
+        #{e.message}
+      STRING
+      raise ArgumentError, message
+    end
+
+    private
+
+    def template
+      @template ||= File.read(File.expand_path('app/_includes/components/feature_table.html'))
+    end
+  end
+end
+
+Liquid::Template.register_tag('feature_table', Jekyll::FeatureTable)


### PR DESCRIPTION
Takes a yaml as input (in the same way the component for landing_pages does, it's using the same template) and renders a table.
I added an extra optional config called `item_title`  in case you want to render a title on the first column.
example usage:

```
{% feature_table %}
item_title: Backend
columns:
  - title: Kong Gateway OSS
    key: oss
  - title: Kong Gateway Enterprise
    key: enterprise
  - title: Uses Vault entity
    key: uses_vault
  - title: Konnect supported
    key: supports_konnect
features:
  - title: Environment variable
    url: /how-to/store-secrets-as-env-variables/
    oss: true
    enterprise: true
    supports_konnect: true
{% endfeature_table %}
```

this renders:

<img width="950" alt="Screenshot 2025-01-10 at 13 46 57" src="https://github.com/user-attachments/assets/e13c205c-fc20-4362-aa42-e44f83a49a88" />


### Preview Links



### Checklist 

- [ ] Every page is page one
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs. 
