### PR TITLE
chore: QA for the entity docs

### DIFF
--- a/app/_gateway_entities/admin.md
+++ b/app/_gateway_entities/admin.md
@@ -16,7 +16,7 @@ related_resources:
   - text: Workspace entity
     url: /gateway/entities/workspace/
   - text: Sending Email with Kong Manager
-    url: /how-to/configure-kong-manager-email
+    url: /how-to/configure-kong-manager-email/
     
 tier: enterprise
 
@@ -36,7 +36,7 @@ faqs:
 
 ---
 
-## What are Admins?
+## What is an Admin?
 Admins in {{site.base_gateway}} are [RBAC](/gateway/entities/rbac/) entities used to used to manage all administrators for a specific [Workspace](/gateway/entities/workspace/). 
 Admins can be managed using the Admin API or Kong Manager and are used in the following operations:
 

--- a/app/_gateway_entities/ca-certificate.md
+++ b/app/_gateway_entities/ca-certificate.md
@@ -11,6 +11,8 @@ related_resources:
     url: /gateway/entities/certificate/
   - text: Mutual TLS Authentication plugin
     url: /plugins/mtls-auth/
+  - text: Header Cert Authentication plugin
+    url: /plugins/header-cert-auth/
   - text: Define Service-level CA certificate
     url: /how-to/ca-cert-for-server-on-service/
   - text: SSL certificates reference

--- a/app/_gateway_entities/consumer-group.md
+++ b/app/_gateway_entities/consumer-group.md
@@ -18,6 +18,8 @@ tier: enterprise
 related_resources:
     - text: Create rate limiting tiers with {{site.base_gateway}}
       url: /how-to/add-rate-limiting-tiers-with-kong-gateway/
+    - text: Consumer entity
+      url: /gateway/entities/consumer/
 
 api_specs:
     - gateway/admin-ee
