### PR TITLE
chore: Plugin metadata

### DIFF
--- a/.github/styles/frontmatter/Keys.txt
+++ b/.github/styles/frontmatter/Keys.txt
@@ -6,6 +6,7 @@ faqs
 icon_url
 include_content
 insomnia_link
+konnect_deployments
 min_version
 next_steps
 prereqs

--- a/.github/styles/frontmatter/Keys.txt
+++ b/.github/styles/frontmatter/Keys.txt
@@ -9,6 +9,7 @@ insomnia_link
 konnect_deployments
 min_version
 next_steps
+on_prem
 prereqs
 related_resources
 tier

--- a/app/_kong_plugins/acl/index.md
+++ b/app/_kong_plugins/acl/index.md
@@ -16,11 +16,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: acl.png
 
 categories:

--- a/app/_kong_plugins/acme/index.md
+++ b/app/_kong_plugins/acme/index.md
@@ -16,10 +16,14 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
 
 icon: acme.png
 

--- a/app/_kong_plugins/ai-azure-content-safety/index.md
+++ b/app/_kong_plugins/ai-azure-content-safety/index.md
@@ -19,11 +19,15 @@ works_on:
 min_version:
     gateway: '3.7'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: ai-azure-content-safety.png
 
 categories:

--- a/app/_kong_plugins/ai-prompt-decorator/index.md
+++ b/app/_kong_plugins/ai-prompt-decorator/index.md
@@ -19,11 +19,15 @@ works_on:
 min_version:
     gateway: '3.6'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: ai-prompt-decorator.png
 
 categories:

--- a/app/_kong_plugins/ai-prompt-guard/index.md
+++ b/app/_kong_plugins/ai-prompt-guard/index.md
@@ -19,11 +19,15 @@ works_on:
 min_version:
     gateway: '3.6'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: ai-prompt-guard.png
 
 categories:

--- a/app/_kong_plugins/ai-prompt-template/index.md
+++ b/app/_kong_plugins/ai-prompt-template/index.md
@@ -19,11 +19,15 @@ works_on:
 min_version:
     gateway: '3.6'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: ai-prompt-template.png
 
 categories:

--- a/app/_kong_plugins/ai-proxy-advanced/index.md
+++ b/app/_kong_plugins/ai-proxy-advanced/index.md
@@ -19,11 +19,15 @@ works_on:
 min_version:
     gateway: '3.8'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: ai-proxy-advanced.png
 
 categories:

--- a/app/_kong_plugins/ai-proxy/index.md
+++ b/app/_kong_plugins/ai-proxy/index.md
@@ -19,11 +19,15 @@ works_on:
 min_version:
     gateway: '3.6'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: ai-proxy.png
 
 categories:

--- a/app/_kong_plugins/ai-rate-limiting-advanced/index.md
+++ b/app/_kong_plugins/ai-rate-limiting-advanced/index.md
@@ -12,6 +12,16 @@ works_on:
     - on-prem
     - konnect
 
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
+
 min_version:
   gateway: '3.7'
 

--- a/app/_kong_plugins/ai-request-transformer/index.md
+++ b/app/_kong_plugins/ai-request-transformer/index.md
@@ -18,11 +18,15 @@ works_on:
 min_version:
     gateway: '3.6'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: ai-request-transformer.png
 
 categories:

--- a/app/_kong_plugins/ai-response-transformer/index.md
+++ b/app/_kong_plugins/ai-response-transformer/index.md
@@ -18,11 +18,15 @@ works_on:
 min_version:
     gateway: '3.6'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 
 icon: ai-response-transformer.png
 

--- a/app/_kong_plugins/ai-semantic-cache/index.md
+++ b/app/_kong_plugins/ai-semantic-cache/index.md
@@ -19,11 +19,15 @@ works_on:
 min_version:
     gateway: '3.8'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 
 icon: ai-semantic-cache.png
 

--- a/app/_kong_plugins/ai-semantic-prompt-guard/index.md
+++ b/app/_kong_plugins/ai-semantic-prompt-guard/index.md
@@ -19,11 +19,15 @@ works_on:
 min_version:
     gateway: '3.8'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: ai-semantic-prompt-guard.png
 
 categories:

