### PR TITLE
fix: Remove square brackets from PR template issue number [skip ci]

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Description
 
-Fixes [#issue]
+Fixes #issue
 
 ## Preview Links
 


### PR DESCRIPTION
## Description

Don't need the square brackets because GH auto-links the issue by its number.

## Preview Links


## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.