@@ -38,6 +40,10 @@ faqs:
   - q: When a Consumer is part of multiple Consumer Groups, how is precedence determined?
     a: |
       Currently, this is determined by the Group name, in alphabetical order. For more details, see [Plugin precedence](/plugins/scopes/#plugin-precedence).
+
+schema:
+    api: gateway/admin-ee
+    path: /schemas/Consumer-Group
 ---
 
 ## What is a Consumer Group?

--- a/app/_gateway_entities/consumer.md
+++ b/app/_gateway_entities/consumer.md
@@ -9,8 +9,8 @@ description: A Consumer typically refers to an entity that consumes or uses the 
 related_resources:
   - text: Authentication in {{site.base_gateway}}
     url: /authentication/
-  - text: Consumer Groups API reference
-    url: /api/gateway/admin-ee/#/operations/get-consumer_groups
+  - text: Consumer Groups entity
+    url: /gateway/entities/consumer-group/
   - text: Plugins that can be enabled on Consumers
     url: /plugins/scopes/
 
@@ -78,7 +78,8 @@ schema:
 
 ## What is a Consumer?
 
-{{ page.description | liquify }} Consumers can be applications, services, or users who interact with your APIs.
+A Consumer typically refers to an entity that consumes or uses the APIs managed by {{site.base_gateway}}.
+Consumers can be applications, services, or users who interact with your APIs.
 Since they are not always human, {{site.base_gateway}} calls them Consumers, because they "consume" the service.
 {{site.base_gateway}} allows you to define and manage Consumers, apply access control policies, and monitor their API usage.
 

--- a/app/_gateway_entities/event-hook.md
+++ b/app/_gateway_entities/event-hook.md
@@ -10,6 +10,14 @@ related_resources:
     url: /gateway/entities/service/
   - text: Routing in {{site.base_gateway}}
     url: /gateway/routing/
+  - text: Create a Web Hook with {{site.base_gateway}}
+    url: /how-to/create-a-webhook-with-kong-gateway/
+  - text: Push Event Hook information to Slack with {{site.base_gateway}}
+    url: /how-to/create-a-custom-webhook-slack-with-kong-gateway/
+  - text: How to create a log Event Hook with {{site.base_gateway}}
+    url: /how-to/create-a-log-event-hook-with-kong-gateway/
+  - text: Configure an Event Hook to log events with {{site.base_gateway}}
+    url: /how-to/create-a-lambda-event-hook-with-kong-gateway/
 products:
     - gateway
 tools:
@@ -21,9 +29,9 @@ schema:
 
 ---
 
-## What is an Event Hook
+## What is an Event Hook?
 
-An Event Hook is a {{site.base_gateway}} entity that can be configured to listen for specific events from Kong entities. An Event Hook can be configured to send information to logs, or web hooks as well as third-party applications. 
+An Event Hook is a {{site.base_gateway}} entity that can be configured to listen for specific events from Kong entities. An Event Hook can be configured to send information to logs, webhooks, or third-party applications. 
 
 ## How do Event Hooks work?
 
@@ -74,7 +82,7 @@ There are four types of handlers that can be used with Event Hooks:
 * **`webhook-custom`**: Fully configurable request. Supports templating, configurable body, payload, and headers. 
 * **`lambda`**: This handler runs Lua code after an event is triggered.
 
-By default, the `lambda` handler is "Sandboxed". Sandboxing means that {{site.base_gateway}} restricts the types of Lua functions that can be loaded as well as the level of access to {{site.base_gateway}} that is available for these custom functions. For example, in `sandbox` mode, a `lambda` Event Hook will not have access to global values such as `kong.configuration.pg_password`, or OS level functions like `os.execute(rm -rf /*)`, but can still run Lua code like `local foo = 1 + 1`. Removing `sandbox` requires editing the `kong.conf` value `untrusted_lua`, for more information see the [kong.conf documentation](https://docs.konghq.com/gateway/3.9.x/reference/configuration/#untrusted_lua).
+By default, the `lambda` handler is "Sandboxed". Sandboxing means that {{site.base_gateway}} restricts the types of Lua functions that can be loaded as well as the level of access to {{site.base_gateway}} that is available for these custom functions. For example, in `sandbox` mode, a `lambda` Event Hook will not have access to global values such as `kong.configuration.pg_password`, or OS level functions like `os.execute(rm -rf /*)`, but can still run Lua code like `local foo = 1 + 1`. Removing `sandbox` requires editing the `kong.conf` value `untrusted_lua`, for more information see the [kong.conf documentation](/gateway/configuration/#untrusted_lua).
 
 ### Sources
 
@@ -134,7 +142,8 @@ These parameters can be used to issue notifications any time an upstream in your
 - `crud`: Create, read, and update events from {{site.base_gateway}} entities such as Consumers.
 - `oas-validation`: Runs an event when [OAS validation Plugin](/plugins/oas-validation/) fails.
 
-For information about specific events related to a source issue a `GET` request to the `/event-hooks/sources/{source}` endpoint. Doing so will return a list of all of the events associated to a source like: `balancer: health`. 
+For information about specific events related to a source, issue a `GET` request to the `/event-hooks/sources/{source}` endpoint. 
+The API returns a list of all of the events associated to a source in the following format: `balancer: health`. 
 
 ## Schema
 
@@ -152,15 +161,3 @@ data:
   config:
       "url": "$WEBHOOK_URL"
 {% endentity_example %}
-
-
-## Configure an Event Hook
-
-
-For step-by-step guides on configuring Event Hooks see the following docs: 
-
-* [Create a Web Hook with {{site.base_gateway}}](/how-to/create-a-webhook-with-kong-gateway/)
-* [Push Event Hook information to Slack with {{site.base_gateway}}](/how-to/create-a-custom-webhook-slack-with-kong-gateway/)
-* [How to create a log Event Hook with {{site.base_gateway}}](/how-to/create-a-log-event-hook-with-kong-gateway/)
-* [Configure an Event Hook to log events with {{site.base_gateway}}](/how-to/create-a-lambda-event-hook-with-kong-gateway/)
-

--- a/app/_gateway_entities/license.md
+++ b/app/_gateway_entities/license.md
@@ -24,16 +24,16 @@ related_resources:
 
 faqs: 
   - q: How do I make sure the License is deployed to data plane nodes correctly in hybrid mode?
-    a: In hybrid mode, the license file must be deployed to each control plane and data plane node. As long as you deploy the License with the [`/licenses` Admin API endpoint](/api/gateway/admin-ee/#/operations/post-licenses), the control plane automatically applies the License to it's data plane nodes. 
+    a: In hybrid mode, the license file must be deployed to each control plane and data plane node. As long as you deploy the License with the [`/licenses` Admin API endpoint](/api/gateway/admin-ee/#/operations/post-licenses), the control plane automatically applies the License to its data plane nodes. 
   - q: What happens to the license file in traditional mode when there are no separate control planes? 
-    a: The license file must be deployed to each node running {{site.base_gateway}}.
+    a: The license file must be manually deployed to each node running {{site.base_gateway}}.
 ---
 
 ## What is a License?
 
 A License entity allows you configure a License in your {{site.base_gateway}} cluster, in both [traditional and hybrid mode deployments](/gateway/deployment-topologies/). {{site.base_gateway}} can be used with or without a License. A License is required to use [{{site.base_gateway}} Enterprise features](/gateway/enterprise-vs-oss/).
 
-A license file when you sign up for a {{site.konnect_product_name}} Enterprise subscription. [Contact Kong](https://support.konghq.com) for more information. If you purchased a subscription but haven’t received a license file, contact your sales representative.
+You receive a license file when you sign up for a {{site.konnect_product_name}} Enterprise subscription. If you purchased a subscription but haven’t received a license file, contact your sales representative.
 
 Kong checks for a license in the following order:
 
@@ -130,7 +130,7 @@ After a License expires, {{site.base_gateway}} behaves as follows:
 
 * All configured Enterprise-specific features become read-only
 * You can't configure additional Enterprise features
-* You can continue to access Kong Manager and change it's configuration
+* You can continue to access Kong Manager and change its configuration
 * You can continue to use OSS features via the Admin API
 * All proxy traffic, including Enterprise plugin traffic, continues to be processed as if the License wasn't expired
 * You can still restart and scale nodes in traditional mode
@@ -152,7 +152,7 @@ You can share the report with Kong Support to perform a health-check analysis of
 |-------|-------------|
 | `license path environment variable not set` | The `KONG_LICENSE_DATA` or `KONG_LICENSE_PATH` environment variables weren't defined. No license file could be opened at the default license location (`/etc/kong/license.json`). |
 | `error opening license file` | The license file defined either in the default location, or using the `KONG_LICENSE_PATH` env variable, couldn't be opened. Check that the user executing the Nginx process (e.g., the user executing the Kong CLI utility) has permissions to read this file. |
-| `error reading license file` | The license file defined either in the default location, or using the `KONG_LICENSE_PATH` env variable, could be opened, but an error occurred while reading it. Confirm that the file isn't corrupt, that there are no kernel error messages reported (e.g., out of memory conditions, etc). |
+| `error reading license file` | The license file defined either in the default location, or using the `KONG_LICENSE_PATH` env variable, could be opened, but an error occurred while reading it. Confirm that the file isn't corrupt, and that there are no kernel error messages reported (e.g., out of memory conditions, etc). |
 | `could not decode license json` | The license file data couldn't be decoded as valid JSON. Confirm that the file isn't corrupt and hasn't been altered since you received it from Kong. Try re-downloading and installing your license file from Kong. If you still receive this error after reinstallation, [contact Kong support](https://support.konghq.com). |
 | `invalid license format` | The license file data is missing one or more key/value pairs. Confirm that the file isn't corrupt and hasn't been altered since you received it from Kong. Try re-downloading and installing your license file from Kong. If you still receive this error after reinstallation, [contact Kong support](https://support.konghq.com). |
 | `validation failed` | Verifying the payload of the License with the License's signature failed. Confirm that the file isn't corrupt and hasn't been altered since you received it from Kong. Try re-downloading and installing your license file from Kong. If you still receive this error after reinstallation, [contact Kong support](https://support.konghq.com). |

--- a/app/_gateway_entities/service.md
+++ b/app/_gateway_entities/service.md
@@ -34,7 +34,7 @@ api_specs:
 
 ## What is a Gateway Service?
 
-{{ page.description | liquify }} 
+A Gateway Service is an abstraction of an upstream application that services requests.
 Services can store collections of objects like plugin configurations, and policies, and they can be associated with routes.
 
 When defining a Service, the administrator provides a name and the upstream application connection information. 

--- a/app/_gateway_entities/sni.md
+++ b/app/_gateway_entities/sni.md
@@ -8,7 +8,7 @@ description: An SNI object represents a many-to-one mapping of hostnames to a ce
 
 related_resources:
   - text: Certificates
-    url: /gateway/entities/certificate
+    url: /gateway/entities/certificate/
       
 tools:
     - admin-api
@@ -29,7 +29,7 @@ schema:
 
 ## What is an SNI?
 
-An SNI (Server Name Indication) is used to map multiple hostnames to a [Certificate](/gateway/entities/certificate). It allows {{site.base_gateway}} to select which SSL/TLS Certificate to use based on the hostname in the client request. This feature ensures that multiple domains can be securely served through the same gateway.
+An SNI (Server Name Indication) is used to map multiple hostnames to a [Certificate](/gateway/entities/certificate/). It allows {{site.base_gateway}} to select which SSL/TLS Certificate to use based on the hostname in the client request. This feature ensures that multiple domains can be securely served through the same gateway.
 
 ## Schema
 

--- a/app/_gateway_entities/target.md
+++ b/app/_gateway_entities/target.md
@@ -27,7 +27,8 @@ schema:
 
 ## What is a Target?
 
-{{page.description | liquify}} Each [Upstream](/gateway/entities/upstream/) can have many Targets. Targets are used by Upstreams for [load balancing](https://docs.konghq.com/gateway/latest/how-kong-works/load-balancing/). For example, if you have an `example_upstream` Upstream, you can point it to two different Targets: `httpbin.konghq.com` and `httpbun.com`. This is so that if one of the servers (like `httpbin.konghq.com`) is unavailable, it automatically detects the problem and routes all traffic to the working server (`httpbun.com`).
+A Target is an IP address/hostname with a port that identifies an instance of a backend service.
+Each [Upstream](/gateway/entities/upstream/) can have many Targets. Targets are used by Upstreams for [load balancing](https://docs.konghq.com/gateway/latest/how-kong-works/load-balancing/). For example, if you have an `example_upstream` Upstream, you can point it to two different Targets: `httpbin.konghq.com` and `httpbun.com`. This is so that if one of the servers (like `httpbin.konghq.com`) is unavailable, it automatically detects the problem and routes all traffic to the working server (`httpbun.com`).
 
 The following diagram illustrates how Targets are used by Upstreams for load balancing:
 

--- a/app/_gateway_entities/upstream.md
+++ b/app/_gateway_entities/upstream.md
@@ -59,7 +59,7 @@ The following are examples of common use cases for Upstreams:
 |----------|-------------|
 | Load balance | When an Upstream points to multiple upstream targets, you can configure the Upstream entity to load balance traffic between the targets. If you don't need to load balance, we recommend using the `host` header on a [Route](/gateway/entities/route/) as the preferred method for routing a request and proxying traffic.|
 | Health check | Configure Upstreams to dynamically mark a target as healthy or unhealthy. This is an active check where a specific HTTP or HTTPS endpoint in the target is periodically requested and the health of the target is determined based on its response. |
-| Circuit break | Configure Upstreams to allow {{site.base_gateway}} to passively analyze the ongoing traffic being proxied and determine the health of targets based on their behavior responding to requests. **Note:** This feature is not supported in hybrid mode. |
+| Circuit break | Configure Upstreams to allow {{site.base_gateway}} to passively analyze the ongoing traffic being proxied and determine the health of targets based on their behavior responding to requests. <br><br>**Note:** This feature is not supported in hybrid mode. |
 
 ## Schema
 

--- a/app/_gateway_entities/vault.md
+++ b/app/_gateway_entities/vault.md
@@ -8,23 +8,16 @@ description: A Vault is used to store secrets.
 
 related_resources:
   - text: Secrets Management
-    url: /secrets-management
+    url: /secrets-management/
   - text: Workspaces
-    url: /gateway/entities/workspace 
+    url: /gateway/entities/workspace/
   - text: RBAC 
-    url: /gateway/entities/rbac
+    url: /gateway/entities/rbac/
   
 
 faqs:
-  - q: What are general best practices for managing Vaults?
-    a: |
-        To keep your environment secure and avoid taking down your proxies by accident, make sure to:
-        * Manage Vaults with distributed configuration via tags.
-        * Use a separate [RBAC role, user, and token](/gateway/entities/rbac/)
-        to manage Vaults. Don't use a generic admin user.
-        * Set up a separate CI pipeline for Vaults.
   - q: What types of fields can be used in Vaults?
-    a: Vault works with "referenceable" fields. All fields in `kong.conf` are referenceable and some fields within entities (ex. plugins, certificates) are also. Refer to the appropriate entity documentation to learn more.
+    a: Vaults work with "referenceable" fields. All fields in `kong.conf` are referenceable and some fields within entities (for example, plugins, certificates) are also. Refer to the appropriate entity documentation to learn more.
   - q: Can Vaults be referenced during custom plugin development?
     a: Yes. The plugin development kit (PDK) offers a Vaults module (`kong.vault`) that can be used to resolve, parse, and verify Vault references.
   - q: What data types can I use when referencing a secret in a Vault?
@@ -120,7 +113,7 @@ features:
 
 <sup>1</sup> You can use environment variables as a Vaults backend either with or without using the Vaults entity.
 
-## How do I reference secrets stored in a Vault
+## How do I reference secrets stored in a Vault?
 
 When you want to use a secret stored in a Vault, you can reference the secret with a `vault` reference. You can use the `vault` reference in places such as `kong.conf`, declarative configuration files, logs, or in the UI.
 
@@ -145,19 +138,29 @@ Would point to a secret object called `pg` inside a HashiCorp Vault, which may r
 `{vault://hcv/pg/username}`.
 <!-- vale on -->
 
-## Secret rotation in Vault
+## Secret rotation in Vaults
 
 By default, {{site.base_gateway}} automatically rotates secrets *once every minute* in the background. You can also configure how often {{site.base_gateway}} rotates secrets using the Vault entity configuration. 
 
 There are two types of rotation configuration available: 
-* Rotate periodically using TTLs (for example: check for a new TLS certificate once per day)
-* Rotate on failure (for example: on a database authentication failure, check if the secrets were updated, and try again)
+* Rotate periodically using TTLs: For example, check for a new TLS certificate once per day.
+* Rotate on failure: For example, on a database authentication failure, check if the secrets were updated, and try again.
 
 For more information, see [Secret management](/secrets-management/).
 
-## Declarative configuration (decK) best practices for Vaults
+## Best practices for Vaults
 
-For larger teams with many contributors, or organizations with multiple teams, we recommend splitting Vault configurations into separate files and managing them isolated from other [entities's](/gateway/entities/) configuration using tags. We recommend splitting the configuration for the following reasons:
+### General best practices
+
+To keep your environment secure and avoid taking down your proxies by accident, make sure to:
+* Manage Vaults with distributed configuration via tags.
+* Use a separate [RBAC role, user, and token](/gateway/entities/rbac/).
+to manage Vaults. Don't use a generic admin user.
+* Set up a separate CI pipeline for Vaults.
+
+### Best practices for managing Vaults using decK
+
+For larger teams with many contributors, or organizations with multiple teams, we recommend splitting Vault configurations into separate files and managing them isolated from other [entities'](/gateway/entities/) configuration using tags. We recommend splitting the configuration for the following reasons:
 * Vaults are closer to infrastructure than other {{site.base_gateway}} configurations. Separation of routing policies from infrastructure-specific configurations helps keep configuration organized.
 * Vaults may be shared across teams. In this case, one specific team shouldn't control the Vault's configuration. One team changing the Vault a can have a negative impact on another team.
 * If a Vault is deleted while in use -- that is, if there are still references to secrets in a Vault in configuration -- it can lead to total loss of proxy capabilities. Those secrets would be unrecoverable.


### PR DESCRIPTION
## Description

Since we have migrated all the Gateway Entities, I went over and did a surface-level QA of all the entity pages.

Some particular callouts:
* For RBAC, there was some residual content from portal and inconsistency in the examples. I went through and tested that one thoroughly to make sure it works now.
* Moved the Vaults best practices from the Q&A into the body of the doc, to place it together with decK best practices. Otherwise, it'll get confusing.
* Moved event hooks related links into metadata
* consumer groups schemas doesn't exist, created an issue to track that

## Preview Links


## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.