--- a/app/_kong_plugins/app-dynamics/index.md
+++ b/app/_kong_plugins/app-dynamics/index.md
@@ -19,10 +19,13 @@ works_on:
 min_version:
     gateway: '3.1'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
 
 icon: app-dynamics.png
 

--- a/app/_kong_plugins/aws-lambda/index.md
+++ b/app/_kong_plugins/aws-lambda/index.md
@@ -16,11 +16,15 @@ works_on:
     - konnect
 
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 
 icon: aws-lambda.png
 

--- a/app/_kong_plugins/azure-functions/index.md
+++ b/app/_kong_plugins/azure-functions/index.md
@@ -16,11 +16,15 @@ works_on:
     - konnect
 
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 
 icon: azure-functions.png
 

--- a/app/_kong_plugins/basic-auth/index.md
+++ b/app/_kong_plugins/basic-auth/index.md
@@ -15,6 +15,15 @@ works_on:
     - on-prem
     - konnect
 
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 
 icon: basic-auth.png
 

--- a/app/_kong_plugins/bot-detection/index.md
+++ b/app/_kong_plugins/bot-detection/index.md
@@ -15,11 +15,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 
 icon: bot-detection.png
 

--- a/app/_kong_plugins/canary/index.md
+++ b/app/_kong_plugins/canary/index.md
@@ -16,11 +16,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 
 icon: canary.png
 

--- a/app/_kong_plugins/confluent/index.md
+++ b/app/_kong_plugins/confluent/index.md
@@ -19,11 +19,15 @@ works_on:
 min_version:
     gateway: '3.8'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 
 icon: confluent.png
 

--- a/app/_kong_plugins/correlation-id/index.md
+++ b/app/_kong_plugins/correlation-id/index.md
@@ -15,11 +15,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: correlation-id.png
 
 categories:

--- a/app/_kong_plugins/cors/index.md
+++ b/app/_kong_plugins/cors/index.md
@@ -21,6 +21,15 @@ topologies:
     - db-less
     - traditional
 
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 
 related_resources:
   - text: DNS configuration reference

--- a/app/_kong_plugins/cors/index.md
+++ b/app/_kong_plugins/cors/index.md
@@ -12,14 +12,9 @@ description: 'The CORS plugin lets you add Cross-Origin Resource Sharing (CORS) 
 products:
     - gateway
 
-
 works_on:
     - on-prem
     - konnect
-topologies:
-    - hybrid
-    - db-less
-    - traditional
 
 topologies:
   on_prem:

--- a/app/_kong_plugins/datadog/index.md
+++ b/app/_kong_plugins/datadog/index.md
@@ -14,11 +14,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: datadog.png
 
 categories:

--- a/app/_kong_plugins/degraphql/index.md
+++ b/app/_kong_plugins/degraphql/index.md
@@ -16,11 +16,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 
 icon: degraphql.png
 

--- a/app/_kong_plugins/exit-transformer/index.md
+++ b/app/_kong_plugins/exit-transformer/index.md
@@ -16,11 +16,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 
 icon: exit-transformer.png
 

--- a/app/_kong_plugins/file-log/index.md
+++ b/app/_kong_plugins/file-log/index.md
@@ -14,10 +14,13 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
 
 icon: file-log.png
 

--- a/app/_kong_plugins/forward-proxy/index.md
+++ b/app/_kong_plugins/forward-proxy/index.md
@@ -16,11 +16,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: forward-proxy.png
 
 categories:

--- a/app/_kong_plugins/graphql-proxy-cache-advanced/index.md
+++ b/app/_kong_plugins/graphql-proxy-cache-advanced/index.md
@@ -16,11 +16,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: graphql-proxy-cache-advanced.png
 
 categories:

--- a/app/_kong_plugins/graphql-rate-limiting-advanced/index.md
+++ b/app/_kong_plugins/graphql-rate-limiting-advanced/index.md
@@ -18,6 +18,15 @@ works_on:
     - on-prem
     - konnect
 
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+
 icon: graphql-rate-limiting-advanced.png
 
 categories:

--- a/app/_kong_plugins/grpc-gateway/index.md
+++ b/app/_kong_plugins/grpc-gateway/index.md
@@ -15,11 +15,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: grpc-gateway.png
 
 categories:

--- a/app/_kong_plugins/grpc-web/index.md
+++ b/app/_kong_plugins/grpc-web/index.md
@@ -15,11 +15,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: grpc-web.png
 
 categories:

--- a/app/_kong_plugins/header-cert-auth/index.md
+++ b/app/_kong_plugins/header-cert-auth/index.md
@@ -19,10 +19,14 @@ works_on:
 min_version:
     gateway: '3.8'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
 
 icon: header-cert-auth.png
 

--- a/app/_kong_plugins/hmac-auth/index.md
+++ b/app/_kong_plugins/hmac-auth/index.md
@@ -15,11 +15,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: hmac-auth.png
 
 categories:

--- a/app/_kong_plugins/http-log/index.md
+++ b/app/_kong_plugins/http-log/index.md
@@ -16,11 +16,15 @@ works_on:
     - konnect
 
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: http-log.png
 
 categories:

--- a/app/_kong_plugins/injection-protection/index.md
+++ b/app/_kong_plugins/injection-protection/index.md
@@ -19,11 +19,15 @@ works_on:
 min_version:
     gateway: '3.9'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: injection-protection.png
 
 categories:

--- a/app/_kong_plugins/ip-restriction/index.md
+++ b/app/_kong_plugins/ip-restriction/index.md
@@ -16,11 +16,15 @@ works_on:
     - konnect
 
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: ip-restriction.png
 
 categories:

--- a/app/_kong_plugins/jq/index.md
+++ b/app/_kong_plugins/jq/index.md
@@ -16,11 +16,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: jq.png
 
 categories:

--- a/app/_kong_plugins/json-threat-protection/index.md
+++ b/app/_kong_plugins/json-threat-protection/index.md
@@ -19,11 +19,15 @@ works_on:
 min_version:
     gateway: '3.8'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: json-threat-protection.png
 
 categories:

--- a/app/_kong_plugins/jwe-decrypt/index.md
+++ b/app/_kong_plugins/jwe-decrypt/index.md
@@ -19,11 +19,15 @@ works_on:
 min_version:
     gateway: '3.1'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: jwe-decrypt.png
 
 categories:

--- a/app/_kong_plugins/jwt-signer/index.md
+++ b/app/_kong_plugins/jwt-signer/index.md
@@ -16,10 +16,11 @@ works_on:
     - on-prem
 
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
 
 icon: jwt-signer.png
 

--- a/app/_kong_plugins/jwt/index.md
+++ b/app/_kong_plugins/jwt/index.md
@@ -15,6 +15,16 @@ works_on:
     - on-prem
     - konnect
 
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
+
 icon: jwt.png
 
 categories:

--- a/app/_kong_plugins/kafka-log/index.md
+++ b/app/_kong_plugins/kafka-log/index.md
@@ -16,11 +16,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: kafka-log.png
 
 categories:

--- a/app/_kong_plugins/kafka-upstream/index.md
+++ b/app/_kong_plugins/kafka-upstream/index.md
@@ -17,11 +17,15 @@ works_on:
     - konnect
 
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: kafka-upstream.png
 
 categories:

--- a/app/_kong_plugins/key-auth-enc/index.md
+++ b/app/_kong_plugins/key-auth-enc/index.md
@@ -15,11 +15,11 @@ products:
 works_on:
     - on-prem
 
-
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
 
 icon: key-auth-enc.png
 

--- a/app/_kong_plugins/key-auth/index.md
+++ b/app/_kong_plugins/key-auth/index.md
@@ -15,6 +15,16 @@ works_on:
     - on-prem
     - konnect
 
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
+
 icon: key-auth.png
 
 categories:

--- a/app/_kong_plugins/ldap-auth-advanced/index.md
+++ b/app/_kong_plugins/ldap-auth-advanced/index.md
@@ -16,11 +16,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: ldap-auth-advanced.png
 
 categories:

--- a/app/_kong_plugins/ldap-auth/index.md
+++ b/app/_kong_plugins/ldap-auth/index.md
@@ -15,11 +15,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: ldap-auth.png
 
 categories:

--- a/app/_kong_plugins/loggly/index.md
+++ b/app/_kong_plugins/loggly/index.md
@@ -15,11 +15,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: loggly.png
 
 categories:

--- a/app/_kong_plugins/mocking/index.md
+++ b/app/_kong_plugins/mocking/index.md
@@ -18,9 +18,14 @@ works_on:
     - konnect
 
 topologies:
+  on_prem:
     - hybrid
     - db-less
     - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 
 icon: mocking.png
 

--- a/app/_kong_plugins/mtls-auth/index.md
+++ b/app/_kong_plugins/mtls-auth/index.md
@@ -16,10 +16,14 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
 
 icon: mtls-auth.png
 

--- a/app/_kong_plugins/oas-validation/index.md
+++ b/app/_kong_plugins/oas-validation/index.md
@@ -19,11 +19,15 @@ works_on:
 min_version:
     gateway: '3.1'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: oas-validation.png
 
 categories:

--- a/app/_kong_plugins/oauth2-introspection/index.md
+++ b/app/_kong_plugins/oauth2-introspection/index.md
@@ -16,11 +16,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: oauth2-introspection.png
 
 categories:

--- a/app/_kong_plugins/oauth2/index.md
+++ b/app/_kong_plugins/oauth2/index.md
@@ -14,10 +14,9 @@ products:
 works_on:
     - on-prem
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
+topologies:
+  on_prem:
+    - traditional
 
 icon: oauth2.png
 

--- a/app/_kong_plugins/opa/index.md
+++ b/app/_kong_plugins/opa/index.md
@@ -16,11 +16,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: opa.png
 
 categories:

--- a/app/_kong_plugins/openid-connect/index.md
+++ b/app/_kong_plugins/openid-connect/index.md
@@ -17,11 +17,15 @@ works_on:
     - konnect
 
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: openid-connect.png
 
 categories:

--- a/app/_kong_plugins/opentelemetry/index.md
+++ b/app/_kong_plugins/opentelemetry/index.md
@@ -18,11 +18,15 @@ works_on:
 min_version:
     gateway: '3.1'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: opentelemetry.png
 
 categories:

--- a/app/_kong_plugins/post-function/index.md
+++ b/app/_kong_plugins/post-function/index.md
@@ -16,11 +16,15 @@ works_on:
     - konnect
 
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: post-function.png
 
 categories:

--- a/app/_kong_plugins/pre-function/index.md
+++ b/app/_kong_plugins/pre-function/index.md
@@ -16,11 +16,15 @@ works_on:
     - konnect
 
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: pre-function.png
 
 categories:

--- a/app/_kong_plugins/prometheus/index.md
+++ b/app/_kong_plugins/prometheus/index.md
@@ -15,11 +15,13 @@ works_on:
     - on-prem
     - konnect
 
-
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
 
 icon: prometheus.png
 

--- a/app/_kong_plugins/proxy-cache-advanced/index.md
+++ b/app/_kong_plugins/proxy-cache-advanced/index.md
@@ -16,11 +16,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: proxy-cache-advanced.png
 
 categories:

--- a/app/_kong_plugins/proxy-cache/index.md
+++ b/app/_kong_plugins/proxy-cache/index.md
@@ -16,11 +16,15 @@ works_on:
     - konnect
 
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: proxy-cache.png
 
 categories:

--- a/app/_kong_plugins/rate-limiting-advanced/index.md
+++ b/app/_kong_plugins/rate-limiting-advanced/index.md
@@ -21,6 +21,16 @@ works_on:
     - on-prem
     - konnect
 
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
+
 icon: rate-limiting-advanced.png
 
 categories:

--- a/app/_kong_plugins/rate-limiting/index.md
+++ b/app/_kong_plugins/rate-limiting/index.md
@@ -32,9 +32,14 @@ works_on:
     - konnect
 
 topologies:
+  on_prem:
     - hybrid
     - db-less
     - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 
 icon: rate-limiting.png
 

--- a/app/_kong_plugins/redirect/index.md
+++ b/app/_kong_plugins/redirect/index.md
@@ -18,11 +18,15 @@ works_on:
 min_version:
     gateway: '3.9'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: redirect.png
 
 categories:

--- a/app/_kong_plugins/request-size-limiting/index.md
+++ b/app/_kong_plugins/request-size-limiting/index.md
@@ -16,11 +16,15 @@ works_on:
     - konnect
 
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: request-size-limiting.png
 
 categories:

--- a/app/_kong_plugins/request-termination/index.md
+++ b/app/_kong_plugins/request-termination/index.md
@@ -15,11 +15,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: request-termination.png
 
 categories:

--- a/app/_kong_plugins/request-transformer-advanced/index.md
+++ b/app/_kong_plugins/request-transformer-advanced/index.md
@@ -16,11 +16,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: request-transformer-advanced.png
 
 categories:

--- a/app/_kong_plugins/request-transformer/index.md
+++ b/app/_kong_plugins/request-transformer/index.md
@@ -15,11 +15,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: request-transformer.png
 
 categories:

--- a/app/_kong_plugins/request-validator/index.md
+++ b/app/_kong_plugins/request-validator/index.md
@@ -16,11 +16,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: request-validator.png
 
 categories:

--- a/app/_kong_plugins/response-ratelimiting/index.md
+++ b/app/_kong_plugins/response-ratelimiting/index.md
@@ -17,6 +17,16 @@ works_on:
     - on-prem
     - konnect
 
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
+
 icon: response-ratelimiting.png
 
 categories:

--- a/app/_kong_plugins/response-transformer-advanced/index.md
+++ b/app/_kong_plugins/response-transformer-advanced/index.md
@@ -17,11 +17,15 @@ works_on:
     - konnect
 
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: response-transformer-advanced.png
 
 categories:

--- a/app/_kong_plugins/response-transformer/index.md
+++ b/app/_kong_plugins/response-transformer/index.md
@@ -16,11 +16,15 @@ works_on:
     - konnect
 
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: response-transformer.png
 
 categories:

--- a/app/_kong_plugins/route-by-header/index.md
+++ b/app/_kong_plugins/route-by-header/index.md
@@ -16,11 +16,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: route-by-header.png
 
 categories:

--- a/app/_kong_plugins/route-transformer-advanced/index.md
+++ b/app/_kong_plugins/route-transformer-advanced/index.md
@@ -17,11 +17,15 @@ works_on:
     - konnect
 
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: route-transformer-advanced.png
 
 categories:

--- a/app/_kong_plugins/saml/index.md
+++ b/app/_kong_plugins/saml/index.md
@@ -19,11 +19,15 @@ works_on:
 min_version:
     gateway: '3.1'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: saml.png
 
 categories:

--- a/app/_kong_plugins/service-protection/index.md
+++ b/app/_kong_plugins/service-protection/index.md
@@ -19,11 +19,15 @@ works_on:
 min_version:
     gateway: '3.9'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: service-protection.png
 
 categories:

--- a/app/_kong_plugins/session/index.md
+++ b/app/_kong_plugins/session/index.md
@@ -15,11 +15,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: session.png
 
 categories:

--- a/app/_kong_plugins/standard-webhooks/index.md
+++ b/app/_kong_plugins/standard-webhooks/index.md
@@ -18,11 +18,15 @@ works_on:
 min_version:
     gateway: '3.8'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: standard-webhooks.png
 
 categories:

--- a/app/_kong_plugins/statsd-advanced/index.md
+++ b/app/_kong_plugins/statsd-advanced/index.md
@@ -17,11 +17,15 @@ works_on:
     - konnect
 
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: statsd-advanced.png
 
 categories:

--- a/app/_kong_plugins/statsd/index.md
+++ b/app/_kong_plugins/statsd/index.md
@@ -16,11 +16,15 @@ works_on:
     - konnect
 
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: statsd.png
 
 categories:

--- a/app/_kong_plugins/syslog/index.md
+++ b/app/_kong_plugins/syslog/index.md
@@ -15,11 +15,13 @@ works_on:
     - on-prem
     - konnect
 
-
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
 
 icon: syslog.png
 

--- a/app/_kong_plugins/tcp-log/index.md
+++ b/app/_kong_plugins/tcp-log/index.md
@@ -15,11 +15,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: tcp-log.png
 
 categories:

--- a/app/_kong_plugins/tls-handshake-modifier/index.md
+++ b/app/_kong_plugins/tls-handshake-modifier/index.md
@@ -19,10 +19,14 @@ works_on:
 min_version:
     gateway: '3.1'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
 
 icon: tls-handshake-modifier.png
 

--- a/app/_kong_plugins/tls-metadata-headers/index.md
+++ b/app/_kong_plugins/tls-metadata-headers/index.md
@@ -19,10 +19,14 @@ works_on:
 min_version:
     gateway: '3.1'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
 
 icon: tls-metadata-headers.png
 

--- a/app/_kong_plugins/udp-log/index.md
+++ b/app/_kong_plugins/udp-log/index.md
@@ -15,11 +15,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: udp-log.png
 
 categories:

--- a/app/_kong_plugins/upstream-oauth/index.md
+++ b/app/_kong_plugins/upstream-oauth/index.md
@@ -19,11 +19,15 @@ works_on:
 min_version:
     gateway: '3.8'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: upstream-oauth.png
 
 categories:

--- a/app/_kong_plugins/upstream-timeout/index.md
+++ b/app/_kong_plugins/upstream-timeout/index.md
@@ -16,11 +16,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: upstream-timeout.png
 
 categories:

--- a/app/_kong_plugins/vault-auth/index.md
+++ b/app/_kong_plugins/vault-auth/index.md
@@ -15,10 +15,11 @@ products:
 works_on:
     - on-prem
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
 
 icon: vault-auth.png
 

--- a/app/_kong_plugins/websocket-size-limit/index.md
+++ b/app/_kong_plugins/websocket-size-limit/index.md
@@ -19,11 +19,15 @@ works_on:
 min_version:
     gateway: '3.1'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: websocket-size-limit.png
 
 categories:

--- a/app/_kong_plugins/websocket-validator/index.md
+++ b/app/_kong_plugins/websocket-validator/index.md
@@ -19,11 +19,15 @@ works_on:
 min_version:
     gateway: '3.1'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: websocket-validator.png
 
 categories:

--- a/app/_kong_plugins/xml-threat-protection/index.md
+++ b/app/_kong_plugins/xml-threat-protection/index.md
@@ -19,11 +19,15 @@ works_on:
 min_version:
     gateway: '3.1'
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: xml-threat-protection.png
 
 categories:

--- a/app/_kong_plugins/zipkin/index.md
+++ b/app/_kong_plugins/zipkin/index.md
@@ -15,11 +15,15 @@ works_on:
     - on-prem
     - konnect
 
-# topologies:
-#    - hybrid
-#    - db-less
-#    - traditional
-
+topologies:
+  on_prem:
+    - hybrid
+    - db-less
+    - traditional
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 icon: zipkin.png
 
 categories:


### PR DESCRIPTION
Fixes #244 

Adding the `on_prem` and `konnect_deployments` categories to plugin `topologies`.

The rule should now be:
* All plugins must have a `topologies` key with at least one entry
* At least one of `on-prem` or `konnect_deployments` must exist, but it doesn't have to have both
* Some plugins have no `konnect_deployments` key because they're not supported in konnect at all

### Preview Links



### Checklist 

- [x] Every page is page one
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenereted instructions render correctly (API, decK, Konnect). 
- [x] Style guide (capital gateway entities, placeholder URLs) implemented correctly.
