### PR TITLE
Add kong conf table

### DIFF
--- a/app/_data/kong-conf/3.4.json
+++ b/app/_data/kong-conf/3.4.json
@@ -1,0 +1,1410 @@
+{
+  "prefix": {
+    "defaultValue": "/usr/local/kong/",
+    "description": "Working directory. Equivalent to Nginx's prefix path, containing temporary files and logs. Each Kong process must have a separate working directory."
+  },
+  "log_level": {
+    "defaultValue": "notice",
+    "description": "Log level of the Nginx server. Logs are found at `<prefix>/logs/error.log`."
+  },
+  "proxy_access_log": {
+    "defaultValue": "logs/access.log",
+    "description": "Path for proxy port request access logs. Set this value to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "proxy_error_log": {
+    "defaultValue": "logs/error.log",
+    "description": "Path for proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "proxy_stream_access_log": {
+    "defaultValue": "logs/access.log basic",
+    "description": "Path for tcp streams proxy port access logs. Set this value to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location. `basic` is defined as `'$remote_addr [$time_local] ' '$protocol $status $bytes_sent $bytes_received ' '$session_time'`"
+  },
+  "proxy_stream_error_log": {
+    "defaultValue": "logs/error.log",
+    "description": "Path for tcp streams proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "admin_access_log": {
+    "defaultValue": "logs/admin_access.log",
+    "description": "Path for Admin API request access logs. If Hybrid Mode is enabled and the current node is set to be the Control Plane, then the connection requests from Data Planes are also written to this file with server name \"kong_cluster_listener\".  Set this value to `off` to disable logging Admin API requests. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "admin_error_log": {
+    "defaultValue": "logs/error.log",
+    "description": "Path for Admin API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "status_access_log": {
+    "defaultValue": "off",
+    "description": "Path for Status API request access logs. The default value of `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "status_error_log": {
+    "defaultValue": "logs/status_error.log",
+    "description": "Path for Status API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "debug_access_log": {
+    "defaultValue": "off",
+    "description": "Path for Debug API request access logs. The default value of `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "debug_error_log": {
+    "defaultValue": "logs/debug_error.log",
+    "description": "Path for Debug API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "vaults": {
+    "defaultValue": "bundled",
+    "description": "Comma-separated list of vaults this node should load. By default, all the bundled vaults are enabled.  The specified name(s) will be substituted as such in the Lua namespace: `kong.vaults.{name}.*`."
+  },
+  "opentelemetry_tracing": {
+    "defaultValue": "off",
+    "description": "Deprecated: use tracing_instrumentations instead"
+  },
+  "tracing_instrumentations": {
+    "defaultValue": "off",
+    "description": "Comma-separated list of tracing instrumentations this node should load. By default, no instrumentations are enabled.  Valid values to this setting are:  - `off`: do not enable instrumentations. - `request`: only enable request-level instrumentations. - `all`: enable all the following instrumentations. - `db_query`: trace database query - `dns_query`: trace DNS query. - `router`: trace router execution, including   router rebuilding. - `http_client`: trace OpenResty HTTP client requests. - `balancer`: trace balancer retries. - `plugin_rewrite`: trace plugins iterator   execution with rewrite phase. - `plugin_access`: trace plugins iterator   execution with access phase. - `plugin_header_filter`: trace plugins iterator   execution with header_filter phase.  **Note:** In the current implementation, tracing instrumentations are not enabled in stream mode."
+  },
+  "opentelemetry_tracing_sampling_rate": {
+    "defaultValue": "1.0",
+    "description": "Deprecated: use tracing_sampling_rate instead"
+  },
+  "tracing_sampling_rate": {
+    "defaultValue": "0.01",
+    "description": "Tracing instrumentation sampling rate. Tracer samples a fixed percentage of all spans following the sampling rate.  Example: `0.25`, this should account for 25% of all traces."
+  },
+  "plugins": {
+    "defaultValue": "bundled",
+    "description": "Comma-separated list of plugins this node should load. By default, only plugins bundled in official distributions are loaded via the `bundled` keyword.  Loading a plugin does not enable it by default, but only instructs Kong to load its source code, and allows to configure the plugin via the various related Admin API endpoints.  The specified name(s) will be substituted as such in the Lua namespace: `kong.plugins.{name}.*`.  When the `off` keyword is specified as the only value, no plugins will be loaded.  `bundled` and plugin names can be mixed together, as the following examples suggest:  - `plugins = bundled,custom-auth,custom-log`   will include the bundled plugins plus two   custom ones - `plugins = custom-auth,custom-log` will   *only* include the `custom-auth` and   `custom-log` plugins. - `plugins = off` will not include any   plugins  **Note:** Kong will not start if some plugins were previously configured (i.e. have rows in the database) and are not specified in this list.  Before disabling a plugin, ensure all instances of it are removed before restarting Kong.  **Note:** Limiting the amount of available plugins can improve P99 latency when experiencing LRU churning in the database cache (i.e. when the configured `mem_cache_size`) is full."
+  },
+  "pluginserver_names": {
+    "defaultValue": null,
+    "description": "Comma-separated list of names for pluginserver processes.  The actual names are used for log messages and to relate the actual settings."
+  },
+  "pluginserver_XXX_socket": {
+    "defaultValue": "<prefix>/<XXX>.socket",
+    "description": "Path to the unix socket used by the <XXX> pluginserver."
+  },
+  "pluginserver_XXX_start_cmd": {
+    "defaultValue": "/usr/local/bin/<XXX>",
+    "description": "Full command (including any needed arguments) to start the <XXX> pluginserver"
+  },
+  "pluginserver_XXX_query_cmd": {
+    "defaultValue": "/usr/local/bin/query_<XXX>",
+    "description": "Full command to \"query\" the <XXX> pluginserver.  Should produce a JSON with the dump info of all plugins it manages"
+  },
+  "port_maps": {
+    "defaultValue": null,
+    "description": "With this configuration parameter, you can let the Kong to know about the port from which the packets are forwarded to it. This is fairly common when running Kong in a containerized or virtualized environment. For example, `port_maps=80:8000, 443:8443` instructs Kong that the port 80 is mapped to 8000 (and the port 443 to 8443), where 8000 and 8443 are the ports that Kong is listening to.  This parameter helps Kong set a proper forwarded upstream HTTP request header or to get the proper forwarded port with the Kong PDK (in case other means determining it has failed). It changes routing by a destination port to route by a port from which packets are forwarded to Kong, and similarly it changes the default plugin log serializer to use the port according to this mapping instead of reporting the port Kong is listening to."
+  },
+  "anonymous_reports": {
+    "defaultValue": "on",
+    "description": "Send anonymous usage data such as error stack traces to help improve Kong."
+  },
+  "proxy_server": {
+    "defaultValue": null,
+    "description": "Proxy server defined as a URL. Kong will only use this option if any component is explicitly configured to use proxy."
+  },
+  "proxy_server_ssl_verify": {
+    "defaultValue": "off",
+    "description": "Toggles server certificate verification if `proxy_server` is in HTTPS. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+  },
+  "error_template_html": {
+    "defaultValue": null,
+    "description": "Path to the custom html error template to override the default html kong error template.  The template may contain up to two `%s` placeholders. The first one will expand to the error message. The second one will expand to the request ID. Both placeholders are optional, but recommended. Adding more than two placeholders will result in a runtime error when trying to render the template: ``` <html>   <body>     <h1>My custom error template</h1>     <p>error: %s</p>     <p>request_id: %s</p>   </body> </html> ```"
+  },
+  "error_template_json": {
+    "defaultValue": null,
+    "description": "Path to the custom json error template to override the default json kong error template.  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+  },
+  "error_template_xml": {
+    "defaultValue": null,
+    "description": "Path to the custom xml error template to override the default xml kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+  },
+  "error_template_plain": {
+    "defaultValue": null,
+    "description": "Path to the custom plain error template to override the default plain kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+  },
+  "role": {
+    "defaultValue": "traditional",
+    "description": "Use this setting to enable Hybrid Mode, This allows running some Kong nodes in a control plane role with a database and have them deliver configuration updates to other nodes running to DB-less running in a Data Plane role.  Valid values to this setting are:  - `traditional`: do not use Hybrid Mode. - `control_plane`: this node runs in a   control plane role. It can use a database   and will deliver configuration updates   to data plane nodes. - `data_plane`: this is a data plane node.   It runs DB-less and receives configuration   updates from a control plane node."
+  },
+  "cluster_mtls": {
+    "defaultValue": "shared",
+    "description": "Sets the verification between nodes of the cluster.  Valid values to this setting are:  - `shared`: use a shared certificate/key   pair specified with the `cluster_cert`   and `cluster_cert_key` settings.   Note that CP and DP nodes have to present   the same certificate to establish mTLS   connections. - `pki`: use `cluster_ca_cert`,   `cluster_server_name` and `cluster_cert`   for verification.   These are different certificates for each   DP node, but issued by a cluster-wide   common CA certificate: `cluster_ca_cert`. - `pki_check_cn`: similar as `pki` but additionally   checks for Common Name of data plane certificate   specified in `cluster_allowed_common_names`."
+  },
+  "cluster_cert": {
+    "defaultValue": null,
+    "description": "Cluster certificate to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes.  Under `pki` mode it should be a different certificate for each DP node.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "cluster_cert_key": {
+    "defaultValue": null,
+    "description": "Cluster certificate key to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes.  Under `pki` mode it should be a different certificate for each DP node.  The certificate key can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+  },
+  "cluster_ca_cert": {
+    "defaultValue": null,
+    "description": "The trusted CA certificate file in PEM format used for Control Plane to verify Data Plane's certificate and Data Plane to verify Control Plane's certificate. Required on data plane if `cluster_mtls` is set to `pki`. If Control Plane certificate is issued by a well known CA, user can set `lua_ssl_trusted_certificate=system` on Data Plane and leave this field empty.  This field is ignored if `cluster_mtls` is set to `shared`.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "cluster_allowed_common_names": {
+    "defaultValue": null,
+    "description": "The list of Common Names that are allowed to connect to control plane. Multiple entries may be supplied in a comma-separated string. When not set, Data Plane with same parent domain of Control Plane cert is allowed to connect.  This field is ignored if `cluster_mtls` is not set to `pki_check_cn`."
+  },
+  "cluster_server_name": {
+    "defaultValue": null,
+    "description": "The server name used in the SNI of the TLS connection from a DP node to a CP node. Must match the Common Name (CN) or Subject Alternative Name (SAN) found in the CP certificate. If `cluster_mtls` is set to `shared`, this setting is ignored and `kong_clustering` is used."
+  },
+  "cluster_control_plane": {
+    "defaultValue": null,
+    "description": "To be used by data plane nodes only: address of the control plane node from which configuration updates will be fetched, in `host:port` format."
+  },
+  "cluster_telemetry_endpoint": {
+    "defaultValue": null,
+    "description": "To be used by data plane nodes only: telemetry address of the control plane node to which telemetry updates will be posted in `host:port` format."
+  },
+  "cluster_telemetry_server_name": {
+    "defaultValue": null,
+    "description": "The SNI (Server Name Indication extension) to use for Vitals telemetry data."
+  },
+  "cluster_dp_labels": {
+    "defaultValue": null,
+    "description": "Comma separated list of Labels for the data plane. Labels are key-value pairs that provide additional context information for each DP. Each label must be configured as a string in the format `key:value`.  Labels are only compatible with hybrid mode deployments with Kong Konnect (SaaS), this configuration doesn't work with self-hosted deployments.  Keys and values follow the AIP standards: https://kong-aip.netlify.app/aip/129/  Example: `deployment:mycloud,region:us-east-1`"
+  },
+  "cluster_listen": {
+    "defaultValue": "0.0.0.0:8005",
+    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster. This port is mTLS protected to ensure end-to-end security and integrity.  This setting has no effect if `role` is not set to `control_plane`.  Connection made to this endpoint are logged to the same location as Admin API access logs. See `admin_access_log` config description for more information."
+  },
+  "cluster_telemetry_listen": {
+    "defaultValue": "0.0.0.0:8006",
+    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane telemetry connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster.  This setting has no effect if `role` is not set to `control_plane`."
+  },
+  "cluster_data_plane_purge_delay": {
+    "defaultValue": "1209600",
+    "description": " How many seconds must pass from the time a DP node becomes offline to the time its entry gets removed from the database, as returned by the /clustering/data-planes Admin API endpoint.  This is to prevent the cluster data plane table from growing indefinitely. The default is set to 14 days. That is, if CP haven't heard from a DP for 14 days, its entry will be removed."
+  },
+  "cluster_ocsp": {
+    "defaultValue": "off",
+    "description": " Whether to check for revocation status of DP certificates using OCSP (Online Certificate Status Protocol). If enabled, the DP certificate should contain the \"Certificate Authority Information Access\" extension and the OCSP method with URI of which the OCSP responder can be reached from CP.  OCSP checks are only performed on CP nodes, it has no effect on DP nodes.  Valid values to this setting are:  - `on`: OCSP revocation check is enabled and DP   must pass the check in order to establish   connection with CP. - `off`: OCSP revocation check is disabled. - `optional`: OCSP revocation check will be attempted,   however, if the required extension is not   found inside DP provided certificate   or communication with the OCSP responder   failed, then DP is still allowed through."
+  },
+  "cluster_use_proxy": {
+    "defaultValue": "off",
+    "description": " Whether to turn on HTTP CONNECT proxy support for hybrid mode connections. `proxy_server` will be used for Hybrid mode connections if this option is turned on."
+  },
+  "cluster_max_payload": {
+    "defaultValue": "16777216",
+    "description": " This sets the maximum compressed payload size allowed to be sent across from CP to DP in Hybrid mode Default is 16MB - 16 * 1024 * 1024."
+  },
+  "proxy_listen": {
+    "defaultValue": [
+      "0.0.0.0:8000 reuseport backlog=16384",
+      "0.0.0.0:8443 http2 ssl reuseport backlog=16384"
+    ],
+    "description": " Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. The proxy server is the public entry point of Kong, which proxies traffic from your consumers to your backend services. This value accepts IPv4, IPv6, and hostnames.  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the TCP_DEFER_ACCEPT socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  This value can be set to `off`, thus disabling the HTTP/HTTPS proxy port for this node. If stream_listen is also set to `off`, this enables 'control-plane' mode for this node (in which all traffic proxying capabilities are disabled). This node can then be used only to configure a cluster of Kong nodes connected to the same datastore.  Example: `proxy_listen = 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`  See http://nginx.org/en/docs/http/ngx_http_core_module.html#listen for a description of the accepted formats for this and other `*_listen` values.  See https://www.nginx.com/resources/admin-guide/proxy-protocol/ for more details about the `proxy_protocol` parameter.  Not all `*_listen` values accept all formats specified in nginx's documentation."
+  },
+  "proxy_url": {
+    "defaultValue": null,
+    "description": "Kong Proxy URL  The lookup, or balancer, address for your Kong Proxy nodes.  This value is commonly used in a microservices or service-mesh oriented architecture.  Accepted format (parts in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`  Examples:  - `<scheme>://<IP>:<PORT>` -> `proxy_url = http://127.0.0.1:8000` - `SSL <scheme>://<HOSTNAME>` -> `proxy_url = https://proxy.domain.tld` - `<scheme>://<HOSTNAME>/<PATH>` -> `proxy_url = http://dev-machine/dev-285`  By default, Kong Manager, and Kong Portal will use the window request host and append the resolved listener port depending on the requested protocol."
+  },
+  "stream_listen": {
+    "defaultValue": "off",
+    "description": " Comma-separated list of addresses and ports on which the stream mode should listen.  This value accepts IPv4, IPv6, and hostnames. Some suffixes can be specified for each pair: - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  Examples:  ``` stream_listen = 127.0.0.1:7000 reuseport backlog=16384 stream_listen = 0.0.0.0:989 reuseport backlog=65536, 0.0.0.0:20 stream_listen = [::1]:1234 backlog=16384 ```  By default this value is set to `off`, thus disabling the stream proxy port for this node."
+  },
+  "admin_api_uri": {
+    "defaultValue": null,
+    "description": "Deprecated: Use admin_gui_api_url instead"
+  },
+  "admin_listen": {
+    "defaultValue": [
+      "127.0.0.1:8001 reuseport backlog=16384",
+      "127.0.0.1:8444 http2 ssl reuseport backlog=16384"
+    ],
+    "description": " Comma-separated list of addresses and ports on which the Admin interface should listen. The Admin interface is the API allowing you to configure and manage Kong. Access to this interface should be *restricted* to Kong administrators *only*. This value accepts IPv4, IPv6, and hostnames.  It is highly recommended to avoid exposing the Admin API to public interface(s), by using values such as 0.0.0.0:8001  See https://docs.konghq.com/gateway/latest/production/running-kong/secure-admin-api/ for more information about how to secure your Admin API  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the TCP_DEFER_ACCEPT socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  This value can be set to `off`, thus disabling the Admin interface for this node, enabling a 'data-plane' mode (without configuration capabilities) pulling its configuration changes from the database.  Example: `admin_listen = 127.0.0.1:8444 http2 ssl`"
+  },
+  "status_listen": {
+    "defaultValue": "off",
+    "description": "Comma-separated list of addresses and ports on which the Status API should listen. The Status API is a read-only endpoint allowing monitoring tools to retrieve metrics, healthiness, and other non-sensitive information of the current Kong node.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Status API server.  This value can be set to `off`, disabling the Status API for this node.  Example: `status_listen = 0.0.0.0:8100 ssl http2`"
+  },
+  "debug_listen": {
+    "defaultValue": "off",
+    "description": "Comma-separated list of addresses and ports on which the Debug API should listen.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Debug API server.  This value can be set to `off`, disabling the Debug API for this node.  Example: `debug_listen = 0.0.0.0:8200 ssl http2`"
+  },
+  "nginx_user": {
+    "defaultValue": "kong kong",
+    "description": "Defines user and group credentials used by worker processes. If group is omitted, a group whose name equals that of user is used.  Example: `nginx_user = nginx www`  **Note**: If the `kong` user and the `kong` group are not available, the default user and group credentials will be `nobody nobody`."
+  },
+  "nginx_worker_processes": {
+    "defaultValue": "auto",
+    "description": "Determines the number of worker processes spawned by Nginx.  See http://nginx.org/en/docs/ngx_core_module.html#worker_processes for detailed usage of the equivalent Nginx directive and a description of accepted values."
+  },
+  "nginx_daemon": {
+    "defaultValue": "on",
+    "description": "Determines whether Nginx will run as a daemon or as a foreground process. Mainly useful for development or when running Kong inside a Docker environment.  See http://nginx.org/en/docs/ngx_core_module.html#daemon."
+  },
+  "mem_cache_size": {
+    "defaultValue": "128m",
+    "description": "Size of each of the two shared memory caches for traditional mode database entities and runtime data. The accepted units are `k` and `m`, with a minimum recommended value of a few MBs.  **Note**: As this option controls the size of two different cache zones, the total memory Kong uses to cache entities might be double this value. The created zones are shared by all worker processes and do not become larger when more worker is used."
+  },
+  "ssl_cipher_suite": {
+    "defaultValue": "intermediate",
+    "description": "Defines the TLS ciphers served by Nginx. Accepted values are `modern`, `intermediate`, `old`, `fips` or `custom`. If you want to enable TLSv1.1, this value has to be `old`.  See https://wiki.mozilla.org/Security/Server_Side_TLS for detailed descriptions of each cipher suite. `fips` cipher suites are as described in https://wiki.openssl.org/index.php/FIPS_mode_and_TLS."
+  },
+  "ssl_ciphers": {
+    "defaultValue": null,
+    "description": "Defines a custom list of TLS ciphers to be served by Nginx. This list must conform to the pattern defined by `openssl ciphers`. This value is ignored if `ssl_cipher_suite` is not `custom`."
+  },
+  "ssl_protocols": {
+    "defaultValue": "TLSv1.2 TLSv1.3",
+    "description": " Enables the specified protocols for client-side connections. The set of supported protocol versions also depends on the version of OpenSSL Kong was built with. This value is ignored if `ssl_cipher_suite` is not `custom`. If you want to enable TLSv1.1, you should set `ssl_cipher_suite` to `old`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols"
+  },
+  "ssl_prefer_server_ciphers": {
+    "defaultValue": "on",
+    "description": "Specifies that server ciphers should be preferred over client ciphers when using the SSLv3 and TLS protocols. This value is ignored if `ssl_cipher_suite` is not `custom`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers"
+  },
+  "ssl_dhparam": {
+    "defaultValue": null,
+    "description": "Defines DH parameters for DHE ciphers from the predefined groups: `ffdhe2048`, `ffdhe3072`, `ffdhe4096`, `ffdhe6144`, `ffdhe8192`, from the absolute path to a parameters file, or directly from the parameters content.  This value is ignored if `ssl_cipher_suite` is `modern` or `intermediate`. The reason is that `modern` has no ciphers that needs this, and `intermediate` uses `ffdhe2048`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam"
+  },
+  "ssl_session_tickets": {
+    "defaultValue": "on",
+    "description": "Enables or disables session resumption through TLS session tickets. This has no impact when used with TLSv1.3.  Kong enables this by default for performance reasons, but it has security implications: https://github.com/mozilla/server-side-tls/issues/135  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets"
+  },
+  "ssl_session_timeout": {
+    "defaultValue": "1d",
+    "description": "Specifies a time during which a client may reuse the session parameters. See the rationale: https://github.com/mozilla/server-side-tls/issues/198  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout"
+  },
+  "ssl_session_cache_size": {
+    "defaultValue": "10m",
+    "description": "Sets the size of the caches that store session parameters  See https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache"
+  },
+  "ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `proxy_listen` values with TLS enabled.  If more than one certificates are specified, it can be used to provide alternate type of certificate (for example, ECC certificate) that will be served to clients that supports them. Note to properly serve using ECC certificates, it is recommended to also set `ssl_cipher_suite` to `modern` or `intermediate`.  Unless this option is explicitly set, Kong will auto-generate a pair of default certificates (RSA + ECC) first time it starts up and use it for serving TLS requests.  Certificates can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `proxy_listen` values with TLS enabled.  If more than one certificate was specified for `ssl_cert`, then this option should contain the corresponding key for all certificates provided in the same order.  Unless this option is explicitly set, Kong will auto-generate a pair of default private keys (RSA + ECC) first time it starts up and use it for serving TLS requests.  Keys can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+  },
+  "client_ssl": {
+    "defaultValue": "off",
+    "description": "Determines if Nginx should attempt to send client-side TLS certificates and perform Mutual TLS Authentication with upstream service when proxying requests."
+  },
+  "client_ssl_cert": {
+    "defaultValue": null,
+    "description": "If `client_ssl` is enabled, the client certificate for the `proxy_ssl_certificate` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "client_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "If `client_ssl` is enabled, the client TLS key for the `proxy_ssl_certificate_key` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate key can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+  },
+  "admin_ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `admin_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+  },
+  "admin_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `admin_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+  },
+  "status_ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `status_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+  },
+  "status_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `status_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+  },
+  "debug_ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `debug_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+  },
+  "debug_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `debug_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+  },
+  "headers": {
+    "defaultValue": [
+      "server_tokens",
+      "latency_tokens",
+      "X-Kong-Request-Id"
+    ],
+    "description": " Comma-separated list of headers Kong should inject in client responses.  Accepted values are: - `Server`: Injects `Server: kong/x.y.z`   on Kong-produced response (e.g. Admin   API, rejected requests from auth plugin). - `Via`: Injects `Via: kong/x.y.z` for   successfully proxied requests. - `X-Kong-Proxy-Latency`: Time taken   (in milliseconds) by Kong to process   a request and run all plugins before   proxying the request upstream. - `X-Kong-Response-Latency`: time taken   (in millisecond) by Kong to produce   a response in case of e.g. plugin   short-circuiting the request, or in   in case of an error. - `X-Kong-Upstream-Latency`: Time taken   (in milliseconds) by the upstream   service to send response headers. - `X-Kong-Admin-Latency`: Time taken   (in milliseconds) by Kong to process   an Admin API request. - `X-Kong-Upstream-Status`: The HTTP status   code returned by the upstream service.   This is particularly useful for clients to   distinguish upstream statuses if the   response is rewritten by a plugin. - `X-Kong-Request-Id`: Unique identifier of   the request. - `server_tokens`: Same as specifying both   `Server` and `Via`. - `latency_tokens`: Same as specifying   `X-Kong-Proxy-Latency`,   `X-Kong-Response-Latency`,   `X-Kong-Admin-Latency` and   `X-Kong-Upstream-Latency`  In addition to those, this value can be set to `off`, which prevents Kong from injecting any of the above headers. Note that this does not prevent plugins from injecting headers of their own.  Example: `headers = via, latency_tokens`"
+  },
+  "headers_upstream": {
+    "defaultValue": "X-Kong-Request-Id",
+    "description": " Comma-separated list of headers Kong should inject in requests to upstream.  At this time, the only accepted value is: - `X-Kong-Request-Id`: Unique identifier of   the request.  In addition, this value can be set to `off`, which prevents Kong from injecting the above header. Note that this does not prevent plugins from injecting headers of their own."
+  },
+  "trusted_ips": {
+    "defaultValue": null,
+    "description": "Defines trusted IP addresses blocks that are known to send correct `X-Forwarded-*` headers. Requests from trusted IPs make Kong forward their `X-Forwarded-*` headers upstream. Non-trusted requests make Kong insert its own `X-Forwarded-*` headers.  This property also sets the `set_real_ip_from` directive(s) in the Nginx configuration. It accepts the same type of values (CIDR blocks) but as a comma-separated list.  To trust *all* /!\\ IPs, set this value to `0.0.0.0/0,::/0`.  If the special value `unix:` is specified, all UNIX-domain sockets will be trusted.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from for examples of accepted values."
+  },
+  "real_ip_header": {
+    "defaultValue": "X-Real-IP",
+    "description": "Defines the request header field whose value will be used to replace the client address. This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  If this value receives `proxy_protocol`:  - at least one of the `proxy_listen` entries   must have the `proxy_protocol` flag   enabled. - the `proxy_protocol` parameter will be   appended to the `listen` directive of the   Nginx template.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header for a description of this directive."
+  },
+  "real_ip_recursive": {
+    "defaultValue": "off",
+    "description": "This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive for a description of this directive."
+  },
+  "error_default_type": {
+    "defaultValue": "text/plain",
+    "description": "Default MIME type to use when the request `Accept` header is missing and Nginx is returning an error for the request. Accepted values are `text/plain`, `text/html`, `application/json`, and `application/xml`."
+  },
+  "upstream_keepalive_pool_size": {
+    "defaultValue": "512",
+    "description": "Sets the default size of the upstream keepalive connection pools. Upstream keepalive connection pools are segmented by the `dst ip/dst port/SNI` attributes of a connection. A value of `0` will disable upstream keepalive connections by default, forcing each upstream request to open a new connection."
+  },
+  "upstream_keepalive_max_requests": {
+    "defaultValue": "10000",
+    "description": "Sets the default maximum number of requests than can be proxied upstream through one keepalive connection. After the maximum number of requests is reached, the connection will be closed. A value of `0` will disable this behavior, and a keepalive connection can be used to proxy an indefinite number of requests."
+  },
+  "upstream_keepalive_idle_timeout": {
+    "defaultValue": "60",
+    "description": "Sets the default timeout (in seconds) for which an upstream keepalive connection should be kept open. When the timeout is reached while the connection has not been reused, it will be closed. A value of `0` will disable this behavior, and an idle keepalive connection may be kept open indefinitely."
+  },
+  "allow_debug_header": {
+    "defaultValue": "off",
+    "description": "Enable the `Kong-Debug` header function. if it is `on`, kong will add `Kong-Route-Id` `Kong-Route-Name` `Kong-Service-Id` `Kong-Service-Name` debug headers to response when the client request header `Kong-Debug: 1` is present."
+  },
+  "nginx_main_worker_rlimit_nofile": {
+    "defaultValue": "auto",
+    "description": " Changes the limit on the maximum number of open files for worker processes.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile"
+  },
+  "nginx_events_worker_connections": {
+    "defaultValue": "auto",
+    "description": " Sets the maximum number of simultaneous connections that can be opened by a worker process.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_connections"
+  },
+  "nginx_http_client_header_buffer_size": {
+    "defaultValue": "1k",
+    "description": "Sets buffer size for reading the client request headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size"
+  },
+  "nginx_http_large_client_header_buffers": {
+    "defaultValue": "4 8k",
+    "description": "Sets the maximum number and size of buffers used for reading large clients requests headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers"
+  },
+  "nginx_http_client_max_body_size": {
+    "defaultValue": "0",
+    "description": "Defines the maximum request body size allowed by requests proxied by Kong, specified in the Content-Length request header. If a request exceeds this limit, Kong will respond with a 413 (Request Entity Too Large). Setting this value to 0 disables checking the request body size. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size"
+  },
+  "nginx_admin_client_max_body_size": {
+    "defaultValue": "10m",
+    "description": "Defines the maximum request body size for Admin API."
+  },
+  "nginx_http_charset": {
+    "defaultValue": "UTF-8",
+    "description": "Adds the specified charset to the “Content-Type” response header field. If this charset is different from the charset specified in the source_charset directive, a conversion is performed.  The parameter `off` cancels the addition of charset to the “Content-Type” response header field. See http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset"
+  },
+  "nginx_http_client_body_buffer_size": {
+    "defaultValue": "8k",
+    "description": "Defines the buffer size for reading the request body. If the client request body is larger than this value, the body will be buffered to disk. Note that when the body is buffered to disk, Kong plugins that access or manipulate the request body may not work, so it is advisable to set this value as high as possible (e.g., set it as high as `client_max_body_size` to force request bodies to be kept in memory). Do note that high-concurrency environments will require significant memory allocations to process many concurrent large request bodies. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size"
+  },
+  "nginx_admin_client_body_buffer_size": {
+    "defaultValue": "10m",
+    "description": "Defines the buffer size for reading the request body on Admin API."
+  },
+  "nginx_http_lua_regex_match_limit": {
+    "defaultValue": "100000",
+    "description": "Global `MATCH_LIMIT` for PCRE regex matching. The default of `100000` should ensure at worst any regex Kong executes could finish within roughly 2 seconds."
+  },
+  "nginx_http_lua_regex_cache_max_entries": {
+    "defaultValue": "8192",
+    "description": "Specifies the maximum number of entries allowed in the worker process level compiled regex cache. It is recommended to set it to at least (number of regex paths * 2) to avoid high CPU usages."
+  },
+  "nginx_http_keepalive_requests": {
+    "defaultValue": "10000",
+    "description": "Sets the maximum number of client requests that can be served through one keep-alive connection. After the maximum number of requests are made, the connection is closed. Closing connections periodically is necessary to free per-connection memory allocations. Therefore, using too high maximum number of requests could result in excessive memory usage and not recommended. See: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests"
+  },
+  "database": {
+    "defaultValue": "postgres",
+    "description": "Determines the database (or no database) for this node Accepted values are `postgres` and `off`."
+  },
+  "pg_host": {
+    "defaultValue": "127.0.0.1",
+    "description": "Host of the Postgres server."
+  },
+  "pg_port": {
+    "defaultValue": "5432",
+    "description": "Port of the Postgres server."
+  },
+  "pg_timeout": {
+    "defaultValue": "5000",
+    "description": "Defines the timeout (in ms), for connecting, reading and writing."
+  },
+  "pg_user": {
+    "defaultValue": "kong",
+    "description": "Postgres user."
+  },
+  "pg_password": {
+    "defaultValue": null,
+    "description": "Postgres user's password."
+  },
+  "pg_iam_auth": {
+    "defaultValue": "off",
+    "description": "Determines whether the AWS IAM database Authentication will be used. When switch to `on`, the username defined in `pg_user` will be used as the database account, and the database connection will be forced to using TLS. `pg_password` will not be used when the switch is `on`. Note that the corresponding IAM policy must be correct, otherwise connecting will fail."
+  },
+  "pg_iam_auth_assume_role_arn": {
+    "defaultValue": null,
+    "description": "The target AWS IAM role ARN that will be assumed when using AWS IAM database authentication. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+  },
+  "pg_iam_auth_role_session_name": {
+    "defaultValue": "KongPostgres",
+    "description": "The role session name used for role assuming in AWS IAM Database Authentication. The default value is `KongPostgres`."
+  },
+  "pg_iam_auth_sts_endpoint_url": {
+    "defaultValue": null,
+    "description": "The custom STS endpoint URL used for role assuming in AWS IAM Database Authentication.  Note that this value will override the default STS endpoint URL(which should be `https://sts.amazonaws.com`, or `https://sts.<region>.amazonaws.com` if you have `AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).  If you are not using private VPC endpoint for STS service, you should not specify this value."
+  },
+  "pg_database": {
+    "defaultValue": "kong",
+    "description": "The database name to connect to."
+  },
+  "pg_schema": {
+    "defaultValue": null,
+    "description": "The database schema to use. If unspecified, Kong will respect the `search_path` value of your PostgreSQL instance."
+  },
+  "pg_ssl": {
+    "defaultValue": "off",
+    "description": "Toggles client-server TLS connections between Kong and PostgreSQL. Because PostgreSQL uses the same port for TLS and non-TLS, this is only a hint. If the server does not support TLS, the established connection will be a plain one."
+  },
+  "pg_ssl_version": {
+    "defaultValue": "tlsv1_2",
+    "description": "When using ssl between Kong and PostgreSQL, the version of tls to use. Accepted values are `tlsv1_1`, `tlsv1_2`, `tlsv1_3`, or 'any'. When `any` is set, the client negotiates the highest version with the server which can't be lower than `tlsv1_1`."
+  },
+  "pg_ssl_required": {
+    "defaultValue": "off",
+    "description": "When `pg_ssl` is on this determines if TLS must be used between Kong and PostgreSQL. It aborts the connection if the server does not support SSL connections."
+  },
+  "pg_ssl_verify": {
+    "defaultValue": "off",
+    "description": "Toggles server certificate verification if `pg_ssl` is enabled. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+  },
+  "pg_ssl_cert": {
+    "defaultValue": null,
+    "description": "The absolute path to the PEM encoded client TLS certificate for the PostgreSQL connection. Mutual TLS authentication against PostgreSQL is only enabled if this value is set."
+  },
+  "pg_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "If `pg_ssl_cert` is set, the absolute path to the PEM encoded client TLS private key for the PostgreSQL connection."
+  },
+  "pg_max_concurrent_queries": {
+    "defaultValue": "0",
+    "description": "Sets the maximum number of concurrent queries that can be executing at any given time. This limit is enforced per worker process; the total number of concurrent queries for this node will be will be: `pg_max_concurrent_queries * nginx_worker_processes`.  The default value of 0 removes this concurrency limitation."
+  },
+  "pg_semaphore_timeout": {
+    "defaultValue": "60000",
+    "description": "Defines the timeout (in ms) after which PostgreSQL query semaphore resource acquisition attempts will fail. Such failures will generally result in the associated proxy or Admin API request failing with an HTTP 500 status code. Detailed discussion of this behavior is available in the online documentation."
+  },
+  "pg_keepalive_timeout": {
+    "defaultValue": null,
+    "description": "Specify the maximal idle timeout (in ms) for the postgres connections in the pool. If this value is set to 0 then the timeout interval is unlimited.  If not specified this value will be same as `lua_socket_keepalive_timeout`"
+  },
+  "pg_pool_size": {
+    "defaultValue": null,
+    "description": "Specifies the size limit (in terms of connection count) for the Postgres server. Note that this connection pool is intended per Nginx worker rather than per Kong instance.  If not specified, the default value is the same as `lua_socket_pool_size`"
+  },
+  "pg_backlog": {
+    "defaultValue": null,
+    "description": "If specified, this value will limit the total number of open connections to the Postgres server to `pg_pool_size`. If the connection pool is full, subsequent connect operations will be inserted in a queue with size equal to this option's value.  If the number of queued connect operations reaches `pg_backlog`, exceeding connections will fail.  If not specified, then number of open connections to the Postgres server is not limited."
+  },
+  "pg_ro_host": {
+    "defaultValue": null,
+    "description": "Same as `pg_host`, but for the read-only connection. **Note:** Refer to the documentation section above for detailed usage."
+  },
+  "pg_ro_port": {
+    "defaultValue": "<pg_port>",
+    "description": "Same as `pg_port`, but for the read-only connection."
+  },
+  "pg_ro_timeout": {
+    "defaultValue": "<pg_timeout>",
+    "description": "Same as `pg_timeout`, but for the read-only connection."
+  },
+  "pg_ro_user": {
+    "defaultValue": "<pg_user>",
+    "description": "Same as `pg_user`, but for the read-only connection."
+  },
+  "pg_ro_password": {
+    "defaultValue": "<pg_password>",
+    "description": "Same as `pg_password`, but for the read-only connection."
+  },
+  "pg_ro_iam_auth": {
+    "defaultValue": "<pg_iam_auth>",
+    "description": "Same as `pg_iam_auth`, but for the read-only connection."
+  },
+  "pg_ro_iam_auth_assume_role_arn": {
+    "defaultValue": null,
+    "description": "Same as `pg_iam_auth_assume_role_arn', but for the read-only connection."
+  },
+  "pg_ro_iam_auth_role_session_name": {
+    "defaultValue": "KongPostgres",
+    "description": "Same as `pg_iam_auth_role_session_name`, but for the read-only connection."
+  },
+  "pg_ro_iam_auth_sts_endpoint_url": {
+    "defaultValue": null,
+    "description": "Same as `pg_iam_auth_sts_endpoint_url`, but for the read-only connection."
+  },
+  "pg_ro_database": {
+    "defaultValue": "<pg_database>",
+    "description": "Same as `pg_database`, but for the read-only connection."
+  },
+  "pg_ro_schema": {
+    "defaultValue": "<pg_schema>",
+    "description": "Same as `pg_schema`, but for the read-only connection."
+  },
+  "pg_ro_ssl": {
+    "defaultValue": "<pg_ssl>",
+    "description": "Same as `pg_ssl`, but for the read-only connection."
+  },
+  "pg_ro_ssl_required": {
+    "defaultValue": "<pg_ssl_required>",
+    "description": " Same as `pg_ssl_required`, but for the read-only connection."
+  },
+  "pg_ro_ssl_verify": {
+    "defaultValue": "<pg_ssl_verify>",
+    "description": " Same as `pg_ssl_verify`, but for the read-only connection."
+  },
+  "pg_ro_ssl_version": {
+    "defaultValue": "<pg_ssl_version>",
+    "description": " Same as `pg_ssl_version`, but for the read-only connection."
+  },
+  "pg_ro_max_concurrent_queries": {
+    "defaultValue": "<pg_max_concurrent_queries>",
+    "description": " Same as `pg_max_concurrent_queries`, but for the read-only connection. Note: read-only concurrency is not shared with the main (read-write) connection."
+  },
+  "pg_ro_semaphore_timeout": {
+    "defaultValue": "<pg_semaphore_timeout>",
+    "description": " Same as `pg_semaphore_timeout`, but for the read-only connection."
+  },
+  "pg_ro_keepalive_timeout": {
+    "defaultValue": "<pg_keepalive_timeout>",
+    "description": " Same as `pg_keepalive_timeout`, but for the read-only connection."
+  },
+  "pg_ro_pool_size": {
+    "defaultValue": "<pg_pool_size>",
+    "description": " Same as `pg_pool_size`, but for the read-only connection."
+  },
+  "pg_ro_backlog": {
+    "defaultValue": "<pg_backlog>",
+    "description": " Same as `pg_backlog`, but for the read-only connection."
+  },
+  "declarative_config": {
+    "defaultValue": null,
+    "description": "The path to the declarative configuration file which holds the specification of all entities (Routes, Services, Consumers, etc.) to be used when the `database` is set to `off`.  Entities are stored in Kong's LMDB cache, so you must ensure that enough headroom is allocated to it via the `lmdb_map_size` property.  If the Hybrid mode `role` is set to `data_plane` and there's no configuration cache file, this configuration is used before connecting to the Control Plane node as a user-controlled fallback."
+  },
+  "declarative_config_string": {
+    "defaultValue": null,
+    "description": "The declarative configuration as a string"
+  },
+  "lmdb_environment_path": {
+    "defaultValue": "dbless.lmdb",
+    "description": "Directory where the LMDB database files used by DB-less and Hybrid mode to store Kong configurations reside.  This path is relative under the Kong `prefix`."
+  },
+  "lmdb_map_size": {
+    "defaultValue": "2048m",
+    "description": "Maximum size of the LMDB memory map, used to store the DB-less and Hybird mode configurations. Default is 2048m.  This config defines the limit of LMDB file size, the actual file size growth will be on-demand and proportional to the actual config size.  Note this value can be set very large, say a couple of GBs to accommodate future database growth and Multi Version Concurrency Control (MVCC) headroom needs. The file size of the LMDB database file should stabilize after a few config reload/Hybrid mode syncs and the actual memory used by the LMDB database will be smaller than the file size due to dynamic swapping of database pages by the OS."
+  },
+  "db_update_frequency": {
+    "defaultValue": "5",
+    "description": "Frequency (in seconds) at which to check for updated entities with the datastore.  When a node creates, updates, or deletes an entity via the Admin API, other nodes need to wait for the next poll (configured by this value) to eventually purge the old cached entity and start using the new one."
+  },
+  "db_update_propagation": {
+    "defaultValue": "0",
+    "description": "Time (in seconds) taken for an entity in the datastore to be propagated to replica nodes of another datacenter.  When set, this property will increase the time taken by Kong to propagate the change of an entity.  Single-datacenter setups or PostgreSQL servers should suffer no such delays, and this value can be safely set to 0. Postgres setups with read replicas should set this value to maximum expected replication lag between the writer and reader instances."
+  },
+  "db_cache_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of an entity from the datastore when cached by this node.  Database misses (no entity) are also cached according to this setting if you do not configure `db_cache_neg_ttl`.  If set to 0 (default), such cached entities or misses never expire."
+  },
+  "db_cache_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a datastore miss (no entity).  If not specified (default), `db_cache_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "db_resurrect_ttl": {
+    "defaultValue": "30",
+    "description": "Time (in seconds) for which stale entities from the datastore should be resurrected for when they cannot be refreshed (e.g., the datastore is unreachable). When this TTL expires, a new attempt to refresh the stale entities will be made."
+  },
+  "db_cache_warmup_entities": {
+    "defaultValue": "services",
+    "description": " Entities to be pre-loaded from the datastore into the in-memory cache at Kong start-up. This speeds up the first access of endpoints that use the given entities.  When the `services` entity is configured for warmup, the DNS entries for values in its `host` attribute are pre-resolved asynchronously as well.  Cache size set in `mem_cache_size` should be set to a value large enough to hold all instances of the specified entities. If the size is insufficient, Kong will log a warning."
+  },
+  "dns_resolver": {
+    "defaultValue": null,
+    "description": "Comma separated list of nameservers, each entry in `ip[:port]` format to be used by Kong. If not specified the nameservers in the local `resolv.conf` file will be used. Port defaults to 53 if omitted. Accepts both IPv4 and IPv6 addresses."
+  },
+  "dns_hostsfile": {
+    "defaultValue": "/etc/hosts",
+    "description": "The hosts file to use. This file is read once and its content is static in memory. To read the file again after modifying it, Kong must be reloaded."
+  },
+  "dns_order": {
+    "defaultValue": [
+      "LAST",
+      "SRV",
+      "A",
+      "CNAME"
+    ],
+    "description": "The order in which to resolve different record types. The `LAST` type means the type of the last successful lookup (for the specified name). The format is a (case insensitive) comma separated list."
+  },
+  "dns_valid_ttl": {
+    "defaultValue": null,
+    "description": "By default, DNS records are cached using the TTL value of a response. If this property receives a value (in seconds), it will override the TTL for all records."
+  },
+  "dns_stale_ttl": {
+    "defaultValue": "3600",
+    "description": "Defines, in seconds, how long a record will remain in cache past its TTL. This value will be used while the new DNS record is fetched in the background. Stale data will be used from expiry of a record until either the refresh query completes, or the `dns_stale_ttl` number of seconds have passed. This configuration enables Kong to be more resilient during resolver downtime."
+  },
+  "dns_cache_size": {
+    "defaultValue": "10000",
+    "description": "Defines the maximum allowed number of DNS records stored in memory cache. Least recently used DNS records are discarded from cache if it is full. Both errors and data are cached, therefore a single name query can easily take up 10-15 slots."
+  },
+  "dns_not_found_ttl": {
+    "defaultValue": "30",
+    "description": "TTL in seconds for empty DNS responses and \"(3) name error\" responses."
+  },
+  "dns_error_ttl": {
+    "defaultValue": "1",
+    "description": "TTL in seconds for error responses."
+  },
+  "dns_no_sync": {
+    "defaultValue": "off",
+    "description": "If enabled, then upon a cache-miss every request will trigger its own dns query. When disabled multiple requests for the same name/type will be synchronised to a single query."
+  },
+  "vault_env_prefix": {
+    "defaultValue": null,
+    "description": "Defines the environment variable vault's default prefix. For example if you have all your secrets stored in environment variables prefixed with `SECRETS_`, it can be configured here so that it isn't necessary to repeat them in Vault references."
+  },
+  "vault_aws_region": {
+    "defaultValue": null,
+    "description": "The AWS region your vault is located in."
+  },
+  "vault_aws_endpoint_url": {
+    "defaultValue": null,
+    "description": "The AWS SecretsManager service endpoint url. If not specified, the value used by vault will be the official AWS SecretsManager service url which is `https://secretsmanager.<region>.amazonaws.com` You can specify a complete URL(including the \"http/https\" scheme) to override the endpoint that vault will connect to."
+  },
+  "vault_aws_assume_role_arn": {
+    "defaultValue": null,
+    "description": "The target AWS IAM role ARN that will be assumed. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+  },
+  "vault_aws_role_session_name": {
+    "defaultValue": "KongVault",
+    "description": "The role session name used for role assuming. The default value is `KongVault`."
+  },
+  "vault_aws_sts_endpoint_url": {
+    "defaultValue": null,
+    "description": "The custom STS endpoint URL used for role assuming in AWS Vault.  Note that this value will override the default STS endpoint URL(which should be `https://sts.amazonaws.com`, or `https://sts.<region>.amazonaws.com` if you have `AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).  If you are not using private VPC endpoint for STS service, you should not specify this value."
+  },
+  "vault_aws_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the AWS vault when cached by this node.  AWS vault misses (no secret) are also cached according to this setting if you do not configure `vault_aws_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_aws_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_aws_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_aws_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the AWS vault should be resurrected for when they cannot be refreshed (e.g., the AWS vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "vault_gcp_project_id": {
+    "defaultValue": null,
+    "description": "The project ID from your Google API Console."
+  },
+  "vault_gcp_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the GCP vault when cached by this node.  GCP vault misses (no secret) are also cached according to this setting if you do not configure `vault_gcp_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_gcp_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_gcp_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_gcp_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the GCP vault should be resurrected for when they cannot be refreshed (e.g., the GCP vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "vault_hcv_protocol": {
+    "defaultValue": "http",
+    "description": "The protocol to connect with. Accepts one of `http` or `https`."
+  },
+  "vault_hcv_host": {
+    "defaultValue": "127.0.0.1",
+    "description": "The hostname of your HashiCorp vault."
+  },
+  "vault_hcv_port": {
+    "defaultValue": "8200",
+    "description": "The port number of your HashiCorp vault."
+  },
+  "vault_hcv_namespace": {
+    "defaultValue": null,
+    "description": "Namespace for the HashiCorp Vault. Vault Enterprise requires a namespace to successfully connect to it."
+  },
+  "vault_hcv_mount": {
+    "defaultValue": "secret",
+    "description": "The mount point."
+  },
+  "vault_hcv_kv": {
+    "defaultValue": "v1",
+    "description": "The secrets engine version. Accepts `v1` or `v2`."
+  },
+  "vault_hcv_token": {
+    "defaultValue": null,
+    "description": "A token string."
+  },
+  "vault_hcv_auth_method": {
+    "defaultValue": "token",
+    "description": "Defines the authentication mechanism when connecting to the Hashicorp Vault service. Accepted values are: `token`, `kubernetes` or `approle`."
+  },
+  "vault_hcv_kube_role": {
+    "defaultValue": null,
+    "description": "Defines the HashiCorp Vault role for the Kubernetes service account of the running pod. `vault_hcv_auth_method` must be set to `kubernetes` for this to activate."
+  },
+  "vault_hcv_kube_auth_path": {
+    "defaultValue": "kubernetes",
+    "description": " Place where the Kubernetes auth method will be accessible: /v1/auth/<vault_hcv_kube_auth_path>"
+  },
+  "vault_hcv_kube_api_token_file": {
+    "defaultValue": null,
+    "description": "Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+  },
+  "vault_hcv_approle_auth_path": {
+    "defaultValue": "approle",
+    "description": " Place where the Approle auth method will be accessible: /v1/auth/<vault_hcv_approle_auth_path>"
+  },
+  "vault_hcv_approle_role_id": {
+    "defaultValue": null,
+    "description": "The Role ID of the Approle in HashiCorp Vault."
+  },
+  "vault_hcv_approle_secret_id": {
+    "defaultValue": null,
+    "description": "The Secret ID of the Approle in HashiCorp Vault."
+  },
+  "vault_hcv_approle_secret_id_file": {
+    "defaultValue": null,
+    "description": "Defines where the Secret ID should be read from the pod's filesystem. This is usually used with HashiCorp Vault's response wrapping."
+  },
+  "vault_hcv_approle_response_wrapping": {
+    "defaultValue": "false",
+    "description": "Defines whether the Secret ID read from configuration or file is actually a response-wrapping token instead of a real Secret ID."
+  },
+  "vault_hcv_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the HashiCorp vault when cached by this node.  HashiCorp vault misses (no secret) are also cached according to this setting if you do not configure `vault_hcv_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_hcv_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a HashiCorp vault miss (no secret).  If not specified (default), `vault_hcv_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_hcv_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the HashiCorp vault should be resurrected for when they cannot be refreshed (e.g., the HashiCorp vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "vault_azure_vault_uri": {
+    "defaultValue": null,
+    "description": "The URI the vault is reachable from."
+  },
+  "vault_azure_client_id": {
+    "defaultValue": null,
+    "description": "The client ID from your registered Application. Visit your Azure Dashboard and select *App Registrations* to check your client ID."
+  },
+  "vault_azure_tenant_id": {
+    "defaultValue": null,
+    "description": "The DirectoryId and TenantId both equate to the GUID representing the ActiveDirectory Tenant. Depending on context, either term may be used by Microsoft documentation and products, which can be confusing. In other words, the \"Tenant ID\" IS the \"Directory ID\""
+  },
+  "vault_azure_type": {
+    "defaultValue": "secrets",
+    "description": "Azure Key Vault enables Microsoft Azure applications and users to store and use several types of secret/key data: keys, secrets, and certificates. Kong currently only supports the `Secrets`"
+  },
+  "vault_azure_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the Azure Key Vault when cached by this node.  Key Vault misses (no secret) are also cached according to this setting if you do not configure `vault_azure_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_azure_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a Azure Key Vault miss (no secret).  If not specified (default), `vault_azure_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_azure_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the Azure Key Vault should be resurrected for when they cannot be refreshed (e.g., the the vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "worker_consistency": {
+    "defaultValue": "eventual",
+    "description": " Defines whether this node should rebuild its state synchronously or asynchronously (the balancers and the router are rebuilt on updates that affects them, e.g., updates to Routes, Services or Upstreams, via the Admin API or loading a declarative configuration file). (This option is deprecated and will be removed in future releases. The new default is `eventual`.)  Accepted values are:  - `strict`: the router will be rebuilt   synchronously, causing incoming requests to   be delayed until the rebuild is finished.   (This option is deprecated and will be removed    in future releases. The new default is `eventual`) - `eventual`: the router will be rebuilt   asynchronously via a recurring background   job running every second inside of each   worker.  Note that `strict` ensures that all workers of a given node will always proxy requests with an identical router, but that increased long tail latency can be observed if frequent Routes and Services updates are expected. Using `eventual` will help preventing long tail latency issues in such cases, but may cause workers to route requests differently for a short period of time after Routes and Services updates."
+  },
+  "worker_state_update_frequency": {
+    "defaultValue": "5",
+    "description": " Defines how often the worker state changes are checked with a background job. When a change is detected, a new router or balancer will be built, as needed. Raising this value will decrease the load on database servers and result in less jitter in proxy latency, but it might take more time to propagate changes to each individual worker."
+  },
+  "router_flavor": {
+    "defaultValue": "traditional_compatible",
+    "description": " Selects the router implementation to use when performing request routing. Incremental router rebuild is available when the flavor is set to either `expressions` or `traditional_compatible` which could significantly shorten rebuild time for large number of routes.  Accepted values are:  - `traditional_compatible`: the DSL based expression   router engine will be used under the hood. However   the router config interface will be the same   as `traditional` and expressions are   automatically generated at router build time.   The `expression` field on the `Route` object   is not visible. - `expressions`: the DSL based expression router engine   will be used under the hood. Traditional router   config interface is not visible and you must write   Router Expression manually and provide them in the   `expression` field on the `Route` object. - `traditional`: the pre-3.0 Router engine will be   used. Config interface will be the same as   pre-3.0 Kong and the `expression` field on the   `Route` object is not visible.    Deprecation warning: In Kong 3.0, `traditional`   mode should be avoided and only be used in case   `traditional_compatible` did not work as expected.   This flavor of router will be removed in the next   major release of Kong."
+  },
+  "lua_max_req_headers": {
+    "defaultValue": "100",
+    "description": "Maximum number of request headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying the Kong sends all the request headers and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many request headers."
+  },
+  "lua_max_resp_headers": {
+    "defaultValue": "100",
+    "description": "Maximum number of response headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong returns all the response headers and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many response headers."
+  },
+  "lua_max_uri_args": {
+    "defaultValue": "100",
+    "description": "Maximum number of request uri arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request query arguments and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many query arguments."
+  },
+  "lua_max_post_args": {
+    "defaultValue": "100",
+    "description": "Maximum number of request post arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request post arguments and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many post arguments."
+  },
+  "lua_ssl_trusted_certificate": {
+    "defaultValue": "system",
+    "description": "Comma-separated list of certificate authorities for Lua cosockets in PEM format.  The special value `system` attempts to search for the \"usual default\" provided by each distro, according to an arbitrary heuristic. In the current implementation, The following pathnames will be tested in order, and the first one found will be used:  - /etc/ssl/certs/ca-certificates.crt (Debian/Ubuntu/Gentoo) - /etc/pki/tls/certs/ca-bundle.crt (Fedora/RHEL 6) - /etc/ssl/ca-bundle.pem (OpenSUSE) - /etc/pki/tls/cacert.pem (OpenELEC) - /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem (CentOS/RHEL 7) - /etc/ssl/cert.pem (OpenBSD, Alpine)  `system` can be used by itself or in conjunction with other CA filepaths.  When `pg_ssl_verify` is enabled, these certificate authority files will be used for verifying Kong's database connections.  Certificates can be configured on this property with either of the following values: * `system` * absolute path to the certificate * certificate content * base64 encoded certificate content  See https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate"
+  },
+  "lua_ssl_verify_depth": {
+    "defaultValue": "1",
+    "description": "Sets the verification depth in the server certificates chain used by Lua cosockets, set by `lua_ssl_trusted_certificate`. This includes the certificates configured for Kong's database connections. If the maximum depth is reached before reaching the end of the chain, verification will fail. This helps mitigate certificate based DoS attacks.  See https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth"
+  },
+  "lua_ssl_protocols": {
+    "defaultValue": "TLSv1.2 TLSv1.3",
+    "description": "Defines the TLS versions supported when handshaking with OpenResty's TCP cosocket APIs.  This affects connections made by Lua code, such as connections to the database Kong uses, or when sending logs using a logging plugin. It does *not* affect connections made to the upstream Service or from downstream clients."
+  },
+  "lua_package_path": {
+    "defaultValue": "./?.lua;./?/init.lua;",
+    "description": "Sets the Lua module search path (LUA_PATH). Useful when developing or using custom plugins not stored in the default search path.  See https://github.com/openresty/lua-nginx-module#lua_package_path"
+  },
+  "lua_package_cpath": {
+    "defaultValue": null,
+    "description": "Sets the Lua C module search path (LUA_CPATH).  See https://github.com/openresty/lua-nginx-module#lua_package_cpath"
+  },
+  "lua_socket_pool_size": {
+    "defaultValue": "30",
+    "description": "Specifies the size limit for every cosocket connection pool associated with every remote server.  See https://github.com/openresty/lua-nginx-module#lua_socket_pool_size"
+  },
+  "enforce_rbac": {
+    "defaultValue": "off",
+    "description": "Specifies whether Admin API RBAC is enforced. Accepts one of `entity`, `both`, `on`, or `off`.  - `on`: only endpoint-level authorization   is enforced. - `entity`: entity-level authorization   applies. - `both`: enables both endpoint and   entity-level authorization. - `off`: disables both endpoint and   entity-level authorization.  When enabled, Kong will deny requests to the Admin API when a nonexistent or invalid RBAC authorization token is passed, or the RBAC user with which the token is associated does not have permissions to access/modify the requested resource."
+  },
+  "rbac_auth_header": {
+    "defaultValue": "Kong-Admin-Token",
+    "description": "Defines the name of the HTTP request header from which the Admin API will attempt to authenticate the RBAC user."
+  },
+  "event_hooks_enabled": {
+    "defaultValue": "on",
+    "description": "When enabled, event hook entities represent a relationship between an event (source and event) and an action (handler). Similar to web hooks, event hooks can be used to communicate Kong Gateway service events. When a particular event happens on a service, the event hook calls a URL with information about that event. Event hook configurations differ depending on the handler. The events that are triggered send associated data.  See: https://docs.konghq.com/enterprise/latest/admin-api/event-hooks/reference/"
+  },
+  "fips": {
+    "defaultValue": "off",
+    "description": "Turn on FIPS mode; this mode is only available on a FIPS build."
+  },
+  "admin_gui_listen": {
+    "defaultValue": [
+      "0.0.0.0:8002",
+      "0.0.0.0:8445 ssl"
+    ],
+    "description": " Kong Manager Listeners  Comma-separated list of addresses and ports on which Kong will expose Kong Manager. This web application lets you configure and manage Kong, and therefore should be kept secured.  Suffixes can be specified for each pair, similarly to the `admin_listen` directive."
+  },
+  "admin_gui_url": {
+    "defaultValue": null,
+    "description": "Kong Manager URL  The lookup, or balancer, address for Kong Manager.  Accepted format (items in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>)`  Examples:  - `http://127.0.0.1:8003` - `https://kong-admin.test` - `http://dev-machine`  By default, Kong Manager will use the window request host and append the resolved listener port depending on the requested protocol."
+  },
+  "admin_gui_path": {
+    "defaultValue": "/",
+    "description": "Kong Manager base path  This configuration parameter allows the user to customize the path prefix where Kong Manager is served. When updating this parameter, it's recommended to update the path in `admin_gui_url` as well.  Accepted format:  - Path must start with a `/` - Path must not end with a `/` (except for the `/`) - Path can only contain letters, digits, hyphens (`-`), underscores (`_`), and slashes (`/`) - Path must not contain continuous slashes (e.g., `//` and `///`)  Examples:  - `/` - `/manager` - `/kong-manager` - `/kong/manager`"
+  },
+  "admin_gui_api_url": {
+    "defaultValue": null,
+    "description": "Hierarchical part of a URI which is composed optionally of a host, port, and path at which the Admin API accepts HTTP or HTTPS traffic. When this config is disabled, Kong Manager will use the window protocol + host and append the resolved admin_listen HTTP/HTTPS port."
+  },
+  "admin_gui_ssl_cert": {
+    "defaultValue": null,
+    "description": "The SSL certificate for `admin_gui_listen` values with SSL enabled.  values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "admin_gui_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "The SSL key for `admin_gui_listen` values with SSL enabled.  values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+  },
+  "admin_gui_flags": {
+    "defaultValue": "{}",
+    "description": " Alters the layout Admin GUI (JSON) The only supported value is `{ \"IMMUNITY_ENABLED\": true }` to enable Kong Immunity in the Admin GUI."
+  },
+  "admin_gui_access_log": {
+    "defaultValue": "logs/admin_gui_access.log",
+    "description": " Kong Manager Access Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables access logs for Kong Manager."
+  },
+  "admin_gui_error_log": {
+    "defaultValue": "logs/admin_gui_error.log",
+    "description": " Kong Manager Error Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables error logs for Kong Manager.  Granularity can be adjusted through the `log_level` directive."
+  },
+  "admin_gui_auth": {
+    "defaultValue": null,
+    "description": "Kong Manager Authentication Plugin Name  Secures access to Kong Manager by specifying an authentication plugin to use.  Supported Plugins:  - `basic-auth`: Basic Authentication plugin - `ldap-auth-advanced`: LDAP Authentication plugin - `openid-connect`: OpenID Connect Authentication   plugin"
+  },
+  "admin_gui_auth_conf": {
+    "defaultValue": null,
+    "description": "Kong Manager Authentication Plugin Config (JSON)  Specifies the configuration for the authentication plugin specified in `admin_gui_auth`.  For information about Plugin Configuration consult the associated plugin documentation.  Example for `basic-auth`:  `admin_gui_auth_conf = { \"hide_credentials\": true }`"
+  },
+  "admin_gui_auth_password_complexity": {
+    "defaultValue": null,
+    "description": "Kong Manager Authentication Password Complexity (JSON)  When `admin_gui_auth = basic-auth`, this property defines the rules required for Kong Manager passwords. Choose from preset rules or write your own.  Example using preset rules:  `admin_gui_auth_password_complexity = { \"kong-preset\": \"min_8\" }`  All values for kong-preset require the password to contain characters from at least three of the following categories:  1. Uppercase characters (A through Z)  2. Lowercase characters (a through z)  3. Base-10 digits (0 through 9)  4. Special characters (for example, &, $, #, %)  Supported preset rules: - `min_8`: minimum length of 8 - `min_12`: minimum length of 12 - `min_20`: minimum length of 20  To write your own rules, see https://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.  NOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.  Example:  `admin_gui_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`"
+  },
+  "admin_gui_session_conf": {
+    "defaultValue": null,
+    "description": "Kong Manager Session Config (JSON)  Specifies the configuration for the Session plugin as used by Kong Manager.  For information about plugin configuration, consult the Kong Session plugin documentation.  Example: ``` admin_gui_session_conf = { \"cookie_name\": \"kookie\", \\                            \"secret\": \"changeme\" } ```"
+  },
+  "admin_gui_auth_header": {
+    "defaultValue": "Kong-Admin-User",
+    "description": " Defines the name of the HTTP request header from which the Admin API will attempt to identify the Kong Admin user."
+  },
+  "admin_gui_auth_login_attempts": {
+    "defaultValue": "0",
+    "description": " Number of times a user can attempt to login to Kong Manager. 0 means infinite attempts allowed."
+  },
+  "admin_gui_header_txt": {
+    "defaultValue": null,
+    "description": "Kong Manager Header Text Sets text for Kong Manager Header Banner. Header Banner is not shown if this config is empty."
+  },
+  "admin_gui_header_bg_color": {
+    "defaultValue": null,
+    "description": "Kong Manager Header Background Color Sets background color for Kong Manager Header Banner Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Manager."
+  },
+  "admin_gui_header_txt_color": {
+    "defaultValue": null,
+    "description": "Kong Manager Header Text Color Sets text color for Kong Manager Header Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Kong Manager."
+  },
+  "admin_gui_footer_txt": {
+    "defaultValue": null,
+    "description": "Kong Manager Footer Text Sets text for Kong Manager Footer Banner. Footer Banner is not shown if this config is empty"
+  },
+  "admin_gui_footer_bg_color": {
+    "defaultValue": null,
+    "description": "Kong Manager Footer Background Color Sets background color for Kong Manager Footer Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Manager."
+  },
+  "admin_gui_footer_txt_color": {
+    "defaultValue": null,
+    "description": "Kong Manager Footer Text Color Sets text color for Kong Manager Footer Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Kong Manager."
+  },
+  "admin_gui_login_banner_title": {
+    "defaultValue": null,
+    "description": "Kong Manager Login Banner Title Text Sets title text for Kong Manager Login Banner. Login Banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+  },
+  "admin_gui_login_banner_body": {
+    "defaultValue": null,
+    "description": "Kong Manager Login Banner Body Text Sets body text for Kong Manager Login Banner. Login Banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+  },
+  "vitals": {
+    "defaultValue": "on",
+    "description": "When enabled, Kong will store and report metrics about its performance.  When running Kong in a multi-node setup, `vitals` entails two separate meanings depending on the node.  On a Proxy-only node, `vitals` determines whether to collect data for Vitals.  On an Admin-only node, `vitals` determines whether to display Vitals metrics and visualizations on the dashboard."
+  },
+  "vitals_strategy": {
+    "defaultValue": "database",
+    "description": "Determines whether to use the Kong database or a separate storage engine for Vitals metrics. Accepted values are `database`, `prometheus`, or `influxdb`."
+  },
+  "vitals_tsdb_address": {
+    "defaultValue": null,
+    "description": "Defines the host and port of the TSDB server to which Vitals data is written and read. This value is only applied when the `vitals_strategy` option is set to `prometheus` or `influxdb`. This value accepts IPv4, IPv6, and hostname values. If the `vitals_strategy` is set to `prometheus`, this value determines the address of the Prometheus server from which Vitals data will be read. For `influxdb` strategies, this value controls both the read and write source for Vitals data."
+  },
+  "vitals_tsdb_user": {
+    "defaultValue": null,
+    "description": "Influxdb user"
+  },
+  "vitals_tsdb_password": {
+    "defaultValue": null,
+    "description": "Influxdb password"
+  },
+  "vitals_statsd_address": {
+    "defaultValue": null,
+    "description": "Defines the host and port (and an optional protocol) of the StatsD server to which Kong should write Vitals metics. This value is only applied when the `vitals_strategy` is set to `prometheus`. This value accepts IPv4, IPv6, and, hostnames. Additionally, the suffix `tcp` can be specified; doing so will result in Kong sending StatsD metrics via TCP instead of the UDP (default)."
+  },
+  "vitals_statsd_prefix": {
+    "defaultValue": "kong",
+    "description": "Defines the prefix value attached to all Vitals StatsD events. This prefix is useful when writing metrics to a multi-tenant StatsD exporter or server."
+  },
+  "vitals_statsd_udp_packet_size": {
+    "defaultValue": "1024",
+    "description": "Defines the maximum buffer size in which Vitals statsd metrics will be held and sent in batches. This value is defined in bytes."
+  },
+  "vitals_prometheus_scrape_interval": {
+    "defaultValue": "5",
+    "description": "Defines the scrape_interval query parameter sent to the Prometheus server when reading Vitals data. This should be same as the scrape interval (in seconds) of the Prometheus server."
+  },
+  "konnect_mode": {
+    "defaultValue": "off",
+    "description": "When enabled, the dataplane is connected to Konnect"
+  },
+  "analytics_flush_interval": {
+    "defaultValue": "1",
+    "description": "Determine the frequency of flushing local data to Konnect in seconds."
+  },
+  "analytics_buffer_size_limit": {
+    "defaultValue": "100000",
+    "description": "Max number of messages can be buffered locally before dropping data in case there is no network connection to Konnect."
+  },
+  "portal": {
+    "defaultValue": "off",
+    "description": " Developer Portal Switch  When enabled:    Kong will expose the Dev Portal interface and   read-only APIs on the `portal_gui_listen` address,   and endpoints on the Admin API to manage assets.  When enabled along with `portal_auth`:    Kong will expose management endpoints for developer   accounts on the Admin API and the Dev Portal API."
+  },
+  "portal_gui_listen": {
+    "defaultValue": [
+      "0.0.0.0:8003",
+      "0.0.0.0:8446 ssl"
+    ],
+    "description": " Developer Portal GUI Listeners  Comma-separated list of addresses on which Kong will expose the Developer Portal GUI. Suffixes can be specified for each pair, similarly to the `admin_listen` directive."
+  },
+  "portal_gui_protocol": {
+    "defaultValue": "http",
+    "description": " Developer Portal GUI protocol  The protocol used in conjunction with `portal_gui_host` to construct the lookup, or balancer address for your Kong Proxy nodes.  Examples: `http`,`https`"
+  },
+  "portal_gui_host": {
+    "defaultValue": "127.0.0.1:8003",
+    "description": " Developer Portal GUI host  The host used in conjunction with `portal_gui_protocol` to construct the lookup, or balancer address for your Kong Proxy nodes.  Examples:  - `<IP>:<PORT>`   -> `portal_gui_host = 127.0.0.1:8003` - `<HOSTNAME>`   -> `portal_gui_host = portal_api.domain.tld` - `<HOSTNAME>/<PATH>`   -> `portal_gui_host = dev-machine/dev-285`"
+  },
+  "portal_cors_origins": {
+    "defaultValue": null,
+    "description": "Developer Portal CORS Origins  A comma separated list of allowed domains for `Access-Control-Allow-Origin` header. This can be used to resolve CORS issues in custom networking environments.  Examples: - list of domains:   `portal_cors_origins = http://localhost:8003, https://localhost:8004` - single domain:   `portal_cors_origins = http://localhost:8003` - all domains:   `portal_cors_origins = *`  NOTE: In most cases, the Developer Portal is able to derive valid CORS origins by using `portal_gui_protocol`, `portal_gui_host`, and if applicable, `portal_gui_use_subdomains`. In these cases, `portal_cors_origins` is not needed and can remain unset."
+  },
+  "portal_gui_use_subdomains": {
+    "defaultValue": "off",
+    "description": " Developer Portal GUI subdomain toggle  By default Kong Portal uses the first namespace in the request path to determine workspace. By turning `portal_gui_subdomains` on, Kong Portal will expect workspace to be included in the request url as a subdomain.  Example (off):   - `<scheme>://<HOSTNAME>/<WORKSPACE>/<PATH>` ->     `http://kong-portal.com/example-workspace/index`  Example (on):   - `<scheme>://<WORKSPACE>.<HOSTNAME>` ->     `http://example-workspace.kong-portal.com/index`"
+  },
+  "portal_gui_ssl_cert": {
+    "defaultValue": null,
+    "description": "Developer Portal GUI SSL Certificate  The SSL certificate for `portal_gui_listen` values with SSL enabled.  values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "portal_gui_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Developer Portal GUI SSL Certificate Key  The SSL key for `portal_gui_listen` values with SSL enabled.  values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+  },
+  "portal_gui_access_log": {
+    "defaultValue": "logs/portal_gui_access.log",
+    "description": " Developer Portal GUI Access Log location  Here you can set an absolute or relative path for your Portal GUI access logs.  Setting this value to `off` will disable logging Portal GUI access logs.  When using relative pathing, logs will be placed under the `prefix` location."
+  },
+  "portal_gui_error_log": {
+    "defaultValue": "logs/portal_gui_error.log",
+    "description": " Developer Portal GUI Error Log location  Here you can set an absolute or relative path for your Portal GUI error logs.  Setting this value to `off` will disable logging Portal GUI error logs.  When using relative pathing, logs will be placed under the `prefix` location.  Granularity can be adjusted through the `log_level` directive."
+  },
+  "portal_api_listen": {
+    "defaultValue": [
+      "0.0.0.0:8004",
+      "0.0.0.0:8447 ssl"
+    ],
+    "description": " Developer Portal API Listeners  Comma-separated list of addresses on which Kong will expose the Developer Portal API. Suffixes can be specified for each pair, similarly to the `admin_listen` directive."
+  },
+  "portal_api_url": {
+    "defaultValue": null,
+    "description": "Developer Portal API URL  The lookup, or balancer, address for your Developer Portal nodes.  This value is commonly used in a microservices or service-mesh oriented architecture.  `portal_api_url` is the address on which your Kong Dev Portal API is accessible by Kong. You should only set this value if your Kong Dev Portal API lives on a different node than your Kong Proxy.  Accepted format (parts in parenthesis are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`  Examples:  - `<scheme>://<IP>:<PORT>`   -> `portal_api_url = http://127.0.0.1:8003` - `SSL <scheme>://<HOSTNAME>`   -> `portal_api_url = https://portal_api.domain.tld` - `<scheme>://<HOSTNAME>/<PATH>`   -> `portal_api_url = http://dev-machine/dev-285`  By default this value points to the local interface:  - `http://0.0.0.0:8004`"
+  },
+  "portal_api_ssl_cert": {
+    "defaultValue": null,
+    "description": "Developer Portal API SSL Certificate  The SSL certificate for `portal_api_listen` values with SSL enabled.  values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "portal_api_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Developer Portal API SSL Certificate Key  The SSL key for `portal_api_listen` values with SSL enabled.  values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+  },
+  "portal_api_access_log": {
+    "defaultValue": "logs/portal_api_access.log",
+    "description": " Developer Portal API Access Log location  Here you can set an absolute or relative path for your Portal API access logs.  Setting this value to `off` will disable logging Portal API access logs.  When using relative pathing, logs will be placed under the `prefix` location."
+  },
+  "portal_api_error_log": {
+    "defaultValue": "logs/portal_api_error.log",
+    "description": " Developer Portal API Error Log location  Here you can set an absolute or relative path for your Portal API error logs.  Setting this value to `off` will disable logging Portal API error logs.  When using relative pathing, logs will be placed under the `prefix` location.  Granularity can be adjusted through the `log_level` directive."
+  },
+  "portal_is_legacy": {
+    "defaultValue": "off",
+    "description": " Developer Portal legacy support  Setting this value to `on` will cause all new portals to render using the legacy rendering system by default.  Setting this value to `off` will cause all new portals to render using the current rendering system."
+  },
+  "portal_app_auth": {
+    "defaultValue": "kong-oauth2",
+    "description": " Developer Portal application registration auth provider and strategy. Must be set to enable application_registration plugin"
+  },
+  "portal_auth": {
+    "defaultValue": null,
+    "description": "Developer Portal Authentication Plugin Name  Specifies the authentication plugin to apply to your Developer Portal. Developers will use the specified form of authentication to request access, register, and login to your Developer Portal.  Supported Plugins:  - Basic Authentication: `portal_auth = basic-auth` - OIDC Authentication: `portal_auth = openid-connect` "
+  },
+  "portal_auth_password_complexity": {
+    "defaultValue": null,
+    "description": "Kong Portal Authentication Password Complexity (JSON)  When portal_auth = basic-auth, this property defines the rules required for Kong Portal passwords. Choose from preset rules or write your own.  Example using preset rules:  `portal_auth_password_complexity = { \"kong-preset\": \"min_8\" }`  All values for kong-preset require the password to contain characters from at least three of the following categories:  1. Uppercase characters (A through Z)  2. Lowercase characters (a through z)  3. Base-10 digits (0 through 9)  4. Special characters (for example, &, $, #, %)  Supported preset rules: - `min_8`: minimum length of 8 - `min_12`: minimum length of 12 - `min_20`: minimum length of 20  To write your own rules, see https://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.  NOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.  Example:  `portal_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`"
+  },
+  "portal_auth_conf": {
+    "defaultValue": null,
+    "description": "Developer Portal Authentication Plugin Config (JSON)  Specifies the plugin configuration object in JSON format to be applied to your Developer Portal authentication.  For information about Plugin Configuration consult the associated plugin documentation.  Example for `basic-auth`:  `portal_auth_conf = { \"hide_credentials\": true }`"
+  },
+  "portal_auth_login_attempts": {
+    "defaultValue": "0",
+    "description": " Number of times a user can attempt to login to the Dev Portal before password must be reset.  0 (default) means infinite attempts allowed.  Note: Any value greater than 0 will only affect Dev Portals secured with basic-auth."
+  },
+  "portal_session_conf": {
+    "defaultValue": null,
+    "description": "Portal Session Config (JSON)  Specifies the configuration for the Session plugin as used by Kong Portal.  For information about Plugin Configuration consult the Kong Session Plugin documentation.  Example: ``` portal_session_conf = { \"cookie_name\": \"portal_session\", \\                          \"secret\": \"changeme\", \\                          \"storage\": \"kong\" } ```"
+  },
+  "portal_auto_approve": {
+    "defaultValue": "off",
+    "description": " Developer Portal Auto Approve Access  When set to `on`, a developer will automatically be marked as \"approved\" after completing registration. Access can still be revoked through Kong Manager or the Admin API.  When set to `off`, a Kong admin will have to manually approve the Developer using Kong Manager or the Admin API."
+  },
+  "portal_token_exp": {
+    "defaultValue": "21600",
+    "description": " Duration in seconds for the expiration of the Dev Portal reset password token. Default is `21600` (six hours)."
+  },
+  "portal_email_verification": {
+    "defaultValue": "off",
+    "description": " Portal Developer Email Verification.  When enabled Developers will receive an email upon registration to verify their account. Developers will not be able to use the Developer Portal until they verify their account, even if auto-approve is enabled.  Note: SMTP must be turned on in order to use this feature."
+  },
+  "portal_invite_email": {
+    "defaultValue": "on",
+    "description": " When enabled, Kong admins can invite developers to a Dev Portal by using the Invite button in Kong Manager.  The email looks like the following:  ``` Subject: Invite to access Dev Portal <WORKSPACE_NAME>  Hello Developer!  You have been invited to create a Dev Portal account at %s. Please visit `<DEV_PORTAL_URL/register>` to create your account. ```"
+  },
+  "portal_access_request_email": {
+    "defaultValue": "on",
+    "description": " When enabled, Kong admins specified by `smtp_admin_emails` will receive an email when a developer requests access to a Dev Portal.  When disabled, Kong admins will have to manually check the Kong Manager to view any requests.  The email looks like the following:  ``` Subject: Request to access Dev Portal <WORKSPACE NAME>  Hello Admin!  <DEVELOPER NAME> has requested Dev Portal access for <WORKSPACE_NAME>. Please visit <KONG_MANAGER_URL/developers/requested> to review this request. ```"
+  },
+  "portal_approved_email": {
+    "defaultValue": "on",
+    "description": " When enabled, developers will receive an email when access to a Dev Portal has been approved.  When disabled, developers will receive no indication that they have beenapproved. It is suggested to only disable this feature if `portal_auto_approve` is enabled.  The email looks like the following:  ``` Subject: Dev Portal access approved  Hello Developer! You have been approved to access <WORKSPACE_NAME>. Please visit <DEV PORTAL URL/login> to login. ```"
+  },
+  "portal_reset_email": {
+    "defaultValue": "on",
+    "description": " When enabled, developers will be able to use the Reset Password flow on a Dev Portal and will receive an email with password reset instructions.  Note: When disabled, developers will *not* be able to reset their account passwords. The password resetting email is the only way to reset developer passwords.  The email looks like the following:  ``` Subject: Password Reset Instructions for Dev Portal <WORKSPACE_NAME>.  Hello Developer,  Please click the link below to reset your Dev Portal password.  <DEV_PORTAL_URL/reset?token=12345>  This link will expire in <portal_reset_token_exp>  If you didn't make this request, keep your account secure by clicking the link above to change your password. ```"
+  },
+  "portal_reset_success_email": {
+    "defaultValue": "on",
+    "description": " When enabled, developers will receive an email after successfully resetting their Dev Portal account password.  When disabled, developers will still be able to reset their account passwords, but will not receive a confirmation email.  The email looks like the following:  ``` Subject: Dev Portal password change success  Hello Developer, We are emailing you to let you know that your Dev Portal password at <DEV_PORTAL_URL> has been changed.  Click the link below to sign in with your new credentials.  <DEV_PORTAL_URL> ```"
+  },
+  "portal_application_status_email": {
+    "defaultValue": "off",
+    "description": " When enabled, developers will receive an email when the status changes for their appliciation service requests.  When disabled, developers will still be able to view the status in their developer portal application page.  The email looks like the following:  ``` Subject: Dev Portal application request <REQUEST_STATUS> (<DEV_PORTAL_URL>)  Hello Developer, We are emailing you to let you know that your request for application access from the Developer Portal account at <DEV_PORTAL_URL> is <REQUEST_STATUS>.  Application: <APPLICATION_NAME> Service: <SERVICE_NAME>  You will receive another email when your access has been approved. ```"
+  },
+  "portal_application_request_email": {
+    "defaultValue": "off",
+    "description": " When enabled, Kong admins specified by `smtp_admin_emails` will receive an email when a developer requests access to service through an application.  When disabled, Kong admins will have to manually check the Kong Manager to view any requests.  By default, `smtp_admin_emails` will be the recipients. This can be overriden by `portal_smtp_admin_emails`, which can be set dynamically per workspace through the Admin API.  The email looks like the following:  ``` Subject: Request to access Dev Portal (<DEV_PORTAL_URL>) service from <DEVELOPER_EMAIL>  Hello Admin,  <DEVELOPER NAME> (<DEVELOPER_EMAIL>) has requested application access for <DEV_PORTAL_URL>.  Requested workspace: <WORKSPACE_NAME> Requested application: <APPLICATION_NAME> Requested service: <SERVICE_NAME>  Please visit <KONG_MANAGER_URL/WORKSPACE_NAME/applications/APPLICATION_ID#requested> to review this request. ```"
+  },
+  "portal_emails_from": {
+    "defaultValue": null,
+    "description": "The name and email address for the `From` header included in all Dev Portal emails.  Example: `portal_emails_from = Your Name <example@example.com>`  Note: Some SMTP servers will not use this value, but instead insert the email and name associated with the account."
+  },
+  "portal_emails_reply_to": {
+    "defaultValue": null,
+    "description": "Email address for the `Reply-To` header for portal emails  Example: `portal_emails_reply_to = example@example.com`  Note: Some SMTP servers will not use this value, but instead insert the email associated with the account."
+  },
+  "portal_smtp_admin_emails": {
+    "defaultValue": null,
+    "description": " Comma separated list of admin emails to receive portal notifications. Can be dynamically set per workspace through the Admin API.  If not set, `smtp_admin_emails` will be used.  Example `admin1@example.com, admin2@example.com`"
+  },
+  "admin_emails_from": {
+    "defaultValue": "\"\"",
+    "description": "The email address for the `From` header for admin emails."
+  },
+  "admin_emails_reply_to": {
+    "defaultValue": null,
+    "description": "Email address for the `Reply-To` header for admin emails."
+  },
+  "admin_invitation_expiry": {
+    "defaultValue": "259200",
+    "description": "Expiration time for the admin invitation link (in seconds). 0 means no expiration.  Example, 72 hours: `72 * 60 * 60 = 259200`"
+  },
+  "smtp_mock": {
+    "defaultValue": "on",
+    "description": "This flag will mock the sending of emails. This can be used for testing before the SMTP client is fully configured."
+  },
+  "smtp_host": {
+    "defaultValue": "localhost",
+    "description": " The hostname of the SMTP server to connect to."
+  },
+  "smtp_port": {
+    "defaultValue": "25",
+    "description": " The port number on the SMTP server to connect to."
+  },
+  "smtp_starttls": {
+    "defaultValue": "off",
+    "description": " When set to `on`, STARTTLS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 587."
+  },
+  "smtp_username": {
+    "defaultValue": null,
+    "description": "Username used for authentication with SMTP server"
+  },
+  "smtp_password": {
+    "defaultValue": null,
+    "description": "Password used for authentication with SMTP server"
+  },
+  "smtp_ssl": {
+    "defaultValue": "off",
+    "description": " When set to `on`, SMTPS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 465."
+  },
+  "smtp_auth_type": {
+    "defaultValue": null,
+    "description": "The method used to authenticate with the SMTP server Valid options are `plain`, `login`, or `nil`"
+  },
+  "smtp_domain": {
+    "defaultValue": "localhost.localdomain",
+    "description": " The domain used in the `EHLO` connection and part of the `Message-ID` header"
+  },
+  "smtp_timeout_connect": {
+    "defaultValue": "60000",
+    "description": " The timeout (in milliseconds) for connecting to the SMTP server."
+  },
+  "smtp_timeout_send": {
+    "defaultValue": "60000",
+    "description": " The timeout (in milliseconds) for sending data to the SMTP server."
+  },
+  "smtp_timeout_read": {
+    "defaultValue": "60000",
+    "description": " The timeout (in milliseconds) for reading data from the SMTP server."
+  },
+  "smtp_admin_emails": {
+    "defaultValue": null,
+    "description": "Comma separated list of admin emails to receive notifications. Example `admin1@example.com, admin2@example.com`"
+  },
+  "audit_log": {
+    "defaultValue": "off",
+    "description": "When enabled, Kong will log information about Admin API access and database row insertions, updates, and deletes."
+  },
+  "audit_log_ignore_methods": {
+    "defaultValue": null,
+    "description": "Comma-separated list of HTTP methods that will not generate audit log entries. By default, all HTTP requests will be logged."
+  },
+  "audit_log_ignore_paths": {
+    "defaultValue": null,
+    "description": "Comma-separated list of request paths that will not generate audit log entries. By default, all HTTP requests will be logged."
+  },
+  "audit_log_ignore_tables": {
+    "defaultValue": null,
+    "description": "Comma-separated list of database tables that will not generate audit log entries. By default, updates to all database tables will be logged (the term \"updates\" refers to the creation, update, or deletion of a row)."
+  },
+  "audit_log_payload_exclude": {
+    "defaultValue": [
+      "token",
+      "secret",
+      "password"
+    ],
+    "description": " Comma-separated list of keys that will be filtered out of the payload. Keys that were filtered will be recorded in the audit log."
+  },
+  "audit_log_record_ttl": {
+    "defaultValue": "2592000",
+    "description": "Length, in seconds, of the TTL for audit log records. Records in the database older than their TTL are automatically purged.  Example, 30 days: `30 * 24 * 60 * 60 = 2592000`"
+  },
+  "audit_log_signing_key": {
+    "defaultValue": null,
+    "description": "Defines the path to a private RSA signing key that can be used to insert a signature of audit records, adjacent to the record. The corresponding public key should be stored offline, and can be used the validate audit entries in the future. If this value is undefined, no signature will be generated."
+  },
+  "tracing": {
+    "defaultValue": "off",
+    "description": "When enabled, Kong will generate granular debug data about various portions of the request lifecycle, such as DB or DNS queries, plugin execution, core handler timing, etc."
+  },
+  "tracing_write_strategy": {
+    "defaultValue": "file",
+    "description": "Defines how Kong will write tracing data at the conclusion of the request. The default option, `file`, writes a human-readable depiction of tracing data to a configurable location on the node's file system. Other strategies write tracing data as a JSON document to the configured endpoint. Valid entries for this option are `file`, `file_raw`, `http`, `tcp`, `tls`, and `udp`."
+  },
+  "tracing_write_endpoint": {
+    "defaultValue": null,
+    "description": "Defines the endpoint to which tracing data will be written.  - For the `file` and `file_raw` tracing write   strategies, this value must be a valid   location on the node's file system to which   Kong must have write access. - For the `tcp`, `tls`, and   `udp` strategies, this value is defined as a   string in the form of:  `<HOST>:<PORT>` - For the `http` strategy, this value is   defined in the form of:  `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`  Traces sent via HTTP are delivered via POST method with an `application/json` Content-Type."
+  },
+  "tracing_time_threshold": {
+    "defaultValue": "0",
+    "description": "The minimum time, in microseconds, over which a trace must execute in order to write the trace data to the configured endpoint. This configuration can be used to lower the noise present in trace data by removing trace objects that are not interesting from a timing perspective. The default value of `0` removes this limitation, causing traces of any duration to be written."
+  },
+  "tracing_types": {
+    "defaultValue": "all",
+    "description": "Defines the types of traces that are written. Trace types not defined in this list are ignored, regardless of their lifetime. The default special value of `all` results in all trace types being written, regardless of type.  The following trace types are included:  - `query`: trace the database query - `legacy_query`: (deprecated) trace the    database query with legacy DAO - `router`: trace Kong routing the request;    internal routing time - `balancer`: trace the execution of the overall    balancer phase - `balancer.getPeer`: trace Kong selecting an    upstream peer from the ring-balancer - `balancer.toip`: trace balancer to resolve    peer's host to IP - `connect.toip`: trace cosocket to resolve    target's host to IP - `access.before`: trace the preprocessing of    access phase, like parameter parsing, route    matching, and balance preparation - `access.after`: trace the postprocess of    access phase, like balancer execution and    internal variable assigning - `plugin`: trace plugins phase handlers"
+  },
+  "tracing_debug_header": {
+    "defaultValue": null,
+    "description": "Defines the name of the HTTP request header that must be present in order to generate traces within a request. Setting this value provides a mechanism to selectively generate request traces at the client's request. Note that the value of the header does not matter, only that the header is present in the request. When this value is not set and tracing is enabled, Kong will generate trace data for all requests flowing through the proxy and Admin API. Note that data from certificate handling phases is not logged when this setting is enabled."
+  },
+  "generate_trace_details": {
+    "defaultValue": "off",
+    "description": "When enabled, Kong will write context- specific details into traces. Trace details offer more data about the context of the trace. This can significantly increase the size of trace reports. Note also that trace details may contain potentially sensitive information, such as raw SQL queries; care should be taken to store traces properly when this option is enabled."
+  },
+  "route_validation_strategy": {
+    "defaultValue": "smart",
+    "description": "The strategy used to validate routes when creating or updating them. Different strategies are available to tune how to enforce splitting traffic of workspaces. - `smart` is the default option and uses the   algorithm described in   https://docs.konghq.com/enterprise/latest/admin-api/workspaces/examples/#important-note-conflicting-services-or-routes-in-workspaces - `off` disables any check - `path` enforces routes to comply with the pattern   described in config enforce_route_path_pattern"
+  },
+  "enforce_route_path_pattern": {
+    "defaultValue": null,
+    "description": "Specifies the Lua pattern which will be enforced on the `paths` attribute of a Route object. You can also add a placeholder for the workspace in the pattern, which will be rendered during runtime based on the workspace to which the `route` belongs. This setting is only relevant if `route_validation_strategy` is set to `path`.   Example For Pattern `/$(workspace)/v%d/.*` valid paths are:  1. `/group1/v1/` if route belongs to   workspace `group1`.  2. `/group2/v1/some_path` if route belongs to   workspace `group2`."
+  },
+  "keyring_enabled": {
+    "defaultValue": "off",
+    "description": "When enabled, Kong will encrypt sensitive field values before writing them to the database, and subsuquently decrypt them when retrieving data for the Admin API, Developer Portal, or proxy business logic. Symmetric encryption keys are managed based on the strategy defined below."
+  },
+  "keyring_strategy": {
+    "defaultValue": "cluster",
+    "description": "Defines the strategy implementation by which Kong nodes will manage symmetric encryption keys. Please see the Kong Enterprise documentation for a detailed description of each strategies. Acceptable values for this option are 'cluster' and 'vault'."
+  },
+  "keyring_public_key": {
+    "defaultValue": null,
+    "description": "Defines the public key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  values: * absolute path to the public key * public key content * base64 encoded public key content"
+  },
+  "keyring_private_key": {
+    "defaultValue": null,
+    "description": "Defines the private key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  values: * absolute path to the private key * private key content * base64 encoded private key content"
+  },
+  "keyring_blob_path": {
+    "defaultValue": null,
+    "description": "Defines the filesystem path at which Kong will backup the initial keyring material. This option is useful largely for development purposes."
+  },
+  "keyring_vault_host": {
+    "defaultValue": null,
+    "description": "Defines the Vault host at which Kong will fetch the encryption material. This value should be defined in the format:  `<scheme>://<IP / HOSTNAME>:<PORT>`"
+  },
+  "keyring_vault_mount": {
+    "defaultValue": null,
+    "description": "Defines the name of the Vault v2 KV secrets engine at which symmetric keys are found."
+  },
+  "keyring_vault_path": {
+    "defaultValue": null,
+    "description": "Defines the names of the Vault v2 KV path at which symmetric keys are found."
+  },
+  "keyring_vault_auth_method": {
+    "defaultValue": "token",
+    "description": " Defines the authentication mechanism when connecting to the Hashicorp Vault service.  Accepted values are: `token`, or `kubernetes`:  * `token`: Uses the static token defined in            the `keyring_vault_token`            configuration property.  * `kubernetes`: Uses the Kubernetes authentication                 mechanism, with the running pod's                 mapped service account, to assume                 the Hashicorp Vault role name that is                 defined in the `keyring_vault_kube_role`                 configuration property."
+  },
+  "keyring_vault_token": {
+    "defaultValue": null,
+    "description": "Defines the token value used to communicate with the v2 KV Vault HTTP(S) API."
+  },
+  "keyring_vault_kube_role": {
+    "defaultValue": "default",
+    "description": " Defines the Hashicorp Vault role that will be assumed using the Kubernetes service account of the running pod.  `keyring_vault_auth_method` must be set to `kubernetes` for this to activate."
+  },
+  "keyring_vault_kube_api_token_file": {
+    "defaultValue": "/run/secrets/kubernetes.io/serviceaccount/token",
+    "description": " Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+  },
+  "untrusted_lua": {
+    "defaultValue": "sandbox",
+    "description": " Controls loading of Lua functions from admin-supplied sources such as the Admin API. LuaJIT bytecode loading is always disabled.  **Warning:** LuaJIT is not designed as a secure runtime for running malicious code, therefore you should properly protect your Admin API endpoint even with sandboxing enabled. The sandbox only provides protection against trivial attackers or unintentional modification of the Kong global environment.  Accepted values are: `off`, `sandbox`, or `on`:  * `off`: Disallow loading of any arbitrary          Lua functions. The `off` option          disables any functionality that runs          arbitrary Lua code, including the          Serverless Functions plugins and any          transformation plugin that allows          custom Lua functions.  * `sandbox`: Allow loading of Lua functions,              but use a sandbox when executing              them. The sandboxed function has              restricted access to the global              environment and only has access              to standard Lua functions that              will generally not cause harm to              the Kong Gateway node.  * `on`: Functions have unrestricted         access to the global environment and         can load any Lua modules. This is         similar to the behavior in         Kong Gateway prior to 2.3.0.  The default `sandbox` environment does not allow importing other modules or libraries, or executing anything at the OS level (for example, file read/write). The global environment is also not accessible.  Examples of `untrusted_lua = sandbox` behavior:  * You can't access or change global values such as `kong.configuration.pg_password` * You can run harmless lua: `local foo = 1 + 1`. However, OS level functions are not allowed, like: `os.execute('rm -rf /*')`.  For a full allowed/disallowed list, see: https://github.com/kikito/sandbox.lua/blob/master/sandbox.lua  To customize the sandbox environment, use the `untrusted_lua_sandbox_requires` and `untrusted_lua_sandbox_environment` parameters below."
+  },
+  "untrusted_lua_sandbox_requires": {
+    "defaultValue": null,
+    "description": "Comma-separated list of modules allowed to be loaded with `require` inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  For example, say you have configured the Serverless pre-function plugin and it contains the following `requires`:  ``` local template = require \"resty.template\" local split = require \"kong.tools.utils\".split ```  To run the plugin, add the modules to the allowed list: ``` untrusted_lua_sandbox_requires = resty.template, kong.tools.utils ```  **Warning:** Allowing certain modules may create opportunities to escape the sandbox. For example, allowing `os` or `luaposix` may be unsafe."
+  },
+  "untrusted_lua_sandbox_environment": {
+    "defaultValue": null,
+    "description": "Comma-separated list of global Lua variables that should be made available inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  **Warning**: Certain variables, when made available, may create opportunities to escape the sandbox."
+  },
+  "openresty_path": {
+    "defaultValue": null,
+    "description": "Path to the OpenResty installation that Kong will use. When this is empty (the default), Kong determines the OpenResty installation by searching for a system-installed OpenResty and falling back to searching $PATH for the nginx binary.  Setting this attribute disables the search behavior and explicitly instructs Kong which OpenResty installation to use."
+  },
+  "node_id": {
+    "defaultValue": null,
+    "description": "Node ID for the Kong node. Every Kong node in a Kong cluster must have a unique and valid UUID. When empty, node ID is automatically generated."
+  },
+  "cluster_fallback_config_import": {
+    "defaultValue": "off",
+    "description": "Enable fallback configuration imports  This should only be enabled for data plane"
+  },
+  "cluster_fallback_config_storage": {
+    "defaultValue": null,
+    "description": "Storage definition used by `cluster_fallback_config_import` and `cluster_fallback_config_export`  Currently supported storage type: S3-like storages and GCP storage service. To use S3 with a bucket named b and place all configs to with a key prefix named p, set it to: s3://b/p To use GCP for the same bucket and prefix, set it to: gcs://b/p  The credentials (and endpoint URL for S3-like) for S3 are passing with environment variables: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` and `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where `AWS_CONFIG_STORAGE_ENDPOINT` is the endpoint that hosts S3-like storage. The credentials for GCP is provided via the environment variable `GCP_SERVICE_ACCOUNT`"
+  },
+  "cluster_fallback_config_export": {
+    "defaultValue": "off",
+    "description": "Enable fallback configuration exports."
+  },
+  "cluster_fallback_config_export_delay": {
+    "defaultValue": "60",
+    "description": "The fallback configuration export interval. If it's set to 60 and configuration A is exported and there're new configurations B, C and D in the next 60 seconds, it will wait until 60 seconds passed and export D, skipping B and C."
+  },
+  "wasm": {
+    "defaultValue": "off",
+    "description": "Enable/disable wasm support. This must be enabled in order to use wasm filters and filter chains."
+  },
+  "wasm_filters_path": {
+    "defaultValue": null,
+    "description": "Path to the directory containing wasm filter modules.  At startup, Kong discovers available wasm filters by scanning this directory for files with the `.wasm` file extension.  The name of a wasm filter module is derived from the filename itself, with the .wasm extension removed. So, given the following tree:  ``` /path/to/wasm_filters ├── my_module.wasm ├── my_other_module.wasm └── not_a_wasm_module.txt ```  The resulting filter modules available for use in Kong will be:  * `my_module` * `my_other_module`  Notes:  * No recursion is performed. Only .wasm files at the   top level are registered * This path _may_ be a symlink to a directory."
+  },
+  "request_debug": {
+    "defaultValue": "on",
+    "description": "When enabled, Kong will provide detailed timing information for its components to the client and the error log if the following headers are present in the proxy request: - `X-Kong-Request-Debug`:   If the value is set to `*`,   timing information will be collected and exported for the current request.   If this header is not present or contains unknown value,   timing information will not be collected for the current request.   You can also specify a list of filters, separated by commas,   to filter the scope of the time information that is collected.   The following filters are supported:   - `rewrite`: Collect timing information from the `rewrite` phase.   - `access`: Collect timing information from the `access` phase.   - `balancer`: Collect timing information from the `balancer` phase.   - `response`: Collect timing information from the `response` phase.   - `header_filter`: Collect timing information from the `header_filter` phase.   - `body_filter`: Collect timing information from the `body_filter` phase.   - `log`: Collect timing information from the `log` phase.   - `upstream`: Collect timing information from the `upstream` phase.  - `X-Kong-Request-Debug-Log`:   If set to `true`, timing information will also be logged   in the Kong error log with a log level of `notice`.   Defaults to `false`.  - `X-Kong-Request-Debug-Token`:   Token for authenticating the client making the debug   request to prevent abuse. Debug requests originating from loopback   addresses do not require this header. "
+  },
+  "request_debug_token": {
+    "defaultValue": "<random>",
+    "description": "The Request Debug Token is used in the `X-Kong-Request-Debug-Token` header to prevent abuse. If this value is not set (the default), a random token will be generated when Kong starts, restarts, or reloads. If a token is specified manually, then the provided token will be used.  You can locate the generated debug token in two locations: - Kong error log:   Debug token will be logged in the error log (notice level)   when Kong starts, restarts, or reloads.   The log line will have the: `[request-debug]` prefix to aid searching. - Filesystem:   Debug token will also be stored in a file located at   `{prefix}/.request_debug_token` and updated   when Kong starts, restarts, or reloads."
+  }
+}

--- a/app/_data/kong-conf/3.4.json
+++ b/app/_data/kong-conf/3.4.json
@@ -1,317 +1,317 @@
 {
   "prefix": {
     "defaultValue": "/usr/local/kong/",
-    "description": "Working directory. Equivalent to Nginx's prefix path, containing temporary files and logs. Each Kong process must have a separate working directory."
+    "description": "Working directory. Equivalent to Nginx's\nprefix path, containing temporary files\nand logs.\nEach Kong process must have a separate\nworking directory.\n"
   },
   "log_level": {
     "defaultValue": "notice",
-    "description": "Log level of the Nginx server. Logs are found at `<prefix>/logs/error.log`."
+    "description": "Log level of the Nginx server. Logs are\nfound at `<prefix>/logs/error.log`.\n"
   },
   "proxy_access_log": {
     "defaultValue": "logs/access.log",
-    "description": "Path for proxy port request access logs. Set this value to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for proxy port request access\nlogs. Set this value to `off` to\ndisable logging proxy requests.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n"
   },
   "proxy_error_log": {
     "defaultValue": "logs/error.log",
-    "description": "Path for proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for proxy port request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "proxy_stream_access_log": {
     "defaultValue": "logs/access.log basic",
-    "description": "Path for tcp streams proxy port access logs. Set this value to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location. `basic` is defined as `'$remote_addr [$time_local] ' '$protocol $status $bytes_sent $bytes_received ' '$session_time'`"
+    "description": "Path for tcp streams proxy port access\nlogs. Set this value to `off` to\ndisable logging proxy requests.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n`basic` is defined as `'$remote_addr [$time_local] '\n'$protocol $status $bytes_sent $bytes_received '\n'$session_time'`\n"
   },
   "proxy_stream_error_log": {
     "defaultValue": "logs/error.log",
-    "description": "Path for tcp streams proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for tcp streams proxy port request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "admin_access_log": {
     "defaultValue": "logs/admin_access.log",
-    "description": "Path for Admin API request access logs. If Hybrid Mode is enabled and the current node is set to be the Control Plane, then the connection requests from Data Planes are also written to this file with server name \"kong_cluster_listener\".  Set this value to `off` to disable logging Admin API requests. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for Admin API request access\nlogs. If Hybrid Mode is enabled\nand the current node is set to be\nthe Control Plane, then the\nconnection requests from Data Planes\nare also written to this file with\nserver name \"kong_cluster_listener\".\n\nSet this value to `off` to\ndisable logging Admin API requests.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n"
   },
   "admin_error_log": {
     "defaultValue": "logs/error.log",
-    "description": "Path for Admin API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for Admin API request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "status_access_log": {
     "defaultValue": "off",
-    "description": "Path for Status API request access logs. The default value of `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for Status API request access\nlogs. The default value of `off`\nimplies that logging for this API\nis disabled by default.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n"
   },
   "status_error_log": {
     "defaultValue": "logs/status_error.log",
-    "description": "Path for Status API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for Status API request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "debug_access_log": {
     "defaultValue": "off",
-    "description": "Path for Debug API request access logs. The default value of `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for Debug API request access\nlogs. The default value of `off`\nimplies that logging for this API\nis disabled by default.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n"
   },
   "debug_error_log": {
     "defaultValue": "logs/debug_error.log",
-    "description": "Path for Debug API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for Debug API request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "vaults": {
     "defaultValue": "bundled",
-    "description": "Comma-separated list of vaults this node should load. By default, all the bundled vaults are enabled.  The specified name(s) will be substituted as such in the Lua namespace: `kong.vaults.{name}.*`."
+    "description": "Comma-separated list of vaults this node\nshould load. By default, all the bundled\nvaults are enabled.\n\nThe specified name(s) will be substituted as\nsuch in the Lua namespace:\n`kong.vaults.{name}.*`.\n"
   },
   "opentelemetry_tracing": {
     "defaultValue": "off",
-    "description": "Deprecated: use tracing_instrumentations instead"
+    "description": "Deprecated: use tracing_instrumentations instead\n"
   },
   "tracing_instrumentations": {
     "defaultValue": "off",
-    "description": "Comma-separated list of tracing instrumentations this node should load. By default, no instrumentations are enabled.  Valid values to this setting are:  - `off`: do not enable instrumentations. - `request`: only enable request-level instrumentations. - `all`: enable all the following instrumentations. - `db_query`: trace database query - `dns_query`: trace DNS query. - `router`: trace router execution, including   router rebuilding. - `http_client`: trace OpenResty HTTP client requests. - `balancer`: trace balancer retries. - `plugin_rewrite`: trace plugins iterator   execution with rewrite phase. - `plugin_access`: trace plugins iterator   execution with access phase. - `plugin_header_filter`: trace plugins iterator   execution with header_filter phase.  **Note:** In the current implementation, tracing instrumentations are not enabled in stream mode."
+    "description": "Comma-separated list of tracing instrumentations\nthis node should load. By default, no instrumentations\nare enabled.\n\nValid values to this setting are:\n\n- `off`: do not enable instrumentations.\n- `request`: only enable request-level instrumentations.\n- `all`: enable all the following instrumentations.\n- `db_query`: trace database query\n- `dns_query`: trace DNS query.\n- `router`: trace router execution, including\n  router rebuilding.\n- `http_client`: trace OpenResty HTTP client requests.\n- `balancer`: trace balancer retries.\n- `plugin_rewrite`: trace plugins iterator\n  execution with rewrite phase.\n- `plugin_access`: trace plugins iterator\n  execution with access phase.\n- `plugin_header_filter`: trace plugins iterator\n  execution with header_filter phase.\n\n**Note:** In the current implementation,\ntracing instrumentations are not enabled in\nstream mode.\n"
   },
   "opentelemetry_tracing_sampling_rate": {
     "defaultValue": "1.0",
-    "description": "Deprecated: use tracing_sampling_rate instead"
+    "description": "Deprecated: use tracing_sampling_rate instead\n"
   },
   "tracing_sampling_rate": {
     "defaultValue": "0.01",
-    "description": "Tracing instrumentation sampling rate. Tracer samples a fixed percentage of all spans following the sampling rate.  Example: `0.25`, this should account for 25% of all traces."
+    "description": "Tracing instrumentation sampling rate.\nTracer samples a fixed percentage of all spans\nfollowing the sampling rate.\n\nExample: `0.25`, this should account for 25% of all traces.\n"
   },
   "plugins": {
     "defaultValue": "bundled",
-    "description": "Comma-separated list of plugins this node should load. By default, only plugins bundled in official distributions are loaded via the `bundled` keyword.  Loading a plugin does not enable it by default, but only instructs Kong to load its source code, and allows to configure the plugin via the various related Admin API endpoints.  The specified name(s) will be substituted as such in the Lua namespace: `kong.plugins.{name}.*`.  When the `off` keyword is specified as the only value, no plugins will be loaded.  `bundled` and plugin names can be mixed together, as the following examples suggest:  - `plugins = bundled,custom-auth,custom-log`   will include the bundled plugins plus two   custom ones - `plugins = custom-auth,custom-log` will   *only* include the `custom-auth` and   `custom-log` plugins. - `plugins = off` will not include any   plugins  **Note:** Kong will not start if some plugins were previously configured (i.e. have rows in the database) and are not specified in this list.  Before disabling a plugin, ensure all instances of it are removed before restarting Kong.  **Note:** Limiting the amount of available plugins can improve P99 latency when experiencing LRU churning in the database cache (i.e. when the configured `mem_cache_size`) is full."
+    "description": "Comma-separated list of plugins this node\nshould load. By default, only plugins\nbundled in official distributions are\nloaded via the `bundled` keyword.\n\nLoading a plugin does not enable it by\ndefault, but only instructs Kong to load its\nsource code, and allows to configure the\nplugin via the various related Admin API\nendpoints.\n\nThe specified name(s) will be substituted as\nsuch in the Lua namespace:\n`kong.plugins.{name}.*`.\n\nWhen the `off` keyword is specified as the\nonly value, no plugins will be loaded.\n\n`bundled` and plugin names can be mixed\ntogether, as the following examples suggest:\n\n- `plugins = bundled,custom-auth,custom-log`\n  will include the bundled plugins plus two\n  custom ones\n- `plugins = custom-auth,custom-log` will\n  *only* include the `custom-auth` and\n  `custom-log` plugins.\n- `plugins = off` will not include any\n  plugins\n\n**Note:** Kong will not start if some\nplugins were previously configured (i.e.\nhave rows in the database) and are not\nspecified in this list.  Before disabling a\nplugin, ensure all instances of it are\nremoved before restarting Kong.\n\n**Note:** Limiting the amount of available\nplugins can improve P99 latency when\nexperiencing LRU churning in the database\ncache (i.e. when the configured\n`mem_cache_size`) is full.\n"
   },
   "pluginserver_names": {
     "defaultValue": null,
-    "description": "Comma-separated list of names for pluginserver processes.  The actual names are used for log messages and to relate the actual settings."
+    "description": "Comma-separated list of names for pluginserver\nprocesses.  The actual names are used for\nlog messages and to relate the actual settings.\n"
   },
   "pluginserver_XXX_socket": {
     "defaultValue": "<prefix>/<XXX>.socket",
-    "description": "Path to the unix socket used by the <XXX> pluginserver."
+    "description": "Path to the unix socket\nused by the <XXX> pluginserver.\n"
   },
   "pluginserver_XXX_start_cmd": {
     "defaultValue": "/usr/local/bin/<XXX>",
-    "description": "Full command (including any needed arguments) to start the <XXX> pluginserver"
+    "description": "Full command (including\nany needed arguments) to\nstart the <XXX> pluginserver\n"
   },
   "pluginserver_XXX_query_cmd": {
     "defaultValue": "/usr/local/bin/query_<XXX>",
-    "description": "Full command to \"query\" the <XXX> pluginserver.  Should produce a JSON with the dump info of all plugins it manages"
+    "description": "Full command to \"query\" the\n<XXX> pluginserver.  Should\nproduce a JSON with the\ndump info of all plugins it\nmanages\n"
   },
   "port_maps": {
     "defaultValue": null,
-    "description": "With this configuration parameter, you can let the Kong to know about the port from which the packets are forwarded to it. This is fairly common when running Kong in a containerized or virtualized environment. For example, `port_maps=80:8000, 443:8443` instructs Kong that the port 80 is mapped to 8000 (and the port 443 to 8443), where 8000 and 8443 are the ports that Kong is listening to.  This parameter helps Kong set a proper forwarded upstream HTTP request header or to get the proper forwarded port with the Kong PDK (in case other means determining it has failed). It changes routing by a destination port to route by a port from which packets are forwarded to Kong, and similarly it changes the default plugin log serializer to use the port according to this mapping instead of reporting the port Kong is listening to."
+    "description": "With this configuration parameter, you can\nlet the Kong to know about the port from\nwhich the packets are forwarded to it. This\nis fairly common when running Kong in a\ncontainerized or virtualized environment.\nFor example, `port_maps=80:8000, 443:8443`\ninstructs Kong that the port 80 is mapped\nto 8000 (and the port 443 to 8443), where\n8000 and 8443 are the ports that Kong is\nlistening to.\n\nThis parameter helps Kong set a proper\nforwarded upstream HTTP request header or to\nget the proper forwarded port with the Kong PDK\n(in case other means determining it has\nfailed). It changes routing by a destination\nport to route by a port from which packets\nare forwarded to Kong, and similarly it\nchanges the default plugin log serializer to\nuse the port according to this mapping\ninstead of reporting the port Kong is\nlistening to.\n"
   },
   "anonymous_reports": {
     "defaultValue": "on",
-    "description": "Send anonymous usage data such as error stack traces to help improve Kong."
+    "description": "Send anonymous usage data such as error\nstack traces to help improve Kong.\n"
   },
   "proxy_server": {
     "defaultValue": null,
-    "description": "Proxy server defined as a URL. Kong will only use this option if any component is explicitly configured to use proxy."
+    "description": "Proxy server defined as a URL. Kong will only use this\noption if any component is explicitly configured\nto use proxy.\n"
   },
   "proxy_server_ssl_verify": {
     "defaultValue": "off",
-    "description": "Toggles server certificate verification if `proxy_server` is in HTTPS. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+    "description": "Toggles server certificate verification if\n`proxy_server` is in HTTPS.\nSee the `lua_ssl_trusted_certificate`\nsetting to specify a certificate authority.\n"
   },
   "error_template_html": {
     "defaultValue": null,
-    "description": "Path to the custom html error template to override the default html kong error template.  The template may contain up to two `%s` placeholders. The first one will expand to the error message. The second one will expand to the request ID. Both placeholders are optional, but recommended. Adding more than two placeholders will result in a runtime error when trying to render the template: ``` <html>   <body>     <h1>My custom error template</h1>     <p>error: %s</p>     <p>request_id: %s</p>   </body> </html> ```"
+    "description": "Path to the custom html error template to\noverride the default html kong error\ntemplate.\n\nThe template may contain up to two `%s`\nplaceholders. The first one will expand to\nthe error message. The second one will\nexpand to the request ID. Both placeholders\nare optional, but recommended.\nAdding more than two placeholders will\nresult in a runtime error when trying to\nrender the template:\n```\n<html>\n  <body>\n    <h1>My custom error template</h1>\n    <p>error: %s</p>\n    <p>request_id: %s</p>\n  </body>\n</html>\n```\n"
   },
   "error_template_json": {
     "defaultValue": null,
-    "description": "Path to the custom json error template to override the default json kong error template.  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+    "description": "Path to the custom json error template to\noverride the default json kong error\ntemplate.\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n"
   },
   "error_template_xml": {
     "defaultValue": null,
-    "description": "Path to the custom xml error template to override the default xml kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+    "description": "Path to the custom xml error template to\noverride the default xml kong error template\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n"
   },
   "error_template_plain": {
     "defaultValue": null,
-    "description": "Path to the custom plain error template to override the default plain kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+    "description": "Path to the custom plain error template to\noverride the default plain kong error\ntemplate\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n"
   },
   "role": {
     "defaultValue": "traditional",
-    "description": "Use this setting to enable Hybrid Mode, This allows running some Kong nodes in a control plane role with a database and have them deliver configuration updates to other nodes running to DB-less running in a Data Plane role.  Valid values to this setting are:  - `traditional`: do not use Hybrid Mode. - `control_plane`: this node runs in a   control plane role. It can use a database   and will deliver configuration updates   to data plane nodes. - `data_plane`: this is a data plane node.   It runs DB-less and receives configuration   updates from a control plane node."
+    "description": "Use this setting to enable Hybrid Mode,\nThis allows running some Kong nodes in a\ncontrol plane role with a database and\nhave them deliver configuration updates\nto other nodes running to DB-less running in\na Data Plane role.\n\nValid values to this setting are:\n\n- `traditional`: do not use Hybrid Mode.\n- `control_plane`: this node runs in a\n  control plane role. It can use a database\n  and will deliver configuration updates\n  to data plane nodes.\n- `data_plane`: this is a data plane node.\n  It runs DB-less and receives configuration\n  updates from a control plane node.\n"
   },
   "cluster_mtls": {
     "defaultValue": "shared",
-    "description": "Sets the verification between nodes of the cluster.  Valid values to this setting are:  - `shared`: use a shared certificate/key   pair specified with the `cluster_cert`   and `cluster_cert_key` settings.   Note that CP and DP nodes have to present   the same certificate to establish mTLS   connections. - `pki`: use `cluster_ca_cert`,   `cluster_server_name` and `cluster_cert`   for verification.   These are different certificates for each   DP node, but issued by a cluster-wide   common CA certificate: `cluster_ca_cert`. - `pki_check_cn`: similar as `pki` but additionally   checks for Common Name of data plane certificate   specified in `cluster_allowed_common_names`."
+    "description": "Sets the verification between nodes of the\ncluster.\n\nValid values to this setting are:\n\n- `shared`: use a shared certificate/key\n  pair specified with the `cluster_cert`\n  and `cluster_cert_key` settings.\n  Note that CP and DP nodes have to present\n  the same certificate to establish mTLS\n  connections.\n- `pki`: use `cluster_ca_cert`,\n  `cluster_server_name` and `cluster_cert`\n  for verification.\n  These are different certificates for each\n  DP node, but issued by a cluster-wide\n  common CA certificate: `cluster_ca_cert`.\n- `pki_check_cn`: similar as `pki` but additionally\n  checks for Common Name of data plane certificate\n  specified in `cluster_allowed_common_names`.\n"
   },
   "cluster_cert": {
     "defaultValue": null,
-    "description": "Cluster certificate to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes.  Under `pki` mode it should be a different certificate for each DP node.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "Cluster certificate to use\nwhen establishing secure communication\nbetween control and data plane nodes.\nYou can use the `kong hybrid` command to\ngenerate the certificate/key pair.\nUnder `shared` mode, it must be the same\nfor all nodes.  Under `pki` mode it\nshould be a different certificate for each\nDP node.\n\nThe certificate can be configured on this\nproperty with either of the following values:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "cluster_cert_key": {
     "defaultValue": null,
-    "description": "Cluster certificate key to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes.  Under `pki` mode it should be a different certificate for each DP node.  The certificate key can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+    "description": "Cluster certificate key to\nuse when establishing secure communication\nbetween control and data plane nodes.\nYou can use the `kong hybrid` command to\ngenerate the certificate/key pair.\nUnder `shared` mode, it must be the same\nfor all nodes.  Under `pki` mode it\nshould be a different certificate for each\nDP node.\n\nThe certificate key can be configured on this\nproperty with either of the following values:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n"
   },
   "cluster_ca_cert": {
     "defaultValue": null,
-    "description": "The trusted CA certificate file in PEM format used for Control Plane to verify Data Plane's certificate and Data Plane to verify Control Plane's certificate. Required on data plane if `cluster_mtls` is set to `pki`. If Control Plane certificate is issued by a well known CA, user can set `lua_ssl_trusted_certificate=system` on Data Plane and leave this field empty.  This field is ignored if `cluster_mtls` is set to `shared`.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "The trusted CA certificate file in PEM\nformat used for Control Plane to verify\nData Plane's certificate and Data Plane\nto verify Control Plane's certificate.\nRequired on data plane if `cluster_mtls`\nis set to `pki`.\nIf Control Plane certificate is issued\nby a well known CA, user can set\n`lua_ssl_trusted_certificate=system`\non Data Plane and leave this field empty.\n\nThis field is ignored if `cluster_mtls` is\nset to `shared`.\n\nThe certificate can be configured on this property\nwith either of the following values:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "cluster_allowed_common_names": {
     "defaultValue": null,
-    "description": "The list of Common Names that are allowed to connect to control plane. Multiple entries may be supplied in a comma-separated string. When not set, Data Plane with same parent domain of Control Plane cert is allowed to connect.  This field is ignored if `cluster_mtls` is not set to `pki_check_cn`."
+    "description": "The list of Common Names that are allowed to\nconnect to control plane. Multiple entries may\nbe supplied in a comma-separated string. When not\nset, Data Plane with same parent domain of\nControl Plane cert is allowed to connect.\n\nThis field is ignored if `cluster_mtls` is\nnot set to `pki_check_cn`.\n"
   },
   "cluster_server_name": {
     "defaultValue": null,
-    "description": "The server name used in the SNI of the TLS connection from a DP node to a CP node. Must match the Common Name (CN) or Subject Alternative Name (SAN) found in the CP certificate. If `cluster_mtls` is set to `shared`, this setting is ignored and `kong_clustering` is used."
+    "description": "The server name used in the SNI of the TLS\nconnection from a DP node to a CP node.\nMust match the Common Name (CN) or Subject\nAlternative Name (SAN) found in the CP\ncertificate.\nIf `cluster_mtls` is set to\n`shared`, this setting is ignored and\n`kong_clustering` is used.\n"
   },
   "cluster_control_plane": {
     "defaultValue": null,
-    "description": "To be used by data plane nodes only: address of the control plane node from which configuration updates will be fetched, in `host:port` format."
+    "description": "To be used by data plane nodes only:\naddress of the control plane node from\nwhich configuration updates will be fetched,\nin `host:port` format.\n"
   },
   "cluster_telemetry_endpoint": {
     "defaultValue": null,
-    "description": "To be used by data plane nodes only: telemetry address of the control plane node to which telemetry updates will be posted in `host:port` format."
+    "description": "To be used by data plane nodes only:\ntelemetry address of the control plane node\nto which telemetry updates will be posted\nin `host:port` format.\n"
   },
   "cluster_telemetry_server_name": {
     "defaultValue": null,
-    "description": "The SNI (Server Name Indication extension) to use for Vitals telemetry data."
+    "description": "The SNI (Server Name Indication extension)\nto use for Vitals telemetry data.\n"
   },
   "cluster_dp_labels": {
     "defaultValue": null,
-    "description": "Comma separated list of Labels for the data plane. Labels are key-value pairs that provide additional context information for each DP. Each label must be configured as a string in the format `key:value`.  Labels are only compatible with hybrid mode deployments with Kong Konnect (SaaS), this configuration doesn't work with self-hosted deployments.  Keys and values follow the AIP standards: https://kong-aip.netlify.app/aip/129/  Example: `deployment:mycloud,region:us-east-1`"
+    "description": "Comma separated list of Labels for the data plane.\nLabels are key-value pairs that provide additional\ncontext information for each DP.\nEach label must be configured as a string in the\nformat `key:value`.\n\nLabels are only compatible with hybrid mode\ndeployments with Kong Konnect (SaaS),\nthis configuration doesn't work with\nself-hosted deployments.\n\nKeys and values follow the AIP standards:\nhttps://kong-aip.netlify.app/aip/129/\n\nExample:\n`deployment:mycloud,region:us-east-1`\n"
   },
   "cluster_listen": {
     "defaultValue": "0.0.0.0:8005",
-    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster. This port is mTLS protected to ensure end-to-end security and integrity.  This setting has no effect if `role` is not set to `control_plane`.  Connection made to this endpoint are logged to the same location as Admin API access logs. See `admin_access_log` config description for more information."
+    "description": "Comma-separated list of addresses and ports on\nwhich the cluster control plane server should listen\nfor data plane connections.\nThe cluster communication port of the control plane\nmust be accessible by all the data planes\nwithin the same cluster. This port is mTLS protected\nto ensure end-to-end security and integrity.\n\nThis setting has no effect if `role` is not set to\n`control_plane`.\n\nConnection made to this endpoint are logged\nto the same location as Admin API access logs.\nSee `admin_access_log` config description for more\ninformation.\n"
   },
   "cluster_telemetry_listen": {
     "defaultValue": "0.0.0.0:8006",
-    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane telemetry connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster.  This setting has no effect if `role` is not set to `control_plane`."
+    "description": "Comma-separated list of addresses and ports on\nwhich the cluster control plane server should listen\nfor data plane telemetry connections.\nThe cluster communication port of the control plane\nmust be accessible by all the data planes\nwithin the same cluster.\n\nThis setting has no effect if `role` is not set to\n`control_plane`.\n"
   },
   "cluster_data_plane_purge_delay": {
     "defaultValue": "1209600",
-    "description": " How many seconds must pass from the time a DP node becomes offline to the time its entry gets removed from the database, as returned by the /clustering/data-planes Admin API endpoint.  This is to prevent the cluster data plane table from growing indefinitely. The default is set to 14 days. That is, if CP haven't heard from a DP for 14 days, its entry will be removed."
+    "description": "How many seconds must pass from the time a DP node\nbecomes offline to the time its entry gets removed\nfrom the database, as returned by the\n/clustering/data-planes Admin API endpoint.\n\nThis is to prevent the cluster data plane table from\ngrowing indefinitely. The default is set to\n14 days. That is, if CP haven't heard from a DP for\n14 days, its entry will be removed.\n"
   },
   "cluster_ocsp": {
     "defaultValue": "off",
-    "description": " Whether to check for revocation status of DP certificates using OCSP (Online Certificate Status Protocol). If enabled, the DP certificate should contain the \"Certificate Authority Information Access\" extension and the OCSP method with URI of which the OCSP responder can be reached from CP.  OCSP checks are only performed on CP nodes, it has no effect on DP nodes.  Valid values to this setting are:  - `on`: OCSP revocation check is enabled and DP   must pass the check in order to establish   connection with CP. - `off`: OCSP revocation check is disabled. - `optional`: OCSP revocation check will be attempted,   however, if the required extension is not   found inside DP provided certificate   or communication with the OCSP responder   failed, then DP is still allowed through."
+    "description": "Whether to check for revocation status of DP\ncertificates using OCSP (Online Certificate Status Protocol).\nIf enabled, the DP certificate should contain the\n\"Certificate Authority Information Access\" extension\nand the OCSP method with URI of which the OCSP responder\ncan be reached from CP.\n\nOCSP checks are only performed on CP nodes, it has no\neffect on DP nodes.\n\nValid values to this setting are:\n\n- `on`: OCSP revocation check is enabled and DP\n  must pass the check in order to establish\n  connection with CP.\n- `off`: OCSP revocation check is disabled.\n- `optional`: OCSP revocation check will be attempted,\n  however, if the required extension is not\n  found inside DP provided certificate\n  or communication with the OCSP responder\n  failed, then DP is still allowed through.\n"
   },
   "cluster_use_proxy": {
     "defaultValue": "off",
-    "description": " Whether to turn on HTTP CONNECT proxy support for hybrid mode connections. `proxy_server` will be used for Hybrid mode connections if this option is turned on."
+    "description": "Whether to turn on HTTP CONNECT proxy support for\nhybrid mode connections. `proxy_server` will be used\nfor Hybrid mode connections if this option is turned on.\n"
   },
   "cluster_max_payload": {
     "defaultValue": "16777216",
-    "description": " This sets the maximum compressed payload size allowed to be sent across from CP to DP in Hybrid mode Default is 16MB - 16 * 1024 * 1024."
+    "description": "This sets the maximum compressed payload size allowed\nto be sent across from CP to DP in Hybrid mode\nDefault is 16MB - 16 * 1024 * 1024.\n"
   },
   "proxy_listen": {
     "defaultValue": [
       "0.0.0.0:8000 reuseport backlog=16384",
       "0.0.0.0:8443 http2 ssl reuseport backlog=16384"
     ],
-    "description": " Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. The proxy server is the public entry point of Kong, which proxies traffic from your consumers to your backend services. This value accepts IPv4, IPv6, and hostnames.  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the TCP_DEFER_ACCEPT socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  This value can be set to `off`, thus disabling the HTTP/HTTPS proxy port for this node. If stream_listen is also set to `off`, this enables 'control-plane' mode for this node (in which all traffic proxying capabilities are disabled). This node can then be used only to configure a cluster of Kong nodes connected to the same datastore.  Example: `proxy_listen = 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`  See http://nginx.org/en/docs/http/ngx_http_core_module.html#listen for a description of the accepted formats for this and other `*_listen` values.  See https://www.nginx.com/resources/admin-guide/proxy-protocol/ for more details about the `proxy_protocol` parameter.  Not all `*_listen` values accept all formats specified in nginx's documentation."
+    "description": "Comma-separated list of addresses and ports on\nwhich the proxy server should listen for\nHTTP/HTTPS traffic.\nThe proxy server is the public entry point of Kong,\nwhich proxies traffic from your consumers to your\nbackend services. This value accepts IPv4, IPv6, and\nhostnames.\n\nSome suffixes can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's proxy server.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `deferred` instructs to use a deferred accept on\n  Linux (the TCP_DEFER_ACCEPT socket option).\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process\n  allowing the Kernel to better distribute incoming\n  connections between worker processes\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small in order to prevent clients\n  seeing \"Connection refused\" error connecting to\n  a busy Kong instance.\n  **Note:** on Linux, this value is limited by the\n  setting of `net.core.somaxconn` Kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections\n- so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]\n  configures the “TCP keepalive” behavior for the listening\n  socket. If this parameter is omitted then the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value “on”, the SO_KEEPALIVE option is turned\n  on for the socket. If it is set to the value “off”, the\n  SO_KEEPALIVE option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,\n  and TCP_KEEPCNT socket options.\n\nThis value can be set to `off`, thus disabling\nthe HTTP/HTTPS proxy port for this node.\nIf stream_listen is also set to `off`, this enables\n'control-plane' mode for this node\n(in which all traffic proxying capabilities are\ndisabled). This node can then be used only to\nconfigure a cluster of Kong\nnodes connected to the same datastore.\n\nExample:\n`proxy_listen = 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`\n\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#listen\nfor a description of the accepted formats for this\nand other `*_listen` values.\n\nSee https://www.nginx.com/resources/admin-guide/proxy-protocol/\nfor more details about the `proxy_protocol`\nparameter.\n\nNot all `*_listen` values accept all formats\nspecified in nginx's documentation.\n"
   },
   "proxy_url": {
     "defaultValue": null,
-    "description": "Kong Proxy URL  The lookup, or balancer, address for your Kong Proxy nodes.  This value is commonly used in a microservices or service-mesh oriented architecture.  Accepted format (parts in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`  Examples:  - `<scheme>://<IP>:<PORT>` -> `proxy_url = http://127.0.0.1:8000` - `SSL <scheme>://<HOSTNAME>` -> `proxy_url = https://proxy.domain.tld` - `<scheme>://<HOSTNAME>/<PATH>` -> `proxy_url = http://dev-machine/dev-285`  By default, Kong Manager, and Kong Portal will use the window request host and append the resolved listener port depending on the requested protocol."
+    "description": "Kong Proxy URL\n\nThe lookup, or balancer, address for your Kong Proxy nodes.\n\nThis value is commonly used in a microservices\nor service-mesh oriented architecture.\n\nAccepted format (parts in parentheses are optional):\n\n  `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`\n\nExamples:\n\n- `<scheme>://<IP>:<PORT>` -> `proxy_url = http://127.0.0.1:8000`\n- `SSL <scheme>://<HOSTNAME>` -> `proxy_url = https://proxy.domain.tld`\n- `<scheme>://<HOSTNAME>/<PATH>` -> `proxy_url = http://dev-machine/dev-285`\n\nBy default, Kong Manager, and Kong Portal will use\nthe window request host and append the resolved\nlistener port depending on the requested protocol.\n"
   },
   "stream_listen": {
     "defaultValue": "off",
-    "description": " Comma-separated list of addresses and ports on which the stream mode should listen.  This value accepts IPv4, IPv6, and hostnames. Some suffixes can be specified for each pair: - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  Examples:  ``` stream_listen = 127.0.0.1:7000 reuseport backlog=16384 stream_listen = 0.0.0.0:989 reuseport backlog=65536, 0.0.0.0:20 stream_listen = [::1]:1234 backlog=16384 ```  By default this value is set to `off`, thus disabling the stream proxy port for this node."
+    "description": "Comma-separated list of addresses and ports on\nwhich the stream mode should listen.\n\nThis value accepts IPv4, IPv6, and hostnames.\nSome suffixes can be specified for each pair:\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process\n  allowing the Kernel to better distribute incoming\n  connections between worker processes\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small in order to prevent clients\n  seeing \"Connection refused\" error connecting to\n  a busy Kong instance.\n  **Note:** on Linux, this value is limited by the\n  setting of `net.core.somaxconn` Kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections\n- so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]\n  configures the “TCP keepalive” behavior for the listening\n  socket. If this parameter is omitted then the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value “on”, the SO_KEEPALIVE option is turned\n  on for the socket. If it is set to the value “off”, the\n  SO_KEEPALIVE option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,\n  and TCP_KEEPCNT socket options.\n\nExamples:\n\n```\nstream_listen = 127.0.0.1:7000 reuseport backlog=16384\nstream_listen = 0.0.0.0:989 reuseport backlog=65536, 0.0.0.0:20\nstream_listen = [::1]:1234 backlog=16384\n```\n\nBy default this value is set to `off`, thus\ndisabling the stream proxy port for this node.\n"
   },
   "admin_api_uri": {
     "defaultValue": null,
-    "description": "Deprecated: Use admin_gui_api_url instead"
+    "description": "Deprecated: Use admin_gui_api_url instead\n"
   },
   "admin_listen": {
     "defaultValue": [
       "127.0.0.1:8001 reuseport backlog=16384",
       "127.0.0.1:8444 http2 ssl reuseport backlog=16384"
     ],
-    "description": " Comma-separated list of addresses and ports on which the Admin interface should listen. The Admin interface is the API allowing you to configure and manage Kong. Access to this interface should be *restricted* to Kong administrators *only*. This value accepts IPv4, IPv6, and hostnames.  It is highly recommended to avoid exposing the Admin API to public interface(s), by using values such as 0.0.0.0:8001  See https://docs.konghq.com/gateway/latest/production/running-kong/secure-admin-api/ for more information about how to secure your Admin API  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the TCP_DEFER_ACCEPT socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  This value can be set to `off`, thus disabling the Admin interface for this node, enabling a 'data-plane' mode (without configuration capabilities) pulling its configuration changes from the database.  Example: `admin_listen = 127.0.0.1:8444 http2 ssl`"
+    "description": "Comma-separated list of addresses and ports on\nwhich the Admin interface should listen.\nThe Admin interface is the API allowing you to\nconfigure and manage Kong.\nAccess to this interface should be *restricted*\nto Kong administrators *only*. This value accepts\nIPv4, IPv6, and hostnames.\n\nIt is highly recommended to avoid exposing the Admin API to public\ninterface(s), by using values such as 0.0.0.0:8001\n\nSee https://docs.konghq.com/gateway/latest/production/running-kong/secure-admin-api/\nfor more information about how to secure your Admin API\n\nSome suffixes can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's proxy server.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `deferred` instructs to use a deferred accept on\n  Linux (the TCP_DEFER_ACCEPT socket option).\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process\n  allowing the Kernel to better distribute incoming\n  connections between worker processes\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small in order to prevent clients\n  seeing \"Connection refused\" error connecting to\n  a busy Kong instance.\n  **Note:** on Linux, this value is limited by the\n  setting of `net.core.somaxconn` Kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections\n- so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]\n  configures the “TCP keepalive” behavior for the listening\n  socket. If this parameter is omitted then the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value “on”, the SO_KEEPALIVE option is turned\n  on for the socket. If it is set to the value “off”, the\n  SO_KEEPALIVE option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,\n  and TCP_KEEPCNT socket options.\n\nThis value can be set to `off`, thus disabling\nthe Admin interface for this node, enabling a\n'data-plane' mode (without configuration\ncapabilities) pulling its configuration changes\nfrom the database.\n\nExample: `admin_listen = 127.0.0.1:8444 http2 ssl`\n"
   },
   "status_listen": {
     "defaultValue": "off",
-    "description": "Comma-separated list of addresses and ports on which the Status API should listen. The Status API is a read-only endpoint allowing monitoring tools to retrieve metrics, healthiness, and other non-sensitive information of the current Kong node.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Status API server.  This value can be set to `off`, disabling the Status API for this node.  Example: `status_listen = 0.0.0.0:8100 ssl http2`"
+    "description": "Comma-separated list of addresses and ports on\nwhich the Status API should listen.\nThe Status API is a read-only endpoint\nallowing monitoring tools to retrieve metrics,\nhealthiness, and other non-sensitive information\nof the current Kong node.\n\nThe following suffix can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's Status API server.\n\nThis value can be set to `off`, disabling\nthe Status API for this node.\n\nExample: `status_listen = 0.0.0.0:8100 ssl http2`\n"
   },
   "debug_listen": {
     "defaultValue": "off",
-    "description": "Comma-separated list of addresses and ports on which the Debug API should listen.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Debug API server.  This value can be set to `off`, disabling the Debug API for this node.  Example: `debug_listen = 0.0.0.0:8200 ssl http2`"
+    "description": "Comma-separated list of addresses and ports on\nwhich the Debug API should listen.\n\nThe following suffix can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's Debug API server.\n\nThis value can be set to `off`, disabling\nthe Debug API for this node.\n\nExample: `debug_listen = 0.0.0.0:8200 ssl http2`\n"
   },
   "nginx_user": {
     "defaultValue": "kong kong",
-    "description": "Defines user and group credentials used by worker processes. If group is omitted, a group whose name equals that of user is used.  Example: `nginx_user = nginx www`  **Note**: If the `kong` user and the `kong` group are not available, the default user and group credentials will be `nobody nobody`."
+    "description": "Defines user and group credentials used by\nworker processes. If group is omitted, a\ngroup whose name equals that of user is\nused.\n\nExample: `nginx_user = nginx www`\n\n**Note**: If the `kong` user and the `kong`\ngroup are not available, the default user\nand group credentials will be\n`nobody nobody`.\n"
   },
   "nginx_worker_processes": {
     "defaultValue": "auto",
-    "description": "Determines the number of worker processes spawned by Nginx.  See http://nginx.org/en/docs/ngx_core_module.html#worker_processes for detailed usage of the equivalent Nginx directive and a description of accepted values."
+    "description": "Determines the number of worker processes\nspawned by Nginx.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_processes\nfor detailed usage of the equivalent Nginx\ndirective and a description of accepted\nvalues.\n"
   },
   "nginx_daemon": {
     "defaultValue": "on",
-    "description": "Determines whether Nginx will run as a daemon or as a foreground process. Mainly useful for development or when running Kong inside a Docker environment.  See http://nginx.org/en/docs/ngx_core_module.html#daemon."
+    "description": "Determines whether Nginx will run as a daemon\nor as a foreground process. Mainly useful\nfor development or when running Kong inside\na Docker environment.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#daemon.\n"
   },
   "mem_cache_size": {
     "defaultValue": "128m",
-    "description": "Size of each of the two shared memory caches for traditional mode database entities and runtime data. The accepted units are `k` and `m`, with a minimum recommended value of a few MBs.  **Note**: As this option controls the size of two different cache zones, the total memory Kong uses to cache entities might be double this value. The created zones are shared by all worker processes and do not become larger when more worker is used."
+    "description": "Size of each of the two shared memory caches\nfor traditional mode database entities\nand runtime data.\nThe accepted units are `k` and `m`, with a minimum\nrecommended value of a few MBs.\n\n**Note**: As this option controls the size of two\ndifferent cache zones, the total memory Kong\nuses to cache entities might be double this value.\nThe created zones are shared by all worker\nprocesses and do not become larger when more\nworker is used.\n"
   },
   "ssl_cipher_suite": {
     "defaultValue": "intermediate",
-    "description": "Defines the TLS ciphers served by Nginx. Accepted values are `modern`, `intermediate`, `old`, `fips` or `custom`. If you want to enable TLSv1.1, this value has to be `old`.  See https://wiki.mozilla.org/Security/Server_Side_TLS for detailed descriptions of each cipher suite. `fips` cipher suites are as described in https://wiki.openssl.org/index.php/FIPS_mode_and_TLS."
+    "description": "Defines the TLS ciphers served by Nginx.\nAccepted values are `modern`,\n`intermediate`, `old`, `fips` or `custom`.\nIf you want to enable TLSv1.1, this value has to be `old`.\n\nSee https://wiki.mozilla.org/Security/Server_Side_TLS\nfor detailed descriptions of each cipher\nsuite. `fips` cipher suites are as described in\nhttps://wiki.openssl.org/index.php/FIPS_mode_and_TLS.\n"
   },
   "ssl_ciphers": {
     "defaultValue": null,
-    "description": "Defines a custom list of TLS ciphers to be served by Nginx. This list must conform to the pattern defined by `openssl ciphers`. This value is ignored if `ssl_cipher_suite` is not `custom`."
+    "description": "Defines a custom list of TLS ciphers to be\nserved by Nginx. This list must conform to\nthe pattern defined by `openssl ciphers`.\nThis value is ignored if `ssl_cipher_suite`\nis not `custom`.\n"
   },
   "ssl_protocols": {
     "defaultValue": "TLSv1.2 TLSv1.3",
-    "description": " Enables the specified protocols for client-side connections. The set of supported protocol versions also depends on the version of OpenSSL Kong was built with. This value is ignored if `ssl_cipher_suite` is not `custom`. If you want to enable TLSv1.1, you should set `ssl_cipher_suite` to `old`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols"
+    "description": "Enables the specified protocols for\nclient-side connections. The set of\nsupported protocol versions also depends\non the version of OpenSSL Kong was built\nwith. This value is ignored if\n`ssl_cipher_suite` is not `custom`.\nIf you want to enable TLSv1.1, you should\nset `ssl_cipher_suite` to `old`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols\n"
   },
   "ssl_prefer_server_ciphers": {
     "defaultValue": "on",
-    "description": "Specifies that server ciphers should be preferred over client ciphers when using the SSLv3 and TLS protocols. This value is ignored if `ssl_cipher_suite` is not `custom`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers"
+    "description": "Specifies that server ciphers should be\npreferred over client ciphers when using\nthe SSLv3 and TLS protocols. This value is\nignored if `ssl_cipher_suite` is not `custom`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers\n"
   },
   "ssl_dhparam": {
     "defaultValue": null,
-    "description": "Defines DH parameters for DHE ciphers from the predefined groups: `ffdhe2048`, `ffdhe3072`, `ffdhe4096`, `ffdhe6144`, `ffdhe8192`, from the absolute path to a parameters file, or directly from the parameters content.  This value is ignored if `ssl_cipher_suite` is `modern` or `intermediate`. The reason is that `modern` has no ciphers that needs this, and `intermediate` uses `ffdhe2048`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam"
+    "description": "Defines DH parameters for DHE ciphers from the\npredefined groups: `ffdhe2048`, `ffdhe3072`,\n`ffdhe4096`, `ffdhe6144`, `ffdhe8192`,\nfrom the absolute path to a parameters file, or\ndirectly from the parameters content.\n\nThis value is ignored if `ssl_cipher_suite`\nis `modern` or `intermediate`. The reason is\nthat `modern` has no ciphers that needs this,\nand `intermediate` uses `ffdhe2048`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam\n"
   },
   "ssl_session_tickets": {
     "defaultValue": "on",
-    "description": "Enables or disables session resumption through TLS session tickets. This has no impact when used with TLSv1.3.  Kong enables this by default for performance reasons, but it has security implications: https://github.com/mozilla/server-side-tls/issues/135  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets"
+    "description": "Enables or disables session resumption through\nTLS session tickets. This has no impact when\nused with TLSv1.3.\n\nKong enables this by default for performance\nreasons, but it has security implications:\nhttps://github.com/mozilla/server-side-tls/issues/135\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets\n"
   },
   "ssl_session_timeout": {
     "defaultValue": "1d",
-    "description": "Specifies a time during which a client may reuse the session parameters. See the rationale: https://github.com/mozilla/server-side-tls/issues/198  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout"
+    "description": "Specifies a time during which a client may\nreuse the session parameters. See the rationale:\nhttps://github.com/mozilla/server-side-tls/issues/198\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout\n"
   },
   "ssl_session_cache_size": {
     "defaultValue": "10m",
-    "description": "Sets the size of the caches that store session parameters  See https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache"
+    "description": "Sets the size of the caches that store session parameters\n\nSee https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache\n"
   },
   "ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `proxy_listen` values with TLS enabled.  If more than one certificates are specified, it can be used to provide alternate type of certificate (for example, ECC certificate) that will be served to clients that supports them. Note to properly serve using ECC certificates, it is recommended to also set `ssl_cipher_suite` to `modern` or `intermediate`.  Unless this option is explicitly set, Kong will auto-generate a pair of default certificates (RSA + ECC) first time it starts up and use it for serving TLS requests.  Certificates can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "Comma-separated list of certificates for `proxy_listen` values with TLS enabled.\n\nIf more than one certificates are specified, it can be used to provide\nalternate type of certificate (for example, ECC certificate) that will be served\nto clients that supports them. Note to properly serve using ECC certificates,\nit is recommended to also set `ssl_cipher_suite` to\n`modern` or `intermediate`.\n\nUnless this option is explicitly set, Kong will auto-generate\na pair of default certificates (RSA + ECC) first time it starts up and use\nit for serving TLS requests.\n\nCertificates can be configured on this property with either of the following\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `proxy_listen` values with TLS enabled.  If more than one certificate was specified for `ssl_cert`, then this option should contain the corresponding key for all certificates provided in the same order.  Unless this option is explicitly set, Kong will auto-generate a pair of default private keys (RSA + ECC) first time it starts up and use it for serving TLS requests.  Keys can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+    "description": "Comma-separated list of keys for `proxy_listen` values with TLS enabled.\n\nIf more than one certificate was specified for `ssl_cert`, then this\noption should contain the corresponding key for all certificates\nprovided in the same order.\n\nUnless this option is explicitly set, Kong will auto-generate\na pair of default private keys (RSA + ECC) first time it starts up and use\nit for serving TLS requests.\n\nKeys can be configured on this property with either of the following\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n"
   },
   "client_ssl": {
     "defaultValue": "off",
-    "description": "Determines if Nginx should attempt to send client-side TLS certificates and perform Mutual TLS Authentication with upstream service when proxying requests."
+    "description": "Determines if Nginx should attempt to send client-side\nTLS certificates and perform Mutual TLS Authentication\nwith upstream service when proxying requests.\n"
   },
   "client_ssl_cert": {
     "defaultValue": null,
-    "description": "If `client_ssl` is enabled, the client certificate for the `proxy_ssl_certificate` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "If `client_ssl` is enabled, the client certificate\nfor the `proxy_ssl_certificate` directive.\n\nThis value can be overwritten dynamically with the `client_certificate`\nattribute of the `Service` object.\n\nThe certificate can be configured on this property with either of the following\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "client_ssl_cert_key": {
     "defaultValue": null,
-    "description": "If `client_ssl` is enabled, the client TLS key for the `proxy_ssl_certificate_key` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate key can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+    "description": "If `client_ssl` is enabled, the client TLS key\nfor the `proxy_ssl_certificate_key` directive.\n\nThis value can be overwritten dynamically with the `client_certificate`\nattribute of the `Service` object.\n\nThe certificate key can be configured on this property with either of the following\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n"
   },
   "admin_ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `admin_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+    "description": "Comma-separated list of certificates for `admin_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n"
   },
   "admin_ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `admin_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+    "description": "Comma-separated list of keys for `admin_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n"
   },
   "status_ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `status_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+    "description": "Comma-separated list of certificates for `status_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n"
   },
   "status_ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `status_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+    "description": "Comma-separated list of keys for `status_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n"
   },
   "debug_ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `debug_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+    "description": "Comma-separated list of certificates for `debug_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n"
   },
   "debug_ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `debug_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+    "description": "Comma-separated list of keys for `debug_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n"
   },
   "headers": {
     "defaultValue": [
@@ -319,311 +319,311 @@
       "latency_tokens",
       "X-Kong-Request-Id"
     ],
-    "description": " Comma-separated list of headers Kong should inject in client responses.  Accepted values are: - `Server`: Injects `Server: kong/x.y.z`   on Kong-produced response (e.g. Admin   API, rejected requests from auth plugin). - `Via`: Injects `Via: kong/x.y.z` for   successfully proxied requests. - `X-Kong-Proxy-Latency`: Time taken   (in milliseconds) by Kong to process   a request and run all plugins before   proxying the request upstream. - `X-Kong-Response-Latency`: time taken   (in millisecond) by Kong to produce   a response in case of e.g. plugin   short-circuiting the request, or in   in case of an error. - `X-Kong-Upstream-Latency`: Time taken   (in milliseconds) by the upstream   service to send response headers. - `X-Kong-Admin-Latency`: Time taken   (in milliseconds) by Kong to process   an Admin API request. - `X-Kong-Upstream-Status`: The HTTP status   code returned by the upstream service.   This is particularly useful for clients to   distinguish upstream statuses if the   response is rewritten by a plugin. - `X-Kong-Request-Id`: Unique identifier of   the request. - `server_tokens`: Same as specifying both   `Server` and `Via`. - `latency_tokens`: Same as specifying   `X-Kong-Proxy-Latency`,   `X-Kong-Response-Latency`,   `X-Kong-Admin-Latency` and   `X-Kong-Upstream-Latency`  In addition to those, this value can be set to `off`, which prevents Kong from injecting any of the above headers. Note that this does not prevent plugins from injecting headers of their own.  Example: `headers = via, latency_tokens`"
+    "description": "Comma-separated list of headers Kong should\ninject in client responses.\n\nAccepted values are:\n- `Server`: Injects `Server: kong/x.y.z`\n  on Kong-produced response (e.g. Admin\n  API, rejected requests from auth plugin).\n- `Via`: Injects `Via: kong/x.y.z` for\n  successfully proxied requests.\n- `X-Kong-Proxy-Latency`: Time taken\n  (in milliseconds) by Kong to process\n  a request and run all plugins before\n  proxying the request upstream.\n- `X-Kong-Response-Latency`: time taken\n  (in millisecond) by Kong to produce\n  a response in case of e.g. plugin\n  short-circuiting the request, or in\n  in case of an error.\n- `X-Kong-Upstream-Latency`: Time taken\n  (in milliseconds) by the upstream\n  service to send response headers.\n- `X-Kong-Admin-Latency`: Time taken\n  (in milliseconds) by Kong to process\n  an Admin API request.\n- `X-Kong-Upstream-Status`: The HTTP status\n  code returned by the upstream service.\n  This is particularly useful for clients to\n  distinguish upstream statuses if the\n  response is rewritten by a plugin.\n- `X-Kong-Request-Id`: Unique identifier of\n  the request.\n- `server_tokens`: Same as specifying both\n  `Server` and `Via`.\n- `latency_tokens`: Same as specifying\n  `X-Kong-Proxy-Latency`,\n  `X-Kong-Response-Latency`,\n  `X-Kong-Admin-Latency` and\n  `X-Kong-Upstream-Latency`\n\nIn addition to those, this value can be set\nto `off`, which prevents Kong from injecting\nany of the above headers. Note that this\ndoes not prevent plugins from injecting\nheaders of their own.\n\nExample: `headers = via, latency_tokens`\n"
   },
   "headers_upstream": {
     "defaultValue": "X-Kong-Request-Id",
-    "description": " Comma-separated list of headers Kong should inject in requests to upstream.  At this time, the only accepted value is: - `X-Kong-Request-Id`: Unique identifier of   the request.  In addition, this value can be set to `off`, which prevents Kong from injecting the above header. Note that this does not prevent plugins from injecting headers of their own."
+    "description": "Comma-separated list of headers Kong should\ninject in requests to upstream.\n\nAt this time, the only accepted value is:\n- `X-Kong-Request-Id`: Unique identifier of\n  the request.\n\nIn addition, this value can be set\nto `off`, which prevents Kong from injecting\nthe above header. Note that this\ndoes not prevent plugins from injecting\nheaders of their own.\n"
   },
   "trusted_ips": {
     "defaultValue": null,
-    "description": "Defines trusted IP addresses blocks that are known to send correct `X-Forwarded-*` headers. Requests from trusted IPs make Kong forward their `X-Forwarded-*` headers upstream. Non-trusted requests make Kong insert its own `X-Forwarded-*` headers.  This property also sets the `set_real_ip_from` directive(s) in the Nginx configuration. It accepts the same type of values (CIDR blocks) but as a comma-separated list.  To trust *all* /!\\ IPs, set this value to `0.0.0.0/0,::/0`.  If the special value `unix:` is specified, all UNIX-domain sockets will be trusted.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from for examples of accepted values."
+    "description": "Defines trusted IP addresses blocks that are\nknown to send correct `X-Forwarded-*`\nheaders.\nRequests from trusted IPs make Kong forward\ntheir `X-Forwarded-*` headers upstream.\nNon-trusted requests make Kong insert its\nown `X-Forwarded-*` headers.\n\nThis property also sets the\n`set_real_ip_from` directive(s) in the Nginx\nconfiguration. It accepts the same type of\nvalues (CIDR blocks) but as a\ncomma-separated list.\n\nTo trust *all* /!\\ IPs, set this value to\n`0.0.0.0/0,::/0`.\n\nIf the special value `unix:` is specified,\nall UNIX-domain sockets will be trusted.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from\nfor examples of accepted values.\n"
   },
   "real_ip_header": {
     "defaultValue": "X-Real-IP",
-    "description": "Defines the request header field whose value will be used to replace the client address. This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  If this value receives `proxy_protocol`:  - at least one of the `proxy_listen` entries   must have the `proxy_protocol` flag   enabled. - the `proxy_protocol` parameter will be   appended to the `listen` directive of the   Nginx template.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header for a description of this directive."
+    "description": "Defines the request header field whose value\nwill be used to replace the client address.\nThis value sets the `ngx_http_realip_module`\ndirective of the same name in the Nginx\nconfiguration.\n\nIf this value receives `proxy_protocol`:\n\n- at least one of the `proxy_listen` entries\n  must have the `proxy_protocol` flag\n  enabled.\n- the `proxy_protocol` parameter will be\n  appended to the `listen` directive of the\n  Nginx template.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header\nfor a description of this directive.\n"
   },
   "real_ip_recursive": {
     "defaultValue": "off",
-    "description": "This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive for a description of this directive."
+    "description": "This value sets the `ngx_http_realip_module`\ndirective of the same name in the Nginx\nconfiguration.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive\nfor a description of this directive.\n"
   },
   "error_default_type": {
     "defaultValue": "text/plain",
-    "description": "Default MIME type to use when the request `Accept` header is missing and Nginx is returning an error for the request. Accepted values are `text/plain`, `text/html`, `application/json`, and `application/xml`."
+    "description": "Default MIME type to use when the request\n`Accept` header is missing and Nginx\nis returning an error for the request.\nAccepted values are `text/plain`,\n`text/html`, `application/json`, and\n`application/xml`.\n"
   },
   "upstream_keepalive_pool_size": {
     "defaultValue": "512",
-    "description": "Sets the default size of the upstream keepalive connection pools. Upstream keepalive connection pools are segmented by the `dst ip/dst port/SNI` attributes of a connection. A value of `0` will disable upstream keepalive connections by default, forcing each upstream request to open a new connection."
+    "description": "Sets the default size of the upstream\nkeepalive connection pools.\nUpstream keepalive connection pools\nare segmented by the `dst ip/dst\nport/SNI` attributes of a connection.\nA value of `0` will disable upstream\nkeepalive connections by default, forcing\neach upstream request to open a new\nconnection.\n"
   },
   "upstream_keepalive_max_requests": {
     "defaultValue": "10000",
-    "description": "Sets the default maximum number of requests than can be proxied upstream through one keepalive connection. After the maximum number of requests is reached, the connection will be closed. A value of `0` will disable this behavior, and a keepalive connection can be used to proxy an indefinite number of requests."
+    "description": "Sets the default maximum number of\nrequests than can be proxied upstream\nthrough one keepalive connection.\nAfter the maximum number of requests\nis reached, the connection will be\nclosed.\nA value of `0` will disable this\nbehavior, and a keepalive connection\ncan be used to proxy an indefinite\nnumber of requests.\n"
   },
   "upstream_keepalive_idle_timeout": {
     "defaultValue": "60",
-    "description": "Sets the default timeout (in seconds) for which an upstream keepalive connection should be kept open. When the timeout is reached while the connection has not been reused, it will be closed. A value of `0` will disable this behavior, and an idle keepalive connection may be kept open indefinitely."
+    "description": "Sets the default timeout (in seconds)\nfor which an upstream keepalive\nconnection should be kept open. When\nthe timeout is reached while the\nconnection has not been reused, it\nwill be closed.\nA value of `0` will disable this\nbehavior, and an idle keepalive\nconnection may be kept open\nindefinitely.\n"
   },
   "allow_debug_header": {
     "defaultValue": "off",
-    "description": "Enable the `Kong-Debug` header function. if it is `on`, kong will add `Kong-Route-Id` `Kong-Route-Name` `Kong-Service-Id` `Kong-Service-Name` debug headers to response when the client request header `Kong-Debug: 1` is present."
+    "description": "Enable the `Kong-Debug` header function.\nif it is `on`, kong will add\n`Kong-Route-Id` `Kong-Route-Name` `Kong-Service-Id`\n`Kong-Service-Name` debug headers to response when\nthe client request header `Kong-Debug: 1` is present.\n"
   },
   "nginx_main_worker_rlimit_nofile": {
     "defaultValue": "auto",
-    "description": " Changes the limit on the maximum number of open files for worker processes.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile"
+    "description": "Changes the limit on the maximum number of open files\nfor worker processes.\n\nThe special and default value of `auto` sets this\nvalue to `ulimit -n` with the upper bound limited to\n16384 as a measure to protect against excess memory use,\nand the lower bound of 1024 as a good default.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile\n"
   },
   "nginx_events_worker_connections": {
     "defaultValue": "auto",
-    "description": " Sets the maximum number of simultaneous connections that can be opened by a worker process.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_connections"
+    "description": "Sets the maximum number of simultaneous\nconnections that can be opened by a worker process.\n\nThe special and default value of `auto` sets this\nvalue to `ulimit -n` with the upper bound limited to\n16384 as a measure to protect against excess memory use,\nand the lower bound of 1024 as a good default.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_connections\n"
   },
   "nginx_http_client_header_buffer_size": {
     "defaultValue": "1k",
-    "description": "Sets buffer size for reading the client request headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size"
+    "description": "Sets buffer size for reading the\nclient request headers.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size\n"
   },
   "nginx_http_large_client_header_buffers": {
     "defaultValue": "4 8k",
-    "description": "Sets the maximum number and size of buffers used for reading large clients requests headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers"
+    "description": "Sets the maximum number and\nsize of buffers used for\nreading large clients\nrequests headers.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers\n"
   },
   "nginx_http_client_max_body_size": {
     "defaultValue": "0",
-    "description": "Defines the maximum request body size allowed by requests proxied by Kong, specified in the Content-Length request header. If a request exceeds this limit, Kong will respond with a 413 (Request Entity Too Large). Setting this value to 0 disables checking the request body size. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size"
+    "description": "Defines the maximum request body size\nallowed by requests proxied by Kong,\nspecified in the Content-Length request\nheader. If a request exceeds this\nlimit, Kong will respond with a 413\n(Request Entity Too Large). Setting\nthis value to 0 disables checking the\nrequest body size.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size\n"
   },
   "nginx_admin_client_max_body_size": {
     "defaultValue": "10m",
-    "description": "Defines the maximum request body size for Admin API."
+    "description": "Defines the maximum request body size for\nAdmin API.\n"
   },
   "nginx_http_charset": {
     "defaultValue": "UTF-8",
-    "description": "Adds the specified charset to the “Content-Type” response header field. If this charset is different from the charset specified in the source_charset directive, a conversion is performed.  The parameter `off` cancels the addition of charset to the “Content-Type” response header field. See http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset"
+    "description": "Adds the specified charset to the “Content-Type”\nresponse header field. If this charset is different\nfrom the charset specified in the source_charset\ndirective, a conversion is performed.\n\nThe parameter `off` cancels the addition of\ncharset to the “Content-Type” response header field.\nSee http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset\n"
   },
   "nginx_http_client_body_buffer_size": {
     "defaultValue": "8k",
-    "description": "Defines the buffer size for reading the request body. If the client request body is larger than this value, the body will be buffered to disk. Note that when the body is buffered to disk, Kong plugins that access or manipulate the request body may not work, so it is advisable to set this value as high as possible (e.g., set it as high as `client_max_body_size` to force request bodies to be kept in memory). Do note that high-concurrency environments will require significant memory allocations to process many concurrent large request bodies. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size"
+    "description": "Defines the buffer size for reading\nthe request body. If the client\nrequest body is larger than this\nvalue, the body will be buffered to\ndisk. Note that when the body is\nbuffered to disk, Kong plugins that\naccess or manipulate the request\nbody may not work, so it is\nadvisable to set this value as high\nas possible (e.g., set it as high\nas `client_max_body_size` to force\nrequest bodies to be kept in\nmemory). Do note that\nhigh-concurrency environments will\nrequire significant memory\nallocations to process many\nconcurrent large request bodies.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size\n"
   },
   "nginx_admin_client_body_buffer_size": {
     "defaultValue": "10m",
-    "description": "Defines the buffer size for reading the request body on Admin API."
+    "description": "Defines the buffer size for reading\nthe request body on Admin API.\n"
   },
   "nginx_http_lua_regex_match_limit": {
     "defaultValue": "100000",
-    "description": "Global `MATCH_LIMIT` for PCRE regex matching. The default of `100000` should ensure at worst any regex Kong executes could finish within roughly 2 seconds."
+    "description": "Global `MATCH_LIMIT` for PCRE\nregex matching. The default of `100000` should ensure\nat worst any regex Kong executes could finish within\nroughly 2 seconds.\n"
   },
   "nginx_http_lua_regex_cache_max_entries": {
     "defaultValue": "8192",
-    "description": "Specifies the maximum number of entries allowed in the worker process level compiled regex cache. It is recommended to set it to at least (number of regex paths * 2) to avoid high CPU usages."
+    "description": "Specifies the maximum number of entries allowed\nin the worker process level compiled regex cache.\nIt is recommended to set it to at least (number of regex paths * 2)\nto avoid high CPU usages.\n"
   },
   "nginx_http_keepalive_requests": {
     "defaultValue": "10000",
-    "description": "Sets the maximum number of client requests that can be served through one keep-alive connection. After the maximum number of requests are made, the connection is closed. Closing connections periodically is necessary to free per-connection memory allocations. Therefore, using too high maximum number of requests could result in excessive memory usage and not recommended. See: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests"
+    "description": "Sets the maximum number of client requests that can be served through one\nkeep-alive connection. After the maximum number of requests are made,\nthe connection is closed.\nClosing connections periodically is necessary to free per-connection\nmemory allocations. Therefore, using too high maximum number of requests\ncould result in excessive memory usage and not recommended.\nSee: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests\n"
   },
   "database": {
     "defaultValue": "postgres",
-    "description": "Determines the database (or no database) for this node Accepted values are `postgres` and `off`."
+    "description": "Determines the database (or no database) for\nthis node\nAccepted values are `postgres` and `off`.\n"
   },
   "pg_host": {
     "defaultValue": "127.0.0.1",
-    "description": "Host of the Postgres server."
+    "description": "Host of the Postgres server.\n"
   },
   "pg_port": {
     "defaultValue": "5432",
-    "description": "Port of the Postgres server."
+    "description": "Port of the Postgres server.\n"
   },
   "pg_timeout": {
     "defaultValue": "5000",
-    "description": "Defines the timeout (in ms), for connecting, reading and writing."
+    "description": "Defines the timeout (in ms), for connecting,\nreading and writing.\n"
   },
   "pg_user": {
     "defaultValue": "kong",
-    "description": "Postgres user."
+    "description": "Postgres user.\n"
   },
   "pg_password": {
     "defaultValue": null,
-    "description": "Postgres user's password."
+    "description": "Postgres user's password.\n"
   },
   "pg_iam_auth": {
     "defaultValue": "off",
-    "description": "Determines whether the AWS IAM database Authentication will be used. When switch to `on`, the username defined in `pg_user` will be used as the database account, and the database connection will be forced to using TLS. `pg_password` will not be used when the switch is `on`. Note that the corresponding IAM policy must be correct, otherwise connecting will fail."
+    "description": "Determines whether the AWS IAM database\nAuthentication will be used. When switch to\n`on`, the username defined in `pg_user` will\nbe used as the database account, and the\ndatabase connection will be forced to using\nTLS. `pg_password` will not be used when\nthe switch is `on`. Note that the corresponding\nIAM policy must be correct, otherwise connecting\nwill fail.\n"
   },
   "pg_iam_auth_assume_role_arn": {
     "defaultValue": null,
-    "description": "The target AWS IAM role ARN that will be assumed when using AWS IAM database authentication. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+    "description": "The target AWS IAM role ARN that will be\nassumed when using AWS IAM database\nauthentication. Typically this is used\nfor operating between multiple roles\nor cross-accounts.\nIf you are not using assume role\nyou should not specify this value.\n"
   },
   "pg_iam_auth_role_session_name": {
     "defaultValue": "KongPostgres",
-    "description": "The role session name used for role assuming in AWS IAM Database Authentication. The default value is `KongPostgres`."
+    "description": "The role session name used for role\nassuming in AWS IAM Database\nAuthentication. The default value is\n`KongPostgres`.\n"
   },
   "pg_iam_auth_sts_endpoint_url": {
     "defaultValue": null,
-    "description": "The custom STS endpoint URL used for role assuming in AWS IAM Database Authentication.  Note that this value will override the default STS endpoint URL(which should be `https://sts.amazonaws.com`, or `https://sts.<region>.amazonaws.com` if you have `AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).  If you are not using private VPC endpoint for STS service, you should not specify this value."
+    "description": "The custom STS endpoint URL used for role assuming\nin AWS IAM Database Authentication.\n\nNote that this value will override the default\nSTS endpoint URL(which should be\n`https://sts.amazonaws.com`, or\n`https://sts.<region>.amazonaws.com` if you have\n`AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).\n\nIf you are not using private VPC endpoint for STS\nservice, you should not specify this value.\n"
   },
   "pg_database": {
     "defaultValue": "kong",
-    "description": "The database name to connect to."
+    "description": "The database name to connect to.\n"
   },
   "pg_schema": {
     "defaultValue": null,
-    "description": "The database schema to use. If unspecified, Kong will respect the `search_path` value of your PostgreSQL instance."
+    "description": "The database schema to use. If unspecified,\nKong will respect the `search_path` value of\nyour PostgreSQL instance.\n"
   },
   "pg_ssl": {
     "defaultValue": "off",
-    "description": "Toggles client-server TLS connections between Kong and PostgreSQL. Because PostgreSQL uses the same port for TLS and non-TLS, this is only a hint. If the server does not support TLS, the established connection will be a plain one."
+    "description": "Toggles client-server TLS connections\nbetween Kong and PostgreSQL.\nBecause PostgreSQL uses the same port for TLS\nand non-TLS, this is only a hint. If the\nserver does not support TLS, the established\nconnection will be a plain one.\n"
   },
   "pg_ssl_version": {
     "defaultValue": "tlsv1_2",
-    "description": "When using ssl between Kong and PostgreSQL, the version of tls to use. Accepted values are `tlsv1_1`, `tlsv1_2`, `tlsv1_3`, or 'any'. When `any` is set, the client negotiates the highest version with the server which can't be lower than `tlsv1_1`."
+    "description": "When using ssl between Kong and PostgreSQL,\nthe version of tls to use. Accepted values are\n`tlsv1_1`, `tlsv1_2`, `tlsv1_3`, or 'any'. When\n`any` is set, the client negotiates the highest\nversion with the server which can't be lower\nthan `tlsv1_1`.\n"
   },
   "pg_ssl_required": {
     "defaultValue": "off",
-    "description": "When `pg_ssl` is on this determines if TLS must be used between Kong and PostgreSQL. It aborts the connection if the server does not support SSL connections."
+    "description": "When `pg_ssl` is on this determines if\nTLS must be used between Kong and PostgreSQL.\nIt aborts the connection if the server does\nnot support SSL connections.\n"
   },
   "pg_ssl_verify": {
     "defaultValue": "off",
-    "description": "Toggles server certificate verification if `pg_ssl` is enabled. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+    "description": "Toggles server certificate verification if\n`pg_ssl` is enabled.\nSee the `lua_ssl_trusted_certificate`\nsetting to specify a certificate authority.\n"
   },
   "pg_ssl_cert": {
     "defaultValue": null,
-    "description": "The absolute path to the PEM encoded client TLS certificate for the PostgreSQL connection. Mutual TLS authentication against PostgreSQL is only enabled if this value is set."
+    "description": "The absolute path to the PEM encoded client\nTLS certificate for the PostgreSQL connection.\nMutual TLS authentication against\nPostgreSQL is only enabled if this value is set.\n"
   },
   "pg_ssl_cert_key": {
     "defaultValue": null,
-    "description": "If `pg_ssl_cert` is set, the absolute path to the PEM encoded client TLS private key for the PostgreSQL connection."
+    "description": "If `pg_ssl_cert` is set, the absolute path to\nthe PEM encoded client TLS private key for the\nPostgreSQL connection.\n"
   },
   "pg_max_concurrent_queries": {
     "defaultValue": "0",
-    "description": "Sets the maximum number of concurrent queries that can be executing at any given time. This limit is enforced per worker process; the total number of concurrent queries for this node will be will be: `pg_max_concurrent_queries * nginx_worker_processes`.  The default value of 0 removes this concurrency limitation."
+    "description": "Sets the maximum number of concurrent queries\nthat can be executing at any given time. This\nlimit is enforced per worker process; the\ntotal number of concurrent queries for this\nnode will be will be:\n`pg_max_concurrent_queries * nginx_worker_processes`.\n\nThe default value of 0 removes this\nconcurrency limitation.\n"
   },
   "pg_semaphore_timeout": {
     "defaultValue": "60000",
-    "description": "Defines the timeout (in ms) after which PostgreSQL query semaphore resource acquisition attempts will fail. Such failures will generally result in the associated proxy or Admin API request failing with an HTTP 500 status code. Detailed discussion of this behavior is available in the online documentation."
+    "description": "Defines the timeout (in ms) after which\nPostgreSQL query semaphore resource\nacquisition attempts will fail. Such\nfailures will generally result in the\nassociated proxy or Admin API request\nfailing with an HTTP 500 status code.\nDetailed discussion of this behavior is\navailable in the online documentation.\n"
   },
   "pg_keepalive_timeout": {
     "defaultValue": null,
-    "description": "Specify the maximal idle timeout (in ms) for the postgres connections in the pool. If this value is set to 0 then the timeout interval is unlimited.  If not specified this value will be same as `lua_socket_keepalive_timeout`"
+    "description": "Specify the maximal idle timeout (in ms)\nfor the postgres connections in the pool.\nIf this value is set to 0 then the timeout interval\nis unlimited.\n\nIf not specified this value will be same as\n`lua_socket_keepalive_timeout`\n"
   },
   "pg_pool_size": {
     "defaultValue": null,
-    "description": "Specifies the size limit (in terms of connection count) for the Postgres server. Note that this connection pool is intended per Nginx worker rather than per Kong instance.  If not specified, the default value is the same as `lua_socket_pool_size`"
+    "description": "Specifies the size limit (in terms of connection\ncount) for the Postgres server.\nNote that this connection pool is intended\nper Nginx worker rather than per Kong instance.\n\nIf not specified, the default value is the same as\n`lua_socket_pool_size`\n"
   },
   "pg_backlog": {
     "defaultValue": null,
-    "description": "If specified, this value will limit the total number of open connections to the Postgres server to `pg_pool_size`. If the connection pool is full, subsequent connect operations will be inserted in a queue with size equal to this option's value.  If the number of queued connect operations reaches `pg_backlog`, exceeding connections will fail.  If not specified, then number of open connections to the Postgres server is not limited."
+    "description": "If specified, this value will limit the total\nnumber of open connections to the Postgres\nserver to `pg_pool_size`. If the connection\npool is full, subsequent connect operations\nwill be inserted in a queue with size equal\nto this option's value.\n\nIf the number of queued connect operations\nreaches `pg_backlog`, exceeding connections will fail.\n\nIf not specified, then number of open connections\nto the Postgres server is not limited.\n"
   },
   "pg_ro_host": {
     "defaultValue": null,
-    "description": "Same as `pg_host`, but for the read-only connection. **Note:** Refer to the documentation section above for detailed usage."
+    "description": "Same as `pg_host`, but for the\nread-only connection.\n**Note:** Refer to the documentation\nsection above for detailed usage.\n"
   },
   "pg_ro_port": {
     "defaultValue": "<pg_port>",
-    "description": "Same as `pg_port`, but for the read-only connection."
+    "description": "Same as `pg_port`, but for the\nread-only connection.\n"
   },
   "pg_ro_timeout": {
     "defaultValue": "<pg_timeout>",
-    "description": "Same as `pg_timeout`, but for the read-only connection."
+    "description": "Same as `pg_timeout`, but for the\nread-only connection.\n"
   },
   "pg_ro_user": {
     "defaultValue": "<pg_user>",
-    "description": "Same as `pg_user`, but for the read-only connection."
+    "description": "Same as `pg_user`, but for the\nread-only connection.\n"
   },
   "pg_ro_password": {
     "defaultValue": "<pg_password>",
-    "description": "Same as `pg_password`, but for the read-only connection."
+    "description": "Same as `pg_password`, but for the\nread-only connection.\n"
   },
   "pg_ro_iam_auth": {
     "defaultValue": "<pg_iam_auth>",
-    "description": "Same as `pg_iam_auth`, but for the read-only connection."
+    "description": "Same as `pg_iam_auth`, but for the\nread-only connection.\n"
   },
   "pg_ro_iam_auth_assume_role_arn": {
     "defaultValue": null,
-    "description": "Same as `pg_iam_auth_assume_role_arn', but for the read-only connection."
+    "description": "Same as `pg_iam_auth_assume_role_arn',\nbut for the read-only connection.\n"
   },
   "pg_ro_iam_auth_role_session_name": {
     "defaultValue": "KongPostgres",
-    "description": "Same as `pg_iam_auth_role_session_name`, but for the read-only connection."
+    "description": "Same as `pg_iam_auth_role_session_name`,\nbut for the read-only connection.\n"
   },
   "pg_ro_iam_auth_sts_endpoint_url": {
     "defaultValue": null,
-    "description": "Same as `pg_iam_auth_sts_endpoint_url`, but for the read-only connection."
+    "description": "Same as `pg_iam_auth_sts_endpoint_url`,\nbut for the read-only connection.\n"
   },
   "pg_ro_database": {
     "defaultValue": "<pg_database>",
-    "description": "Same as `pg_database`, but for the read-only connection."
+    "description": "Same as `pg_database`, but for the\nread-only connection.\n"
   },
   "pg_ro_schema": {
     "defaultValue": "<pg_schema>",
-    "description": "Same as `pg_schema`, but for the read-only connection."
+    "description": "Same as `pg_schema`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl": {
     "defaultValue": "<pg_ssl>",
-    "description": "Same as `pg_ssl`, but for the read-only connection."
+    "description": "Same as `pg_ssl`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl_required": {
     "defaultValue": "<pg_ssl_required>",
-    "description": " Same as `pg_ssl_required`, but for the read-only connection."
+    "description": "Same as `pg_ssl_required`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl_verify": {
     "defaultValue": "<pg_ssl_verify>",
-    "description": " Same as `pg_ssl_verify`, but for the read-only connection."
+    "description": "Same as `pg_ssl_verify`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl_version": {
     "defaultValue": "<pg_ssl_version>",
-    "description": " Same as `pg_ssl_version`, but for the read-only connection."
+    "description": "Same as `pg_ssl_version`, but for the\nread-only connection.\n"
   },
   "pg_ro_max_concurrent_queries": {
     "defaultValue": "<pg_max_concurrent_queries>",
-    "description": " Same as `pg_max_concurrent_queries`, but for the read-only connection. Note: read-only concurrency is not shared with the main (read-write) connection."
+    "description": "Same as `pg_max_concurrent_queries`, but for\nthe read-only connection.\nNote: read-only concurrency is not shared\nwith the main (read-write) connection.\n"
   },
   "pg_ro_semaphore_timeout": {
     "defaultValue": "<pg_semaphore_timeout>",
-    "description": " Same as `pg_semaphore_timeout`, but for the read-only connection."
+    "description": "Same as `pg_semaphore_timeout`, but for the\nread-only connection.\n"
   },
   "pg_ro_keepalive_timeout": {
     "defaultValue": "<pg_keepalive_timeout>",
-    "description": " Same as `pg_keepalive_timeout`, but for the read-only connection."
+    "description": "Same as `pg_keepalive_timeout`, but for the\nread-only connection.\n"
   },
   "pg_ro_pool_size": {
     "defaultValue": "<pg_pool_size>",
-    "description": " Same as `pg_pool_size`, but for the read-only connection."
+    "description": "Same as `pg_pool_size`, but for the\nread-only connection.\n"
   },
   "pg_ro_backlog": {
     "defaultValue": "<pg_backlog>",
-    "description": " Same as `pg_backlog`, but for the read-only connection."
+    "description": "Same as `pg_backlog`, but for the\nread-only connection.\n"
   },
   "declarative_config": {
     "defaultValue": null,
-    "description": "The path to the declarative configuration file which holds the specification of all entities (Routes, Services, Consumers, etc.) to be used when the `database` is set to `off`.  Entities are stored in Kong's LMDB cache, so you must ensure that enough headroom is allocated to it via the `lmdb_map_size` property.  If the Hybrid mode `role` is set to `data_plane` and there's no configuration cache file, this configuration is used before connecting to the Control Plane node as a user-controlled fallback."
+    "description": "The path to the declarative configuration\nfile which holds the specification of all\nentities (Routes, Services, Consumers, etc.)\nto be used when the `database` is set to\n`off`.\n\nEntities are stored in Kong's LMDB cache,\nso you must ensure that enough headroom is\nallocated to it via the `lmdb_map_size`\nproperty.\n\nIf the Hybrid mode `role` is set to `data_plane`\nand there's no configuration cache file,\nthis configuration is used before connecting\nto the Control Plane node as a user-controlled\nfallback.\n"
   },
   "declarative_config_string": {
     "defaultValue": null,
-    "description": "The declarative configuration as a string"
+    "description": "The declarative configuration as a string\n"
   },
   "lmdb_environment_path": {
     "defaultValue": "dbless.lmdb",
-    "description": "Directory where the LMDB database files used by DB-less and Hybrid mode to store Kong configurations reside.  This path is relative under the Kong `prefix`."
+    "description": "Directory where the LMDB database files used by\nDB-less and Hybrid mode to store Kong\nconfigurations reside.\n\nThis path is relative under the Kong `prefix`.\n"
   },
   "lmdb_map_size": {
     "defaultValue": "2048m",
-    "description": "Maximum size of the LMDB memory map, used to store the DB-less and Hybird mode configurations. Default is 2048m.  This config defines the limit of LMDB file size, the actual file size growth will be on-demand and proportional to the actual config size.  Note this value can be set very large, say a couple of GBs to accommodate future database growth and Multi Version Concurrency Control (MVCC) headroom needs. The file size of the LMDB database file should stabilize after a few config reload/Hybrid mode syncs and the actual memory used by the LMDB database will be smaller than the file size due to dynamic swapping of database pages by the OS."
+    "description": "Maximum size of the LMDB memory map, used to store the\nDB-less and Hybird mode configurations. Default is 2048m.\n\nThis config defines the limit of LMDB file size, the\nactual file size growth will be on-demand and\nproportional to the actual config size.\n\nNote this value can be set very large, say a couple of GBs\nto accommodate future database growth and\nMulti Version Concurrency Control (MVCC) headroom needs.\nThe file size of the LMDB database file should stabilize\nafter a few config reload/Hybrid mode syncs and the actual\nmemory used by the LMDB database will be smaller than\nthe file size due to dynamic swapping of database pages by\nthe OS.\n"
   },
   "db_update_frequency": {
     "defaultValue": "5",
-    "description": "Frequency (in seconds) at which to check for updated entities with the datastore.  When a node creates, updates, or deletes an entity via the Admin API, other nodes need to wait for the next poll (configured by this value) to eventually purge the old cached entity and start using the new one."
+    "description": "Frequency (in seconds) at which to check for\nupdated entities with the datastore.\n\nWhen a node creates, updates, or deletes an\nentity via the Admin API, other nodes need\nto wait for the next poll (configured by\nthis value) to eventually purge the old\ncached entity and start using the new one.\n"
   },
   "db_update_propagation": {
     "defaultValue": "0",
-    "description": "Time (in seconds) taken for an entity in the datastore to be propagated to replica nodes of another datacenter.  When set, this property will increase the time taken by Kong to propagate the change of an entity.  Single-datacenter setups or PostgreSQL servers should suffer no such delays, and this value can be safely set to 0. Postgres setups with read replicas should set this value to maximum expected replication lag between the writer and reader instances."
+    "description": "Time (in seconds) taken for an entity in the\ndatastore to be propagated to replica nodes\nof another datacenter.\n\nWhen set, this property will increase the\ntime taken by Kong to propagate the change\nof an entity.\n\nSingle-datacenter setups or PostgreSQL\nservers should suffer no such delays, and\nthis value can be safely set to 0.\nPostgres setups with read replicas should\nset this value to maximum expected replication\nlag between the writer and reader instances.\n"
   },
   "db_cache_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of an entity from the datastore when cached by this node.  Database misses (no entity) are also cached according to this setting if you do not configure `db_cache_neg_ttl`.  If set to 0 (default), such cached entities or misses never expire."
+    "description": "Time-to-live (in seconds) of an entity from\nthe datastore when cached by this node.\n\nDatabase misses (no entity) are also cached\naccording to this setting if you do not\nconfigure `db_cache_neg_ttl`.\n\nIf set to 0 (default), such cached entities\nor misses never expire.\n"
   },
   "db_cache_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a datastore miss (no entity).  If not specified (default), `db_cache_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a datastore\nmiss (no entity).\n\nIf not specified (default), `db_cache_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "db_resurrect_ttl": {
     "defaultValue": "30",
-    "description": "Time (in seconds) for which stale entities from the datastore should be resurrected for when they cannot be refreshed (e.g., the datastore is unreachable). When this TTL expires, a new attempt to refresh the stale entities will be made."
+    "description": "Time (in seconds) for which stale entities\nfrom the datastore should be resurrected for\nwhen they cannot be refreshed (e.g., the\ndatastore is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nentities will be made.\n"
   },
   "db_cache_warmup_entities": {
     "defaultValue": "services",
-    "description": " Entities to be pre-loaded from the datastore into the in-memory cache at Kong start-up. This speeds up the first access of endpoints that use the given entities.  When the `services` entity is configured for warmup, the DNS entries for values in its `host` attribute are pre-resolved asynchronously as well.  Cache size set in `mem_cache_size` should be set to a value large enough to hold all instances of the specified entities. If the size is insufficient, Kong will log a warning."
+    "description": "Entities to be pre-loaded from the datastore\ninto the in-memory cache at Kong start-up.\nThis speeds up the first access of endpoints\nthat use the given entities.\n\nWhen the `services` entity is configured\nfor warmup, the DNS entries for values in\nits `host` attribute are pre-resolved\nasynchronously as well.\n\nCache size set in `mem_cache_size` should\nbe set to a value large enough to hold all\ninstances of the specified entities.\nIf the size is insufficient, Kong will log\na warning.\n"
   },
   "dns_resolver": {
     "defaultValue": null,
-    "description": "Comma separated list of nameservers, each entry in `ip[:port]` format to be used by Kong. If not specified the nameservers in the local `resolv.conf` file will be used. Port defaults to 53 if omitted. Accepts both IPv4 and IPv6 addresses."
+    "description": "Comma separated list of nameservers, each\nentry in `ip[:port]` format to be used by\nKong. If not specified the nameservers in\nthe local `resolv.conf` file will be used.\nPort defaults to 53 if omitted. Accepts\nboth IPv4 and IPv6 addresses.\n"
   },
   "dns_hostsfile": {
     "defaultValue": "/etc/hosts",
-    "description": "The hosts file to use. This file is read once and its content is static in memory. To read the file again after modifying it, Kong must be reloaded."
+    "description": "The hosts file to use. This file is read\nonce and its content is static in memory.\nTo read the file again after modifying it,\nKong must be reloaded.\n"
   },
   "dns_order": {
     "defaultValue": [
@@ -632,628 +632,628 @@
       "A",
       "CNAME"
     ],
-    "description": "The order in which to resolve different record types. The `LAST` type means the type of the last successful lookup (for the specified name). The format is a (case insensitive) comma separated list."
+    "description": "The order in which to resolve different\nrecord types. The `LAST` type means the\ntype of the last successful lookup (for the\nspecified name). The format is a (case\ninsensitive) comma separated list.\n"
   },
   "dns_valid_ttl": {
     "defaultValue": null,
-    "description": "By default, DNS records are cached using the TTL value of a response. If this property receives a value (in seconds), it will override the TTL for all records."
+    "description": "By default, DNS records are cached using\nthe TTL value of a response. If this\nproperty receives a value (in seconds), it\nwill override the TTL for all records.\n"
   },
   "dns_stale_ttl": {
     "defaultValue": "3600",
-    "description": "Defines, in seconds, how long a record will remain in cache past its TTL. This value will be used while the new DNS record is fetched in the background. Stale data will be used from expiry of a record until either the refresh query completes, or the `dns_stale_ttl` number of seconds have passed. This configuration enables Kong to be more resilient during resolver downtime."
+    "description": "Defines, in seconds, how long a record will\nremain in cache past its TTL. This value\nwill be used while the new DNS record is\nfetched in the background.\nStale data will be used from expiry of a\nrecord until either the refresh query\ncompletes, or the `dns_stale_ttl` number of\nseconds have passed.\nThis configuration enables Kong to be more\nresilient during resolver downtime.\n"
   },
   "dns_cache_size": {
     "defaultValue": "10000",
-    "description": "Defines the maximum allowed number of DNS records stored in memory cache. Least recently used DNS records are discarded from cache if it is full. Both errors and data are cached, therefore a single name query can easily take up 10-15 slots."
+    "description": "Defines the maximum allowed number of\nDNS records stored in memory cache.\nLeast recently used DNS records are discarded\nfrom cache if it is full. Both errors and\ndata are cached, therefore a single name query\ncan easily take up 10-15 slots.\n"
   },
   "dns_not_found_ttl": {
     "defaultValue": "30",
-    "description": "TTL in seconds for empty DNS responses and \"(3) name error\" responses."
+    "description": "TTL in seconds for empty DNS responses and\n\"(3) name error\" responses.\n"
   },
   "dns_error_ttl": {
     "defaultValue": "1",
-    "description": "TTL in seconds for error responses."
+    "description": "TTL in seconds for error responses.\n"
   },
   "dns_no_sync": {
     "defaultValue": "off",
-    "description": "If enabled, then upon a cache-miss every request will trigger its own dns query. When disabled multiple requests for the same name/type will be synchronised to a single query."
+    "description": "If enabled, then upon a cache-miss every\nrequest will trigger its own dns query.\nWhen disabled multiple requests for the\nsame name/type will be synchronised to a\nsingle query.\n"
   },
   "vault_env_prefix": {
     "defaultValue": null,
-    "description": "Defines the environment variable vault's default prefix. For example if you have all your secrets stored in environment variables prefixed with `SECRETS_`, it can be configured here so that it isn't necessary to repeat them in Vault references."
+    "description": "Defines the environment variable vault's\ndefault prefix. For example if you have\nall your secrets stored in environment\nvariables prefixed with `SECRETS_`, it\ncan be configured here so that it isn't\nnecessary to repeat them in Vault\nreferences.\n"
   },
   "vault_aws_region": {
     "defaultValue": null,
-    "description": "The AWS region your vault is located in."
+    "description": "The AWS region your vault is located in.\n"
   },
   "vault_aws_endpoint_url": {
     "defaultValue": null,
-    "description": "The AWS SecretsManager service endpoint url. If not specified, the value used by vault will be the official AWS SecretsManager service url which is `https://secretsmanager.<region>.amazonaws.com` You can specify a complete URL(including the \"http/https\" scheme) to override the endpoint that vault will connect to."
+    "description": "The AWS SecretsManager service endpoint url.\nIf not specified, the value used by vault will\nbe the official AWS SecretsManager service url\nwhich is\n`https://secretsmanager.<region>.amazonaws.com`\nYou can specify a complete URL(including\nthe \"http/https\" scheme) to override the\nendpoint that vault will connect to.\n"
   },
   "vault_aws_assume_role_arn": {
     "defaultValue": null,
-    "description": "The target AWS IAM role ARN that will be assumed. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+    "description": "The target AWS IAM role ARN that will be\nassumed. Typically this is used for\noperating between multiple roles\nor cross-accounts.\nIf you are not using assume role\nyou should not specify this value.\n"
   },
   "vault_aws_role_session_name": {
     "defaultValue": "KongVault",
-    "description": "The role session name used for role assuming. The default value is `KongVault`."
+    "description": "The role session name used for role\nassuming. The default value is\n`KongVault`.\n"
   },
   "vault_aws_sts_endpoint_url": {
     "defaultValue": null,
-    "description": "The custom STS endpoint URL used for role assuming in AWS Vault.  Note that this value will override the default STS endpoint URL(which should be `https://sts.amazonaws.com`, or `https://sts.<region>.amazonaws.com` if you have `AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).  If you are not using private VPC endpoint for STS service, you should not specify this value."
+    "description": "The custom STS endpoint URL used for role assuming\nin AWS Vault.\n\nNote that this value will override the default\nSTS endpoint URL(which should be\n`https://sts.amazonaws.com`, or\n`https://sts.<region>.amazonaws.com` if you have\n`AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).\n\nIf you are not using private VPC endpoint for STS\nservice, you should not specify this value.\n"
   },
   "vault_aws_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the AWS vault when cached by this node.  AWS vault misses (no secret) are also cached according to this setting if you do not configure `vault_aws_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe AWS vault when cached by this node.\n\nAWS vault misses (no secret) are also cached\naccording to this setting if you do not\nconfigure `vault_aws_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_aws_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_aws_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a AWS vault\nmiss (no secret).\n\nIf not specified (default), `vault_aws_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_aws_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the AWS vault should be resurrected for when they cannot be refreshed (e.g., the AWS vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the AWS vault should be resurrected for\nwhen they cannot be refreshed (e.g., the\nAWS vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "vault_gcp_project_id": {
     "defaultValue": null,
-    "description": "The project ID from your Google API Console."
+    "description": "The project ID from your Google API Console.\n"
   },
   "vault_gcp_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the GCP vault when cached by this node.  GCP vault misses (no secret) are also cached according to this setting if you do not configure `vault_gcp_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe GCP vault when cached by this node.\n\nGCP vault misses (no secret) are also cached\naccording to this setting if you do not\nconfigure `vault_gcp_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_gcp_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_gcp_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a AWS vault\nmiss (no secret).\n\nIf not specified (default), `vault_gcp_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_gcp_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the GCP vault should be resurrected for when they cannot be refreshed (e.g., the GCP vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the GCP vault should be resurrected for\nwhen they cannot be refreshed (e.g., the\nGCP vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "vault_hcv_protocol": {
     "defaultValue": "http",
-    "description": "The protocol to connect with. Accepts one of `http` or `https`."
+    "description": "The protocol to connect with. Accepts one of\n`http` or `https`.\n"
   },
   "vault_hcv_host": {
     "defaultValue": "127.0.0.1",
-    "description": "The hostname of your HashiCorp vault."
+    "description": "The hostname of your HashiCorp vault.\n"
   },
   "vault_hcv_port": {
     "defaultValue": "8200",
-    "description": "The port number of your HashiCorp vault."
+    "description": "The port number of your HashiCorp vault.\n"
   },
   "vault_hcv_namespace": {
     "defaultValue": null,
-    "description": "Namespace for the HashiCorp Vault. Vault Enterprise requires a namespace to successfully connect to it."
+    "description": "Namespace for the HashiCorp Vault. Vault\nEnterprise requires a namespace to\nsuccessfully connect to it.\n"
   },
   "vault_hcv_mount": {
     "defaultValue": "secret",
-    "description": "The mount point."
+    "description": "The mount point.\n"
   },
   "vault_hcv_kv": {
     "defaultValue": "v1",
-    "description": "The secrets engine version. Accepts `v1` or `v2`."
+    "description": "The secrets engine version. Accepts `v1` or\n`v2`.\n"
   },
   "vault_hcv_token": {
     "defaultValue": null,
-    "description": "A token string."
+    "description": "A token string.\n"
   },
   "vault_hcv_auth_method": {
     "defaultValue": "token",
-    "description": "Defines the authentication mechanism when connecting to the Hashicorp Vault service. Accepted values are: `token`, `kubernetes` or `approle`."
+    "description": "Defines the authentication mechanism when\nconnecting to the Hashicorp Vault service.\nAccepted values are: `token`,\n`kubernetes` or `approle`.\n"
   },
   "vault_hcv_kube_role": {
     "defaultValue": null,
-    "description": "Defines the HashiCorp Vault role for the Kubernetes service account of the running pod. `vault_hcv_auth_method` must be set to `kubernetes` for this to activate."
+    "description": "Defines the HashiCorp Vault role for the\nKubernetes service account of the running\npod. `vault_hcv_auth_method` must be\nset to `kubernetes` for this to activate.\n"
   },
   "vault_hcv_kube_auth_path": {
     "defaultValue": "kubernetes",
-    "description": " Place where the Kubernetes auth method will be accessible: /v1/auth/<vault_hcv_kube_auth_path>"
+    "description": "Place where the Kubernetes auth method will be\naccessible: /v1/auth/<vault_hcv_kube_auth_path>\n"
   },
   "vault_hcv_kube_api_token_file": {
     "defaultValue": null,
-    "description": "Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+    "description": "Defines where the Kubernetes service account\ntoken should be read from the pod's\nfilesystem, if using a non-standard\ncontainer platform setup.\n"
   },
   "vault_hcv_approle_auth_path": {
     "defaultValue": "approle",
-    "description": " Place where the Approle auth method will be accessible: /v1/auth/<vault_hcv_approle_auth_path>"
+    "description": "Place where the Approle auth method will be\naccessible: /v1/auth/<vault_hcv_approle_auth_path>\n"
   },
   "vault_hcv_approle_role_id": {
     "defaultValue": null,
-    "description": "The Role ID of the Approle in HashiCorp Vault."
+    "description": "The Role ID of the Approle in HashiCorp Vault.\n"
   },
   "vault_hcv_approle_secret_id": {
     "defaultValue": null,
-    "description": "The Secret ID of the Approle in HashiCorp Vault."
+    "description": "The Secret ID of the Approle in HashiCorp Vault.\n"
   },
   "vault_hcv_approle_secret_id_file": {
     "defaultValue": null,
-    "description": "Defines where the Secret ID should be read from the pod's filesystem. This is usually used with HashiCorp Vault's response wrapping."
+    "description": "Defines where the Secret ID should be read from\nthe pod's filesystem. This is usually used with\nHashiCorp Vault's response wrapping.\n"
   },
   "vault_hcv_approle_response_wrapping": {
     "defaultValue": "false",
-    "description": "Defines whether the Secret ID read from configuration or file is actually a response-wrapping token instead of a real Secret ID."
+    "description": "Defines whether the Secret ID read from configuration\nor file is actually a response-wrapping token instead\nof a real Secret ID.\n"
   },
   "vault_hcv_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the HashiCorp vault when cached by this node.  HashiCorp vault misses (no secret) are also cached according to this setting if you do not configure `vault_hcv_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe HashiCorp vault when cached by this node.\n\nHashiCorp vault misses (no secret) are also\ncached according to this setting if you do not\nconfigure `vault_hcv_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_hcv_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a HashiCorp vault miss (no secret).  If not specified (default), `vault_hcv_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a HashiCorp vault\nmiss (no secret).\n\nIf not specified (default), `vault_hcv_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_hcv_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the HashiCorp vault should be resurrected for when they cannot be refreshed (e.g., the HashiCorp vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the HashiCorp vault should be resurrected\nfor when they cannot be refreshed (e.g., the\nHashiCorp vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "vault_azure_vault_uri": {
     "defaultValue": null,
-    "description": "The URI the vault is reachable from."
+    "description": "The URI the vault is reachable from.\n"
   },
   "vault_azure_client_id": {
     "defaultValue": null,
-    "description": "The client ID from your registered Application. Visit your Azure Dashboard and select *App Registrations* to check your client ID."
+    "description": "The client ID from your registered Application. Visit your Azure Dashboard and select *App Registrations* to check your client ID.\n"
   },
   "vault_azure_tenant_id": {
     "defaultValue": null,
-    "description": "The DirectoryId and TenantId both equate to the GUID representing the ActiveDirectory Tenant. Depending on context, either term may be used by Microsoft documentation and products, which can be confusing. In other words, the \"Tenant ID\" IS the \"Directory ID\""
+    "description": "The DirectoryId and TenantId both equate to the GUID representing the ActiveDirectory Tenant. Depending on context, either term may be used by Microsoft documentation and products, which can be confusing. In other words, the \"Tenant ID\" IS the \"Directory ID\"\n"
   },
   "vault_azure_type": {
     "defaultValue": "secrets",
-    "description": "Azure Key Vault enables Microsoft Azure applications and users to store and use several types of secret/key data: keys, secrets, and certificates. Kong currently only supports the `Secrets`"
+    "description": "Azure Key Vault enables Microsoft Azure applications and users to store and use several types of secret/key data: keys, secrets, and certificates. Kong currently only supports the `Secrets`\n"
   },
   "vault_azure_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the Azure Key Vault when cached by this node.  Key Vault misses (no secret) are also cached according to this setting if you do not configure `vault_azure_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe Azure Key Vault when cached by this node.\n\nKey Vault misses (no secret) are also\ncached according to this setting if you do not\nconfigure `vault_azure_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_azure_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a Azure Key Vault miss (no secret).  If not specified (default), `vault_azure_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a Azure Key Vault\nmiss (no secret).\n\nIf not specified (default), `vault_azure_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_azure_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the Azure Key Vault should be resurrected for when they cannot be refreshed (e.g., the the vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the Azure Key Vault should be resurrected\nfor when they cannot be refreshed (e.g., the\nthe vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "worker_consistency": {
     "defaultValue": "eventual",
-    "description": " Defines whether this node should rebuild its state synchronously or asynchronously (the balancers and the router are rebuilt on updates that affects them, e.g., updates to Routes, Services or Upstreams, via the Admin API or loading a declarative configuration file). (This option is deprecated and will be removed in future releases. The new default is `eventual`.)  Accepted values are:  - `strict`: the router will be rebuilt   synchronously, causing incoming requests to   be delayed until the rebuild is finished.   (This option is deprecated and will be removed    in future releases. The new default is `eventual`) - `eventual`: the router will be rebuilt   asynchronously via a recurring background   job running every second inside of each   worker.  Note that `strict` ensures that all workers of a given node will always proxy requests with an identical router, but that increased long tail latency can be observed if frequent Routes and Services updates are expected. Using `eventual` will help preventing long tail latency issues in such cases, but may cause workers to route requests differently for a short period of time after Routes and Services updates."
+    "description": "Defines whether this node should rebuild its\nstate synchronously or asynchronously (the\nbalancers and the router are rebuilt on\nupdates that affects them, e.g., updates to\nRoutes, Services or Upstreams, via the Admin\nAPI or loading a declarative configuration\nfile). (This option is deprecated and will be\nremoved in future releases. The new default\nis `eventual`.)\n\nAccepted values are:\n\n- `strict`: the router will be rebuilt\n  synchronously, causing incoming requests to\n  be delayed until the rebuild is finished.\n  (This option is deprecated and will be removed\n   in future releases. The new default is `eventual`)\n- `eventual`: the router will be rebuilt\n  asynchronously via a recurring background\n  job running every second inside of each\n  worker.\n\nNote that `strict` ensures that all workers\nof a given node will always proxy requests\nwith an identical router, but that increased\nlong tail latency can be observed if\nfrequent Routes and Services updates are\nexpected.\nUsing `eventual` will help preventing long\ntail latency issues in such cases, but may\ncause workers to route requests differently\nfor a short period of time after Routes and\nServices updates.\n"
   },
   "worker_state_update_frequency": {
     "defaultValue": "5",
-    "description": " Defines how often the worker state changes are checked with a background job. When a change is detected, a new router or balancer will be built, as needed. Raising this value will decrease the load on database servers and result in less jitter in proxy latency, but it might take more time to propagate changes to each individual worker."
+    "description": "Defines how often the worker state changes are\nchecked with a background job. When a change\nis detected, a new router or balancer will be\nbuilt, as needed. Raising this value will\ndecrease the load on database servers and\nresult in less jitter in proxy latency, but\nit might take more time to propagate changes\nto each individual worker.\n"
   },
   "router_flavor": {
     "defaultValue": "traditional_compatible",
-    "description": " Selects the router implementation to use when performing request routing. Incremental router rebuild is available when the flavor is set to either `expressions` or `traditional_compatible` which could significantly shorten rebuild time for large number of routes.  Accepted values are:  - `traditional_compatible`: the DSL based expression   router engine will be used under the hood. However   the router config interface will be the same   as `traditional` and expressions are   automatically generated at router build time.   The `expression` field on the `Route` object   is not visible. - `expressions`: the DSL based expression router engine   will be used under the hood. Traditional router   config interface is not visible and you must write   Router Expression manually and provide them in the   `expression` field on the `Route` object. - `traditional`: the pre-3.0 Router engine will be   used. Config interface will be the same as   pre-3.0 Kong and the `expression` field on the   `Route` object is not visible.    Deprecation warning: In Kong 3.0, `traditional`   mode should be avoided and only be used in case   `traditional_compatible` did not work as expected.   This flavor of router will be removed in the next   major release of Kong."
+    "description": "Selects the router implementation to use when\nperforming request routing. Incremental router\nrebuild is available when the flavor is set\nto either `expressions` or\n`traditional_compatible` which could\nsignificantly shorten rebuild time for large\nnumber of routes.\n\nAccepted values are:\n\n- `traditional_compatible`: the DSL based expression\n  router engine will be used under the hood. However\n  the router config interface will be the same\n  as `traditional` and expressions are\n  automatically generated at router build time.\n  The `expression` field on the `Route` object\n  is not visible.\n- `expressions`: the DSL based expression router engine\n  will be used under the hood. Traditional router\n  config interface is not visible and you must write\n  Router Expression manually and provide them in the\n  `expression` field on the `Route` object.\n- `traditional`: the pre-3.0 Router engine will be\n  used. Config interface will be the same as\n  pre-3.0 Kong and the `expression` field on the\n  `Route` object is not visible.\n\n  Deprecation warning: In Kong 3.0, `traditional`\n  mode should be avoided and only be used in case\n  `traditional_compatible` did not work as expected.\n  This flavor of router will be removed in the next\n  major release of Kong.\n"
   },
   "lua_max_req_headers": {
     "defaultValue": "100",
-    "description": "Maximum number of request headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying the Kong sends all the request headers and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many request headers."
+    "description": "Maximum number of request headers to parse by default.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying the Kong sends all the request headers\nand this setting does not have any effect. It is used\nto limit Kong and its plugins from reading too many\nrequest headers.\n"
   },
   "lua_max_resp_headers": {
     "defaultValue": "100",
-    "description": "Maximum number of response headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong returns all the response headers and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many response headers."
+    "description": "Maximum number of response headers to parse by default.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong returns all the response headers\nand this setting does not have any effect. It is used\nto limit Kong and its plugins from reading too many\nresponse headers.\n"
   },
   "lua_max_uri_args": {
     "defaultValue": "100",
-    "description": "Maximum number of request uri arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request query arguments and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many query arguments."
+    "description": "Maximum number of request uri arguments to parse by\ndefault.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request query\narguments and this setting does not have any effect.\nIt is used to limit Kong and its plugins from reading\ntoo many query arguments.\n"
   },
   "lua_max_post_args": {
     "defaultValue": "100",
-    "description": "Maximum number of request post arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request post arguments and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many post arguments."
+    "description": "Maximum number of request post arguments to parse by\ndefault.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request post\narguments and this setting does not have any effect.\nIt is used to limit Kong and its plugins from reading\ntoo many post arguments.\n"
   },
   "lua_ssl_trusted_certificate": {
     "defaultValue": "system",
-    "description": "Comma-separated list of certificate authorities for Lua cosockets in PEM format.  The special value `system` attempts to search for the \"usual default\" provided by each distro, according to an arbitrary heuristic. In the current implementation, The following pathnames will be tested in order, and the first one found will be used:  - /etc/ssl/certs/ca-certificates.crt (Debian/Ubuntu/Gentoo) - /etc/pki/tls/certs/ca-bundle.crt (Fedora/RHEL 6) - /etc/ssl/ca-bundle.pem (OpenSUSE) - /etc/pki/tls/cacert.pem (OpenELEC) - /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem (CentOS/RHEL 7) - /etc/ssl/cert.pem (OpenBSD, Alpine)  `system` can be used by itself or in conjunction with other CA filepaths.  When `pg_ssl_verify` is enabled, these certificate authority files will be used for verifying Kong's database connections.  Certificates can be configured on this property with either of the following values: * `system` * absolute path to the certificate * certificate content * base64 encoded certificate content  See https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate"
+    "description": "Comma-separated list of certificate authorities\nfor Lua cosockets in PEM format.\n\nThe special value `system` attempts to search for the\n\"usual default\" provided by each distro, according\nto an arbitrary heuristic. In the current implementation,\nThe following pathnames will be tested in order,\nand the first one found will be used:\n\n- /etc/ssl/certs/ca-certificates.crt (Debian/Ubuntu/Gentoo)\n- /etc/pki/tls/certs/ca-bundle.crt (Fedora/RHEL 6)\n- /etc/ssl/ca-bundle.pem (OpenSUSE)\n- /etc/pki/tls/cacert.pem (OpenELEC)\n- /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem (CentOS/RHEL 7)\n- /etc/ssl/cert.pem (OpenBSD, Alpine)\n\n`system` can be used by itself or in conjunction with other\nCA filepaths.\n\nWhen `pg_ssl_verify` is enabled, these\ncertificate authority files will be\nused for verifying Kong's database connections.\n\nCertificates can be configured on this property\nwith either of the following values:\n* `system`\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n\nSee https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate\n"
   },
   "lua_ssl_verify_depth": {
     "defaultValue": "1",
-    "description": "Sets the verification depth in the server certificates chain used by Lua cosockets, set by `lua_ssl_trusted_certificate`. This includes the certificates configured for Kong's database connections. If the maximum depth is reached before reaching the end of the chain, verification will fail. This helps mitigate certificate based DoS attacks.  See https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth"
+    "description": "Sets the verification depth in the server\ncertificates chain used by Lua cosockets,\nset by `lua_ssl_trusted_certificate`.\nThis includes the certificates configured\nfor Kong's database connections.\nIf the maximum depth is reached before\nreaching the end of the chain, verification\nwill fail. This helps mitigate certificate\nbased DoS attacks.\n\nSee https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth\n"
   },
   "lua_ssl_protocols": {
     "defaultValue": "TLSv1.2 TLSv1.3",
-    "description": "Defines the TLS versions supported when handshaking with OpenResty's TCP cosocket APIs.  This affects connections made by Lua code, such as connections to the database Kong uses, or when sending logs using a logging plugin. It does *not* affect connections made to the upstream Service or from downstream clients."
+    "description": "Defines the TLS versions supported\nwhen handshaking with OpenResty's\nTCP cosocket APIs.\n\nThis affects connections made by Lua\ncode, such as connections to the\ndatabase Kong uses, or when sending logs\nusing a logging plugin. It does *not*\naffect connections made to the upstream\nService or from downstream clients.\n"
   },
   "lua_package_path": {
     "defaultValue": "./?.lua;./?/init.lua;",
-    "description": "Sets the Lua module search path (LUA_PATH). Useful when developing or using custom plugins not stored in the default search path.  See https://github.com/openresty/lua-nginx-module#lua_package_path"
+    "description": "Sets the Lua module search path\n(LUA_PATH). Useful when developing\nor using custom plugins not stored\nin the default search path.\n\nSee https://github.com/openresty/lua-nginx-module#lua_package_path\n"
   },
   "lua_package_cpath": {
     "defaultValue": null,
-    "description": "Sets the Lua C module search path (LUA_CPATH).  See https://github.com/openresty/lua-nginx-module#lua_package_cpath"
+    "description": "Sets the Lua C module search path\n(LUA_CPATH).\n\nSee https://github.com/openresty/lua-nginx-module#lua_package_cpath\n"
   },
   "lua_socket_pool_size": {
     "defaultValue": "30",
-    "description": "Specifies the size limit for every cosocket connection pool associated with every remote server.  See https://github.com/openresty/lua-nginx-module#lua_socket_pool_size"
+    "description": "Specifies the size limit for every cosocket\nconnection pool associated with every remote\nserver.\n\nSee https://github.com/openresty/lua-nginx-module#lua_socket_pool_size\n"
   },
   "enforce_rbac": {
     "defaultValue": "off",
-    "description": "Specifies whether Admin API RBAC is enforced. Accepts one of `entity`, `both`, `on`, or `off`.  - `on`: only endpoint-level authorization   is enforced. - `entity`: entity-level authorization   applies. - `both`: enables both endpoint and   entity-level authorization. - `off`: disables both endpoint and   entity-level authorization.  When enabled, Kong will deny requests to the Admin API when a nonexistent or invalid RBAC authorization token is passed, or the RBAC user with which the token is associated does not have permissions to access/modify the requested resource."
+    "description": "Specifies whether Admin API RBAC is enforced.\nAccepts one of `entity`, `both`, `on`, or\n`off`.\n\n- `on`: only endpoint-level authorization\n  is enforced.\n- `entity`: entity-level authorization\n  applies.\n- `both`: enables both endpoint and\n  entity-level authorization.\n- `off`: disables both endpoint and\n  entity-level authorization.\n\nWhen enabled, Kong will deny requests to the\nAdmin API when a nonexistent or invalid RBAC\nauthorization token is passed, or the RBAC\nuser with which the token is associated does\nnot have permissions to access/modify the\nrequested resource.\n"
   },
   "rbac_auth_header": {
     "defaultValue": "Kong-Admin-Token",
-    "description": "Defines the name of the HTTP request header from which the Admin API will attempt to authenticate the RBAC user."
+    "description": "Defines the name of the HTTP request\nheader from which the Admin API will\nattempt to authenticate the RBAC user.\n"
   },
   "event_hooks_enabled": {
     "defaultValue": "on",
-    "description": "When enabled, event hook entities represent a relationship between an event (source and event) and an action (handler). Similar to web hooks, event hooks can be used to communicate Kong Gateway service events. When a particular event happens on a service, the event hook calls a URL with information about that event. Event hook configurations differ depending on the handler. The events that are triggered send associated data.  See: https://docs.konghq.com/enterprise/latest/admin-api/event-hooks/reference/"
+    "description": "When enabled, event hook entities represent a relationship\nbetween an event (source and event) and an action\n(handler). Similar to web hooks, event hooks can be used to\ncommunicate Kong Gateway service events. When a particular\nevent happens on a service, the event hook calls a URL with\ninformation about that event. Event hook configurations\ndiffer depending on the handler. The events that are\ntriggered send associated data.\n\nSee: https://docs.konghq.com/enterprise/latest/admin-api/event-hooks/reference/\n"
   },
   "fips": {
     "defaultValue": "off",
-    "description": "Turn on FIPS mode; this mode is only available on a FIPS build."
+    "description": "Turn on FIPS mode; this mode is only available on a FIPS build.\n"
   },
   "admin_gui_listen": {
     "defaultValue": [
       "0.0.0.0:8002",
       "0.0.0.0:8445 ssl"
     ],
-    "description": " Kong Manager Listeners  Comma-separated list of addresses and ports on which Kong will expose Kong Manager. This web application lets you configure and manage Kong, and therefore should be kept secured.  Suffixes can be specified for each pair, similarly to the `admin_listen` directive."
+    "description": "Kong Manager Listeners\n\nComma-separated list of addresses and ports on which\nKong will expose Kong Manager. This web application\nlets you configure and manage Kong, and therefore\nshould be kept secured.\n\nSuffixes can be specified for each pair, similarly to\nthe `admin_listen` directive.\n"
   },
   "admin_gui_url": {
     "defaultValue": null,
-    "description": "Kong Manager URL  The lookup, or balancer, address for Kong Manager.  Accepted format (items in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>)`  Examples:  - `http://127.0.0.1:8003` - `https://kong-admin.test` - `http://dev-machine`  By default, Kong Manager will use the window request host and append the resolved listener port depending on the requested protocol."
+    "description": "Kong Manager URL\n\nThe lookup, or balancer, address for Kong Manager.\n\nAccepted format (items in parentheses are optional):\n\n  `<scheme>://<IP / HOSTNAME>(:<PORT>)`\n\nExamples:\n\n- `http://127.0.0.1:8003`\n- `https://kong-admin.test`\n- `http://dev-machine`\n\nBy default, Kong Manager will use the window request\nhost and append the resolved listener port depending\non the requested protocol.\n"
   },
   "admin_gui_path": {
     "defaultValue": "/",
-    "description": "Kong Manager base path  This configuration parameter allows the user to customize the path prefix where Kong Manager is served. When updating this parameter, it's recommended to update the path in `admin_gui_url` as well.  Accepted format:  - Path must start with a `/` - Path must not end with a `/` (except for the `/`) - Path can only contain letters, digits, hyphens (`-`), underscores (`_`), and slashes (`/`) - Path must not contain continuous slashes (e.g., `//` and `///`)  Examples:  - `/` - `/manager` - `/kong-manager` - `/kong/manager`"
+    "description": "Kong Manager base path\n\nThis configuration parameter allows the user to customize\nthe path prefix where Kong Manager is served. When updating\nthis parameter, it's recommended to update the path in `admin_gui_url`\nas well.\n\nAccepted format:\n\n- Path must start with a `/`\n- Path must not end with a `/` (except for the `/`)\n- Path can only contain letters, digits, hyphens (`-`),\nunderscores (`_`), and slashes (`/`)\n- Path must not contain continuous slashes (e.g., `//` and `///`)\n\nExamples:\n\n- `/`\n- `/manager`\n- `/kong-manager`\n- `/kong/manager`\n"
   },
   "admin_gui_api_url": {
     "defaultValue": null,
-    "description": "Hierarchical part of a URI which is composed optionally of a host, port, and path at which the Admin API accepts HTTP or HTTPS traffic. When this config is disabled, Kong Manager will use the window protocol + host and append the resolved admin_listen HTTP/HTTPS port."
+    "description": "Hierarchical part of a URI which is composed\noptionally of a host, port, and path at which the\nAdmin API accepts HTTP or HTTPS traffic. When\nthis config is disabled, Kong Manager will\nuse the window protocol + host and append the\nresolved admin_listen HTTP/HTTPS port.\n"
   },
   "admin_gui_ssl_cert": {
     "defaultValue": null,
-    "description": "The SSL certificate for `admin_gui_listen` values with SSL enabled.  values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "The SSL certificate for `admin_gui_listen` values\nwith SSL enabled.\n\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "admin_gui_ssl_cert_key": {
     "defaultValue": null,
-    "description": "The SSL key for `admin_gui_listen` values with SSL enabled.  values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+    "description": "The SSL key for `admin_gui_listen` values with SSL\nenabled.\n\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n"
   },
   "admin_gui_flags": {
     "defaultValue": "{}",
-    "description": " Alters the layout Admin GUI (JSON) The only supported value is `{ \"IMMUNITY_ENABLED\": true }` to enable Kong Immunity in the Admin GUI."
+    "description": "Alters the layout Admin GUI (JSON)\nThe only supported value is `{ \"IMMUNITY_ENABLED\": true }`\nto enable Kong Immunity in the Admin GUI.\n"
   },
   "admin_gui_access_log": {
     "defaultValue": "logs/admin_gui_access.log",
-    "description": " Kong Manager Access Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables access logs for Kong Manager."
+    "description": "Kong Manager Access Logs\n\nHere you can set an absolute or relative path for Kong\nManager access logs. When the path is relative,\nlogs are placed in the `prefix` location.\n\nSetting this value to `off` disables access logs\nfor Kong Manager.\n"
   },
   "admin_gui_error_log": {
     "defaultValue": "logs/admin_gui_error.log",
-    "description": " Kong Manager Error Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables error logs for Kong Manager.  Granularity can be adjusted through the `log_level` directive."
+    "description": "Kong Manager Error Logs\n\nHere you can set an absolute or relative path for Kong\nManager access logs. When the path is relative,\nlogs are placed in the `prefix` location.\n\nSetting this value to `off` disables error logs for\nKong Manager.\n\nGranularity can be adjusted through the `log_level`\ndirective.\n"
   },
   "admin_gui_auth": {
     "defaultValue": null,
-    "description": "Kong Manager Authentication Plugin Name  Secures access to Kong Manager by specifying an authentication plugin to use.  Supported Plugins:  - `basic-auth`: Basic Authentication plugin - `ldap-auth-advanced`: LDAP Authentication plugin - `openid-connect`: OpenID Connect Authentication   plugin"
+    "description": "Kong Manager Authentication Plugin Name\n\nSecures access to Kong Manager by specifying an\nauthentication plugin to use.\n\nSupported Plugins:\n\n- `basic-auth`: Basic Authentication plugin\n- `ldap-auth-advanced`: LDAP Authentication plugin\n- `openid-connect`: OpenID Connect Authentication\n  plugin\n"
   },
   "admin_gui_auth_conf": {
     "defaultValue": null,
-    "description": "Kong Manager Authentication Plugin Config (JSON)  Specifies the configuration for the authentication plugin specified in `admin_gui_auth`.  For information about Plugin Configuration consult the associated plugin documentation.  Example for `basic-auth`:  `admin_gui_auth_conf = { \"hide_credentials\": true }`"
+    "description": "Kong Manager Authentication Plugin Config (JSON)\n\nSpecifies the configuration for the authentication\nplugin specified in `admin_gui_auth`.\n\nFor information about Plugin Configuration\nconsult the associated plugin documentation.\n\nExample for `basic-auth`:\n\n`admin_gui_auth_conf = { \"hide_credentials\": true }`\n"
   },
   "admin_gui_auth_password_complexity": {
     "defaultValue": null,
-    "description": "Kong Manager Authentication Password Complexity (JSON)  When `admin_gui_auth = basic-auth`, this property defines the rules required for Kong Manager passwords. Choose from preset rules or write your own.  Example using preset rules:  `admin_gui_auth_password_complexity = { \"kong-preset\": \"min_8\" }`  All values for kong-preset require the password to contain characters from at least three of the following categories:  1. Uppercase characters (A through Z)  2. Lowercase characters (a through z)  3. Base-10 digits (0 through 9)  4. Special characters (for example, &, $, #, %)  Supported preset rules: - `min_8`: minimum length of 8 - `min_12`: minimum length of 12 - `min_20`: minimum length of 20  To write your own rules, see https://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.  NOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.  Example:  `admin_gui_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`"
+    "description": "Kong Manager Authentication Password Complexity (JSON)\n\nWhen `admin_gui_auth = basic-auth`, this property defines\nthe rules required for Kong Manager passwords. Choose\nfrom preset rules or write your own.\n\nExample using preset rules:\n\n`admin_gui_auth_password_complexity = { \"kong-preset\": \"min_8\" }`\n\nAll values for kong-preset require the password to contain\ncharacters from at least three of the following categories:\n\n1. Uppercase characters (A through Z)\n\n2. Lowercase characters (a through z)\n\n3. Base-10 digits (0 through 9)\n\n4. Special characters (for example, &, $, #, %)\n\nSupported preset rules:\n- `min_8`: minimum length of 8\n- `min_12`: minimum length of 12\n- `min_20`: minimum length of 20\n\nTo write your own rules, see\nhttps://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.\n\nNOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.\n\nExample:\n\n`admin_gui_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`\n"
   },
   "admin_gui_session_conf": {
     "defaultValue": null,
-    "description": "Kong Manager Session Config (JSON)  Specifies the configuration for the Session plugin as used by Kong Manager.  For information about plugin configuration, consult the Kong Session plugin documentation.  Example: ``` admin_gui_session_conf = { \"cookie_name\": \"kookie\", \\                            \"secret\": \"changeme\" } ```"
+    "description": "Kong Manager Session Config (JSON)\n\nSpecifies the configuration for the Session plugin as\nused by Kong Manager.\n\nFor information about plugin configuration, consult\nthe Kong Session plugin documentation.\n\nExample:\n```\nadmin_gui_session_conf = { \"cookie_name\": \"kookie\", \\\n                           \"secret\": \"changeme\" }\n```\n"
   },
   "admin_gui_auth_header": {
     "defaultValue": "Kong-Admin-User",
-    "description": " Defines the name of the HTTP request header from which the Admin API will attempt to identify the Kong Admin user."
+    "description": "Defines the name of the HTTP request header from which\nthe Admin API will attempt to identify the Kong Admin\nuser.\n"
   },
   "admin_gui_auth_login_attempts": {
     "defaultValue": "0",
-    "description": " Number of times a user can attempt to login to Kong Manager. 0 means infinite attempts allowed."
+    "description": "Number of times a user can attempt to login to Kong\nManager. 0 means infinite attempts allowed.\n"
   },
   "admin_gui_header_txt": {
     "defaultValue": null,
-    "description": "Kong Manager Header Text Sets text for Kong Manager Header Banner. Header Banner is not shown if this config is empty."
+    "description": "Kong Manager Header Text\nSets text for Kong Manager Header Banner. Header Banner\nis not shown if this config is empty.\n"
   },
   "admin_gui_header_bg_color": {
     "defaultValue": null,
-    "description": "Kong Manager Header Background Color Sets background color for Kong Manager Header Banner Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Manager."
+    "description": "Kong Manager Header Background Color\nSets background color for Kong Manager Header Banner\nAccepts css color keyword, #-hexadecimal or rgb\nformat. Invalid values are ignored by Manager.\n"
   },
   "admin_gui_header_txt_color": {
     "defaultValue": null,
-    "description": "Kong Manager Header Text Color Sets text color for Kong Manager Header Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Kong Manager."
+    "description": "Kong Manager Header Text Color\nSets text color for Kong Manager Header Banner.\nAccepts css color keyword, #-hexadecimal or rgb\nformat. Invalid values are ignored by Kong Manager.\n"
   },
   "admin_gui_footer_txt": {
     "defaultValue": null,
-    "description": "Kong Manager Footer Text Sets text for Kong Manager Footer Banner. Footer Banner is not shown if this config is empty"
+    "description": "Kong Manager Footer Text\nSets text for Kong Manager Footer Banner. Footer Banner\nis not shown if this config is empty\n"
   },
   "admin_gui_footer_bg_color": {
     "defaultValue": null,
-    "description": "Kong Manager Footer Background Color Sets background color for Kong Manager Footer Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Manager."
+    "description": "Kong Manager Footer Background Color\nSets background color for Kong Manager Footer Banner.\nAccepts css color keyword, #-hexadecimal or rgb\nformat. Invalid values are ignored by Manager.\n"
   },
   "admin_gui_footer_txt_color": {
     "defaultValue": null,
-    "description": "Kong Manager Footer Text Color Sets text color for Kong Manager Footer Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Kong Manager."
+    "description": "Kong Manager Footer Text Color\nSets text color for Kong Manager Footer Banner.\nAccepts css color keyword, #-hexadecimal or rgb\nformat. Invalid values are ignored by Kong Manager.\n"
   },
   "admin_gui_login_banner_title": {
     "defaultValue": null,
-    "description": "Kong Manager Login Banner Title Text Sets title text for Kong Manager Login Banner. Login Banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+    "description": "Kong Manager Login Banner Title Text\nSets title text for Kong Manager Login Banner.\nLogin Banner is not shown if both\n`admin_gui_login_banner_title` and\n`admin_gui_login_banner_body` are empty.\n"
   },
   "admin_gui_login_banner_body": {
     "defaultValue": null,
-    "description": "Kong Manager Login Banner Body Text Sets body text for Kong Manager Login Banner. Login Banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+    "description": "Kong Manager Login Banner Body Text\nSets body text for Kong Manager Login Banner.\nLogin Banner is not shown if both\n`admin_gui_login_banner_title` and\n`admin_gui_login_banner_body` are empty.\n"
   },
   "vitals": {
     "defaultValue": "on",
-    "description": "When enabled, Kong will store and report metrics about its performance.  When running Kong in a multi-node setup, `vitals` entails two separate meanings depending on the node.  On a Proxy-only node, `vitals` determines whether to collect data for Vitals.  On an Admin-only node, `vitals` determines whether to display Vitals metrics and visualizations on the dashboard."
+    "description": "When enabled, Kong will store and report\nmetrics about its performance.\n\nWhen running Kong in a multi-node setup,\n`vitals` entails two separate meanings\ndepending on the node.\n\nOn a Proxy-only node, `vitals` determines\nwhether to collect data for Vitals.\n\nOn an Admin-only node, `vitals` determines\nwhether to display Vitals metrics and\nvisualizations on the dashboard.\n"
   },
   "vitals_strategy": {
     "defaultValue": "database",
-    "description": "Determines whether to use the Kong database or a separate storage engine for Vitals metrics. Accepted values are `database`, `prometheus`, or `influxdb`."
+    "description": "Determines whether to use the Kong database or\na separate storage engine for Vitals metrics.\nAccepted values are `database`, `prometheus`,\nor `influxdb`.\n"
   },
   "vitals_tsdb_address": {
     "defaultValue": null,
-    "description": "Defines the host and port of the TSDB server to which Vitals data is written and read. This value is only applied when the `vitals_strategy` option is set to `prometheus` or `influxdb`. This value accepts IPv4, IPv6, and hostname values. If the `vitals_strategy` is set to `prometheus`, this value determines the address of the Prometheus server from which Vitals data will be read. For `influxdb` strategies, this value controls both the read and write source for Vitals data."
+    "description": "Defines the host and port of the TSDB server\nto which Vitals data is written and read.\nThis value is only applied when the\n`vitals_strategy` option is set to\n`prometheus` or `influxdb`. This value\naccepts IPv4, IPv6, and hostname values.\nIf the `vitals_strategy` is set to\n`prometheus`, this value determines the\naddress of the Prometheus server from which\nVitals data will be read. For `influxdb`\nstrategies, this value controls both the read\nand write source for Vitals data.\n"
   },
   "vitals_tsdb_user": {
     "defaultValue": null,
-    "description": "Influxdb user"
+    "description": "Influxdb user\n"
   },
   "vitals_tsdb_password": {
     "defaultValue": null,
-    "description": "Influxdb password"
+    "description": "Influxdb password\n"
   },
   "vitals_statsd_address": {
     "defaultValue": null,
-    "description": "Defines the host and port (and an optional protocol) of the StatsD server to which Kong should write Vitals metics. This value is only applied when the `vitals_strategy` is set to `prometheus`. This value accepts IPv4, IPv6, and, hostnames. Additionally, the suffix `tcp` can be specified; doing so will result in Kong sending StatsD metrics via TCP instead of the UDP (default)."
+    "description": "Defines the host and port (and an optional\nprotocol) of the StatsD server to which\nKong should write Vitals metics. This value\nis only applied when the `vitals_strategy` is\nset to `prometheus`. This value accepts IPv4,\nIPv6, and, hostnames. Additionally, the suffix\n`tcp` can be specified; doing so will result\nin Kong sending StatsD metrics via TCP\ninstead of the UDP (default).\n"
   },
   "vitals_statsd_prefix": {
     "defaultValue": "kong",
-    "description": "Defines the prefix value attached to all Vitals StatsD events. This prefix is useful when writing metrics to a multi-tenant StatsD exporter or server."
+    "description": "Defines the prefix value attached to all\nVitals StatsD events. This prefix is useful\nwhen writing metrics to a multi-tenant StatsD\nexporter or server.\n"
   },
   "vitals_statsd_udp_packet_size": {
     "defaultValue": "1024",
-    "description": "Defines the maximum buffer size in which Vitals statsd metrics will be held and sent in batches. This value is defined in bytes."
+    "description": "Defines the maximum buffer size in\nwhich Vitals statsd metrics will be\nheld and sent in batches.\nThis value is defined in bytes.\n"
   },
   "vitals_prometheus_scrape_interval": {
     "defaultValue": "5",
-    "description": "Defines the scrape_interval query parameter sent to the Prometheus server when reading Vitals data. This should be same as the scrape interval (in seconds) of the Prometheus server."
+    "description": "Defines the scrape_interval query\nparameter sent to the Prometheus\nserver when reading Vitals data.\nThis should be same as the scrape\ninterval (in seconds) of the\nPrometheus server.\n"
   },
   "konnect_mode": {
     "defaultValue": "off",
-    "description": "When enabled, the dataplane is connected to Konnect"
+    "description": "When enabled, the dataplane is connected to Konnect\n"
   },
   "analytics_flush_interval": {
     "defaultValue": "1",
-    "description": "Determine the frequency of flushing local data to Konnect in seconds."
+    "description": "Determine the frequency of flushing local data\nto Konnect in seconds.\n"
   },
   "analytics_buffer_size_limit": {
     "defaultValue": "100000",
-    "description": "Max number of messages can be buffered locally before dropping data in case there is no network connection to Konnect."
+    "description": "Max number of messages can be buffered locally\nbefore dropping data in case there is no\nnetwork connection to Konnect.\n"
   },
   "portal": {
     "defaultValue": "off",
-    "description": " Developer Portal Switch  When enabled:    Kong will expose the Dev Portal interface and   read-only APIs on the `portal_gui_listen` address,   and endpoints on the Admin API to manage assets.  When enabled along with `portal_auth`:    Kong will expose management endpoints for developer   accounts on the Admin API and the Dev Portal API."
+    "description": "Developer Portal Switch\n\nWhen enabled:\n\n  Kong will expose the Dev Portal interface and\n  read-only APIs on the `portal_gui_listen` address,\n  and endpoints on the Admin API to manage assets.\n\nWhen enabled along with `portal_auth`:\n\n  Kong will expose management endpoints for developer\n  accounts on the Admin API and the Dev Portal API.\n"
   },
   "portal_gui_listen": {
     "defaultValue": [
       "0.0.0.0:8003",
       "0.0.0.0:8446 ssl"
     ],
-    "description": " Developer Portal GUI Listeners  Comma-separated list of addresses on which Kong will expose the Developer Portal GUI. Suffixes can be specified for each pair, similarly to the `admin_listen` directive."
+    "description": "Developer Portal GUI Listeners\n\nComma-separated list of addresses on which Kong will\nexpose the Developer Portal GUI. Suffixes can be\nspecified for each pair, similarly to\nthe `admin_listen` directive.\n"
   },
   "portal_gui_protocol": {
     "defaultValue": "http",
-    "description": " Developer Portal GUI protocol  The protocol used in conjunction with `portal_gui_host` to construct the lookup, or balancer address for your Kong Proxy nodes.  Examples: `http`,`https`"
+    "description": "Developer Portal GUI protocol\n\nThe protocol used in conjunction with\n`portal_gui_host` to construct the lookup, or balancer\naddress for your Kong Proxy nodes.\n\nExamples: `http`,`https`\n"
   },
   "portal_gui_host": {
     "defaultValue": "127.0.0.1:8003",
-    "description": " Developer Portal GUI host  The host used in conjunction with `portal_gui_protocol` to construct the lookup, or balancer address for your Kong Proxy nodes.  Examples:  - `<IP>:<PORT>`   -> `portal_gui_host = 127.0.0.1:8003` - `<HOSTNAME>`   -> `portal_gui_host = portal_api.domain.tld` - `<HOSTNAME>/<PATH>`   -> `portal_gui_host = dev-machine/dev-285`"
+    "description": "Developer Portal GUI host\n\nThe host used in conjunction with\n`portal_gui_protocol` to construct the lookup,\nor balancer address for your Kong Proxy nodes.\n\nExamples:\n\n- `<IP>:<PORT>`\n  -> `portal_gui_host = 127.0.0.1:8003`\n- `<HOSTNAME>`\n  -> `portal_gui_host = portal_api.domain.tld`\n- `<HOSTNAME>/<PATH>`\n  -> `portal_gui_host = dev-machine/dev-285`\n"
   },
   "portal_cors_origins": {
     "defaultValue": null,
-    "description": "Developer Portal CORS Origins  A comma separated list of allowed domains for `Access-Control-Allow-Origin` header. This can be used to resolve CORS issues in custom networking environments.  Examples: - list of domains:   `portal_cors_origins = http://localhost:8003, https://localhost:8004` - single domain:   `portal_cors_origins = http://localhost:8003` - all domains:   `portal_cors_origins = *`  NOTE: In most cases, the Developer Portal is able to derive valid CORS origins by using `portal_gui_protocol`, `portal_gui_host`, and if applicable, `portal_gui_use_subdomains`. In these cases, `portal_cors_origins` is not needed and can remain unset."
+    "description": "Developer Portal CORS Origins\n\nA comma separated list of allowed domains for\n`Access-Control-Allow-Origin` header. This can be used to\nresolve CORS issues in custom networking environments.\n\nExamples:\n- list of domains:\n  `portal_cors_origins = http://localhost:8003, https://localhost:8004`\n- single domain:\n  `portal_cors_origins = http://localhost:8003`\n- all domains:\n  `portal_cors_origins = *`\n\nNOTE: In most cases, the Developer Portal is able to derive\nvalid CORS origins by using `portal_gui_protocol`, `portal_gui_host`,\nand if applicable, `portal_gui_use_subdomains`. In these cases,\n`portal_cors_origins` is not needed and can remain unset.\n"
   },
   "portal_gui_use_subdomains": {
     "defaultValue": "off",
-    "description": " Developer Portal GUI subdomain toggle  By default Kong Portal uses the first namespace in the request path to determine workspace. By turning `portal_gui_subdomains` on, Kong Portal will expect workspace to be included in the request url as a subdomain.  Example (off):   - `<scheme>://<HOSTNAME>/<WORKSPACE>/<PATH>` ->     `http://kong-portal.com/example-workspace/index`  Example (on):   - `<scheme>://<WORKSPACE>.<HOSTNAME>` ->     `http://example-workspace.kong-portal.com/index`"
+    "description": "Developer Portal GUI subdomain toggle\n\nBy default Kong Portal uses the first namespace in\nthe request path to determine workspace. By turning\n`portal_gui_subdomains` on, Kong Portal will expect\nworkspace to be included in the request url as a subdomain.\n\nExample (off):\n  - `<scheme>://<HOSTNAME>/<WORKSPACE>/<PATH>` ->\n    `http://kong-portal.com/example-workspace/index`\n\nExample (on):\n  - `<scheme>://<WORKSPACE>.<HOSTNAME>` ->\n    `http://example-workspace.kong-portal.com/index`\n"
   },
   "portal_gui_ssl_cert": {
     "defaultValue": null,
-    "description": "Developer Portal GUI SSL Certificate  The SSL certificate for `portal_gui_listen` values with SSL enabled.  values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "Developer Portal GUI SSL Certificate\n\nThe SSL certificate for `portal_gui_listen` values\nwith SSL enabled.\n\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "portal_gui_ssl_cert_key": {
     "defaultValue": null,
-    "description": "Developer Portal GUI SSL Certificate Key  The SSL key for `portal_gui_listen` values with SSL enabled.  values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+    "description": "Developer Portal GUI SSL Certificate Key\n\nThe SSL key for `portal_gui_listen` values with\nSSL enabled.\n\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n"
   },
   "portal_gui_access_log": {
     "defaultValue": "logs/portal_gui_access.log",
-    "description": " Developer Portal GUI Access Log location  Here you can set an absolute or relative path for your Portal GUI access logs.  Setting this value to `off` will disable logging Portal GUI access logs.  When using relative pathing, logs will be placed under the `prefix` location."
+    "description": "Developer Portal GUI Access Log location\n\nHere you can set an absolute or relative path for your\nPortal GUI access logs.\n\nSetting this value to `off` will disable logging\nPortal GUI access logs.\n\nWhen using relative pathing, logs will be placed under\nthe `prefix` location.\n"
   },
   "portal_gui_error_log": {
     "defaultValue": "logs/portal_gui_error.log",
-    "description": " Developer Portal GUI Error Log location  Here you can set an absolute or relative path for your Portal GUI error logs.  Setting this value to `off` will disable logging Portal GUI error logs.  When using relative pathing, logs will be placed under the `prefix` location.  Granularity can be adjusted through the `log_level` directive."
+    "description": "Developer Portal GUI Error Log location\n\nHere you can set an absolute or relative path for your\nPortal GUI error logs.\n\nSetting this value to `off` will disable logging\nPortal GUI error logs.\n\nWhen using relative pathing, logs will be placed under\nthe `prefix` location.\n\nGranularity can be adjusted through the `log_level`\ndirective.\n"
   },
   "portal_api_listen": {
     "defaultValue": [
       "0.0.0.0:8004",
       "0.0.0.0:8447 ssl"
     ],
-    "description": " Developer Portal API Listeners  Comma-separated list of addresses on which Kong will expose the Developer Portal API. Suffixes can be specified for each pair, similarly to the `admin_listen` directive."
+    "description": "Developer Portal API Listeners\n\nComma-separated list of addresses on which Kong will\nexpose the Developer Portal API. Suffixes can be\nspecified for each pair, similarly to\nthe `admin_listen` directive.\n"
   },
   "portal_api_url": {
     "defaultValue": null,
-    "description": "Developer Portal API URL  The lookup, or balancer, address for your Developer Portal nodes.  This value is commonly used in a microservices or service-mesh oriented architecture.  `portal_api_url` is the address on which your Kong Dev Portal API is accessible by Kong. You should only set this value if your Kong Dev Portal API lives on a different node than your Kong Proxy.  Accepted format (parts in parenthesis are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`  Examples:  - `<scheme>://<IP>:<PORT>`   -> `portal_api_url = http://127.0.0.1:8003` - `SSL <scheme>://<HOSTNAME>`   -> `portal_api_url = https://portal_api.domain.tld` - `<scheme>://<HOSTNAME>/<PATH>`   -> `portal_api_url = http://dev-machine/dev-285`  By default this value points to the local interface:  - `http://0.0.0.0:8004`"
+    "description": "Developer Portal API URL\n\nThe lookup, or balancer, address for your Developer\nPortal nodes.\n\nThis value is commonly used in a microservices\nor service-mesh oriented architecture.\n\n`portal_api_url` is the address on which your\nKong Dev Portal API is accessible by Kong. You\nshould only set this value if your Kong Dev Portal API\nlives on a different node than your Kong Proxy.\n\nAccepted format (parts in parenthesis are optional):\n\n  `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`\n\nExamples:\n\n- `<scheme>://<IP>:<PORT>`\n  -> `portal_api_url = http://127.0.0.1:8003`\n- `SSL <scheme>://<HOSTNAME>`\n  -> `portal_api_url = https://portal_api.domain.tld`\n- `<scheme>://<HOSTNAME>/<PATH>`\n  -> `portal_api_url = http://dev-machine/dev-285`\n\nBy default this value points to the local interface:\n\n- `http://0.0.0.0:8004`\n"
   },
   "portal_api_ssl_cert": {
     "defaultValue": null,
-    "description": "Developer Portal API SSL Certificate  The SSL certificate for `portal_api_listen` values with SSL enabled.  values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "Developer Portal API SSL Certificate\n\nThe SSL certificate for `portal_api_listen` values\nwith SSL enabled.\n\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "portal_api_ssl_cert_key": {
     "defaultValue": null,
-    "description": "Developer Portal API SSL Certificate Key  The SSL key for `portal_api_listen` values with SSL enabled.  values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+    "description": "Developer Portal API SSL Certificate Key\n\nThe SSL key for `portal_api_listen` values with\nSSL enabled.\n\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n"
   },
   "portal_api_access_log": {
     "defaultValue": "logs/portal_api_access.log",
-    "description": " Developer Portal API Access Log location  Here you can set an absolute or relative path for your Portal API access logs.  Setting this value to `off` will disable logging Portal API access logs.  When using relative pathing, logs will be placed under the `prefix` location."
+    "description": "Developer Portal API Access Log location\n\nHere you can set an absolute or relative path for your\nPortal API access logs.\n\nSetting this value to `off` will disable logging\nPortal API access logs.\n\nWhen using relative pathing, logs will be placed under\nthe `prefix` location.\n"
   },
   "portal_api_error_log": {
     "defaultValue": "logs/portal_api_error.log",
-    "description": " Developer Portal API Error Log location  Here you can set an absolute or relative path for your Portal API error logs.  Setting this value to `off` will disable logging Portal API error logs.  When using relative pathing, logs will be placed under the `prefix` location.  Granularity can be adjusted through the `log_level` directive."
+    "description": "Developer Portal API Error Log location\n\nHere you can set an absolute or relative path for your\nPortal API error logs.\n\nSetting this value to `off` will disable logging\nPortal API error logs.\n\nWhen using relative pathing, logs will be placed under\nthe `prefix` location.\n\nGranularity can be adjusted through the `log_level`\ndirective.\n"
   },
   "portal_is_legacy": {
     "defaultValue": "off",
-    "description": " Developer Portal legacy support  Setting this value to `on` will cause all new portals to render using the legacy rendering system by default.  Setting this value to `off` will cause all new portals to render using the current rendering system."
+    "description": "Developer Portal legacy support\n\nSetting this value to `on` will cause all new\nportals to render using the legacy rendering system by default.\n\nSetting this value to `off` will cause all new\nportals to render using the current rendering system.\n"
   },
   "portal_app_auth": {
     "defaultValue": "kong-oauth2",
-    "description": " Developer Portal application registration auth provider and strategy. Must be set to enable application_registration plugin"
+    "description": "Developer Portal application registration\nauth provider and strategy. Must be set to enable\napplication_registration plugin\n"
   },
   "portal_auth": {
     "defaultValue": null,
-    "description": "Developer Portal Authentication Plugin Name  Specifies the authentication plugin to apply to your Developer Portal. Developers will use the specified form of authentication to request access, register, and login to your Developer Portal.  Supported Plugins:  - Basic Authentication: `portal_auth = basic-auth` - OIDC Authentication: `portal_auth = openid-connect` "
+    "description": "Developer Portal Authentication Plugin Name\n\nSpecifies the authentication plugin\nto apply to your Developer Portal. Developers\nwill use the specified form of authentication\nto request access, register, and login to your\nDeveloper Portal.\n\nSupported Plugins:\n\n- Basic Authentication: `portal_auth = basic-auth`\n- OIDC Authentication: `portal_auth = openid-connect`\n\n"
   },
   "portal_auth_password_complexity": {
     "defaultValue": null,
-    "description": "Kong Portal Authentication Password Complexity (JSON)  When portal_auth = basic-auth, this property defines the rules required for Kong Portal passwords. Choose from preset rules or write your own.  Example using preset rules:  `portal_auth_password_complexity = { \"kong-preset\": \"min_8\" }`  All values for kong-preset require the password to contain characters from at least three of the following categories:  1. Uppercase characters (A through Z)  2. Lowercase characters (a through z)  3. Base-10 digits (0 through 9)  4. Special characters (for example, &, $, #, %)  Supported preset rules: - `min_8`: minimum length of 8 - `min_12`: minimum length of 12 - `min_20`: minimum length of 20  To write your own rules, see https://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.  NOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.  Example:  `portal_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`"
+    "description": "Kong Portal Authentication Password Complexity (JSON)\n\nWhen portal_auth = basic-auth, this property defines\nthe rules required for Kong Portal passwords. Choose\nfrom preset rules or write your own.\n\nExample using preset rules:\n\n`portal_auth_password_complexity = { \"kong-preset\": \"min_8\" }`\n\nAll values for kong-preset require the password to contain\ncharacters from at least three of the following categories:\n\n1. Uppercase characters (A through Z)\n\n2. Lowercase characters (a through z)\n\n3. Base-10 digits (0 through 9)\n\n4. Special characters (for example, &, $, #, %)\n\nSupported preset rules:\n- `min_8`: minimum length of 8\n- `min_12`: minimum length of 12\n- `min_20`: minimum length of 20\n\nTo write your own rules, see\nhttps://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.\n\nNOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.\n\nExample:\n\n`portal_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`\n"
   },
   "portal_auth_conf": {
     "defaultValue": null,
-    "description": "Developer Portal Authentication Plugin Config (JSON)  Specifies the plugin configuration object in JSON format to be applied to your Developer Portal authentication.  For information about Plugin Configuration consult the associated plugin documentation.  Example for `basic-auth`:  `portal_auth_conf = { \"hide_credentials\": true }`"
+    "description": "Developer Portal Authentication Plugin Config (JSON)\n\nSpecifies the plugin configuration object\nin JSON format to be applied to your Developer\nPortal authentication.\n\nFor information about Plugin Configuration\nconsult the associated plugin documentation.\n\nExample for `basic-auth`:\n\n`portal_auth_conf = { \"hide_credentials\": true }`\n"
   },
   "portal_auth_login_attempts": {
     "defaultValue": "0",
-    "description": " Number of times a user can attempt to login to the Dev Portal before password must be reset.  0 (default) means infinite attempts allowed.  Note: Any value greater than 0 will only affect Dev Portals secured with basic-auth."
+    "description": "Number of times a user can attempt to login to the\nDev Portal before password must be reset.\n\n0 (default) means infinite attempts allowed.\n\nNote: Any value greater than 0 will only affect\nDev Portals secured with basic-auth.\n"
   },
   "portal_session_conf": {
     "defaultValue": null,
-    "description": "Portal Session Config (JSON)  Specifies the configuration for the Session plugin as used by Kong Portal.  For information about Plugin Configuration consult the Kong Session Plugin documentation.  Example: ``` portal_session_conf = { \"cookie_name\": \"portal_session\", \\                          \"secret\": \"changeme\", \\                          \"storage\": \"kong\" } ```"
+    "description": "Portal Session Config (JSON)\n\nSpecifies the configuration for the\nSession plugin as used by Kong Portal.\n\nFor information about Plugin Configuration consult\nthe Kong Session Plugin documentation.\n\nExample:\n```\nportal_session_conf = { \"cookie_name\": \"portal_session\", \\\n                         \"secret\": \"changeme\", \\\n                         \"storage\": \"kong\" }\n```\n"
   },
   "portal_auto_approve": {
     "defaultValue": "off",
-    "description": " Developer Portal Auto Approve Access  When set to `on`, a developer will automatically be marked as \"approved\" after completing registration. Access can still be revoked through Kong Manager or the Admin API.  When set to `off`, a Kong admin will have to manually approve the Developer using Kong Manager or the Admin API."
+    "description": "Developer Portal Auto Approve Access\n\nWhen set to `on`, a developer will\nautomatically be marked as \"approved\" after completing\nregistration. Access can still be revoked through\nKong Manager or the Admin API.\n\nWhen set to `off`, a Kong admin will have to manually approve the Developer\nusing Kong Manager or the Admin API.\n"
   },
   "portal_token_exp": {
     "defaultValue": "21600",
-    "description": " Duration in seconds for the expiration of the Dev Portal reset password token. Default is `21600` (six hours)."
+    "description": "Duration in seconds for the expiration of the Dev Portal\nreset password token. Default is `21600` (six hours).\n"
   },
   "portal_email_verification": {
     "defaultValue": "off",
-    "description": " Portal Developer Email Verification.  When enabled Developers will receive an email upon registration to verify their account. Developers will not be able to use the Developer Portal until they verify their account, even if auto-approve is enabled.  Note: SMTP must be turned on in order to use this feature."
+    "description": "Portal Developer Email Verification.\n\nWhen enabled Developers will receive an email upon\nregistration to verify their account. Developers will\nnot be able to use the Developer Portal until they\nverify their account, even if auto-approve is enabled.\n\nNote: SMTP must be turned on in order to use this feature.\n"
   },
   "portal_invite_email": {
     "defaultValue": "on",
-    "description": " When enabled, Kong admins can invite developers to a Dev Portal by using the Invite button in Kong Manager.  The email looks like the following:  ``` Subject: Invite to access Dev Portal <WORKSPACE_NAME>  Hello Developer!  You have been invited to create a Dev Portal account at %s. Please visit `<DEV_PORTAL_URL/register>` to create your account. ```"
+    "description": "When enabled, Kong admins can invite developers to a Dev Portal by using\nthe Invite button in Kong Manager.\n\nThe email looks like the following:\n\n```\nSubject: Invite to access Dev Portal <WORKSPACE_NAME>\n\nHello Developer!\n\nYou have been invited to create a Dev Portal account at %s.\nPlease visit `<DEV_PORTAL_URL/register>` to create your account.\n```\n"
   },
   "portal_access_request_email": {
     "defaultValue": "on",
-    "description": " When enabled, Kong admins specified by `smtp_admin_emails` will receive an email when a developer requests access to a Dev Portal.  When disabled, Kong admins will have to manually check the Kong Manager to view any requests.  The email looks like the following:  ``` Subject: Request to access Dev Portal <WORKSPACE NAME>  Hello Admin!  <DEVELOPER NAME> has requested Dev Portal access for <WORKSPACE_NAME>. Please visit <KONG_MANAGER_URL/developers/requested> to review this request. ```"
+    "description": "When enabled, Kong admins specified by `smtp_admin_emails`\nwill receive an email when a developer requests access\nto a Dev Portal.\n\nWhen disabled, Kong admins will have to manually check\nthe Kong Manager to view any requests.\n\nThe email looks like the following:\n\n```\nSubject: Request to access Dev Portal <WORKSPACE NAME>\n\nHello Admin!\n\n<DEVELOPER NAME> has requested Dev Portal access for <WORKSPACE_NAME>.\nPlease visit <KONG_MANAGER_URL/developers/requested> to review this request.\n```\n"
   },
   "portal_approved_email": {
     "defaultValue": "on",
-    "description": " When enabled, developers will receive an email when access to a Dev Portal has been approved.  When disabled, developers will receive no indication that they have beenapproved. It is suggested to only disable this feature if `portal_auto_approve` is enabled.  The email looks like the following:  ``` Subject: Dev Portal access approved  Hello Developer! You have been approved to access <WORKSPACE_NAME>. Please visit <DEV PORTAL URL/login> to login. ```"
+    "description": "When enabled, developers will receive an email when\naccess to a Dev Portal has been approved.\n\nWhen disabled, developers will receive no indication\nthat they have beenapproved. It is suggested to only\ndisable this feature if `portal_auto_approve`\nis enabled.\n\nThe email looks like the following:\n\n```\nSubject: Dev Portal access approved\n\nHello Developer!\nYou have been approved to access <WORKSPACE_NAME>.\nPlease visit <DEV PORTAL URL/login> to login.\n```\n"
   },
   "portal_reset_email": {
     "defaultValue": "on",
-    "description": " When enabled, developers will be able to use the Reset Password flow on a Dev Portal and will receive an email with password reset instructions.  Note: When disabled, developers will *not* be able to reset their account passwords. The password resetting email is the only way to reset developer passwords.  The email looks like the following:  ``` Subject: Password Reset Instructions for Dev Portal <WORKSPACE_NAME>.  Hello Developer,  Please click the link below to reset your Dev Portal password.  <DEV_PORTAL_URL/reset?token=12345>  This link will expire in <portal_reset_token_exp>  If you didn't make this request, keep your account secure by clicking the link above to change your password. ```"
+    "description": "When enabled, developers will be able to use the\nReset Password flow on a Dev Portal and will\nreceive an email with password reset instructions.\n\nNote: When disabled, developers will *not* be able to reset their account\npasswords. The password resetting email is the only way to reset developer\npasswords.\n\nThe email looks like the following:\n\n```\nSubject: Password Reset Instructions for Dev Portal <WORKSPACE_NAME>.\n\nHello Developer,\n\nPlease click the link below to reset your Dev Portal password.\n\n<DEV_PORTAL_URL/reset?token=12345>\n\nThis link will expire in <portal_reset_token_exp>\n\nIf you didn't make this request, keep your account secure by clicking\nthe link above to change your password.\n```\n"
   },
   "portal_reset_success_email": {
     "defaultValue": "on",
-    "description": " When enabled, developers will receive an email after successfully resetting their Dev Portal account password.  When disabled, developers will still be able to reset their account passwords, but will not receive a confirmation email.  The email looks like the following:  ``` Subject: Dev Portal password change success  Hello Developer, We are emailing you to let you know that your Dev Portal password at <DEV_PORTAL_URL> has been changed.  Click the link below to sign in with your new credentials.  <DEV_PORTAL_URL> ```"
+    "description": "When enabled, developers will receive an email\nafter successfully resetting their Dev Portal\naccount password.\n\nWhen disabled, developers will still be able\nto reset their account passwords, but will not\nreceive a confirmation email.\n\nThe email looks like the following:\n\n```\nSubject: Dev Portal password change success\n\nHello Developer,\nWe are emailing you to let you know that your Dev Portal password at <DEV_PORTAL_URL> has been changed.\n\nClick the link below to sign in with your new credentials.\n\n<DEV_PORTAL_URL>\n```\n"
   },
   "portal_application_status_email": {
     "defaultValue": "off",
-    "description": " When enabled, developers will receive an email when the status changes for their appliciation service requests.  When disabled, developers will still be able to view the status in their developer portal application page.  The email looks like the following:  ``` Subject: Dev Portal application request <REQUEST_STATUS> (<DEV_PORTAL_URL>)  Hello Developer, We are emailing you to let you know that your request for application access from the Developer Portal account at <DEV_PORTAL_URL> is <REQUEST_STATUS>.  Application: <APPLICATION_NAME> Service: <SERVICE_NAME>  You will receive another email when your access has been approved. ```"
+    "description": "When enabled, developers will receive an email\nwhen the status changes for their appliciation\nservice requests.\n\nWhen disabled, developers will still be able\nto view the status in their developer portal\napplication page.\n\nThe email looks like the following:\n\n```\nSubject: Dev Portal application request <REQUEST_STATUS> (<DEV_PORTAL_URL>)\n\nHello Developer,\nWe are emailing you to let you know that your request for application access from the\nDeveloper Portal account at <DEV_PORTAL_URL> is <REQUEST_STATUS>.\n\nApplication: <APPLICATION_NAME>\nService: <SERVICE_NAME>\n\nYou will receive another email when your access has been approved.\n```\n"
   },
   "portal_application_request_email": {
     "defaultValue": "off",
-    "description": " When enabled, Kong admins specified by `smtp_admin_emails` will receive an email when a developer requests access to service through an application.  When disabled, Kong admins will have to manually check the Kong Manager to view any requests.  By default, `smtp_admin_emails` will be the recipients. This can be overriden by `portal_smtp_admin_emails`, which can be set dynamically per workspace through the Admin API.  The email looks like the following:  ``` Subject: Request to access Dev Portal (<DEV_PORTAL_URL>) service from <DEVELOPER_EMAIL>  Hello Admin,  <DEVELOPER NAME> (<DEVELOPER_EMAIL>) has requested application access for <DEV_PORTAL_URL>.  Requested workspace: <WORKSPACE_NAME> Requested application: <APPLICATION_NAME> Requested service: <SERVICE_NAME>  Please visit <KONG_MANAGER_URL/WORKSPACE_NAME/applications/APPLICATION_ID#requested> to review this request. ```"
+    "description": "When enabled, Kong admins specified by `smtp_admin_emails`\nwill receive an email when a developer requests access\nto service through an application.\n\nWhen disabled, Kong admins will have to manually check\nthe Kong Manager to view any requests.\n\nBy default, `smtp_admin_emails` will be the recipients.\nThis can be overriden by `portal_smtp_admin_emails`,\nwhich can be set dynamically per workspace through\nthe Admin API.\n\nThe email looks like the following:\n\n```\nSubject: Request to access Dev Portal (<DEV_PORTAL_URL>) service from <DEVELOPER_EMAIL>\n\nHello Admin,\n\n<DEVELOPER NAME> (<DEVELOPER_EMAIL>) has requested application access for <DEV_PORTAL_URL>.\n\nRequested workspace: <WORKSPACE_NAME>\nRequested application: <APPLICATION_NAME>\nRequested service: <SERVICE_NAME>\n\nPlease visit <KONG_MANAGER_URL/WORKSPACE_NAME/applications/APPLICATION_ID#requested> to review this request.\n```\n"
   },
   "portal_emails_from": {
     "defaultValue": null,
-    "description": "The name and email address for the `From` header included in all Dev Portal emails.  Example: `portal_emails_from = Your Name <example@example.com>`  Note: Some SMTP servers will not use this value, but instead insert the email and name associated with the account."
+    "description": "The name and email address for the `From` header\nincluded in all Dev Portal emails.\n\nExample:\n`portal_emails_from = Your Name <example@example.com>`\n\nNote: Some SMTP servers will not use\nthis value, but instead insert the email and name\nassociated with the account.\n"
   },
   "portal_emails_reply_to": {
     "defaultValue": null,
-    "description": "Email address for the `Reply-To` header for portal emails  Example: `portal_emails_reply_to = example@example.com`  Note: Some SMTP servers will not use this value, but instead insert the email associated with the account."
+    "description": "Email address for the `Reply-To` header for\nportal emails\n\nExample:\n`portal_emails_reply_to = example@example.com`\n\nNote: Some SMTP servers will not use\nthis value, but instead insert the email\nassociated with the account.\n"
   },
   "portal_smtp_admin_emails": {
     "defaultValue": null,
-    "description": " Comma separated list of admin emails to receive portal notifications. Can be dynamically set per workspace through the Admin API.  If not set, `smtp_admin_emails` will be used.  Example `admin1@example.com, admin2@example.com`"
+    "description": "Comma separated list of admin emails to receive\nportal notifications. Can be dynamically set per\nworkspace through the Admin API.\n\nIf not set, `smtp_admin_emails` will be used.\n\nExample `admin1@example.com, admin2@example.com`\n"
   },
   "admin_emails_from": {
     "defaultValue": "\"\"",
-    "description": "The email address for the `From` header for admin emails."
+    "description": "The email address for the `From` header\nfor admin emails.\n"
   },
   "admin_emails_reply_to": {
     "defaultValue": null,
-    "description": "Email address for the `Reply-To` header for admin emails."
+    "description": "Email address for the `Reply-To` header\nfor admin emails.\n"
   },
   "admin_invitation_expiry": {
     "defaultValue": "259200",
-    "description": "Expiration time for the admin invitation link (in seconds). 0 means no expiration.  Example, 72 hours: `72 * 60 * 60 = 259200`"
+    "description": "Expiration time for the admin invitation link\n(in seconds). 0 means no expiration.\n\nExample, 72 hours: `72 * 60 * 60 = 259200`\n"
   },
   "smtp_mock": {
     "defaultValue": "on",
-    "description": "This flag will mock the sending of emails. This can be used for testing before the SMTP client is fully configured."
+    "description": "This flag will mock the sending of emails. This can be\nused for testing before the SMTP client is fully\nconfigured.\n"
   },
   "smtp_host": {
     "defaultValue": "localhost",
-    "description": " The hostname of the SMTP server to connect to."
+    "description": "The hostname of the SMTP server to connect to.\n"
   },
   "smtp_port": {
     "defaultValue": "25",
-    "description": " The port number on the SMTP server to connect to."
+    "description": "The port number on the SMTP server to connect to.\n"
   },
   "smtp_starttls": {
     "defaultValue": "off",
-    "description": " When set to `on`, STARTTLS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 587."
+    "description": "When set to `on`, STARTTLS is used to encrypt\ncommunication with the SMTP server. This is normally\nused in conjunction with port 587.\n"
   },
   "smtp_username": {
     "defaultValue": null,
-    "description": "Username used for authentication with SMTP server"
+    "description": "Username used for authentication with SMTP server\n"
   },
   "smtp_password": {
     "defaultValue": null,
-    "description": "Password used for authentication with SMTP server"
+    "description": "Password used for authentication with SMTP server\n"
   },
   "smtp_ssl": {
     "defaultValue": "off",
-    "description": " When set to `on`, SMTPS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 465."
+    "description": "When set to `on`, SMTPS is used to encrypt\ncommunication with the SMTP server. This is normally\nused in conjunction with port 465.\n"
   },
   "smtp_auth_type": {
     "defaultValue": null,
-    "description": "The method used to authenticate with the SMTP server Valid options are `plain`, `login`, or `nil`"
+    "description": "The method used to authenticate with the SMTP server\nValid options are `plain`, `login`, or `nil`\n"
   },
   "smtp_domain": {
     "defaultValue": "localhost.localdomain",
-    "description": " The domain used in the `EHLO` connection and part of the `Message-ID` header"
+    "description": "The domain used in the `EHLO` connection and part of\nthe `Message-ID` header\n"
   },
   "smtp_timeout_connect": {
     "defaultValue": "60000",
-    "description": " The timeout (in milliseconds) for connecting to the SMTP server."
+    "description": "The timeout (in milliseconds) for connecting to the\nSMTP server.\n"
   },
   "smtp_timeout_send": {
     "defaultValue": "60000",
-    "description": " The timeout (in milliseconds) for sending data to the SMTP server."
+    "description": "The timeout (in milliseconds) for sending data to the\nSMTP server.\n"
   },
   "smtp_timeout_read": {
     "defaultValue": "60000",
-    "description": " The timeout (in milliseconds) for reading data from the SMTP server."
+    "description": "The timeout (in milliseconds) for reading data from\nthe SMTP server.\n"
   },
   "smtp_admin_emails": {
     "defaultValue": null,
-    "description": "Comma separated list of admin emails to receive notifications. Example `admin1@example.com, admin2@example.com`"
+    "description": "Comma separated list of admin emails to receive\nnotifications.\nExample `admin1@example.com, admin2@example.com`\n"
   },
   "audit_log": {
     "defaultValue": "off",
-    "description": "When enabled, Kong will log information about Admin API access and database row insertions, updates, and deletes."
+    "description": "When enabled, Kong will log information about\nAdmin API access and database row insertions,\nupdates, and deletes.\n"
   },
   "audit_log_ignore_methods": {
     "defaultValue": null,
-    "description": "Comma-separated list of HTTP methods that will not generate audit log entries. By default, all HTTP requests will be logged."
+    "description": "Comma-separated list of HTTP methods that\nwill not generate audit log entries. By\ndefault, all HTTP requests will be logged.\n"
   },
   "audit_log_ignore_paths": {
     "defaultValue": null,
-    "description": "Comma-separated list of request paths that will not generate audit log entries. By default, all HTTP requests will be logged."
+    "description": "Comma-separated list of request paths that\nwill not generate audit log entries. By\ndefault, all HTTP requests will be logged.\n"
   },
   "audit_log_ignore_tables": {
     "defaultValue": null,
-    "description": "Comma-separated list of database tables that will not generate audit log entries. By default, updates to all database tables will be logged (the term \"updates\" refers to the creation, update, or deletion of a row)."
+    "description": "Comma-separated list of database tables that\nwill not generate audit log entries. By\ndefault, updates to all database tables will\nbe logged (the term \"updates\" refers to the\ncreation, update, or deletion of a row).\n"
   },
   "audit_log_payload_exclude": {
     "defaultValue": [
@@ -1261,150 +1261,150 @@
       "secret",
       "password"
     ],
-    "description": " Comma-separated list of keys that will be filtered out of the payload. Keys that were filtered will be recorded in the audit log."
+    "description": "Comma-separated list of keys that will be\nfiltered out of the payload. Keys that were\nfiltered will be recorded in the audit log.\n"
   },
   "audit_log_record_ttl": {
     "defaultValue": "2592000",
-    "description": "Length, in seconds, of the TTL for audit log records. Records in the database older than their TTL are automatically purged.  Example, 30 days: `30 * 24 * 60 * 60 = 2592000`"
+    "description": "Length, in seconds, of the TTL for audit log\nrecords. Records in the database older than\ntheir TTL are automatically purged.\n\nExample, 30 days: `30 * 24 * 60 * 60 = 2592000`\n"
   },
   "audit_log_signing_key": {
     "defaultValue": null,
-    "description": "Defines the path to a private RSA signing key that can be used to insert a signature of audit records, adjacent to the record. The corresponding public key should be stored offline, and can be used the validate audit entries in the future. If this value is undefined, no signature will be generated."
+    "description": "Defines the path to a private RSA signing key\nthat can be used to insert a signature of\naudit records, adjacent to the record. The\ncorresponding public key should be stored\noffline, and can be used the validate audit\nentries in the future. If this value is\nundefined, no signature will be generated.\n"
   },
   "tracing": {
     "defaultValue": "off",
-    "description": "When enabled, Kong will generate granular debug data about various portions of the request lifecycle, such as DB or DNS queries, plugin execution, core handler timing, etc."
+    "description": "When enabled, Kong will generate granular\ndebug data about various portions of the\nrequest lifecycle, such as DB or DNS queries,\nplugin execution, core handler timing, etc.\n"
   },
   "tracing_write_strategy": {
     "defaultValue": "file",
-    "description": "Defines how Kong will write tracing data at the conclusion of the request. The default option, `file`, writes a human-readable depiction of tracing data to a configurable location on the node's file system. Other strategies write tracing data as a JSON document to the configured endpoint. Valid entries for this option are `file`, `file_raw`, `http`, `tcp`, `tls`, and `udp`."
+    "description": "Defines how Kong will write tracing data at\nthe conclusion of the request. The default\noption, `file`, writes a human-readable\ndepiction of tracing data to a configurable\nlocation on the node's file system. Other\nstrategies write tracing data as a JSON\ndocument to the configured endpoint. Valid\nentries for this option are `file`,\n`file_raw`, `http`, `tcp`, `tls`, and `udp`.\n"
   },
   "tracing_write_endpoint": {
     "defaultValue": null,
-    "description": "Defines the endpoint to which tracing data will be written.  - For the `file` and `file_raw` tracing write   strategies, this value must be a valid   location on the node's file system to which   Kong must have write access. - For the `tcp`, `tls`, and   `udp` strategies, this value is defined as a   string in the form of:  `<HOST>:<PORT>` - For the `http` strategy, this value is   defined in the form of:  `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`  Traces sent via HTTP are delivered via POST method with an `application/json` Content-Type."
+    "description": "Defines the endpoint to which tracing data\nwill be written.\n\n- For the `file` and `file_raw` tracing write\n  strategies, this value must be a valid\n  location on the node's file system to which\n  Kong must have write access.\n- For the `tcp`, `tls`, and\n  `udp` strategies, this value is defined as a\n  string in the form of:\n `<HOST>:<PORT>`\n- For the `http` strategy, this value is\n  defined in the form of:\n `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`\n\nTraces sent via HTTP are delivered via POST\nmethod with an `application/json`\nContent-Type.\n"
   },
   "tracing_time_threshold": {
     "defaultValue": "0",
-    "description": "The minimum time, in microseconds, over which a trace must execute in order to write the trace data to the configured endpoint. This configuration can be used to lower the noise present in trace data by removing trace objects that are not interesting from a timing perspective. The default value of `0` removes this limitation, causing traces of any duration to be written."
+    "description": "The minimum time, in microseconds, over which\na trace must execute in order to write the\ntrace data to the configured endpoint. This\nconfiguration can be used to lower the noise\npresent in trace data by removing trace\nobjects that are not interesting from a\ntiming perspective. The default value of `0`\nremoves this limitation, causing traces of\nany duration to be written.\n"
   },
   "tracing_types": {
     "defaultValue": "all",
-    "description": "Defines the types of traces that are written. Trace types not defined in this list are ignored, regardless of their lifetime. The default special value of `all` results in all trace types being written, regardless of type.  The following trace types are included:  - `query`: trace the database query - `legacy_query`: (deprecated) trace the    database query with legacy DAO - `router`: trace Kong routing the request;    internal routing time - `balancer`: trace the execution of the overall    balancer phase - `balancer.getPeer`: trace Kong selecting an    upstream peer from the ring-balancer - `balancer.toip`: trace balancer to resolve    peer's host to IP - `connect.toip`: trace cosocket to resolve    target's host to IP - `access.before`: trace the preprocessing of    access phase, like parameter parsing, route    matching, and balance preparation - `access.after`: trace the postprocess of    access phase, like balancer execution and    internal variable assigning - `plugin`: trace plugins phase handlers"
+    "description": "Defines the types of traces that are written.\nTrace types not defined in this list are\nignored, regardless of their lifetime. The\ndefault special value of `all` results in all\ntrace types being written, regardless of type.\n\nThe following trace types are included:\n\n- `query`: trace the database query\n- `legacy_query`: (deprecated) trace the\n   database query with legacy DAO\n- `router`: trace Kong routing the request;\n   internal routing time\n- `balancer`: trace the execution of the overall\n   balancer phase\n- `balancer.getPeer`: trace Kong selecting an\n   upstream peer from the ring-balancer\n- `balancer.toip`: trace balancer to resolve\n   peer's host to IP\n- `connect.toip`: trace cosocket to resolve\n   target's host to IP\n- `access.before`: trace the preprocessing of\n   access phase, like parameter parsing, route\n   matching, and balance preparation\n- `access.after`: trace the postprocess of\n   access phase, like balancer execution and\n   internal variable assigning\n- `plugin`: trace plugins phase handlers\n"
   },
   "tracing_debug_header": {
     "defaultValue": null,
-    "description": "Defines the name of the HTTP request header that must be present in order to generate traces within a request. Setting this value provides a mechanism to selectively generate request traces at the client's request. Note that the value of the header does not matter, only that the header is present in the request. When this value is not set and tracing is enabled, Kong will generate trace data for all requests flowing through the proxy and Admin API. Note that data from certificate handling phases is not logged when this setting is enabled."
+    "description": "Defines the name of the HTTP request header\nthat must be present in order to generate\ntraces within a request. Setting this value\nprovides a mechanism to selectively generate\nrequest traces at the client's request. Note\nthat the value of the header does not matter,\nonly that the header is present in the\nrequest. When this value is not set and\ntracing is enabled, Kong will generate trace\ndata for all requests flowing through the\nproxy and Admin API. Note that data from\ncertificate handling phases is not logged\nwhen this setting is enabled.\n"
   },
   "generate_trace_details": {
     "defaultValue": "off",
-    "description": "When enabled, Kong will write context- specific details into traces. Trace details offer more data about the context of the trace. This can significantly increase the size of trace reports. Note also that trace details may contain potentially sensitive information, such as raw SQL queries; care should be taken to store traces properly when this option is enabled."
+    "description": "When enabled, Kong will write context-\nspecific details into traces. Trace details\noffer more data about the context of the\ntrace. This can significantly increase the\nsize of trace reports. Note also that trace\ndetails may contain potentially sensitive\ninformation, such as raw SQL queries; care\nshould be taken to store traces properly when\nthis option is enabled.\n"
   },
   "route_validation_strategy": {
     "defaultValue": "smart",
-    "description": "The strategy used to validate routes when creating or updating them. Different strategies are available to tune how to enforce splitting traffic of workspaces. - `smart` is the default option and uses the   algorithm described in   https://docs.konghq.com/enterprise/latest/admin-api/workspaces/examples/#important-note-conflicting-services-or-routes-in-workspaces - `off` disables any check - `path` enforces routes to comply with the pattern   described in config enforce_route_path_pattern"
+    "description": "The strategy used to validate\nroutes when creating or updating them.\nDifferent strategies are available to tune\nhow to enforce splitting traffic of\nworkspaces.\n- `smart` is the default option and uses the\n  algorithm described in\n  https://docs.konghq.com/enterprise/latest/admin-api/workspaces/examples/#important-note-conflicting-services-or-routes-in-workspaces\n- `off` disables any check\n- `path` enforces routes to comply with the pattern\n  described in config enforce_route_path_pattern\n"
   },
   "enforce_route_path_pattern": {
     "defaultValue": null,
-    "description": "Specifies the Lua pattern which will be enforced on the `paths` attribute of a Route object. You can also add a placeholder for the workspace in the pattern, which will be rendered during runtime based on the workspace to which the `route` belongs. This setting is only relevant if `route_validation_strategy` is set to `path`.   Example For Pattern `/$(workspace)/v%d/.*` valid paths are:  1. `/group1/v1/` if route belongs to   workspace `group1`.  2. `/group2/v1/some_path` if route belongs to   workspace `group2`."
+    "description": "Specifies the Lua pattern which will\nbe enforced on the `paths` attribute of a\nRoute object. You can also add a placeholder\nfor the workspace in the pattern, which\nwill be rendered during runtime based on the\nworkspace to which the `route` belongs.\nThis setting is only relevant if\n`route_validation_strategy` is set to `path`.\n\n\nExample\nFor Pattern `/$(workspace)/v%d/.*` valid paths\nare:\n\n1. `/group1/v1/` if route belongs to\n  workspace `group1`.\n\n2. `/group2/v1/some_path` if route belongs to\n  workspace `group2`.\n"
   },
   "keyring_enabled": {
     "defaultValue": "off",
-    "description": "When enabled, Kong will encrypt sensitive field values before writing them to the database, and subsuquently decrypt them when retrieving data for the Admin API, Developer Portal, or proxy business logic. Symmetric encryption keys are managed based on the strategy defined below."
+    "description": "When enabled, Kong will encrypt sensitive\nfield values before writing them to the\ndatabase, and subsuquently decrypt them when\nretrieving data for the Admin API, Developer\nPortal, or proxy business logic. Symmetric\nencryption keys are managed based on the\nstrategy defined below.\n"
   },
   "keyring_strategy": {
     "defaultValue": "cluster",
-    "description": "Defines the strategy implementation by which Kong nodes will manage symmetric encryption keys. Please see the Kong Enterprise documentation for a detailed description of each strategies. Acceptable values for this option are 'cluster' and 'vault'."
+    "description": "Defines the strategy implementation by which\nKong nodes will manage symmetric encryption\nkeys. Please see the Kong Enterprise\ndocumentation for a detailed description of\neach strategies. Acceptable values for this\noption are 'cluster' and 'vault'.\n"
   },
   "keyring_public_key": {
     "defaultValue": null,
-    "description": "Defines the public key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  values: * absolute path to the public key * public key content * base64 encoded public key content"
+    "description": "Defines the public key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nvalues:\n* absolute path to the public key\n* public key content\n* base64 encoded public key content\n"
   },
   "keyring_private_key": {
     "defaultValue": null,
-    "description": "Defines the private key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  values: * absolute path to the private key * private key content * base64 encoded private key content"
+    "description": "Defines the private key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nvalues:\n* absolute path to the private key\n* private key content\n* base64 encoded private key content\n"
   },
   "keyring_blob_path": {
     "defaultValue": null,
-    "description": "Defines the filesystem path at which Kong will backup the initial keyring material. This option is useful largely for development purposes."
+    "description": "Defines the filesystem path at which Kong\nwill backup the initial keyring material.\nThis option is useful largely for development\npurposes.\n"
   },
   "keyring_vault_host": {
     "defaultValue": null,
-    "description": "Defines the Vault host at which Kong will fetch the encryption material. This value should be defined in the format:  `<scheme>://<IP / HOSTNAME>:<PORT>`"
+    "description": "Defines the Vault host at which Kong will\nfetch the encryption material. This value\nshould be defined in the format:\n\n`<scheme>://<IP / HOSTNAME>:<PORT>`\n"
   },
   "keyring_vault_mount": {
     "defaultValue": null,
-    "description": "Defines the name of the Vault v2 KV secrets engine at which symmetric keys are found."
+    "description": "Defines the name of the Vault v2 KV secrets\nengine at which symmetric keys are found.\n"
   },
   "keyring_vault_path": {
     "defaultValue": null,
-    "description": "Defines the names of the Vault v2 KV path at which symmetric keys are found."
+    "description": "Defines the names of the Vault v2 KV path\nat which symmetric keys are found.\n"
   },
   "keyring_vault_auth_method": {
     "defaultValue": "token",
-    "description": " Defines the authentication mechanism when connecting to the Hashicorp Vault service.  Accepted values are: `token`, or `kubernetes`:  * `token`: Uses the static token defined in            the `keyring_vault_token`            configuration property.  * `kubernetes`: Uses the Kubernetes authentication                 mechanism, with the running pod's                 mapped service account, to assume                 the Hashicorp Vault role name that is                 defined in the `keyring_vault_kube_role`                 configuration property."
+    "description": "Defines the authentication mechanism when\nconnecting to the Hashicorp Vault service.\n\nAccepted values are: `token`, or `kubernetes`:\n\n* `token`: Uses the static token defined in\n           the `keyring_vault_token`\n           configuration property.\n\n* `kubernetes`: Uses the Kubernetes authentication\n                mechanism, with the running pod's\n                mapped service account, to assume\n                the Hashicorp Vault role name that is\n                defined in the `keyring_vault_kube_role`\n                configuration property.\n"
   },
   "keyring_vault_token": {
     "defaultValue": null,
-    "description": "Defines the token value used to communicate with the v2 KV Vault HTTP(S) API."
+    "description": "Defines the token value used to communicate\nwith the v2 KV Vault HTTP(S) API.\n"
   },
   "keyring_vault_kube_role": {
     "defaultValue": "default",
-    "description": " Defines the Hashicorp Vault role that will be assumed using the Kubernetes service account of the running pod.  `keyring_vault_auth_method` must be set to `kubernetes` for this to activate."
+    "description": "Defines the Hashicorp Vault role that will be\nassumed using the Kubernetes service account of\nthe running pod.\n\n`keyring_vault_auth_method` must be set to `kubernetes`\nfor this to activate.\n"
   },
   "keyring_vault_kube_api_token_file": {
     "defaultValue": "/run/secrets/kubernetes.io/serviceaccount/token",
-    "description": " Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+    "description": "Defines where the Kubernetes service account token\nshould be read from the pod's filesystem, if using\na non-standard container platform setup.\n"
   },
   "untrusted_lua": {
     "defaultValue": "sandbox",
-    "description": " Controls loading of Lua functions from admin-supplied sources such as the Admin API. LuaJIT bytecode loading is always disabled.  **Warning:** LuaJIT is not designed as a secure runtime for running malicious code, therefore you should properly protect your Admin API endpoint even with sandboxing enabled. The sandbox only provides protection against trivial attackers or unintentional modification of the Kong global environment.  Accepted values are: `off`, `sandbox`, or `on`:  * `off`: Disallow loading of any arbitrary          Lua functions. The `off` option          disables any functionality that runs          arbitrary Lua code, including the          Serverless Functions plugins and any          transformation plugin that allows          custom Lua functions.  * `sandbox`: Allow loading of Lua functions,              but use a sandbox when executing              them. The sandboxed function has              restricted access to the global              environment and only has access              to standard Lua functions that              will generally not cause harm to              the Kong Gateway node.  * `on`: Functions have unrestricted         access to the global environment and         can load any Lua modules. This is         similar to the behavior in         Kong Gateway prior to 2.3.0.  The default `sandbox` environment does not allow importing other modules or libraries, or executing anything at the OS level (for example, file read/write). The global environment is also not accessible.  Examples of `untrusted_lua = sandbox` behavior:  * You can't access or change global values such as `kong.configuration.pg_password` * You can run harmless lua: `local foo = 1 + 1`. However, OS level functions are not allowed, like: `os.execute('rm -rf /*')`.  For a full allowed/disallowed list, see: https://github.com/kikito/sandbox.lua/blob/master/sandbox.lua  To customize the sandbox environment, use the `untrusted_lua_sandbox_requires` and `untrusted_lua_sandbox_environment` parameters below."
+    "description": "Controls loading of Lua functions from admin-supplied\nsources such as the Admin API. LuaJIT bytecode\nloading is always disabled.\n\n**Warning:** LuaJIT is not designed as a secure\nruntime for running malicious code, therefore\nyou should properly protect your Admin API endpoint\neven with sandboxing enabled. The sandbox only\nprovides protection against trivial attackers or\nunintentional modification of the Kong global\nenvironment.\n\nAccepted values are: `off`, `sandbox`, or\n`on`:\n\n* `off`: Disallow loading of any arbitrary\n         Lua functions. The `off` option\n         disables any functionality that runs\n         arbitrary Lua code, including the\n         Serverless Functions plugins and any\n         transformation plugin that allows\n         custom Lua functions.\n\n* `sandbox`: Allow loading of Lua functions,\n             but use a sandbox when executing\n             them. The sandboxed function has\n             restricted access to the global\n             environment and only has access\n             to standard Lua functions that\n             will generally not cause harm to\n             the Kong Gateway node.\n\n* `on`: Functions have unrestricted\n        access to the global environment and\n        can load any Lua modules. This is\n        similar to the behavior in\n        Kong Gateway prior to 2.3.0.\n\nThe default `sandbox` environment does not\nallow importing other modules or libraries,\nor executing anything at the OS level (for\nexample, file read/write). The global\nenvironment is also not accessible.\n\nExamples of `untrusted_lua = sandbox`\nbehavior:\n\n* You can't access or change global values\nsuch as `kong.configuration.pg_password`\n* You can run harmless lua:\n`local foo = 1 + 1`. However, OS level\nfunctions are not allowed, like:\n`os.execute('rm -rf /*')`.\n\nFor a full allowed/disallowed list, see:\nhttps://github.com/kikito/sandbox.lua/blob/master/sandbox.lua\n\nTo customize the sandbox environment, use\nthe `untrusted_lua_sandbox_requires` and\n`untrusted_lua_sandbox_environment`\nparameters below.\n"
   },
   "untrusted_lua_sandbox_requires": {
     "defaultValue": null,
-    "description": "Comma-separated list of modules allowed to be loaded with `require` inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  For example, say you have configured the Serverless pre-function plugin and it contains the following `requires`:  ``` local template = require \"resty.template\" local split = require \"kong.tools.utils\".split ```  To run the plugin, add the modules to the allowed list: ``` untrusted_lua_sandbox_requires = resty.template, kong.tools.utils ```  **Warning:** Allowing certain modules may create opportunities to escape the sandbox. For example, allowing `os` or `luaposix` may be unsafe."
+    "description": "Comma-separated list of modules allowed to\nbe loaded with `require` inside the\nsandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\nFor example, say you have configured the\nServerless pre-function plugin and it\ncontains the following `requires`:\n\n```\nlocal template = require \"resty.template\"\nlocal split = require \"kong.tools.utils\".split\n```\n\nTo run the plugin, add the modules to the\nallowed list:\n```\nuntrusted_lua_sandbox_requires = resty.template, kong.tools.utils\n```\n\n**Warning:** Allowing certain modules may\ncreate opportunities to escape the\nsandbox. For example, allowing `os` or\n`luaposix` may be unsafe.\n"
   },
   "untrusted_lua_sandbox_environment": {
     "defaultValue": null,
-    "description": "Comma-separated list of global Lua variables that should be made available inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  **Warning**: Certain variables, when made available, may create opportunities to escape the sandbox."
+    "description": "Comma-separated list of global Lua\nvariables that should be made available\ninside the sandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\n**Warning**: Certain variables, when made\navailable, may create opportunities to\nescape the sandbox.\n"
   },
   "openresty_path": {
     "defaultValue": null,
-    "description": "Path to the OpenResty installation that Kong will use. When this is empty (the default), Kong determines the OpenResty installation by searching for a system-installed OpenResty and falling back to searching $PATH for the nginx binary.  Setting this attribute disables the search behavior and explicitly instructs Kong which OpenResty installation to use."
+    "description": "Path to the OpenResty installation that Kong\nwill use. When this is empty (the default),\nKong determines the OpenResty installation\nby searching for a system-installed OpenResty\nand falling back to searching $PATH for the\nnginx binary.\n\nSetting this attribute disables the search\nbehavior and explicitly instructs Kong which\nOpenResty installation to use.\n"
   },
   "node_id": {
     "defaultValue": null,
-    "description": "Node ID for the Kong node. Every Kong node in a Kong cluster must have a unique and valid UUID. When empty, node ID is automatically generated."
+    "description": "Node ID for the Kong node. Every Kong node\nin a Kong cluster must have a unique and\nvalid UUID. When empty, node ID is\nautomatically generated.\n"
   },
   "cluster_fallback_config_import": {
     "defaultValue": "off",
-    "description": "Enable fallback configuration imports  This should only be enabled for data plane"
+    "description": "Enable fallback configuration imports\n\nThis should only be enabled for data plane\n"
   },
   "cluster_fallback_config_storage": {
     "defaultValue": null,
-    "description": "Storage definition used by `cluster_fallback_config_import` and `cluster_fallback_config_export`  Currently supported storage type: S3-like storages and GCP storage service. To use S3 with a bucket named b and place all configs to with a key prefix named p, set it to: s3://b/p To use GCP for the same bucket and prefix, set it to: gcs://b/p  The credentials (and endpoint URL for S3-like) for S3 are passing with environment variables: `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` and `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where `AWS_CONFIG_STORAGE_ENDPOINT` is the endpoint that hosts S3-like storage. The credentials for GCP is provided via the environment variable `GCP_SERVICE_ACCOUNT`"
+    "description": "Storage definition used by `cluster_fallback_config_import`\nand `cluster_fallback_config_export`\n\nCurrently supported storage type:\nS3-like storages and GCP storage service.\nTo use S3 with a bucket named b and place all configs\nto with a key prefix named p, set it to:\ns3://b/p\nTo use GCP for the same bucket and prefix, set it to:\ngcs://b/p\n\nThe credentials (and endpoint URL for S3-like) for S3\nare passing with environment variables:\n`AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`\nand `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where `AWS_CONFIG_STORAGE_ENDPOINT`\nis the endpoint that hosts S3-like storage.\nThe credentials for GCP is provided via the environment variable `GCP_SERVICE_ACCOUNT`\n"
   },
   "cluster_fallback_config_export": {
     "defaultValue": "off",
-    "description": "Enable fallback configuration exports."
+    "description": "Enable fallback configuration exports.\n"
   },
   "cluster_fallback_config_export_delay": {
     "defaultValue": "60",
-    "description": "The fallback configuration export interval. If it's set to 60 and configuration A is exported and there're new configurations B, C and D in the next 60 seconds, it will wait until 60 seconds passed and export D, skipping B and C."
+    "description": "The fallback configuration export interval.\nIf it's set to 60 and configuration A is exported\nand there're new configurations B, C and D in the next 60 seconds,\nit will wait until 60 seconds passed and export D, skipping B and C.\n"
   },
   "wasm": {
     "defaultValue": "off",
-    "description": "Enable/disable wasm support. This must be enabled in order to use wasm filters and filter chains."
+    "description": "Enable/disable wasm support. This must be enabled in\norder to use wasm filters and filter chains.\n"
   },
   "wasm_filters_path": {
     "defaultValue": null,
-    "description": "Path to the directory containing wasm filter modules.  At startup, Kong discovers available wasm filters by scanning this directory for files with the `.wasm` file extension.  The name of a wasm filter module is derived from the filename itself, with the .wasm extension removed. So, given the following tree:  ``` /path/to/wasm_filters ├── my_module.wasm ├── my_other_module.wasm └── not_a_wasm_module.txt ```  The resulting filter modules available for use in Kong will be:  * `my_module` * `my_other_module`  Notes:  * No recursion is performed. Only .wasm files at the   top level are registered * This path _may_ be a symlink to a directory."
+    "description": "Path to the directory containing wasm filter modules.\n\nAt startup, Kong discovers available wasm filters by\nscanning this directory for files with the `.wasm`\nfile extension.\n\nThe name of a wasm filter module is derived from the\nfilename itself, with the .wasm extension removed. So,\ngiven the following tree:\n\n```\n/path/to/wasm_filters\n├── my_module.wasm\n├── my_other_module.wasm\n└── not_a_wasm_module.txt\n```\n\nThe resulting filter modules available for use in Kong\nwill be:\n\n* `my_module`\n* `my_other_module`\n\nNotes:\n\n* No recursion is performed. Only .wasm files at the\n  top level are registered\n* This path _may_ be a symlink to a directory.\n"
   },
   "request_debug": {
     "defaultValue": "on",
-    "description": "When enabled, Kong will provide detailed timing information for its components to the client and the error log if the following headers are present in the proxy request: - `X-Kong-Request-Debug`:   If the value is set to `*`,   timing information will be collected and exported for the current request.   If this header is not present or contains unknown value,   timing information will not be collected for the current request.   You can also specify a list of filters, separated by commas,   to filter the scope of the time information that is collected.   The following filters are supported:   - `rewrite`: Collect timing information from the `rewrite` phase.   - `access`: Collect timing information from the `access` phase.   - `balancer`: Collect timing information from the `balancer` phase.   - `response`: Collect timing information from the `response` phase.   - `header_filter`: Collect timing information from the `header_filter` phase.   - `body_filter`: Collect timing information from the `body_filter` phase.   - `log`: Collect timing information from the `log` phase.   - `upstream`: Collect timing information from the `upstream` phase.  - `X-Kong-Request-Debug-Log`:   If set to `true`, timing information will also be logged   in the Kong error log with a log level of `notice`.   Defaults to `false`.  - `X-Kong-Request-Debug-Token`:   Token for authenticating the client making the debug   request to prevent abuse. Debug requests originating from loopback   addresses do not require this header. "
+    "description": "When enabled, Kong will provide detailed timing information\nfor its components to the client and the error log\nif the following headers are present in the proxy request:\n- `X-Kong-Request-Debug`:\n  If the value is set to `*`,\n  timing information will be collected and exported for the current request.\n  If this header is not present or contains unknown value,\n  timing information will not be collected for the current request.\n  You can also specify a list of filters, separated by commas,\n  to filter the scope of the time information that is collected.\n  The following filters are supported:\n  - `rewrite`: Collect timing information from the `rewrite` phase.\n  - `access`: Collect timing information from the `access` phase.\n  - `balancer`: Collect timing information from the `balancer` phase.\n  - `response`: Collect timing information from the `response` phase.\n  - `header_filter`: Collect timing information from the `header_filter` phase.\n  - `body_filter`: Collect timing information from the `body_filter` phase.\n  - `log`: Collect timing information from the `log` phase.\n  - `upstream`: Collect timing information from the `upstream` phase.\n\n- `X-Kong-Request-Debug-Log`:\n  If set to `true`, timing information will also be logged\n  in the Kong error log with a log level of `notice`.\n  Defaults to `false`.\n\n- `X-Kong-Request-Debug-Token`:\n  Token for authenticating the client making the debug\n  request to prevent abuse. Debug requests originating from loopback\n  addresses do not require this header.\n\n"
   },
   "request_debug_token": {
     "defaultValue": "<random>",
-    "description": "The Request Debug Token is used in the `X-Kong-Request-Debug-Token` header to prevent abuse. If this value is not set (the default), a random token will be generated when Kong starts, restarts, or reloads. If a token is specified manually, then the provided token will be used.  You can locate the generated debug token in two locations: - Kong error log:   Debug token will be logged in the error log (notice level)   when Kong starts, restarts, or reloads.   The log line will have the: `[request-debug]` prefix to aid searching. - Filesystem:   Debug token will also be stored in a file located at   `{prefix}/.request_debug_token` and updated   when Kong starts, restarts, or reloads."
+    "description": "The Request Debug Token is used in the\n`X-Kong-Request-Debug-Token` header to prevent abuse.\nIf this value is not set (the default),\na random token will be generated\nwhen Kong starts, restarts, or reloads. If a token is\nspecified manually, then the provided token will be used.\n\nYou can locate the generated debug token in two locations:\n- Kong error log:\n  Debug token will be logged in the error log (notice level)\n  when Kong starts, restarts, or reloads.\n  The log line will have the: `[request-debug]` prefix to aid searching.\n- Filesystem:\n  Debug token will also be stored in a file located at\n  `{prefix}/.request_debug_token` and updated\n  when Kong starts, restarts, or reloads.\n"
   }
 }

--- a/app/_data/kong-conf/3.5.json
+++ b/app/_data/kong-conf/3.5.json
@@ -1,325 +1,325 @@
 {
   "prefix": {
     "defaultValue": "/usr/local/kong/",
-    "description": "Working directory. Equivalent to Nginx's prefix path, containing temporary files and logs. Each Kong process must have a separate working directory."
+    "description": "Working directory. Equivalent to Nginx's\nprefix path, containing temporary files\nand logs.\nEach Kong process must have a separate\nworking directory.\n"
   },
   "log_level": {
     "defaultValue": "notice",
-    "description": "Log level of the Nginx server. Logs are found at `<prefix>/logs/error.log`."
+    "description": "Log level of the Nginx server. Logs are\nfound at `<prefix>/logs/error.log`.\n"
   },
   "proxy_access_log": {
     "defaultValue": "logs/access.log",
-    "description": "Path for proxy port request access logs. Set this value to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for proxy port request access\nlogs. Set this value to `off` to\ndisable logging proxy requests.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n"
   },
   "proxy_error_log": {
     "defaultValue": "logs/error.log",
-    "description": "Path for proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for proxy port request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "proxy_stream_access_log": {
     "defaultValue": "logs/access.log basic",
-    "description": "Path for tcp streams proxy port access logs. Set this value to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location. `basic` is defined as `'$remote_addr [$time_local] ' '$protocol $status $bytes_sent $bytes_received ' '$session_time'`"
+    "description": "Path for tcp streams proxy port access\nlogs. Set this value to `off` to\ndisable logging proxy requests.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n`basic` is defined as `'$remote_addr [$time_local] '\n'$protocol $status $bytes_sent $bytes_received '\n'$session_time'`\n"
   },
   "proxy_stream_error_log": {
     "defaultValue": "logs/error.log",
-    "description": "Path for tcp streams proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for tcp streams proxy port request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "admin_access_log": {
     "defaultValue": "logs/admin_access.log",
-    "description": "Path for Admin API request access logs. If Hybrid Mode is enabled and the current node is set to be the Control Plane, then the connection requests from Data Planes are also written to this file with server name \"kong_cluster_listener\".  Set this value to `off` to disable logging Admin API requests. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for Admin API request access\nlogs. If Hybrid Mode is enabled\nand the current node is set to be\nthe Control Plane, then the\nconnection requests from Data Planes\nare also written to this file with\nserver name \"kong_cluster_listener\".\n\nSet this value to `off` to\ndisable logging Admin API requests.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n"
   },
   "admin_error_log": {
     "defaultValue": "logs/error.log",
-    "description": "Path for Admin API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for Admin API request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "status_access_log": {
     "defaultValue": "off",
-    "description": "Path for Status API request access logs. The default value of `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for Status API request access\nlogs. The default value of `off`\nimplies that logging for this API\nis disabled by default.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n"
   },
   "status_error_log": {
     "defaultValue": "logs/status_error.log",
-    "description": "Path for Status API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for Status API request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "debug_access_log": {
     "defaultValue": "off",
-    "description": "Path for Debug API request access logs. The default value of `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for Debug API request access\nlogs. The default value of `off`\nimplies that logging for this API\nis disabled by default.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n"
   },
   "debug_error_log": {
     "defaultValue": "logs/debug_error.log",
-    "description": "Path for Debug API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for Debug API request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "vaults": {
     "defaultValue": "bundled",
-    "description": "Comma-separated list of vaults this node should load. By default, all the bundled vaults are enabled.  The specified name(s) will be substituted as such in the Lua namespace: `kong.vaults.{name}.*`."
+    "description": "Comma-separated list of vaults this node\nshould load. By default, all the bundled\nvaults are enabled.\n\nThe specified name(s) will be substituted as\nsuch in the Lua namespace:\n`kong.vaults.{name}.*`.\n"
   },
   "opentelemetry_tracing": {
     "defaultValue": "off",
-    "description": "Deprecated: use tracing_instrumentations instead"
+    "description": "Deprecated: use tracing_instrumentations instead\n"
   },
   "tracing_instrumentations": {
     "defaultValue": "off",
-    "description": "Comma-separated list of tracing instrumentations this node should load. By default, no instrumentations are enabled.  Valid values to this setting are:  - `off`: do not enable instrumentations. - `request`: only enable request-level instrumentations. - `all`: enable all the following instrumentations. - `db_query`: trace database query - `dns_query`: trace DNS query. - `router`: trace router execution, including   router rebuilding. - `http_client`: trace OpenResty HTTP client requests. - `balancer`: trace balancer retries. - `plugin_rewrite`: trace plugins iterator   execution with rewrite phase. - `plugin_access`: trace plugins iterator   execution with access phase. - `plugin_header_filter`: trace plugins iterator   execution with header_filter phase.  **Note:** In the current implementation, tracing instrumentations are not enabled in stream mode."
+    "description": "Comma-separated list of tracing instrumentations\nthis node should load. By default, no instrumentations\nare enabled.\n\nValid values to this setting are:\n\n- `off`: do not enable instrumentations.\n- `request`: only enable request-level instrumentations.\n- `all`: enable all the following instrumentations.\n- `db_query`: trace database query\n- `dns_query`: trace DNS query.\n- `router`: trace router execution, including\n  router rebuilding.\n- `http_client`: trace OpenResty HTTP client requests.\n- `balancer`: trace balancer retries.\n- `plugin_rewrite`: trace plugins iterator\n  execution with rewrite phase.\n- `plugin_access`: trace plugins iterator\n  execution with access phase.\n- `plugin_header_filter`: trace plugins iterator\n  execution with header_filter phase.\n\n**Note:** In the current implementation,\ntracing instrumentations are not enabled in\nstream mode.\n"
   },
   "opentelemetry_tracing_sampling_rate": {
     "defaultValue": "1.0",
-    "description": "Deprecated: use tracing_sampling_rate instead"
+    "description": "Deprecated: use tracing_sampling_rate instead\n"
   },
   "tracing_sampling_rate": {
     "defaultValue": "0.01",
-    "description": "Tracing instrumentation sampling rate. Tracer samples a fixed percentage of all spans following the sampling rate.  Example: `0.25`, this should account for 25% of all traces."
+    "description": "Tracing instrumentation sampling rate.\nTracer samples a fixed percentage of all spans\nfollowing the sampling rate.\n\nExample: `0.25`, this should account for 25% of all traces.\n"
   },
   "plugins": {
     "defaultValue": "bundled",
-    "description": "Comma-separated list of plugins this node should load. By default, only plugins bundled in official distributions are loaded via the `bundled` keyword.  Loading a plugin does not enable it by default, but only instructs Kong to load its source code, and allows to configure the plugin via the various related Admin API endpoints.  The specified name(s) will be substituted as such in the Lua namespace: `kong.plugins.{name}.*`.  When the `off` keyword is specified as the only value, no plugins will be loaded.  `bundled` and plugin names can be mixed together, as the following examples suggest:  - `plugins = bundled,custom-auth,custom-log`   will include the bundled plugins plus two   custom ones - `plugins = custom-auth,custom-log` will   *only* include the `custom-auth` and   `custom-log` plugins. - `plugins = off` will not include any   plugins  **Note:** Kong will not start if some plugins were previously configured (i.e. have rows in the database) and are not specified in this list.  Before disabling a plugin, ensure all instances of it are removed before restarting Kong.  **Note:** Limiting the amount of available plugins can improve P99 latency when experiencing LRU churning in the database cache (i.e. when the configured `mem_cache_size`) is full."
+    "description": "Comma-separated list of plugins this node\nshould load. By default, only plugins\nbundled in official distributions are\nloaded via the `bundled` keyword.\n\nLoading a plugin does not enable it by\ndefault, but only instructs Kong to load its\nsource code, and allows to configure the\nplugin via the various related Admin API\nendpoints.\n\nThe specified name(s) will be substituted as\nsuch in the Lua namespace:\n`kong.plugins.{name}.*`.\n\nWhen the `off` keyword is specified as the\nonly value, no plugins will be loaded.\n\n`bundled` and plugin names can be mixed\ntogether, as the following examples suggest:\n\n- `plugins = bundled,custom-auth,custom-log`\n  will include the bundled plugins plus two\n  custom ones\n- `plugins = custom-auth,custom-log` will\n  *only* include the `custom-auth` and\n  `custom-log` plugins.\n- `plugins = off` will not include any\n  plugins\n\n**Note:** Kong will not start if some\nplugins were previously configured (i.e.\nhave rows in the database) and are not\nspecified in this list.  Before disabling a\nplugin, ensure all instances of it are\nremoved before restarting Kong.\n\n**Note:** Limiting the amount of available\nplugins can improve P99 latency when\nexperiencing LRU churning in the database\ncache (i.e. when the configured\n`mem_cache_size`) is full.\n"
   },
   "dedicated_config_processing": {
     "defaultValue": "on",
-    "description": "Enables or disables a special worker process for configuration processing. This process increases memory usage a little bit while allowing to reduce latencies by moving some background tasks, such as CP/DP connection handling, to an additional worker process specific to handling these background tasks. Currently this has effect only on data planes."
+    "description": "Enables or disables a special worker\nprocess for configuration processing. This process\nincreases memory usage a little bit while\nallowing to reduce latencies by moving some\nbackground tasks, such as CP/DP connection\nhandling, to an additional worker process specific\nto handling these background tasks.\nCurrently this has effect only on data planes.\n"
   },
   "pluginserver_names": {
     "defaultValue": null,
-    "description": "Comma-separated list of names for pluginserver processes.  The actual names are used for log messages and to relate the actual settings."
+    "description": "Comma-separated list of names for pluginserver\nprocesses.  The actual names are used for\nlog messages and to relate the actual settings.\n"
   },
   "pluginserver_XXX_socket": {
     "defaultValue": "<prefix>/<XXX>.socket",
-    "description": "Path to the unix socket used by the <XXX> pluginserver."
+    "description": "Path to the unix socket\nused by the <XXX> pluginserver.\n"
   },
   "pluginserver_XXX_start_cmd": {
     "defaultValue": "/usr/local/bin/<XXX>",
-    "description": "Full command (including any needed arguments) to start the <XXX> pluginserver"
+    "description": "Full command (including\nany needed arguments) to\nstart the <XXX> pluginserver\n"
   },
   "pluginserver_XXX_query_cmd": {
     "defaultValue": "/usr/local/bin/query_<XXX>",
-    "description": "Full command to \"query\" the <XXX> pluginserver.  Should produce a JSON with the dump info of all plugins it manages"
+    "description": "Full command to \"query\" the\n<XXX> pluginserver.  Should\nproduce a JSON with the\ndump info of all plugins it\nmanages\n"
   },
   "port_maps": {
     "defaultValue": null,
-    "description": "With this configuration parameter, you can let the Kong to know about the port from which the packets are forwarded to it. This is fairly common when running Kong in a containerized or virtualized environment. For example, `port_maps=80:8000, 443:8443` instructs Kong that the port 80 is mapped to 8000 (and the port 443 to 8443), where 8000 and 8443 are the ports that Kong is listening to.  This parameter helps Kong set a proper forwarded upstream HTTP request header or to get the proper forwarded port with the Kong PDK (in case other means determining it has failed). It changes routing by a destination port to route by a port from which packets are forwarded to Kong, and similarly it changes the default plugin log serializer to use the port according to this mapping instead of reporting the port Kong is listening to."
+    "description": "With this configuration parameter, you can\nlet the Kong to know about the port from\nwhich the packets are forwarded to it. This\nis fairly common when running Kong in a\ncontainerized or virtualized environment.\nFor example, `port_maps=80:8000, 443:8443`\ninstructs Kong that the port 80 is mapped\nto 8000 (and the port 443 to 8443), where\n8000 and 8443 are the ports that Kong is\nlistening to.\n\nThis parameter helps Kong set a proper\nforwarded upstream HTTP request header or to\nget the proper forwarded port with the Kong PDK\n(in case other means determining it has\nfailed). It changes routing by a destination\nport to route by a port from which packets\nare forwarded to Kong, and similarly it\nchanges the default plugin log serializer to\nuse the port according to this mapping\ninstead of reporting the port Kong is\nlistening to.\n"
   },
   "anonymous_reports": {
     "defaultValue": "on",
-    "description": "Send anonymous usage data such as error stack traces to help improve Kong."
+    "description": "Send anonymous usage data such as error\nstack traces to help improve Kong.\n"
   },
   "proxy_server": {
     "defaultValue": null,
-    "description": "Proxy server defined as a URL. Kong will only use this option if any component is explicitly configured to use proxy."
+    "description": "Proxy server defined as a URL. Kong will only use this\noption if any component is explicitly configured\nto use proxy.\n"
   },
   "proxy_server_ssl_verify": {
     "defaultValue": "off",
-    "description": "Toggles server certificate verification if `proxy_server` is in HTTPS. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+    "description": "Toggles server certificate verification if\n`proxy_server` is in HTTPS.\nSee the `lua_ssl_trusted_certificate`\nsetting to specify a certificate authority.\n"
   },
   "error_template_html": {
     "defaultValue": null,
-    "description": "Path to the custom html error template to override the default html kong error template.  The template may contain up to two `%s` placeholders. The first one will expand to the error message. The second one will expand to the request ID. Both placeholders are optional, but recommended. Adding more than two placeholders will result in a runtime error when trying to render the template: ``` <html>   <body>     <h1>My custom error template</h1>     <p>error: %s</p>     <p>request_id: %s</p>   </body> </html> ```"
+    "description": "Path to the custom html error template to\noverride the default html kong error\ntemplate.\n\nThe template may contain up to two `%s`\nplaceholders. The first one will expand to\nthe error message. The second one will\nexpand to the request ID. Both placeholders\nare optional, but recommended.\nAdding more than two placeholders will\nresult in a runtime error when trying to\nrender the template:\n```\n<html>\n  <body>\n    <h1>My custom error template</h1>\n    <p>error: %s</p>\n    <p>request_id: %s</p>\n  </body>\n</html>\n```\n"
   },
   "error_template_json": {
     "defaultValue": null,
-    "description": "Path to the custom json error template to override the default json kong error template.  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+    "description": "Path to the custom json error template to\noverride the default json kong error\ntemplate.\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n"
   },
   "error_template_xml": {
     "defaultValue": null,
-    "description": "Path to the custom xml error template to override the default xml kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+    "description": "Path to the custom xml error template to\noverride the default xml kong error template\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n"
   },
   "error_template_plain": {
     "defaultValue": null,
-    "description": "Path to the custom plain error template to override the default plain kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+    "description": "Path to the custom plain error template to\noverride the default plain kong error\ntemplate\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n"
   },
   "role": {
     "defaultValue": "traditional",
-    "description": "Use this setting to enable Hybrid Mode, This allows running some Kong nodes in a control plane role with a database and have them deliver configuration updates to other nodes running to DB-less running in a Data Plane role.  Valid values to this setting are:  - `traditional`: do not use Hybrid Mode. - `control_plane`: this node runs in a   control plane role. It can use a database   and will deliver configuration updates   to data plane nodes. - `data_plane`: this is a data plane node.   It runs DB-less and receives configuration   updates from a control plane node."
+    "description": "Use this setting to enable Hybrid Mode,\nThis allows running some Kong nodes in a\ncontrol plane role with a database and\nhave them deliver configuration updates\nto other nodes running to DB-less running in\na Data Plane role.\n\nValid values to this setting are:\n\n- `traditional`: do not use Hybrid Mode.\n- `control_plane`: this node runs in a\n  control plane role. It can use a database\n  and will deliver configuration updates\n  to data plane nodes.\n- `data_plane`: this is a data plane node.\n  It runs DB-less and receives configuration\n  updates from a control plane node.\n"
   },
   "cluster_mtls": {
     "defaultValue": "shared",
-    "description": "Sets the verification between nodes of the cluster.  Valid values to this setting are:  - `shared`: use a shared certificate/key   pair specified with the `cluster_cert`   and `cluster_cert_key` settings.   Note that CP and DP nodes have to present   the same certificate to establish mTLS   connections. - `pki`: use `cluster_ca_cert`,   `cluster_server_name` and `cluster_cert`   for verification.   These are different certificates for each   DP node, but issued by a cluster-wide   common CA certificate: `cluster_ca_cert`. - `pki_check_cn`: similar as `pki` but additionally   checks for Common Name of data plane certificate   specified in `cluster_allowed_common_names`."
+    "description": "Sets the verification between nodes of the\ncluster.\n\nValid values to this setting are:\n\n- `shared`: use a shared certificate/key\n  pair specified with the `cluster_cert`\n  and `cluster_cert_key` settings.\n  Note that CP and DP nodes have to present\n  the same certificate to establish mTLS\n  connections.\n- `pki`: use `cluster_ca_cert`,\n  `cluster_server_name` and `cluster_cert`\n  for verification.\n  These are different certificates for each\n  DP node, but issued by a cluster-wide\n  common CA certificate: `cluster_ca_cert`.\n- `pki_check_cn`: similar as `pki` but additionally\n  checks for Common Name of data plane certificate\n  specified in `cluster_allowed_common_names`.\n"
   },
   "cluster_cert": {
     "defaultValue": null,
-    "description": "Cluster certificate to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes.  Under `pki` mode it should be a different certificate for each DP node.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "Cluster certificate to use\nwhen establishing secure communication\nbetween control and data plane nodes.\nYou can use the `kong hybrid` command to\ngenerate the certificate/key pair.\nUnder `shared` mode, it must be the same\nfor all nodes.  Under `pki` mode it\nshould be a different certificate for each\nDP node.\n\nThe certificate can be configured on this\nproperty with either of the following values:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "cluster_cert_key": {
     "defaultValue": null,
-    "description": "Cluster certificate key to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes.  Under `pki` mode it should be a different certificate for each DP node.  The certificate key can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+    "description": "Cluster certificate key to\nuse when establishing secure communication\nbetween control and data plane nodes.\nYou can use the `kong hybrid` command to\ngenerate the certificate/key pair.\nUnder `shared` mode, it must be the same\nfor all nodes.  Under `pki` mode it\nshould be a different certificate for each\nDP node.\n\nThe certificate key can be configured on this\nproperty with either of the following values:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n"
   },
   "cluster_ca_cert": {
     "defaultValue": null,
-    "description": "The trusted CA certificate file in PEM format used for Control Plane to verify Data Plane's certificate and Data Plane to verify Control Plane's certificate. Required on data plane if `cluster_mtls` is set to `pki`. If Control Plane certificate is issued by a well known CA, user can set `lua_ssl_trusted_certificate=system` on Data Plane and leave this field empty.  This field is ignored if `cluster_mtls` is set to `shared`.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "The trusted CA certificate file in PEM\nformat used for Control Plane to verify\nData Plane's certificate and Data Plane\nto verify Control Plane's certificate.\nRequired on data plane if `cluster_mtls`\nis set to `pki`.\nIf Control Plane certificate is issued\nby a well known CA, user can set\n`lua_ssl_trusted_certificate=system`\non Data Plane and leave this field empty.\n\nThis field is ignored if `cluster_mtls` is\nset to `shared`.\n\nThe certificate can be configured on this property\nwith either of the following values:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "cluster_allowed_common_names": {
     "defaultValue": null,
-    "description": "The list of Common Names that are allowed to connect to control plane. Multiple entries may be supplied in a comma-separated string. When not set, Data Plane with same parent domain of Control Plane cert is allowed to connect.  This field is ignored if `cluster_mtls` is not set to `pki_check_cn`."
+    "description": "The list of Common Names that are allowed to\nconnect to control plane. Multiple entries may\nbe supplied in a comma-separated string. When not\nset, Data Plane with same parent domain of\nControl Plane cert is allowed to connect.\n\nThis field is ignored if `cluster_mtls` is\nnot set to `pki_check_cn`.\n"
   },
   "cluster_server_name": {
     "defaultValue": null,
-    "description": "The server name used in the SNI of the TLS connection from a DP node to a CP node. Must match the Common Name (CN) or Subject Alternative Name (SAN) found in the CP certificate. If `cluster_mtls` is set to `shared`, this setting is ignored and `kong_clustering` is used."
+    "description": "The server name used in the SNI of the TLS\nconnection from a DP node to a CP node.\nMust match the Common Name (CN) or Subject\nAlternative Name (SAN) found in the CP\ncertificate.\nIf `cluster_mtls` is set to\n`shared`, this setting is ignored and\n`kong_clustering` is used.\n"
   },
   "cluster_control_plane": {
     "defaultValue": null,
-    "description": "To be used by data plane nodes only: address of the control plane node from which configuration updates will be fetched, in `host:port` format."
+    "description": "To be used by data plane nodes only:\naddress of the control plane node from\nwhich configuration updates will be fetched,\nin `host:port` format.\n"
   },
   "cluster_telemetry_endpoint": {
     "defaultValue": null,
-    "description": "To be used by data plane nodes only: telemetry address of the control plane node to which telemetry updates will be posted in `host:port` format."
+    "description": "To be used by data plane nodes only:\ntelemetry address of the control plane node\nto which telemetry updates will be posted\nin `host:port` format.\n"
   },
   "cluster_telemetry_server_name": {
     "defaultValue": null,
-    "description": "The SNI (Server Name Indication extension) to use for Vitals telemetry data."
+    "description": "The SNI (Server Name Indication extension)\nto use for Vitals telemetry data.\n"
   },
   "cluster_dp_labels": {
     "defaultValue": null,
-    "description": "Comma separated list of Labels for the data plane. Labels are key-value pairs that provide additional context information for each DP. Each label must be configured as a string in the format `key:value`.  Labels are only compatible with hybrid mode deployments with Kong Konnect (SaaS), this configuration doesn't work with self-hosted deployments.  Keys and values follow the AIP standards: https://kong-aip.netlify.app/aip/129/  Example: `deployment:mycloud,region:us-east-1`"
+    "description": "Comma separated list of Labels for the data plane.\nLabels are key-value pairs that provide additional\ncontext information for each DP.\nEach label must be configured as a string in the\nformat `key:value`.\n\nLabels are only compatible with hybrid mode\ndeployments with Kong Konnect (SaaS),\nthis configuration doesn't work with\nself-hosted deployments.\n\nKeys and values follow the AIP standards:\nhttps://kong-aip.netlify.app/aip/129/\n\nExample:\n`deployment:mycloud,region:us-east-1`\n"
   },
   "cluster_listen": {
     "defaultValue": "0.0.0.0:8005",
-    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster. This port is mTLS protected to ensure end-to-end security and integrity.  This setting has no effect if `role` is not set to `control_plane`.  Connection made to this endpoint are logged to the same location as Admin API access logs. See `admin_access_log` config description for more information."
+    "description": "Comma-separated list of addresses and ports on\nwhich the cluster control plane server should listen\nfor data plane connections.\nThe cluster communication port of the control plane\nmust be accessible by all the data planes\nwithin the same cluster. This port is mTLS protected\nto ensure end-to-end security and integrity.\n\nThis setting has no effect if `role` is not set to\n`control_plane`.\n\nConnection made to this endpoint are logged\nto the same location as Admin API access logs.\nSee `admin_access_log` config description for more\ninformation.\n"
   },
   "cluster_telemetry_listen": {
     "defaultValue": "0.0.0.0:8006",
-    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane telemetry connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster.  This setting has no effect if `role` is not set to `control_plane`."
+    "description": "Comma-separated list of addresses and ports on\nwhich the cluster control plane server should listen\nfor data plane telemetry connections.\nThe cluster communication port of the control plane\nmust be accessible by all the data planes\nwithin the same cluster.\n\nThis setting has no effect if `role` is not set to\n`control_plane`.\n"
   },
   "cluster_data_plane_purge_delay": {
     "defaultValue": "1209600",
-    "description": " How many seconds must pass from the time a DP node becomes offline to the time its entry gets removed from the database, as returned by the /clustering/data-planes Admin API endpoint.  This is to prevent the cluster data plane table from growing indefinitely. The default is set to 14 days. That is, if CP haven't heard from a DP for 14 days, its entry will be removed."
+    "description": "How many seconds must pass from the time a DP node\nbecomes offline to the time its entry gets removed\nfrom the database, as returned by the\n/clustering/data-planes Admin API endpoint.\n\nThis is to prevent the cluster data plane table from\ngrowing indefinitely. The default is set to\n14 days. That is, if CP haven't heard from a DP for\n14 days, its entry will be removed.\n"
   },
   "cluster_ocsp": {
     "defaultValue": "off",
-    "description": " Whether to check for revocation status of DP certificates using OCSP (Online Certificate Status Protocol). If enabled, the DP certificate should contain the \"Certificate Authority Information Access\" extension and the OCSP method with URI of which the OCSP responder can be reached from CP.  OCSP checks are only performed on CP nodes, it has no effect on DP nodes.  Valid values to this setting are:  - `on`: OCSP revocation check is enabled and DP   must pass the check in order to establish   connection with CP. - `off`: OCSP revocation check is disabled. - `optional`: OCSP revocation check will be attempted,   however, if the required extension is not   found inside DP provided certificate   or communication with the OCSP responder   failed, then DP is still allowed through."
+    "description": "Whether to check for revocation status of DP\ncertificates using OCSP (Online Certificate Status Protocol).\nIf enabled, the DP certificate should contain the\n\"Certificate Authority Information Access\" extension\nand the OCSP method with URI of which the OCSP responder\ncan be reached from CP.\n\nOCSP checks are only performed on CP nodes, it has no\neffect on DP nodes.\n\nValid values to this setting are:\n\n- `on`: OCSP revocation check is enabled and DP\n  must pass the check in order to establish\n  connection with CP.\n- `off`: OCSP revocation check is disabled.\n- `optional`: OCSP revocation check will be attempted,\n  however, if the required extension is not\n  found inside DP provided certificate\n  or communication with the OCSP responder\n  failed, then DP is still allowed through.\n"
   },
   "cluster_use_proxy": {
     "defaultValue": "off",
-    "description": " Whether to turn on HTTP CONNECT proxy support for hybrid mode connections. `proxy_server` will be used for Hybrid mode connections if this option is turned on."
+    "description": "Whether to turn on HTTP CONNECT proxy support for\nhybrid mode connections. `proxy_server` will be used\nfor Hybrid mode connections if this option is turned on.\n"
   },
   "cluster_max_payload": {
     "defaultValue": "16777216",
-    "description": " This sets the maximum compressed payload size allowed to be sent across from CP to DP in Hybrid mode Default is 16MB - 16 * 1024 * 1024."
+    "description": "This sets the maximum compressed payload size allowed\nto be sent across from CP to DP in Hybrid mode\nDefault is 16MB - 16 * 1024 * 1024.\n"
   },
   "proxy_listen": {
     "defaultValue": [
       "0.0.0.0:8000 reuseport backlog=16384",
       "0.0.0.0:8443 http2 ssl reuseport backlog=16384"
     ],
-    "description": " Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. The proxy server is the public entry point of Kong, which proxies traffic from your consumers to your backend services. This value accepts IPv4, IPv6, and hostnames.  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the TCP_DEFER_ACCEPT socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  This value can be set to `off`, thus disabling the HTTP/HTTPS proxy port for this node. If stream_listen is also set to `off`, this enables 'control-plane' mode for this node (in which all traffic proxying capabilities are disabled). This node can then be used only to configure a cluster of Kong nodes connected to the same datastore.  Example: `proxy_listen = 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`  See http://nginx.org/en/docs/http/ngx_http_core_module.html#listen for a description of the accepted formats for this and other `*_listen` values.  See https://www.nginx.com/resources/admin-guide/proxy-protocol/ for more details about the `proxy_protocol` parameter.  Not all `*_listen` values accept all formats specified in nginx's documentation."
+    "description": "Comma-separated list of addresses and ports on\nwhich the proxy server should listen for\nHTTP/HTTPS traffic.\nThe proxy server is the public entry point of Kong,\nwhich proxies traffic from your consumers to your\nbackend services. This value accepts IPv4, IPv6, and\nhostnames.\n\nSome suffixes can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's proxy server.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `deferred` instructs to use a deferred accept on\n  Linux (the TCP_DEFER_ACCEPT socket option).\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process\n  allowing the Kernel to better distribute incoming\n  connections between worker processes\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small in order to prevent clients\n  seeing \"Connection refused\" error connecting to\n  a busy Kong instance.\n  **Note:** on Linux, this value is limited by the\n  setting of `net.core.somaxconn` Kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections\n- so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]\n  configures the “TCP keepalive” behavior for the listening\n  socket. If this parameter is omitted then the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value “on”, the SO_KEEPALIVE option is turned\n  on for the socket. If it is set to the value “off”, the\n  SO_KEEPALIVE option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,\n  and TCP_KEEPCNT socket options.\n\nThis value can be set to `off`, thus disabling\nthe HTTP/HTTPS proxy port for this node.\nIf stream_listen is also set to `off`, this enables\n'control-plane' mode for this node\n(in which all traffic proxying capabilities are\ndisabled). This node can then be used only to\nconfigure a cluster of Kong\nnodes connected to the same datastore.\n\nExample:\n`proxy_listen = 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`\n\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#listen\nfor a description of the accepted formats for this\nand other `*_listen` values.\n\nSee https://www.nginx.com/resources/admin-guide/proxy-protocol/\nfor more details about the `proxy_protocol`\nparameter.\n\nNot all `*_listen` values accept all formats\nspecified in nginx's documentation.\n"
   },
   "proxy_url": {
     "defaultValue": null,
-    "description": "Kong Proxy URL  The lookup, or balancer, address for your Kong Proxy nodes.  This value is commonly used in a microservices or service-mesh oriented architecture.  Accepted format (parts in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`  Examples:  - `<scheme>://<IP>:<PORT>` -> `proxy_url = http://127.0.0.1:8000` - `SSL <scheme>://<HOSTNAME>` -> `proxy_url = https://proxy.domain.tld` - `<scheme>://<HOSTNAME>/<PATH>` -> `proxy_url = http://dev-machine/dev-285`  By default, Kong Manager, and Kong Portal will use the window request host and append the resolved listener port depending on the requested protocol."
+    "description": "Kong Proxy URL\n\nThe lookup, or balancer, address for your Kong Proxy nodes.\n\nThis value is commonly used in a microservices\nor service-mesh oriented architecture.\n\nAccepted format (parts in parentheses are optional):\n\n  `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`\n\nExamples:\n\n- `<scheme>://<IP>:<PORT>` -> `proxy_url = http://127.0.0.1:8000`\n- `SSL <scheme>://<HOSTNAME>` -> `proxy_url = https://proxy.domain.tld`\n- `<scheme>://<HOSTNAME>/<PATH>` -> `proxy_url = http://dev-machine/dev-285`\n\nBy default, Kong Manager, and Kong Portal will use\nthe window request host and append the resolved\nlistener port depending on the requested protocol.\n"
   },
   "stream_listen": {
     "defaultValue": "off",
-    "description": " Comma-separated list of addresses and ports on which the stream mode should listen.  This value accepts IPv4, IPv6, and hostnames. Some suffixes can be specified for each pair: - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  Examples:  ``` stream_listen = 127.0.0.1:7000 reuseport backlog=16384 stream_listen = 0.0.0.0:989 reuseport backlog=65536, 0.0.0.0:20 stream_listen = [::1]:1234 backlog=16384 ```  By default this value is set to `off`, thus disabling the stream proxy port for this node."
+    "description": "Comma-separated list of addresses and ports on\nwhich the stream mode should listen.\n\nThis value accepts IPv4, IPv6, and hostnames.\nSome suffixes can be specified for each pair:\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process\n  allowing the Kernel to better distribute incoming\n  connections between worker processes\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small in order to prevent clients\n  seeing \"Connection refused\" error connecting to\n  a busy Kong instance.\n  **Note:** on Linux, this value is limited by the\n  setting of `net.core.somaxconn` Kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections\n- so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]\n  configures the “TCP keepalive” behavior for the listening\n  socket. If this parameter is omitted then the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value “on”, the SO_KEEPALIVE option is turned\n  on for the socket. If it is set to the value “off”, the\n  SO_KEEPALIVE option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,\n  and TCP_KEEPCNT socket options.\n\nExamples:\n\n```\nstream_listen = 127.0.0.1:7000 reuseport backlog=16384\nstream_listen = 0.0.0.0:989 reuseport backlog=65536, 0.0.0.0:20\nstream_listen = [::1]:1234 backlog=16384\n```\n\nBy default this value is set to `off`, thus\ndisabling the stream proxy port for this node.\n"
   },
   "admin_api_uri": {
     "defaultValue": null,
-    "description": "Deprecated: Use admin_gui_api_url instead"
+    "description": "Deprecated: Use admin_gui_api_url instead\n"
   },
   "admin_listen": {
     "defaultValue": [
       "127.0.0.1:8001 reuseport backlog=16384",
       "127.0.0.1:8444 http2 ssl reuseport backlog=16384"
     ],
-    "description": " Comma-separated list of addresses and ports on which the Admin interface should listen. The Admin interface is the API allowing you to configure and manage Kong. Access to this interface should be *restricted* to Kong administrators *only*. This value accepts IPv4, IPv6, and hostnames.  It is highly recommended to avoid exposing the Admin API to public interface(s), by using values such as 0.0.0.0:8001  See https://docs.konghq.com/gateway/latest/production/running-kong/secure-admin-api/ for more information about how to secure your Admin API  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the TCP_DEFER_ACCEPT socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  This value can be set to `off`, thus disabling the Admin interface for this node, enabling a 'data-plane' mode (without configuration capabilities) pulling its configuration changes from the database.  Example: `admin_listen = 127.0.0.1:8444 http2 ssl`"
+    "description": "Comma-separated list of addresses and ports on\nwhich the Admin interface should listen.\nThe Admin interface is the API allowing you to\nconfigure and manage Kong.\nAccess to this interface should be *restricted*\nto Kong administrators *only*. This value accepts\nIPv4, IPv6, and hostnames.\n\nIt is highly recommended to avoid exposing the Admin API to public\ninterface(s), by using values such as 0.0.0.0:8001\n\nSee https://docs.konghq.com/gateway/latest/production/running-kong/secure-admin-api/\nfor more information about how to secure your Admin API\n\nSome suffixes can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's proxy server.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `deferred` instructs to use a deferred accept on\n  Linux (the TCP_DEFER_ACCEPT socket option).\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process\n  allowing the Kernel to better distribute incoming\n  connections between worker processes\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small in order to prevent clients\n  seeing \"Connection refused\" error connecting to\n  a busy Kong instance.\n  **Note:** on Linux, this value is limited by the\n  setting of `net.core.somaxconn` Kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections\n- so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]\n  configures the “TCP keepalive” behavior for the listening\n  socket. If this parameter is omitted then the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value “on”, the SO_KEEPALIVE option is turned\n  on for the socket. If it is set to the value “off”, the\n  SO_KEEPALIVE option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,\n  and TCP_KEEPCNT socket options.\n\nThis value can be set to `off`, thus disabling\nthe Admin interface for this node, enabling a\n'data-plane' mode (without configuration\ncapabilities) pulling its configuration changes\nfrom the database.\n\nExample: `admin_listen = 127.0.0.1:8444 http2 ssl`\n"
   },
   "status_listen": {
     "defaultValue": "off",
-    "description": "Comma-separated list of addresses and ports on which the Status API should listen. The Status API is a read-only endpoint allowing monitoring tools to retrieve metrics, healthiness, and other non-sensitive information of the current Kong node.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Status API server.  This value can be set to `off`, disabling the Status API for this node.  Example: `status_listen = 0.0.0.0:8100 ssl http2`"
+    "description": "Comma-separated list of addresses and ports on\nwhich the Status API should listen.\nThe Status API is a read-only endpoint\nallowing monitoring tools to retrieve metrics,\nhealthiness, and other non-sensitive information\nof the current Kong node.\n\nThe following suffix can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's Status API server.\n\nThis value can be set to `off`, disabling\nthe Status API for this node.\n\nExample: `status_listen = 0.0.0.0:8100 ssl http2`\n"
   },
   "debug_listen": {
     "defaultValue": "off",
-    "description": "Comma-separated list of addresses and ports on which the Debug API should listen.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Debug API server.  This value can be set to `off`, disabling the Debug API for this node.  Example: `debug_listen = 0.0.0.0:8200 ssl http2`"
+    "description": "Comma-separated list of addresses and ports on\nwhich the Debug API should listen.\n\nThe following suffix can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's Debug API server.\n\nThis value can be set to `off`, disabling\nthe Debug API for this node.\n\nExample: `debug_listen = 0.0.0.0:8200 ssl http2`\n"
   },
   "debug_listen_local": {
     "defaultValue": "on",
-    "description": "Expose `debug_listen` functionalities via a Unix domain socket under the Kong prefix.  This option allows local user to use \"kong debug\" command to invoke various debug functionalities without needing to enable `debug_listen` ahead of time."
+    "description": "Expose `debug_listen` functionalities via a\nUnix domain socket under the Kong prefix.\n\nThis option allows local user to use \"kong debug\" command\nto invoke various debug functionalities without needing to\nenable `debug_listen` ahead of time.\n"
   },
   "nginx_user": {
     "defaultValue": "kong kong",
-    "description": "Defines user and group credentials used by worker processes. If group is omitted, a group whose name equals that of user is used.  Example: `nginx_user = nginx www`  **Note**: If the `kong` user and the `kong` group are not available, the default user and group credentials will be `nobody nobody`."
+    "description": "Defines user and group credentials used by\nworker processes. If group is omitted, a\ngroup whose name equals that of user is\nused.\n\nExample: `nginx_user = nginx www`\n\n**Note**: If the `kong` user and the `kong`\ngroup are not available, the default user\nand group credentials will be\n`nobody nobody`.\n"
   },
   "nginx_worker_processes": {
     "defaultValue": "auto",
-    "description": "Determines the number of worker processes spawned by Nginx.  See http://nginx.org/en/docs/ngx_core_module.html#worker_processes for detailed usage of the equivalent Nginx directive and a description of accepted values."
+    "description": "Determines the number of worker processes\nspawned by Nginx.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_processes\nfor detailed usage of the equivalent Nginx\ndirective and a description of accepted\nvalues.\n"
   },
   "nginx_daemon": {
     "defaultValue": "on",
-    "description": "Determines whether Nginx will run as a daemon or as a foreground process. Mainly useful for development or when running Kong inside a Docker environment.  See http://nginx.org/en/docs/ngx_core_module.html#daemon."
+    "description": "Determines whether Nginx will run as a daemon\nor as a foreground process. Mainly useful\nfor development or when running Kong inside\na Docker environment.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#daemon.\n"
   },
   "mem_cache_size": {
     "defaultValue": "128m",
-    "description": "Size of each of the two shared memory caches for traditional mode database entities and runtime data. The accepted units are `k` and `m`, with a minimum recommended value of a few MBs.  **Note**: As this option controls the size of two different cache zones, the total memory Kong uses to cache entities might be double this value. The created zones are shared by all worker processes and do not become larger when more worker is used."
+    "description": "Size of each of the two shared memory caches\nfor traditional mode database entities\nand runtime data.\nThe accepted units are `k` and `m`, with a minimum\nrecommended value of a few MBs.\n\n**Note**: As this option controls the size of two\ndifferent cache zones, the total memory Kong\nuses to cache entities might be double this value.\nThe created zones are shared by all worker\nprocesses and do not become larger when more\nworker is used.\n"
   },
   "ssl_cipher_suite": {
     "defaultValue": "intermediate",
-    "description": "Defines the TLS ciphers served by Nginx. Accepted values are `modern`, `intermediate`, `old`, `fips` or `custom`. If you want to enable TLSv1.1, this value has to be `old`.  See https://wiki.mozilla.org/Security/Server_Side_TLS for detailed descriptions of each cipher suite. `fips` cipher suites are as described in https://wiki.openssl.org/index.php/FIPS_mode_and_TLS."
+    "description": "Defines the TLS ciphers served by Nginx.\nAccepted values are `modern`,\n`intermediate`, `old`, `fips` or `custom`.\nIf you want to enable TLSv1.1, this value has to be `old`.\n\nSee https://wiki.mozilla.org/Security/Server_Side_TLS\nfor detailed descriptions of each cipher\nsuite. `fips` cipher suites are as described in\nhttps://wiki.openssl.org/index.php/FIPS_mode_and_TLS.\n"
   },
   "ssl_ciphers": {
     "defaultValue": null,
-    "description": "Defines a custom list of TLS ciphers to be served by Nginx. This list must conform to the pattern defined by `openssl ciphers`. This value is ignored if `ssl_cipher_suite` is not `custom`. If you use DHE ciphers, you must also configure the `ssl_dhparam` parameter."
+    "description": "Defines a custom list of TLS ciphers to be\nserved by Nginx. This list must conform to\nthe pattern defined by `openssl ciphers`.\nThis value is ignored if `ssl_cipher_suite`\nis not `custom`.\nIf you use DHE ciphers, you must also\nconfigure the `ssl_dhparam` parameter.\n"
   },
   "ssl_protocols": {
     "defaultValue": "TLSv1.2 TLSv1.3",
-    "description": " Enables the specified protocols for client-side connections. The set of supported protocol versions also depends on the version of OpenSSL Kong was built with. This value is ignored if `ssl_cipher_suite` is not `custom`. If you want to enable TLSv1.1, you should set `ssl_cipher_suite` to `old`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols"
+    "description": "Enables the specified protocols for\nclient-side connections. The set of\nsupported protocol versions also depends\non the version of OpenSSL Kong was built\nwith. This value is ignored if\n`ssl_cipher_suite` is not `custom`.\nIf you want to enable TLSv1.1, you should\nset `ssl_cipher_suite` to `old`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols\n"
   },
   "ssl_prefer_server_ciphers": {
     "defaultValue": "on",
-    "description": "Specifies that server ciphers should be preferred over client ciphers when using the SSLv3 and TLS protocols. This value is ignored if `ssl_cipher_suite` is not `custom`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers"
+    "description": "Specifies that server ciphers should be\npreferred over client ciphers when using\nthe SSLv3 and TLS protocols. This value is\nignored if `ssl_cipher_suite` is not `custom`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers\n"
   },
   "ssl_dhparam": {
     "defaultValue": null,
-    "description": "Defines DH parameters for DHE ciphers from the predefined groups: `ffdhe2048`, `ffdhe3072`, `ffdhe4096`, `ffdhe6144`, `ffdhe8192`, from the absolute path to a parameters file, or directly from the parameters content.  This value is ignored if `ssl_cipher_suite` is `modern` or `intermediate`. The reason is that `modern` has no ciphers that needs this, and `intermediate` uses `ffdhe2048`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam"
+    "description": "Defines DH parameters for DHE ciphers from the\npredefined groups: `ffdhe2048`, `ffdhe3072`,\n`ffdhe4096`, `ffdhe6144`, `ffdhe8192`,\nfrom the absolute path to a parameters file, or\ndirectly from the parameters content.\n\nThis value is ignored if `ssl_cipher_suite`\nis `modern` or `intermediate`. The reason is\nthat `modern` has no ciphers that needs this,\nand `intermediate` uses `ffdhe2048`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam\n"
   },
   "ssl_session_tickets": {
     "defaultValue": "on",
-    "description": "Enables or disables session resumption through TLS session tickets. This has no impact when used with TLSv1.3.  Kong enables this by default for performance reasons, but it has security implications: https://github.com/mozilla/server-side-tls/issues/135  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets"
+    "description": "Enables or disables session resumption through\nTLS session tickets. This has no impact when\nused with TLSv1.3.\n\nKong enables this by default for performance\nreasons, but it has security implications:\nhttps://github.com/mozilla/server-side-tls/issues/135\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets\n"
   },
   "ssl_session_timeout": {
     "defaultValue": "1d",
-    "description": "Specifies a time during which a client may reuse the session parameters. See the rationale: https://github.com/mozilla/server-side-tls/issues/198  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout"
+    "description": "Specifies a time during which a client may\nreuse the session parameters. See the rationale:\nhttps://github.com/mozilla/server-side-tls/issues/198\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout\n"
   },
   "ssl_session_cache_size": {
     "defaultValue": "10m",
-    "description": "Sets the size of the caches that store session parameters  See https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache"
+    "description": "Sets the size of the caches that store session parameters\n\nSee https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache\n"
   },
   "ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `proxy_listen` values with TLS enabled.  If more than one certificates are specified, it can be used to provide alternate type of certificate (for example, ECC certificate) that will be served to clients that supports them. Note to properly serve using ECC certificates, it is recommended to also set `ssl_cipher_suite` to `modern` or `intermediate`.  Unless this option is explicitly set, Kong will auto-generate a pair of default certificates (RSA + ECC) first time it starts up and use it for serving TLS requests.  Certificates can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "Comma-separated list of certificates for `proxy_listen` values with TLS enabled.\n\nIf more than one certificates are specified, it can be used to provide\nalternate type of certificate (for example, ECC certificate) that will be served\nto clients that supports them. Note to properly serve using ECC certificates,\nit is recommended to also set `ssl_cipher_suite` to\n`modern` or `intermediate`.\n\nUnless this option is explicitly set, Kong will auto-generate\na pair of default certificates (RSA + ECC) first time it starts up and use\nit for serving TLS requests.\n\nCertificates can be configured on this property with either of the following\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `proxy_listen` values with TLS enabled.  If more than one certificate was specified for `ssl_cert`, then this option should contain the corresponding key for all certificates provided in the same order.  Unless this option is explicitly set, Kong will auto-generate a pair of default private keys (RSA + ECC) first time it starts up and use it for serving TLS requests.  Keys can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+    "description": "Comma-separated list of keys for `proxy_listen` values with TLS enabled.\n\nIf more than one certificate was specified for `ssl_cert`, then this\noption should contain the corresponding key for all certificates\nprovided in the same order.\n\nUnless this option is explicitly set, Kong will auto-generate\na pair of default private keys (RSA + ECC) first time it starts up and use\nit for serving TLS requests.\n\nKeys can be configured on this property with either of the following\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n"
   },
   "client_ssl": {
     "defaultValue": "off",
-    "description": "Determines if Nginx should attempt to send client-side TLS certificates and perform Mutual TLS Authentication with upstream service when proxying requests."
+    "description": "Determines if Nginx should attempt to send client-side\nTLS certificates and perform Mutual TLS Authentication\nwith upstream service when proxying requests.\n"
   },
   "client_ssl_cert": {
     "defaultValue": null,
-    "description": "If `client_ssl` is enabled, the client certificate for the `proxy_ssl_certificate` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "If `client_ssl` is enabled, the client certificate\nfor the `proxy_ssl_certificate` directive.\n\nThis value can be overwritten dynamically with the `client_certificate`\nattribute of the `Service` object.\n\nThe certificate can be configured on this property with either of the following\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "client_ssl_cert_key": {
     "defaultValue": null,
-    "description": "If `client_ssl` is enabled, the client TLS key for the `proxy_ssl_certificate_key` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate key can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+    "description": "If `client_ssl` is enabled, the client TLS key\nfor the `proxy_ssl_certificate_key` directive.\n\nThis value can be overwritten dynamically with the `client_certificate`\nattribute of the `Service` object.\n\nThe certificate key can be configured on this property with either of the following\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n"
   },
   "admin_ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `admin_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+    "description": "Comma-separated list of certificates for `admin_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n"
   },
   "admin_ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `admin_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+    "description": "Comma-separated list of keys for `admin_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n"
   },
   "status_ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `status_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+    "description": "Comma-separated list of certificates for `status_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n"
   },
   "status_ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `status_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+    "description": "Comma-separated list of keys for `status_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n"
   },
   "debug_ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `debug_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+    "description": "Comma-separated list of certificates for `debug_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n"
   },
   "debug_ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `debug_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+    "description": "Comma-separated list of keys for `debug_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n"
   },
   "headers": {
     "defaultValue": [
@@ -327,287 +327,287 @@
       "latency_tokens",
       "X-Kong-Request-Id"
     ],
-    "description": " Comma-separated list of headers Kong should inject in client responses.  Accepted values are: - `Server`: Injects `Server: kong/x.y.z`   on Kong-produced response (e.g. Admin   API, rejected requests from auth plugin). - `Via`: Injects `Via: kong/x.y.z` for   successfully proxied requests. - `X-Kong-Proxy-Latency`: Time taken   (in milliseconds) by Kong to process   a request and run all plugins before   proxying the request upstream. - `X-Kong-Response-Latency`: time taken   (in millisecond) by Kong to produce   a response in case of e.g. plugin   short-circuiting the request, or in   in case of an error. - `X-Kong-Upstream-Latency`: Time taken   (in milliseconds) by the upstream   service to send response headers. - `X-Kong-Admin-Latency`: Time taken   (in milliseconds) by Kong to process   an Admin API request. - `X-Kong-Upstream-Status`: The HTTP status   code returned by the upstream service.   This is particularly useful for clients to   distinguish upstream statuses if the   response is rewritten by a plugin. - `X-Kong-Request-Id`: Unique identifier of   the request. - `server_tokens`: Same as specifying both   `Server` and `Via`. - `latency_tokens`: Same as specifying   `X-Kong-Proxy-Latency`,   `X-Kong-Response-Latency`,   `X-Kong-Admin-Latency` and   `X-Kong-Upstream-Latency`  In addition to those, this value can be set to `off`, which prevents Kong from injecting any of the above headers. Note that this does not prevent plugins from injecting headers of their own.  Example: `headers = via, latency_tokens`"
+    "description": "Comma-separated list of headers Kong should\ninject in client responses.\n\nAccepted values are:\n- `Server`: Injects `Server: kong/x.y.z`\n  on Kong-produced response (e.g. Admin\n  API, rejected requests from auth plugin).\n- `Via`: Injects `Via: kong/x.y.z` for\n  successfully proxied requests.\n- `X-Kong-Proxy-Latency`: Time taken\n  (in milliseconds) by Kong to process\n  a request and run all plugins before\n  proxying the request upstream.\n- `X-Kong-Response-Latency`: time taken\n  (in millisecond) by Kong to produce\n  a response in case of e.g. plugin\n  short-circuiting the request, or in\n  in case of an error.\n- `X-Kong-Upstream-Latency`: Time taken\n  (in milliseconds) by the upstream\n  service to send response headers.\n- `X-Kong-Admin-Latency`: Time taken\n  (in milliseconds) by Kong to process\n  an Admin API request.\n- `X-Kong-Upstream-Status`: The HTTP status\n  code returned by the upstream service.\n  This is particularly useful for clients to\n  distinguish upstream statuses if the\n  response is rewritten by a plugin.\n- `X-Kong-Request-Id`: Unique identifier of\n  the request.\n- `server_tokens`: Same as specifying both\n  `Server` and `Via`.\n- `latency_tokens`: Same as specifying\n  `X-Kong-Proxy-Latency`,\n  `X-Kong-Response-Latency`,\n  `X-Kong-Admin-Latency` and\n  `X-Kong-Upstream-Latency`\n\nIn addition to those, this value can be set\nto `off`, which prevents Kong from injecting\nany of the above headers. Note that this\ndoes not prevent plugins from injecting\nheaders of their own.\n\nExample: `headers = via, latency_tokens`\n"
   },
   "headers_upstream": {
     "defaultValue": "X-Kong-Request-Id",
-    "description": " Comma-separated list of headers Kong should inject in requests to upstream.  At this time, the only accepted value is: - `X-Kong-Request-Id`: Unique identifier of   the request.  In addition, this value can be set to `off`, which prevents Kong from injecting the above header. Note that this does not prevent plugins from injecting headers of their own."
+    "description": "Comma-separated list of headers Kong should\ninject in requests to upstream.\n\nAt this time, the only accepted value is:\n- `X-Kong-Request-Id`: Unique identifier of\n  the request.\n\nIn addition, this value can be set\nto `off`, which prevents Kong from injecting\nthe above header. Note that this\ndoes not prevent plugins from injecting\nheaders of their own.\n"
   },
   "trusted_ips": {
     "defaultValue": null,
-    "description": "Defines trusted IP addresses blocks that are known to send correct `X-Forwarded-*` headers. Requests from trusted IPs make Kong forward their `X-Forwarded-*` headers upstream. Non-trusted requests make Kong insert its own `X-Forwarded-*` headers.  This property also sets the `set_real_ip_from` directive(s) in the Nginx configuration. It accepts the same type of values (CIDR blocks) but as a comma-separated list.  To trust *all* /!\\ IPs, set this value to `0.0.0.0/0,::/0`.  If the special value `unix:` is specified, all UNIX-domain sockets will be trusted.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from for examples of accepted values."
+    "description": "Defines trusted IP addresses blocks that are\nknown to send correct `X-Forwarded-*`\nheaders.\nRequests from trusted IPs make Kong forward\ntheir `X-Forwarded-*` headers upstream.\nNon-trusted requests make Kong insert its\nown `X-Forwarded-*` headers.\n\nThis property also sets the\n`set_real_ip_from` directive(s) in the Nginx\nconfiguration. It accepts the same type of\nvalues (CIDR blocks) but as a\ncomma-separated list.\n\nTo trust *all* /!\\ IPs, set this value to\n`0.0.0.0/0,::/0`.\n\nIf the special value `unix:` is specified,\nall UNIX-domain sockets will be trusted.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from\nfor examples of accepted values.\n"
   },
   "real_ip_header": {
     "defaultValue": "X-Real-IP",
-    "description": "Defines the request header field whose value will be used to replace the client address. This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  If this value receives `proxy_protocol`:  - at least one of the `proxy_listen` entries   must have the `proxy_protocol` flag   enabled. - the `proxy_protocol` parameter will be   appended to the `listen` directive of the   Nginx template.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header for a description of this directive."
+    "description": "Defines the request header field whose value\nwill be used to replace the client address.\nThis value sets the `ngx_http_realip_module`\ndirective of the same name in the Nginx\nconfiguration.\n\nIf this value receives `proxy_protocol`:\n\n- at least one of the `proxy_listen` entries\n  must have the `proxy_protocol` flag\n  enabled.\n- the `proxy_protocol` parameter will be\n  appended to the `listen` directive of the\n  Nginx template.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header\nfor a description of this directive.\n"
   },
   "real_ip_recursive": {
     "defaultValue": "off",
-    "description": "This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive for a description of this directive."
+    "description": "This value sets the `ngx_http_realip_module`\ndirective of the same name in the Nginx\nconfiguration.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive\nfor a description of this directive.\n"
   },
   "error_default_type": {
     "defaultValue": "text/plain",
-    "description": "Default MIME type to use when the request `Accept` header is missing and Nginx is returning an error for the request. Accepted values are `text/plain`, `text/html`, `application/json`, and `application/xml`."
+    "description": "Default MIME type to use when the request\n`Accept` header is missing and Nginx\nis returning an error for the request.\nAccepted values are `text/plain`,\n`text/html`, `application/json`, and\n`application/xml`.\n"
   },
   "upstream_keepalive_pool_size": {
     "defaultValue": "512",
-    "description": "Sets the default size of the upstream keepalive connection pools. Upstream keepalive connection pools are segmented by the `dst ip/dst port/SNI` attributes of a connection. A value of `0` will disable upstream keepalive connections by default, forcing each upstream request to open a new connection."
+    "description": "Sets the default size of the upstream\nkeepalive connection pools.\nUpstream keepalive connection pools\nare segmented by the `dst ip/dst\nport/SNI` attributes of a connection.\nA value of `0` will disable upstream\nkeepalive connections by default, forcing\neach upstream request to open a new\nconnection.\n"
   },
   "upstream_keepalive_max_requests": {
     "defaultValue": "10000",
-    "description": "Sets the default maximum number of requests than can be proxied upstream through one keepalive connection. After the maximum number of requests is reached, the connection will be closed. A value of `0` will disable this behavior, and a keepalive connection can be used to proxy an indefinite number of requests."
+    "description": "Sets the default maximum number of\nrequests than can be proxied upstream\nthrough one keepalive connection.\nAfter the maximum number of requests\nis reached, the connection will be\nclosed.\nA value of `0` will disable this\nbehavior, and a keepalive connection\ncan be used to proxy an indefinite\nnumber of requests.\n"
   },
   "upstream_keepalive_idle_timeout": {
     "defaultValue": "60",
-    "description": "Sets the default timeout (in seconds) for which an upstream keepalive connection should be kept open. When the timeout is reached while the connection has not been reused, it will be closed. A value of `0` will disable this behavior, and an idle keepalive connection may be kept open indefinitely."
+    "description": "Sets the default timeout (in seconds)\nfor which an upstream keepalive\nconnection should be kept open. When\nthe timeout is reached while the\nconnection has not been reused, it\nwill be closed.\nA value of `0` will disable this\nbehavior, and an idle keepalive\nconnection may be kept open\nindefinitely.\n"
   },
   "allow_debug_header": {
     "defaultValue": "off",
-    "description": "Enable the `Kong-Debug` header function. if it is `on`, kong will add `Kong-Route-Id` `Kong-Route-Name` `Kong-Service-Id` `Kong-Service-Name` debug headers to response when the client request header `Kong-Debug: 1` is present."
+    "description": "Enable the `Kong-Debug` header function.\nif it is `on`, kong will add\n`Kong-Route-Id` `Kong-Route-Name` `Kong-Service-Id`\n`Kong-Service-Name` debug headers to response when\nthe client request header `Kong-Debug: 1` is present.\n"
   },
   "nginx_main_worker_rlimit_nofile": {
     "defaultValue": "auto",
-    "description": " Changes the limit on the maximum number of open files for worker processes.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile"
+    "description": "Changes the limit on the maximum number of open files\nfor worker processes.\n\nThe special and default value of `auto` sets this\nvalue to `ulimit -n` with the upper bound limited to\n16384 as a measure to protect against excess memory use,\nand the lower bound of 1024 as a good default.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile\n"
   },
   "nginx_events_worker_connections": {
     "defaultValue": "auto",
-    "description": " Sets the maximum number of simultaneous connections that can be opened by a worker process.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_connections"
+    "description": "Sets the maximum number of simultaneous\nconnections that can be opened by a worker process.\n\nThe special and default value of `auto` sets this\nvalue to `ulimit -n` with the upper bound limited to\n16384 as a measure to protect against excess memory use,\nand the lower bound of 1024 as a good default.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_connections\n"
   },
   "nginx_http_client_header_buffer_size": {
     "defaultValue": "1k",
-    "description": "Sets buffer size for reading the client request headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size"
+    "description": "Sets buffer size for reading the\nclient request headers.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size\n"
   },
   "nginx_http_large_client_header_buffers": {
     "defaultValue": "4 8k",
-    "description": "Sets the maximum number and size of buffers used for reading large clients requests headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers"
+    "description": "Sets the maximum number and\nsize of buffers used for\nreading large clients\nrequests headers.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers\n"
   },
   "nginx_http_client_max_body_size": {
     "defaultValue": "0",
-    "description": "Defines the maximum request body size allowed by requests proxied by Kong, specified in the Content-Length request header. If a request exceeds this limit, Kong will respond with a 413 (Request Entity Too Large). Setting this value to 0 disables checking the request body size. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size"
+    "description": "Defines the maximum request body size\nallowed by requests proxied by Kong,\nspecified in the Content-Length request\nheader. If a request exceeds this\nlimit, Kong will respond with a 413\n(Request Entity Too Large). Setting\nthis value to 0 disables checking the\nrequest body size.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size\n"
   },
   "nginx_admin_client_max_body_size": {
     "defaultValue": "10m",
-    "description": "Defines the maximum request body size for Admin API."
+    "description": "Defines the maximum request body size for\nAdmin API.\n"
   },
   "nginx_http_charset": {
     "defaultValue": "UTF-8",
-    "description": "Adds the specified charset to the “Content-Type” response header field. If this charset is different from the charset specified in the source_charset directive, a conversion is performed.  The parameter `off` cancels the addition of charset to the “Content-Type” response header field. See http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset"
+    "description": "Adds the specified charset to the “Content-Type”\nresponse header field. If this charset is different\nfrom the charset specified in the source_charset\ndirective, a conversion is performed.\n\nThe parameter `off` cancels the addition of\ncharset to the “Content-Type” response header field.\nSee http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset\n"
   },
   "nginx_http_client_body_buffer_size": {
     "defaultValue": "8k",
-    "description": "Defines the buffer size for reading the request body. If the client request body is larger than this value, the body will be buffered to disk. Note that when the body is buffered to disk, Kong plugins that access or manipulate the request body may not work, so it is advisable to set this value as high as possible (e.g., set it as high as `client_max_body_size` to force request bodies to be kept in memory). Do note that high-concurrency environments will require significant memory allocations to process many concurrent large request bodies. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size"
+    "description": "Defines the buffer size for reading\nthe request body. If the client\nrequest body is larger than this\nvalue, the body will be buffered to\ndisk. Note that when the body is\nbuffered to disk, Kong plugins that\naccess or manipulate the request\nbody may not work, so it is\nadvisable to set this value as high\nas possible (e.g., set it as high\nas `client_max_body_size` to force\nrequest bodies to be kept in\nmemory). Do note that\nhigh-concurrency environments will\nrequire significant memory\nallocations to process many\nconcurrent large request bodies.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size\n"
   },
   "nginx_admin_client_body_buffer_size": {
     "defaultValue": "10m",
-    "description": "Defines the buffer size for reading the request body on Admin API."
+    "description": "Defines the buffer size for reading\nthe request body on Admin API.\n"
   },
   "nginx_http_lua_regex_match_limit": {
     "defaultValue": "100000",
-    "description": "Global `MATCH_LIMIT` for PCRE regex matching. The default of `100000` should ensure at worst any regex Kong executes could finish within roughly 2 seconds."
+    "description": "Global `MATCH_LIMIT` for PCRE\nregex matching. The default of `100000` should ensure\nat worst any regex Kong executes could finish within\nroughly 2 seconds.\n"
   },
   "nginx_http_lua_regex_cache_max_entries": {
     "defaultValue": "8192",
-    "description": "Specifies the maximum number of entries allowed in the worker process level compiled regex cache. It is recommended to set it to at least (number of regex paths * 2) to avoid high CPU usages."
+    "description": "Specifies the maximum number of entries allowed\nin the worker process level compiled regex cache.\nIt is recommended to set it to at least (number of regex paths * 2)\nto avoid high CPU usages.\n"
   },
   "nginx_http_keepalive_requests": {
     "defaultValue": "10000",
-    "description": "Sets the maximum number of client requests that can be served through one keep-alive connection. After the maximum number of requests are made, the connection is closed. Closing connections periodically is necessary to free per-connection memory allocations. Therefore, using too high maximum number of requests could result in excessive memory usage and not recommended. See: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests"
+    "description": "Sets the maximum number of client requests that can be served through one\nkeep-alive connection. After the maximum number of requests are made,\nthe connection is closed.\nClosing connections periodically is necessary to free per-connection\nmemory allocations. Therefore, using too high maximum number of requests\ncould result in excessive memory usage and not recommended.\nSee: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests\n"
   },
   "database": {
     "defaultValue": "postgres",
-    "description": "Determines the database (or no database) for this node Accepted values are `postgres` and `off`."
+    "description": "Determines the database (or no database) for\nthis node\nAccepted values are `postgres` and `off`.\n"
   },
   "pg_host": {
     "defaultValue": "127.0.0.1",
-    "description": "Host of the Postgres server."
+    "description": "Host of the Postgres server.\n"
   },
   "pg_port": {
     "defaultValue": "5432",
-    "description": "Port of the Postgres server."
+    "description": "Port of the Postgres server.\n"
   },
   "pg_timeout": {
     "defaultValue": "5000",
-    "description": "Defines the timeout (in ms), for connecting, reading and writing."
+    "description": "Defines the timeout (in ms), for connecting,\nreading and writing.\n"
   },
   "pg_user": {
     "defaultValue": "kong",
-    "description": "Postgres user."
+    "description": "Postgres user.\n"
   },
   "pg_password": {
     "defaultValue": null,
-    "description": "Postgres user's password."
+    "description": "Postgres user's password.\n"
   },
   "pg_iam_auth": {
     "defaultValue": "off",
-    "description": "Determines whether the AWS IAM database Authentication will be used. When switch to `on`, the username defined in `pg_user` will be used as the database account, and the database connection will be forced to using TLS. `pg_password` will not be used when the switch is `on`. Note that the corresponding IAM policy must be correct, otherwise connecting will fail."
+    "description": "Determines whether the AWS IAM database\nAuthentication will be used. When switch to\n`on`, the username defined in `pg_user` will\nbe used as the database account, and the\ndatabase connection will be forced to using\nTLS. `pg_password` will not be used when\nthe switch is `on`. Note that the corresponding\nIAM policy must be correct, otherwise connecting\nwill fail.\n"
   },
   "pg_database": {
     "defaultValue": "kong",
-    "description": "The database name to connect to."
+    "description": "The database name to connect to.\n"
   },
   "pg_schema": {
     "defaultValue": null,
-    "description": "The database schema to use. If unspecified, Kong will respect the `search_path` value of your PostgreSQL instance."
+    "description": "The database schema to use. If unspecified,\nKong will respect the `search_path` value of\nyour PostgreSQL instance.\n"
   },
   "pg_ssl": {
     "defaultValue": "off",
-    "description": "Toggles client-server TLS connections between Kong and PostgreSQL. Because PostgreSQL uses the same port for TLS and non-TLS, this is only a hint. If the server does not support TLS, the established connection will be a plain one."
+    "description": "Toggles client-server TLS connections\nbetween Kong and PostgreSQL.\nBecause PostgreSQL uses the same port for TLS\nand non-TLS, this is only a hint. If the\nserver does not support TLS, the established\nconnection will be a plain one.\n"
   },
   "pg_ssl_version": {
     "defaultValue": "tlsv1_2",
-    "description": "When using ssl between Kong and PostgreSQL, the version of tls to use. Accepted values are `tlsv1_1`, `tlsv1_2`, `tlsv1_3`, or 'any'. When `any` is set, the client negotiates the highest version with the server which can't be lower than `tlsv1_1`."
+    "description": "When using ssl between Kong and PostgreSQL,\nthe version of tls to use. Accepted values are\n`tlsv1_1`, `tlsv1_2`, `tlsv1_3`, or 'any'. When\n`any` is set, the client negotiates the highest\nversion with the server which can't be lower\nthan `tlsv1_1`.\n"
   },
   "pg_ssl_required": {
     "defaultValue": "off",
-    "description": "When `pg_ssl` is on this determines if TLS must be used between Kong and PostgreSQL. It aborts the connection if the server does not support SSL connections."
+    "description": "When `pg_ssl` is on this determines if\nTLS must be used between Kong and PostgreSQL.\nIt aborts the connection if the server does\nnot support SSL connections.\n"
   },
   "pg_ssl_verify": {
     "defaultValue": "off",
-    "description": "Toggles server certificate verification if `pg_ssl` is enabled. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+    "description": "Toggles server certificate verification if\n`pg_ssl` is enabled.\nSee the `lua_ssl_trusted_certificate`\nsetting to specify a certificate authority.\n"
   },
   "pg_ssl_cert": {
     "defaultValue": null,
-    "description": "The absolute path to the PEM encoded client TLS certificate for the PostgreSQL connection. Mutual TLS authentication against PostgreSQL is only enabled if this value is set."
+    "description": "The absolute path to the PEM encoded client\nTLS certificate for the PostgreSQL connection.\nMutual TLS authentication against\nPostgreSQL is only enabled if this value is set.\n"
   },
   "pg_ssl_cert_key": {
     "defaultValue": null,
-    "description": "If `pg_ssl_cert` is set, the absolute path to the PEM encoded client TLS private key for the PostgreSQL connection."
+    "description": "If `pg_ssl_cert` is set, the absolute path to\nthe PEM encoded client TLS private key for the\nPostgreSQL connection.\n"
   },
   "pg_max_concurrent_queries": {
     "defaultValue": "0",
-    "description": "Sets the maximum number of concurrent queries that can be executing at any given time. This limit is enforced per worker process; the total number of concurrent queries for this node will be will be: `pg_max_concurrent_queries * nginx_worker_processes`.  The default value of 0 removes this concurrency limitation."
+    "description": "Sets the maximum number of concurrent queries\nthat can be executing at any given time. This\nlimit is enforced per worker process; the\ntotal number of concurrent queries for this\nnode will be will be:\n`pg_max_concurrent_queries * nginx_worker_processes`.\n\nThe default value of 0 removes this\nconcurrency limitation.\n"
   },
   "pg_semaphore_timeout": {
     "defaultValue": "60000",
-    "description": "Defines the timeout (in ms) after which PostgreSQL query semaphore resource acquisition attempts will fail. Such failures will generally result in the associated proxy or Admin API request failing with an HTTP 500 status code. Detailed discussion of this behavior is available in the online documentation."
+    "description": "Defines the timeout (in ms) after which\nPostgreSQL query semaphore resource\nacquisition attempts will fail. Such\nfailures will generally result in the\nassociated proxy or Admin API request\nfailing with an HTTP 500 status code.\nDetailed discussion of this behavior is\navailable in the online documentation.\n"
   },
   "pg_keepalive_timeout": {
     "defaultValue": null,
-    "description": "Specify the maximal idle timeout (in ms) for the postgres connections in the pool. If this value is set to 0 then the timeout interval is unlimited.  If not specified this value will be same as `lua_socket_keepalive_timeout`"
+    "description": "Specify the maximal idle timeout (in ms)\nfor the postgres connections in the pool.\nIf this value is set to 0 then the timeout interval\nis unlimited.\n\nIf not specified this value will be same as\n`lua_socket_keepalive_timeout`\n"
   },
   "pg_pool_size": {
     "defaultValue": null,
-    "description": "Specifies the size limit (in terms of connection count) for the Postgres server. Note that this connection pool is intended per Nginx worker rather than per Kong instance.  If not specified, the default value is the same as `lua_socket_pool_size`"
+    "description": "Specifies the size limit (in terms of connection\ncount) for the Postgres server.\nNote that this connection pool is intended\nper Nginx worker rather than per Kong instance.\n\nIf not specified, the default value is the same as\n`lua_socket_pool_size`\n"
   },
   "pg_backlog": {
     "defaultValue": null,
-    "description": "If specified, this value will limit the total number of open connections to the Postgres server to `pg_pool_size`. If the connection pool is full, subsequent connect operations will be inserted in a queue with size equal to this option's value.  If the number of queued connect operations reaches `pg_backlog`, exceeding connections will fail.  If not specified, then number of open connections to the Postgres server is not limited."
+    "description": "If specified, this value will limit the total\nnumber of open connections to the Postgres\nserver to `pg_pool_size`. If the connection\npool is full, subsequent connect operations\nwill be inserted in a queue with size equal\nto this option's value.\n\nIf the number of queued connect operations\nreaches `pg_backlog`, exceeding connections will fail.\n\nIf not specified, then number of open connections\nto the Postgres server is not limited.\n"
   },
   "pg_ro_host": {
     "defaultValue": null,
-    "description": "Same as `pg_host`, but for the read-only connection. **Note:** Refer to the documentation section above for detailed usage."
+    "description": "Same as `pg_host`, but for the\nread-only connection.\n**Note:** Refer to the documentation\nsection above for detailed usage.\n"
   },
   "pg_ro_port": {
     "defaultValue": "<pg_port>",
-    "description": "Same as `pg_port`, but for the read-only connection."
+    "description": "Same as `pg_port`, but for the\nread-only connection.\n"
   },
   "pg_ro_timeout": {
     "defaultValue": "<pg_timeout>",
-    "description": "Same as `pg_timeout`, but for the read-only connection."
+    "description": "Same as `pg_timeout`, but for the\nread-only connection.\n"
   },
   "pg_ro_user": {
     "defaultValue": "<pg_user>",
-    "description": "Same as `pg_user`, but for the read-only connection."
+    "description": "Same as `pg_user`, but for the\nread-only connection.\n"
   },
   "pg_ro_password": {
     "defaultValue": "<pg_password>",
-    "description": "Same as `pg_password`, but for the read-only connection."
+    "description": "Same as `pg_password`, but for the\nread-only connection.\n"
   },
   "pg_ro_iam_auth": {
     "defaultValue": "<pg_iam_auth>",
-    "description": "Same as `pg_iam_auth`, but for the read-only connection."
+    "description": "Same as `pg_iam_auth`, but for the\nread-only connection.\n"
   },
   "pg_ro_database": {
     "defaultValue": "<pg_database>",
-    "description": "Same as `pg_database`, but for the read-only connection."
+    "description": "Same as `pg_database`, but for the\nread-only connection.\n"
   },
   "pg_ro_schema": {
     "defaultValue": "<pg_schema>",
-    "description": "Same as `pg_schema`, but for the read-only connection."
+    "description": "Same as `pg_schema`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl": {
     "defaultValue": "<pg_ssl>",
-    "description": "Same as `pg_ssl`, but for the read-only connection."
+    "description": "Same as `pg_ssl`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl_required": {
     "defaultValue": "<pg_ssl_required>",
-    "description": " Same as `pg_ssl_required`, but for the read-only connection."
+    "description": "Same as `pg_ssl_required`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl_verify": {
     "defaultValue": "<pg_ssl_verify>",
-    "description": " Same as `pg_ssl_verify`, but for the read-only connection."
+    "description": "Same as `pg_ssl_verify`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl_version": {
     "defaultValue": "<pg_ssl_version>",
-    "description": " Same as `pg_ssl_version`, but for the read-only connection."
+    "description": "Same as `pg_ssl_version`, but for the\nread-only connection.\n"
   },
   "pg_ro_max_concurrent_queries": {
     "defaultValue": "<pg_max_concurrent_queries>",
-    "description": " Same as `pg_max_concurrent_queries`, but for the read-only connection. Note: read-only concurrency is not shared with the main (read-write) connection."
+    "description": "Same as `pg_max_concurrent_queries`, but for\nthe read-only connection.\nNote: read-only concurrency is not shared\nwith the main (read-write) connection.\n"
   },
   "pg_ro_semaphore_timeout": {
     "defaultValue": "<pg_semaphore_timeout>",
-    "description": " Same as `pg_semaphore_timeout`, but for the read-only connection."
+    "description": "Same as `pg_semaphore_timeout`, but for the\nread-only connection.\n"
   },
   "pg_ro_keepalive_timeout": {
     "defaultValue": "<pg_keepalive_timeout>",
-    "description": " Same as `pg_keepalive_timeout`, but for the read-only connection."
+    "description": "Same as `pg_keepalive_timeout`, but for the\nread-only connection.\n"
   },
   "pg_ro_pool_size": {
     "defaultValue": "<pg_pool_size>",
-    "description": " Same as `pg_pool_size`, but for the read-only connection."
+    "description": "Same as `pg_pool_size`, but for the\nread-only connection.\n"
   },
   "pg_ro_backlog": {
     "defaultValue": "<pg_backlog>",
-    "description": " Same as `pg_backlog`, but for the read-only connection."
+    "description": "Same as `pg_backlog`, but for the\nread-only connection.\n"
   },
   "declarative_config": {
     "defaultValue": null,
-    "description": "The path to the declarative configuration file which holds the specification of all entities (Routes, Services, Consumers, etc.) to be used when the `database` is set to `off`.  Entities are stored in Kong's LMDB cache, so you must ensure that enough headroom is allocated to it via the `lmdb_map_size` property.  If the Hybrid mode `role` is set to `data_plane` and there's no configuration cache file, this configuration is used before connecting to the Control Plane node as a user-controlled fallback."
+    "description": "The path to the declarative configuration\nfile which holds the specification of all\nentities (Routes, Services, Consumers, etc.)\nto be used when the `database` is set to\n`off`.\n\nEntities are stored in Kong's LMDB cache,\nso you must ensure that enough headroom is\nallocated to it via the `lmdb_map_size`\nproperty.\n\nIf the Hybrid mode `role` is set to `data_plane`\nand there's no configuration cache file,\nthis configuration is used before connecting\nto the Control Plane node as a user-controlled\nfallback.\n"
   },
   "declarative_config_string": {
     "defaultValue": null,
-    "description": "The declarative configuration as a string"
+    "description": "The declarative configuration as a string\n"
   },
   "lmdb_environment_path": {
     "defaultValue": "dbless.lmdb",
-    "description": "Directory where the LMDB database files used by DB-less and Hybrid mode to store Kong configurations reside.  This path is relative under the Kong `prefix`."
+    "description": "Directory where the LMDB database files used by\nDB-less and Hybrid mode to store Kong\nconfigurations reside.\n\nThis path is relative under the Kong `prefix`.\n"
   },
   "lmdb_map_size": {
     "defaultValue": "2048m",
-    "description": "Maximum size of the LMDB memory map, used to store the DB-less and Hybird mode configurations. Default is 2048m.  This config defines the limit of LMDB file size, the actual file size growth will be on-demand and proportional to the actual config size.  Note this value can be set very large, say a couple of GBs to accommodate future database growth and Multi Version Concurrency Control (MVCC) headroom needs. The file size of the LMDB database file should stabilize after a few config reload/Hybrid mode syncs and the actual memory used by the LMDB database will be smaller than the file size due to dynamic swapping of database pages by the OS."
+    "description": "Maximum size of the LMDB memory map, used to store the\nDB-less and Hybird mode configurations. Default is 2048m.\n\nThis config defines the limit of LMDB file size, the\nactual file size growth will be on-demand and\nproportional to the actual config size.\n\nNote this value can be set very large, say a couple of GBs\nto accommodate future database growth and\nMulti Version Concurrency Control (MVCC) headroom needs.\nThe file size of the LMDB database file should stabilize\nafter a few config reload/Hybrid mode syncs and the actual\nmemory used by the LMDB database will be smaller than\nthe file size due to dynamic swapping of database pages by\nthe OS.\n"
   },
   "db_update_frequency": {
     "defaultValue": "5",
-    "description": "Frequency (in seconds) at which to check for updated entities with the datastore.  When a node creates, updates, or deletes an entity via the Admin API, other nodes need to wait for the next poll (configured by this value) to eventually purge the old cached entity and start using the new one."
+    "description": "Frequency (in seconds) at which to check for\nupdated entities with the datastore.\n\nWhen a node creates, updates, or deletes an\nentity via the Admin API, other nodes need\nto wait for the next poll (configured by\nthis value) to eventually purge the old\ncached entity and start using the new one.\n"
   },
   "db_update_propagation": {
     "defaultValue": "0",
-    "description": "Time (in seconds) taken for an entity in the datastore to be propagated to replica nodes of another datacenter.  When set, this property will increase the time taken by Kong to propagate the change of an entity.  Single-datacenter setups or PostgreSQL servers should suffer no such delays, and this value can be safely set to 0. Postgres setups with read replicas should set this value to maximum expected replication lag between the writer and reader instances."
+    "description": "Time (in seconds) taken for an entity in the\ndatastore to be propagated to replica nodes\nof another datacenter.\n\nWhen set, this property will increase the\ntime taken by Kong to propagate the change\nof an entity.\n\nSingle-datacenter setups or PostgreSQL\nservers should suffer no such delays, and\nthis value can be safely set to 0.\nPostgres setups with read replicas should\nset this value to maximum expected replication\nlag between the writer and reader instances.\n"
   },
   "db_cache_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of an entity from the datastore when cached by this node.  Database misses (no entity) are also cached according to this setting if you do not configure `db_cache_neg_ttl`.  If set to 0 (default), such cached entities or misses never expire."
+    "description": "Time-to-live (in seconds) of an entity from\nthe datastore when cached by this node.\n\nDatabase misses (no entity) are also cached\naccording to this setting if you do not\nconfigure `db_cache_neg_ttl`.\n\nIf set to 0 (default), such cached entities\nor misses never expire.\n"
   },
   "db_cache_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a datastore miss (no entity).  If not specified (default), `db_cache_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a datastore\nmiss (no entity).\n\nIf not specified (default), `db_cache_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "db_resurrect_ttl": {
     "defaultValue": "30",
-    "description": "Time (in seconds) for which stale entities from the datastore should be resurrected for when they cannot be refreshed (e.g., the datastore is unreachable). When this TTL expires, a new attempt to refresh the stale entities will be made."
+    "description": "Time (in seconds) for which stale entities\nfrom the datastore should be resurrected for\nwhen they cannot be refreshed (e.g., the\ndatastore is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nentities will be made.\n"
   },
   "db_cache_warmup_entities": {
     "defaultValue": "services",
-    "description": " Entities to be pre-loaded from the datastore into the in-memory cache at Kong start-up. This speeds up the first access of endpoints that use the given entities.  When the `services` entity is configured for warmup, the DNS entries for values in its `host` attribute are pre-resolved asynchronously as well.  Cache size set in `mem_cache_size` should be set to a value large enough to hold all instances of the specified entities. If the size is insufficient, Kong will log a warning."
+    "description": "Entities to be pre-loaded from the datastore\ninto the in-memory cache at Kong start-up.\nThis speeds up the first access of endpoints\nthat use the given entities.\n\nWhen the `services` entity is configured\nfor warmup, the DNS entries for values in\nits `host` attribute are pre-resolved\nasynchronously as well.\n\nCache size set in `mem_cache_size` should\nbe set to a value large enough to hold all\ninstances of the specified entities.\nIf the size is insufficient, Kong will log\na warning.\n"
   },
   "dns_resolver": {
     "defaultValue": null,
-    "description": "Comma separated list of nameservers, each entry in `ip[:port]` format to be used by Kong. If not specified the nameservers in the local `resolv.conf` file will be used. Port defaults to 53 if omitted. Accepts both IPv4 and IPv6 addresses."
+    "description": "Comma separated list of nameservers, each\nentry in `ip[:port]` format to be used by\nKong. If not specified the nameservers in\nthe local `resolv.conf` file will be used.\nPort defaults to 53 if omitted. Accepts\nboth IPv4 and IPv6 addresses.\n"
   },
   "dns_hostsfile": {
     "defaultValue": "/etc/hosts",
-    "description": "The hosts file to use. This file is read once and its content is static in memory. To read the file again after modifying it, Kong must be reloaded."
+    "description": "The hosts file to use. This file is read\nonce and its content is static in memory.\nTo read the file again after modifying it,\nKong must be reloaded.\n"
   },
   "dns_order": {
     "defaultValue": [
@@ -616,446 +616,446 @@
       "A",
       "CNAME"
     ],
-    "description": "The order in which to resolve different record types. The `LAST` type means the type of the last successful lookup (for the specified name). The format is a (case insensitive) comma separated list."
+    "description": "The order in which to resolve different\nrecord types. The `LAST` type means the\ntype of the last successful lookup (for the\nspecified name). The format is a (case\ninsensitive) comma separated list.\n"
   },
   "dns_valid_ttl": {
     "defaultValue": null,
-    "description": "By default, DNS records are cached using the TTL value of a response. If this property receives a value (in seconds), it will override the TTL for all records."
+    "description": "By default, DNS records are cached using\nthe TTL value of a response. If this\nproperty receives a value (in seconds), it\nwill override the TTL for all records.\n"
   },
   "dns_stale_ttl": {
     "defaultValue": "3600",
-    "description": "Defines, in seconds, how long a record will remain in cache past its TTL. This value will be used while the new DNS record is fetched in the background. Stale data will be used from expiry of a record until either the refresh query completes, or the `dns_stale_ttl` number of seconds have passed. This configuration enables Kong to be more resilient during resolver downtime."
+    "description": "Defines, in seconds, how long a record will\nremain in cache past its TTL. This value\nwill be used while the new DNS record is\nfetched in the background.\nStale data will be used from expiry of a\nrecord until either the refresh query\ncompletes, or the `dns_stale_ttl` number of\nseconds have passed.\nThis configuration enables Kong to be more\nresilient during resolver downtime.\n"
   },
   "dns_cache_size": {
     "defaultValue": "10000",
-    "description": "Defines the maximum allowed number of DNS records stored in memory cache. Least recently used DNS records are discarded from cache if it is full. Both errors and data are cached, therefore a single name query can easily take up 10-15 slots."
+    "description": "Defines the maximum allowed number of\nDNS records stored in memory cache.\nLeast recently used DNS records are discarded\nfrom cache if it is full. Both errors and\ndata are cached, therefore a single name query\ncan easily take up 10-15 slots.\n"
   },
   "dns_not_found_ttl": {
     "defaultValue": "30",
-    "description": "TTL in seconds for empty DNS responses and \"(3) name error\" responses."
+    "description": "TTL in seconds for empty DNS responses and\n\"(3) name error\" responses.\n"
   },
   "dns_error_ttl": {
     "defaultValue": "1",
-    "description": "TTL in seconds for error responses."
+    "description": "TTL in seconds for error responses.\n"
   },
   "dns_no_sync": {
     "defaultValue": "off",
-    "description": "If enabled, then upon a cache-miss every request will trigger its own dns query. When disabled multiple requests for the same name/type will be synchronised to a single query."
+    "description": "If enabled, then upon a cache-miss every\nrequest will trigger its own dns query.\nWhen disabled multiple requests for the\nsame name/type will be synchronised to a\nsingle query.\n"
   },
   "vault_env_prefix": {
     "defaultValue": null,
-    "description": "Defines the environment variable vault's default prefix. For example if you have all your secrets stored in environment variables prefixed with `SECRETS_`, it can be configured here so that it isn't necessary to repeat them in Vault references."
+    "description": "Defines the environment variable vault's\ndefault prefix. For example if you have\nall your secrets stored in environment\nvariables prefixed with `SECRETS_`, it\ncan be configured here so that it isn't\nnecessary to repeat them in Vault\nreferences.\n"
   },
   "vault_aws_region": {
     "defaultValue": null,
-    "description": "The AWS region your vault is located in."
+    "description": "The AWS region your vault is located in.\n"
   },
   "vault_aws_endpoint_url": {
     "defaultValue": null,
-    "description": "The AWS SecretsManager service endpoint url. If not specified, the value used by vault will be the official AWS SecretsManager service url which is `https://secretsmanager.<region>.amazonaws.com` You can specify a complete URL(including the \"http/https\" scheme) to override the endpoint that vault will connect to."
+    "description": "The AWS SecretsManager service endpoint url.\nIf not specified, the value used by vault will\nbe the official AWS SecretsManager service url\nwhich is\n`https://secretsmanager.<region>.amazonaws.com`\nYou can specify a complete URL(including\nthe \"http/https\" scheme) to override the\nendpoint that vault will connect to.\n"
   },
   "vault_aws_assume_role_arn": {
     "defaultValue": null,
-    "description": "The target AWS IAM role ARN that will be assumed. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+    "description": "The target AWS IAM role ARN that will be\nassumed. Typically this is used for\noperating between multiple roles\nor cross-accounts.\nIf you are not using assume role\nyou should not specify this value.\n"
   },
   "vault_aws_role_session_name": {
     "defaultValue": "KongVault",
-    "description": "The role session name used for role assuming. The default value is `KongVault`."
+    "description": "The role session name used for role\nassuming. The default value is\n`KongVault`.\n"
   },
   "vault_aws_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the AWS vault when cached by this node.  AWS vault misses (no secret) are also cached according to this setting if you do not configure `vault_aws_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe AWS vault when cached by this node.\n\nAWS vault misses (no secret) are also cached\naccording to this setting if you do not\nconfigure `vault_aws_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_aws_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_aws_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a AWS vault\nmiss (no secret).\n\nIf not specified (default), `vault_aws_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_aws_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the AWS vault should be resurrected for when they cannot be refreshed (e.g., the AWS vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the AWS vault should be resurrected for\nwhen they cannot be refreshed (e.g., the\nAWS vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "vault_gcp_project_id": {
     "defaultValue": null,
-    "description": "The project ID from your Google API Console."
+    "description": "The project ID from your Google API Console.\n"
   },
   "vault_gcp_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the GCP vault when cached by this node.  GCP vault misses (no secret) are also cached according to this setting if you do not configure `vault_gcp_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe GCP vault when cached by this node.\n\nGCP vault misses (no secret) are also cached\naccording to this setting if you do not\nconfigure `vault_gcp_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_gcp_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_gcp_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a AWS vault\nmiss (no secret).\n\nIf not specified (default), `vault_gcp_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_gcp_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the GCP vault should be resurrected for when they cannot be refreshed (e.g., the GCP vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the GCP vault should be resurrected for\nwhen they cannot be refreshed (e.g., the\nGCP vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "vault_hcv_protocol": {
     "defaultValue": "http",
-    "description": "The protocol to connect with. Accepts one of `http` or `https`."
+    "description": "The protocol to connect with. Accepts one of\n`http` or `https`.\n"
   },
   "vault_hcv_host": {
     "defaultValue": "127.0.0.1",
-    "description": "The hostname of your HashiCorp vault."
+    "description": "The hostname of your HashiCorp vault.\n"
   },
   "vault_hcv_port": {
     "defaultValue": "8200",
-    "description": "The port number of your HashiCorp vault."
+    "description": "The port number of your HashiCorp vault.\n"
   },
   "vault_hcv_namespace": {
     "defaultValue": null,
-    "description": "Namespace for the HashiCorp Vault. Vault Enterprise requires a namespace to successfully connect to it."
+    "description": "Namespace for the HashiCorp Vault. Vault\nEnterprise requires a namespace to\nsuccessfully connect to it.\n"
   },
   "vault_hcv_mount": {
     "defaultValue": "secret",
-    "description": "The mount point."
+    "description": "The mount point.\n"
   },
   "vault_hcv_kv": {
     "defaultValue": "v1",
-    "description": "The secrets engine version. Accepts `v1` or `v2`."
+    "description": "The secrets engine version. Accepts `v1` or\n`v2`.\n"
   },
   "vault_hcv_token": {
     "defaultValue": null,
-    "description": "A token string."
+    "description": "A token string.\n"
   },
   "vault_hcv_auth_method": {
     "defaultValue": "token",
-    "description": "Defines the authentication mechanism when connecting to the Hashicorp Vault service. Accepted values are: `token`, `kubernetes` or `approle`."
+    "description": "Defines the authentication mechanism when\nconnecting to the Hashicorp Vault service.\nAccepted values are: `token`,\n`kubernetes` or `approle`.\n"
   },
   "vault_hcv_kube_role": {
     "defaultValue": null,
-    "description": "Defines the HashiCorp Vault role for the Kubernetes service account of the running pod. `vault_hcv_auth_method` must be set to `kubernetes` for this to activate."
+    "description": "Defines the HashiCorp Vault role for the\nKubernetes service account of the running\npod. `vault_hcv_auth_method` must be\nset to `kubernetes` for this to activate.\n"
   },
   "vault_hcv_kube_auth_path": {
     "defaultValue": "kubernetes",
-    "description": " Place where the Kubernetes auth method will be accessible: /v1/auth/<vault_hcv_kube_auth_path>"
+    "description": "Place where the Kubernetes auth method will be\naccessible: /v1/auth/<vault_hcv_kube_auth_path>\n"
   },
   "vault_hcv_kube_api_token_file": {
     "defaultValue": null,
-    "description": "Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+    "description": "Defines where the Kubernetes service account\ntoken should be read from the pod's\nfilesystem, if using a non-standard\ncontainer platform setup.\n"
   },
   "vault_hcv_approle_auth_path": {
     "defaultValue": "approle",
-    "description": " Place where the Approle auth method will be accessible: /v1/auth/<vault_hcv_approle_auth_path>"
+    "description": "Place where the Approle auth method will be\naccessible: /v1/auth/<vault_hcv_approle_auth_path>\n"
   },
   "vault_hcv_approle_role_id": {
     "defaultValue": null,
-    "description": "The Role ID of the Approle in HashiCorp Vault."
+    "description": "The Role ID of the Approle in HashiCorp Vault.\n"
   },
   "vault_hcv_approle_secret_id": {
     "defaultValue": null,
-    "description": "The Secret ID of the Approle in HashiCorp Vault."
+    "description": "The Secret ID of the Approle in HashiCorp Vault.\n"
   },
   "vault_hcv_approle_secret_id_file": {
     "defaultValue": null,
-    "description": "Defines where the Secret ID should be read from the pod's filesystem. This is usually used with HashiCorp Vault's response wrapping."
+    "description": "Defines where the Secret ID should be read from\nthe pod's filesystem. This is usually used with\nHashiCorp Vault's response wrapping.\n"
   },
   "vault_hcv_approle_response_wrapping": {
     "defaultValue": "false",
-    "description": "Defines whether the Secret ID read from configuration or file is actually a response-wrapping token instead of a real Secret ID."
+    "description": "Defines whether the Secret ID read from configuration\nor file is actually a response-wrapping token instead\nof a real Secret ID.\n"
   },
   "vault_hcv_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the HashiCorp vault when cached by this node.  HashiCorp vault misses (no secret) are also cached according to this setting if you do not configure `vault_hcv_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe HashiCorp vault when cached by this node.\n\nHashiCorp vault misses (no secret) are also\ncached according to this setting if you do not\nconfigure `vault_hcv_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_hcv_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a HashiCorp vault miss (no secret).  If not specified (default), `vault_hcv_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a HashiCorp vault\nmiss (no secret).\n\nIf not specified (default), `vault_hcv_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_hcv_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the HashiCorp vault should be resurrected for when they cannot be refreshed (e.g., the HashiCorp vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the HashiCorp vault should be resurrected\nfor when they cannot be refreshed (e.g., the\nHashiCorp vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "vault_azure_vault_uri": {
     "defaultValue": null,
-    "description": "The URI the vault is reachable from."
+    "description": "The URI the vault is reachable from.\n"
   },
   "vault_azure_client_id": {
     "defaultValue": null,
-    "description": "The client ID from your registered Application. Visit your Azure Dashboard and select *App Registrations* to check your client ID."
+    "description": "The client ID from your registered Application. Visit your Azure Dashboard and select *App Registrations* to check your client ID.\n"
   },
   "vault_azure_tenant_id": {
     "defaultValue": null,
-    "description": "The DirectoryId and TenantId both equate to the GUID representing the ActiveDirectory Tenant. Depending on context, either term may be used by Microsoft documentation and products, which can be confusing. In other words, the \"Tenant ID\" IS the \"Directory ID\""
+    "description": "The DirectoryId and TenantId both equate to the GUID representing the ActiveDirectory Tenant. Depending on context, either term may be used by Microsoft documentation and products, which can be confusing. In other words, the \"Tenant ID\" IS the \"Directory ID\"\n"
   },
   "vault_azure_type": {
     "defaultValue": "secrets",
-    "description": "Azure Key Vault enables Microsoft Azure applications and users to store and use several types of secret/key data: keys, secrets, and certificates. Kong currently only supports the `Secrets`"
+    "description": "Azure Key Vault enables Microsoft Azure applications and users to store and use several types of secret/key data: keys, secrets, and certificates. Kong currently only supports the `Secrets`\n"
   },
   "vault_azure_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the Azure Key Vault when cached by this node.  Key Vault misses (no secret) are also cached according to this setting if you do not configure `vault_azure_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe Azure Key Vault when cached by this node.\n\nKey Vault misses (no secret) are also\ncached according to this setting if you do not\nconfigure `vault_azure_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_azure_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a Azure Key Vault miss (no secret).  If not specified (default), `vault_azure_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a Azure Key Vault\nmiss (no secret).\n\nIf not specified (default), `vault_azure_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_azure_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the Azure Key Vault should be resurrected for when they cannot be refreshed (e.g., the the vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the Azure Key Vault should be resurrected\nfor when they cannot be refreshed (e.g., the\nthe vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "worker_consistency": {
     "defaultValue": "eventual",
-    "description": " Defines whether this node should rebuild its state synchronously or asynchronously (the balancers and the router are rebuilt on updates that affects them, e.g., updates to Routes, Services or Upstreams, via the Admin API or loading a declarative configuration file). (This option is deprecated and will be removed in future releases. The new default is `eventual`.)  Accepted values are:  - `strict`: the router will be rebuilt   synchronously, causing incoming requests to   be delayed until the rebuild is finished.   (This option is deprecated and will be removed    in future releases. The new default is `eventual`) - `eventual`: the router will be rebuilt   asynchronously via a recurring background   job running every second inside of each   worker.  Note that `strict` ensures that all workers of a given node will always proxy requests with an identical router, but that increased long tail latency can be observed if frequent Routes and Services updates are expected. Using `eventual` will help preventing long tail latency issues in such cases, but may cause workers to route requests differently for a short period of time after Routes and Services updates."
+    "description": "Defines whether this node should rebuild its\nstate synchronously or asynchronously (the\nbalancers and the router are rebuilt on\nupdates that affects them, e.g., updates to\nRoutes, Services or Upstreams, via the Admin\nAPI or loading a declarative configuration\nfile). (This option is deprecated and will be\nremoved in future releases. The new default\nis `eventual`.)\n\nAccepted values are:\n\n- `strict`: the router will be rebuilt\n  synchronously, causing incoming requests to\n  be delayed until the rebuild is finished.\n  (This option is deprecated and will be removed\n   in future releases. The new default is `eventual`)\n- `eventual`: the router will be rebuilt\n  asynchronously via a recurring background\n  job running every second inside of each\n  worker.\n\nNote that `strict` ensures that all workers\nof a given node will always proxy requests\nwith an identical router, but that increased\nlong tail latency can be observed if\nfrequent Routes and Services updates are\nexpected.\nUsing `eventual` will help preventing long\ntail latency issues in such cases, but may\ncause workers to route requests differently\nfor a short period of time after Routes and\nServices updates.\n"
   },
   "worker_state_update_frequency": {
     "defaultValue": "5",
-    "description": " Defines (in seconds) how often the worker state changes are checked with a background job. When a change is detected, a new router or balancer will be built, as needed. Raising this value will decrease the load on database servers and result in less jitter in proxy latency, but it might take more time to propagate changes to each individual worker."
+    "description": "Defines (in seconds) how often the worker state changes are\nchecked with a background job. When a change\nis detected, a new router or balancer will be\nbuilt, as needed. Raising this value will\ndecrease the load on database servers and\nresult in less jitter in proxy latency, but\nit might take more time to propagate changes\nto each individual worker.\n"
   },
   "router_flavor": {
     "defaultValue": "traditional_compatible",
-    "description": " Selects the router implementation to use when performing request routing. Incremental router rebuild is available when the flavor is set to either `expressions` or `traditional_compatible` which could significantly shorten rebuild time for large number of routes.  Accepted values are:  - `traditional_compatible`: the DSL based expression   router engine will be used under the hood. However   the router config interface will be the same   as `traditional` and expressions are   automatically generated at router build time.   The `expression` field on the `Route` object   is not visible. - `expressions`: the DSL based expression router engine   will be used under the hood. Traditional router   config interface is not visible and you must write   Router Expression manually and provide them in the   `expression` field on the `Route` object. - `traditional`: the pre-3.0 Router engine will be   used. Config interface will be the same as   pre-3.0 Kong and the `expression` field on the   `Route` object is not visible.    Deprecation warning: In Kong 3.0, `traditional`   mode should be avoided and only be used in case   `traditional_compatible` did not work as expected.   This flavor of router will be removed in the next   major release of Kong."
+    "description": "Selects the router implementation to use when\nperforming request routing. Incremental router\nrebuild is available when the flavor is set\nto either `expressions` or\n`traditional_compatible` which could\nsignificantly shorten rebuild time for large\nnumber of routes.\n\nAccepted values are:\n\n- `traditional_compatible`: the DSL based expression\n  router engine will be used under the hood. However\n  the router config interface will be the same\n  as `traditional` and expressions are\n  automatically generated at router build time.\n  The `expression` field on the `Route` object\n  is not visible.\n- `expressions`: the DSL based expression router engine\n  will be used under the hood. Traditional router\n  config interface is not visible and you must write\n  Router Expression manually and provide them in the\n  `expression` field on the `Route` object.\n- `traditional`: the pre-3.0 Router engine will be\n  used. Config interface will be the same as\n  pre-3.0 Kong and the `expression` field on the\n  `Route` object is not visible.\n\n  Deprecation warning: In Kong 3.0, `traditional`\n  mode should be avoided and only be used in case\n  `traditional_compatible` did not work as expected.\n  This flavor of router will be removed in the next\n  major release of Kong.\n"
   },
   "lua_max_req_headers": {
     "defaultValue": "100",
-    "description": "Maximum number of request headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying the Kong sends all the request headers and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many request headers."
+    "description": "Maximum number of request headers to parse by default.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying the Kong sends all the request headers\nand this setting does not have any effect. It is used\nto limit Kong and its plugins from reading too many\nrequest headers.\n"
   },
   "lua_max_resp_headers": {
     "defaultValue": "100",
-    "description": "Maximum number of response headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong returns all the response headers and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many response headers."
+    "description": "Maximum number of response headers to parse by default.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong returns all the response headers\nand this setting does not have any effect. It is used\nto limit Kong and its plugins from reading too many\nresponse headers.\n"
   },
   "lua_max_uri_args": {
     "defaultValue": "100",
-    "description": "Maximum number of request uri arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request query arguments and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many query arguments."
+    "description": "Maximum number of request uri arguments to parse by\ndefault.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request query\narguments and this setting does not have any effect.\nIt is used to limit Kong and its plugins from reading\ntoo many query arguments.\n"
   },
   "lua_max_post_args": {
     "defaultValue": "100",
-    "description": "Maximum number of request post arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request post arguments and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many post arguments."
+    "description": "Maximum number of request post arguments to parse by\ndefault.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request post\narguments and this setting does not have any effect.\nIt is used to limit Kong and its plugins from reading\ntoo many post arguments.\n"
   },
   "lua_ssl_trusted_certificate": {
     "defaultValue": "system",
-    "description": "Comma-separated list of certificate authorities for Lua cosockets in PEM format.  The special value `system` attempts to search for the \"usual default\" provided by each distro, according to an arbitrary heuristic. In the current implementation, The following pathnames will be tested in order, and the first one found will be used:  - /etc/ssl/certs/ca-certificates.crt (Debian/Ubuntu/Gentoo) - /etc/pki/tls/certs/ca-bundle.crt (Fedora/RHEL 6) - /etc/ssl/ca-bundle.pem (OpenSUSE) - /etc/pki/tls/cacert.pem (OpenELEC) - /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem (CentOS/RHEL 7) - /etc/ssl/cert.pem (OpenBSD, Alpine)  `system` can be used by itself or in conjunction with other CA filepaths.  When `pg_ssl_verify` is enabled, these certificate authority files will be used for verifying Kong's database connections.  Certificates can be configured on this property with either of the following values: * `system` * absolute path to the certificate * certificate content * base64 encoded certificate content  See https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate"
+    "description": "Comma-separated list of certificate authorities\nfor Lua cosockets in PEM format.\n\nThe special value `system` attempts to search for the\n\"usual default\" provided by each distro, according\nto an arbitrary heuristic. In the current implementation,\nThe following pathnames will be tested in order,\nand the first one found will be used:\n\n- /etc/ssl/certs/ca-certificates.crt (Debian/Ubuntu/Gentoo)\n- /etc/pki/tls/certs/ca-bundle.crt (Fedora/RHEL 6)\n- /etc/ssl/ca-bundle.pem (OpenSUSE)\n- /etc/pki/tls/cacert.pem (OpenELEC)\n- /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem (CentOS/RHEL 7)\n- /etc/ssl/cert.pem (OpenBSD, Alpine)\n\n`system` can be used by itself or in conjunction with other\nCA filepaths.\n\nWhen `pg_ssl_verify` is enabled, these\ncertificate authority files will be\nused for verifying Kong's database connections.\n\nCertificates can be configured on this property\nwith either of the following values:\n* `system`\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n\nSee https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate\n"
   },
   "lua_ssl_verify_depth": {
     "defaultValue": "1",
-    "description": "Sets the verification depth in the server certificates chain used by Lua cosockets, set by `lua_ssl_trusted_certificate`. This includes the certificates configured for Kong's database connections. If the maximum depth is reached before reaching the end of the chain, verification will fail. This helps mitigate certificate based DoS attacks.  See https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth"
+    "description": "Sets the verification depth in the server\ncertificates chain used by Lua cosockets,\nset by `lua_ssl_trusted_certificate`.\nThis includes the certificates configured\nfor Kong's database connections.\nIf the maximum depth is reached before\nreaching the end of the chain, verification\nwill fail. This helps mitigate certificate\nbased DoS attacks.\n\nSee https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth\n"
   },
   "lua_ssl_protocols": {
     "defaultValue": "TLSv1.2 TLSv1.3",
-    "description": "Defines the TLS versions supported when handshaking with OpenResty's TCP cosocket APIs.  This affects connections made by Lua code, such as connections to the database Kong uses, or when sending logs using a logging plugin. It does *not* affect connections made to the upstream Service or from downstream clients."
+    "description": "Defines the TLS versions supported\nwhen handshaking with OpenResty's\nTCP cosocket APIs.\n\nThis affects connections made by Lua\ncode, such as connections to the\ndatabase Kong uses, or when sending logs\nusing a logging plugin. It does *not*\naffect connections made to the upstream\nService or from downstream clients.\n"
   },
   "lua_package_path": {
     "defaultValue": "./?.lua;./?/init.lua;",
-    "description": "Sets the Lua module search path (LUA_PATH). Useful when developing or using custom plugins not stored in the default search path.  See https://github.com/openresty/lua-nginx-module#lua_package_path"
+    "description": "Sets the Lua module search path\n(LUA_PATH). Useful when developing\nor using custom plugins not stored\nin the default search path.\n\nSee https://github.com/openresty/lua-nginx-module#lua_package_path\n"
   },
   "lua_package_cpath": {
     "defaultValue": null,
-    "description": "Sets the Lua C module search path (LUA_CPATH).  See https://github.com/openresty/lua-nginx-module#lua_package_cpath"
+    "description": "Sets the Lua C module search path\n(LUA_CPATH).\n\nSee https://github.com/openresty/lua-nginx-module#lua_package_cpath\n"
   },
   "lua_socket_pool_size": {
     "defaultValue": "256",
-    "description": "Specifies the size limit for every cosocket connection pool associated with every remote server.  See https://github.com/openresty/lua-nginx-module#lua_socket_pool_size"
+    "description": "Specifies the size limit for every cosocket\nconnection pool associated with every remote\nserver.\n\nSee https://github.com/openresty/lua-nginx-module#lua_socket_pool_size\n"
   },
   "enforce_rbac": {
     "defaultValue": "off",
-    "description": "Specifies whether Admin API RBAC is enforced. Accepts one of `entity`, `both`, `on`, or `off`.  - `on`: only endpoint-level authorization   is enforced. - `entity`: entity-level authorization   applies. - `both`: enables both endpoint and   entity-level authorization. - `off`: disables both endpoint and   entity-level authorization.  When enabled, Kong will deny requests to the Admin API when a nonexistent or invalid RBAC authorization token is passed, or the RBAC user with which the token is associated does not have permissions to access/modify the requested resource."
+    "description": "Specifies whether Admin API RBAC is enforced.\nAccepts one of `entity`, `both`, `on`, or\n`off`.\n\n- `on`: only endpoint-level authorization\n  is enforced.\n- `entity`: entity-level authorization\n  applies.\n- `both`: enables both endpoint and\n  entity-level authorization.\n- `off`: disables both endpoint and\n  entity-level authorization.\n\nWhen enabled, Kong will deny requests to the\nAdmin API when a nonexistent or invalid RBAC\nauthorization token is passed, or the RBAC\nuser with which the token is associated does\nnot have permissions to access/modify the\nrequested resource.\n"
   },
   "rbac_auth_header": {
     "defaultValue": "Kong-Admin-Token",
-    "description": "Defines the name of the HTTP request header from which the Admin API will attempt to authenticate the RBAC user."
+    "description": "Defines the name of the HTTP request\nheader from which the Admin API will\nattempt to authenticate the RBAC user.\n"
   },
   "event_hooks_enabled": {
     "defaultValue": "on",
-    "description": "When enabled, event hook entities represent a relationship between an event (source and event) and an action (handler). Similar to web hooks, event hooks can be used to communicate Kong Gateway service events. When a particular event happens on a service, the event hook calls a URL with information about that event. Event hook configurations differ depending on the handler. The events that are triggered send associated data.  See: https://docs.konghq.com/enterprise/latest/admin-api/event-hooks/reference/"
+    "description": "When enabled, event hook entities represent a relationship\nbetween an event (source and event) and an action\n(handler). Similar to web hooks, event hooks can be used to\ncommunicate Kong Gateway service events. When a particular\nevent happens on a service, the event hook calls a URL with\ninformation about that event. Event hook configurations\ndiffer depending on the handler. The events that are\ntriggered send associated data.\n\nSee: https://docs.konghq.com/enterprise/latest/admin-api/event-hooks/reference/\n"
   },
   "fips": {
     "defaultValue": "off",
-    "description": "Turn on FIPS mode; this mode is only available on a FIPS build."
+    "description": "Turn on FIPS mode; this mode is only available on a FIPS build.\n"
   },
   "admin_gui_listen": {
     "defaultValue": [
       "0.0.0.0:8002",
       "0.0.0.0:8445 ssl"
     ],
-    "description": " Kong Manager Listeners  Comma-separated list of addresses and ports on which Kong will expose Kong Manager. This web application lets you configure and manage Kong, and therefore should be kept secured.  Suffixes can be specified for each pair, similarly to the `admin_listen` directive."
+    "description": "Kong Manager Listeners\n\nComma-separated list of addresses and ports on which\nKong will expose Kong Manager. This web application\nlets you configure and manage Kong, and therefore\nshould be kept secured.\n\nSuffixes can be specified for each pair, similarly to\nthe `admin_listen` directive.\n"
   },
   "admin_gui_url": {
     "defaultValue": null,
-    "description": "Kong Manager URL  The lookup, or balancer, address for Kong Manager.  Accepted format (items in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>)`  Examples:  - `http://127.0.0.1:8003` - `https://kong-admin.test` - `http://dev-machine`  By default, Kong Manager will use the window request host and append the resolved listener port depending on the requested protocol."
+    "description": "Kong Manager URL\n\nThe lookup, or balancer, address for Kong Manager.\n\nAccepted format (items in parentheses are optional):\n\n  `<scheme>://<IP / HOSTNAME>(:<PORT>)`\n\nExamples:\n\n- `http://127.0.0.1:8003`\n- `https://kong-admin.test`\n- `http://dev-machine`\n\nBy default, Kong Manager will use the window request\nhost and append the resolved listener port depending\non the requested protocol.\n"
   },
   "admin_gui_path": {
     "defaultValue": "/",
-    "description": "Kong Manager base path  This configuration parameter allows the user to customize the path prefix where Kong Manager is served. When updating this parameter, it's recommended to update the path in `admin_gui_url` as well.  Accepted format:  - Path must start with a `/` - Path must not end with a `/` (except for the `/`) - Path can only contain letters, digits, hyphens (`-`), underscores (`_`), and slashes (`/`) - Path must not contain continuous slashes (e.g., `//` and `///`)  Examples:  - `/` - `/manager` - `/kong-manager` - `/kong/manager`"
+    "description": "Kong Manager base path\n\nThis configuration parameter allows the user to customize\nthe path prefix where Kong Manager is served. When updating\nthis parameter, it's recommended to update the path in `admin_gui_url`\nas well.\n\nAccepted format:\n\n- Path must start with a `/`\n- Path must not end with a `/` (except for the `/`)\n- Path can only contain letters, digits, hyphens (`-`),\nunderscores (`_`), and slashes (`/`)\n- Path must not contain continuous slashes (e.g., `//` and `///`)\n\nExamples:\n\n- `/`\n- `/manager`\n- `/kong-manager`\n- `/kong/manager`\n"
   },
   "admin_gui_api_url": {
     "defaultValue": null,
-    "description": "Hierarchical part of a URI which is composed optionally of a host, port, and path at which the Admin API accepts HTTP or HTTPS traffic. When this config is disabled, Kong Manager will use the window protocol + host and append the resolved admin_listen HTTP/HTTPS port."
+    "description": "Hierarchical part of a URI which is composed\noptionally of a host, port, and path at which the\nAdmin API accepts HTTP or HTTPS traffic. When\nthis config is disabled, Kong Manager will\nuse the window protocol + host and append the\nresolved admin_listen HTTP/HTTPS port.\n"
   },
   "admin_gui_ssl_protocols": {
     "defaultValue": "TLSv1.2 TLSv1.3",
-    "description": " Defines the TLS versions supported for Kong Manager"
+    "description": "Defines the TLS versions supported\nfor Kong Manager\n"
   },
   "admin_gui_ssl_cert": {
     "defaultValue": null,
-    "description": "The SSL certificate for `admin_gui_listen` values with SSL enabled.  values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "The SSL certificate for `admin_gui_listen` values\nwith SSL enabled.\n\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "admin_gui_ssl_cert_key": {
     "defaultValue": null,
-    "description": "The SSL key for `admin_gui_listen` values with SSL enabled.  values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+    "description": "The SSL key for `admin_gui_listen` values with SSL\nenabled.\n\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n"
   },
   "admin_gui_flags": {
     "defaultValue": "{}",
-    "description": " Alters the layout Admin GUI (JSON) The only supported value is `{ \"IMMUNITY_ENABLED\": true }` to enable Kong Immunity in the Admin GUI."
+    "description": "Alters the layout Admin GUI (JSON)\nThe only supported value is `{ \"IMMUNITY_ENABLED\": true }`\nto enable Kong Immunity in the Admin GUI.\n"
   },
   "admin_gui_access_log": {
     "defaultValue": "logs/admin_gui_access.log",
-    "description": " Kong Manager Access Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables access logs for Kong Manager."
+    "description": "Kong Manager Access Logs\n\nHere you can set an absolute or relative path for Kong\nManager access logs. When the path is relative,\nlogs are placed in the `prefix` location.\n\nSetting this value to `off` disables access logs\nfor Kong Manager.\n"
   },
   "admin_gui_error_log": {
     "defaultValue": "logs/admin_gui_error.log",
-    "description": " Kong Manager Error Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables error logs for Kong Manager.  Granularity can be adjusted through the `log_level` directive."
+    "description": "Kong Manager Error Logs\n\nHere you can set an absolute or relative path for Kong\nManager access logs. When the path is relative,\nlogs are placed in the `prefix` location.\n\nSetting this value to `off` disables error logs for\nKong Manager.\n\nGranularity can be adjusted through the `log_level`\ndirective.\n"
   },
   "admin_gui_auth": {
     "defaultValue": null,
-    "description": "Kong Manager Authentication Plugin Name  Secures access to Kong Manager by specifying an authentication plugin to use.  Supported Plugins:  - `basic-auth`: Basic Authentication plugin - `ldap-auth-advanced`: LDAP Authentication plugin - `openid-connect`: OpenID Connect Authentication   plugin"
+    "description": "Kong Manager Authentication Plugin Name\n\nSecures access to Kong Manager by specifying an\nauthentication plugin to use.\n\nSupported Plugins:\n\n- `basic-auth`: Basic Authentication plugin\n- `ldap-auth-advanced`: LDAP Authentication plugin\n- `openid-connect`: OpenID Connect Authentication\n  plugin\n"
   },
   "admin_gui_auth_conf": {
     "defaultValue": null,
-    "description": "Kong Manager Authentication Plugin Config (JSON)  Specifies the configuration for the authentication plugin specified in `admin_gui_auth`.  For information about Plugin Configuration consult the associated plugin documentation.  Example for `basic-auth`:  `admin_gui_auth_conf = { \"hide_credentials\": true }`"
+    "description": "Kong Manager Authentication Plugin Config (JSON)\n\nSpecifies the configuration for the authentication\nplugin specified in `admin_gui_auth`.\n\nFor information about Plugin Configuration\nconsult the associated plugin documentation.\n\nExample for `basic-auth`:\n\n`admin_gui_auth_conf = { \"hide_credentials\": true }`\n"
   },
   "admin_gui_auth_password_complexity": {
     "defaultValue": null,
-    "description": "Kong Manager Authentication Password Complexity (JSON)  When `admin_gui_auth = basic-auth`, this property defines the rules required for Kong Manager passwords. Choose from preset rules or write your own.  Example using preset rules:  `admin_gui_auth_password_complexity = { \"kong-preset\": \"min_8\" }`  All values for kong-preset require the password to contain characters from at least three of the following categories:  1. Uppercase characters (A through Z)  2. Lowercase characters (a through z)  3. Base-10 digits (0 through 9)  4. Special characters (for example, &, $, #, %)  Supported preset rules: - `min_8`: minimum length of 8 - `min_12`: minimum length of 12 - `min_20`: minimum length of 20  To write your own rules, see https://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.  NOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.  Example:  `admin_gui_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`"
+    "description": "Kong Manager Authentication Password Complexity (JSON)\n\nWhen `admin_gui_auth = basic-auth`, this property defines\nthe rules required for Kong Manager passwords. Choose\nfrom preset rules or write your own.\n\nExample using preset rules:\n\n`admin_gui_auth_password_complexity = { \"kong-preset\": \"min_8\" }`\n\nAll values for kong-preset require the password to contain\ncharacters from at least three of the following categories:\n\n1. Uppercase characters (A through Z)\n\n2. Lowercase characters (a through z)\n\n3. Base-10 digits (0 through 9)\n\n4. Special characters (for example, &, $, #, %)\n\nSupported preset rules:\n- `min_8`: minimum length of 8\n- `min_12`: minimum length of 12\n- `min_20`: minimum length of 20\n\nTo write your own rules, see\nhttps://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.\n\nNOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.\n\nExample:\n\n`admin_gui_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`\n"
   },
   "admin_gui_session_conf": {
     "defaultValue": null,
-    "description": "Kong Manager Session Config (JSON)  Specifies the configuration for the Session plugin as used by Kong Manager.  For information about plugin configuration, consult the Kong Session plugin documentation.  Example: ``` admin_gui_session_conf = { \"cookie_name\": \"kookie\", \\                            \"secret\": \"changeme\" } ```"
+    "description": "Kong Manager Session Config (JSON)\n\nSpecifies the configuration for the Session plugin as\nused by Kong Manager.\n\nFor information about plugin configuration, consult\nthe Kong Session plugin documentation.\n\nExample:\n```\nadmin_gui_session_conf = { \"cookie_name\": \"kookie\", \\\n                           \"secret\": \"changeme\" }\n```\n"
   },
   "admin_gui_auth_header": {
     "defaultValue": "Kong-Admin-User",
-    "description": " Defines the name of the HTTP request header from which the Admin API will attempt to identify the Kong Admin user."
+    "description": "Defines the name of the HTTP request header from which\nthe Admin API will attempt to identify the Kong Admin\nuser.\n"
   },
   "admin_gui_auth_login_attempts": {
     "defaultValue": "0",
-    "description": " Number of times a user can attempt to login to Kong Manager. 0 means infinite attempts allowed."
+    "description": "Number of times a user can attempt to login to Kong\nManager. 0 means infinite attempts allowed.\n"
   },
   "admin_gui_header_txt": {
     "defaultValue": null,
-    "description": "Kong Manager Header Text Sets text for Kong Manager Header Banner. Header Banner is not shown if this config is empty."
+    "description": "Kong Manager Header Text\nSets text for Kong Manager Header Banner. Header Banner\nis not shown if this config is empty.\n"
   },
   "admin_gui_header_bg_color": {
     "defaultValue": null,
-    "description": "Kong Manager Header Background Color Sets background color for Kong Manager Header Banner Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Manager."
+    "description": "Kong Manager Header Background Color\nSets background color for Kong Manager Header Banner\nAccepts css color keyword, #-hexadecimal or rgb\nformat. Invalid values are ignored by Manager.\n"
   },
   "admin_gui_header_txt_color": {
     "defaultValue": null,
-    "description": "Kong Manager Header Text Color Sets text color for Kong Manager Header Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Kong Manager."
+    "description": "Kong Manager Header Text Color\nSets text color for Kong Manager Header Banner.\nAccepts css color keyword, #-hexadecimal or rgb\nformat. Invalid values are ignored by Kong Manager.\n"
   },
   "admin_gui_footer_txt": {
     "defaultValue": null,
-    "description": "Kong Manager Footer Text Sets text for Kong Manager Footer Banner. Footer Banner is not shown if this config is empty"
+    "description": "Kong Manager Footer Text\nSets text for Kong Manager Footer Banner. Footer Banner\nis not shown if this config is empty\n"
   },
   "admin_gui_footer_bg_color": {
     "defaultValue": null,
-    "description": "Kong Manager Footer Background Color Sets background color for Kong Manager Footer Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Manager."
+    "description": "Kong Manager Footer Background Color\nSets background color for Kong Manager Footer Banner.\nAccepts css color keyword, #-hexadecimal or rgb\nformat. Invalid values are ignored by Manager.\n"
   },
   "admin_gui_footer_txt_color": {
     "defaultValue": null,
-    "description": "Kong Manager Footer Text Color Sets text color for Kong Manager Footer Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Kong Manager."
+    "description": "Kong Manager Footer Text Color\nSets text color for Kong Manager Footer Banner.\nAccepts css color keyword, #-hexadecimal or rgb\nformat. Invalid values are ignored by Kong Manager.\n"
   },
   "admin_gui_login_banner_title": {
     "defaultValue": null,
-    "description": "Kong Manager Login Banner Title Text Sets title text for Kong Manager Login Banner. Login Banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+    "description": "Kong Manager Login Banner Title Text\nSets title text for Kong Manager Login Banner.\nLogin Banner is not shown if both\n`admin_gui_login_banner_title` and\n`admin_gui_login_banner_body` are empty.\n"
   },
   "admin_gui_login_banner_body": {
     "defaultValue": null,
-    "description": "Kong Manager Login Banner Body Text Sets body text for Kong Manager Login Banner. Login Banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+    "description": "Kong Manager Login Banner Body Text\nSets body text for Kong Manager Login Banner.\nLogin Banner is not shown if both\n`admin_gui_login_banner_title` and\n`admin_gui_login_banner_body` are empty.\n"
   },
   "konnect_mode": {
     "defaultValue": "off",
-    "description": "When enabled, the dataplane is connected to Konnect"
+    "description": "When enabled, the dataplane is connected to Konnect\n"
   },
   "analytics_flush_interval": {
     "defaultValue": "1",
-    "description": "Determine the frequency of flushing local data to Konnect in seconds."
+    "description": "Determine the frequency of flushing local data\nto Konnect in seconds.\n"
   },
   "analytics_buffer_size_limit": {
     "defaultValue": "100000",
-    "description": "Max number of messages can be buffered locally before dropping data in case there is no network connection to Konnect."
+    "description": "Max number of messages can be buffered locally\nbefore dropping data in case there is no\nnetwork connection to Konnect.\n"
   },
   "analytics_debug": {
     "defaultValue": "off",
-    "description": "Outputs analytics payload to Kong logs."
+    "description": "Outputs analytics payload to Kong logs.\n"
   },
   "admin_emails_from": {
     "defaultValue": "\"\"",
-    "description": "The email address for the `From` header for admin emails."
+    "description": "The email address for the `From` header\nfor admin emails.\n"
   },
   "admin_emails_reply_to": {
     "defaultValue": null,
-    "description": "Email address for the `Reply-To` header for admin emails."
+    "description": "Email address for the `Reply-To` header\nfor admin emails.\n"
   },
   "admin_invitation_expiry": {
     "defaultValue": "259200",
-    "description": "Expiration time for the admin invitation link (in seconds). 0 means no expiration.  Example, 72 hours: `72 * 60 * 60 = 259200`"
+    "description": "Expiration time for the admin invitation link\n(in seconds). 0 means no expiration.\n\nExample, 72 hours: `72 * 60 * 60 = 259200`\n"
   },
   "smtp_mock": {
     "defaultValue": "on",
-    "description": "This flag will mock the sending of emails. This can be used for testing before the SMTP client is fully configured."
+    "description": "This flag will mock the sending of emails. This can be\nused for testing before the SMTP client is fully\nconfigured.\n"
   },
   "smtp_host": {
     "defaultValue": "localhost",
-    "description": " The hostname of the SMTP server to connect to."
+    "description": "The hostname of the SMTP server to connect to.\n"
   },
   "smtp_port": {
     "defaultValue": "25",
-    "description": " The port number on the SMTP server to connect to."
+    "description": "The port number on the SMTP server to connect to.\n"
   },
   "smtp_starttls": {
     "defaultValue": "off",
-    "description": " When set to `on`, STARTTLS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 587."
+    "description": "When set to `on`, STARTTLS is used to encrypt\ncommunication with the SMTP server. This is normally\nused in conjunction with port 587.\n"
   },
   "smtp_username": {
     "defaultValue": null,
-    "description": "Username used for authentication with SMTP server"
+    "description": "Username used for authentication with SMTP server\n"
   },
   "smtp_password": {
     "defaultValue": null,
-    "description": "Password used for authentication with SMTP server"
+    "description": "Password used for authentication with SMTP server\n"
   },
   "smtp_ssl": {
     "defaultValue": "off",
-    "description": " When set to `on`, SMTPS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 465."
+    "description": "When set to `on`, SMTPS is used to encrypt\ncommunication with the SMTP server. This is normally\nused in conjunction with port 465.\n"
   },
   "smtp_auth_type": {
     "defaultValue": null,
-    "description": "The method used to authenticate with the SMTP server Valid options are `plain`, `login`, or `nil`"
+    "description": "The method used to authenticate with the SMTP server\nValid options are `plain`, `login`, or `nil`\n"
   },
   "smtp_domain": {
     "defaultValue": "localhost.localdomain",
-    "description": " The domain used in the `EHLO` connection and part of the `Message-ID` header"
+    "description": "The domain used in the `EHLO` connection and part of\nthe `Message-ID` header\n"
   },
   "smtp_timeout_connect": {
     "defaultValue": "60000",
-    "description": " The timeout (in milliseconds) for connecting to the SMTP server."
+    "description": "The timeout (in milliseconds) for connecting to the\nSMTP server.\n"
   },
   "smtp_timeout_send": {
     "defaultValue": "60000",
-    "description": " The timeout (in milliseconds) for sending data to the SMTP server."
+    "description": "The timeout (in milliseconds) for sending data to the\nSMTP server.\n"
   },
   "smtp_timeout_read": {
     "defaultValue": "60000",
-    "description": " The timeout (in milliseconds) for reading data from the SMTP server."
+    "description": "The timeout (in milliseconds) for reading data from\nthe SMTP server.\n"
   },
   "smtp_admin_emails": {
     "defaultValue": null,
-    "description": "Comma separated list of admin emails to receive notifications. Example `admin1@example.com, admin2@example.com`"
+    "description": "Comma separated list of admin emails to receive\nnotifications.\nExample `admin1@example.com, admin2@example.com`\n"
   },
   "audit_log": {
     "defaultValue": "off",
-    "description": "When enabled, Kong will log information about Admin API access and database row insertions, updates, and deletes."
+    "description": "When enabled, Kong will log information about\nAdmin API access and database row insertions,\nupdates, and deletes.\n"
   },
   "audit_log_ignore_methods": {
     "defaultValue": null,
-    "description": "Comma-separated list of HTTP methods that will not generate audit log entries. By default, all HTTP requests will be logged."
+    "description": "Comma-separated list of HTTP methods that\nwill not generate audit log entries. By\ndefault, all HTTP requests will be logged.\n"
   },
   "audit_log_ignore_paths": {
     "defaultValue": null,
-    "description": "Comma-separated list of request paths that will not generate audit log entries. By default, all HTTP requests will be logged."
+    "description": "Comma-separated list of request paths that\nwill not generate audit log entries. By\ndefault, all HTTP requests will be logged.\n"
   },
   "audit_log_ignore_tables": {
     "defaultValue": null,
-    "description": "Comma-separated list of database tables that will not generate audit log entries. By default, updates to all database tables will be logged (the term \"updates\" refers to the creation, update, or deletion of a row)."
+    "description": "Comma-separated list of database tables that\nwill not generate audit log entries. By\ndefault, updates to all database tables will\nbe logged (the term \"updates\" refers to the\ncreation, update, or deletion of a row).\n"
   },
   "audit_log_payload_exclude": {
     "defaultValue": [
@@ -1063,154 +1063,154 @@
       "secret",
       "password"
     ],
-    "description": " Comma-separated list of keys that will be filtered out of the payload. Keys that were filtered will be recorded in the audit log."
+    "description": "Comma-separated list of keys that will be\nfiltered out of the payload. Keys that were\nfiltered will be recorded in the audit log.\n"
   },
   "audit_log_record_ttl": {
     "defaultValue": "2592000",
-    "description": "Length, in seconds, of the TTL for audit log records. Records in the database older than their TTL are automatically purged.  Example, 30 days: `30 * 24 * 60 * 60 = 2592000`"
+    "description": "Length, in seconds, of the TTL for audit log\nrecords. Records in the database older than\ntheir TTL are automatically purged.\n\nExample, 30 days: `30 * 24 * 60 * 60 = 2592000`\n"
   },
   "audit_log_signing_key": {
     "defaultValue": null,
-    "description": "Defines the path to a private RSA signing key that can be used to insert a signature of audit records, adjacent to the record. The corresponding public key should be stored offline, and can be used the validate audit entries in the future. If this value is undefined, no signature will be generated."
+    "description": "Defines the path to a private RSA signing key\nthat can be used to insert a signature of\naudit records, adjacent to the record. The\ncorresponding public key should be stored\noffline, and can be used the validate audit\nentries in the future. If this value is\nundefined, no signature will be generated.\n"
   },
   "tracing": {
     "defaultValue": "off",
-    "description": "When enabled, Kong will generate granular debug data about various portions of the request lifecycle, such as DB or DNS queries, plugin execution, core handler timing, etc."
+    "description": "When enabled, Kong will generate granular\ndebug data about various portions of the\nrequest lifecycle, such as DB or DNS queries,\nplugin execution, core handler timing, etc.\n"
   },
   "tracing_write_strategy": {
     "defaultValue": "file",
-    "description": "Defines how Kong will write tracing data at the conclusion of the request. The default option, `file`, writes a human-readable depiction of tracing data to a configurable location on the node's file system. Other strategies write tracing data as a JSON document to the configured endpoint. Valid entries for this option are `file`, `file_raw`, `http`, `tcp`, `tls`, and `udp`."
+    "description": "Defines how Kong will write tracing data at\nthe conclusion of the request. The default\noption, `file`, writes a human-readable\ndepiction of tracing data to a configurable\nlocation on the node's file system. Other\nstrategies write tracing data as a JSON\ndocument to the configured endpoint. Valid\nentries for this option are `file`,\n`file_raw`, `http`, `tcp`, `tls`, and `udp`.\n"
   },
   "tracing_write_endpoint": {
     "defaultValue": null,
-    "description": "Defines the endpoint to which tracing data will be written.  - For the `file` and `file_raw` tracing write   strategies, this value must be a valid   location on the node's file system to which   Kong must have write access. - For the `tcp`, `tls`, and   `udp` strategies, this value is defined as a   string in the form of:  `<HOST>:<PORT>` - For the `http` strategy, this value is   defined in the form of:  `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`  Traces sent via HTTP are delivered via POST method with an `application/json` Content-Type."
+    "description": "Defines the endpoint to which tracing data\nwill be written.\n\n- For the `file` and `file_raw` tracing write\n  strategies, this value must be a valid\n  location on the node's file system to which\n  Kong must have write access.\n- For the `tcp`, `tls`, and\n  `udp` strategies, this value is defined as a\n  string in the form of:\n `<HOST>:<PORT>`\n- For the `http` strategy, this value is\n  defined in the form of:\n `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`\n\nTraces sent via HTTP are delivered via POST\nmethod with an `application/json`\nContent-Type.\n"
   },
   "tracing_time_threshold": {
     "defaultValue": "0",
-    "description": "The minimum time, in microseconds, over which a trace must execute in order to write the trace data to the configured endpoint. This configuration can be used to lower the noise present in trace data by removing trace objects that are not interesting from a timing perspective. The default value of `0` removes this limitation, causing traces of any duration to be written."
+    "description": "The minimum time, in microseconds, over which\na trace must execute in order to write the\ntrace data to the configured endpoint. This\nconfiguration can be used to lower the noise\npresent in trace data by removing trace\nobjects that are not interesting from a\ntiming perspective. The default value of `0`\nremoves this limitation, causing traces of\nany duration to be written.\n"
   },
   "tracing_types": {
     "defaultValue": "all",
-    "description": "Defines the types of traces that are written. Trace types not defined in this list are ignored, regardless of their lifetime. The default special value of `all` results in all trace types being written, regardless of type.  The following trace types are included:  - `query`: trace the database query - `legacy_query`: (deprecated) trace the    database query with legacy DAO - `router`: trace Kong routing the request;    internal routing time - `balancer`: trace the execution of the overall    balancer phase - `balancer.getPeer`: trace Kong selecting an    upstream peer from the ring-balancer - `balancer.toip`: trace balancer to resolve    peer's host to IP - `connect.toip`: trace cosocket to resolve    target's host to IP - `access.before`: trace the preprocessing of    access phase, like parameter parsing, route    matching, and balance preparation - `access.after`: trace the postprocess of    access phase, like balancer execution and    internal variable assigning - `plugin`: trace plugins phase handlers"
+    "description": "Defines the types of traces that are written.\nTrace types not defined in this list are\nignored, regardless of their lifetime. The\ndefault special value of `all` results in all\ntrace types being written, regardless of type.\n\nThe following trace types are included:\n\n- `query`: trace the database query\n- `legacy_query`: (deprecated) trace the\n   database query with legacy DAO\n- `router`: trace Kong routing the request;\n   internal routing time\n- `balancer`: trace the execution of the overall\n   balancer phase\n- `balancer.getPeer`: trace Kong selecting an\n   upstream peer from the ring-balancer\n- `balancer.toip`: trace balancer to resolve\n   peer's host to IP\n- `connect.toip`: trace cosocket to resolve\n   target's host to IP\n- `access.before`: trace the preprocessing of\n   access phase, like parameter parsing, route\n   matching, and balance preparation\n- `access.after`: trace the postprocess of\n   access phase, like balancer execution and\n   internal variable assigning\n- `plugin`: trace plugins phase handlers\n"
   },
   "tracing_debug_header": {
     "defaultValue": null,
-    "description": "Defines the name of the HTTP request header that must be present in order to generate traces within a request. Setting this value provides a mechanism to selectively generate request traces at the client's request. Note that the value of the header does not matter, only that the header is present in the request. When this value is not set and tracing is enabled, Kong will generate trace data for all requests flowing through the proxy and Admin API. Note that data from certificate handling phases is not logged when this setting is enabled."
+    "description": "Defines the name of the HTTP request header\nthat must be present in order to generate\ntraces within a request. Setting this value\nprovides a mechanism to selectively generate\nrequest traces at the client's request. Note\nthat the value of the header does not matter,\nonly that the header is present in the\nrequest. When this value is not set and\ntracing is enabled, Kong will generate trace\ndata for all requests flowing through the\nproxy and Admin API. Note that data from\ncertificate handling phases is not logged\nwhen this setting is enabled.\n"
   },
   "generate_trace_details": {
     "defaultValue": "off",
-    "description": "When enabled, Kong will write context- specific details into traces. Trace details offer more data about the context of the trace. This can significantly increase the size of trace reports. Note also that trace details may contain potentially sensitive information, such as raw SQL queries; care should be taken to store traces properly when this option is enabled."
+    "description": "When enabled, Kong will write context-\nspecific details into traces. Trace details\noffer more data about the context of the\ntrace. This can significantly increase the\nsize of trace reports. Note also that trace\ndetails may contain potentially sensitive\ninformation, such as raw SQL queries; care\nshould be taken to store traces properly when\nthis option is enabled.\n"
   },
   "route_validation_strategy": {
     "defaultValue": "smart",
-    "description": "The strategy used to validate routes when creating or updating them. Different strategies are available to tune how to enforce splitting traffic of workspaces. - `smart` is the default option and uses the   algorithm described in   https://docs.konghq.com/enterprise/latest/admin-api/workspaces/examples/#important-note-conflicting-services-or-routes-in-workspaces - `off` disables any check - `path` enforces routes to comply with the pattern   described in config enforce_route_path_pattern"
+    "description": "The strategy used to validate\nroutes when creating or updating them.\nDifferent strategies are available to tune\nhow to enforce splitting traffic of\nworkspaces.\n- `smart` is the default option and uses the\n  algorithm described in\n  https://docs.konghq.com/enterprise/latest/admin-api/workspaces/examples/#important-note-conflicting-services-or-routes-in-workspaces\n- `off` disables any check\n- `path` enforces routes to comply with the pattern\n  described in config enforce_route_path_pattern\n"
   },
   "enforce_route_path_pattern": {
     "defaultValue": null,
-    "description": "Specifies the Lua pattern which will be enforced on the `paths` attribute of a Route object. You can also add a placeholder for the workspace in the pattern, which will be rendered during runtime based on the workspace to which the `route` belongs. This setting is only relevant if `route_validation_strategy` is set to `path`.   Example For Pattern `/$(workspace)/v%d/.*` valid paths are:  1. `/group1/v1/` if route belongs to   workspace `group1`.  2. `/group2/v1/some_path` if route belongs to   workspace `group2`."
+    "description": "Specifies the Lua pattern which will\nbe enforced on the `paths` attribute of a\nRoute object. You can also add a placeholder\nfor the workspace in the pattern, which\nwill be rendered during runtime based on the\nworkspace to which the `route` belongs.\nThis setting is only relevant if\n`route_validation_strategy` is set to `path`.\n\n\nExample\nFor Pattern `/$(workspace)/v%d/.*` valid paths\nare:\n\n1. `/group1/v1/` if route belongs to\n  workspace `group1`.\n\n2. `/group2/v1/some_path` if route belongs to\n  workspace `group2`.\n"
   },
   "keyring_enabled": {
     "defaultValue": "off",
-    "description": "When enabled, Kong will encrypt sensitive field values before writing them to the database, and subsuquently decrypt them when retrieving data for the Admin API, Developer Portal, or proxy business logic. Symmetric encryption keys are managed based on the strategy defined below."
+    "description": "When enabled, Kong will encrypt sensitive\nfield values before writing them to the\ndatabase, and subsuquently decrypt them when\nretrieving data for the Admin API, Developer\nPortal, or proxy business logic. Symmetric\nencryption keys are managed based on the\nstrategy defined below.\n"
   },
   "keyring_strategy": {
     "defaultValue": "cluster",
-    "description": "Defines the strategy implementation by which Kong nodes will manage symmetric encryption keys. Please see the Kong Enterprise documentation for a detailed description of each strategies. Acceptable values for this option are 'cluster' and 'vault'."
+    "description": "Defines the strategy implementation by which\nKong nodes will manage symmetric encryption\nkeys. Please see the Kong Enterprise\ndocumentation for a detailed description of\neach strategies. Acceptable values for this\noption are 'cluster' and 'vault'.\n"
   },
   "keyring_public_key": {
     "defaultValue": null,
-    "description": "Defines the public key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  values: * absolute path to the public key * public key content * base64 encoded public key content"
+    "description": "Defines the public key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nvalues:\n* absolute path to the public key\n* public key content\n* base64 encoded public key content\n"
   },
   "keyring_private_key": {
     "defaultValue": null,
-    "description": "Defines the private key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  values: * absolute path to the private key * private key content * base64 encoded private key content"
+    "description": "Defines the private key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nvalues:\n* absolute path to the private key\n* private key content\n* base64 encoded private key content\n"
   },
   "keyring_blob_path": {
     "defaultValue": null,
-    "description": "Defines the filesystem path at which Kong will backup the initial keyring material. This option is useful largely for development purposes."
+    "description": "Defines the filesystem path at which Kong\nwill backup the initial keyring material.\nThis option is useful largely for development\npurposes.\n"
   },
   "keyring_vault_host": {
     "defaultValue": null,
-    "description": "Defines the Vault host at which Kong will fetch the encryption material. This value should be defined in the format:  `<scheme>://<IP / HOSTNAME>:<PORT>`"
+    "description": "Defines the Vault host at which Kong will\nfetch the encryption material. This value\nshould be defined in the format:\n\n`<scheme>://<IP / HOSTNAME>:<PORT>`\n"
   },
   "keyring_vault_mount": {
     "defaultValue": null,
-    "description": "Defines the name of the Vault v2 KV secrets engine at which symmetric keys are found."
+    "description": "Defines the name of the Vault v2 KV secrets\nengine at which symmetric keys are found.\n"
   },
   "keyring_vault_path": {
     "defaultValue": null,
-    "description": "Defines the names of the Vault v2 KV path at which symmetric keys are found."
+    "description": "Defines the names of the Vault v2 KV path\nat which symmetric keys are found.\n"
   },
   "keyring_vault_auth_method": {
     "defaultValue": "token",
-    "description": " Defines the authentication mechanism when connecting to the Hashicorp Vault service.  Accepted values are: `token`, or `kubernetes`:  * `token`: Uses the static token defined in            the `keyring_vault_token`            configuration property.  * `kubernetes`: Uses the Kubernetes authentication                 mechanism, with the running pod's                 mapped service account, to assume                 the Hashicorp Vault role name that is                 defined in the `keyring_vault_kube_role`                 configuration property."
+    "description": "Defines the authentication mechanism when\nconnecting to the Hashicorp Vault service.\n\nAccepted values are: `token`, or `kubernetes`:\n\n* `token`: Uses the static token defined in\n           the `keyring_vault_token`\n           configuration property.\n\n* `kubernetes`: Uses the Kubernetes authentication\n                mechanism, with the running pod's\n                mapped service account, to assume\n                the Hashicorp Vault role name that is\n                defined in the `keyring_vault_kube_role`\n                configuration property.\n"
   },
   "keyring_vault_token": {
     "defaultValue": null,
-    "description": "Defines the token value used to communicate with the v2 KV Vault HTTP(S) API."
+    "description": "Defines the token value used to communicate\nwith the v2 KV Vault HTTP(S) API.\n"
   },
   "keyring_vault_kube_role": {
     "defaultValue": "default",
-    "description": " Defines the Hashicorp Vault role that will be assumed using the Kubernetes service account of the running pod.  `keyring_vault_auth_method` must be set to `kubernetes` for this to activate."
+    "description": "Defines the Hashicorp Vault role that will be\nassumed using the Kubernetes service account of\nthe running pod.\n\n`keyring_vault_auth_method` must be set to `kubernetes`\nfor this to activate.\n"
   },
   "keyring_vault_kube_api_token_file": {
     "defaultValue": "/run/secrets/kubernetes.io/serviceaccount/token",
-    "description": " Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+    "description": "Defines where the Kubernetes service account token\nshould be read from the pod's filesystem, if using\na non-standard container platform setup.\n"
   },
   "untrusted_lua": {
     "defaultValue": "sandbox",
-    "description": " Controls loading of Lua functions from admin-supplied sources such as the Admin API. LuaJIT bytecode loading is always disabled.  **Warning:** LuaJIT is not designed as a secure runtime for running malicious code, therefore you should properly protect your Admin API endpoint even with sandboxing enabled. The sandbox only provides protection against trivial attackers or unintentional modification of the Kong global environment.  Accepted values are: `off`, `sandbox`, or `on`:  * `off`: Disallow loading of any arbitrary          Lua functions. The `off` option          disables any functionality that runs          arbitrary Lua code, including the          Serverless Functions plugins and any          transformation plugin that allows          custom Lua functions.  * `sandbox`: Allow loading of Lua functions,              but use a sandbox when executing              them. The sandboxed function has              restricted access to the global              environment and only has access              to standard Lua functions that              will generally not cause harm to              the Kong Gateway node.  * `on`: Functions have unrestricted         access to the global environment and         can load any Lua modules. This is         similar to the behavior in         Kong Gateway prior to 2.3.0.  The default `sandbox` environment does not allow importing other modules or libraries, or executing anything at the OS level (for example, file read/write). The global environment is also not accessible.  Examples of `untrusted_lua = sandbox` behavior:  * You can't access or change global values such as `kong.configuration.pg_password` * You can run harmless lua: `local foo = 1 + 1`. However, OS level functions are not allowed, like: `os.execute('rm -rf /*')`.  For a full allowed/disallowed list, see: https://github.com/kikito/sandbox.lua/blob/master/sandbox.lua  To customize the sandbox environment, use the `untrusted_lua_sandbox_requires` and `untrusted_lua_sandbox_environment` parameters below."
+    "description": "Controls loading of Lua functions from admin-supplied\nsources such as the Admin API. LuaJIT bytecode\nloading is always disabled.\n\n**Warning:** LuaJIT is not designed as a secure\nruntime for running malicious code, therefore\nyou should properly protect your Admin API endpoint\neven with sandboxing enabled. The sandbox only\nprovides protection against trivial attackers or\nunintentional modification of the Kong global\nenvironment.\n\nAccepted values are: `off`, `sandbox`, or\n`on`:\n\n* `off`: Disallow loading of any arbitrary\n         Lua functions. The `off` option\n         disables any functionality that runs\n         arbitrary Lua code, including the\n         Serverless Functions plugins and any\n         transformation plugin that allows\n         custom Lua functions.\n\n* `sandbox`: Allow loading of Lua functions,\n             but use a sandbox when executing\n             them. The sandboxed function has\n             restricted access to the global\n             environment and only has access\n             to standard Lua functions that\n             will generally not cause harm to\n             the Kong Gateway node.\n\n* `on`: Functions have unrestricted\n        access to the global environment and\n        can load any Lua modules. This is\n        similar to the behavior in\n        Kong Gateway prior to 2.3.0.\n\nThe default `sandbox` environment does not\nallow importing other modules or libraries,\nor executing anything at the OS level (for\nexample, file read/write). The global\nenvironment is also not accessible.\n\nExamples of `untrusted_lua = sandbox`\nbehavior:\n\n* You can't access or change global values\nsuch as `kong.configuration.pg_password`\n* You can run harmless lua:\n`local foo = 1 + 1`. However, OS level\nfunctions are not allowed, like:\n`os.execute('rm -rf /*')`.\n\nFor a full allowed/disallowed list, see:\nhttps://github.com/kikito/sandbox.lua/blob/master/sandbox.lua\n\nTo customize the sandbox environment, use\nthe `untrusted_lua_sandbox_requires` and\n`untrusted_lua_sandbox_environment`\nparameters below.\n"
   },
   "untrusted_lua_sandbox_requires": {
     "defaultValue": null,
-    "description": "Comma-separated list of modules allowed to be loaded with `require` inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  For example, say you have configured the Serverless pre-function plugin and it contains the following `requires`:  ``` local template = require \"resty.template\" local split = require \"kong.tools.utils\".split ```  To run the plugin, add the modules to the allowed list: ``` untrusted_lua_sandbox_requires = resty.template, kong.tools.utils ```  **Warning:** Allowing certain modules may create opportunities to escape the sandbox. For example, allowing `os` or `luaposix` may be unsafe."
+    "description": "Comma-separated list of modules allowed to\nbe loaded with `require` inside the\nsandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\nFor example, say you have configured the\nServerless pre-function plugin and it\ncontains the following `requires`:\n\n```\nlocal template = require \"resty.template\"\nlocal split = require \"kong.tools.utils\".split\n```\n\nTo run the plugin, add the modules to the\nallowed list:\n```\nuntrusted_lua_sandbox_requires = resty.template, kong.tools.utils\n```\n\n**Warning:** Allowing certain modules may\ncreate opportunities to escape the\nsandbox. For example, allowing `os` or\n`luaposix` may be unsafe.\n"
   },
   "untrusted_lua_sandbox_environment": {
     "defaultValue": null,
-    "description": "Comma-separated list of global Lua variables that should be made available inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  **Warning**: Certain variables, when made available, may create opportunities to escape the sandbox."
+    "description": "Comma-separated list of global Lua\nvariables that should be made available\ninside the sandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\n**Warning**: Certain variables, when made\navailable, may create opportunities to\nescape the sandbox.\n"
   },
   "openresty_path": {
     "defaultValue": null,
-    "description": "Path to the OpenResty installation that Kong will use. When this is empty (the default), Kong determines the OpenResty installation by searching for a system-installed OpenResty and falling back to searching $PATH for the nginx binary.  Setting this attribute disables the search behavior and explicitly instructs Kong which OpenResty installation to use."
+    "description": "Path to the OpenResty installation that Kong\nwill use. When this is empty (the default),\nKong determines the OpenResty installation\nby searching for a system-installed OpenResty\nand falling back to searching $PATH for the\nnginx binary.\n\nSetting this attribute disables the search\nbehavior and explicitly instructs Kong which\nOpenResty installation to use.\n"
   },
   "node_id": {
     "defaultValue": null,
-    "description": "Node ID for the Kong node. Every Kong node in a Kong cluster must have a unique and valid UUID. When empty, node ID is automatically generated."
+    "description": "Node ID for the Kong node. Every Kong node\nin a Kong cluster must have a unique and\nvalid UUID. When empty, node ID is\nautomatically generated.\n"
   },
   "cluster_fallback_config_import": {
     "defaultValue": "off",
-    "description": "Enable fallback configuration imports.  This should only be enabled for data planes."
+    "description": "Enable fallback configuration imports.\n\nThis should only be enabled for data planes.\n"
   },
   "cluster_fallback_config_storage": {
     "defaultValue": null,
-    "description": "Storage definition used by `cluster_fallback_config_import` and `cluster_fallback_config_export`.  Supported storage types: - S3-like storages - GCP storage service  To use S3 with a bucket named b and place all configs to with a key prefix named p, set it to: `s3://b/p` To use GCP for the same bucket and prefix, set it to: `gcs://b/p`  The credentials (and the endpoint URL for S3-like) for S3 are passed with environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where `AWS_CONFIG_STORAGE_ENDPOINT` is the endpoint that hosts S3-like storage.  The credentials for GCP are provided via the environment variable `GCP_SERVICE_ACCOUNT`."
+    "description": "Storage definition used by `cluster_fallback_config_import`\nand `cluster_fallback_config_export`.\n\nSupported storage types:\n- S3-like storages\n- GCP storage service\n\nTo use S3 with a bucket named b and place all configs\nto with a key prefix named p, set it to:\n`s3://b/p`\nTo use GCP for the same bucket and prefix, set it to:\n`gcs://b/p`\n\nThe credentials (and the endpoint URL for S3-like) for S3\nare passed with environment variables:\n`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,\nand `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where\n`AWS_CONFIG_STORAGE_ENDPOINT`\nis the endpoint that hosts S3-like storage.\n\nThe credentials for GCP are provided via the environment\nvariable `GCP_SERVICE_ACCOUNT`.\n"
   },
   "cluster_fallback_export_s3_config": {
     "defaultValue": null,
-    "description": "fallback config export S3 config This is used only when `cluster_fallback_config_storage` is S3-like schema. If set, it will add config table to kong exporter config S3 putObject request. The config table should be in JSON format and can be unserialized into a table. It should contain the necessary parameters as described in the documentation.  https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property. For example, if you want to set the ServerSideEncryption headers / KMS Key ID for the S3 putObject request, you can set the config table to: `{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"your-kms-key-id\"}`"
+    "description": "fallback config export S3 config\nThis is used only when `cluster_fallback_config_storage` is S3-like schema.\nIf set, it will add config table to kong exporter config S3 putObject request.\nThe config table should be in JSON format and can be unserialized into a table.\nIt should contain the necessary parameters as described in the documentation.\n https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property.\nFor example, if you want to set the ServerSideEncryption headers / KMS Key ID\nfor the S3 putObject request, you can set the config table to:\n`{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"your-kms-key-id\"}`\n"
   },
   "cluster_fallback_config_export": {
     "defaultValue": "off",
-    "description": "Enable fallback configuration exports."
+    "description": "Enable fallback configuration exports.\n"
   },
   "cluster_fallback_config_export_delay": {
     "defaultValue": "60",
-    "description": "The fallback configuration export interval.  If the interval is set to 60 and configuration A is exported and there are new configurations B, C, and D in the next 60 seconds, it will wait until 60 seconds passed and export D, skipping B and C."
+    "description": "The fallback configuration export interval.\n\nIf the interval is set to 60 and configuration A is exported\nand there are new configurations B, C, and D in the next 60 seconds,\nit will wait until 60 seconds passed and export D, skipping B and C.\n"
   },
   "wasm": {
     "defaultValue": "off",
-    "description": "Enable/disable wasm support. This must be enabled in order to use wasm filters and filter chains."
+    "description": "Enable/disable wasm support. This must be enabled in\norder to use wasm filters and filter chains.\n"
   },
   "wasm_filters_path": {
     "defaultValue": null,
-    "description": "Path to the directory containing wasm filter modules.  At startup, Kong discovers available wasm filters by scanning this directory for files with the `.wasm` file extension.  The name of a wasm filter module is derived from the filename itself, with the .wasm extension removed. So, given the following tree:  ``` /path/to/wasm_filters ├── my_module.wasm ├── my_other_module.wasm └── not_a_wasm_module.txt ```  The resulting filter modules available for use in Kong will be:  * `my_module` * `my_other_module`  Notes:  * No recursion is performed. Only .wasm files at the   top level are registered * This path _may_ be a symlink to a directory."
+    "description": "Path to the directory containing wasm filter modules.\n\nAt startup, Kong discovers available wasm filters by\nscanning this directory for files with the `.wasm`\nfile extension.\n\nThe name of a wasm filter module is derived from the\nfilename itself, with the .wasm extension removed. So,\ngiven the following tree:\n\n```\n/path/to/wasm_filters\n├── my_module.wasm\n├── my_other_module.wasm\n└── not_a_wasm_module.txt\n```\n\nThe resulting filter modules available for use in Kong\nwill be:\n\n* `my_module`\n* `my_other_module`\n\nNotes:\n\n* No recursion is performed. Only .wasm files at the\n  top level are registered\n* This path _may_ be a symlink to a directory.\n"
   },
   "request_debug": {
     "defaultValue": "on",
-    "description": "When enabled, Kong will provide detailed timing information for its components to the client and the error log if the following headers are present in the proxy request: - `X-Kong-Request-Debug`:   If the value is set to `*`,   timing information will be collected and exported for the current request.   If this header is not present or contains unknown value,   timing information will not be collected for the current request.   You can also specify a list of filters, separated by commas,   to filter the scope of the time information that is collected.   The following filters are supported:   - `rewrite`: Collect timing information from the `rewrite` phase.   - `access`: Collect timing information from the `access` phase.   - `balancer`: Collect timing information from the `balancer` phase.   - `response`: Collect timing information from the `response` phase.   - `header_filter`: Collect timing information from the `header_filter` phase.   - `body_filter`: Collect timing information from the `body_filter` phase.   - `log`: Collect timing information from the `log` phase.   - `upstream`: Collect timing information from the `upstream` phase.  - `X-Kong-Request-Debug-Log`:   If set to `true`, timing information will also be logged   in the Kong error log with a log level of `notice`.   Defaults to `false`.  - `X-Kong-Request-Debug-Token`:   Token for authenticating the client making the debug   request to prevent abuse. Debug requests originating from loopback   addresses do not require this header. "
+    "description": "When enabled, Kong will provide detailed timing information\nfor its components to the client and the error log\nif the following headers are present in the proxy request:\n- `X-Kong-Request-Debug`:\n  If the value is set to `*`,\n  timing information will be collected and exported for the current request.\n  If this header is not present or contains unknown value,\n  timing information will not be collected for the current request.\n  You can also specify a list of filters, separated by commas,\n  to filter the scope of the time information that is collected.\n  The following filters are supported:\n  - `rewrite`: Collect timing information from the `rewrite` phase.\n  - `access`: Collect timing information from the `access` phase.\n  - `balancer`: Collect timing information from the `balancer` phase.\n  - `response`: Collect timing information from the `response` phase.\n  - `header_filter`: Collect timing information from the `header_filter` phase.\n  - `body_filter`: Collect timing information from the `body_filter` phase.\n  - `log`: Collect timing information from the `log` phase.\n  - `upstream`: Collect timing information from the `upstream` phase.\n\n- `X-Kong-Request-Debug-Log`:\n  If set to `true`, timing information will also be logged\n  in the Kong error log with a log level of `notice`.\n  Defaults to `false`.\n\n- `X-Kong-Request-Debug-Token`:\n  Token for authenticating the client making the debug\n  request to prevent abuse. Debug requests originating from loopback\n  addresses do not require this header.\n\n"
   },
   "request_debug_token": {
     "defaultValue": "<random>",
-    "description": "The Request Debug Token is used in the `X-Kong-Request-Debug-Token` header to prevent abuse. If this value is not set (the default), a random token will be generated when Kong starts, restarts, or reloads. If a token is specified manually, then the provided token will be used.  You can locate the generated debug token in two locations: - Kong error log:   Debug token will be logged in the error log (notice level)   when Kong starts, restarts, or reloads.   The log line will have the: `[request-debug]` prefix to aid searching. - Filesystem:   Debug token will also be stored in a file located at   `{prefix}/.request_debug_token` and updated   when Kong starts, restarts, or reloads."
+    "description": "The Request Debug Token is used in the\n`X-Kong-Request-Debug-Token` header to prevent abuse.\nIf this value is not set (the default),\na random token will be generated\nwhen Kong starts, restarts, or reloads. If a token is\nspecified manually, then the provided token will be used.\n\nYou can locate the generated debug token in two locations:\n- Kong error log:\n  Debug token will be logged in the error log (notice level)\n  when Kong starts, restarts, or reloads.\n  The log line will have the: `[request-debug]` prefix to aid searching.\n- Filesystem:\n  Debug token will also be stored in a file located at\n  `{prefix}/.request_debug_token` and updated\n  when Kong starts, restarts, or reloads.\n"
   }
 }

--- a/app/_data/kong-conf/3.5.json
+++ b/app/_data/kong-conf/3.5.json
@@ -1,0 +1,1216 @@
+{
+  "prefix": {
+    "defaultValue": "/usr/local/kong/",
+    "description": "Working directory. Equivalent to Nginx's prefix path, containing temporary files and logs. Each Kong process must have a separate working directory."
+  },
+  "log_level": {
+    "defaultValue": "notice",
+    "description": "Log level of the Nginx server. Logs are found at `<prefix>/logs/error.log`."
+  },
+  "proxy_access_log": {
+    "defaultValue": "logs/access.log",
+    "description": "Path for proxy port request access logs. Set this value to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "proxy_error_log": {
+    "defaultValue": "logs/error.log",
+    "description": "Path for proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "proxy_stream_access_log": {
+    "defaultValue": "logs/access.log basic",
+    "description": "Path for tcp streams proxy port access logs. Set this value to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location. `basic` is defined as `'$remote_addr [$time_local] ' '$protocol $status $bytes_sent $bytes_received ' '$session_time'`"
+  },
+  "proxy_stream_error_log": {
+    "defaultValue": "logs/error.log",
+    "description": "Path for tcp streams proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "admin_access_log": {
+    "defaultValue": "logs/admin_access.log",
+    "description": "Path for Admin API request access logs. If Hybrid Mode is enabled and the current node is set to be the Control Plane, then the connection requests from Data Planes are also written to this file with server name \"kong_cluster_listener\".  Set this value to `off` to disable logging Admin API requests. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "admin_error_log": {
+    "defaultValue": "logs/error.log",
+    "description": "Path for Admin API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "status_access_log": {
+    "defaultValue": "off",
+    "description": "Path for Status API request access logs. The default value of `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "status_error_log": {
+    "defaultValue": "logs/status_error.log",
+    "description": "Path for Status API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "debug_access_log": {
+    "defaultValue": "off",
+    "description": "Path for Debug API request access logs. The default value of `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "debug_error_log": {
+    "defaultValue": "logs/debug_error.log",
+    "description": "Path for Debug API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "vaults": {
+    "defaultValue": "bundled",
+    "description": "Comma-separated list of vaults this node should load. By default, all the bundled vaults are enabled.  The specified name(s) will be substituted as such in the Lua namespace: `kong.vaults.{name}.*`."
+  },
+  "opentelemetry_tracing": {
+    "defaultValue": "off",
+    "description": "Deprecated: use tracing_instrumentations instead"
+  },
+  "tracing_instrumentations": {
+    "defaultValue": "off",
+    "description": "Comma-separated list of tracing instrumentations this node should load. By default, no instrumentations are enabled.  Valid values to this setting are:  - `off`: do not enable instrumentations. - `request`: only enable request-level instrumentations. - `all`: enable all the following instrumentations. - `db_query`: trace database query - `dns_query`: trace DNS query. - `router`: trace router execution, including   router rebuilding. - `http_client`: trace OpenResty HTTP client requests. - `balancer`: trace balancer retries. - `plugin_rewrite`: trace plugins iterator   execution with rewrite phase. - `plugin_access`: trace plugins iterator   execution with access phase. - `plugin_header_filter`: trace plugins iterator   execution with header_filter phase.  **Note:** In the current implementation, tracing instrumentations are not enabled in stream mode."
+  },
+  "opentelemetry_tracing_sampling_rate": {
+    "defaultValue": "1.0",
+    "description": "Deprecated: use tracing_sampling_rate instead"
+  },
+  "tracing_sampling_rate": {
+    "defaultValue": "0.01",
+    "description": "Tracing instrumentation sampling rate. Tracer samples a fixed percentage of all spans following the sampling rate.  Example: `0.25`, this should account for 25% of all traces."
+  },
+  "plugins": {
+    "defaultValue": "bundled",
+    "description": "Comma-separated list of plugins this node should load. By default, only plugins bundled in official distributions are loaded via the `bundled` keyword.  Loading a plugin does not enable it by default, but only instructs Kong to load its source code, and allows to configure the plugin via the various related Admin API endpoints.  The specified name(s) will be substituted as such in the Lua namespace: `kong.plugins.{name}.*`.  When the `off` keyword is specified as the only value, no plugins will be loaded.  `bundled` and plugin names can be mixed together, as the following examples suggest:  - `plugins = bundled,custom-auth,custom-log`   will include the bundled plugins plus two   custom ones - `plugins = custom-auth,custom-log` will   *only* include the `custom-auth` and   `custom-log` plugins. - `plugins = off` will not include any   plugins  **Note:** Kong will not start if some plugins were previously configured (i.e. have rows in the database) and are not specified in this list.  Before disabling a plugin, ensure all instances of it are removed before restarting Kong.  **Note:** Limiting the amount of available plugins can improve P99 latency when experiencing LRU churning in the database cache (i.e. when the configured `mem_cache_size`) is full."
+  },
+  "dedicated_config_processing": {
+    "defaultValue": "on",
+    "description": "Enables or disables a special worker process for configuration processing. This process increases memory usage a little bit while allowing to reduce latencies by moving some background tasks, such as CP/DP connection handling, to an additional worker process specific to handling these background tasks. Currently this has effect only on data planes."
+  },
+  "pluginserver_names": {
+    "defaultValue": null,
+    "description": "Comma-separated list of names for pluginserver processes.  The actual names are used for log messages and to relate the actual settings."
+  },
+  "pluginserver_XXX_socket": {
+    "defaultValue": "<prefix>/<XXX>.socket",
+    "description": "Path to the unix socket used by the <XXX> pluginserver."
+  },
+  "pluginserver_XXX_start_cmd": {
+    "defaultValue": "/usr/local/bin/<XXX>",
+    "description": "Full command (including any needed arguments) to start the <XXX> pluginserver"
+  },
+  "pluginserver_XXX_query_cmd": {
+    "defaultValue": "/usr/local/bin/query_<XXX>",
+    "description": "Full command to \"query\" the <XXX> pluginserver.  Should produce a JSON with the dump info of all plugins it manages"
+  },
+  "port_maps": {
+    "defaultValue": null,
+    "description": "With this configuration parameter, you can let the Kong to know about the port from which the packets are forwarded to it. This is fairly common when running Kong in a containerized or virtualized environment. For example, `port_maps=80:8000, 443:8443` instructs Kong that the port 80 is mapped to 8000 (and the port 443 to 8443), where 8000 and 8443 are the ports that Kong is listening to.  This parameter helps Kong set a proper forwarded upstream HTTP request header or to get the proper forwarded port with the Kong PDK (in case other means determining it has failed). It changes routing by a destination port to route by a port from which packets are forwarded to Kong, and similarly it changes the default plugin log serializer to use the port according to this mapping instead of reporting the port Kong is listening to."
+  },
+  "anonymous_reports": {
+    "defaultValue": "on",
+    "description": "Send anonymous usage data such as error stack traces to help improve Kong."
+  },
+  "proxy_server": {
+    "defaultValue": null,
+    "description": "Proxy server defined as a URL. Kong will only use this option if any component is explicitly configured to use proxy."
+  },
+  "proxy_server_ssl_verify": {
+    "defaultValue": "off",
+    "description": "Toggles server certificate verification if `proxy_server` is in HTTPS. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+  },
+  "error_template_html": {
+    "defaultValue": null,
+    "description": "Path to the custom html error template to override the default html kong error template.  The template may contain up to two `%s` placeholders. The first one will expand to the error message. The second one will expand to the request ID. Both placeholders are optional, but recommended. Adding more than two placeholders will result in a runtime error when trying to render the template: ``` <html>   <body>     <h1>My custom error template</h1>     <p>error: %s</p>     <p>request_id: %s</p>   </body> </html> ```"
+  },
+  "error_template_json": {
+    "defaultValue": null,
+    "description": "Path to the custom json error template to override the default json kong error template.  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+  },
+  "error_template_xml": {
+    "defaultValue": null,
+    "description": "Path to the custom xml error template to override the default xml kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+  },
+  "error_template_plain": {
+    "defaultValue": null,
+    "description": "Path to the custom plain error template to override the default plain kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+  },
+  "role": {
+    "defaultValue": "traditional",
+    "description": "Use this setting to enable Hybrid Mode, This allows running some Kong nodes in a control plane role with a database and have them deliver configuration updates to other nodes running to DB-less running in a Data Plane role.  Valid values to this setting are:  - `traditional`: do not use Hybrid Mode. - `control_plane`: this node runs in a   control plane role. It can use a database   and will deliver configuration updates   to data plane nodes. - `data_plane`: this is a data plane node.   It runs DB-less and receives configuration   updates from a control plane node."
+  },
+  "cluster_mtls": {
+    "defaultValue": "shared",
+    "description": "Sets the verification between nodes of the cluster.  Valid values to this setting are:  - `shared`: use a shared certificate/key   pair specified with the `cluster_cert`   and `cluster_cert_key` settings.   Note that CP and DP nodes have to present   the same certificate to establish mTLS   connections. - `pki`: use `cluster_ca_cert`,   `cluster_server_name` and `cluster_cert`   for verification.   These are different certificates for each   DP node, but issued by a cluster-wide   common CA certificate: `cluster_ca_cert`. - `pki_check_cn`: similar as `pki` but additionally   checks for Common Name of data plane certificate   specified in `cluster_allowed_common_names`."
+  },
+  "cluster_cert": {
+    "defaultValue": null,
+    "description": "Cluster certificate to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes.  Under `pki` mode it should be a different certificate for each DP node.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "cluster_cert_key": {
+    "defaultValue": null,
+    "description": "Cluster certificate key to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes.  Under `pki` mode it should be a different certificate for each DP node.  The certificate key can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+  },
+  "cluster_ca_cert": {
+    "defaultValue": null,
+    "description": "The trusted CA certificate file in PEM format used for Control Plane to verify Data Plane's certificate and Data Plane to verify Control Plane's certificate. Required on data plane if `cluster_mtls` is set to `pki`. If Control Plane certificate is issued by a well known CA, user can set `lua_ssl_trusted_certificate=system` on Data Plane and leave this field empty.  This field is ignored if `cluster_mtls` is set to `shared`.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "cluster_allowed_common_names": {
+    "defaultValue": null,
+    "description": "The list of Common Names that are allowed to connect to control plane. Multiple entries may be supplied in a comma-separated string. When not set, Data Plane with same parent domain of Control Plane cert is allowed to connect.  This field is ignored if `cluster_mtls` is not set to `pki_check_cn`."
+  },
+  "cluster_server_name": {
+    "defaultValue": null,
+    "description": "The server name used in the SNI of the TLS connection from a DP node to a CP node. Must match the Common Name (CN) or Subject Alternative Name (SAN) found in the CP certificate. If `cluster_mtls` is set to `shared`, this setting is ignored and `kong_clustering` is used."
+  },
+  "cluster_control_plane": {
+    "defaultValue": null,
+    "description": "To be used by data plane nodes only: address of the control plane node from which configuration updates will be fetched, in `host:port` format."
+  },
+  "cluster_telemetry_endpoint": {
+    "defaultValue": null,
+    "description": "To be used by data plane nodes only: telemetry address of the control plane node to which telemetry updates will be posted in `host:port` format."
+  },
+  "cluster_telemetry_server_name": {
+    "defaultValue": null,
+    "description": "The SNI (Server Name Indication extension) to use for Vitals telemetry data."
+  },
+  "cluster_dp_labels": {
+    "defaultValue": null,
+    "description": "Comma separated list of Labels for the data plane. Labels are key-value pairs that provide additional context information for each DP. Each label must be configured as a string in the format `key:value`.  Labels are only compatible with hybrid mode deployments with Kong Konnect (SaaS), this configuration doesn't work with self-hosted deployments.  Keys and values follow the AIP standards: https://kong-aip.netlify.app/aip/129/  Example: `deployment:mycloud,region:us-east-1`"
+  },
+  "cluster_listen": {
+    "defaultValue": "0.0.0.0:8005",
+    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster. This port is mTLS protected to ensure end-to-end security and integrity.  This setting has no effect if `role` is not set to `control_plane`.  Connection made to this endpoint are logged to the same location as Admin API access logs. See `admin_access_log` config description for more information."
+  },
+  "cluster_telemetry_listen": {
+    "defaultValue": "0.0.0.0:8006",
+    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane telemetry connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster.  This setting has no effect if `role` is not set to `control_plane`."
+  },
+  "cluster_data_plane_purge_delay": {
+    "defaultValue": "1209600",
+    "description": " How many seconds must pass from the time a DP node becomes offline to the time its entry gets removed from the database, as returned by the /clustering/data-planes Admin API endpoint.  This is to prevent the cluster data plane table from growing indefinitely. The default is set to 14 days. That is, if CP haven't heard from a DP for 14 days, its entry will be removed."
+  },
+  "cluster_ocsp": {
+    "defaultValue": "off",
+    "description": " Whether to check for revocation status of DP certificates using OCSP (Online Certificate Status Protocol). If enabled, the DP certificate should contain the \"Certificate Authority Information Access\" extension and the OCSP method with URI of which the OCSP responder can be reached from CP.  OCSP checks are only performed on CP nodes, it has no effect on DP nodes.  Valid values to this setting are:  - `on`: OCSP revocation check is enabled and DP   must pass the check in order to establish   connection with CP. - `off`: OCSP revocation check is disabled. - `optional`: OCSP revocation check will be attempted,   however, if the required extension is not   found inside DP provided certificate   or communication with the OCSP responder   failed, then DP is still allowed through."
+  },
+  "cluster_use_proxy": {
+    "defaultValue": "off",
+    "description": " Whether to turn on HTTP CONNECT proxy support for hybrid mode connections. `proxy_server` will be used for Hybrid mode connections if this option is turned on."
+  },
+  "cluster_max_payload": {
+    "defaultValue": "16777216",
+    "description": " This sets the maximum compressed payload size allowed to be sent across from CP to DP in Hybrid mode Default is 16MB - 16 * 1024 * 1024."
+  },
+  "proxy_listen": {
+    "defaultValue": [
+      "0.0.0.0:8000 reuseport backlog=16384",
+      "0.0.0.0:8443 http2 ssl reuseport backlog=16384"
+    ],
+    "description": " Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. The proxy server is the public entry point of Kong, which proxies traffic from your consumers to your backend services. This value accepts IPv4, IPv6, and hostnames.  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the TCP_DEFER_ACCEPT socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  This value can be set to `off`, thus disabling the HTTP/HTTPS proxy port for this node. If stream_listen is also set to `off`, this enables 'control-plane' mode for this node (in which all traffic proxying capabilities are disabled). This node can then be used only to configure a cluster of Kong nodes connected to the same datastore.  Example: `proxy_listen = 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`  See http://nginx.org/en/docs/http/ngx_http_core_module.html#listen for a description of the accepted formats for this and other `*_listen` values.  See https://www.nginx.com/resources/admin-guide/proxy-protocol/ for more details about the `proxy_protocol` parameter.  Not all `*_listen` values accept all formats specified in nginx's documentation."
+  },
+  "proxy_url": {
+    "defaultValue": null,
+    "description": "Kong Proxy URL  The lookup, or balancer, address for your Kong Proxy nodes.  This value is commonly used in a microservices or service-mesh oriented architecture.  Accepted format (parts in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`  Examples:  - `<scheme>://<IP>:<PORT>` -> `proxy_url = http://127.0.0.1:8000` - `SSL <scheme>://<HOSTNAME>` -> `proxy_url = https://proxy.domain.tld` - `<scheme>://<HOSTNAME>/<PATH>` -> `proxy_url = http://dev-machine/dev-285`  By default, Kong Manager, and Kong Portal will use the window request host and append the resolved listener port depending on the requested protocol."
+  },
+  "stream_listen": {
+    "defaultValue": "off",
+    "description": " Comma-separated list of addresses and ports on which the stream mode should listen.  This value accepts IPv4, IPv6, and hostnames. Some suffixes can be specified for each pair: - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  Examples:  ``` stream_listen = 127.0.0.1:7000 reuseport backlog=16384 stream_listen = 0.0.0.0:989 reuseport backlog=65536, 0.0.0.0:20 stream_listen = [::1]:1234 backlog=16384 ```  By default this value is set to `off`, thus disabling the stream proxy port for this node."
+  },
+  "admin_api_uri": {
+    "defaultValue": null,
+    "description": "Deprecated: Use admin_gui_api_url instead"
+  },
+  "admin_listen": {
+    "defaultValue": [
+      "127.0.0.1:8001 reuseport backlog=16384",
+      "127.0.0.1:8444 http2 ssl reuseport backlog=16384"
+    ],
+    "description": " Comma-separated list of addresses and ports on which the Admin interface should listen. The Admin interface is the API allowing you to configure and manage Kong. Access to this interface should be *restricted* to Kong administrators *only*. This value accepts IPv4, IPv6, and hostnames.  It is highly recommended to avoid exposing the Admin API to public interface(s), by using values such as 0.0.0.0:8001  See https://docs.konghq.com/gateway/latest/production/running-kong/secure-admin-api/ for more information about how to secure your Admin API  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the TCP_DEFER_ACCEPT socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  This value can be set to `off`, thus disabling the Admin interface for this node, enabling a 'data-plane' mode (without configuration capabilities) pulling its configuration changes from the database.  Example: `admin_listen = 127.0.0.1:8444 http2 ssl`"
+  },
+  "status_listen": {
+    "defaultValue": "off",
+    "description": "Comma-separated list of addresses and ports on which the Status API should listen. The Status API is a read-only endpoint allowing monitoring tools to retrieve metrics, healthiness, and other non-sensitive information of the current Kong node.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Status API server.  This value can be set to `off`, disabling the Status API for this node.  Example: `status_listen = 0.0.0.0:8100 ssl http2`"
+  },
+  "debug_listen": {
+    "defaultValue": "off",
+    "description": "Comma-separated list of addresses and ports on which the Debug API should listen.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Debug API server.  This value can be set to `off`, disabling the Debug API for this node.  Example: `debug_listen = 0.0.0.0:8200 ssl http2`"
+  },
+  "debug_listen_local": {
+    "defaultValue": "on",
+    "description": "Expose `debug_listen` functionalities via a Unix domain socket under the Kong prefix.  This option allows local user to use \"kong debug\" command to invoke various debug functionalities without needing to enable `debug_listen` ahead of time."
+  },
+  "nginx_user": {
+    "defaultValue": "kong kong",
+    "description": "Defines user and group credentials used by worker processes. If group is omitted, a group whose name equals that of user is used.  Example: `nginx_user = nginx www`  **Note**: If the `kong` user and the `kong` group are not available, the default user and group credentials will be `nobody nobody`."
+  },
+  "nginx_worker_processes": {
+    "defaultValue": "auto",
+    "description": "Determines the number of worker processes spawned by Nginx.  See http://nginx.org/en/docs/ngx_core_module.html#worker_processes for detailed usage of the equivalent Nginx directive and a description of accepted values."
+  },
+  "nginx_daemon": {
+    "defaultValue": "on",
+    "description": "Determines whether Nginx will run as a daemon or as a foreground process. Mainly useful for development or when running Kong inside a Docker environment.  See http://nginx.org/en/docs/ngx_core_module.html#daemon."
+  },
+  "mem_cache_size": {
+    "defaultValue": "128m",
+    "description": "Size of each of the two shared memory caches for traditional mode database entities and runtime data. The accepted units are `k` and `m`, with a minimum recommended value of a few MBs.  **Note**: As this option controls the size of two different cache zones, the total memory Kong uses to cache entities might be double this value. The created zones are shared by all worker processes and do not become larger when more worker is used."
+  },
+  "ssl_cipher_suite": {
+    "defaultValue": "intermediate",
+    "description": "Defines the TLS ciphers served by Nginx. Accepted values are `modern`, `intermediate`, `old`, `fips` or `custom`. If you want to enable TLSv1.1, this value has to be `old`.  See https://wiki.mozilla.org/Security/Server_Side_TLS for detailed descriptions of each cipher suite. `fips` cipher suites are as described in https://wiki.openssl.org/index.php/FIPS_mode_and_TLS."
+  },
+  "ssl_ciphers": {
+    "defaultValue": null,
+    "description": "Defines a custom list of TLS ciphers to be served by Nginx. This list must conform to the pattern defined by `openssl ciphers`. This value is ignored if `ssl_cipher_suite` is not `custom`. If you use DHE ciphers, you must also configure the `ssl_dhparam` parameter."
+  },
+  "ssl_protocols": {
+    "defaultValue": "TLSv1.2 TLSv1.3",
+    "description": " Enables the specified protocols for client-side connections. The set of supported protocol versions also depends on the version of OpenSSL Kong was built with. This value is ignored if `ssl_cipher_suite` is not `custom`. If you want to enable TLSv1.1, you should set `ssl_cipher_suite` to `old`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols"
+  },
+  "ssl_prefer_server_ciphers": {
+    "defaultValue": "on",
+    "description": "Specifies that server ciphers should be preferred over client ciphers when using the SSLv3 and TLS protocols. This value is ignored if `ssl_cipher_suite` is not `custom`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers"
+  },
+  "ssl_dhparam": {
+    "defaultValue": null,
+    "description": "Defines DH parameters for DHE ciphers from the predefined groups: `ffdhe2048`, `ffdhe3072`, `ffdhe4096`, `ffdhe6144`, `ffdhe8192`, from the absolute path to a parameters file, or directly from the parameters content.  This value is ignored if `ssl_cipher_suite` is `modern` or `intermediate`. The reason is that `modern` has no ciphers that needs this, and `intermediate` uses `ffdhe2048`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam"
+  },
+  "ssl_session_tickets": {
+    "defaultValue": "on",
+    "description": "Enables or disables session resumption through TLS session tickets. This has no impact when used with TLSv1.3.  Kong enables this by default for performance reasons, but it has security implications: https://github.com/mozilla/server-side-tls/issues/135  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets"
+  },
+  "ssl_session_timeout": {
+    "defaultValue": "1d",
+    "description": "Specifies a time during which a client may reuse the session parameters. See the rationale: https://github.com/mozilla/server-side-tls/issues/198  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout"
+  },
+  "ssl_session_cache_size": {
+    "defaultValue": "10m",
+    "description": "Sets the size of the caches that store session parameters  See https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache"
+  },
+  "ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `proxy_listen` values with TLS enabled.  If more than one certificates are specified, it can be used to provide alternate type of certificate (for example, ECC certificate) that will be served to clients that supports them. Note to properly serve using ECC certificates, it is recommended to also set `ssl_cipher_suite` to `modern` or `intermediate`.  Unless this option is explicitly set, Kong will auto-generate a pair of default certificates (RSA + ECC) first time it starts up and use it for serving TLS requests.  Certificates can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `proxy_listen` values with TLS enabled.  If more than one certificate was specified for `ssl_cert`, then this option should contain the corresponding key for all certificates provided in the same order.  Unless this option is explicitly set, Kong will auto-generate a pair of default private keys (RSA + ECC) first time it starts up and use it for serving TLS requests.  Keys can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+  },
+  "client_ssl": {
+    "defaultValue": "off",
+    "description": "Determines if Nginx should attempt to send client-side TLS certificates and perform Mutual TLS Authentication with upstream service when proxying requests."
+  },
+  "client_ssl_cert": {
+    "defaultValue": null,
+    "description": "If `client_ssl` is enabled, the client certificate for the `proxy_ssl_certificate` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "client_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "If `client_ssl` is enabled, the client TLS key for the `proxy_ssl_certificate_key` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate key can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+  },
+  "admin_ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `admin_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+  },
+  "admin_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `admin_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+  },
+  "status_ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `status_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+  },
+  "status_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `status_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+  },
+  "debug_ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `debug_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+  },
+  "debug_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `debug_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+  },
+  "headers": {
+    "defaultValue": [
+      "server_tokens",
+      "latency_tokens",
+      "X-Kong-Request-Id"
+    ],
+    "description": " Comma-separated list of headers Kong should inject in client responses.  Accepted values are: - `Server`: Injects `Server: kong/x.y.z`   on Kong-produced response (e.g. Admin   API, rejected requests from auth plugin). - `Via`: Injects `Via: kong/x.y.z` for   successfully proxied requests. - `X-Kong-Proxy-Latency`: Time taken   (in milliseconds) by Kong to process   a request and run all plugins before   proxying the request upstream. - `X-Kong-Response-Latency`: time taken   (in millisecond) by Kong to produce   a response in case of e.g. plugin   short-circuiting the request, or in   in case of an error. - `X-Kong-Upstream-Latency`: Time taken   (in milliseconds) by the upstream   service to send response headers. - `X-Kong-Admin-Latency`: Time taken   (in milliseconds) by Kong to process   an Admin API request. - `X-Kong-Upstream-Status`: The HTTP status   code returned by the upstream service.   This is particularly useful for clients to   distinguish upstream statuses if the   response is rewritten by a plugin. - `X-Kong-Request-Id`: Unique identifier of   the request. - `server_tokens`: Same as specifying both   `Server` and `Via`. - `latency_tokens`: Same as specifying   `X-Kong-Proxy-Latency`,   `X-Kong-Response-Latency`,   `X-Kong-Admin-Latency` and   `X-Kong-Upstream-Latency`  In addition to those, this value can be set to `off`, which prevents Kong from injecting any of the above headers. Note that this does not prevent plugins from injecting headers of their own.  Example: `headers = via, latency_tokens`"
+  },
+  "headers_upstream": {
+    "defaultValue": "X-Kong-Request-Id",
+    "description": " Comma-separated list of headers Kong should inject in requests to upstream.  At this time, the only accepted value is: - `X-Kong-Request-Id`: Unique identifier of   the request.  In addition, this value can be set to `off`, which prevents Kong from injecting the above header. Note that this does not prevent plugins from injecting headers of their own."
+  },
+  "trusted_ips": {
+    "defaultValue": null,
+    "description": "Defines trusted IP addresses blocks that are known to send correct `X-Forwarded-*` headers. Requests from trusted IPs make Kong forward their `X-Forwarded-*` headers upstream. Non-trusted requests make Kong insert its own `X-Forwarded-*` headers.  This property also sets the `set_real_ip_from` directive(s) in the Nginx configuration. It accepts the same type of values (CIDR blocks) but as a comma-separated list.  To trust *all* /!\\ IPs, set this value to `0.0.0.0/0,::/0`.  If the special value `unix:` is specified, all UNIX-domain sockets will be trusted.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from for examples of accepted values."
+  },
+  "real_ip_header": {
+    "defaultValue": "X-Real-IP",
+    "description": "Defines the request header field whose value will be used to replace the client address. This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  If this value receives `proxy_protocol`:  - at least one of the `proxy_listen` entries   must have the `proxy_protocol` flag   enabled. - the `proxy_protocol` parameter will be   appended to the `listen` directive of the   Nginx template.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header for a description of this directive."
+  },
+  "real_ip_recursive": {
+    "defaultValue": "off",
+    "description": "This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive for a description of this directive."
+  },
+  "error_default_type": {
+    "defaultValue": "text/plain",
+    "description": "Default MIME type to use when the request `Accept` header is missing and Nginx is returning an error for the request. Accepted values are `text/plain`, `text/html`, `application/json`, and `application/xml`."
+  },
+  "upstream_keepalive_pool_size": {
+    "defaultValue": "512",
+    "description": "Sets the default size of the upstream keepalive connection pools. Upstream keepalive connection pools are segmented by the `dst ip/dst port/SNI` attributes of a connection. A value of `0` will disable upstream keepalive connections by default, forcing each upstream request to open a new connection."
+  },
+  "upstream_keepalive_max_requests": {
+    "defaultValue": "10000",
+    "description": "Sets the default maximum number of requests than can be proxied upstream through one keepalive connection. After the maximum number of requests is reached, the connection will be closed. A value of `0` will disable this behavior, and a keepalive connection can be used to proxy an indefinite number of requests."
+  },
+  "upstream_keepalive_idle_timeout": {
+    "defaultValue": "60",
+    "description": "Sets the default timeout (in seconds) for which an upstream keepalive connection should be kept open. When the timeout is reached while the connection has not been reused, it will be closed. A value of `0` will disable this behavior, and an idle keepalive connection may be kept open indefinitely."
+  },
+  "allow_debug_header": {
+    "defaultValue": "off",
+    "description": "Enable the `Kong-Debug` header function. if it is `on`, kong will add `Kong-Route-Id` `Kong-Route-Name` `Kong-Service-Id` `Kong-Service-Name` debug headers to response when the client request header `Kong-Debug: 1` is present."
+  },
+  "nginx_main_worker_rlimit_nofile": {
+    "defaultValue": "auto",
+    "description": " Changes the limit on the maximum number of open files for worker processes.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile"
+  },
+  "nginx_events_worker_connections": {
+    "defaultValue": "auto",
+    "description": " Sets the maximum number of simultaneous connections that can be opened by a worker process.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_connections"
+  },
+  "nginx_http_client_header_buffer_size": {
+    "defaultValue": "1k",
+    "description": "Sets buffer size for reading the client request headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size"
+  },
+  "nginx_http_large_client_header_buffers": {
+    "defaultValue": "4 8k",
+    "description": "Sets the maximum number and size of buffers used for reading large clients requests headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers"
+  },
+  "nginx_http_client_max_body_size": {
+    "defaultValue": "0",
+    "description": "Defines the maximum request body size allowed by requests proxied by Kong, specified in the Content-Length request header. If a request exceeds this limit, Kong will respond with a 413 (Request Entity Too Large). Setting this value to 0 disables checking the request body size. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size"
+  },
+  "nginx_admin_client_max_body_size": {
+    "defaultValue": "10m",
+    "description": "Defines the maximum request body size for Admin API."
+  },
+  "nginx_http_charset": {
+    "defaultValue": "UTF-8",
+    "description": "Adds the specified charset to the “Content-Type” response header field. If this charset is different from the charset specified in the source_charset directive, a conversion is performed.  The parameter `off` cancels the addition of charset to the “Content-Type” response header field. See http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset"
+  },
+  "nginx_http_client_body_buffer_size": {
+    "defaultValue": "8k",
+    "description": "Defines the buffer size for reading the request body. If the client request body is larger than this value, the body will be buffered to disk. Note that when the body is buffered to disk, Kong plugins that access or manipulate the request body may not work, so it is advisable to set this value as high as possible (e.g., set it as high as `client_max_body_size` to force request bodies to be kept in memory). Do note that high-concurrency environments will require significant memory allocations to process many concurrent large request bodies. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size"
+  },
+  "nginx_admin_client_body_buffer_size": {
+    "defaultValue": "10m",
+    "description": "Defines the buffer size for reading the request body on Admin API."
+  },
+  "nginx_http_lua_regex_match_limit": {
+    "defaultValue": "100000",
+    "description": "Global `MATCH_LIMIT` for PCRE regex matching. The default of `100000` should ensure at worst any regex Kong executes could finish within roughly 2 seconds."
+  },
+  "nginx_http_lua_regex_cache_max_entries": {
+    "defaultValue": "8192",
+    "description": "Specifies the maximum number of entries allowed in the worker process level compiled regex cache. It is recommended to set it to at least (number of regex paths * 2) to avoid high CPU usages."
+  },
+  "nginx_http_keepalive_requests": {
+    "defaultValue": "10000",
+    "description": "Sets the maximum number of client requests that can be served through one keep-alive connection. After the maximum number of requests are made, the connection is closed. Closing connections periodically is necessary to free per-connection memory allocations. Therefore, using too high maximum number of requests could result in excessive memory usage and not recommended. See: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests"
+  },
+  "database": {
+    "defaultValue": "postgres",
+    "description": "Determines the database (or no database) for this node Accepted values are `postgres` and `off`."
+  },
+  "pg_host": {
+    "defaultValue": "127.0.0.1",
+    "description": "Host of the Postgres server."
+  },
+  "pg_port": {
+    "defaultValue": "5432",
+    "description": "Port of the Postgres server."
+  },
+  "pg_timeout": {
+    "defaultValue": "5000",
+    "description": "Defines the timeout (in ms), for connecting, reading and writing."
+  },
+  "pg_user": {
+    "defaultValue": "kong",
+    "description": "Postgres user."
+  },
+  "pg_password": {
+    "defaultValue": null,
+    "description": "Postgres user's password."
+  },
+  "pg_iam_auth": {
+    "defaultValue": "off",
+    "description": "Determines whether the AWS IAM database Authentication will be used. When switch to `on`, the username defined in `pg_user` will be used as the database account, and the database connection will be forced to using TLS. `pg_password` will not be used when the switch is `on`. Note that the corresponding IAM policy must be correct, otherwise connecting will fail."
+  },
+  "pg_database": {
+    "defaultValue": "kong",
+    "description": "The database name to connect to."
+  },
+  "pg_schema": {
+    "defaultValue": null,
+    "description": "The database schema to use. If unspecified, Kong will respect the `search_path` value of your PostgreSQL instance."
+  },
+  "pg_ssl": {
+    "defaultValue": "off",
+    "description": "Toggles client-server TLS connections between Kong and PostgreSQL. Because PostgreSQL uses the same port for TLS and non-TLS, this is only a hint. If the server does not support TLS, the established connection will be a plain one."
+  },
+  "pg_ssl_version": {
+    "defaultValue": "tlsv1_2",
+    "description": "When using ssl between Kong and PostgreSQL, the version of tls to use. Accepted values are `tlsv1_1`, `tlsv1_2`, `tlsv1_3`, or 'any'. When `any` is set, the client negotiates the highest version with the server which can't be lower than `tlsv1_1`."
+  },
+  "pg_ssl_required": {
+    "defaultValue": "off",
+    "description": "When `pg_ssl` is on this determines if TLS must be used between Kong and PostgreSQL. It aborts the connection if the server does not support SSL connections."
+  },
+  "pg_ssl_verify": {
+    "defaultValue": "off",
+    "description": "Toggles server certificate verification if `pg_ssl` is enabled. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+  },
+  "pg_ssl_cert": {
+    "defaultValue": null,
+    "description": "The absolute path to the PEM encoded client TLS certificate for the PostgreSQL connection. Mutual TLS authentication against PostgreSQL is only enabled if this value is set."
+  },
+  "pg_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "If `pg_ssl_cert` is set, the absolute path to the PEM encoded client TLS private key for the PostgreSQL connection."
+  },
+  "pg_max_concurrent_queries": {
+    "defaultValue": "0",
+    "description": "Sets the maximum number of concurrent queries that can be executing at any given time. This limit is enforced per worker process; the total number of concurrent queries for this node will be will be: `pg_max_concurrent_queries * nginx_worker_processes`.  The default value of 0 removes this concurrency limitation."
+  },
+  "pg_semaphore_timeout": {
+    "defaultValue": "60000",
+    "description": "Defines the timeout (in ms) after which PostgreSQL query semaphore resource acquisition attempts will fail. Such failures will generally result in the associated proxy or Admin API request failing with an HTTP 500 status code. Detailed discussion of this behavior is available in the online documentation."
+  },
+  "pg_keepalive_timeout": {
+    "defaultValue": null,
+    "description": "Specify the maximal idle timeout (in ms) for the postgres connections in the pool. If this value is set to 0 then the timeout interval is unlimited.  If not specified this value will be same as `lua_socket_keepalive_timeout`"
+  },
+  "pg_pool_size": {
+    "defaultValue": null,
+    "description": "Specifies the size limit (in terms of connection count) for the Postgres server. Note that this connection pool is intended per Nginx worker rather than per Kong instance.  If not specified, the default value is the same as `lua_socket_pool_size`"
+  },
+  "pg_backlog": {
+    "defaultValue": null,
+    "description": "If specified, this value will limit the total number of open connections to the Postgres server to `pg_pool_size`. If the connection pool is full, subsequent connect operations will be inserted in a queue with size equal to this option's value.  If the number of queued connect operations reaches `pg_backlog`, exceeding connections will fail.  If not specified, then number of open connections to the Postgres server is not limited."
+  },
+  "pg_ro_host": {
+    "defaultValue": null,
+    "description": "Same as `pg_host`, but for the read-only connection. **Note:** Refer to the documentation section above for detailed usage."
+  },
+  "pg_ro_port": {
+    "defaultValue": "<pg_port>",
+    "description": "Same as `pg_port`, but for the read-only connection."
+  },
+  "pg_ro_timeout": {
+    "defaultValue": "<pg_timeout>",
+    "description": "Same as `pg_timeout`, but for the read-only connection."
+  },
+  "pg_ro_user": {
+    "defaultValue": "<pg_user>",
+    "description": "Same as `pg_user`, but for the read-only connection."
+  },
+  "pg_ro_password": {
+    "defaultValue": "<pg_password>",
+    "description": "Same as `pg_password`, but for the read-only connection."
+  },
+  "pg_ro_iam_auth": {
+    "defaultValue": "<pg_iam_auth>",
+    "description": "Same as `pg_iam_auth`, but for the read-only connection."
+  },
+  "pg_ro_database": {
+    "defaultValue": "<pg_database>",
+    "description": "Same as `pg_database`, but for the read-only connection."
+  },
+  "pg_ro_schema": {
+    "defaultValue": "<pg_schema>",
+    "description": "Same as `pg_schema`, but for the read-only connection."
+  },
+  "pg_ro_ssl": {
+    "defaultValue": "<pg_ssl>",
+    "description": "Same as `pg_ssl`, but for the read-only connection."
+  },
+  "pg_ro_ssl_required": {
+    "defaultValue": "<pg_ssl_required>",
+    "description": " Same as `pg_ssl_required`, but for the read-only connection."
+  },
+  "pg_ro_ssl_verify": {
+    "defaultValue": "<pg_ssl_verify>",
+    "description": " Same as `pg_ssl_verify`, but for the read-only connection."
+  },
+  "pg_ro_ssl_version": {
+    "defaultValue": "<pg_ssl_version>",
+    "description": " Same as `pg_ssl_version`, but for the read-only connection."
+  },
+  "pg_ro_max_concurrent_queries": {
+    "defaultValue": "<pg_max_concurrent_queries>",
+    "description": " Same as `pg_max_concurrent_queries`, but for the read-only connection. Note: read-only concurrency is not shared with the main (read-write) connection."
+  },
+  "pg_ro_semaphore_timeout": {
+    "defaultValue": "<pg_semaphore_timeout>",
+    "description": " Same as `pg_semaphore_timeout`, but for the read-only connection."
+  },
+  "pg_ro_keepalive_timeout": {
+    "defaultValue": "<pg_keepalive_timeout>",
+    "description": " Same as `pg_keepalive_timeout`, but for the read-only connection."
+  },
+  "pg_ro_pool_size": {
+    "defaultValue": "<pg_pool_size>",
+    "description": " Same as `pg_pool_size`, but for the read-only connection."
+  },
+  "pg_ro_backlog": {
+    "defaultValue": "<pg_backlog>",
+    "description": " Same as `pg_backlog`, but for the read-only connection."
+  },
+  "declarative_config": {
+    "defaultValue": null,
+    "description": "The path to the declarative configuration file which holds the specification of all entities (Routes, Services, Consumers, etc.) to be used when the `database` is set to `off`.  Entities are stored in Kong's LMDB cache, so you must ensure that enough headroom is allocated to it via the `lmdb_map_size` property.  If the Hybrid mode `role` is set to `data_plane` and there's no configuration cache file, this configuration is used before connecting to the Control Plane node as a user-controlled fallback."
+  },
+  "declarative_config_string": {
+    "defaultValue": null,
+    "description": "The declarative configuration as a string"
+  },
+  "lmdb_environment_path": {
+    "defaultValue": "dbless.lmdb",
+    "description": "Directory where the LMDB database files used by DB-less and Hybrid mode to store Kong configurations reside.  This path is relative under the Kong `prefix`."
+  },
+  "lmdb_map_size": {
+    "defaultValue": "2048m",
+    "description": "Maximum size of the LMDB memory map, used to store the DB-less and Hybird mode configurations. Default is 2048m.  This config defines the limit of LMDB file size, the actual file size growth will be on-demand and proportional to the actual config size.  Note this value can be set very large, say a couple of GBs to accommodate future database growth and Multi Version Concurrency Control (MVCC) headroom needs. The file size of the LMDB database file should stabilize after a few config reload/Hybrid mode syncs and the actual memory used by the LMDB database will be smaller than the file size due to dynamic swapping of database pages by the OS."
+  },
+  "db_update_frequency": {
+    "defaultValue": "5",
+    "description": "Frequency (in seconds) at which to check for updated entities with the datastore.  When a node creates, updates, or deletes an entity via the Admin API, other nodes need to wait for the next poll (configured by this value) to eventually purge the old cached entity and start using the new one."
+  },
+  "db_update_propagation": {
+    "defaultValue": "0",
+    "description": "Time (in seconds) taken for an entity in the datastore to be propagated to replica nodes of another datacenter.  When set, this property will increase the time taken by Kong to propagate the change of an entity.  Single-datacenter setups or PostgreSQL servers should suffer no such delays, and this value can be safely set to 0. Postgres setups with read replicas should set this value to maximum expected replication lag between the writer and reader instances."
+  },
+  "db_cache_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of an entity from the datastore when cached by this node.  Database misses (no entity) are also cached according to this setting if you do not configure `db_cache_neg_ttl`.  If set to 0 (default), such cached entities or misses never expire."
+  },
+  "db_cache_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a datastore miss (no entity).  If not specified (default), `db_cache_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "db_resurrect_ttl": {
+    "defaultValue": "30",
+    "description": "Time (in seconds) for which stale entities from the datastore should be resurrected for when they cannot be refreshed (e.g., the datastore is unreachable). When this TTL expires, a new attempt to refresh the stale entities will be made."
+  },
+  "db_cache_warmup_entities": {
+    "defaultValue": "services",
+    "description": " Entities to be pre-loaded from the datastore into the in-memory cache at Kong start-up. This speeds up the first access of endpoints that use the given entities.  When the `services` entity is configured for warmup, the DNS entries for values in its `host` attribute are pre-resolved asynchronously as well.  Cache size set in `mem_cache_size` should be set to a value large enough to hold all instances of the specified entities. If the size is insufficient, Kong will log a warning."
+  },
+  "dns_resolver": {
+    "defaultValue": null,
+    "description": "Comma separated list of nameservers, each entry in `ip[:port]` format to be used by Kong. If not specified the nameservers in the local `resolv.conf` file will be used. Port defaults to 53 if omitted. Accepts both IPv4 and IPv6 addresses."
+  },
+  "dns_hostsfile": {
+    "defaultValue": "/etc/hosts",
+    "description": "The hosts file to use. This file is read once and its content is static in memory. To read the file again after modifying it, Kong must be reloaded."
+  },
+  "dns_order": {
+    "defaultValue": [
+      "LAST",
+      "SRV",
+      "A",
+      "CNAME"
+    ],
+    "description": "The order in which to resolve different record types. The `LAST` type means the type of the last successful lookup (for the specified name). The format is a (case insensitive) comma separated list."
+  },
+  "dns_valid_ttl": {
+    "defaultValue": null,
+    "description": "By default, DNS records are cached using the TTL value of a response. If this property receives a value (in seconds), it will override the TTL for all records."
+  },
+  "dns_stale_ttl": {
+    "defaultValue": "3600",
+    "description": "Defines, in seconds, how long a record will remain in cache past its TTL. This value will be used while the new DNS record is fetched in the background. Stale data will be used from expiry of a record until either the refresh query completes, or the `dns_stale_ttl` number of seconds have passed. This configuration enables Kong to be more resilient during resolver downtime."
+  },
+  "dns_cache_size": {
+    "defaultValue": "10000",
+    "description": "Defines the maximum allowed number of DNS records stored in memory cache. Least recently used DNS records are discarded from cache if it is full. Both errors and data are cached, therefore a single name query can easily take up 10-15 slots."
+  },
+  "dns_not_found_ttl": {
+    "defaultValue": "30",
+    "description": "TTL in seconds for empty DNS responses and \"(3) name error\" responses."
+  },
+  "dns_error_ttl": {
+    "defaultValue": "1",
+    "description": "TTL in seconds for error responses."
+  },
+  "dns_no_sync": {
+    "defaultValue": "off",
+    "description": "If enabled, then upon a cache-miss every request will trigger its own dns query. When disabled multiple requests for the same name/type will be synchronised to a single query."
+  },
+  "vault_env_prefix": {
+    "defaultValue": null,
+    "description": "Defines the environment variable vault's default prefix. For example if you have all your secrets stored in environment variables prefixed with `SECRETS_`, it can be configured here so that it isn't necessary to repeat them in Vault references."
+  },
+  "vault_aws_region": {
+    "defaultValue": null,
+    "description": "The AWS region your vault is located in."
+  },
+  "vault_aws_endpoint_url": {
+    "defaultValue": null,
+    "description": "The AWS SecretsManager service endpoint url. If not specified, the value used by vault will be the official AWS SecretsManager service url which is `https://secretsmanager.<region>.amazonaws.com` You can specify a complete URL(including the \"http/https\" scheme) to override the endpoint that vault will connect to."
+  },
+  "vault_aws_assume_role_arn": {
+    "defaultValue": null,
+    "description": "The target AWS IAM role ARN that will be assumed. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+  },
+  "vault_aws_role_session_name": {
+    "defaultValue": "KongVault",
+    "description": "The role session name used for role assuming. The default value is `KongVault`."
+  },
+  "vault_aws_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the AWS vault when cached by this node.  AWS vault misses (no secret) are also cached according to this setting if you do not configure `vault_aws_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_aws_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_aws_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_aws_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the AWS vault should be resurrected for when they cannot be refreshed (e.g., the AWS vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "vault_gcp_project_id": {
+    "defaultValue": null,
+    "description": "The project ID from your Google API Console."
+  },
+  "vault_gcp_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the GCP vault when cached by this node.  GCP vault misses (no secret) are also cached according to this setting if you do not configure `vault_gcp_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_gcp_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_gcp_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_gcp_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the GCP vault should be resurrected for when they cannot be refreshed (e.g., the GCP vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "vault_hcv_protocol": {
+    "defaultValue": "http",
+    "description": "The protocol to connect with. Accepts one of `http` or `https`."
+  },
+  "vault_hcv_host": {
+    "defaultValue": "127.0.0.1",
+    "description": "The hostname of your HashiCorp vault."
+  },
+  "vault_hcv_port": {
+    "defaultValue": "8200",
+    "description": "The port number of your HashiCorp vault."
+  },
+  "vault_hcv_namespace": {
+    "defaultValue": null,
+    "description": "Namespace for the HashiCorp Vault. Vault Enterprise requires a namespace to successfully connect to it."
+  },
+  "vault_hcv_mount": {
+    "defaultValue": "secret",
+    "description": "The mount point."
+  },
+  "vault_hcv_kv": {
+    "defaultValue": "v1",
+    "description": "The secrets engine version. Accepts `v1` or `v2`."
+  },
+  "vault_hcv_token": {
+    "defaultValue": null,
+    "description": "A token string."
+  },
+  "vault_hcv_auth_method": {
+    "defaultValue": "token",
+    "description": "Defines the authentication mechanism when connecting to the Hashicorp Vault service. Accepted values are: `token`, `kubernetes` or `approle`."
+  },
+  "vault_hcv_kube_role": {
+    "defaultValue": null,
+    "description": "Defines the HashiCorp Vault role for the Kubernetes service account of the running pod. `vault_hcv_auth_method` must be set to `kubernetes` for this to activate."
+  },
+  "vault_hcv_kube_auth_path": {
+    "defaultValue": "kubernetes",
+    "description": " Place where the Kubernetes auth method will be accessible: /v1/auth/<vault_hcv_kube_auth_path>"
+  },
+  "vault_hcv_kube_api_token_file": {
+    "defaultValue": null,
+    "description": "Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+  },
+  "vault_hcv_approle_auth_path": {
+    "defaultValue": "approle",
+    "description": " Place where the Approle auth method will be accessible: /v1/auth/<vault_hcv_approle_auth_path>"
+  },
+  "vault_hcv_approle_role_id": {
+    "defaultValue": null,
+    "description": "The Role ID of the Approle in HashiCorp Vault."
+  },
+  "vault_hcv_approle_secret_id": {
+    "defaultValue": null,
+    "description": "The Secret ID of the Approle in HashiCorp Vault."
+  },
+  "vault_hcv_approle_secret_id_file": {
+    "defaultValue": null,
+    "description": "Defines where the Secret ID should be read from the pod's filesystem. This is usually used with HashiCorp Vault's response wrapping."
+  },
+  "vault_hcv_approle_response_wrapping": {
+    "defaultValue": "false",
+    "description": "Defines whether the Secret ID read from configuration or file is actually a response-wrapping token instead of a real Secret ID."
+  },
+  "vault_hcv_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the HashiCorp vault when cached by this node.  HashiCorp vault misses (no secret) are also cached according to this setting if you do not configure `vault_hcv_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_hcv_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a HashiCorp vault miss (no secret).  If not specified (default), `vault_hcv_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_hcv_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the HashiCorp vault should be resurrected for when they cannot be refreshed (e.g., the HashiCorp vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "vault_azure_vault_uri": {
+    "defaultValue": null,
+    "description": "The URI the vault is reachable from."
+  },
+  "vault_azure_client_id": {
+    "defaultValue": null,
+    "description": "The client ID from your registered Application. Visit your Azure Dashboard and select *App Registrations* to check your client ID."
+  },
+  "vault_azure_tenant_id": {
+    "defaultValue": null,
+    "description": "The DirectoryId and TenantId both equate to the GUID representing the ActiveDirectory Tenant. Depending on context, either term may be used by Microsoft documentation and products, which can be confusing. In other words, the \"Tenant ID\" IS the \"Directory ID\""
+  },
+  "vault_azure_type": {
+    "defaultValue": "secrets",
+    "description": "Azure Key Vault enables Microsoft Azure applications and users to store and use several types of secret/key data: keys, secrets, and certificates. Kong currently only supports the `Secrets`"
+  },
+  "vault_azure_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the Azure Key Vault when cached by this node.  Key Vault misses (no secret) are also cached according to this setting if you do not configure `vault_azure_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_azure_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a Azure Key Vault miss (no secret).  If not specified (default), `vault_azure_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_azure_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the Azure Key Vault should be resurrected for when they cannot be refreshed (e.g., the the vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "worker_consistency": {
+    "defaultValue": "eventual",
+    "description": " Defines whether this node should rebuild its state synchronously or asynchronously (the balancers and the router are rebuilt on updates that affects them, e.g., updates to Routes, Services or Upstreams, via the Admin API or loading a declarative configuration file). (This option is deprecated and will be removed in future releases. The new default is `eventual`.)  Accepted values are:  - `strict`: the router will be rebuilt   synchronously, causing incoming requests to   be delayed until the rebuild is finished.   (This option is deprecated and will be removed    in future releases. The new default is `eventual`) - `eventual`: the router will be rebuilt   asynchronously via a recurring background   job running every second inside of each   worker.  Note that `strict` ensures that all workers of a given node will always proxy requests with an identical router, but that increased long tail latency can be observed if frequent Routes and Services updates are expected. Using `eventual` will help preventing long tail latency issues in such cases, but may cause workers to route requests differently for a short period of time after Routes and Services updates."
+  },
+  "worker_state_update_frequency": {
+    "defaultValue": "5",
+    "description": " Defines (in seconds) how often the worker state changes are checked with a background job. When a change is detected, a new router or balancer will be built, as needed. Raising this value will decrease the load on database servers and result in less jitter in proxy latency, but it might take more time to propagate changes to each individual worker."
+  },
+  "router_flavor": {
+    "defaultValue": "traditional_compatible",
+    "description": " Selects the router implementation to use when performing request routing. Incremental router rebuild is available when the flavor is set to either `expressions` or `traditional_compatible` which could significantly shorten rebuild time for large number of routes.  Accepted values are:  - `traditional_compatible`: the DSL based expression   router engine will be used under the hood. However   the router config interface will be the same   as `traditional` and expressions are   automatically generated at router build time.   The `expression` field on the `Route` object   is not visible. - `expressions`: the DSL based expression router engine   will be used under the hood. Traditional router   config interface is not visible and you must write   Router Expression manually and provide them in the   `expression` field on the `Route` object. - `traditional`: the pre-3.0 Router engine will be   used. Config interface will be the same as   pre-3.0 Kong and the `expression` field on the   `Route` object is not visible.    Deprecation warning: In Kong 3.0, `traditional`   mode should be avoided and only be used in case   `traditional_compatible` did not work as expected.   This flavor of router will be removed in the next   major release of Kong."
+  },
+  "lua_max_req_headers": {
+    "defaultValue": "100",
+    "description": "Maximum number of request headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying the Kong sends all the request headers and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many request headers."
+  },
+  "lua_max_resp_headers": {
+    "defaultValue": "100",
+    "description": "Maximum number of response headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong returns all the response headers and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many response headers."
+  },
+  "lua_max_uri_args": {
+    "defaultValue": "100",
+    "description": "Maximum number of request uri arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request query arguments and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many query arguments."
+  },
+  "lua_max_post_args": {
+    "defaultValue": "100",
+    "description": "Maximum number of request post arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request post arguments and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many post arguments."
+  },
+  "lua_ssl_trusted_certificate": {
+    "defaultValue": "system",
+    "description": "Comma-separated list of certificate authorities for Lua cosockets in PEM format.  The special value `system` attempts to search for the \"usual default\" provided by each distro, according to an arbitrary heuristic. In the current implementation, The following pathnames will be tested in order, and the first one found will be used:  - /etc/ssl/certs/ca-certificates.crt (Debian/Ubuntu/Gentoo) - /etc/pki/tls/certs/ca-bundle.crt (Fedora/RHEL 6) - /etc/ssl/ca-bundle.pem (OpenSUSE) - /etc/pki/tls/cacert.pem (OpenELEC) - /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem (CentOS/RHEL 7) - /etc/ssl/cert.pem (OpenBSD, Alpine)  `system` can be used by itself or in conjunction with other CA filepaths.  When `pg_ssl_verify` is enabled, these certificate authority files will be used for verifying Kong's database connections.  Certificates can be configured on this property with either of the following values: * `system` * absolute path to the certificate * certificate content * base64 encoded certificate content  See https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate"
+  },
+  "lua_ssl_verify_depth": {
+    "defaultValue": "1",
+    "description": "Sets the verification depth in the server certificates chain used by Lua cosockets, set by `lua_ssl_trusted_certificate`. This includes the certificates configured for Kong's database connections. If the maximum depth is reached before reaching the end of the chain, verification will fail. This helps mitigate certificate based DoS attacks.  See https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth"
+  },
+  "lua_ssl_protocols": {
+    "defaultValue": "TLSv1.2 TLSv1.3",
+    "description": "Defines the TLS versions supported when handshaking with OpenResty's TCP cosocket APIs.  This affects connections made by Lua code, such as connections to the database Kong uses, or when sending logs using a logging plugin. It does *not* affect connections made to the upstream Service or from downstream clients."
+  },
+  "lua_package_path": {
+    "defaultValue": "./?.lua;./?/init.lua;",
+    "description": "Sets the Lua module search path (LUA_PATH). Useful when developing or using custom plugins not stored in the default search path.  See https://github.com/openresty/lua-nginx-module#lua_package_path"
+  },
+  "lua_package_cpath": {
+    "defaultValue": null,
+    "description": "Sets the Lua C module search path (LUA_CPATH).  See https://github.com/openresty/lua-nginx-module#lua_package_cpath"
+  },
+  "lua_socket_pool_size": {
+    "defaultValue": "256",
+    "description": "Specifies the size limit for every cosocket connection pool associated with every remote server.  See https://github.com/openresty/lua-nginx-module#lua_socket_pool_size"
+  },
+  "enforce_rbac": {
+    "defaultValue": "off",
+    "description": "Specifies whether Admin API RBAC is enforced. Accepts one of `entity`, `both`, `on`, or `off`.  - `on`: only endpoint-level authorization   is enforced. - `entity`: entity-level authorization   applies. - `both`: enables both endpoint and   entity-level authorization. - `off`: disables both endpoint and   entity-level authorization.  When enabled, Kong will deny requests to the Admin API when a nonexistent or invalid RBAC authorization token is passed, or the RBAC user with which the token is associated does not have permissions to access/modify the requested resource."
+  },
+  "rbac_auth_header": {
+    "defaultValue": "Kong-Admin-Token",
+    "description": "Defines the name of the HTTP request header from which the Admin API will attempt to authenticate the RBAC user."
+  },
+  "event_hooks_enabled": {
+    "defaultValue": "on",
+    "description": "When enabled, event hook entities represent a relationship between an event (source and event) and an action (handler). Similar to web hooks, event hooks can be used to communicate Kong Gateway service events. When a particular event happens on a service, the event hook calls a URL with information about that event. Event hook configurations differ depending on the handler. The events that are triggered send associated data.  See: https://docs.konghq.com/enterprise/latest/admin-api/event-hooks/reference/"
+  },
+  "fips": {
+    "defaultValue": "off",
+    "description": "Turn on FIPS mode; this mode is only available on a FIPS build."
+  },
+  "admin_gui_listen": {
+    "defaultValue": [
+      "0.0.0.0:8002",
+      "0.0.0.0:8445 ssl"
+    ],
+    "description": " Kong Manager Listeners  Comma-separated list of addresses and ports on which Kong will expose Kong Manager. This web application lets you configure and manage Kong, and therefore should be kept secured.  Suffixes can be specified for each pair, similarly to the `admin_listen` directive."
+  },
+  "admin_gui_url": {
+    "defaultValue": null,
+    "description": "Kong Manager URL  The lookup, or balancer, address for Kong Manager.  Accepted format (items in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>)`  Examples:  - `http://127.0.0.1:8003` - `https://kong-admin.test` - `http://dev-machine`  By default, Kong Manager will use the window request host and append the resolved listener port depending on the requested protocol."
+  },
+  "admin_gui_path": {
+    "defaultValue": "/",
+    "description": "Kong Manager base path  This configuration parameter allows the user to customize the path prefix where Kong Manager is served. When updating this parameter, it's recommended to update the path in `admin_gui_url` as well.  Accepted format:  - Path must start with a `/` - Path must not end with a `/` (except for the `/`) - Path can only contain letters, digits, hyphens (`-`), underscores (`_`), and slashes (`/`) - Path must not contain continuous slashes (e.g., `//` and `///`)  Examples:  - `/` - `/manager` - `/kong-manager` - `/kong/manager`"
+  },
+  "admin_gui_api_url": {
+    "defaultValue": null,
+    "description": "Hierarchical part of a URI which is composed optionally of a host, port, and path at which the Admin API accepts HTTP or HTTPS traffic. When this config is disabled, Kong Manager will use the window protocol + host and append the resolved admin_listen HTTP/HTTPS port."
+  },
+  "admin_gui_ssl_protocols": {
+    "defaultValue": "TLSv1.2 TLSv1.3",
+    "description": " Defines the TLS versions supported for Kong Manager"
+  },
+  "admin_gui_ssl_cert": {
+    "defaultValue": null,
+    "description": "The SSL certificate for `admin_gui_listen` values with SSL enabled.  values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "admin_gui_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "The SSL key for `admin_gui_listen` values with SSL enabled.  values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+  },
+  "admin_gui_flags": {
+    "defaultValue": "{}",
+    "description": " Alters the layout Admin GUI (JSON) The only supported value is `{ \"IMMUNITY_ENABLED\": true }` to enable Kong Immunity in the Admin GUI."
+  },
+  "admin_gui_access_log": {
+    "defaultValue": "logs/admin_gui_access.log",
+    "description": " Kong Manager Access Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables access logs for Kong Manager."
+  },
+  "admin_gui_error_log": {
+    "defaultValue": "logs/admin_gui_error.log",
+    "description": " Kong Manager Error Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables error logs for Kong Manager.  Granularity can be adjusted through the `log_level` directive."
+  },
+  "admin_gui_auth": {
+    "defaultValue": null,
+    "description": "Kong Manager Authentication Plugin Name  Secures access to Kong Manager by specifying an authentication plugin to use.  Supported Plugins:  - `basic-auth`: Basic Authentication plugin - `ldap-auth-advanced`: LDAP Authentication plugin - `openid-connect`: OpenID Connect Authentication   plugin"
+  },
+  "admin_gui_auth_conf": {
+    "defaultValue": null,
+    "description": "Kong Manager Authentication Plugin Config (JSON)  Specifies the configuration for the authentication plugin specified in `admin_gui_auth`.  For information about Plugin Configuration consult the associated plugin documentation.  Example for `basic-auth`:  `admin_gui_auth_conf = { \"hide_credentials\": true }`"
+  },
+  "admin_gui_auth_password_complexity": {
+    "defaultValue": null,
+    "description": "Kong Manager Authentication Password Complexity (JSON)  When `admin_gui_auth = basic-auth`, this property defines the rules required for Kong Manager passwords. Choose from preset rules or write your own.  Example using preset rules:  `admin_gui_auth_password_complexity = { \"kong-preset\": \"min_8\" }`  All values for kong-preset require the password to contain characters from at least three of the following categories:  1. Uppercase characters (A through Z)  2. Lowercase characters (a through z)  3. Base-10 digits (0 through 9)  4. Special characters (for example, &, $, #, %)  Supported preset rules: - `min_8`: minimum length of 8 - `min_12`: minimum length of 12 - `min_20`: minimum length of 20  To write your own rules, see https://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.  NOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.  Example:  `admin_gui_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`"
+  },
+  "admin_gui_session_conf": {
+    "defaultValue": null,
+    "description": "Kong Manager Session Config (JSON)  Specifies the configuration for the Session plugin as used by Kong Manager.  For information about plugin configuration, consult the Kong Session plugin documentation.  Example: ``` admin_gui_session_conf = { \"cookie_name\": \"kookie\", \\                            \"secret\": \"changeme\" } ```"
+  },
+  "admin_gui_auth_header": {
+    "defaultValue": "Kong-Admin-User",
+    "description": " Defines the name of the HTTP request header from which the Admin API will attempt to identify the Kong Admin user."
+  },
+  "admin_gui_auth_login_attempts": {
+    "defaultValue": "0",
+    "description": " Number of times a user can attempt to login to Kong Manager. 0 means infinite attempts allowed."
+  },
+  "admin_gui_header_txt": {
+    "defaultValue": null,
+    "description": "Kong Manager Header Text Sets text for Kong Manager Header Banner. Header Banner is not shown if this config is empty."
+  },
+  "admin_gui_header_bg_color": {
+    "defaultValue": null,
+    "description": "Kong Manager Header Background Color Sets background color for Kong Manager Header Banner Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Manager."
+  },
+  "admin_gui_header_txt_color": {
+    "defaultValue": null,
+    "description": "Kong Manager Header Text Color Sets text color for Kong Manager Header Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Kong Manager."
+  },
+  "admin_gui_footer_txt": {
+    "defaultValue": null,
+    "description": "Kong Manager Footer Text Sets text for Kong Manager Footer Banner. Footer Banner is not shown if this config is empty"
+  },
+  "admin_gui_footer_bg_color": {
+    "defaultValue": null,
+    "description": "Kong Manager Footer Background Color Sets background color for Kong Manager Footer Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Manager."
+  },
+  "admin_gui_footer_txt_color": {
+    "defaultValue": null,
+    "description": "Kong Manager Footer Text Color Sets text color for Kong Manager Footer Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Kong Manager."
+  },
+  "admin_gui_login_banner_title": {
+    "defaultValue": null,
+    "description": "Kong Manager Login Banner Title Text Sets title text for Kong Manager Login Banner. Login Banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+  },
+  "admin_gui_login_banner_body": {
+    "defaultValue": null,
+    "description": "Kong Manager Login Banner Body Text Sets body text for Kong Manager Login Banner. Login Banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+  },
+  "konnect_mode": {
+    "defaultValue": "off",
+    "description": "When enabled, the dataplane is connected to Konnect"
+  },
+  "analytics_flush_interval": {
+    "defaultValue": "1",
+    "description": "Determine the frequency of flushing local data to Konnect in seconds."
+  },
+  "analytics_buffer_size_limit": {
+    "defaultValue": "100000",
+    "description": "Max number of messages can be buffered locally before dropping data in case there is no network connection to Konnect."
+  },
+  "analytics_debug": {
+    "defaultValue": "off",
+    "description": "Outputs analytics payload to Kong logs."
+  },
+  "admin_emails_from": {
+    "defaultValue": "\"\"",
+    "description": "The email address for the `From` header for admin emails."
+  },
+  "admin_emails_reply_to": {
+    "defaultValue": null,
+    "description": "Email address for the `Reply-To` header for admin emails."
+  },
+  "admin_invitation_expiry": {
+    "defaultValue": "259200",
+    "description": "Expiration time for the admin invitation link (in seconds). 0 means no expiration.  Example, 72 hours: `72 * 60 * 60 = 259200`"
+  },
+  "smtp_mock": {
+    "defaultValue": "on",
+    "description": "This flag will mock the sending of emails. This can be used for testing before the SMTP client is fully configured."
+  },
+  "smtp_host": {
+    "defaultValue": "localhost",
+    "description": " The hostname of the SMTP server to connect to."
+  },
+  "smtp_port": {
+    "defaultValue": "25",
+    "description": " The port number on the SMTP server to connect to."
+  },
+  "smtp_starttls": {
+    "defaultValue": "off",
+    "description": " When set to `on`, STARTTLS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 587."
+  },
+  "smtp_username": {
+    "defaultValue": null,
+    "description": "Username used for authentication with SMTP server"
+  },
+  "smtp_password": {
+    "defaultValue": null,
+    "description": "Password used for authentication with SMTP server"
+  },
+  "smtp_ssl": {
+    "defaultValue": "off",
+    "description": " When set to `on`, SMTPS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 465."
+  },
+  "smtp_auth_type": {
+    "defaultValue": null,
+    "description": "The method used to authenticate with the SMTP server Valid options are `plain`, `login`, or `nil`"
+  },
+  "smtp_domain": {
+    "defaultValue": "localhost.localdomain",
+    "description": " The domain used in the `EHLO` connection and part of the `Message-ID` header"
+  },
+  "smtp_timeout_connect": {
+    "defaultValue": "60000",
+    "description": " The timeout (in milliseconds) for connecting to the SMTP server."
+  },
+  "smtp_timeout_send": {
+    "defaultValue": "60000",
+    "description": " The timeout (in milliseconds) for sending data to the SMTP server."
+  },
+  "smtp_timeout_read": {
+    "defaultValue": "60000",
+    "description": " The timeout (in milliseconds) for reading data from the SMTP server."
+  },
+  "smtp_admin_emails": {
+    "defaultValue": null,
+    "description": "Comma separated list of admin emails to receive notifications. Example `admin1@example.com, admin2@example.com`"
+  },
+  "audit_log": {
+    "defaultValue": "off",
+    "description": "When enabled, Kong will log information about Admin API access and database row insertions, updates, and deletes."
+  },
+  "audit_log_ignore_methods": {
+    "defaultValue": null,
+    "description": "Comma-separated list of HTTP methods that will not generate audit log entries. By default, all HTTP requests will be logged."
+  },
+  "audit_log_ignore_paths": {
+    "defaultValue": null,
+    "description": "Comma-separated list of request paths that will not generate audit log entries. By default, all HTTP requests will be logged."
+  },
+  "audit_log_ignore_tables": {
+    "defaultValue": null,
+    "description": "Comma-separated list of database tables that will not generate audit log entries. By default, updates to all database tables will be logged (the term \"updates\" refers to the creation, update, or deletion of a row)."
+  },
+  "audit_log_payload_exclude": {
+    "defaultValue": [
+      "token",
+      "secret",
+      "password"
+    ],
+    "description": " Comma-separated list of keys that will be filtered out of the payload. Keys that were filtered will be recorded in the audit log."
+  },
+  "audit_log_record_ttl": {
+    "defaultValue": "2592000",
+    "description": "Length, in seconds, of the TTL for audit log records. Records in the database older than their TTL are automatically purged.  Example, 30 days: `30 * 24 * 60 * 60 = 2592000`"
+  },
+  "audit_log_signing_key": {
+    "defaultValue": null,
+    "description": "Defines the path to a private RSA signing key that can be used to insert a signature of audit records, adjacent to the record. The corresponding public key should be stored offline, and can be used the validate audit entries in the future. If this value is undefined, no signature will be generated."
+  },
+  "tracing": {
+    "defaultValue": "off",
+    "description": "When enabled, Kong will generate granular debug data about various portions of the request lifecycle, such as DB or DNS queries, plugin execution, core handler timing, etc."
+  },
+  "tracing_write_strategy": {
+    "defaultValue": "file",
+    "description": "Defines how Kong will write tracing data at the conclusion of the request. The default option, `file`, writes a human-readable depiction of tracing data to a configurable location on the node's file system. Other strategies write tracing data as a JSON document to the configured endpoint. Valid entries for this option are `file`, `file_raw`, `http`, `tcp`, `tls`, and `udp`."
+  },
+  "tracing_write_endpoint": {
+    "defaultValue": null,
+    "description": "Defines the endpoint to which tracing data will be written.  - For the `file` and `file_raw` tracing write   strategies, this value must be a valid   location on the node's file system to which   Kong must have write access. - For the `tcp`, `tls`, and   `udp` strategies, this value is defined as a   string in the form of:  `<HOST>:<PORT>` - For the `http` strategy, this value is   defined in the form of:  `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`  Traces sent via HTTP are delivered via POST method with an `application/json` Content-Type."
+  },
+  "tracing_time_threshold": {
+    "defaultValue": "0",
+    "description": "The minimum time, in microseconds, over which a trace must execute in order to write the trace data to the configured endpoint. This configuration can be used to lower the noise present in trace data by removing trace objects that are not interesting from a timing perspective. The default value of `0` removes this limitation, causing traces of any duration to be written."
+  },
+  "tracing_types": {
+    "defaultValue": "all",
+    "description": "Defines the types of traces that are written. Trace types not defined in this list are ignored, regardless of their lifetime. The default special value of `all` results in all trace types being written, regardless of type.  The following trace types are included:  - `query`: trace the database query - `legacy_query`: (deprecated) trace the    database query with legacy DAO - `router`: trace Kong routing the request;    internal routing time - `balancer`: trace the execution of the overall    balancer phase - `balancer.getPeer`: trace Kong selecting an    upstream peer from the ring-balancer - `balancer.toip`: trace balancer to resolve    peer's host to IP - `connect.toip`: trace cosocket to resolve    target's host to IP - `access.before`: trace the preprocessing of    access phase, like parameter parsing, route    matching, and balance preparation - `access.after`: trace the postprocess of    access phase, like balancer execution and    internal variable assigning - `plugin`: trace plugins phase handlers"
+  },
+  "tracing_debug_header": {
+    "defaultValue": null,
+    "description": "Defines the name of the HTTP request header that must be present in order to generate traces within a request. Setting this value provides a mechanism to selectively generate request traces at the client's request. Note that the value of the header does not matter, only that the header is present in the request. When this value is not set and tracing is enabled, Kong will generate trace data for all requests flowing through the proxy and Admin API. Note that data from certificate handling phases is not logged when this setting is enabled."
+  },
+  "generate_trace_details": {
+    "defaultValue": "off",
+    "description": "When enabled, Kong will write context- specific details into traces. Trace details offer more data about the context of the trace. This can significantly increase the size of trace reports. Note also that trace details may contain potentially sensitive information, such as raw SQL queries; care should be taken to store traces properly when this option is enabled."
+  },
+  "route_validation_strategy": {
+    "defaultValue": "smart",
+    "description": "The strategy used to validate routes when creating or updating them. Different strategies are available to tune how to enforce splitting traffic of workspaces. - `smart` is the default option and uses the   algorithm described in   https://docs.konghq.com/enterprise/latest/admin-api/workspaces/examples/#important-note-conflicting-services-or-routes-in-workspaces - `off` disables any check - `path` enforces routes to comply with the pattern   described in config enforce_route_path_pattern"
+  },
+  "enforce_route_path_pattern": {
+    "defaultValue": null,
+    "description": "Specifies the Lua pattern which will be enforced on the `paths` attribute of a Route object. You can also add a placeholder for the workspace in the pattern, which will be rendered during runtime based on the workspace to which the `route` belongs. This setting is only relevant if `route_validation_strategy` is set to `path`.   Example For Pattern `/$(workspace)/v%d/.*` valid paths are:  1. `/group1/v1/` if route belongs to   workspace `group1`.  2. `/group2/v1/some_path` if route belongs to   workspace `group2`."
+  },
+  "keyring_enabled": {
+    "defaultValue": "off",
+    "description": "When enabled, Kong will encrypt sensitive field values before writing them to the database, and subsuquently decrypt them when retrieving data for the Admin API, Developer Portal, or proxy business logic. Symmetric encryption keys are managed based on the strategy defined below."
+  },
+  "keyring_strategy": {
+    "defaultValue": "cluster",
+    "description": "Defines the strategy implementation by which Kong nodes will manage symmetric encryption keys. Please see the Kong Enterprise documentation for a detailed description of each strategies. Acceptable values for this option are 'cluster' and 'vault'."
+  },
+  "keyring_public_key": {
+    "defaultValue": null,
+    "description": "Defines the public key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  values: * absolute path to the public key * public key content * base64 encoded public key content"
+  },
+  "keyring_private_key": {
+    "defaultValue": null,
+    "description": "Defines the private key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  values: * absolute path to the private key * private key content * base64 encoded private key content"
+  },
+  "keyring_blob_path": {
+    "defaultValue": null,
+    "description": "Defines the filesystem path at which Kong will backup the initial keyring material. This option is useful largely for development purposes."
+  },
+  "keyring_vault_host": {
+    "defaultValue": null,
+    "description": "Defines the Vault host at which Kong will fetch the encryption material. This value should be defined in the format:  `<scheme>://<IP / HOSTNAME>:<PORT>`"
+  },
+  "keyring_vault_mount": {
+    "defaultValue": null,
+    "description": "Defines the name of the Vault v2 KV secrets engine at which symmetric keys are found."
+  },
+  "keyring_vault_path": {
+    "defaultValue": null,
+    "description": "Defines the names of the Vault v2 KV path at which symmetric keys are found."
+  },
+  "keyring_vault_auth_method": {
+    "defaultValue": "token",
+    "description": " Defines the authentication mechanism when connecting to the Hashicorp Vault service.  Accepted values are: `token`, or `kubernetes`:  * `token`: Uses the static token defined in            the `keyring_vault_token`            configuration property.  * `kubernetes`: Uses the Kubernetes authentication                 mechanism, with the running pod's                 mapped service account, to assume                 the Hashicorp Vault role name that is                 defined in the `keyring_vault_kube_role`                 configuration property."
+  },
+  "keyring_vault_token": {
+    "defaultValue": null,
+    "description": "Defines the token value used to communicate with the v2 KV Vault HTTP(S) API."
+  },
+  "keyring_vault_kube_role": {
+    "defaultValue": "default",
+    "description": " Defines the Hashicorp Vault role that will be assumed using the Kubernetes service account of the running pod.  `keyring_vault_auth_method` must be set to `kubernetes` for this to activate."
+  },
+  "keyring_vault_kube_api_token_file": {
+    "defaultValue": "/run/secrets/kubernetes.io/serviceaccount/token",
+    "description": " Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+  },
+  "untrusted_lua": {
+    "defaultValue": "sandbox",
+    "description": " Controls loading of Lua functions from admin-supplied sources such as the Admin API. LuaJIT bytecode loading is always disabled.  **Warning:** LuaJIT is not designed as a secure runtime for running malicious code, therefore you should properly protect your Admin API endpoint even with sandboxing enabled. The sandbox only provides protection against trivial attackers or unintentional modification of the Kong global environment.  Accepted values are: `off`, `sandbox`, or `on`:  * `off`: Disallow loading of any arbitrary          Lua functions. The `off` option          disables any functionality that runs          arbitrary Lua code, including the          Serverless Functions plugins and any          transformation plugin that allows          custom Lua functions.  * `sandbox`: Allow loading of Lua functions,              but use a sandbox when executing              them. The sandboxed function has              restricted access to the global              environment and only has access              to standard Lua functions that              will generally not cause harm to              the Kong Gateway node.  * `on`: Functions have unrestricted         access to the global environment and         can load any Lua modules. This is         similar to the behavior in         Kong Gateway prior to 2.3.0.  The default `sandbox` environment does not allow importing other modules or libraries, or executing anything at the OS level (for example, file read/write). The global environment is also not accessible.  Examples of `untrusted_lua = sandbox` behavior:  * You can't access or change global values such as `kong.configuration.pg_password` * You can run harmless lua: `local foo = 1 + 1`. However, OS level functions are not allowed, like: `os.execute('rm -rf /*')`.  For a full allowed/disallowed list, see: https://github.com/kikito/sandbox.lua/blob/master/sandbox.lua  To customize the sandbox environment, use the `untrusted_lua_sandbox_requires` and `untrusted_lua_sandbox_environment` parameters below."
+  },
+  "untrusted_lua_sandbox_requires": {
+    "defaultValue": null,
+    "description": "Comma-separated list of modules allowed to be loaded with `require` inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  For example, say you have configured the Serverless pre-function plugin and it contains the following `requires`:  ``` local template = require \"resty.template\" local split = require \"kong.tools.utils\".split ```  To run the plugin, add the modules to the allowed list: ``` untrusted_lua_sandbox_requires = resty.template, kong.tools.utils ```  **Warning:** Allowing certain modules may create opportunities to escape the sandbox. For example, allowing `os` or `luaposix` may be unsafe."
+  },
+  "untrusted_lua_sandbox_environment": {
+    "defaultValue": null,
+    "description": "Comma-separated list of global Lua variables that should be made available inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  **Warning**: Certain variables, when made available, may create opportunities to escape the sandbox."
+  },
+  "openresty_path": {
+    "defaultValue": null,
+    "description": "Path to the OpenResty installation that Kong will use. When this is empty (the default), Kong determines the OpenResty installation by searching for a system-installed OpenResty and falling back to searching $PATH for the nginx binary.  Setting this attribute disables the search behavior and explicitly instructs Kong which OpenResty installation to use."
+  },
+  "node_id": {
+    "defaultValue": null,
+    "description": "Node ID for the Kong node. Every Kong node in a Kong cluster must have a unique and valid UUID. When empty, node ID is automatically generated."
+  },
+  "cluster_fallback_config_import": {
+    "defaultValue": "off",
+    "description": "Enable fallback configuration imports.  This should only be enabled for data planes."
+  },
+  "cluster_fallback_config_storage": {
+    "defaultValue": null,
+    "description": "Storage definition used by `cluster_fallback_config_import` and `cluster_fallback_config_export`.  Supported storage types: - S3-like storages - GCP storage service  To use S3 with a bucket named b and place all configs to with a key prefix named p, set it to: `s3://b/p` To use GCP for the same bucket and prefix, set it to: `gcs://b/p`  The credentials (and the endpoint URL for S3-like) for S3 are passed with environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where `AWS_CONFIG_STORAGE_ENDPOINT` is the endpoint that hosts S3-like storage.  The credentials for GCP are provided via the environment variable `GCP_SERVICE_ACCOUNT`."
+  },
+  "cluster_fallback_export_s3_config": {
+    "defaultValue": null,
+    "description": "fallback config export S3 config This is used only when `cluster_fallback_config_storage` is S3-like schema. If set, it will add config table to kong exporter config S3 putObject request. The config table should be in JSON format and can be unserialized into a table. It should contain the necessary parameters as described in the documentation.  https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property. For example, if you want to set the ServerSideEncryption headers / KMS Key ID for the S3 putObject request, you can set the config table to: `{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"your-kms-key-id\"}`"
+  },
+  "cluster_fallback_config_export": {
+    "defaultValue": "off",
+    "description": "Enable fallback configuration exports."
+  },
+  "cluster_fallback_config_export_delay": {
+    "defaultValue": "60",
+    "description": "The fallback configuration export interval.  If the interval is set to 60 and configuration A is exported and there are new configurations B, C, and D in the next 60 seconds, it will wait until 60 seconds passed and export D, skipping B and C."
+  },
+  "wasm": {
+    "defaultValue": "off",
+    "description": "Enable/disable wasm support. This must be enabled in order to use wasm filters and filter chains."
+  },
+  "wasm_filters_path": {
+    "defaultValue": null,
+    "description": "Path to the directory containing wasm filter modules.  At startup, Kong discovers available wasm filters by scanning this directory for files with the `.wasm` file extension.  The name of a wasm filter module is derived from the filename itself, with the .wasm extension removed. So, given the following tree:  ``` /path/to/wasm_filters ├── my_module.wasm ├── my_other_module.wasm └── not_a_wasm_module.txt ```  The resulting filter modules available for use in Kong will be:  * `my_module` * `my_other_module`  Notes:  * No recursion is performed. Only .wasm files at the   top level are registered * This path _may_ be a symlink to a directory."
+  },
+  "request_debug": {
+    "defaultValue": "on",
+    "description": "When enabled, Kong will provide detailed timing information for its components to the client and the error log if the following headers are present in the proxy request: - `X-Kong-Request-Debug`:   If the value is set to `*`,   timing information will be collected and exported for the current request.   If this header is not present or contains unknown value,   timing information will not be collected for the current request.   You can also specify a list of filters, separated by commas,   to filter the scope of the time information that is collected.   The following filters are supported:   - `rewrite`: Collect timing information from the `rewrite` phase.   - `access`: Collect timing information from the `access` phase.   - `balancer`: Collect timing information from the `balancer` phase.   - `response`: Collect timing information from the `response` phase.   - `header_filter`: Collect timing information from the `header_filter` phase.   - `body_filter`: Collect timing information from the `body_filter` phase.   - `log`: Collect timing information from the `log` phase.   - `upstream`: Collect timing information from the `upstream` phase.  - `X-Kong-Request-Debug-Log`:   If set to `true`, timing information will also be logged   in the Kong error log with a log level of `notice`.   Defaults to `false`.  - `X-Kong-Request-Debug-Token`:   Token for authenticating the client making the debug   request to prevent abuse. Debug requests originating from loopback   addresses do not require this header. "
+  },
+  "request_debug_token": {
+    "defaultValue": "<random>",
+    "description": "The Request Debug Token is used in the `X-Kong-Request-Debug-Token` header to prevent abuse. If this value is not set (the default), a random token will be generated when Kong starts, restarts, or reloads. If a token is specified manually, then the provided token will be used.  You can locate the generated debug token in two locations: - Kong error log:   Debug token will be logged in the error log (notice level)   when Kong starts, restarts, or reloads.   The log line will have the: `[request-debug]` prefix to aid searching. - Filesystem:   Debug token will also be stored in a file located at   `{prefix}/.request_debug_token` and updated   when Kong starts, restarts, or reloads."
+  }
+}

--- a/app/_data/kong-conf/3.6.json
+++ b/app/_data/kong-conf/3.6.json
@@ -1,0 +1,1244 @@
+{
+  "prefix": {
+    "defaultValue": "/usr/local/kong/",
+    "description": "Working directory. Equivalent to Nginx's prefix path, containing temporary files and logs. Each Kong process must have a separate working directory."
+  },
+  "log_level": {
+    "defaultValue": "notice",
+    "description": "Log level of the Nginx server. Logs are found at `<prefix>/logs/error.log`."
+  },
+  "proxy_access_log": {
+    "defaultValue": "logs/access.log",
+    "description": "Path for proxy port request access logs. Set this value to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "proxy_error_log": {
+    "defaultValue": "logs/error.log",
+    "description": "Path for proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "proxy_stream_access_log": {
+    "defaultValue": "logs/access.log basic",
+    "description": "Path for tcp streams proxy port access logs. Set this value to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location. `basic` is defined as `'$remote_addr [$time_local] ' '$protocol $status $bytes_sent $bytes_received ' '$session_time'`"
+  },
+  "proxy_stream_error_log": {
+    "defaultValue": "logs/error.log",
+    "description": "Path for tcp streams proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "admin_access_log": {
+    "defaultValue": "logs/admin_access.log",
+    "description": "Path for Admin API request access logs. If Hybrid Mode is enabled and the current node is set to be the Control Plane, then the connection requests from Data Planes are also written to this file with server name \"kong_cluster_listener\".  Set this value to `off` to disable logging Admin API requests. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "admin_error_log": {
+    "defaultValue": "logs/error.log",
+    "description": "Path for Admin API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "status_access_log": {
+    "defaultValue": "off",
+    "description": "Path for Status API request access logs. The default value of `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "status_error_log": {
+    "defaultValue": "logs/status_error.log",
+    "description": "Path for Status API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "debug_access_log": {
+    "defaultValue": "off",
+    "description": "Path for Debug API request access logs. The default value of `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "debug_error_log": {
+    "defaultValue": "logs/debug_error.log",
+    "description": "Path for Debug API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "vaults": {
+    "defaultValue": "bundled",
+    "description": "Comma-separated list of vaults this node should load. By default, all the bundled vaults are enabled.  The specified name(s) will be substituted as such in the Lua namespace: `kong.vaults.{name}.*`."
+  },
+  "opentelemetry_tracing": {
+    "defaultValue": "off",
+    "description": "Deprecated: use tracing_instrumentations instead"
+  },
+  "tracing_instrumentations": {
+    "defaultValue": "off",
+    "description": "Comma-separated list of tracing instrumentations this node should load. By default, no instrumentations are enabled.  Valid values to this setting are:  - `off`: do not enable instrumentations. - `request`: only enable request-level instrumentations. - `all`: enable all the following instrumentations. - `db_query`: trace database query - `dns_query`: trace DNS query. - `router`: trace router execution, including   router rebuilding. - `http_client`: trace OpenResty HTTP client requests. - `balancer`: trace balancer retries. - `plugin_rewrite`: trace plugins iterator   execution with rewrite phase. - `plugin_access`: trace plugins iterator   execution with access phase. - `plugin_header_filter`: trace plugins iterator   execution with header_filter phase.  **Note:** In the current implementation, tracing instrumentations are not enabled in stream mode."
+  },
+  "opentelemetry_tracing_sampling_rate": {
+    "defaultValue": "1.0",
+    "description": "Deprecated: use tracing_sampling_rate instead"
+  },
+  "tracing_sampling_rate": {
+    "defaultValue": "0.01",
+    "description": "Tracing instrumentation sampling rate. Tracer samples a fixed percentage of all spans following the sampling rate.  Example: `0.25`, this should account for 25% of all traces."
+  },
+  "plugins": {
+    "defaultValue": "bundled",
+    "description": "Comma-separated list of plugins this node should load. By default, only plugins bundled in official distributions are loaded via the `bundled` keyword.  Loading a plugin does not enable it by default, but only instructs Kong to load its source code, and allows to configure the plugin via the various related Admin API endpoints.  The specified name(s) will be substituted as such in the Lua namespace: `kong.plugins.{name}.*`.  When the `off` keyword is specified as the only value, no plugins will be loaded.  `bundled` and plugin names can be mixed together, as the following examples suggest:  - `plugins = bundled,custom-auth,custom-log`   will include the bundled plugins plus two   custom ones - `plugins = custom-auth,custom-log` will   *only* include the `custom-auth` and   `custom-log` plugins. - `plugins = off` will not include any   plugins  **Note:** Kong will not start if some plugins were previously configured (i.e. have rows in the database) and are not specified in this list.  Before disabling a plugin, ensure all instances of it are removed before restarting Kong.  **Note:** Limiting the amount of available plugins can improve P99 latency when experiencing LRU churning in the database cache (i.e. when the configured `mem_cache_size`) is full."
+  },
+  "dedicated_config_processing": {
+    "defaultValue": "on",
+    "description": "Enables or disables a special worker process for configuration processing. This process increases memory usage a little bit while allowing to reduce latencies by moving some background tasks, such as CP/DP connection handling, to an additional worker process specific to handling these background tasks. Currently this has effect only on data planes."
+  },
+  "pluginserver_names": {
+    "defaultValue": null,
+    "description": "Comma-separated list of names for pluginserver processes.  The actual names are used for log messages and to relate the actual settings."
+  },
+  "pluginserver_XXX_socket": {
+    "defaultValue": "<prefix>/<XXX>.socket",
+    "description": "Path to the unix socket used by the <XXX> pluginserver."
+  },
+  "pluginserver_XXX_start_cmd": {
+    "defaultValue": "/usr/local/bin/<XXX>",
+    "description": "Full command (including any needed arguments) to start the <XXX> pluginserver"
+  },
+  "pluginserver_XXX_query_cmd": {
+    "defaultValue": "/usr/local/bin/query_<XXX>",
+    "description": "Full command to \"query\" the <XXX> pluginserver.  Should produce a JSON with the dump info of all plugins it manages"
+  },
+  "port_maps": {
+    "defaultValue": null,
+    "description": "With this configuration parameter, you can let the Kong to know about the port from which the packets are forwarded to it. This is fairly common when running Kong in a containerized or virtualized environment. For example, `port_maps=80:8000, 443:8443` instructs Kong that the port 80 is mapped to 8000 (and the port 443 to 8443), where 8000 and 8443 are the ports that Kong is listening to.  This parameter helps Kong set a proper forwarded upstream HTTP request header or to get the proper forwarded port with the Kong PDK (in case other means determining it has failed). It changes routing by a destination port to route by a port from which packets are forwarded to Kong, and similarly it changes the default plugin log serializer to use the port according to this mapping instead of reporting the port Kong is listening to."
+  },
+  "anonymous_reports": {
+    "defaultValue": "on",
+    "description": "Send anonymous usage data such as error stack traces to help improve Kong."
+  },
+  "proxy_server": {
+    "defaultValue": null,
+    "description": "Proxy server defined as a URL. Kong will only use this option if any component is explicitly configured to use proxy."
+  },
+  "proxy_server_ssl_verify": {
+    "defaultValue": "off",
+    "description": "Toggles server certificate verification if `proxy_server` is in HTTPS. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+  },
+  "error_template_html": {
+    "defaultValue": null,
+    "description": "Path to the custom html error template to override the default html kong error template.  The template may contain up to two `%s` placeholders. The first one will expand to the error message. The second one will expand to the request ID. Both placeholders are optional, but recommended. Adding more than two placeholders will result in a runtime error when trying to render the template: ``` <html>   <body>     <h1>My custom error template</h1>     <p>error: %s</p>     <p>request_id: %s</p>   </body> </html> ```"
+  },
+  "error_template_json": {
+    "defaultValue": null,
+    "description": "Path to the custom json error template to override the default json kong error template.  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+  },
+  "error_template_xml": {
+    "defaultValue": null,
+    "description": "Path to the custom xml error template to override the default xml kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+  },
+  "error_template_plain": {
+    "defaultValue": null,
+    "description": "Path to the custom plain error template to override the default plain kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+  },
+  "role": {
+    "defaultValue": "traditional",
+    "description": "Use this setting to enable Hybrid Mode, This allows running some Kong nodes in a control plane role with a database and have them deliver configuration updates to other nodes running to DB-less running in a Data Plane role.  Valid values to this setting are:  - `traditional`: do not use Hybrid Mode. - `control_plane`: this node runs in a   control plane role. It can use a database   and will deliver configuration updates   to data plane nodes. - `data_plane`: this is a data plane node.   It runs DB-less and receives configuration   updates from a control plane node."
+  },
+  "cluster_mtls": {
+    "defaultValue": "shared",
+    "description": "Sets the verification between nodes of the cluster.  Valid values to this setting are:  - `shared`: use a shared certificate/key   pair specified with the `cluster_cert`   and `cluster_cert_key` settings.   Note that CP and DP nodes have to present   the same certificate to establish mTLS   connections. - `pki`: use `cluster_ca_cert`,   `cluster_server_name` and `cluster_cert`   for verification.   These are different certificates for each   DP node, but issued by a cluster-wide   common CA certificate: `cluster_ca_cert`. - `pki_check_cn`: similar as `pki` but additionally   checks for Common Name of data plane certificate   specified in `cluster_allowed_common_names`."
+  },
+  "cluster_cert": {
+    "defaultValue": null,
+    "description": "Cluster certificate to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes.  Under `pki` mode it should be a different certificate for each DP node.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "cluster_cert_key": {
+    "defaultValue": null,
+    "description": "Cluster certificate key to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes.  Under `pki` mode it should be a different certificate for each DP node.  The certificate key can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+  },
+  "cluster_ca_cert": {
+    "defaultValue": null,
+    "description": "The trusted CA certificate file in PEM format used for Control Plane to verify Data Plane's certificate and Data Plane to verify Control Plane's certificate. Required on data plane if `cluster_mtls` is set to `pki`. If Control Plane certificate is issued by a well known CA, user can set `lua_ssl_trusted_certificate=system` on Data Plane and leave this field empty.  This field is ignored if `cluster_mtls` is set to `shared`.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "cluster_allowed_common_names": {
+    "defaultValue": null,
+    "description": "The list of Common Names that are allowed to connect to control plane. Multiple entries may be supplied in a comma-separated string. When not set, Data Plane with same parent domain of Control Plane cert is allowed to connect.  This field is ignored if `cluster_mtls` is not set to `pki_check_cn`."
+  },
+  "cluster_server_name": {
+    "defaultValue": null,
+    "description": "The server name used in the SNI of the TLS connection from a DP node to a CP node. Must match the Common Name (CN) or Subject Alternative Name (SAN) found in the CP certificate. If `cluster_mtls` is set to `shared`, this setting is ignored and `kong_clustering` is used."
+  },
+  "cluster_control_plane": {
+    "defaultValue": null,
+    "description": "To be used by data plane nodes only: address of the control plane node from which configuration updates will be fetched, in `host:port` format."
+  },
+  "cluster_telemetry_endpoint": {
+    "defaultValue": null,
+    "description": "To be used by data plane nodes only: telemetry address of the control plane node to which telemetry updates will be posted in `host:port` format."
+  },
+  "cluster_telemetry_server_name": {
+    "defaultValue": null,
+    "description": "The SNI (Server Name Indication extension) to use for Vitals telemetry data."
+  },
+  "cluster_dp_labels": {
+    "defaultValue": null,
+    "description": "Comma separated list of Labels for the data plane. Labels are key-value pairs that provide additional context information for each DP. Each label must be configured as a string in the format `key:value`.  Labels are only compatible with hybrid mode deployments with Kong Konnect (SaaS), this configuration doesn't work with self-hosted deployments.  Keys and values follow the AIP standards: https://kong-aip.netlify.app/aip/129/  Example: `deployment:mycloud,region:us-east-1`"
+  },
+  "cluster_listen": {
+    "defaultValue": "0.0.0.0:8005",
+    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster. This port is mTLS protected to ensure end-to-end security and integrity.  This setting has no effect if `role` is not set to `control_plane`.  Connection made to this endpoint are logged to the same location as Admin API access logs. See `admin_access_log` config description for more information."
+  },
+  "cluster_telemetry_listen": {
+    "defaultValue": "0.0.0.0:8006",
+    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane telemetry connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster.  This setting has no effect if `role` is not set to `control_plane`."
+  },
+  "cluster_data_plane_purge_delay": {
+    "defaultValue": "1209600",
+    "description": " How many seconds must pass from the time a DP node becomes offline to the time its entry gets removed from the database, as returned by the /clustering/data-planes Admin API endpoint.  This is to prevent the cluster data plane table from growing indefinitely. The default is set to 14 days. That is, if CP haven't heard from a DP for 14 days, its entry will be removed."
+  },
+  "cluster_ocsp": {
+    "defaultValue": "off",
+    "description": " Whether to check for revocation status of DP certificates using OCSP (Online Certificate Status Protocol). If enabled, the DP certificate should contain the \"Certificate Authority Information Access\" extension and the OCSP method with URI of which the OCSP responder can be reached from CP.  OCSP checks are only performed on CP nodes, it has no effect on DP nodes.  Valid values to this setting are:  - `on`: OCSP revocation check is enabled and DP   must pass the check in order to establish   connection with CP. - `off`: OCSP revocation check is disabled. - `optional`: OCSP revocation check will be attempted,   however, if the required extension is not   found inside DP provided certificate   or communication with the OCSP responder   failed, then DP is still allowed through."
+  },
+  "cluster_use_proxy": {
+    "defaultValue": "off",
+    "description": " Whether to turn on HTTP CONNECT proxy support for hybrid mode connections. `proxy_server` will be used for Hybrid mode connections if this option is turned on."
+  },
+  "cluster_max_payload": {
+    "defaultValue": "16777216",
+    "description": " This sets the maximum compressed payload size allowed to be sent across from CP to DP in Hybrid mode Default is 16MB - 16 * 1024 * 1024."
+  },
+  "proxy_listen": {
+    "defaultValue": [
+      "0.0.0.0:8000 reuseport backlog=16384",
+      "0.0.0.0:8443 http2 ssl reuseport backlog=16384"
+    ],
+    "description": " Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. The proxy server is the public entry point of Kong, which proxies traffic from your consumers to your backend services. This value accepts IPv4, IPv6, and hostnames.  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the TCP_DEFER_ACCEPT socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  This value can be set to `off`, thus disabling the HTTP/HTTPS proxy port for this node. If stream_listen is also set to `off`, this enables 'control-plane' mode for this node (in which all traffic proxying capabilities are disabled). This node can then be used only to configure a cluster of Kong nodes connected to the same datastore.  Example: `proxy_listen = 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`  See http://nginx.org/en/docs/http/ngx_http_core_module.html#listen for a description of the accepted formats for this and other `*_listen` values.  See https://www.nginx.com/resources/admin-guide/proxy-protocol/ for more details about the `proxy_protocol` parameter.  Not all `*_listen` values accept all formats specified in nginx's documentation."
+  },
+  "proxy_url": {
+    "defaultValue": null,
+    "description": "Kong Proxy URL  The lookup, or balancer, address for your Kong Proxy nodes.  This value is commonly used in a microservices or service-mesh oriented architecture.  Accepted format (parts in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`  Examples:  - `<scheme>://<IP>:<PORT>` -> `proxy_url = http://127.0.0.1:8000` - `SSL <scheme>://<HOSTNAME>` -> `proxy_url = https://proxy.domain.tld` - `<scheme>://<HOSTNAME>/<PATH>` -> `proxy_url = http://dev-machine/dev-285`  By default, Kong Manager, and Kong Portal will use the window request host and append the resolved listener port depending on the requested protocol."
+  },
+  "stream_listen": {
+    "defaultValue": "off",
+    "description": " Comma-separated list of addresses and ports on which the stream mode should listen.  This value accepts IPv4, IPv6, and hostnames. Some suffixes can be specified for each pair: - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  Examples:  ``` stream_listen = 127.0.0.1:7000 reuseport backlog=16384 stream_listen = 0.0.0.0:989 reuseport backlog=65536, 0.0.0.0:20 stream_listen = [::1]:1234 backlog=16384 ```  By default this value is set to `off`, thus disabling the stream proxy port for this node."
+  },
+  "admin_api_uri": {
+    "defaultValue": null,
+    "description": "Deprecated: Use admin_gui_api_url instead"
+  },
+  "admin_listen": {
+    "defaultValue": [
+      "127.0.0.1:8001 reuseport backlog=16384",
+      "127.0.0.1:8444 http2 ssl reuseport backlog=16384"
+    ],
+    "description": " Comma-separated list of addresses and ports on which the Admin interface should listen. The Admin interface is the API allowing you to configure and manage Kong. Access to this interface should be *restricted* to Kong administrators *only*. This value accepts IPv4, IPv6, and hostnames.  It is highly recommended to avoid exposing the Admin API to public interface(s), by using values such as 0.0.0.0:8001  See https://docs.konghq.com/gateway/latest/production/running-kong/secure-admin-api/ for more information about how to secure your Admin API  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the TCP_DEFER_ACCEPT socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  This value can be set to `off`, thus disabling the Admin interface for this node, enabling a 'data-plane' mode (without configuration capabilities) pulling its configuration changes from the database.  Example: `admin_listen = 127.0.0.1:8444 http2 ssl`"
+  },
+  "status_listen": {
+    "defaultValue": "127.0.0.1:8007 reuseport backlog=16384",
+    "description": " Comma-separated list of addresses and ports on which the Status API should listen. The Status API is a read-only endpoint allowing monitoring tools to retrieve metrics, healthiness, and other non-sensitive information of the current Kong node.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Status API server. - `proxy_protocol` will enable usage of the PROXY protocol.  This value can be set to `off`, disabling the Status API for this node.  Example: `status_listen = 0.0.0.0:8100 ssl http2`"
+  },
+  "debug_listen": {
+    "defaultValue": "off",
+    "description": "Comma-separated list of addresses and ports on which the Debug API should listen.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Debug API server.  This value can be set to `off`, disabling the Debug API for this node.  Example: `debug_listen = 0.0.0.0:8200 ssl http2`"
+  },
+  "debug_listen_local": {
+    "defaultValue": "on",
+    "description": "Expose `debug_listen` functionalities via a Unix domain socket under the Kong prefix.  This option allows local user to use \"kong debug\" command to invoke various debug functionalities without needing to enable `debug_listen` ahead of time."
+  },
+  "nginx_user": {
+    "defaultValue": "kong kong",
+    "description": "Defines user and group credentials used by worker processes. If group is omitted, a group whose name equals that of user is used.  Example: `nginx_user = nginx www`  **Note**: If the `kong` user and the `kong` group are not available, the default user and group credentials will be `nobody nobody`."
+  },
+  "nginx_worker_processes": {
+    "defaultValue": "auto",
+    "description": "Determines the number of worker processes spawned by Nginx.  See http://nginx.org/en/docs/ngx_core_module.html#worker_processes for detailed usage of the equivalent Nginx directive and a description of accepted values."
+  },
+  "nginx_daemon": {
+    "defaultValue": "on",
+    "description": "Determines whether Nginx will run as a daemon or as a foreground process. Mainly useful for development or when running Kong inside a Docker environment.  See http://nginx.org/en/docs/ngx_core_module.html#daemon."
+  },
+  "mem_cache_size": {
+    "defaultValue": "128m",
+    "description": "Size of each of the two shared memory caches for traditional mode database entities and runtime data, `kong_core_cache` and `kong_cache`.  The accepted units are `k` and `m`, with a minimum recommended value of a few MBs.  **Note**: As this option controls the size of two different cache zones, the total memory Kong uses to cache entities might be double this value. The created zones are shared by all worker processes and do not become larger when more worker is used."
+  },
+  "ssl_cipher_suite": {
+    "defaultValue": "intermediate",
+    "description": "Defines the TLS ciphers served by Nginx. Accepted values are `modern`, `intermediate`, `old`, `fips` or `custom`. If you want to enable TLSv1.1, this value has to be `old`.  See https://wiki.mozilla.org/Security/Server_Side_TLS for detailed descriptions of each cipher suite. `fips` cipher suites are as described in https://wiki.openssl.org/index.php/FIPS_mode_and_TLS."
+  },
+  "ssl_ciphers": {
+    "defaultValue": null,
+    "description": "Defines a custom list of TLS ciphers to be served by Nginx. This list must conform to the pattern defined by `openssl ciphers`. This value is ignored if `ssl_cipher_suite` is not `custom`. If you use DHE ciphers, you must also configure the `ssl_dhparam` parameter."
+  },
+  "ssl_protocols": {
+    "defaultValue": "TLSv1.2 TLSv1.3",
+    "description": " Enables the specified protocols for client-side connections. The set of supported protocol versions also depends on the version of OpenSSL Kong was built with. This value is ignored if `ssl_cipher_suite` is not `custom`. If you want to enable TLSv1.1, you should set `ssl_cipher_suite` to `old`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols"
+  },
+  "ssl_prefer_server_ciphers": {
+    "defaultValue": "on",
+    "description": "Specifies that server ciphers should be preferred over client ciphers when using the SSLv3 and TLS protocols. This value is ignored if `ssl_cipher_suite` is not `custom`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers"
+  },
+  "ssl_dhparam": {
+    "defaultValue": null,
+    "description": "Defines DH parameters for DHE ciphers from the predefined groups: `ffdhe2048`, `ffdhe3072`, `ffdhe4096`, `ffdhe6144`, `ffdhe8192`, from the absolute path to a parameters file, or directly from the parameters content.  This value is ignored if `ssl_cipher_suite` is `modern` or `intermediate`. The reason is that `modern` has no ciphers that needs this, and `intermediate` uses `ffdhe2048`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam"
+  },
+  "ssl_session_tickets": {
+    "defaultValue": "on",
+    "description": "Enables or disables session resumption through TLS session tickets. This has no impact when used with TLSv1.3.  Kong enables this by default for performance reasons, but it has security implications: https://github.com/mozilla/server-side-tls/issues/135  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets"
+  },
+  "ssl_session_timeout": {
+    "defaultValue": "1d",
+    "description": "Specifies a time during which a client may reuse the session parameters. See the rationale: https://github.com/mozilla/server-side-tls/issues/198  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout"
+  },
+  "ssl_session_cache_size": {
+    "defaultValue": "10m",
+    "description": "Sets the size of the caches that store session parameters  See https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache"
+  },
+  "ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `proxy_listen` values with TLS enabled.  If more than one certificates are specified, it can be used to provide alternate type of certificate (for example, ECC certificate) that will be served to clients that supports them. Note to properly serve using ECC certificates, it is recommended to also set `ssl_cipher_suite` to `modern` or `intermediate`.  Unless this option is explicitly set, Kong will auto-generate a pair of default certificates (RSA + ECC) first time it starts up and use it for serving TLS requests.  Certificates can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `proxy_listen` values with TLS enabled.  If more than one certificate was specified for `ssl_cert`, then this option should contain the corresponding key for all certificates provided in the same order.  Unless this option is explicitly set, Kong will auto-generate a pair of default private keys (RSA + ECC) first time it starts up and use it for serving TLS requests.  Keys can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+  },
+  "client_ssl": {
+    "defaultValue": "off",
+    "description": "Determines if Nginx should attempt to send client-side TLS certificates and perform Mutual TLS Authentication with upstream service when proxying requests."
+  },
+  "client_ssl_cert": {
+    "defaultValue": null,
+    "description": "If `client_ssl` is enabled, the client certificate for the `proxy_ssl_certificate` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "client_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "If `client_ssl` is enabled, the client TLS key for the `proxy_ssl_certificate_key` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate key can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+  },
+  "admin_ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `admin_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+  },
+  "admin_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `admin_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+  },
+  "status_ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `status_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+  },
+  "status_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `status_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+  },
+  "debug_ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `debug_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+  },
+  "debug_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `debug_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+  },
+  "headers": {
+    "defaultValue": [
+      "server_tokens",
+      "latency_tokens",
+      "X-Kong-Request-Id"
+    ],
+    "description": " Comma-separated list of headers Kong should inject in client responses.  Accepted values are: - `Server`: Injects `Server: kong/x.y.z`   on Kong-produced response (e.g. Admin   API, rejected requests from auth plugin). - `Via`: Injects `Via: kong/x.y.z` for   successfully proxied requests. - `X-Kong-Proxy-Latency`: Time taken   (in milliseconds) by Kong to process   a request and run all plugins before   proxying the request upstream. - `X-Kong-Response-Latency`: time taken   (in millisecond) by Kong to produce   a response in case of e.g. plugin   short-circuiting the request, or in   in case of an error. - `X-Kong-Upstream-Latency`: Time taken   (in milliseconds) by the upstream   service to send response headers. - `X-Kong-Admin-Latency`: Time taken   (in milliseconds) by Kong to process   an Admin API request. - `X-Kong-Upstream-Status`: The HTTP status   code returned by the upstream service.   This is particularly useful for clients to   distinguish upstream statuses if the   response is rewritten by a plugin. - `X-Kong-Request-Id`: Unique identifier of   the request. - `server_tokens`: Same as specifying both   `Server` and `Via`. - `latency_tokens`: Same as specifying   `X-Kong-Proxy-Latency`,   `X-Kong-Response-Latency`,   `X-Kong-Admin-Latency` and   `X-Kong-Upstream-Latency`  In addition to those, this value can be set to `off`, which prevents Kong from injecting any of the above headers. Note that this does not prevent plugins from injecting headers of their own.  Example: `headers = via, latency_tokens`"
+  },
+  "headers_upstream": {
+    "defaultValue": "X-Kong-Request-Id",
+    "description": " Comma-separated list of headers Kong should inject in requests to upstream.  At this time, the only accepted value is: - `X-Kong-Request-Id`: Unique identifier of   the request.  In addition, this value can be set to `off`, which prevents Kong from injecting the above header. Note that this does not prevent plugins from injecting headers of their own."
+  },
+  "trusted_ips": {
+    "defaultValue": null,
+    "description": "Defines trusted IP addresses blocks that are known to send correct `X-Forwarded-*` headers. Requests from trusted IPs make Kong forward their `X-Forwarded-*` headers upstream. Non-trusted requests make Kong insert its own `X-Forwarded-*` headers.  This property also sets the `set_real_ip_from` directive(s) in the Nginx configuration. It accepts the same type of values (CIDR blocks) but as a comma-separated list.  To trust *all* /!\\ IPs, set this value to `0.0.0.0/0,::/0`.  If the special value `unix:` is specified, all UNIX-domain sockets will be trusted.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from for examples of accepted values."
+  },
+  "real_ip_header": {
+    "defaultValue": "X-Real-IP",
+    "description": "Defines the request header field whose value will be used to replace the client address. This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  If this value receives `proxy_protocol`:  - at least one of the `proxy_listen` entries   must have the `proxy_protocol` flag   enabled. - the `proxy_protocol` parameter will be   appended to the `listen` directive of the   Nginx template.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header for a description of this directive."
+  },
+  "real_ip_recursive": {
+    "defaultValue": "off",
+    "description": "This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive for a description of this directive."
+  },
+  "error_default_type": {
+    "defaultValue": "text/plain",
+    "description": "Default MIME type to use when the request `Accept` header is missing and Nginx is returning an error for the request. Accepted values are `text/plain`, `text/html`, `application/json`, and `application/xml`."
+  },
+  "upstream_keepalive_pool_size": {
+    "defaultValue": "512",
+    "description": "Sets the default size of the upstream keepalive connection pools. Upstream keepalive connection pools are segmented by the `dst ip/dst port/SNI` attributes of a connection. A value of `0` will disable upstream keepalive connections by default, forcing each upstream request to open a new connection."
+  },
+  "upstream_keepalive_max_requests": {
+    "defaultValue": "1000",
+    "description": "Sets the default maximum number of requests than can be proxied upstream through one keepalive connection. After the maximum number of requests is reached, the connection will be closed. A value of `0` will disable this behavior, and a keepalive connection can be used to proxy an indefinite number of requests."
+  },
+  "upstream_keepalive_idle_timeout": {
+    "defaultValue": "60",
+    "description": "Sets the default timeout (in seconds) for which an upstream keepalive connection should be kept open. When the timeout is reached while the connection has not been reused, it will be closed. A value of `0` will disable this behavior, and an idle keepalive connection may be kept open indefinitely."
+  },
+  "allow_debug_header": {
+    "defaultValue": "off",
+    "description": "Enable the `Kong-Debug` header function. if it is `on`, kong will add `Kong-Route-Id` `Kong-Route-Name` `Kong-Service-Id` `Kong-Service-Name` debug headers to response when the client request header `Kong-Debug: 1` is present."
+  },
+  "nginx_main_worker_rlimit_nofile": {
+    "defaultValue": "auto",
+    "description": " Changes the limit on the maximum number of open files for worker processes.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile"
+  },
+  "nginx_events_worker_connections": {
+    "defaultValue": "auto",
+    "description": " Sets the maximum number of simultaneous connections that can be opened by a worker process.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_connections"
+  },
+  "nginx_http_client_header_buffer_size": {
+    "defaultValue": "1k",
+    "description": "Sets buffer size for reading the client request headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size"
+  },
+  "nginx_http_large_client_header_buffers": {
+    "defaultValue": "4 8k",
+    "description": "Sets the maximum number and size of buffers used for reading large clients requests headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers"
+  },
+  "nginx_http_client_max_body_size": {
+    "defaultValue": "0",
+    "description": "Defines the maximum request body size allowed by requests proxied by Kong, specified in the Content-Length request header. If a request exceeds this limit, Kong will respond with a 413 (Request Entity Too Large). Setting this value to 0 disables checking the request body size. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size"
+  },
+  "nginx_admin_client_max_body_size": {
+    "defaultValue": "10m",
+    "description": "Defines the maximum request body size for Admin API."
+  },
+  "nginx_http_charset": {
+    "defaultValue": "UTF-8",
+    "description": "Adds the specified charset to the “Content-Type” response header field. If this charset is different from the charset specified in the source_charset directive, a conversion is performed.  The parameter `off` cancels the addition of charset to the “Content-Type” response header field. See http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset"
+  },
+  "nginx_http_client_body_buffer_size": {
+    "defaultValue": "8k",
+    "description": "Defines the buffer size for reading the request body. If the client request body is larger than this value, the body will be buffered to disk. Note that when the body is buffered to disk, Kong plugins that access or manipulate the request body may not work, so it is advisable to set this value as high as possible (e.g., set it as high as `client_max_body_size` to force request bodies to be kept in memory). Do note that high-concurrency environments will require significant memory allocations to process many concurrent large request bodies. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size"
+  },
+  "nginx_admin_client_body_buffer_size": {
+    "defaultValue": "10m",
+    "description": "Defines the buffer size for reading the request body on Admin API."
+  },
+  "nginx_http_lua_regex_match_limit": {
+    "defaultValue": "100000",
+    "description": "Global `MATCH_LIMIT` for PCRE regex matching. The default of `100000` should ensure at worst any regex Kong executes could finish within roughly 2 seconds."
+  },
+  "nginx_http_lua_regex_cache_max_entries": {
+    "defaultValue": "8192",
+    "description": "Specifies the maximum number of entries allowed in the worker process level PCRE JIT compiled regex cache. It is recommended to set it to at least (number of regex paths * 2) to avoid high CPU usages if you manually specified `router_flavor` to `traditional`. `expressions` and `traditional_compat` router does not make use of the PCRE library and their behavior is unaffected by this setting."
+  },
+  "nginx_http_keepalive_requests": {
+    "defaultValue": "10000",
+    "description": "Sets the maximum number of client requests that can be served through one keep-alive connection. After the maximum number of requests are made, the connection is closed. Closing connections periodically is necessary to free per-connection memory allocations. Therefore, using too high maximum number of requests could result in excessive memory usage and not recommended. See: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests"
+  },
+  "database": {
+    "defaultValue": "postgres",
+    "description": "Determines the database (or no database) for this node Accepted values are `postgres` and `off`."
+  },
+  "pg_host": {
+    "defaultValue": "127.0.0.1",
+    "description": "Host of the Postgres server."
+  },
+  "pg_port": {
+    "defaultValue": "5432",
+    "description": "Port of the Postgres server."
+  },
+  "pg_timeout": {
+    "defaultValue": "5000",
+    "description": "Defines the timeout (in ms), for connecting, reading and writing."
+  },
+  "pg_user": {
+    "defaultValue": "kong",
+    "description": "Postgres user."
+  },
+  "pg_password": {
+    "defaultValue": null,
+    "description": "Postgres user's password."
+  },
+  "pg_iam_auth": {
+    "defaultValue": "off",
+    "description": "Determines whether the AWS IAM database Authentication will be used. When switch to `on`, the username defined in `pg_user` will be used as the database account, and the database connection will be forced to using TLS. `pg_password` will not be used when the switch is `on`. Note that the corresponding IAM policy must be correct, otherwise connecting will fail."
+  },
+  "pg_iam_auth_assume_role_arn": {
+    "defaultValue": null,
+    "description": "The target AWS IAM role ARN that will be assumed when using AWS IAM database authentication. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+  },
+  "pg_iam_auth_role_session_name": {
+    "defaultValue": "KongPostgres",
+    "description": "The role session name used for role assuming in AWS IAM Database Authentication. The default value is `KongPostgres`."
+  },
+  "pg_iam_auth_sts_endpoint_url": {
+    "defaultValue": null,
+    "description": "The custom STS endpoint URL used for role assuming in AWS IAM Database Authentication.  Note that this value will override the default STS endpoint URL(which should be `https://sts.amazonaws.com`, or `https://sts.<region>.amazonaws.com` if you have `AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).  If you are not using private VPC endpoint for STS service, you should not specify this value."
+  },
+  "pg_database": {
+    "defaultValue": "kong",
+    "description": "The database name to connect to."
+  },
+  "pg_schema": {
+    "defaultValue": null,
+    "description": "The database schema to use. If unspecified, Kong will respect the `search_path` value of your PostgreSQL instance."
+  },
+  "pg_ssl": {
+    "defaultValue": "off",
+    "description": "Toggles client-server TLS connections between Kong and PostgreSQL. Because PostgreSQL uses the same port for TLS and non-TLS, this is only a hint. If the server does not support TLS, the established connection will be a plain one."
+  },
+  "pg_ssl_version": {
+    "defaultValue": "tlsv1_2",
+    "description": "When using ssl between Kong and PostgreSQL, the version of tls to use. Accepted values are `tlsv1_1`, `tlsv1_2`, `tlsv1_3`, or 'any'. When `any` is set, the client negotiates the highest version with the server which can't be lower than `tlsv1_1`."
+  },
+  "pg_ssl_required": {
+    "defaultValue": "off",
+    "description": "When `pg_ssl` is on this determines if TLS must be used between Kong and PostgreSQL. It aborts the connection if the server does not support SSL connections."
+  },
+  "pg_ssl_verify": {
+    "defaultValue": "off",
+    "description": "Toggles server certificate verification if `pg_ssl` is enabled. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+  },
+  "pg_ssl_cert": {
+    "defaultValue": null,
+    "description": "The absolute path to the PEM encoded client TLS certificate for the PostgreSQL connection. Mutual TLS authentication against PostgreSQL is only enabled if this value is set."
+  },
+  "pg_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "If `pg_ssl_cert` is set, the absolute path to the PEM encoded client TLS private key for the PostgreSQL connection."
+  },
+  "pg_max_concurrent_queries": {
+    "defaultValue": "0",
+    "description": "Sets the maximum number of concurrent queries that can be executing at any given time. This limit is enforced per worker process; the total number of concurrent queries for this node will be will be: `pg_max_concurrent_queries * nginx_worker_processes`.  The default value of 0 removes this concurrency limitation."
+  },
+  "pg_semaphore_timeout": {
+    "defaultValue": "60000",
+    "description": "Defines the timeout (in ms) after which PostgreSQL query semaphore resource acquisition attempts will fail. Such failures will generally result in the associated proxy or Admin API request failing with an HTTP 500 status code. Detailed discussion of this behavior is available in the online documentation."
+  },
+  "pg_keepalive_timeout": {
+    "defaultValue": null,
+    "description": "Specify the maximal idle timeout (in ms) for the postgres connections in the pool. If this value is set to 0 then the timeout interval is unlimited.  If not specified this value will be same as `lua_socket_keepalive_timeout`"
+  },
+  "pg_pool_size": {
+    "defaultValue": null,
+    "description": "Specifies the size limit (in terms of connection count) for the Postgres server. Note that this connection pool is intended per Nginx worker rather than per Kong instance.  If not specified, the default value is the same as `lua_socket_pool_size`"
+  },
+  "pg_backlog": {
+    "defaultValue": null,
+    "description": "If specified, this value will limit the total number of open connections to the Postgres server to `pg_pool_size`. If the connection pool is full, subsequent connect operations will be inserted in a queue with size equal to this option's value.  If the number of queued connect operations reaches `pg_backlog`, exceeding connections will fail.  If not specified, then number of open connections to the Postgres server is not limited."
+  },
+  "pg_ro_host": {
+    "defaultValue": null,
+    "description": "Same as `pg_host`, but for the read-only connection. **Note:** Refer to the documentation section above for detailed usage."
+  },
+  "pg_ro_port": {
+    "defaultValue": "<pg_port>",
+    "description": "Same as `pg_port`, but for the read-only connection."
+  },
+  "pg_ro_timeout": {
+    "defaultValue": "<pg_timeout>",
+    "description": "Same as `pg_timeout`, but for the read-only connection."
+  },
+  "pg_ro_user": {
+    "defaultValue": "<pg_user>",
+    "description": "Same as `pg_user`, but for the read-only connection."
+  },
+  "pg_ro_password": {
+    "defaultValue": "<pg_password>",
+    "description": "Same as `pg_password`, but for the read-only connection."
+  },
+  "pg_ro_iam_auth": {
+    "defaultValue": "<pg_iam_auth>",
+    "description": "Same as `pg_iam_auth`, but for the read-only connection."
+  },
+  "pg_ro_iam_auth_assume_role_arn": {
+    "defaultValue": null,
+    "description": "Same as `pg_iam_auth_assume_role_arn', but for the read-only connection."
+  },
+  "pg_ro_iam_auth_role_session_name": {
+    "defaultValue": "KongPostgres",
+    "description": "Same as `pg_iam_auth_role_session_name`, but for the read-only connection."
+  },
+  "pg_ro_iam_auth_sts_endpoint_url": {
+    "defaultValue": null,
+    "description": "Same as `pg_iam_auth_sts_endpoint_url`, but for the read-only connection."
+  },
+  "pg_ro_database": {
+    "defaultValue": "<pg_database>",
+    "description": "Same as `pg_database`, but for the read-only connection."
+  },
+  "pg_ro_schema": {
+    "defaultValue": "<pg_schema>",
+    "description": "Same as `pg_schema`, but for the read-only connection."
+  },
+  "pg_ro_ssl": {
+    "defaultValue": "<pg_ssl>",
+    "description": "Same as `pg_ssl`, but for the read-only connection."
+  },
+  "pg_ro_ssl_required": {
+    "defaultValue": "<pg_ssl_required>",
+    "description": " Same as `pg_ssl_required`, but for the read-only connection."
+  },
+  "pg_ro_ssl_verify": {
+    "defaultValue": "<pg_ssl_verify>",
+    "description": " Same as `pg_ssl_verify`, but for the read-only connection."
+  },
+  "pg_ro_ssl_version": {
+    "defaultValue": "<pg_ssl_version>",
+    "description": " Same as `pg_ssl_version`, but for the read-only connection."
+  },
+  "pg_ro_max_concurrent_queries": {
+    "defaultValue": "<pg_max_concurrent_queries>",
+    "description": " Same as `pg_max_concurrent_queries`, but for the read-only connection. Note: read-only concurrency is not shared with the main (read-write) connection."
+  },
+  "pg_ro_semaphore_timeout": {
+    "defaultValue": "<pg_semaphore_timeout>",
+    "description": " Same as `pg_semaphore_timeout`, but for the read-only connection."
+  },
+  "pg_ro_keepalive_timeout": {
+    "defaultValue": "<pg_keepalive_timeout>",
+    "description": " Same as `pg_keepalive_timeout`, but for the read-only connection."
+  },
+  "pg_ro_pool_size": {
+    "defaultValue": "<pg_pool_size>",
+    "description": " Same as `pg_pool_size`, but for the read-only connection."
+  },
+  "pg_ro_backlog": {
+    "defaultValue": "<pg_backlog>",
+    "description": " Same as `pg_backlog`, but for the read-only connection."
+  },
+  "declarative_config": {
+    "defaultValue": null,
+    "description": "The path to the declarative configuration file which holds the specification of all entities (Routes, Services, Consumers, etc.) to be used when the `database` is set to `off`.  Entities are stored in Kong's LMDB cache, so you must ensure that enough headroom is allocated to it via the `lmdb_map_size` property.  If the Hybrid mode `role` is set to `data_plane` and there's no configuration cache file, this configuration is used before connecting to the Control Plane node as a user-controlled fallback."
+  },
+  "declarative_config_string": {
+    "defaultValue": null,
+    "description": "The declarative configuration as a string"
+  },
+  "lmdb_environment_path": {
+    "defaultValue": "dbless.lmdb",
+    "description": "Directory where the LMDB database files used by DB-less and Hybrid mode to store Kong configurations reside.  This path is relative under the Kong `prefix`."
+  },
+  "lmdb_map_size": {
+    "defaultValue": "2048m",
+    "description": "Maximum size of the LMDB memory map, used to store the DB-less and Hybird mode configurations. Default is 2048m.  This config defines the limit of LMDB file size, the actual file size growth will be on-demand and proportional to the actual config size.  Note this value can be set very large, say a couple of GBs to accommodate future database growth and Multi Version Concurrency Control (MVCC) headroom needs. The file size of the LMDB database file should stabilize after a few config reload/Hybrid mode syncs and the actual memory used by the LMDB database will be smaller than the file size due to dynamic swapping of database pages by the OS."
+  },
+  "db_update_frequency": {
+    "defaultValue": "5",
+    "description": "Frequency (in seconds) at which to check for updated entities with the datastore.  When a node creates, updates, or deletes an entity via the Admin API, other nodes need to wait for the next poll (configured by this value) to eventually purge the old cached entity and start using the new one."
+  },
+  "db_update_propagation": {
+    "defaultValue": "0",
+    "description": "Time (in seconds) taken for an entity in the datastore to be propagated to replica nodes of another datacenter.  When set, this property will increase the time taken by Kong to propagate the change of an entity.  Single-datacenter setups or PostgreSQL servers should suffer no such delays, and this value can be safely set to 0. Postgres setups with read replicas should set this value to maximum expected replication lag between the writer and reader instances."
+  },
+  "db_cache_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of an entity from the datastore when cached by this node.  Database misses (no entity) are also cached according to this setting if you do not configure `db_cache_neg_ttl`.  If set to 0 (default), such cached entities or misses never expire."
+  },
+  "db_cache_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a datastore miss (no entity).  If not specified (default), `db_cache_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "db_resurrect_ttl": {
+    "defaultValue": "30",
+    "description": "Time (in seconds) for which stale entities from the datastore should be resurrected for when they cannot be refreshed (e.g., the datastore is unreachable). When this TTL expires, a new attempt to refresh the stale entities will be made."
+  },
+  "db_cache_warmup_entities": {
+    "defaultValue": "services",
+    "description": " Entities to be pre-loaded from the datastore into the in-memory cache at Kong start-up. This speeds up the first access of endpoints that use the given entities.  When the `services` entity is configured for warmup, the DNS entries for values in its `host` attribute are pre-resolved asynchronously as well.  Cache size set in `mem_cache_size` should be set to a value large enough to hold all instances of the specified entities. If the size is insufficient, Kong will log a warning."
+  },
+  "dns_resolver": {
+    "defaultValue": null,
+    "description": "Comma separated list of nameservers, each entry in `ip[:port]` format to be used by Kong. If not specified the nameservers in the local `resolv.conf` file will be used. Port defaults to 53 if omitted. Accepts both IPv4 and IPv6 addresses."
+  },
+  "dns_hostsfile": {
+    "defaultValue": "/etc/hosts",
+    "description": "The hosts file to use. This file is read once and its content is static in memory. To read the file again after modifying it, Kong must be reloaded."
+  },
+  "dns_order": {
+    "defaultValue": [
+      "LAST",
+      "SRV",
+      "A",
+      "CNAME"
+    ],
+    "description": "The order in which to resolve different record types. The `LAST` type means the type of the last successful lookup (for the specified name). The format is a (case insensitive) comma separated list."
+  },
+  "dns_valid_ttl": {
+    "defaultValue": null,
+    "description": "By default, DNS records are cached using the TTL value of a response. If this property receives a value (in seconds), it will override the TTL for all records."
+  },
+  "dns_stale_ttl": {
+    "defaultValue": "3600",
+    "description": "Defines, in seconds, how long a record will remain in cache past its TTL. This value will be used while the new DNS record is fetched in the background. Stale data will be used from expiry of a record until either the refresh query completes, or the `dns_stale_ttl` number of seconds have passed. This configuration enables Kong to be more resilient during resolver downtime."
+  },
+  "dns_cache_size": {
+    "defaultValue": "10000",
+    "description": "Defines the maximum allowed number of DNS records stored in memory cache. Least recently used DNS records are discarded from cache if it is full. Both errors and data are cached, therefore a single name query can easily take up 10-15 slots."
+  },
+  "dns_not_found_ttl": {
+    "defaultValue": "30",
+    "description": "TTL in seconds for empty DNS responses and \"(3) name error\" responses."
+  },
+  "dns_error_ttl": {
+    "defaultValue": "1",
+    "description": "TTL in seconds for error responses."
+  },
+  "dns_no_sync": {
+    "defaultValue": "off",
+    "description": "If enabled, then upon a cache-miss every request will trigger its own dns query. When disabled multiple requests for the same name/type will be synchronised to a single query."
+  },
+  "vault_env_prefix": {
+    "defaultValue": null,
+    "description": "Defines the environment variable vault's default prefix. For example if you have all your secrets stored in environment variables prefixed with `SECRETS_`, it can be configured here so that it isn't necessary to repeat them in Vault references."
+  },
+  "vault_aws_region": {
+    "defaultValue": null,
+    "description": "The AWS region your vault is located in."
+  },
+  "vault_aws_endpoint_url": {
+    "defaultValue": null,
+    "description": "The AWS SecretsManager service endpoint url. If not specified, the value used by vault will be the official AWS SecretsManager service url which is `https://secretsmanager.<region>.amazonaws.com` You can specify a complete URL(including the \"http/https\" scheme) to override the endpoint that vault will connect to."
+  },
+  "vault_aws_assume_role_arn": {
+    "defaultValue": null,
+    "description": "The target AWS IAM role ARN that will be assumed. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+  },
+  "vault_aws_role_session_name": {
+    "defaultValue": "KongVault",
+    "description": "The role session name used for role assuming. The default value is `KongVault`."
+  },
+  "vault_aws_sts_endpoint_url": {
+    "defaultValue": null,
+    "description": "The custom STS endpoint URL used for role assuming in AWS Vault.  Note that this value will override the default STS endpoint URL(which should be `https://sts.amazonaws.com`, or `https://sts.<region>.amazonaws.com` if you have `AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).  If you are not using private VPC endpoint for STS service, you should not specify this value."
+  },
+  "vault_aws_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the AWS vault when cached by this node.  AWS vault misses (no secret) are also cached according to this setting if you do not configure `vault_aws_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_aws_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_aws_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_aws_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the AWS vault should be resurrected for when they cannot be refreshed (e.g., the AWS vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "vault_gcp_project_id": {
+    "defaultValue": null,
+    "description": "The project ID from your Google API Console."
+  },
+  "vault_gcp_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the GCP vault when cached by this node.  GCP vault misses (no secret) are also cached according to this setting if you do not configure `vault_gcp_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_gcp_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_gcp_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_gcp_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the GCP vault should be resurrected for when they cannot be refreshed (e.g., the GCP vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "vault_hcv_protocol": {
+    "defaultValue": "http",
+    "description": "The protocol to connect with. Accepts one of `http` or `https`."
+  },
+  "vault_hcv_host": {
+    "defaultValue": "127.0.0.1",
+    "description": "The hostname of your HashiCorp vault."
+  },
+  "vault_hcv_port": {
+    "defaultValue": "8200",
+    "description": "The port number of your HashiCorp vault."
+  },
+  "vault_hcv_namespace": {
+    "defaultValue": null,
+    "description": "Namespace for the HashiCorp Vault. Vault Enterprise requires a namespace to successfully connect to it."
+  },
+  "vault_hcv_mount": {
+    "defaultValue": "secret",
+    "description": "The mount point."
+  },
+  "vault_hcv_kv": {
+    "defaultValue": "v1",
+    "description": "The secrets engine version. Accepts `v1` or `v2`."
+  },
+  "vault_hcv_token": {
+    "defaultValue": null,
+    "description": "A token string."
+  },
+  "vault_hcv_auth_method": {
+    "defaultValue": "token",
+    "description": "Defines the authentication mechanism when connecting to the Hashicorp Vault service. Accepted values are: `token`, `kubernetes` or `approle`."
+  },
+  "vault_hcv_kube_role": {
+    "defaultValue": null,
+    "description": "Defines the HashiCorp Vault role for the Kubernetes service account of the running pod. `vault_hcv_auth_method` must be set to `kubernetes` for this to activate."
+  },
+  "vault_hcv_kube_auth_path": {
+    "defaultValue": "kubernetes",
+    "description": " Place where the Kubernetes auth method will be accessible: /v1/auth/<vault_hcv_kube_auth_path>"
+  },
+  "vault_hcv_kube_api_token_file": {
+    "defaultValue": null,
+    "description": "Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+  },
+  "vault_hcv_approle_auth_path": {
+    "defaultValue": "approle",
+    "description": " Place where the Approle auth method will be accessible: /v1/auth/<vault_hcv_approle_auth_path>"
+  },
+  "vault_hcv_approle_role_id": {
+    "defaultValue": null,
+    "description": "The Role ID of the Approle in HashiCorp Vault."
+  },
+  "vault_hcv_approle_secret_id": {
+    "defaultValue": null,
+    "description": "The Secret ID of the Approle in HashiCorp Vault."
+  },
+  "vault_hcv_approle_secret_id_file": {
+    "defaultValue": null,
+    "description": "Defines where the Secret ID should be read from the pod's filesystem. This is usually used with HashiCorp Vault's response wrapping."
+  },
+  "vault_hcv_approle_response_wrapping": {
+    "defaultValue": "false",
+    "description": "Defines whether the Secret ID read from configuration or file is actually a response-wrapping token instead of a real Secret ID."
+  },
+  "vault_hcv_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the HashiCorp vault when cached by this node.  HashiCorp vault misses (no secret) are also cached according to this setting if you do not configure `vault_hcv_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_hcv_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a HashiCorp vault miss (no secret).  If not specified (default), `vault_hcv_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_hcv_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the HashiCorp vault should be resurrected for when they cannot be refreshed (e.g., the HashiCorp vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "vault_azure_vault_uri": {
+    "defaultValue": null,
+    "description": "The URI the vault is reachable from."
+  },
+  "vault_azure_client_id": {
+    "defaultValue": null,
+    "description": "The client ID from your registered Application. Visit your Azure Dashboard and select *App Registrations* to check your client ID."
+  },
+  "vault_azure_tenant_id": {
+    "defaultValue": null,
+    "description": "The DirectoryId and TenantId both equate to the GUID representing the ActiveDirectory Tenant. Depending on context, either term may be used by Microsoft documentation and products, which can be confusing. In other words, the \"Tenant ID\" IS the \"Directory ID\""
+  },
+  "vault_azure_type": {
+    "defaultValue": "secrets",
+    "description": "Azure Key Vault enables Microsoft Azure applications and users to store and use several types of secret/key data: keys, secrets, and certificates. Kong currently only supports the `Secrets`"
+  },
+  "vault_azure_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the Azure Key Vault when cached by this node.  Key Vault misses (no secret) are also cached according to this setting if you do not configure `vault_azure_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_azure_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a Azure Key Vault miss (no secret).  If not specified (default), `vault_azure_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_azure_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the Azure Key Vault should be resurrected for when they cannot be refreshed (e.g., the the vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "worker_consistency": {
+    "defaultValue": "eventual",
+    "description": " Defines whether this node should rebuild its state synchronously or asynchronously (the balancers and the router are rebuilt on updates that affects them, e.g., updates to Routes, Services or Upstreams, via the Admin API or loading a declarative configuration file). (This option is deprecated and will be removed in future releases. The new default is `eventual`.)  Accepted values are:  - `strict`: the router will be rebuilt   synchronously, causing incoming requests to   be delayed until the rebuild is finished.   (This option is deprecated and will be removed    in future releases. The new default is `eventual`) - `eventual`: the router will be rebuilt   asynchronously via a recurring background   job running every second inside of each   worker.  Note that `strict` ensures that all workers of a given node will always proxy requests with an identical router, but that increased long tail latency can be observed if frequent Routes and Services updates are expected. Using `eventual` will help preventing long tail latency issues in such cases, but may cause workers to route requests differently for a short period of time after Routes and Services updates."
+  },
+  "worker_state_update_frequency": {
+    "defaultValue": "5",
+    "description": " Defines how often the worker state changes are checked with a background job. When a change is detected, a new router or balancer will be built, as needed. Raising this value will decrease the load on database servers and result in less jitter in proxy latency, but it might take more time to propagate changes to each individual worker."
+  },
+  "router_flavor": {
+    "defaultValue": "traditional_compatible",
+    "description": " Selects the router implementation to use when performing request routing. Incremental router rebuild is available when the flavor is set to either `expressions` or `traditional_compatible` which could significantly shorten rebuild time for large number of routes.  Accepted values are:  - `traditional_compatible`: the DSL based expression   router engine will be used under the hood. However   the router config interface will be the same   as `traditional` and expressions are   automatically generated at router build time.   The `expression` field on the `Route` object   is not visible. - `expressions`: the DSL based expression router engine   will be used under the hood. Traditional router   config interface is not visible and you must write   Router Expression manually and provide them in the   `expression` field on the `Route` object. - `traditional`: the pre-3.0 Router engine will be   used. Config interface will be the same as   pre-3.0 Kong and the `expression` field on the   `Route` object is not visible.    Deprecation warning: In Kong 3.0, `traditional`   mode should be avoided and only be used in case   `traditional_compatible` did not work as expected.   This flavor of router will be removed in the next   major release of Kong."
+  },
+  "lua_max_req_headers": {
+    "defaultValue": "100",
+    "description": "Maximum number of request headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying the Kong sends all the request headers and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many request headers."
+  },
+  "lua_max_resp_headers": {
+    "defaultValue": "100",
+    "description": "Maximum number of response headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong returns all the response headers and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many response headers."
+  },
+  "lua_max_uri_args": {
+    "defaultValue": "100",
+    "description": "Maximum number of request uri arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request query arguments and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many query arguments."
+  },
+  "lua_max_post_args": {
+    "defaultValue": "100",
+    "description": "Maximum number of request post arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request post arguments and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many post arguments."
+  },
+  "lua_ssl_trusted_certificate": {
+    "defaultValue": "system",
+    "description": "Comma-separated list of certificate authorities for Lua cosockets in PEM format.  The special value `system` attempts to search for the \"usual default\" provided by each distro, according to an arbitrary heuristic. In the current implementation, The following pathnames will be tested in order, and the first one found will be used:  - /etc/ssl/certs/ca-certificates.crt (Debian/Ubuntu/Gentoo) - /etc/pki/tls/certs/ca-bundle.crt (Fedora/RHEL 6) - /etc/ssl/ca-bundle.pem (OpenSUSE) - /etc/pki/tls/cacert.pem (OpenELEC) - /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem (CentOS/RHEL 7) - /etc/ssl/cert.pem (OpenBSD, Alpine)  `system` can be used by itself or in conjunction with other CA filepaths.  When `pg_ssl_verify` is enabled, these certificate authority files will be used for verifying Kong's database connections.  Certificates can be configured on this property with either of the following values: * `system` * absolute path to the certificate * certificate content * base64 encoded certificate content  See https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate"
+  },
+  "lua_ssl_verify_depth": {
+    "defaultValue": "1",
+    "description": "Sets the verification depth in the server certificates chain used by Lua cosockets, set by `lua_ssl_trusted_certificate`. This includes the certificates configured for Kong's database connections. If the maximum depth is reached before reaching the end of the chain, verification will fail. This helps mitigate certificate based DoS attacks.  See https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth"
+  },
+  "lua_ssl_protocols": {
+    "defaultValue": "TLSv1.2 TLSv1.3",
+    "description": "Defines the TLS versions supported when handshaking with OpenResty's TCP cosocket APIs.  This affects connections made by Lua code, such as connections to the database Kong uses, or when sending logs using a logging plugin. It does *not* affect connections made to the upstream Service or from downstream clients."
+  },
+  "lua_package_path": {
+    "defaultValue": "./?.lua;./?/init.lua;",
+    "description": "Sets the Lua module search path (LUA_PATH). Useful when developing or using custom plugins not stored in the default search path.  See https://github.com/openresty/lua-nginx-module#lua_package_path"
+  },
+  "lua_package_cpath": {
+    "defaultValue": null,
+    "description": "Sets the Lua C module search path (LUA_CPATH).  See https://github.com/openresty/lua-nginx-module#lua_package_cpath"
+  },
+  "lua_socket_pool_size": {
+    "defaultValue": "256",
+    "description": "Specifies the size limit for every cosocket connection pool associated with every remote server.  See https://github.com/openresty/lua-nginx-module#lua_socket_pool_size"
+  },
+  "enforce_rbac": {
+    "defaultValue": "off",
+    "description": "Specifies whether Admin API RBAC is enforced. Accepts one of `entity`, `both`, `on`, or `off`.  - `on`: only endpoint-level authorization   is enforced. - `entity`: entity-level authorization   applies. - `both`: enables both endpoint and   entity-level authorization. - `off`: disables both endpoint and   entity-level authorization.  When enabled, Kong will deny requests to the Admin API when a nonexistent or invalid RBAC authorization token is passed, or the RBAC user with which the token is associated does not have permissions to access/modify the requested resource."
+  },
+  "rbac_auth_header": {
+    "defaultValue": "Kong-Admin-Token",
+    "description": "Defines the name of the HTTP request header from which the Admin API will attempt to authenticate the RBAC user."
+  },
+  "event_hooks_enabled": {
+    "defaultValue": "on",
+    "description": "When enabled, event hook entities represent a relationship between an event (source and event) and an action (handler). Similar to web hooks, event hooks can be used to communicate Kong Gateway service events. When a particular event happens on a service, the event hook calls a URL with information about that event. Event hook configurations differ depending on the handler. The events that are triggered send associated data.  See: https://docs.konghq.com/enterprise/latest/admin-api/event-hooks/reference/"
+  },
+  "fips": {
+    "defaultValue": "off",
+    "description": "Turn on FIPS mode; this mode is only available on a FIPS build."
+  },
+  "admin_gui_listen": {
+    "defaultValue": [
+      "0.0.0.0:8002",
+      "0.0.0.0:8445 ssl"
+    ],
+    "description": " Kong Manager Listeners  Comma-separated list of addresses and ports on which Kong will expose Kong Manager. This web application lets you configure and manage Kong, and therefore should be kept secured.  Suffixes can be specified for each pair, similarly to the `admin_listen` directive."
+  },
+  "admin_gui_url": {
+    "defaultValue": null,
+    "description": "Kong Manager URL  The lookup, or balancer, address for Kong Manager.  Accepted format (items in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>)`  Examples:  - `http://127.0.0.1:8003` - `https://kong-admin.test` - `http://dev-machine`  By default, Kong Manager will use the window request host and append the resolved listener port depending on the requested protocol."
+  },
+  "admin_gui_path": {
+    "defaultValue": "/",
+    "description": "Kong Manager base path  This configuration parameter allows the user to customize the path prefix where Kong Manager is served. When updating this parameter, it's recommended to update the path in `admin_gui_url` as well.  Accepted format:  - Path must start with a `/` - Path must not end with a `/` (except for the `/`) - Path can only contain letters, digits, hyphens (`-`), underscores (`_`), and slashes (`/`) - Path must not contain continuous slashes (e.g., `//` and `///`)  Examples:  - `/` - `/manager` - `/kong-manager` - `/kong/manager`"
+  },
+  "admin_gui_api_url": {
+    "defaultValue": null,
+    "description": "Hierarchical part of a URI which is composed optionally of a host, port, and path at which the Admin API accepts HTTP or HTTPS traffic. When this config is disabled, Kong Manager will use the window protocol + host and append the resolved admin_listen HTTP/HTTPS port."
+  },
+  "admin_gui_ssl_protocols": {
+    "defaultValue": "TLSv1.2 TLSv1.3",
+    "description": " Defines the TLS versions supported for Kong Manager"
+  },
+  "admin_gui_ssl_cert": {
+    "defaultValue": null,
+    "description": "The SSL certificate for `admin_gui_listen` values with SSL enabled.  values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "admin_gui_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "The SSL key for `admin_gui_listen` values with SSL enabled.  values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+  },
+  "admin_gui_flags": {
+    "defaultValue": "{}",
+    "description": " Alters the layout Admin GUI (JSON) The only supported value is `{ \"IMMUNITY_ENABLED\": true }` to enable Kong Immunity in the Admin GUI."
+  },
+  "admin_gui_access_log": {
+    "defaultValue": "logs/admin_gui_access.log",
+    "description": " Kong Manager Access Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables access logs for Kong Manager."
+  },
+  "admin_gui_error_log": {
+    "defaultValue": "logs/admin_gui_error.log",
+    "description": " Kong Manager Error Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables error logs for Kong Manager.  Granularity can be adjusted through the `log_level` directive."
+  },
+  "admin_gui_auth": {
+    "defaultValue": null,
+    "description": "Kong Manager Authentication Plugin Name  Secures access to Kong Manager by specifying an authentication plugin to use.  Supported Plugins:  - `basic-auth`: Basic Authentication plugin - `ldap-auth-advanced`: LDAP Authentication plugin - `openid-connect`: OpenID Connect Authentication   plugin"
+  },
+  "admin_gui_auth_conf": {
+    "defaultValue": null,
+    "description": "Kong Manager Authentication Plugin Config (JSON)  Specifies the configuration for the authentication plugin specified in `admin_gui_auth`.  For information about Plugin Configuration consult the associated plugin documentation.  Example for `basic-auth`:  `admin_gui_auth_conf = { \"hide_credentials\": true }`"
+  },
+  "admin_gui_auth_password_complexity": {
+    "defaultValue": null,
+    "description": "Kong Manager Authentication Password Complexity (JSON)  When `admin_gui_auth = basic-auth`, this property defines the rules required for Kong Manager passwords. Choose from preset rules or write your own.  Example using preset rules:  `admin_gui_auth_password_complexity = { \"kong-preset\": \"min_8\" }`  All values for kong-preset require the password to contain characters from at least three of the following categories:  1. Uppercase characters (A through Z)  2. Lowercase characters (a through z)  3. Base-10 digits (0 through 9)  4. Special characters (for example, &, $, #, %)  Supported preset rules: - `min_8`: minimum length of 8 - `min_12`: minimum length of 12 - `min_20`: minimum length of 20  To write your own rules, see https://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.  NOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.  Example:  `admin_gui_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`"
+  },
+  "admin_gui_session_conf": {
+    "defaultValue": null,
+    "description": "Kong Manager Session Config (JSON)  Specifies the configuration for the Session plugin as used by Kong Manager.  For information about plugin configuration, consult the Kong Session plugin documentation.  Example: ``` admin_gui_session_conf = { \"cookie_name\": \"kookie\", \\                            \"secret\": \"changeme\" } ```"
+  },
+  "admin_gui_auth_header": {
+    "defaultValue": "Kong-Admin-User",
+    "description": " Defines the name of the HTTP request header from which the Admin API will attempt to identify the Kong Admin user."
+  },
+  "admin_gui_auth_login_attempts": {
+    "defaultValue": "0",
+    "description": " Number of times a user can attempt to login to Kong Manager. 0 means infinite attempts allowed."
+  },
+  "admin_gui_header_txt": {
+    "defaultValue": null,
+    "description": "Kong Manager Header Text Sets text for Kong Manager Header Banner. Header Banner is not shown if this config is empty."
+  },
+  "admin_gui_header_bg_color": {
+    "defaultValue": null,
+    "description": "Kong Manager Header Background Color Sets background color for Kong Manager Header Banner Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Manager."
+  },
+  "admin_gui_header_txt_color": {
+    "defaultValue": null,
+    "description": "Kong Manager Header Text Color Sets text color for Kong Manager Header Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Kong Manager."
+  },
+  "admin_gui_footer_txt": {
+    "defaultValue": null,
+    "description": "Kong Manager Footer Text Sets text for Kong Manager Footer Banner. Footer Banner is not shown if this config is empty"
+  },
+  "admin_gui_footer_bg_color": {
+    "defaultValue": null,
+    "description": "Kong Manager Footer Background Color Sets background color for Kong Manager Footer Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Manager."
+  },
+  "admin_gui_footer_txt_color": {
+    "defaultValue": null,
+    "description": "Kong Manager Footer Text Color Sets text color for Kong Manager Footer Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Kong Manager."
+  },
+  "admin_gui_login_banner_title": {
+    "defaultValue": null,
+    "description": "Kong Manager Login Banner Title Text Sets title text for Kong Manager Login Banner. Login Banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+  },
+  "admin_gui_login_banner_body": {
+    "defaultValue": null,
+    "description": "Kong Manager Login Banner Body Text Sets body text for Kong Manager Login Banner. Login Banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+  },
+  "konnect_mode": {
+    "defaultValue": "off",
+    "description": "When enabled, the dataplane is connected to Konnect"
+  },
+  "analytics_flush_interval": {
+    "defaultValue": "1",
+    "description": "Determine the frequency of flushing local data to Konnect in seconds."
+  },
+  "analytics_buffer_size_limit": {
+    "defaultValue": "100000",
+    "description": "Max number of messages can be buffered locally before dropping data in case there is no network connection to Konnect."
+  },
+  "analytics_debug": {
+    "defaultValue": "off",
+    "description": "Outputs analytics payload to Kong logs."
+  },
+  "admin_emails_from": {
+    "defaultValue": "\"\"",
+    "description": "The email address for the `From` header for admin emails."
+  },
+  "admin_emails_reply_to": {
+    "defaultValue": null,
+    "description": "Email address for the `Reply-To` header for admin emails."
+  },
+  "admin_invitation_expiry": {
+    "defaultValue": "259200",
+    "description": "Expiration time for the admin invitation link (in seconds). 0 means no expiration.  Example, 72 hours: `72 * 60 * 60 = 259200`"
+  },
+  "smtp_mock": {
+    "defaultValue": "on",
+    "description": "This flag will mock the sending of emails. This can be used for testing before the SMTP client is fully configured."
+  },
+  "smtp_host": {
+    "defaultValue": "localhost",
+    "description": " The hostname of the SMTP server to connect to."
+  },
+  "smtp_port": {
+    "defaultValue": "25",
+    "description": " The port number on the SMTP server to connect to."
+  },
+  "smtp_starttls": {
+    "defaultValue": "off",
+    "description": " When set to `on`, STARTTLS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 587."
+  },
+  "smtp_username": {
+    "defaultValue": null,
+    "description": "Username used for authentication with SMTP server"
+  },
+  "smtp_password": {
+    "defaultValue": null,
+    "description": "Password used for authentication with SMTP server"
+  },
+  "smtp_ssl": {
+    "defaultValue": "off",
+    "description": " When set to `on`, SMTPS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 465."
+  },
+  "smtp_auth_type": {
+    "defaultValue": null,
+    "description": "The method used to authenticate with the SMTP server Valid options are `plain`, `login`, or `nil`"
+  },
+  "smtp_domain": {
+    "defaultValue": "localhost.localdomain",
+    "description": " The domain used in the `EHLO` connection and part of the `Message-ID` header"
+  },
+  "smtp_timeout_connect": {
+    "defaultValue": "60000",
+    "description": " The timeout (in milliseconds) for connecting to the SMTP server."
+  },
+  "smtp_timeout_send": {
+    "defaultValue": "60000",
+    "description": " The timeout (in milliseconds) for sending data to the SMTP server."
+  },
+  "smtp_timeout_read": {
+    "defaultValue": "60000",
+    "description": " The timeout (in milliseconds) for reading data from the SMTP server."
+  },
+  "smtp_admin_emails": {
+    "defaultValue": null,
+    "description": "Comma separated list of admin emails to receive notifications. Example `admin1@example.com, admin2@example.com`"
+  },
+  "audit_log": {
+    "defaultValue": "off",
+    "description": "When enabled, Kong will log information about Admin API access and database row insertions, updates, and deletes."
+  },
+  "audit_log_ignore_methods": {
+    "defaultValue": null,
+    "description": "Comma-separated list of HTTP methods that will not generate audit log entries. By default, all HTTP requests will be logged."
+  },
+  "audit_log_ignore_paths": {
+    "defaultValue": null,
+    "description": "Comma-separated list of request paths that will not generate audit log entries. By default, all HTTP requests will be logged."
+  },
+  "audit_log_ignore_tables": {
+    "defaultValue": null,
+    "description": "Comma-separated list of database tables that will not generate audit log entries. By default, updates to all database tables will be logged (the term \"updates\" refers to the creation, update, or deletion of a row)."
+  },
+  "audit_log_payload_exclude": {
+    "defaultValue": [
+      "token",
+      "secret",
+      "password"
+    ],
+    "description": " Comma-separated list of keys that will be filtered out of the payload. Keys that were filtered will be recorded in the audit log."
+  },
+  "audit_log_record_ttl": {
+    "defaultValue": "2592000",
+    "description": "Length, in seconds, of the TTL for audit log records. Records in the database older than their TTL are automatically purged.  Example, 30 days: `30 * 24 * 60 * 60 = 2592000`"
+  },
+  "audit_log_signing_key": {
+    "defaultValue": null,
+    "description": "Defines the path to a private RSA signing key that can be used to insert a signature of audit records, adjacent to the record. The corresponding public key should be stored offline, and can be used the validate audit entries in the future. If this value is undefined, no signature will be generated."
+  },
+  "tracing": {
+    "defaultValue": "off",
+    "description": "When enabled, Kong will generate granular debug data about various portions of the request lifecycle, such as DB or DNS queries, plugin execution, core handler timing, etc."
+  },
+  "tracing_write_strategy": {
+    "defaultValue": "file",
+    "description": "Defines how Kong will write tracing data at the conclusion of the request. The default option, `file`, writes a human-readable depiction of tracing data to a configurable location on the node's file system. Other strategies write tracing data as a JSON document to the configured endpoint. Valid entries for this option are `file`, `file_raw`, `http`, `tcp`, `tls`, and `udp`."
+  },
+  "tracing_write_endpoint": {
+    "defaultValue": null,
+    "description": "Defines the endpoint to which tracing data will be written.  - For the `file` and `file_raw` tracing write   strategies, this value must be a valid   location on the node's file system to which   Kong must have write access. - For the `tcp`, `tls`, and   `udp` strategies, this value is defined as a   string in the form of:  `<HOST>:<PORT>` - For the `http` strategy, this value is   defined in the form of:  `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`  Traces sent via HTTP are delivered via POST method with an `application/json` Content-Type."
+  },
+  "tracing_time_threshold": {
+    "defaultValue": "0",
+    "description": "The minimum time, in microseconds, over which a trace must execute in order to write the trace data to the configured endpoint. This configuration can be used to lower the noise present in trace data by removing trace objects that are not interesting from a timing perspective. The default value of `0` removes this limitation, causing traces of any duration to be written."
+  },
+  "tracing_types": {
+    "defaultValue": "all",
+    "description": "Defines the types of traces that are written. Trace types not defined in this list are ignored, regardless of their lifetime. The default special value of `all` results in all trace types being written, regardless of type.  The following trace types are included:  - `query`: trace the database query - `legacy_query`: (deprecated) trace the    database query with legacy DAO - `router`: trace Kong routing the request;    internal routing time - `balancer`: trace the execution of the overall    balancer phase - `balancer.getPeer`: trace Kong selecting an    upstream peer from the ring-balancer - `balancer.toip`: trace balancer to resolve    peer's host to IP - `connect.toip`: trace cosocket to resolve    target's host to IP - `access.before`: trace the preprocessing of    access phase, like parameter parsing, route    matching, and balance preparation - `access.after`: trace the postprocess of    access phase, like balancer execution and    internal variable assigning - `plugin`: trace plugins phase handlers"
+  },
+  "tracing_debug_header": {
+    "defaultValue": null,
+    "description": "Defines the name of the HTTP request header that must be present in order to generate traces within a request. Setting this value provides a mechanism to selectively generate request traces at the client's request. Note that the value of the header does not matter, only that the header is present in the request. When this value is not set and tracing is enabled, Kong will generate trace data for all requests flowing through the proxy and Admin API. Note that data from certificate handling phases is not logged when this setting is enabled."
+  },
+  "generate_trace_details": {
+    "defaultValue": "off",
+    "description": "When enabled, Kong will write context- specific details into traces. Trace details offer more data about the context of the trace. This can significantly increase the size of trace reports. Note also that trace details may contain potentially sensitive information, such as raw SQL queries; care should be taken to store traces properly when this option is enabled."
+  },
+  "route_validation_strategy": {
+    "defaultValue": "smart",
+    "description": "The strategy used to validate routes when creating or updating them. Different strategies are available to tune how to enforce splitting traffic of workspaces. - `smart` is the default option and uses the   algorithm described in   https://docs.konghq.com/gateway/latest/admin-api/workspaces/examples/#important-note-conflicting-services-or-routes-in-workspaces. - `off` disables any check. - `path` enforces routes to comply with the pattern   described in config `enforce_route_path_pattern`. - `static` relies on the PostgreSQL database. Before creating a new route, it checks if the route is unique across all workspaces based on the following params: `paths`, `methods`, and `hosts`. If all fields of the new route overlap with an existing one, a 409 is returned with the route of the collision. The array order is not important for the overlap filter."
+  },
+  "enforce_route_path_pattern": {
+    "defaultValue": null,
+    "description": "Specifies the Lua pattern which will be enforced on the `paths` attribute of a Route object. You can also add a placeholder for the workspace in the pattern, which will be rendered during runtime based on the workspace to which the `route` belongs. This setting is only relevant if `route_validation_strategy` is set to `path`.   Example For Pattern `/$(workspace)/v%d/.*` valid paths are:  1. `/group1/v1/` if route belongs to   workspace `group1`.  2. `/group2/v1/some_path` if route belongs to   workspace `group2`."
+  },
+  "keyring_enabled": {
+    "defaultValue": "off",
+    "description": "When enabled, Kong will encrypt sensitive field values before writing them to the database, and subsuquently decrypt them when retrieving data for the Admin API, Developer Portal, or proxy business logic. Symmetric encryption keys are managed based on the strategy defined below."
+  },
+  "keyring_strategy": {
+    "defaultValue": "cluster",
+    "description": "Defines the strategy implementation by which Kong nodes will manage symmetric encryption keys. Please see the Kong Enterprise documentation for a detailed description of each strategies. Acceptable values for this option are 'cluster' and 'vault'."
+  },
+  "keyring_public_key": {
+    "defaultValue": null,
+    "description": "Defines the public key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  values: * absolute path to the public key * public key content * base64 encoded public key content"
+  },
+  "keyring_private_key": {
+    "defaultValue": null,
+    "description": "Defines the private key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  values: * absolute path to the private key * private key content * base64 encoded private key content"
+  },
+  "keyring_blob_path": {
+    "defaultValue": null,
+    "description": "Defines the filesystem path at which Kong will backup the initial keyring material. This option is useful largely for development purposes."
+  },
+  "keyring_vault_host": {
+    "defaultValue": null,
+    "description": "Defines the Vault host at which Kong will fetch the encryption material. This value should be defined in the format:  `<scheme>://<IP / HOSTNAME>:<PORT>`"
+  },
+  "keyring_vault_mount": {
+    "defaultValue": null,
+    "description": "Defines the name of the Vault v2 KV secrets engine at which symmetric keys are found."
+  },
+  "keyring_vault_path": {
+    "defaultValue": null,
+    "description": "Defines the names of the Vault v2 KV path at which symmetric keys are found."
+  },
+  "keyring_vault_auth_method": {
+    "defaultValue": "token",
+    "description": " Defines the authentication mechanism when connecting to the Hashicorp Vault service.  Accepted values are: `token`, or `kubernetes`:  * `token`: Uses the static token defined in            the `keyring_vault_token`            configuration property.  * `kubernetes`: Uses the Kubernetes authentication                 mechanism, with the running pod's                 mapped service account, to assume                 the Hashicorp Vault role name that is                 defined in the `keyring_vault_kube_role`                 configuration property."
+  },
+  "keyring_vault_token": {
+    "defaultValue": null,
+    "description": "Defines the token value used to communicate with the v2 KV Vault HTTP(S) API."
+  },
+  "keyring_vault_kube_role": {
+    "defaultValue": "default",
+    "description": " Defines the Hashicorp Vault role that will be assumed using the Kubernetes service account of the running pod.  `keyring_vault_auth_method` must be set to `kubernetes` for this to activate."
+  },
+  "keyring_vault_kube_api_token_file": {
+    "defaultValue": "/run/secrets/kubernetes.io/serviceaccount/token",
+    "description": " Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+  },
+  "untrusted_lua": {
+    "defaultValue": "sandbox",
+    "description": " Controls loading of Lua functions from admin-supplied sources such as the Admin API. LuaJIT bytecode loading is always disabled.  **Warning:** LuaJIT is not designed as a secure runtime for running malicious code, therefore you should properly protect your Admin API endpoint even with sandboxing enabled. The sandbox only provides protection against trivial attackers or unintentional modification of the Kong global environment.  Accepted values are: `off`, `sandbox`, or `on`:  * `off`: Disallow loading of any arbitrary          Lua functions. The `off` option          disables any functionality that runs          arbitrary Lua code, including the          Serverless Functions plugins and any          transformation plugin that allows          custom Lua functions.  * `sandbox`: Allow loading of Lua functions,              but use a sandbox when executing              them. The sandboxed function has              restricted access to the global              environment and only has access              to standard Lua functions that              will generally not cause harm to              the Kong Gateway node.  * `on`: Functions have unrestricted         access to the global environment and         can load any Lua modules. This is         similar to the behavior in         Kong Gateway prior to 2.3.0.  The default `sandbox` environment does not allow importing other modules or libraries, or executing anything at the OS level (for example, file read/write). The global environment is also not accessible.  Examples of `untrusted_lua = sandbox` behavior:  * You can't access or change global values such as `kong.configuration.pg_password` * You can run harmless lua: `local foo = 1 + 1`. However, OS level functions are not allowed, like: `os.execute('rm -rf /*')`.  For a full allowed/disallowed list, see: https://github.com/kikito/sandbox.lua/blob/master/sandbox.lua  To customize the sandbox environment, use the `untrusted_lua_sandbox_requires` and `untrusted_lua_sandbox_environment` parameters below."
+  },
+  "untrusted_lua_sandbox_requires": {
+    "defaultValue": null,
+    "description": "Comma-separated list of modules allowed to be loaded with `require` inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  For example, say you have configured the Serverless pre-function plugin and it contains the following `requires`:  ``` local template = require \"resty.template\" local split = require \"kong.tools.utils\".split ```  To run the plugin, add the modules to the allowed list: ``` untrusted_lua_sandbox_requires = resty.template, kong.tools.utils ```  **Warning:** Allowing certain modules may create opportunities to escape the sandbox. For example, allowing `os` or `luaposix` may be unsafe."
+  },
+  "untrusted_lua_sandbox_environment": {
+    "defaultValue": null,
+    "description": "Comma-separated list of global Lua variables that should be made available inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  **Warning**: Certain variables, when made available, may create opportunities to escape the sandbox."
+  },
+  "openresty_path": {
+    "defaultValue": null,
+    "description": "Path to the OpenResty installation that Kong will use. When this is empty (the default), Kong determines the OpenResty installation by searching for a system-installed OpenResty and falling back to searching $PATH for the nginx binary.  Setting this attribute disables the search behavior and explicitly instructs Kong which OpenResty installation to use."
+  },
+  "node_id": {
+    "defaultValue": null,
+    "description": "Node ID for the Kong node. Every Kong node in a Kong cluster must have a unique and valid UUID. When empty, node ID is automatically generated."
+  },
+  "cluster_fallback_config_import": {
+    "defaultValue": "off",
+    "description": "Enable fallback configuration imports.  This should only be enabled for data planes."
+  },
+  "cluster_fallback_config_storage": {
+    "defaultValue": null,
+    "description": "Storage definition used by `cluster_fallback_config_import` and `cluster_fallback_config_export`.  Supported storage types: - S3-like storages - GCP storage service  To use S3 with a bucket named b and place all configs to with a key prefix named p, set it to: `s3://b/p` To use GCP for the same bucket and prefix, set it to: `gcs://b/p`  The credentials (and the endpoint URL for S3-like) for S3 are passed with environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where `AWS_CONFIG_STORAGE_ENDPOINT` is the endpoint that hosts S3-like storage.  The credentials for GCP are provided via the environment variable `GCP_SERVICE_ACCOUNT`."
+  },
+  "cluster_fallback_export_s3_config": {
+    "defaultValue": null,
+    "description": "fallback config export S3 config This is used only when `cluster_fallback_config_storage` is S3-like schema. If set, it will add config table to kong exporter config S3 putObject request. The config table should be in JSON format and can be unserialized into a table. It should contain the necessary parameters as described in the documentation.  https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property. For example, if you want to set the ServerSideEncryption headers / KMS Key ID for the S3 putObject request, you can set the config table to: `{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"your-kms-key-id\"}`"
+  },
+  "cluster_fallback_config_export": {
+    "defaultValue": "off",
+    "description": "Enable fallback configuration exports."
+  },
+  "cluster_fallback_config_export_delay": {
+    "defaultValue": "60",
+    "description": "The fallback configuration export interval.  If the interval is set to 60 and configuration A is exported and there are new configurations B, C, and D in the next 60 seconds, it will wait until 60 seconds passed and export D, skipping B and C."
+  },
+  "wasm": {
+    "defaultValue": "off",
+    "description": "Enable/disable wasm support. This must be enabled in order to use wasm filters and filter chains."
+  },
+  "wasm_filters_path": {
+    "defaultValue": null,
+    "description": "Path to the directory containing wasm filter modules.  At startup, Kong discovers available wasm filters by scanning this directory for files with the `.wasm` file extension.  The name of a wasm filter module is derived from the filename itself, with the .wasm extension removed. So, given the following tree:  ``` /path/to/wasm_filters ├── my_module.wasm ├── my_other_module.wasm └── not_a_wasm_module.txt ```  The resulting filter modules available for use in Kong will be:  * `my_module` * `my_other_module`  Notes:  * No recursion is performed. Only .wasm files at the   top level are registered * This path _may_ be a symlink to a directory."
+  },
+  "request_debug": {
+    "defaultValue": "on",
+    "description": "When enabled, Kong will provide detailed timing information for its components to the client and the error log if the following headers are present in the proxy request: - `X-Kong-Request-Debug`:   If the value is set to `*`,   timing information will be collected and exported for the current request.   If this header is not present or contains unknown value,   timing information will not be collected for the current request.   You can also specify a list of filters, separated by commas,   to filter the scope of the time information that is collected.   The following filters are supported:   - `rewrite`: Collect timing information from the `rewrite` phase.   - `access`: Collect timing information from the `access` phase.   - `balancer`: Collect timing information from the `balancer` phase.   - `response`: Collect timing information from the `response` phase.   - `header_filter`: Collect timing information from the `header_filter` phase.   - `body_filter`: Collect timing information from the `body_filter` phase.   - `log`: Collect timing information from the `log` phase.   - `upstream`: Collect timing information from the `upstream` phase.  - `X-Kong-Request-Debug-Log`:   If set to `true`, timing information will also be logged   in the Kong error log with a log level of `notice`.   Defaults to `false`.  - `X-Kong-Request-Debug-Token`:   Token for authenticating the client making the debug   request to prevent abuse. Debug requests originating from loopback   addresses do not require this header. "
+  },
+  "request_debug_token": {
+    "defaultValue": "<random>",
+    "description": "The Request Debug Token is used in the `X-Kong-Request-Debug-Token` header to prevent abuse. If this value is not set (the default), a random token will be generated when Kong starts, restarts, or reloads. If a token is specified manually, then the provided token will be used.  You can locate the generated debug token in two locations: - Kong error log:   Debug token will be logged in the error log (notice level)   when Kong starts, restarts, or reloads.   The log line will have the: `[request-debug]` prefix to aid searching. - Filesystem:   Debug token will also be stored in a file located at   `{prefix}/.request_debug_token` and updated   when Kong starts, restarts, or reloads."
+  }
+}

--- a/app/_data/kong-conf/3.6.json
+++ b/app/_data/kong-conf/3.6.json
@@ -1,325 +1,325 @@
 {
   "prefix": {
     "defaultValue": "/usr/local/kong/",
-    "description": "Working directory. Equivalent to Nginx's prefix path, containing temporary files and logs. Each Kong process must have a separate working directory."
+    "description": "Working directory. Equivalent to Nginx's\nprefix path, containing temporary files\nand logs.\nEach Kong process must have a separate\nworking directory.\n"
   },
   "log_level": {
     "defaultValue": "notice",
-    "description": "Log level of the Nginx server. Logs are found at `<prefix>/logs/error.log`."
+    "description": "Log level of the Nginx server. Logs are\nfound at `<prefix>/logs/error.log`.\n"
   },
   "proxy_access_log": {
     "defaultValue": "logs/access.log",
-    "description": "Path for proxy port request access logs. Set this value to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for proxy port request access\nlogs. Set this value to `off` to\ndisable logging proxy requests.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n"
   },
   "proxy_error_log": {
     "defaultValue": "logs/error.log",
-    "description": "Path for proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for proxy port request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "proxy_stream_access_log": {
     "defaultValue": "logs/access.log basic",
-    "description": "Path for tcp streams proxy port access logs. Set this value to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location. `basic` is defined as `'$remote_addr [$time_local] ' '$protocol $status $bytes_sent $bytes_received ' '$session_time'`"
+    "description": "Path for tcp streams proxy port access\nlogs. Set this value to `off` to\ndisable logging proxy requests.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n`basic` is defined as `'$remote_addr [$time_local] '\n'$protocol $status $bytes_sent $bytes_received '\n'$session_time'`\n"
   },
   "proxy_stream_error_log": {
     "defaultValue": "logs/error.log",
-    "description": "Path for tcp streams proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for tcp streams proxy port request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "admin_access_log": {
     "defaultValue": "logs/admin_access.log",
-    "description": "Path for Admin API request access logs. If Hybrid Mode is enabled and the current node is set to be the Control Plane, then the connection requests from Data Planes are also written to this file with server name \"kong_cluster_listener\".  Set this value to `off` to disable logging Admin API requests. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for Admin API request access\nlogs. If Hybrid Mode is enabled\nand the current node is set to be\nthe Control Plane, then the\nconnection requests from Data Planes\nare also written to this file with\nserver name \"kong_cluster_listener\".\n\nSet this value to `off` to\ndisable logging Admin API requests.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n"
   },
   "admin_error_log": {
     "defaultValue": "logs/error.log",
-    "description": "Path for Admin API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for Admin API request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "status_access_log": {
     "defaultValue": "off",
-    "description": "Path for Status API request access logs. The default value of `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for Status API request access\nlogs. The default value of `off`\nimplies that logging for this API\nis disabled by default.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n"
   },
   "status_error_log": {
     "defaultValue": "logs/status_error.log",
-    "description": "Path for Status API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for Status API request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "debug_access_log": {
     "defaultValue": "off",
-    "description": "Path for Debug API request access logs. The default value of `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for Debug API request access\nlogs. The default value of `off`\nimplies that logging for this API\nis disabled by default.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n"
   },
   "debug_error_log": {
     "defaultValue": "logs/debug_error.log",
-    "description": "Path for Debug API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for Debug API request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "vaults": {
     "defaultValue": "bundled",
-    "description": "Comma-separated list of vaults this node should load. By default, all the bundled vaults are enabled.  The specified name(s) will be substituted as such in the Lua namespace: `kong.vaults.{name}.*`."
+    "description": "Comma-separated list of vaults this node\nshould load. By default, all the bundled\nvaults are enabled.\n\nThe specified name(s) will be substituted as\nsuch in the Lua namespace:\n`kong.vaults.{name}.*`.\n"
   },
   "opentelemetry_tracing": {
     "defaultValue": "off",
-    "description": "Deprecated: use tracing_instrumentations instead"
+    "description": "Deprecated: use tracing_instrumentations instead\n"
   },
   "tracing_instrumentations": {
     "defaultValue": "off",
-    "description": "Comma-separated list of tracing instrumentations this node should load. By default, no instrumentations are enabled.  Valid values to this setting are:  - `off`: do not enable instrumentations. - `request`: only enable request-level instrumentations. - `all`: enable all the following instrumentations. - `db_query`: trace database query - `dns_query`: trace DNS query. - `router`: trace router execution, including   router rebuilding. - `http_client`: trace OpenResty HTTP client requests. - `balancer`: trace balancer retries. - `plugin_rewrite`: trace plugins iterator   execution with rewrite phase. - `plugin_access`: trace plugins iterator   execution with access phase. - `plugin_header_filter`: trace plugins iterator   execution with header_filter phase.  **Note:** In the current implementation, tracing instrumentations are not enabled in stream mode."
+    "description": "Comma-separated list of tracing instrumentations\nthis node should load. By default, no instrumentations\nare enabled.\n\nValid values to this setting are:\n\n- `off`: do not enable instrumentations.\n- `request`: only enable request-level instrumentations.\n- `all`: enable all the following instrumentations.\n- `db_query`: trace database query\n- `dns_query`: trace DNS query.\n- `router`: trace router execution, including\n  router rebuilding.\n- `http_client`: trace OpenResty HTTP client requests.\n- `balancer`: trace balancer retries.\n- `plugin_rewrite`: trace plugins iterator\n  execution with rewrite phase.\n- `plugin_access`: trace plugins iterator\n  execution with access phase.\n- `plugin_header_filter`: trace plugins iterator\n  execution with header_filter phase.\n\n**Note:** In the current implementation,\ntracing instrumentations are not enabled in\nstream mode.\n"
   },
   "opentelemetry_tracing_sampling_rate": {
     "defaultValue": "1.0",
-    "description": "Deprecated: use tracing_sampling_rate instead"
+    "description": "Deprecated: use tracing_sampling_rate instead\n"
   },
   "tracing_sampling_rate": {
     "defaultValue": "0.01",
-    "description": "Tracing instrumentation sampling rate. Tracer samples a fixed percentage of all spans following the sampling rate.  Example: `0.25`, this should account for 25% of all traces."
+    "description": "Tracing instrumentation sampling rate.\nTracer samples a fixed percentage of all spans\nfollowing the sampling rate.\n\nExample: `0.25`, this should account for 25% of all traces.\n"
   },
   "plugins": {
     "defaultValue": "bundled",
-    "description": "Comma-separated list of plugins this node should load. By default, only plugins bundled in official distributions are loaded via the `bundled` keyword.  Loading a plugin does not enable it by default, but only instructs Kong to load its source code, and allows to configure the plugin via the various related Admin API endpoints.  The specified name(s) will be substituted as such in the Lua namespace: `kong.plugins.{name}.*`.  When the `off` keyword is specified as the only value, no plugins will be loaded.  `bundled` and plugin names can be mixed together, as the following examples suggest:  - `plugins = bundled,custom-auth,custom-log`   will include the bundled plugins plus two   custom ones - `plugins = custom-auth,custom-log` will   *only* include the `custom-auth` and   `custom-log` plugins. - `plugins = off` will not include any   plugins  **Note:** Kong will not start if some plugins were previously configured (i.e. have rows in the database) and are not specified in this list.  Before disabling a plugin, ensure all instances of it are removed before restarting Kong.  **Note:** Limiting the amount of available plugins can improve P99 latency when experiencing LRU churning in the database cache (i.e. when the configured `mem_cache_size`) is full."
+    "description": "Comma-separated list of plugins this node\nshould load. By default, only plugins\nbundled in official distributions are\nloaded via the `bundled` keyword.\n\nLoading a plugin does not enable it by\ndefault, but only instructs Kong to load its\nsource code, and allows to configure the\nplugin via the various related Admin API\nendpoints.\n\nThe specified name(s) will be substituted as\nsuch in the Lua namespace:\n`kong.plugins.{name}.*`.\n\nWhen the `off` keyword is specified as the\nonly value, no plugins will be loaded.\n\n`bundled` and plugin names can be mixed\ntogether, as the following examples suggest:\n\n- `plugins = bundled,custom-auth,custom-log`\n  will include the bundled plugins plus two\n  custom ones\n- `plugins = custom-auth,custom-log` will\n  *only* include the `custom-auth` and\n  `custom-log` plugins.\n- `plugins = off` will not include any\n  plugins\n\n**Note:** Kong will not start if some\nplugins were previously configured (i.e.\nhave rows in the database) and are not\nspecified in this list.  Before disabling a\nplugin, ensure all instances of it are\nremoved before restarting Kong.\n\n**Note:** Limiting the amount of available\nplugins can improve P99 latency when\nexperiencing LRU churning in the database\ncache (i.e. when the configured\n`mem_cache_size`) is full.\n"
   },
   "dedicated_config_processing": {
     "defaultValue": "on",
-    "description": "Enables or disables a special worker process for configuration processing. This process increases memory usage a little bit while allowing to reduce latencies by moving some background tasks, such as CP/DP connection handling, to an additional worker process specific to handling these background tasks. Currently this has effect only on data planes."
+    "description": "Enables or disables a special worker\nprocess for configuration processing. This process\nincreases memory usage a little bit while\nallowing to reduce latencies by moving some\nbackground tasks, such as CP/DP connection\nhandling, to an additional worker process specific\nto handling these background tasks.\nCurrently this has effect only on data planes.\n"
   },
   "pluginserver_names": {
     "defaultValue": null,
-    "description": "Comma-separated list of names for pluginserver processes.  The actual names are used for log messages and to relate the actual settings."
+    "description": "Comma-separated list of names for pluginserver\nprocesses.  The actual names are used for\nlog messages and to relate the actual settings.\n"
   },
   "pluginserver_XXX_socket": {
     "defaultValue": "<prefix>/<XXX>.socket",
-    "description": "Path to the unix socket used by the <XXX> pluginserver."
+    "description": "Path to the unix socket\nused by the <XXX> pluginserver.\n"
   },
   "pluginserver_XXX_start_cmd": {
     "defaultValue": "/usr/local/bin/<XXX>",
-    "description": "Full command (including any needed arguments) to start the <XXX> pluginserver"
+    "description": "Full command (including\nany needed arguments) to\nstart the <XXX> pluginserver\n"
   },
   "pluginserver_XXX_query_cmd": {
     "defaultValue": "/usr/local/bin/query_<XXX>",
-    "description": "Full command to \"query\" the <XXX> pluginserver.  Should produce a JSON with the dump info of all plugins it manages"
+    "description": "Full command to \"query\" the\n<XXX> pluginserver.  Should\nproduce a JSON with the\ndump info of all plugins it\nmanages\n"
   },
   "port_maps": {
     "defaultValue": null,
-    "description": "With this configuration parameter, you can let the Kong to know about the port from which the packets are forwarded to it. This is fairly common when running Kong in a containerized or virtualized environment. For example, `port_maps=80:8000, 443:8443` instructs Kong that the port 80 is mapped to 8000 (and the port 443 to 8443), where 8000 and 8443 are the ports that Kong is listening to.  This parameter helps Kong set a proper forwarded upstream HTTP request header or to get the proper forwarded port with the Kong PDK (in case other means determining it has failed). It changes routing by a destination port to route by a port from which packets are forwarded to Kong, and similarly it changes the default plugin log serializer to use the port according to this mapping instead of reporting the port Kong is listening to."
+    "description": "With this configuration parameter, you can\nlet the Kong to know about the port from\nwhich the packets are forwarded to it. This\nis fairly common when running Kong in a\ncontainerized or virtualized environment.\nFor example, `port_maps=80:8000, 443:8443`\ninstructs Kong that the port 80 is mapped\nto 8000 (and the port 443 to 8443), where\n8000 and 8443 are the ports that Kong is\nlistening to.\n\nThis parameter helps Kong set a proper\nforwarded upstream HTTP request header or to\nget the proper forwarded port with the Kong PDK\n(in case other means determining it has\nfailed). It changes routing by a destination\nport to route by a port from which packets\nare forwarded to Kong, and similarly it\nchanges the default plugin log serializer to\nuse the port according to this mapping\ninstead of reporting the port Kong is\nlistening to.\n"
   },
   "anonymous_reports": {
     "defaultValue": "on",
-    "description": "Send anonymous usage data such as error stack traces to help improve Kong."
+    "description": "Send anonymous usage data such as error\nstack traces to help improve Kong.\n"
   },
   "proxy_server": {
     "defaultValue": null,
-    "description": "Proxy server defined as a URL. Kong will only use this option if any component is explicitly configured to use proxy."
+    "description": "Proxy server defined as a URL. Kong will only use this\noption if any component is explicitly configured\nto use proxy.\n"
   },
   "proxy_server_ssl_verify": {
     "defaultValue": "off",
-    "description": "Toggles server certificate verification if `proxy_server` is in HTTPS. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+    "description": "Toggles server certificate verification if\n`proxy_server` is in HTTPS.\nSee the `lua_ssl_trusted_certificate`\nsetting to specify a certificate authority.\n"
   },
   "error_template_html": {
     "defaultValue": null,
-    "description": "Path to the custom html error template to override the default html kong error template.  The template may contain up to two `%s` placeholders. The first one will expand to the error message. The second one will expand to the request ID. Both placeholders are optional, but recommended. Adding more than two placeholders will result in a runtime error when trying to render the template: ``` <html>   <body>     <h1>My custom error template</h1>     <p>error: %s</p>     <p>request_id: %s</p>   </body> </html> ```"
+    "description": "Path to the custom html error template to\noverride the default html kong error\ntemplate.\n\nThe template may contain up to two `%s`\nplaceholders. The first one will expand to\nthe error message. The second one will\nexpand to the request ID. Both placeholders\nare optional, but recommended.\nAdding more than two placeholders will\nresult in a runtime error when trying to\nrender the template:\n```\n<html>\n  <body>\n    <h1>My custom error template</h1>\n    <p>error: %s</p>\n    <p>request_id: %s</p>\n  </body>\n</html>\n```\n"
   },
   "error_template_json": {
     "defaultValue": null,
-    "description": "Path to the custom json error template to override the default json kong error template.  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+    "description": "Path to the custom json error template to\noverride the default json kong error\ntemplate.\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n"
   },
   "error_template_xml": {
     "defaultValue": null,
-    "description": "Path to the custom xml error template to override the default xml kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+    "description": "Path to the custom xml error template to\noverride the default xml kong error template\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n"
   },
   "error_template_plain": {
     "defaultValue": null,
-    "description": "Path to the custom plain error template to override the default plain kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+    "description": "Path to the custom plain error template to\noverride the default plain kong error\ntemplate\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n"
   },
   "role": {
     "defaultValue": "traditional",
-    "description": "Use this setting to enable Hybrid Mode, This allows running some Kong nodes in a control plane role with a database and have them deliver configuration updates to other nodes running to DB-less running in a Data Plane role.  Valid values to this setting are:  - `traditional`: do not use Hybrid Mode. - `control_plane`: this node runs in a   control plane role. It can use a database   and will deliver configuration updates   to data plane nodes. - `data_plane`: this is a data plane node.   It runs DB-less and receives configuration   updates from a control plane node."
+    "description": "Use this setting to enable Hybrid Mode,\nThis allows running some Kong nodes in a\ncontrol plane role with a database and\nhave them deliver configuration updates\nto other nodes running to DB-less running in\na Data Plane role.\n\nValid values to this setting are:\n\n- `traditional`: do not use Hybrid Mode.\n- `control_plane`: this node runs in a\n  control plane role. It can use a database\n  and will deliver configuration updates\n  to data plane nodes.\n- `data_plane`: this is a data plane node.\n  It runs DB-less and receives configuration\n  updates from a control plane node.\n"
   },
   "cluster_mtls": {
     "defaultValue": "shared",
-    "description": "Sets the verification between nodes of the cluster.  Valid values to this setting are:  - `shared`: use a shared certificate/key   pair specified with the `cluster_cert`   and `cluster_cert_key` settings.   Note that CP and DP nodes have to present   the same certificate to establish mTLS   connections. - `pki`: use `cluster_ca_cert`,   `cluster_server_name` and `cluster_cert`   for verification.   These are different certificates for each   DP node, but issued by a cluster-wide   common CA certificate: `cluster_ca_cert`. - `pki_check_cn`: similar as `pki` but additionally   checks for Common Name of data plane certificate   specified in `cluster_allowed_common_names`."
+    "description": "Sets the verification between nodes of the\ncluster.\n\nValid values to this setting are:\n\n- `shared`: use a shared certificate/key\n  pair specified with the `cluster_cert`\n  and `cluster_cert_key` settings.\n  Note that CP and DP nodes have to present\n  the same certificate to establish mTLS\n  connections.\n- `pki`: use `cluster_ca_cert`,\n  `cluster_server_name` and `cluster_cert`\n  for verification.\n  These are different certificates for each\n  DP node, but issued by a cluster-wide\n  common CA certificate: `cluster_ca_cert`.\n- `pki_check_cn`: similar as `pki` but additionally\n  checks for Common Name of data plane certificate\n  specified in `cluster_allowed_common_names`.\n"
   },
   "cluster_cert": {
     "defaultValue": null,
-    "description": "Cluster certificate to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes.  Under `pki` mode it should be a different certificate for each DP node.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "Cluster certificate to use\nwhen establishing secure communication\nbetween control and data plane nodes.\nYou can use the `kong hybrid` command to\ngenerate the certificate/key pair.\nUnder `shared` mode, it must be the same\nfor all nodes.  Under `pki` mode it\nshould be a different certificate for each\nDP node.\n\nThe certificate can be configured on this\nproperty with either of the following values:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "cluster_cert_key": {
     "defaultValue": null,
-    "description": "Cluster certificate key to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes.  Under `pki` mode it should be a different certificate for each DP node.  The certificate key can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+    "description": "Cluster certificate key to\nuse when establishing secure communication\nbetween control and data plane nodes.\nYou can use the `kong hybrid` command to\ngenerate the certificate/key pair.\nUnder `shared` mode, it must be the same\nfor all nodes.  Under `pki` mode it\nshould be a different certificate for each\nDP node.\n\nThe certificate key can be configured on this\nproperty with either of the following values:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n"
   },
   "cluster_ca_cert": {
     "defaultValue": null,
-    "description": "The trusted CA certificate file in PEM format used for Control Plane to verify Data Plane's certificate and Data Plane to verify Control Plane's certificate. Required on data plane if `cluster_mtls` is set to `pki`. If Control Plane certificate is issued by a well known CA, user can set `lua_ssl_trusted_certificate=system` on Data Plane and leave this field empty.  This field is ignored if `cluster_mtls` is set to `shared`.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "The trusted CA certificate file in PEM\nformat used for Control Plane to verify\nData Plane's certificate and Data Plane\nto verify Control Plane's certificate.\nRequired on data plane if `cluster_mtls`\nis set to `pki`.\nIf Control Plane certificate is issued\nby a well known CA, user can set\n`lua_ssl_trusted_certificate=system`\non Data Plane and leave this field empty.\n\nThis field is ignored if `cluster_mtls` is\nset to `shared`.\n\nThe certificate can be configured on this property\nwith either of the following values:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "cluster_allowed_common_names": {
     "defaultValue": null,
-    "description": "The list of Common Names that are allowed to connect to control plane. Multiple entries may be supplied in a comma-separated string. When not set, Data Plane with same parent domain of Control Plane cert is allowed to connect.  This field is ignored if `cluster_mtls` is not set to `pki_check_cn`."
+    "description": "The list of Common Names that are allowed to\nconnect to control plane. Multiple entries may\nbe supplied in a comma-separated string. When not\nset, Data Plane with same parent domain of\nControl Plane cert is allowed to connect.\n\nThis field is ignored if `cluster_mtls` is\nnot set to `pki_check_cn`.\n"
   },
   "cluster_server_name": {
     "defaultValue": null,
-    "description": "The server name used in the SNI of the TLS connection from a DP node to a CP node. Must match the Common Name (CN) or Subject Alternative Name (SAN) found in the CP certificate. If `cluster_mtls` is set to `shared`, this setting is ignored and `kong_clustering` is used."
+    "description": "The server name used in the SNI of the TLS\nconnection from a DP node to a CP node.\nMust match the Common Name (CN) or Subject\nAlternative Name (SAN) found in the CP\ncertificate.\nIf `cluster_mtls` is set to\n`shared`, this setting is ignored and\n`kong_clustering` is used.\n"
   },
   "cluster_control_plane": {
     "defaultValue": null,
-    "description": "To be used by data plane nodes only: address of the control plane node from which configuration updates will be fetched, in `host:port` format."
+    "description": "To be used by data plane nodes only:\naddress of the control plane node from\nwhich configuration updates will be fetched,\nin `host:port` format.\n"
   },
   "cluster_telemetry_endpoint": {
     "defaultValue": null,
-    "description": "To be used by data plane nodes only: telemetry address of the control plane node to which telemetry updates will be posted in `host:port` format."
+    "description": "To be used by data plane nodes only:\ntelemetry address of the control plane node\nto which telemetry updates will be posted\nin `host:port` format.\n"
   },
   "cluster_telemetry_server_name": {
     "defaultValue": null,
-    "description": "The SNI (Server Name Indication extension) to use for Vitals telemetry data."
+    "description": "The SNI (Server Name Indication extension)\nto use for Vitals telemetry data.\n"
   },
   "cluster_dp_labels": {
     "defaultValue": null,
-    "description": "Comma separated list of Labels for the data plane. Labels are key-value pairs that provide additional context information for each DP. Each label must be configured as a string in the format `key:value`.  Labels are only compatible with hybrid mode deployments with Kong Konnect (SaaS), this configuration doesn't work with self-hosted deployments.  Keys and values follow the AIP standards: https://kong-aip.netlify.app/aip/129/  Example: `deployment:mycloud,region:us-east-1`"
+    "description": "Comma separated list of Labels for the data plane.\nLabels are key-value pairs that provide additional\ncontext information for each DP.\nEach label must be configured as a string in the\nformat `key:value`.\n\nLabels are only compatible with hybrid mode\ndeployments with Kong Konnect (SaaS),\nthis configuration doesn't work with\nself-hosted deployments.\n\nKeys and values follow the AIP standards:\nhttps://kong-aip.netlify.app/aip/129/\n\nExample:\n`deployment:mycloud,region:us-east-1`\n"
   },
   "cluster_listen": {
     "defaultValue": "0.0.0.0:8005",
-    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster. This port is mTLS protected to ensure end-to-end security and integrity.  This setting has no effect if `role` is not set to `control_plane`.  Connection made to this endpoint are logged to the same location as Admin API access logs. See `admin_access_log` config description for more information."
+    "description": "Comma-separated list of addresses and ports on\nwhich the cluster control plane server should listen\nfor data plane connections.\nThe cluster communication port of the control plane\nmust be accessible by all the data planes\nwithin the same cluster. This port is mTLS protected\nto ensure end-to-end security and integrity.\n\nThis setting has no effect if `role` is not set to\n`control_plane`.\n\nConnection made to this endpoint are logged\nto the same location as Admin API access logs.\nSee `admin_access_log` config description for more\ninformation.\n"
   },
   "cluster_telemetry_listen": {
     "defaultValue": "0.0.0.0:8006",
-    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane telemetry connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster.  This setting has no effect if `role` is not set to `control_plane`."
+    "description": "Comma-separated list of addresses and ports on\nwhich the cluster control plane server should listen\nfor data plane telemetry connections.\nThe cluster communication port of the control plane\nmust be accessible by all the data planes\nwithin the same cluster.\n\nThis setting has no effect if `role` is not set to\n`control_plane`.\n"
   },
   "cluster_data_plane_purge_delay": {
     "defaultValue": "1209600",
-    "description": " How many seconds must pass from the time a DP node becomes offline to the time its entry gets removed from the database, as returned by the /clustering/data-planes Admin API endpoint.  This is to prevent the cluster data plane table from growing indefinitely. The default is set to 14 days. That is, if CP haven't heard from a DP for 14 days, its entry will be removed."
+    "description": "How many seconds must pass from the time a DP node\nbecomes offline to the time its entry gets removed\nfrom the database, as returned by the\n/clustering/data-planes Admin API endpoint.\n\nThis is to prevent the cluster data plane table from\ngrowing indefinitely. The default is set to\n14 days. That is, if CP haven't heard from a DP for\n14 days, its entry will be removed.\n"
   },
   "cluster_ocsp": {
     "defaultValue": "off",
-    "description": " Whether to check for revocation status of DP certificates using OCSP (Online Certificate Status Protocol). If enabled, the DP certificate should contain the \"Certificate Authority Information Access\" extension and the OCSP method with URI of which the OCSP responder can be reached from CP.  OCSP checks are only performed on CP nodes, it has no effect on DP nodes.  Valid values to this setting are:  - `on`: OCSP revocation check is enabled and DP   must pass the check in order to establish   connection with CP. - `off`: OCSP revocation check is disabled. - `optional`: OCSP revocation check will be attempted,   however, if the required extension is not   found inside DP provided certificate   or communication with the OCSP responder   failed, then DP is still allowed through."
+    "description": "Whether to check for revocation status of DP\ncertificates using OCSP (Online Certificate Status Protocol).\nIf enabled, the DP certificate should contain the\n\"Certificate Authority Information Access\" extension\nand the OCSP method with URI of which the OCSP responder\ncan be reached from CP.\n\nOCSP checks are only performed on CP nodes, it has no\neffect on DP nodes.\n\nValid values to this setting are:\n\n- `on`: OCSP revocation check is enabled and DP\n  must pass the check in order to establish\n  connection with CP.\n- `off`: OCSP revocation check is disabled.\n- `optional`: OCSP revocation check will be attempted,\n  however, if the required extension is not\n  found inside DP provided certificate\n  or communication with the OCSP responder\n  failed, then DP is still allowed through.\n"
   },
   "cluster_use_proxy": {
     "defaultValue": "off",
-    "description": " Whether to turn on HTTP CONNECT proxy support for hybrid mode connections. `proxy_server` will be used for Hybrid mode connections if this option is turned on."
+    "description": "Whether to turn on HTTP CONNECT proxy support for\nhybrid mode connections. `proxy_server` will be used\nfor Hybrid mode connections if this option is turned on.\n"
   },
   "cluster_max_payload": {
     "defaultValue": "16777216",
-    "description": " This sets the maximum compressed payload size allowed to be sent across from CP to DP in Hybrid mode Default is 16MB - 16 * 1024 * 1024."
+    "description": "This sets the maximum compressed payload size allowed\nto be sent across from CP to DP in Hybrid mode\nDefault is 16MB - 16 * 1024 * 1024.\n"
   },
   "proxy_listen": {
     "defaultValue": [
       "0.0.0.0:8000 reuseport backlog=16384",
       "0.0.0.0:8443 http2 ssl reuseport backlog=16384"
     ],
-    "description": " Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. The proxy server is the public entry point of Kong, which proxies traffic from your consumers to your backend services. This value accepts IPv4, IPv6, and hostnames.  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the TCP_DEFER_ACCEPT socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  This value can be set to `off`, thus disabling the HTTP/HTTPS proxy port for this node. If stream_listen is also set to `off`, this enables 'control-plane' mode for this node (in which all traffic proxying capabilities are disabled). This node can then be used only to configure a cluster of Kong nodes connected to the same datastore.  Example: `proxy_listen = 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`  See http://nginx.org/en/docs/http/ngx_http_core_module.html#listen for a description of the accepted formats for this and other `*_listen` values.  See https://www.nginx.com/resources/admin-guide/proxy-protocol/ for more details about the `proxy_protocol` parameter.  Not all `*_listen` values accept all formats specified in nginx's documentation."
+    "description": "Comma-separated list of addresses and ports on\nwhich the proxy server should listen for\nHTTP/HTTPS traffic.\nThe proxy server is the public entry point of Kong,\nwhich proxies traffic from your consumers to your\nbackend services. This value accepts IPv4, IPv6, and\nhostnames.\n\nSome suffixes can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's proxy server.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `deferred` instructs to use a deferred accept on\n  Linux (the TCP_DEFER_ACCEPT socket option).\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process\n  allowing the Kernel to better distribute incoming\n  connections between worker processes\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small in order to prevent clients\n  seeing \"Connection refused\" error connecting to\n  a busy Kong instance.\n  **Note:** on Linux, this value is limited by the\n  setting of `net.core.somaxconn` Kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections\n- so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]\n  configures the “TCP keepalive” behavior for the listening\n  socket. If this parameter is omitted then the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value “on”, the SO_KEEPALIVE option is turned\n  on for the socket. If it is set to the value “off”, the\n  SO_KEEPALIVE option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,\n  and TCP_KEEPCNT socket options.\n\nThis value can be set to `off`, thus disabling\nthe HTTP/HTTPS proxy port for this node.\nIf stream_listen is also set to `off`, this enables\n'control-plane' mode for this node\n(in which all traffic proxying capabilities are\ndisabled). This node can then be used only to\nconfigure a cluster of Kong\nnodes connected to the same datastore.\n\nExample:\n`proxy_listen = 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`\n\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#listen\nfor a description of the accepted formats for this\nand other `*_listen` values.\n\nSee https://www.nginx.com/resources/admin-guide/proxy-protocol/\nfor more details about the `proxy_protocol`\nparameter.\n\nNot all `*_listen` values accept all formats\nspecified in nginx's documentation.\n"
   },
   "proxy_url": {
     "defaultValue": null,
-    "description": "Kong Proxy URL  The lookup, or balancer, address for your Kong Proxy nodes.  This value is commonly used in a microservices or service-mesh oriented architecture.  Accepted format (parts in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`  Examples:  - `<scheme>://<IP>:<PORT>` -> `proxy_url = http://127.0.0.1:8000` - `SSL <scheme>://<HOSTNAME>` -> `proxy_url = https://proxy.domain.tld` - `<scheme>://<HOSTNAME>/<PATH>` -> `proxy_url = http://dev-machine/dev-285`  By default, Kong Manager, and Kong Portal will use the window request host and append the resolved listener port depending on the requested protocol."
+    "description": "Kong Proxy URL\n\nThe lookup, or balancer, address for your Kong Proxy nodes.\n\nThis value is commonly used in a microservices\nor service-mesh oriented architecture.\n\nAccepted format (parts in parentheses are optional):\n\n  `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`\n\nExamples:\n\n- `<scheme>://<IP>:<PORT>` -> `proxy_url = http://127.0.0.1:8000`\n- `SSL <scheme>://<HOSTNAME>` -> `proxy_url = https://proxy.domain.tld`\n- `<scheme>://<HOSTNAME>/<PATH>` -> `proxy_url = http://dev-machine/dev-285`\n\nBy default, Kong Manager, and Kong Portal will use\nthe window request host and append the resolved\nlistener port depending on the requested protocol.\n"
   },
   "stream_listen": {
     "defaultValue": "off",
-    "description": " Comma-separated list of addresses and ports on which the stream mode should listen.  This value accepts IPv4, IPv6, and hostnames. Some suffixes can be specified for each pair: - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  Examples:  ``` stream_listen = 127.0.0.1:7000 reuseport backlog=16384 stream_listen = 0.0.0.0:989 reuseport backlog=65536, 0.0.0.0:20 stream_listen = [::1]:1234 backlog=16384 ```  By default this value is set to `off`, thus disabling the stream proxy port for this node."
+    "description": "Comma-separated list of addresses and ports on\nwhich the stream mode should listen.\n\nThis value accepts IPv4, IPv6, and hostnames.\nSome suffixes can be specified for each pair:\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process\n  allowing the Kernel to better distribute incoming\n  connections between worker processes\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small in order to prevent clients\n  seeing \"Connection refused\" error connecting to\n  a busy Kong instance.\n  **Note:** on Linux, this value is limited by the\n  setting of `net.core.somaxconn` Kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections\n- so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]\n  configures the “TCP keepalive” behavior for the listening\n  socket. If this parameter is omitted then the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value “on”, the SO_KEEPALIVE option is turned\n  on for the socket. If it is set to the value “off”, the\n  SO_KEEPALIVE option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,\n  and TCP_KEEPCNT socket options.\n\nExamples:\n\n```\nstream_listen = 127.0.0.1:7000 reuseport backlog=16384\nstream_listen = 0.0.0.0:989 reuseport backlog=65536, 0.0.0.0:20\nstream_listen = [::1]:1234 backlog=16384\n```\n\nBy default this value is set to `off`, thus\ndisabling the stream proxy port for this node.\n"
   },
   "admin_api_uri": {
     "defaultValue": null,
-    "description": "Deprecated: Use admin_gui_api_url instead"
+    "description": "Deprecated: Use admin_gui_api_url instead\n"
   },
   "admin_listen": {
     "defaultValue": [
       "127.0.0.1:8001 reuseport backlog=16384",
       "127.0.0.1:8444 http2 ssl reuseport backlog=16384"
     ],
-    "description": " Comma-separated list of addresses and ports on which the Admin interface should listen. The Admin interface is the API allowing you to configure and manage Kong. Access to this interface should be *restricted* to Kong administrators *only*. This value accepts IPv4, IPv6, and hostnames.  It is highly recommended to avoid exposing the Admin API to public interface(s), by using values such as 0.0.0.0:8001  See https://docs.konghq.com/gateway/latest/production/running-kong/secure-admin-api/ for more information about how to secure your Admin API  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the TCP_DEFER_ACCEPT socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  This value can be set to `off`, thus disabling the Admin interface for this node, enabling a 'data-plane' mode (without configuration capabilities) pulling its configuration changes from the database.  Example: `admin_listen = 127.0.0.1:8444 http2 ssl`"
+    "description": "Comma-separated list of addresses and ports on\nwhich the Admin interface should listen.\nThe Admin interface is the API allowing you to\nconfigure and manage Kong.\nAccess to this interface should be *restricted*\nto Kong administrators *only*. This value accepts\nIPv4, IPv6, and hostnames.\n\nIt is highly recommended to avoid exposing the Admin API to public\ninterface(s), by using values such as 0.0.0.0:8001\n\nSee https://docs.konghq.com/gateway/latest/production/running-kong/secure-admin-api/\nfor more information about how to secure your Admin API\n\nSome suffixes can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's proxy server.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `deferred` instructs to use a deferred accept on\n  Linux (the TCP_DEFER_ACCEPT socket option).\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process\n  allowing the Kernel to better distribute incoming\n  connections between worker processes\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small in order to prevent clients\n  seeing \"Connection refused\" error connecting to\n  a busy Kong instance.\n  **Note:** on Linux, this value is limited by the\n  setting of `net.core.somaxconn` Kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections\n- so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]\n  configures the “TCP keepalive” behavior for the listening\n  socket. If this parameter is omitted then the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value “on”, the SO_KEEPALIVE option is turned\n  on for the socket. If it is set to the value “off”, the\n  SO_KEEPALIVE option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,\n  and TCP_KEEPCNT socket options.\n\nThis value can be set to `off`, thus disabling\nthe Admin interface for this node, enabling a\n'data-plane' mode (without configuration\ncapabilities) pulling its configuration changes\nfrom the database.\n\nExample: `admin_listen = 127.0.0.1:8444 http2 ssl`\n"
   },
   "status_listen": {
     "defaultValue": "127.0.0.1:8007 reuseport backlog=16384",
-    "description": " Comma-separated list of addresses and ports on which the Status API should listen. The Status API is a read-only endpoint allowing monitoring tools to retrieve metrics, healthiness, and other non-sensitive information of the current Kong node.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Status API server. - `proxy_protocol` will enable usage of the PROXY protocol.  This value can be set to `off`, disabling the Status API for this node.  Example: `status_listen = 0.0.0.0:8100 ssl http2`"
+    "description": "Comma-separated list of addresses and ports on\nwhich the Status API should listen.\nThe Status API is a read-only endpoint\nallowing monitoring tools to retrieve metrics,\nhealthiness, and other non-sensitive information\nof the current Kong node.\n\nThe following suffix can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's Status API server.\n- `proxy_protocol` will enable usage of the PROXY protocol.\n\nThis value can be set to `off`, disabling\nthe Status API for this node.\n\nExample: `status_listen = 0.0.0.0:8100 ssl http2`\n"
   },
   "debug_listen": {
     "defaultValue": "off",
-    "description": "Comma-separated list of addresses and ports on which the Debug API should listen.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Debug API server.  This value can be set to `off`, disabling the Debug API for this node.  Example: `debug_listen = 0.0.0.0:8200 ssl http2`"
+    "description": "Comma-separated list of addresses and ports on\nwhich the Debug API should listen.\n\nThe following suffix can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's Debug API server.\n\nThis value can be set to `off`, disabling\nthe Debug API for this node.\n\nExample: `debug_listen = 0.0.0.0:8200 ssl http2`\n"
   },
   "debug_listen_local": {
     "defaultValue": "on",
-    "description": "Expose `debug_listen` functionalities via a Unix domain socket under the Kong prefix.  This option allows local user to use \"kong debug\" command to invoke various debug functionalities without needing to enable `debug_listen` ahead of time."
+    "description": "Expose `debug_listen` functionalities via a\nUnix domain socket under the Kong prefix.\n\nThis option allows local user to use \"kong debug\" command\nto invoke various debug functionalities without needing to\nenable `debug_listen` ahead of time.\n"
   },
   "nginx_user": {
     "defaultValue": "kong kong",
-    "description": "Defines user and group credentials used by worker processes. If group is omitted, a group whose name equals that of user is used.  Example: `nginx_user = nginx www`  **Note**: If the `kong` user and the `kong` group are not available, the default user and group credentials will be `nobody nobody`."
+    "description": "Defines user and group credentials used by\nworker processes. If group is omitted, a\ngroup whose name equals that of user is\nused.\n\nExample: `nginx_user = nginx www`\n\n**Note**: If the `kong` user and the `kong`\ngroup are not available, the default user\nand group credentials will be\n`nobody nobody`.\n"
   },
   "nginx_worker_processes": {
     "defaultValue": "auto",
-    "description": "Determines the number of worker processes spawned by Nginx.  See http://nginx.org/en/docs/ngx_core_module.html#worker_processes for detailed usage of the equivalent Nginx directive and a description of accepted values."
+    "description": "Determines the number of worker processes\nspawned by Nginx.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_processes\nfor detailed usage of the equivalent Nginx\ndirective and a description of accepted\nvalues.\n"
   },
   "nginx_daemon": {
     "defaultValue": "on",
-    "description": "Determines whether Nginx will run as a daemon or as a foreground process. Mainly useful for development or when running Kong inside a Docker environment.  See http://nginx.org/en/docs/ngx_core_module.html#daemon."
+    "description": "Determines whether Nginx will run as a daemon\nor as a foreground process. Mainly useful\nfor development or when running Kong inside\na Docker environment.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#daemon.\n"
   },
   "mem_cache_size": {
     "defaultValue": "128m",
-    "description": "Size of each of the two shared memory caches for traditional mode database entities and runtime data, `kong_core_cache` and `kong_cache`.  The accepted units are `k` and `m`, with a minimum recommended value of a few MBs.  **Note**: As this option controls the size of two different cache zones, the total memory Kong uses to cache entities might be double this value. The created zones are shared by all worker processes and do not become larger when more worker is used."
+    "description": "Size of each of the two shared memory caches\nfor traditional mode database entities\nand runtime data, `kong_core_cache` and\n`kong_cache`.\n\nThe accepted units are `k` and `m`, with a minimum\nrecommended value of a few MBs.\n\n**Note**: As this option controls the size of two\ndifferent cache zones, the total memory Kong\nuses to cache entities might be double this value.\nThe created zones are shared by all worker\nprocesses and do not become larger when more\nworker is used.\n"
   },
   "ssl_cipher_suite": {
     "defaultValue": "intermediate",
-    "description": "Defines the TLS ciphers served by Nginx. Accepted values are `modern`, `intermediate`, `old`, `fips` or `custom`. If you want to enable TLSv1.1, this value has to be `old`.  See https://wiki.mozilla.org/Security/Server_Side_TLS for detailed descriptions of each cipher suite. `fips` cipher suites are as described in https://wiki.openssl.org/index.php/FIPS_mode_and_TLS."
+    "description": "Defines the TLS ciphers served by Nginx.\nAccepted values are `modern`,\n`intermediate`, `old`, `fips` or `custom`.\nIf you want to enable TLSv1.1, this value has to be `old`.\n\nSee https://wiki.mozilla.org/Security/Server_Side_TLS\nfor detailed descriptions of each cipher\nsuite. `fips` cipher suites are as described in\nhttps://wiki.openssl.org/index.php/FIPS_mode_and_TLS.\n"
   },
   "ssl_ciphers": {
     "defaultValue": null,
-    "description": "Defines a custom list of TLS ciphers to be served by Nginx. This list must conform to the pattern defined by `openssl ciphers`. This value is ignored if `ssl_cipher_suite` is not `custom`. If you use DHE ciphers, you must also configure the `ssl_dhparam` parameter."
+    "description": "Defines a custom list of TLS ciphers to be\nserved by Nginx. This list must conform to\nthe pattern defined by `openssl ciphers`.\nThis value is ignored if `ssl_cipher_suite`\nis not `custom`.\nIf you use DHE ciphers, you must also\nconfigure the `ssl_dhparam` parameter.\n"
   },
   "ssl_protocols": {
     "defaultValue": "TLSv1.2 TLSv1.3",
-    "description": " Enables the specified protocols for client-side connections. The set of supported protocol versions also depends on the version of OpenSSL Kong was built with. This value is ignored if `ssl_cipher_suite` is not `custom`. If you want to enable TLSv1.1, you should set `ssl_cipher_suite` to `old`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols"
+    "description": "Enables the specified protocols for\nclient-side connections. The set of\nsupported protocol versions also depends\non the version of OpenSSL Kong was built\nwith. This value is ignored if\n`ssl_cipher_suite` is not `custom`.\nIf you want to enable TLSv1.1, you should\nset `ssl_cipher_suite` to `old`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols\n"
   },
   "ssl_prefer_server_ciphers": {
     "defaultValue": "on",
-    "description": "Specifies that server ciphers should be preferred over client ciphers when using the SSLv3 and TLS protocols. This value is ignored if `ssl_cipher_suite` is not `custom`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers"
+    "description": "Specifies that server ciphers should be\npreferred over client ciphers when using\nthe SSLv3 and TLS protocols. This value is\nignored if `ssl_cipher_suite` is not `custom`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers\n"
   },
   "ssl_dhparam": {
     "defaultValue": null,
-    "description": "Defines DH parameters for DHE ciphers from the predefined groups: `ffdhe2048`, `ffdhe3072`, `ffdhe4096`, `ffdhe6144`, `ffdhe8192`, from the absolute path to a parameters file, or directly from the parameters content.  This value is ignored if `ssl_cipher_suite` is `modern` or `intermediate`. The reason is that `modern` has no ciphers that needs this, and `intermediate` uses `ffdhe2048`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam"
+    "description": "Defines DH parameters for DHE ciphers from the\npredefined groups: `ffdhe2048`, `ffdhe3072`,\n`ffdhe4096`, `ffdhe6144`, `ffdhe8192`,\nfrom the absolute path to a parameters file, or\ndirectly from the parameters content.\n\nThis value is ignored if `ssl_cipher_suite`\nis `modern` or `intermediate`. The reason is\nthat `modern` has no ciphers that needs this,\nand `intermediate` uses `ffdhe2048`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam\n"
   },
   "ssl_session_tickets": {
     "defaultValue": "on",
-    "description": "Enables or disables session resumption through TLS session tickets. This has no impact when used with TLSv1.3.  Kong enables this by default for performance reasons, but it has security implications: https://github.com/mozilla/server-side-tls/issues/135  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets"
+    "description": "Enables or disables session resumption through\nTLS session tickets. This has no impact when\nused with TLSv1.3.\n\nKong enables this by default for performance\nreasons, but it has security implications:\nhttps://github.com/mozilla/server-side-tls/issues/135\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets\n"
   },
   "ssl_session_timeout": {
     "defaultValue": "1d",
-    "description": "Specifies a time during which a client may reuse the session parameters. See the rationale: https://github.com/mozilla/server-side-tls/issues/198  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout"
+    "description": "Specifies a time during which a client may\nreuse the session parameters. See the rationale:\nhttps://github.com/mozilla/server-side-tls/issues/198\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout\n"
   },
   "ssl_session_cache_size": {
     "defaultValue": "10m",
-    "description": "Sets the size of the caches that store session parameters  See https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache"
+    "description": "Sets the size of the caches that store session parameters\n\nSee https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache\n"
   },
   "ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `proxy_listen` values with TLS enabled.  If more than one certificates are specified, it can be used to provide alternate type of certificate (for example, ECC certificate) that will be served to clients that supports them. Note to properly serve using ECC certificates, it is recommended to also set `ssl_cipher_suite` to `modern` or `intermediate`.  Unless this option is explicitly set, Kong will auto-generate a pair of default certificates (RSA + ECC) first time it starts up and use it for serving TLS requests.  Certificates can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "Comma-separated list of certificates for `proxy_listen` values with TLS enabled.\n\nIf more than one certificates are specified, it can be used to provide\nalternate type of certificate (for example, ECC certificate) that will be served\nto clients that supports them. Note to properly serve using ECC certificates,\nit is recommended to also set `ssl_cipher_suite` to\n`modern` or `intermediate`.\n\nUnless this option is explicitly set, Kong will auto-generate\na pair of default certificates (RSA + ECC) first time it starts up and use\nit for serving TLS requests.\n\nCertificates can be configured on this property with either of the following\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `proxy_listen` values with TLS enabled.  If more than one certificate was specified for `ssl_cert`, then this option should contain the corresponding key for all certificates provided in the same order.  Unless this option is explicitly set, Kong will auto-generate a pair of default private keys (RSA + ECC) first time it starts up and use it for serving TLS requests.  Keys can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+    "description": "Comma-separated list of keys for `proxy_listen` values with TLS enabled.\n\nIf more than one certificate was specified for `ssl_cert`, then this\noption should contain the corresponding key for all certificates\nprovided in the same order.\n\nUnless this option is explicitly set, Kong will auto-generate\na pair of default private keys (RSA + ECC) first time it starts up and use\nit for serving TLS requests.\n\nKeys can be configured on this property with either of the following\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n"
   },
   "client_ssl": {
     "defaultValue": "off",
-    "description": "Determines if Nginx should attempt to send client-side TLS certificates and perform Mutual TLS Authentication with upstream service when proxying requests."
+    "description": "Determines if Nginx should attempt to send client-side\nTLS certificates and perform Mutual TLS Authentication\nwith upstream service when proxying requests.\n"
   },
   "client_ssl_cert": {
     "defaultValue": null,
-    "description": "If `client_ssl` is enabled, the client certificate for the `proxy_ssl_certificate` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "If `client_ssl` is enabled, the client certificate\nfor the `proxy_ssl_certificate` directive.\n\nThis value can be overwritten dynamically with the `client_certificate`\nattribute of the `Service` object.\n\nThe certificate can be configured on this property with either of the following\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "client_ssl_cert_key": {
     "defaultValue": null,
-    "description": "If `client_ssl` is enabled, the client TLS key for the `proxy_ssl_certificate_key` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate key can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+    "description": "If `client_ssl` is enabled, the client TLS key\nfor the `proxy_ssl_certificate_key` directive.\n\nThis value can be overwritten dynamically with the `client_certificate`\nattribute of the `Service` object.\n\nThe certificate key can be configured on this property with either of the following\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n"
   },
   "admin_ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `admin_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+    "description": "Comma-separated list of certificates for `admin_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n"
   },
   "admin_ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `admin_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+    "description": "Comma-separated list of keys for `admin_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n"
   },
   "status_ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `status_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+    "description": "Comma-separated list of certificates for `status_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n"
   },
   "status_ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `status_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+    "description": "Comma-separated list of keys for `status_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n"
   },
   "debug_ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `debug_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+    "description": "Comma-separated list of certificates for `debug_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n"
   },
   "debug_ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `debug_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+    "description": "Comma-separated list of keys for `debug_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n"
   },
   "headers": {
     "defaultValue": [
@@ -327,311 +327,311 @@
       "latency_tokens",
       "X-Kong-Request-Id"
     ],
-    "description": " Comma-separated list of headers Kong should inject in client responses.  Accepted values are: - `Server`: Injects `Server: kong/x.y.z`   on Kong-produced response (e.g. Admin   API, rejected requests from auth plugin). - `Via`: Injects `Via: kong/x.y.z` for   successfully proxied requests. - `X-Kong-Proxy-Latency`: Time taken   (in milliseconds) by Kong to process   a request and run all plugins before   proxying the request upstream. - `X-Kong-Response-Latency`: time taken   (in millisecond) by Kong to produce   a response in case of e.g. plugin   short-circuiting the request, or in   in case of an error. - `X-Kong-Upstream-Latency`: Time taken   (in milliseconds) by the upstream   service to send response headers. - `X-Kong-Admin-Latency`: Time taken   (in milliseconds) by Kong to process   an Admin API request. - `X-Kong-Upstream-Status`: The HTTP status   code returned by the upstream service.   This is particularly useful for clients to   distinguish upstream statuses if the   response is rewritten by a plugin. - `X-Kong-Request-Id`: Unique identifier of   the request. - `server_tokens`: Same as specifying both   `Server` and `Via`. - `latency_tokens`: Same as specifying   `X-Kong-Proxy-Latency`,   `X-Kong-Response-Latency`,   `X-Kong-Admin-Latency` and   `X-Kong-Upstream-Latency`  In addition to those, this value can be set to `off`, which prevents Kong from injecting any of the above headers. Note that this does not prevent plugins from injecting headers of their own.  Example: `headers = via, latency_tokens`"
+    "description": "Comma-separated list of headers Kong should\ninject in client responses.\n\nAccepted values are:\n- `Server`: Injects `Server: kong/x.y.z`\n  on Kong-produced response (e.g. Admin\n  API, rejected requests from auth plugin).\n- `Via`: Injects `Via: kong/x.y.z` for\n  successfully proxied requests.\n- `X-Kong-Proxy-Latency`: Time taken\n  (in milliseconds) by Kong to process\n  a request and run all plugins before\n  proxying the request upstream.\n- `X-Kong-Response-Latency`: time taken\n  (in millisecond) by Kong to produce\n  a response in case of e.g. plugin\n  short-circuiting the request, or in\n  in case of an error.\n- `X-Kong-Upstream-Latency`: Time taken\n  (in milliseconds) by the upstream\n  service to send response headers.\n- `X-Kong-Admin-Latency`: Time taken\n  (in milliseconds) by Kong to process\n  an Admin API request.\n- `X-Kong-Upstream-Status`: The HTTP status\n  code returned by the upstream service.\n  This is particularly useful for clients to\n  distinguish upstream statuses if the\n  response is rewritten by a plugin.\n- `X-Kong-Request-Id`: Unique identifier of\n  the request.\n- `server_tokens`: Same as specifying both\n  `Server` and `Via`.\n- `latency_tokens`: Same as specifying\n  `X-Kong-Proxy-Latency`,\n  `X-Kong-Response-Latency`,\n  `X-Kong-Admin-Latency` and\n  `X-Kong-Upstream-Latency`\n\nIn addition to those, this value can be set\nto `off`, which prevents Kong from injecting\nany of the above headers. Note that this\ndoes not prevent plugins from injecting\nheaders of their own.\n\nExample: `headers = via, latency_tokens`\n"
   },
   "headers_upstream": {
     "defaultValue": "X-Kong-Request-Id",
-    "description": " Comma-separated list of headers Kong should inject in requests to upstream.  At this time, the only accepted value is: - `X-Kong-Request-Id`: Unique identifier of   the request.  In addition, this value can be set to `off`, which prevents Kong from injecting the above header. Note that this does not prevent plugins from injecting headers of their own."
+    "description": "Comma-separated list of headers Kong should\ninject in requests to upstream.\n\nAt this time, the only accepted value is:\n- `X-Kong-Request-Id`: Unique identifier of\n  the request.\n\nIn addition, this value can be set\nto `off`, which prevents Kong from injecting\nthe above header. Note that this\ndoes not prevent plugins from injecting\nheaders of their own.\n"
   },
   "trusted_ips": {
     "defaultValue": null,
-    "description": "Defines trusted IP addresses blocks that are known to send correct `X-Forwarded-*` headers. Requests from trusted IPs make Kong forward their `X-Forwarded-*` headers upstream. Non-trusted requests make Kong insert its own `X-Forwarded-*` headers.  This property also sets the `set_real_ip_from` directive(s) in the Nginx configuration. It accepts the same type of values (CIDR blocks) but as a comma-separated list.  To trust *all* /!\\ IPs, set this value to `0.0.0.0/0,::/0`.  If the special value `unix:` is specified, all UNIX-domain sockets will be trusted.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from for examples of accepted values."
+    "description": "Defines trusted IP addresses blocks that are\nknown to send correct `X-Forwarded-*`\nheaders.\nRequests from trusted IPs make Kong forward\ntheir `X-Forwarded-*` headers upstream.\nNon-trusted requests make Kong insert its\nown `X-Forwarded-*` headers.\n\nThis property also sets the\n`set_real_ip_from` directive(s) in the Nginx\nconfiguration. It accepts the same type of\nvalues (CIDR blocks) but as a\ncomma-separated list.\n\nTo trust *all* /!\\ IPs, set this value to\n`0.0.0.0/0,::/0`.\n\nIf the special value `unix:` is specified,\nall UNIX-domain sockets will be trusted.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from\nfor examples of accepted values.\n"
   },
   "real_ip_header": {
     "defaultValue": "X-Real-IP",
-    "description": "Defines the request header field whose value will be used to replace the client address. This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  If this value receives `proxy_protocol`:  - at least one of the `proxy_listen` entries   must have the `proxy_protocol` flag   enabled. - the `proxy_protocol` parameter will be   appended to the `listen` directive of the   Nginx template.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header for a description of this directive."
+    "description": "Defines the request header field whose value\nwill be used to replace the client address.\nThis value sets the `ngx_http_realip_module`\ndirective of the same name in the Nginx\nconfiguration.\n\nIf this value receives `proxy_protocol`:\n\n- at least one of the `proxy_listen` entries\n  must have the `proxy_protocol` flag\n  enabled.\n- the `proxy_protocol` parameter will be\n  appended to the `listen` directive of the\n  Nginx template.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header\nfor a description of this directive.\n"
   },
   "real_ip_recursive": {
     "defaultValue": "off",
-    "description": "This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive for a description of this directive."
+    "description": "This value sets the `ngx_http_realip_module`\ndirective of the same name in the Nginx\nconfiguration.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive\nfor a description of this directive.\n"
   },
   "error_default_type": {
     "defaultValue": "text/plain",
-    "description": "Default MIME type to use when the request `Accept` header is missing and Nginx is returning an error for the request. Accepted values are `text/plain`, `text/html`, `application/json`, and `application/xml`."
+    "description": "Default MIME type to use when the request\n`Accept` header is missing and Nginx\nis returning an error for the request.\nAccepted values are `text/plain`,\n`text/html`, `application/json`, and\n`application/xml`.\n"
   },
   "upstream_keepalive_pool_size": {
     "defaultValue": "512",
-    "description": "Sets the default size of the upstream keepalive connection pools. Upstream keepalive connection pools are segmented by the `dst ip/dst port/SNI` attributes of a connection. A value of `0` will disable upstream keepalive connections by default, forcing each upstream request to open a new connection."
+    "description": "Sets the default size of the upstream\nkeepalive connection pools.\nUpstream keepalive connection pools\nare segmented by the `dst ip/dst\nport/SNI` attributes of a connection.\nA value of `0` will disable upstream\nkeepalive connections by default, forcing\neach upstream request to open a new\nconnection.\n"
   },
   "upstream_keepalive_max_requests": {
     "defaultValue": "1000",
-    "description": "Sets the default maximum number of requests than can be proxied upstream through one keepalive connection. After the maximum number of requests is reached, the connection will be closed. A value of `0` will disable this behavior, and a keepalive connection can be used to proxy an indefinite number of requests."
+    "description": "Sets the default maximum number of\nrequests than can be proxied upstream\nthrough one keepalive connection.\nAfter the maximum number of requests\nis reached, the connection will be\nclosed.\nA value of `0` will disable this\nbehavior, and a keepalive connection\ncan be used to proxy an indefinite\nnumber of requests.\n"
   },
   "upstream_keepalive_idle_timeout": {
     "defaultValue": "60",
-    "description": "Sets the default timeout (in seconds) for which an upstream keepalive connection should be kept open. When the timeout is reached while the connection has not been reused, it will be closed. A value of `0` will disable this behavior, and an idle keepalive connection may be kept open indefinitely."
+    "description": "Sets the default timeout (in seconds)\nfor which an upstream keepalive\nconnection should be kept open. When\nthe timeout is reached while the\nconnection has not been reused, it\nwill be closed.\nA value of `0` will disable this\nbehavior, and an idle keepalive\nconnection may be kept open\nindefinitely.\n"
   },
   "allow_debug_header": {
     "defaultValue": "off",
-    "description": "Enable the `Kong-Debug` header function. if it is `on`, kong will add `Kong-Route-Id` `Kong-Route-Name` `Kong-Service-Id` `Kong-Service-Name` debug headers to response when the client request header `Kong-Debug: 1` is present."
+    "description": "Enable the `Kong-Debug` header function.\nif it is `on`, kong will add\n`Kong-Route-Id` `Kong-Route-Name` `Kong-Service-Id`\n`Kong-Service-Name` debug headers to response when\nthe client request header `Kong-Debug: 1` is present.\n"
   },
   "nginx_main_worker_rlimit_nofile": {
     "defaultValue": "auto",
-    "description": " Changes the limit on the maximum number of open files for worker processes.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile"
+    "description": "Changes the limit on the maximum number of open files\nfor worker processes.\n\nThe special and default value of `auto` sets this\nvalue to `ulimit -n` with the upper bound limited to\n16384 as a measure to protect against excess memory use,\nand the lower bound of 1024 as a good default.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile\n"
   },
   "nginx_events_worker_connections": {
     "defaultValue": "auto",
-    "description": " Sets the maximum number of simultaneous connections that can be opened by a worker process.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_connections"
+    "description": "Sets the maximum number of simultaneous\nconnections that can be opened by a worker process.\n\nThe special and default value of `auto` sets this\nvalue to `ulimit -n` with the upper bound limited to\n16384 as a measure to protect against excess memory use,\nand the lower bound of 1024 as a good default.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_connections\n"
   },
   "nginx_http_client_header_buffer_size": {
     "defaultValue": "1k",
-    "description": "Sets buffer size for reading the client request headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size"
+    "description": "Sets buffer size for reading the\nclient request headers.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size\n"
   },
   "nginx_http_large_client_header_buffers": {
     "defaultValue": "4 8k",
-    "description": "Sets the maximum number and size of buffers used for reading large clients requests headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers"
+    "description": "Sets the maximum number and\nsize of buffers used for\nreading large clients\nrequests headers.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers\n"
   },
   "nginx_http_client_max_body_size": {
     "defaultValue": "0",
-    "description": "Defines the maximum request body size allowed by requests proxied by Kong, specified in the Content-Length request header. If a request exceeds this limit, Kong will respond with a 413 (Request Entity Too Large). Setting this value to 0 disables checking the request body size. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size"
+    "description": "Defines the maximum request body size\nallowed by requests proxied by Kong,\nspecified in the Content-Length request\nheader. If a request exceeds this\nlimit, Kong will respond with a 413\n(Request Entity Too Large). Setting\nthis value to 0 disables checking the\nrequest body size.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size\n"
   },
   "nginx_admin_client_max_body_size": {
     "defaultValue": "10m",
-    "description": "Defines the maximum request body size for Admin API."
+    "description": "Defines the maximum request body size for\nAdmin API.\n"
   },
   "nginx_http_charset": {
     "defaultValue": "UTF-8",
-    "description": "Adds the specified charset to the “Content-Type” response header field. If this charset is different from the charset specified in the source_charset directive, a conversion is performed.  The parameter `off` cancels the addition of charset to the “Content-Type” response header field. See http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset"
+    "description": "Adds the specified charset to the “Content-Type”\nresponse header field. If this charset is different\nfrom the charset specified in the source_charset\ndirective, a conversion is performed.\n\nThe parameter `off` cancels the addition of\ncharset to the “Content-Type” response header field.\nSee http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset\n"
   },
   "nginx_http_client_body_buffer_size": {
     "defaultValue": "8k",
-    "description": "Defines the buffer size for reading the request body. If the client request body is larger than this value, the body will be buffered to disk. Note that when the body is buffered to disk, Kong plugins that access or manipulate the request body may not work, so it is advisable to set this value as high as possible (e.g., set it as high as `client_max_body_size` to force request bodies to be kept in memory). Do note that high-concurrency environments will require significant memory allocations to process many concurrent large request bodies. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size"
+    "description": "Defines the buffer size for reading\nthe request body. If the client\nrequest body is larger than this\nvalue, the body will be buffered to\ndisk. Note that when the body is\nbuffered to disk, Kong plugins that\naccess or manipulate the request\nbody may not work, so it is\nadvisable to set this value as high\nas possible (e.g., set it as high\nas `client_max_body_size` to force\nrequest bodies to be kept in\nmemory). Do note that\nhigh-concurrency environments will\nrequire significant memory\nallocations to process many\nconcurrent large request bodies.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size\n"
   },
   "nginx_admin_client_body_buffer_size": {
     "defaultValue": "10m",
-    "description": "Defines the buffer size for reading the request body on Admin API."
+    "description": "Defines the buffer size for reading\nthe request body on Admin API.\n"
   },
   "nginx_http_lua_regex_match_limit": {
     "defaultValue": "100000",
-    "description": "Global `MATCH_LIMIT` for PCRE regex matching. The default of `100000` should ensure at worst any regex Kong executes could finish within roughly 2 seconds."
+    "description": "Global `MATCH_LIMIT` for PCRE\nregex matching. The default of `100000` should ensure\nat worst any regex Kong executes could finish within\nroughly 2 seconds.\n"
   },
   "nginx_http_lua_regex_cache_max_entries": {
     "defaultValue": "8192",
-    "description": "Specifies the maximum number of entries allowed in the worker process level PCRE JIT compiled regex cache. It is recommended to set it to at least (number of regex paths * 2) to avoid high CPU usages if you manually specified `router_flavor` to `traditional`. `expressions` and `traditional_compat` router does not make use of the PCRE library and their behavior is unaffected by this setting."
+    "description": "Specifies the maximum number of entries allowed\nin the worker process level PCRE JIT compiled regex cache.\nIt is recommended to set it to at least (number of regex paths * 2)\nto avoid high CPU usages if you manually specified `router_flavor` to\n`traditional`. `expressions` and `traditional_compat` router does\nnot make use of the PCRE library and their behavior\nis unaffected by this setting.\n"
   },
   "nginx_http_keepalive_requests": {
     "defaultValue": "10000",
-    "description": "Sets the maximum number of client requests that can be served through one keep-alive connection. After the maximum number of requests are made, the connection is closed. Closing connections periodically is necessary to free per-connection memory allocations. Therefore, using too high maximum number of requests could result in excessive memory usage and not recommended. See: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests"
+    "description": "Sets the maximum number of client requests that can be served through one\nkeep-alive connection. After the maximum number of requests are made,\nthe connection is closed.\nClosing connections periodically is necessary to free per-connection\nmemory allocations. Therefore, using too high maximum number of requests\ncould result in excessive memory usage and not recommended.\nSee: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests\n"
   },
   "database": {
     "defaultValue": "postgres",
-    "description": "Determines the database (or no database) for this node Accepted values are `postgres` and `off`."
+    "description": "Determines the database (or no database) for\nthis node\nAccepted values are `postgres` and `off`.\n"
   },
   "pg_host": {
     "defaultValue": "127.0.0.1",
-    "description": "Host of the Postgres server."
+    "description": "Host of the Postgres server.\n"
   },
   "pg_port": {
     "defaultValue": "5432",
-    "description": "Port of the Postgres server."
+    "description": "Port of the Postgres server.\n"
   },
   "pg_timeout": {
     "defaultValue": "5000",
-    "description": "Defines the timeout (in ms), for connecting, reading and writing."
+    "description": "Defines the timeout (in ms), for connecting,\nreading and writing.\n"
   },
   "pg_user": {
     "defaultValue": "kong",
-    "description": "Postgres user."
+    "description": "Postgres user.\n"
   },
   "pg_password": {
     "defaultValue": null,
-    "description": "Postgres user's password."
+    "description": "Postgres user's password.\n"
   },
   "pg_iam_auth": {
     "defaultValue": "off",
-    "description": "Determines whether the AWS IAM database Authentication will be used. When switch to `on`, the username defined in `pg_user` will be used as the database account, and the database connection will be forced to using TLS. `pg_password` will not be used when the switch is `on`. Note that the corresponding IAM policy must be correct, otherwise connecting will fail."
+    "description": "Determines whether the AWS IAM database\nAuthentication will be used. When switch to\n`on`, the username defined in `pg_user` will\nbe used as the database account, and the\ndatabase connection will be forced to using\nTLS. `pg_password` will not be used when\nthe switch is `on`. Note that the corresponding\nIAM policy must be correct, otherwise connecting\nwill fail.\n"
   },
   "pg_iam_auth_assume_role_arn": {
     "defaultValue": null,
-    "description": "The target AWS IAM role ARN that will be assumed when using AWS IAM database authentication. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+    "description": "The target AWS IAM role ARN that will be\nassumed when using AWS IAM database\nauthentication. Typically this is used\nfor operating between multiple roles\nor cross-accounts.\nIf you are not using assume role\nyou should not specify this value.\n"
   },
   "pg_iam_auth_role_session_name": {
     "defaultValue": "KongPostgres",
-    "description": "The role session name used for role assuming in AWS IAM Database Authentication. The default value is `KongPostgres`."
+    "description": "The role session name used for role\nassuming in AWS IAM Database\nAuthentication. The default value is\n`KongPostgres`.\n"
   },
   "pg_iam_auth_sts_endpoint_url": {
     "defaultValue": null,
-    "description": "The custom STS endpoint URL used for role assuming in AWS IAM Database Authentication.  Note that this value will override the default STS endpoint URL(which should be `https://sts.amazonaws.com`, or `https://sts.<region>.amazonaws.com` if you have `AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).  If you are not using private VPC endpoint for STS service, you should not specify this value."
+    "description": "The custom STS endpoint URL used for role assuming\nin AWS IAM Database Authentication.\n\nNote that this value will override the default\nSTS endpoint URL(which should be\n`https://sts.amazonaws.com`, or\n`https://sts.<region>.amazonaws.com` if you have\n`AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).\n\nIf you are not using private VPC endpoint for STS\nservice, you should not specify this value.\n"
   },
   "pg_database": {
     "defaultValue": "kong",
-    "description": "The database name to connect to."
+    "description": "The database name to connect to.\n"
   },
   "pg_schema": {
     "defaultValue": null,
-    "description": "The database schema to use. If unspecified, Kong will respect the `search_path` value of your PostgreSQL instance."
+    "description": "The database schema to use. If unspecified,\nKong will respect the `search_path` value of\nyour PostgreSQL instance.\n"
   },
   "pg_ssl": {
     "defaultValue": "off",
-    "description": "Toggles client-server TLS connections between Kong and PostgreSQL. Because PostgreSQL uses the same port for TLS and non-TLS, this is only a hint. If the server does not support TLS, the established connection will be a plain one."
+    "description": "Toggles client-server TLS connections\nbetween Kong and PostgreSQL.\nBecause PostgreSQL uses the same port for TLS\nand non-TLS, this is only a hint. If the\nserver does not support TLS, the established\nconnection will be a plain one.\n"
   },
   "pg_ssl_version": {
     "defaultValue": "tlsv1_2",
-    "description": "When using ssl between Kong and PostgreSQL, the version of tls to use. Accepted values are `tlsv1_1`, `tlsv1_2`, `tlsv1_3`, or 'any'. When `any` is set, the client negotiates the highest version with the server which can't be lower than `tlsv1_1`."
+    "description": "When using ssl between Kong and PostgreSQL,\nthe version of tls to use. Accepted values are\n`tlsv1_1`, `tlsv1_2`, `tlsv1_3`, or 'any'. When\n`any` is set, the client negotiates the highest\nversion with the server which can't be lower\nthan `tlsv1_1`.\n"
   },
   "pg_ssl_required": {
     "defaultValue": "off",
-    "description": "When `pg_ssl` is on this determines if TLS must be used between Kong and PostgreSQL. It aborts the connection if the server does not support SSL connections."
+    "description": "When `pg_ssl` is on this determines if\nTLS must be used between Kong and PostgreSQL.\nIt aborts the connection if the server does\nnot support SSL connections.\n"
   },
   "pg_ssl_verify": {
     "defaultValue": "off",
-    "description": "Toggles server certificate verification if `pg_ssl` is enabled. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+    "description": "Toggles server certificate verification if\n`pg_ssl` is enabled.\nSee the `lua_ssl_trusted_certificate`\nsetting to specify a certificate authority.\n"
   },
   "pg_ssl_cert": {
     "defaultValue": null,
-    "description": "The absolute path to the PEM encoded client TLS certificate for the PostgreSQL connection. Mutual TLS authentication against PostgreSQL is only enabled if this value is set."
+    "description": "The absolute path to the PEM encoded client\nTLS certificate for the PostgreSQL connection.\nMutual TLS authentication against\nPostgreSQL is only enabled if this value is set.\n"
   },
   "pg_ssl_cert_key": {
     "defaultValue": null,
-    "description": "If `pg_ssl_cert` is set, the absolute path to the PEM encoded client TLS private key for the PostgreSQL connection."
+    "description": "If `pg_ssl_cert` is set, the absolute path to\nthe PEM encoded client TLS private key for the\nPostgreSQL connection.\n"
   },
   "pg_max_concurrent_queries": {
     "defaultValue": "0",
-    "description": "Sets the maximum number of concurrent queries that can be executing at any given time. This limit is enforced per worker process; the total number of concurrent queries for this node will be will be: `pg_max_concurrent_queries * nginx_worker_processes`.  The default value of 0 removes this concurrency limitation."
+    "description": "Sets the maximum number of concurrent queries\nthat can be executing at any given time. This\nlimit is enforced per worker process; the\ntotal number of concurrent queries for this\nnode will be will be:\n`pg_max_concurrent_queries * nginx_worker_processes`.\n\nThe default value of 0 removes this\nconcurrency limitation.\n"
   },
   "pg_semaphore_timeout": {
     "defaultValue": "60000",
-    "description": "Defines the timeout (in ms) after which PostgreSQL query semaphore resource acquisition attempts will fail. Such failures will generally result in the associated proxy or Admin API request failing with an HTTP 500 status code. Detailed discussion of this behavior is available in the online documentation."
+    "description": "Defines the timeout (in ms) after which\nPostgreSQL query semaphore resource\nacquisition attempts will fail. Such\nfailures will generally result in the\nassociated proxy or Admin API request\nfailing with an HTTP 500 status code.\nDetailed discussion of this behavior is\navailable in the online documentation.\n"
   },
   "pg_keepalive_timeout": {
     "defaultValue": null,
-    "description": "Specify the maximal idle timeout (in ms) for the postgres connections in the pool. If this value is set to 0 then the timeout interval is unlimited.  If not specified this value will be same as `lua_socket_keepalive_timeout`"
+    "description": "Specify the maximal idle timeout (in ms)\nfor the postgres connections in the pool.\nIf this value is set to 0 then the timeout interval\nis unlimited.\n\nIf not specified this value will be same as\n`lua_socket_keepalive_timeout`\n"
   },
   "pg_pool_size": {
     "defaultValue": null,
-    "description": "Specifies the size limit (in terms of connection count) for the Postgres server. Note that this connection pool is intended per Nginx worker rather than per Kong instance.  If not specified, the default value is the same as `lua_socket_pool_size`"
+    "description": "Specifies the size limit (in terms of connection\ncount) for the Postgres server.\nNote that this connection pool is intended\nper Nginx worker rather than per Kong instance.\n\nIf not specified, the default value is the same as\n`lua_socket_pool_size`\n"
   },
   "pg_backlog": {
     "defaultValue": null,
-    "description": "If specified, this value will limit the total number of open connections to the Postgres server to `pg_pool_size`. If the connection pool is full, subsequent connect operations will be inserted in a queue with size equal to this option's value.  If the number of queued connect operations reaches `pg_backlog`, exceeding connections will fail.  If not specified, then number of open connections to the Postgres server is not limited."
+    "description": "If specified, this value will limit the total\nnumber of open connections to the Postgres\nserver to `pg_pool_size`. If the connection\npool is full, subsequent connect operations\nwill be inserted in a queue with size equal\nto this option's value.\n\nIf the number of queued connect operations\nreaches `pg_backlog`, exceeding connections will fail.\n\nIf not specified, then number of open connections\nto the Postgres server is not limited.\n"
   },
   "pg_ro_host": {
     "defaultValue": null,
-    "description": "Same as `pg_host`, but for the read-only connection. **Note:** Refer to the documentation section above for detailed usage."
+    "description": "Same as `pg_host`, but for the\nread-only connection.\n**Note:** Refer to the documentation\nsection above for detailed usage.\n"
   },
   "pg_ro_port": {
     "defaultValue": "<pg_port>",
-    "description": "Same as `pg_port`, but for the read-only connection."
+    "description": "Same as `pg_port`, but for the\nread-only connection.\n"
   },
   "pg_ro_timeout": {
     "defaultValue": "<pg_timeout>",
-    "description": "Same as `pg_timeout`, but for the read-only connection."
+    "description": "Same as `pg_timeout`, but for the\nread-only connection.\n"
   },
   "pg_ro_user": {
     "defaultValue": "<pg_user>",
-    "description": "Same as `pg_user`, but for the read-only connection."
+    "description": "Same as `pg_user`, but for the\nread-only connection.\n"
   },
   "pg_ro_password": {
     "defaultValue": "<pg_password>",
-    "description": "Same as `pg_password`, but for the read-only connection."
+    "description": "Same as `pg_password`, but for the\nread-only connection.\n"
   },
   "pg_ro_iam_auth": {
     "defaultValue": "<pg_iam_auth>",
-    "description": "Same as `pg_iam_auth`, but for the read-only connection."
+    "description": "Same as `pg_iam_auth`, but for the\nread-only connection.\n"
   },
   "pg_ro_iam_auth_assume_role_arn": {
     "defaultValue": null,
-    "description": "Same as `pg_iam_auth_assume_role_arn', but for the read-only connection."
+    "description": "Same as `pg_iam_auth_assume_role_arn',\nbut for the read-only connection.\n"
   },
   "pg_ro_iam_auth_role_session_name": {
     "defaultValue": "KongPostgres",
-    "description": "Same as `pg_iam_auth_role_session_name`, but for the read-only connection."
+    "description": "Same as `pg_iam_auth_role_session_name`,\nbut for the read-only connection.\n"
   },
   "pg_ro_iam_auth_sts_endpoint_url": {
     "defaultValue": null,
-    "description": "Same as `pg_iam_auth_sts_endpoint_url`, but for the read-only connection."
+    "description": "Same as `pg_iam_auth_sts_endpoint_url`,\nbut for the read-only connection.\n"
   },
   "pg_ro_database": {
     "defaultValue": "<pg_database>",
-    "description": "Same as `pg_database`, but for the read-only connection."
+    "description": "Same as `pg_database`, but for the\nread-only connection.\n"
   },
   "pg_ro_schema": {
     "defaultValue": "<pg_schema>",
-    "description": "Same as `pg_schema`, but for the read-only connection."
+    "description": "Same as `pg_schema`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl": {
     "defaultValue": "<pg_ssl>",
-    "description": "Same as `pg_ssl`, but for the read-only connection."
+    "description": "Same as `pg_ssl`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl_required": {
     "defaultValue": "<pg_ssl_required>",
-    "description": " Same as `pg_ssl_required`, but for the read-only connection."
+    "description": "Same as `pg_ssl_required`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl_verify": {
     "defaultValue": "<pg_ssl_verify>",
-    "description": " Same as `pg_ssl_verify`, but for the read-only connection."
+    "description": "Same as `pg_ssl_verify`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl_version": {
     "defaultValue": "<pg_ssl_version>",
-    "description": " Same as `pg_ssl_version`, but for the read-only connection."
+    "description": "Same as `pg_ssl_version`, but for the\nread-only connection.\n"
   },
   "pg_ro_max_concurrent_queries": {
     "defaultValue": "<pg_max_concurrent_queries>",
-    "description": " Same as `pg_max_concurrent_queries`, but for the read-only connection. Note: read-only concurrency is not shared with the main (read-write) connection."
+    "description": "Same as `pg_max_concurrent_queries`, but for\nthe read-only connection.\nNote: read-only concurrency is not shared\nwith the main (read-write) connection.\n"
   },
   "pg_ro_semaphore_timeout": {
     "defaultValue": "<pg_semaphore_timeout>",
-    "description": " Same as `pg_semaphore_timeout`, but for the read-only connection."
+    "description": "Same as `pg_semaphore_timeout`, but for the\nread-only connection.\n"
   },
   "pg_ro_keepalive_timeout": {
     "defaultValue": "<pg_keepalive_timeout>",
-    "description": " Same as `pg_keepalive_timeout`, but for the read-only connection."
+    "description": "Same as `pg_keepalive_timeout`, but for the\nread-only connection.\n"
   },
   "pg_ro_pool_size": {
     "defaultValue": "<pg_pool_size>",
-    "description": " Same as `pg_pool_size`, but for the read-only connection."
+    "description": "Same as `pg_pool_size`, but for the\nread-only connection.\n"
   },
   "pg_ro_backlog": {
     "defaultValue": "<pg_backlog>",
-    "description": " Same as `pg_backlog`, but for the read-only connection."
+    "description": "Same as `pg_backlog`, but for the\nread-only connection.\n"
   },
   "declarative_config": {
     "defaultValue": null,
-    "description": "The path to the declarative configuration file which holds the specification of all entities (Routes, Services, Consumers, etc.) to be used when the `database` is set to `off`.  Entities are stored in Kong's LMDB cache, so you must ensure that enough headroom is allocated to it via the `lmdb_map_size` property.  If the Hybrid mode `role` is set to `data_plane` and there's no configuration cache file, this configuration is used before connecting to the Control Plane node as a user-controlled fallback."
+    "description": "The path to the declarative configuration\nfile which holds the specification of all\nentities (Routes, Services, Consumers, etc.)\nto be used when the `database` is set to\n`off`.\n\nEntities are stored in Kong's LMDB cache,\nso you must ensure that enough headroom is\nallocated to it via the `lmdb_map_size`\nproperty.\n\nIf the Hybrid mode `role` is set to `data_plane`\nand there's no configuration cache file,\nthis configuration is used before connecting\nto the Control Plane node as a user-controlled\nfallback.\n"
   },
   "declarative_config_string": {
     "defaultValue": null,
-    "description": "The declarative configuration as a string"
+    "description": "The declarative configuration as a string\n"
   },
   "lmdb_environment_path": {
     "defaultValue": "dbless.lmdb",
-    "description": "Directory where the LMDB database files used by DB-less and Hybrid mode to store Kong configurations reside.  This path is relative under the Kong `prefix`."
+    "description": "Directory where the LMDB database files used by\nDB-less and Hybrid mode to store Kong\nconfigurations reside.\n\nThis path is relative under the Kong `prefix`.\n"
   },
   "lmdb_map_size": {
     "defaultValue": "2048m",
-    "description": "Maximum size of the LMDB memory map, used to store the DB-less and Hybird mode configurations. Default is 2048m.  This config defines the limit of LMDB file size, the actual file size growth will be on-demand and proportional to the actual config size.  Note this value can be set very large, say a couple of GBs to accommodate future database growth and Multi Version Concurrency Control (MVCC) headroom needs. The file size of the LMDB database file should stabilize after a few config reload/Hybrid mode syncs and the actual memory used by the LMDB database will be smaller than the file size due to dynamic swapping of database pages by the OS."
+    "description": "Maximum size of the LMDB memory map, used to store the\nDB-less and Hybird mode configurations. Default is 2048m.\n\nThis config defines the limit of LMDB file size, the\nactual file size growth will be on-demand and\nproportional to the actual config size.\n\nNote this value can be set very large, say a couple of GBs\nto accommodate future database growth and\nMulti Version Concurrency Control (MVCC) headroom needs.\nThe file size of the LMDB database file should stabilize\nafter a few config reload/Hybrid mode syncs and the actual\nmemory used by the LMDB database will be smaller than\nthe file size due to dynamic swapping of database pages by\nthe OS.\n"
   },
   "db_update_frequency": {
     "defaultValue": "5",
-    "description": "Frequency (in seconds) at which to check for updated entities with the datastore.  When a node creates, updates, or deletes an entity via the Admin API, other nodes need to wait for the next poll (configured by this value) to eventually purge the old cached entity and start using the new one."
+    "description": "Frequency (in seconds) at which to check for\nupdated entities with the datastore.\n\nWhen a node creates, updates, or deletes an\nentity via the Admin API, other nodes need\nto wait for the next poll (configured by\nthis value) to eventually purge the old\ncached entity and start using the new one.\n"
   },
   "db_update_propagation": {
     "defaultValue": "0",
-    "description": "Time (in seconds) taken for an entity in the datastore to be propagated to replica nodes of another datacenter.  When set, this property will increase the time taken by Kong to propagate the change of an entity.  Single-datacenter setups or PostgreSQL servers should suffer no such delays, and this value can be safely set to 0. Postgres setups with read replicas should set this value to maximum expected replication lag between the writer and reader instances."
+    "description": "Time (in seconds) taken for an entity in the\ndatastore to be propagated to replica nodes\nof another datacenter.\n\nWhen set, this property will increase the\ntime taken by Kong to propagate the change\nof an entity.\n\nSingle-datacenter setups or PostgreSQL\nservers should suffer no such delays, and\nthis value can be safely set to 0.\nPostgres setups with read replicas should\nset this value to maximum expected replication\nlag between the writer and reader instances.\n"
   },
   "db_cache_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of an entity from the datastore when cached by this node.  Database misses (no entity) are also cached according to this setting if you do not configure `db_cache_neg_ttl`.  If set to 0 (default), such cached entities or misses never expire."
+    "description": "Time-to-live (in seconds) of an entity from\nthe datastore when cached by this node.\n\nDatabase misses (no entity) are also cached\naccording to this setting if you do not\nconfigure `db_cache_neg_ttl`.\n\nIf set to 0 (default), such cached entities\nor misses never expire.\n"
   },
   "db_cache_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a datastore miss (no entity).  If not specified (default), `db_cache_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a datastore\nmiss (no entity).\n\nIf not specified (default), `db_cache_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "db_resurrect_ttl": {
     "defaultValue": "30",
-    "description": "Time (in seconds) for which stale entities from the datastore should be resurrected for when they cannot be refreshed (e.g., the datastore is unreachable). When this TTL expires, a new attempt to refresh the stale entities will be made."
+    "description": "Time (in seconds) for which stale entities\nfrom the datastore should be resurrected for\nwhen they cannot be refreshed (e.g., the\ndatastore is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nentities will be made.\n"
   },
   "db_cache_warmup_entities": {
     "defaultValue": "services",
-    "description": " Entities to be pre-loaded from the datastore into the in-memory cache at Kong start-up. This speeds up the first access of endpoints that use the given entities.  When the `services` entity is configured for warmup, the DNS entries for values in its `host` attribute are pre-resolved asynchronously as well.  Cache size set in `mem_cache_size` should be set to a value large enough to hold all instances of the specified entities. If the size is insufficient, Kong will log a warning."
+    "description": "Entities to be pre-loaded from the datastore\ninto the in-memory cache at Kong start-up.\nThis speeds up the first access of endpoints\nthat use the given entities.\n\nWhen the `services` entity is configured\nfor warmup, the DNS entries for values in\nits `host` attribute are pre-resolved\nasynchronously as well.\n\nCache size set in `mem_cache_size` should\nbe set to a value large enough to hold all\ninstances of the specified entities.\nIf the size is insufficient, Kong will log\na warning.\n"
   },
   "dns_resolver": {
     "defaultValue": null,
-    "description": "Comma separated list of nameservers, each entry in `ip[:port]` format to be used by Kong. If not specified the nameservers in the local `resolv.conf` file will be used. Port defaults to 53 if omitted. Accepts both IPv4 and IPv6 addresses."
+    "description": "Comma separated list of nameservers, each\nentry in `ip[:port]` format to be used by\nKong. If not specified the nameservers in\nthe local `resolv.conf` file will be used.\nPort defaults to 53 if omitted. Accepts\nboth IPv4 and IPv6 addresses.\n"
   },
   "dns_hostsfile": {
     "defaultValue": "/etc/hosts",
-    "description": "The hosts file to use. This file is read once and its content is static in memory. To read the file again after modifying it, Kong must be reloaded."
+    "description": "The hosts file to use. This file is read\nonce and its content is static in memory.\nTo read the file again after modifying it,\nKong must be reloaded.\n"
   },
   "dns_order": {
     "defaultValue": [
@@ -640,450 +640,450 @@
       "A",
       "CNAME"
     ],
-    "description": "The order in which to resolve different record types. The `LAST` type means the type of the last successful lookup (for the specified name). The format is a (case insensitive) comma separated list."
+    "description": "The order in which to resolve different\nrecord types. The `LAST` type means the\ntype of the last successful lookup (for the\nspecified name). The format is a (case\ninsensitive) comma separated list.\n"
   },
   "dns_valid_ttl": {
     "defaultValue": null,
-    "description": "By default, DNS records are cached using the TTL value of a response. If this property receives a value (in seconds), it will override the TTL for all records."
+    "description": "By default, DNS records are cached using\nthe TTL value of a response. If this\nproperty receives a value (in seconds), it\nwill override the TTL for all records.\n"
   },
   "dns_stale_ttl": {
     "defaultValue": "3600",
-    "description": "Defines, in seconds, how long a record will remain in cache past its TTL. This value will be used while the new DNS record is fetched in the background. Stale data will be used from expiry of a record until either the refresh query completes, or the `dns_stale_ttl` number of seconds have passed. This configuration enables Kong to be more resilient during resolver downtime."
+    "description": "Defines, in seconds, how long a record will\nremain in cache past its TTL. This value\nwill be used while the new DNS record is\nfetched in the background.\nStale data will be used from expiry of a\nrecord until either the refresh query\ncompletes, or the `dns_stale_ttl` number of\nseconds have passed.\nThis configuration enables Kong to be more\nresilient during resolver downtime.\n"
   },
   "dns_cache_size": {
     "defaultValue": "10000",
-    "description": "Defines the maximum allowed number of DNS records stored in memory cache. Least recently used DNS records are discarded from cache if it is full. Both errors and data are cached, therefore a single name query can easily take up 10-15 slots."
+    "description": "Defines the maximum allowed number of\nDNS records stored in memory cache.\nLeast recently used DNS records are discarded\nfrom cache if it is full. Both errors and\ndata are cached, therefore a single name query\ncan easily take up 10-15 slots.\n"
   },
   "dns_not_found_ttl": {
     "defaultValue": "30",
-    "description": "TTL in seconds for empty DNS responses and \"(3) name error\" responses."
+    "description": "TTL in seconds for empty DNS responses and\n\"(3) name error\" responses.\n"
   },
   "dns_error_ttl": {
     "defaultValue": "1",
-    "description": "TTL in seconds for error responses."
+    "description": "TTL in seconds for error responses.\n"
   },
   "dns_no_sync": {
     "defaultValue": "off",
-    "description": "If enabled, then upon a cache-miss every request will trigger its own dns query. When disabled multiple requests for the same name/type will be synchronised to a single query."
+    "description": "If enabled, then upon a cache-miss every\nrequest will trigger its own dns query.\nWhen disabled multiple requests for the\nsame name/type will be synchronised to a\nsingle query.\n"
   },
   "vault_env_prefix": {
     "defaultValue": null,
-    "description": "Defines the environment variable vault's default prefix. For example if you have all your secrets stored in environment variables prefixed with `SECRETS_`, it can be configured here so that it isn't necessary to repeat them in Vault references."
+    "description": "Defines the environment variable vault's\ndefault prefix. For example if you have\nall your secrets stored in environment\nvariables prefixed with `SECRETS_`, it\ncan be configured here so that it isn't\nnecessary to repeat them in Vault\nreferences.\n"
   },
   "vault_aws_region": {
     "defaultValue": null,
-    "description": "The AWS region your vault is located in."
+    "description": "The AWS region your vault is located in.\n"
   },
   "vault_aws_endpoint_url": {
     "defaultValue": null,
-    "description": "The AWS SecretsManager service endpoint url. If not specified, the value used by vault will be the official AWS SecretsManager service url which is `https://secretsmanager.<region>.amazonaws.com` You can specify a complete URL(including the \"http/https\" scheme) to override the endpoint that vault will connect to."
+    "description": "The AWS SecretsManager service endpoint url.\nIf not specified, the value used by vault will\nbe the official AWS SecretsManager service url\nwhich is\n`https://secretsmanager.<region>.amazonaws.com`\nYou can specify a complete URL(including\nthe \"http/https\" scheme) to override the\nendpoint that vault will connect to.\n"
   },
   "vault_aws_assume_role_arn": {
     "defaultValue": null,
-    "description": "The target AWS IAM role ARN that will be assumed. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+    "description": "The target AWS IAM role ARN that will be\nassumed. Typically this is used for\noperating between multiple roles\nor cross-accounts.\nIf you are not using assume role\nyou should not specify this value.\n"
   },
   "vault_aws_role_session_name": {
     "defaultValue": "KongVault",
-    "description": "The role session name used for role assuming. The default value is `KongVault`."
+    "description": "The role session name used for role\nassuming. The default value is\n`KongVault`.\n"
   },
   "vault_aws_sts_endpoint_url": {
     "defaultValue": null,
-    "description": "The custom STS endpoint URL used for role assuming in AWS Vault.  Note that this value will override the default STS endpoint URL(which should be `https://sts.amazonaws.com`, or `https://sts.<region>.amazonaws.com` if you have `AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).  If you are not using private VPC endpoint for STS service, you should not specify this value."
+    "description": "The custom STS endpoint URL used for role assuming\nin AWS Vault.\n\nNote that this value will override the default\nSTS endpoint URL(which should be\n`https://sts.amazonaws.com`, or\n`https://sts.<region>.amazonaws.com` if you have\n`AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).\n\nIf you are not using private VPC endpoint for STS\nservice, you should not specify this value.\n"
   },
   "vault_aws_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the AWS vault when cached by this node.  AWS vault misses (no secret) are also cached according to this setting if you do not configure `vault_aws_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe AWS vault when cached by this node.\n\nAWS vault misses (no secret) are also cached\naccording to this setting if you do not\nconfigure `vault_aws_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_aws_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_aws_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a AWS vault\nmiss (no secret).\n\nIf not specified (default), `vault_aws_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_aws_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the AWS vault should be resurrected for when they cannot be refreshed (e.g., the AWS vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the AWS vault should be resurrected for\nwhen they cannot be refreshed (e.g., the\nAWS vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "vault_gcp_project_id": {
     "defaultValue": null,
-    "description": "The project ID from your Google API Console."
+    "description": "The project ID from your Google API Console.\n"
   },
   "vault_gcp_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the GCP vault when cached by this node.  GCP vault misses (no secret) are also cached according to this setting if you do not configure `vault_gcp_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe GCP vault when cached by this node.\n\nGCP vault misses (no secret) are also cached\naccording to this setting if you do not\nconfigure `vault_gcp_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_gcp_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_gcp_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a AWS vault\nmiss (no secret).\n\nIf not specified (default), `vault_gcp_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_gcp_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the GCP vault should be resurrected for when they cannot be refreshed (e.g., the GCP vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the GCP vault should be resurrected for\nwhen they cannot be refreshed (e.g., the\nGCP vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "vault_hcv_protocol": {
     "defaultValue": "http",
-    "description": "The protocol to connect with. Accepts one of `http` or `https`."
+    "description": "The protocol to connect with. Accepts one of\n`http` or `https`.\n"
   },
   "vault_hcv_host": {
     "defaultValue": "127.0.0.1",
-    "description": "The hostname of your HashiCorp vault."
+    "description": "The hostname of your HashiCorp vault.\n"
   },
   "vault_hcv_port": {
     "defaultValue": "8200",
-    "description": "The port number of your HashiCorp vault."
+    "description": "The port number of your HashiCorp vault.\n"
   },
   "vault_hcv_namespace": {
     "defaultValue": null,
-    "description": "Namespace for the HashiCorp Vault. Vault Enterprise requires a namespace to successfully connect to it."
+    "description": "Namespace for the HashiCorp Vault. Vault\nEnterprise requires a namespace to\nsuccessfully connect to it.\n"
   },
   "vault_hcv_mount": {
     "defaultValue": "secret",
-    "description": "The mount point."
+    "description": "The mount point.\n"
   },
   "vault_hcv_kv": {
     "defaultValue": "v1",
-    "description": "The secrets engine version. Accepts `v1` or `v2`."
+    "description": "The secrets engine version. Accepts `v1` or\n`v2`.\n"
   },
   "vault_hcv_token": {
     "defaultValue": null,
-    "description": "A token string."
+    "description": "A token string.\n"
   },
   "vault_hcv_auth_method": {
     "defaultValue": "token",
-    "description": "Defines the authentication mechanism when connecting to the Hashicorp Vault service. Accepted values are: `token`, `kubernetes` or `approle`."
+    "description": "Defines the authentication mechanism when\nconnecting to the Hashicorp Vault service.\nAccepted values are: `token`,\n`kubernetes` or `approle`.\n"
   },
   "vault_hcv_kube_role": {
     "defaultValue": null,
-    "description": "Defines the HashiCorp Vault role for the Kubernetes service account of the running pod. `vault_hcv_auth_method` must be set to `kubernetes` for this to activate."
+    "description": "Defines the HashiCorp Vault role for the\nKubernetes service account of the running\npod. `vault_hcv_auth_method` must be\nset to `kubernetes` for this to activate.\n"
   },
   "vault_hcv_kube_auth_path": {
     "defaultValue": "kubernetes",
-    "description": " Place where the Kubernetes auth method will be accessible: /v1/auth/<vault_hcv_kube_auth_path>"
+    "description": "Place where the Kubernetes auth method will be\naccessible: /v1/auth/<vault_hcv_kube_auth_path>\n"
   },
   "vault_hcv_kube_api_token_file": {
     "defaultValue": null,
-    "description": "Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+    "description": "Defines where the Kubernetes service account\ntoken should be read from the pod's\nfilesystem, if using a non-standard\ncontainer platform setup.\n"
   },
   "vault_hcv_approle_auth_path": {
     "defaultValue": "approle",
-    "description": " Place where the Approle auth method will be accessible: /v1/auth/<vault_hcv_approle_auth_path>"
+    "description": "Place where the Approle auth method will be\naccessible: /v1/auth/<vault_hcv_approle_auth_path>\n"
   },
   "vault_hcv_approle_role_id": {
     "defaultValue": null,
-    "description": "The Role ID of the Approle in HashiCorp Vault."
+    "description": "The Role ID of the Approle in HashiCorp Vault.\n"
   },
   "vault_hcv_approle_secret_id": {
     "defaultValue": null,
-    "description": "The Secret ID of the Approle in HashiCorp Vault."
+    "description": "The Secret ID of the Approle in HashiCorp Vault.\n"
   },
   "vault_hcv_approle_secret_id_file": {
     "defaultValue": null,
-    "description": "Defines where the Secret ID should be read from the pod's filesystem. This is usually used with HashiCorp Vault's response wrapping."
+    "description": "Defines where the Secret ID should be read from\nthe pod's filesystem. This is usually used with\nHashiCorp Vault's response wrapping.\n"
   },
   "vault_hcv_approle_response_wrapping": {
     "defaultValue": "false",
-    "description": "Defines whether the Secret ID read from configuration or file is actually a response-wrapping token instead of a real Secret ID."
+    "description": "Defines whether the Secret ID read from configuration\nor file is actually a response-wrapping token instead\nof a real Secret ID.\n"
   },
   "vault_hcv_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the HashiCorp vault when cached by this node.  HashiCorp vault misses (no secret) are also cached according to this setting if you do not configure `vault_hcv_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe HashiCorp vault when cached by this node.\n\nHashiCorp vault misses (no secret) are also\ncached according to this setting if you do not\nconfigure `vault_hcv_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_hcv_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a HashiCorp vault miss (no secret).  If not specified (default), `vault_hcv_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a HashiCorp vault\nmiss (no secret).\n\nIf not specified (default), `vault_hcv_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_hcv_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the HashiCorp vault should be resurrected for when they cannot be refreshed (e.g., the HashiCorp vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the HashiCorp vault should be resurrected\nfor when they cannot be refreshed (e.g., the\nHashiCorp vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "vault_azure_vault_uri": {
     "defaultValue": null,
-    "description": "The URI the vault is reachable from."
+    "description": "The URI the vault is reachable from.\n"
   },
   "vault_azure_client_id": {
     "defaultValue": null,
-    "description": "The client ID from your registered Application. Visit your Azure Dashboard and select *App Registrations* to check your client ID."
+    "description": "The client ID from your registered Application. Visit your Azure Dashboard and select *App Registrations* to check your client ID.\n"
   },
   "vault_azure_tenant_id": {
     "defaultValue": null,
-    "description": "The DirectoryId and TenantId both equate to the GUID representing the ActiveDirectory Tenant. Depending on context, either term may be used by Microsoft documentation and products, which can be confusing. In other words, the \"Tenant ID\" IS the \"Directory ID\""
+    "description": "The DirectoryId and TenantId both equate to the GUID representing the ActiveDirectory Tenant. Depending on context, either term may be used by Microsoft documentation and products, which can be confusing. In other words, the \"Tenant ID\" IS the \"Directory ID\"\n"
   },
   "vault_azure_type": {
     "defaultValue": "secrets",
-    "description": "Azure Key Vault enables Microsoft Azure applications and users to store and use several types of secret/key data: keys, secrets, and certificates. Kong currently only supports the `Secrets`"
+    "description": "Azure Key Vault enables Microsoft Azure applications and users to store and use several types of secret/key data: keys, secrets, and certificates. Kong currently only supports the `Secrets`\n"
   },
   "vault_azure_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the Azure Key Vault when cached by this node.  Key Vault misses (no secret) are also cached according to this setting if you do not configure `vault_azure_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe Azure Key Vault when cached by this node.\n\nKey Vault misses (no secret) are also\ncached according to this setting if you do not\nconfigure `vault_azure_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_azure_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a Azure Key Vault miss (no secret).  If not specified (default), `vault_azure_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a Azure Key Vault\nmiss (no secret).\n\nIf not specified (default), `vault_azure_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_azure_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the Azure Key Vault should be resurrected for when they cannot be refreshed (e.g., the the vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the Azure Key Vault should be resurrected\nfor when they cannot be refreshed (e.g., the\nthe vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "worker_consistency": {
     "defaultValue": "eventual",
-    "description": " Defines whether this node should rebuild its state synchronously or asynchronously (the balancers and the router are rebuilt on updates that affects them, e.g., updates to Routes, Services or Upstreams, via the Admin API or loading a declarative configuration file). (This option is deprecated and will be removed in future releases. The new default is `eventual`.)  Accepted values are:  - `strict`: the router will be rebuilt   synchronously, causing incoming requests to   be delayed until the rebuild is finished.   (This option is deprecated and will be removed    in future releases. The new default is `eventual`) - `eventual`: the router will be rebuilt   asynchronously via a recurring background   job running every second inside of each   worker.  Note that `strict` ensures that all workers of a given node will always proxy requests with an identical router, but that increased long tail latency can be observed if frequent Routes and Services updates are expected. Using `eventual` will help preventing long tail latency issues in such cases, but may cause workers to route requests differently for a short period of time after Routes and Services updates."
+    "description": "Defines whether this node should rebuild its\nstate synchronously or asynchronously (the\nbalancers and the router are rebuilt on\nupdates that affects them, e.g., updates to\nRoutes, Services or Upstreams, via the Admin\nAPI or loading a declarative configuration\nfile). (This option is deprecated and will be\nremoved in future releases. The new default\nis `eventual`.)\n\nAccepted values are:\n\n- `strict`: the router will be rebuilt\n  synchronously, causing incoming requests to\n  be delayed until the rebuild is finished.\n  (This option is deprecated and will be removed\n   in future releases. The new default is `eventual`)\n- `eventual`: the router will be rebuilt\n  asynchronously via a recurring background\n  job running every second inside of each\n  worker.\n\nNote that `strict` ensures that all workers\nof a given node will always proxy requests\nwith an identical router, but that increased\nlong tail latency can be observed if\nfrequent Routes and Services updates are\nexpected.\nUsing `eventual` will help preventing long\ntail latency issues in such cases, but may\ncause workers to route requests differently\nfor a short period of time after Routes and\nServices updates.\n"
   },
   "worker_state_update_frequency": {
     "defaultValue": "5",
-    "description": " Defines how often the worker state changes are checked with a background job. When a change is detected, a new router or balancer will be built, as needed. Raising this value will decrease the load on database servers and result in less jitter in proxy latency, but it might take more time to propagate changes to each individual worker."
+    "description": "Defines how often the worker state changes are\nchecked with a background job. When a change\nis detected, a new router or balancer will be\nbuilt, as needed. Raising this value will\ndecrease the load on database servers and\nresult in less jitter in proxy latency, but\nit might take more time to propagate changes\nto each individual worker.\n"
   },
   "router_flavor": {
     "defaultValue": "traditional_compatible",
-    "description": " Selects the router implementation to use when performing request routing. Incremental router rebuild is available when the flavor is set to either `expressions` or `traditional_compatible` which could significantly shorten rebuild time for large number of routes.  Accepted values are:  - `traditional_compatible`: the DSL based expression   router engine will be used under the hood. However   the router config interface will be the same   as `traditional` and expressions are   automatically generated at router build time.   The `expression` field on the `Route` object   is not visible. - `expressions`: the DSL based expression router engine   will be used under the hood. Traditional router   config interface is not visible and you must write   Router Expression manually and provide them in the   `expression` field on the `Route` object. - `traditional`: the pre-3.0 Router engine will be   used. Config interface will be the same as   pre-3.0 Kong and the `expression` field on the   `Route` object is not visible.    Deprecation warning: In Kong 3.0, `traditional`   mode should be avoided and only be used in case   `traditional_compatible` did not work as expected.   This flavor of router will be removed in the next   major release of Kong."
+    "description": "Selects the router implementation to use when\nperforming request routing. Incremental router\nrebuild is available when the flavor is set\nto either `expressions` or\n`traditional_compatible` which could\nsignificantly shorten rebuild time for large\nnumber of routes.\n\nAccepted values are:\n\n- `traditional_compatible`: the DSL based expression\n  router engine will be used under the hood. However\n  the router config interface will be the same\n  as `traditional` and expressions are\n  automatically generated at router build time.\n  The `expression` field on the `Route` object\n  is not visible.\n- `expressions`: the DSL based expression router engine\n  will be used under the hood. Traditional router\n  config interface is not visible and you must write\n  Router Expression manually and provide them in the\n  `expression` field on the `Route` object.\n- `traditional`: the pre-3.0 Router engine will be\n  used. Config interface will be the same as\n  pre-3.0 Kong and the `expression` field on the\n  `Route` object is not visible.\n\n  Deprecation warning: In Kong 3.0, `traditional`\n  mode should be avoided and only be used in case\n  `traditional_compatible` did not work as expected.\n  This flavor of router will be removed in the next\n  major release of Kong.\n"
   },
   "lua_max_req_headers": {
     "defaultValue": "100",
-    "description": "Maximum number of request headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying the Kong sends all the request headers and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many request headers."
+    "description": "Maximum number of request headers to parse by default.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying the Kong sends all the request headers\nand this setting does not have any effect. It is used\nto limit Kong and its plugins from reading too many\nrequest headers.\n"
   },
   "lua_max_resp_headers": {
     "defaultValue": "100",
-    "description": "Maximum number of response headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong returns all the response headers and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many response headers."
+    "description": "Maximum number of response headers to parse by default.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong returns all the response headers\nand this setting does not have any effect. It is used\nto limit Kong and its plugins from reading too many\nresponse headers.\n"
   },
   "lua_max_uri_args": {
     "defaultValue": "100",
-    "description": "Maximum number of request uri arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request query arguments and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many query arguments."
+    "description": "Maximum number of request uri arguments to parse by\ndefault.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request query\narguments and this setting does not have any effect.\nIt is used to limit Kong and its plugins from reading\ntoo many query arguments.\n"
   },
   "lua_max_post_args": {
     "defaultValue": "100",
-    "description": "Maximum number of request post arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request post arguments and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many post arguments."
+    "description": "Maximum number of request post arguments to parse by\ndefault.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request post\narguments and this setting does not have any effect.\nIt is used to limit Kong and its plugins from reading\ntoo many post arguments.\n"
   },
   "lua_ssl_trusted_certificate": {
     "defaultValue": "system",
-    "description": "Comma-separated list of certificate authorities for Lua cosockets in PEM format.  The special value `system` attempts to search for the \"usual default\" provided by each distro, according to an arbitrary heuristic. In the current implementation, The following pathnames will be tested in order, and the first one found will be used:  - /etc/ssl/certs/ca-certificates.crt (Debian/Ubuntu/Gentoo) - /etc/pki/tls/certs/ca-bundle.crt (Fedora/RHEL 6) - /etc/ssl/ca-bundle.pem (OpenSUSE) - /etc/pki/tls/cacert.pem (OpenELEC) - /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem (CentOS/RHEL 7) - /etc/ssl/cert.pem (OpenBSD, Alpine)  `system` can be used by itself or in conjunction with other CA filepaths.  When `pg_ssl_verify` is enabled, these certificate authority files will be used for verifying Kong's database connections.  Certificates can be configured on this property with either of the following values: * `system` * absolute path to the certificate * certificate content * base64 encoded certificate content  See https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate"
+    "description": "Comma-separated list of certificate authorities\nfor Lua cosockets in PEM format.\n\nThe special value `system` attempts to search for the\n\"usual default\" provided by each distro, according\nto an arbitrary heuristic. In the current implementation,\nThe following pathnames will be tested in order,\nand the first one found will be used:\n\n- /etc/ssl/certs/ca-certificates.crt (Debian/Ubuntu/Gentoo)\n- /etc/pki/tls/certs/ca-bundle.crt (Fedora/RHEL 6)\n- /etc/ssl/ca-bundle.pem (OpenSUSE)\n- /etc/pki/tls/cacert.pem (OpenELEC)\n- /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem (CentOS/RHEL 7)\n- /etc/ssl/cert.pem (OpenBSD, Alpine)\n\n`system` can be used by itself or in conjunction with other\nCA filepaths.\n\nWhen `pg_ssl_verify` is enabled, these\ncertificate authority files will be\nused for verifying Kong's database connections.\n\nCertificates can be configured on this property\nwith either of the following values:\n* `system`\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n\nSee https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate\n"
   },
   "lua_ssl_verify_depth": {
     "defaultValue": "1",
-    "description": "Sets the verification depth in the server certificates chain used by Lua cosockets, set by `lua_ssl_trusted_certificate`. This includes the certificates configured for Kong's database connections. If the maximum depth is reached before reaching the end of the chain, verification will fail. This helps mitigate certificate based DoS attacks.  See https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth"
+    "description": "Sets the verification depth in the server\ncertificates chain used by Lua cosockets,\nset by `lua_ssl_trusted_certificate`.\nThis includes the certificates configured\nfor Kong's database connections.\nIf the maximum depth is reached before\nreaching the end of the chain, verification\nwill fail. This helps mitigate certificate\nbased DoS attacks.\n\nSee https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth\n"
   },
   "lua_ssl_protocols": {
     "defaultValue": "TLSv1.2 TLSv1.3",
-    "description": "Defines the TLS versions supported when handshaking with OpenResty's TCP cosocket APIs.  This affects connections made by Lua code, such as connections to the database Kong uses, or when sending logs using a logging plugin. It does *not* affect connections made to the upstream Service or from downstream clients."
+    "description": "Defines the TLS versions supported\nwhen handshaking with OpenResty's\nTCP cosocket APIs.\n\nThis affects connections made by Lua\ncode, such as connections to the\ndatabase Kong uses, or when sending logs\nusing a logging plugin. It does *not*\naffect connections made to the upstream\nService or from downstream clients.\n"
   },
   "lua_package_path": {
     "defaultValue": "./?.lua;./?/init.lua;",
-    "description": "Sets the Lua module search path (LUA_PATH). Useful when developing or using custom plugins not stored in the default search path.  See https://github.com/openresty/lua-nginx-module#lua_package_path"
+    "description": "Sets the Lua module search path\n(LUA_PATH). Useful when developing\nor using custom plugins not stored\nin the default search path.\n\nSee https://github.com/openresty/lua-nginx-module#lua_package_path\n"
   },
   "lua_package_cpath": {
     "defaultValue": null,
-    "description": "Sets the Lua C module search path (LUA_CPATH).  See https://github.com/openresty/lua-nginx-module#lua_package_cpath"
+    "description": "Sets the Lua C module search path\n(LUA_CPATH).\n\nSee https://github.com/openresty/lua-nginx-module#lua_package_cpath\n"
   },
   "lua_socket_pool_size": {
     "defaultValue": "256",
-    "description": "Specifies the size limit for every cosocket connection pool associated with every remote server.  See https://github.com/openresty/lua-nginx-module#lua_socket_pool_size"
+    "description": "Specifies the size limit for every cosocket\nconnection pool associated with every remote\nserver.\n\nSee https://github.com/openresty/lua-nginx-module#lua_socket_pool_size\n"
   },
   "enforce_rbac": {
     "defaultValue": "off",
-    "description": "Specifies whether Admin API RBAC is enforced. Accepts one of `entity`, `both`, `on`, or `off`.  - `on`: only endpoint-level authorization   is enforced. - `entity`: entity-level authorization   applies. - `both`: enables both endpoint and   entity-level authorization. - `off`: disables both endpoint and   entity-level authorization.  When enabled, Kong will deny requests to the Admin API when a nonexistent or invalid RBAC authorization token is passed, or the RBAC user with which the token is associated does not have permissions to access/modify the requested resource."
+    "description": "Specifies whether Admin API RBAC is enforced.\nAccepts one of `entity`, `both`, `on`, or\n`off`.\n\n- `on`: only endpoint-level authorization\n  is enforced.\n- `entity`: entity-level authorization\n  applies.\n- `both`: enables both endpoint and\n  entity-level authorization.\n- `off`: disables both endpoint and\n  entity-level authorization.\n\nWhen enabled, Kong will deny requests to the\nAdmin API when a nonexistent or invalid RBAC\nauthorization token is passed, or the RBAC\nuser with which the token is associated does\nnot have permissions to access/modify the\nrequested resource.\n"
   },
   "rbac_auth_header": {
     "defaultValue": "Kong-Admin-Token",
-    "description": "Defines the name of the HTTP request header from which the Admin API will attempt to authenticate the RBAC user."
+    "description": "Defines the name of the HTTP request\nheader from which the Admin API will\nattempt to authenticate the RBAC user.\n"
   },
   "event_hooks_enabled": {
     "defaultValue": "on",
-    "description": "When enabled, event hook entities represent a relationship between an event (source and event) and an action (handler). Similar to web hooks, event hooks can be used to communicate Kong Gateway service events. When a particular event happens on a service, the event hook calls a URL with information about that event. Event hook configurations differ depending on the handler. The events that are triggered send associated data.  See: https://docs.konghq.com/enterprise/latest/admin-api/event-hooks/reference/"
+    "description": "When enabled, event hook entities represent a relationship\nbetween an event (source and event) and an action\n(handler). Similar to web hooks, event hooks can be used to\ncommunicate Kong Gateway service events. When a particular\nevent happens on a service, the event hook calls a URL with\ninformation about that event. Event hook configurations\ndiffer depending on the handler. The events that are\ntriggered send associated data.\n\nSee: https://docs.konghq.com/enterprise/latest/admin-api/event-hooks/reference/\n"
   },
   "fips": {
     "defaultValue": "off",
-    "description": "Turn on FIPS mode; this mode is only available on a FIPS build."
+    "description": "Turn on FIPS mode; this mode is only available on a FIPS build.\n"
   },
   "admin_gui_listen": {
     "defaultValue": [
       "0.0.0.0:8002",
       "0.0.0.0:8445 ssl"
     ],
-    "description": " Kong Manager Listeners  Comma-separated list of addresses and ports on which Kong will expose Kong Manager. This web application lets you configure and manage Kong, and therefore should be kept secured.  Suffixes can be specified for each pair, similarly to the `admin_listen` directive."
+    "description": "Kong Manager Listeners\n\nComma-separated list of addresses and ports on which\nKong will expose Kong Manager. This web application\nlets you configure and manage Kong, and therefore\nshould be kept secured.\n\nSuffixes can be specified for each pair, similarly to\nthe `admin_listen` directive.\n"
   },
   "admin_gui_url": {
     "defaultValue": null,
-    "description": "Kong Manager URL  The lookup, or balancer, address for Kong Manager.  Accepted format (items in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>)`  Examples:  - `http://127.0.0.1:8003` - `https://kong-admin.test` - `http://dev-machine`  By default, Kong Manager will use the window request host and append the resolved listener port depending on the requested protocol."
+    "description": "Kong Manager URL\n\nThe lookup, or balancer, address for Kong Manager.\n\nAccepted format (items in parentheses are optional):\n\n  `<scheme>://<IP / HOSTNAME>(:<PORT>)`\n\nExamples:\n\n- `http://127.0.0.1:8003`\n- `https://kong-admin.test`\n- `http://dev-machine`\n\nBy default, Kong Manager will use the window request\nhost and append the resolved listener port depending\non the requested protocol.\n"
   },
   "admin_gui_path": {
     "defaultValue": "/",
-    "description": "Kong Manager base path  This configuration parameter allows the user to customize the path prefix where Kong Manager is served. When updating this parameter, it's recommended to update the path in `admin_gui_url` as well.  Accepted format:  - Path must start with a `/` - Path must not end with a `/` (except for the `/`) - Path can only contain letters, digits, hyphens (`-`), underscores (`_`), and slashes (`/`) - Path must not contain continuous slashes (e.g., `//` and `///`)  Examples:  - `/` - `/manager` - `/kong-manager` - `/kong/manager`"
+    "description": "Kong Manager base path\n\nThis configuration parameter allows the user to customize\nthe path prefix where Kong Manager is served. When updating\nthis parameter, it's recommended to update the path in `admin_gui_url`\nas well.\n\nAccepted format:\n\n- Path must start with a `/`\n- Path must not end with a `/` (except for the `/`)\n- Path can only contain letters, digits, hyphens (`-`),\nunderscores (`_`), and slashes (`/`)\n- Path must not contain continuous slashes (e.g., `//` and `///`)\n\nExamples:\n\n- `/`\n- `/manager`\n- `/kong-manager`\n- `/kong/manager`\n"
   },
   "admin_gui_api_url": {
     "defaultValue": null,
-    "description": "Hierarchical part of a URI which is composed optionally of a host, port, and path at which the Admin API accepts HTTP or HTTPS traffic. When this config is disabled, Kong Manager will use the window protocol + host and append the resolved admin_listen HTTP/HTTPS port."
+    "description": "Hierarchical part of a URI which is composed\noptionally of a host, port, and path at which the\nAdmin API accepts HTTP or HTTPS traffic. When\nthis config is disabled, Kong Manager will\nuse the window protocol + host and append the\nresolved admin_listen HTTP/HTTPS port.\n"
   },
   "admin_gui_ssl_protocols": {
     "defaultValue": "TLSv1.2 TLSv1.3",
-    "description": " Defines the TLS versions supported for Kong Manager"
+    "description": "Defines the TLS versions supported\nfor Kong Manager\n"
   },
   "admin_gui_ssl_cert": {
     "defaultValue": null,
-    "description": "The SSL certificate for `admin_gui_listen` values with SSL enabled.  values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "The SSL certificate for `admin_gui_listen` values\nwith SSL enabled.\n\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "admin_gui_ssl_cert_key": {
     "defaultValue": null,
-    "description": "The SSL key for `admin_gui_listen` values with SSL enabled.  values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+    "description": "The SSL key for `admin_gui_listen` values with SSL\nenabled.\n\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n"
   },
   "admin_gui_flags": {
     "defaultValue": "{}",
-    "description": " Alters the layout Admin GUI (JSON) The only supported value is `{ \"IMMUNITY_ENABLED\": true }` to enable Kong Immunity in the Admin GUI."
+    "description": "Alters the layout Admin GUI (JSON)\nThe only supported value is `{ \"IMMUNITY_ENABLED\": true }`\nto enable Kong Immunity in the Admin GUI.\n"
   },
   "admin_gui_access_log": {
     "defaultValue": "logs/admin_gui_access.log",
-    "description": " Kong Manager Access Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables access logs for Kong Manager."
+    "description": "Kong Manager Access Logs\n\nHere you can set an absolute or relative path for Kong\nManager access logs. When the path is relative,\nlogs are placed in the `prefix` location.\n\nSetting this value to `off` disables access logs\nfor Kong Manager.\n"
   },
   "admin_gui_error_log": {
     "defaultValue": "logs/admin_gui_error.log",
-    "description": " Kong Manager Error Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables error logs for Kong Manager.  Granularity can be adjusted through the `log_level` directive."
+    "description": "Kong Manager Error Logs\n\nHere you can set an absolute or relative path for Kong\nManager access logs. When the path is relative,\nlogs are placed in the `prefix` location.\n\nSetting this value to `off` disables error logs for\nKong Manager.\n\nGranularity can be adjusted through the `log_level`\ndirective.\n"
   },
   "admin_gui_auth": {
     "defaultValue": null,
-    "description": "Kong Manager Authentication Plugin Name  Secures access to Kong Manager by specifying an authentication plugin to use.  Supported Plugins:  - `basic-auth`: Basic Authentication plugin - `ldap-auth-advanced`: LDAP Authentication plugin - `openid-connect`: OpenID Connect Authentication   plugin"
+    "description": "Kong Manager Authentication Plugin Name\n\nSecures access to Kong Manager by specifying an\nauthentication plugin to use.\n\nSupported Plugins:\n\n- `basic-auth`: Basic Authentication plugin\n- `ldap-auth-advanced`: LDAP Authentication plugin\n- `openid-connect`: OpenID Connect Authentication\n  plugin\n"
   },
   "admin_gui_auth_conf": {
     "defaultValue": null,
-    "description": "Kong Manager Authentication Plugin Config (JSON)  Specifies the configuration for the authentication plugin specified in `admin_gui_auth`.  For information about Plugin Configuration consult the associated plugin documentation.  Example for `basic-auth`:  `admin_gui_auth_conf = { \"hide_credentials\": true }`"
+    "description": "Kong Manager Authentication Plugin Config (JSON)\n\nSpecifies the configuration for the authentication\nplugin specified in `admin_gui_auth`.\n\nFor information about Plugin Configuration\nconsult the associated plugin documentation.\n\nExample for `basic-auth`:\n\n`admin_gui_auth_conf = { \"hide_credentials\": true }`\n"
   },
   "admin_gui_auth_password_complexity": {
     "defaultValue": null,
-    "description": "Kong Manager Authentication Password Complexity (JSON)  When `admin_gui_auth = basic-auth`, this property defines the rules required for Kong Manager passwords. Choose from preset rules or write your own.  Example using preset rules:  `admin_gui_auth_password_complexity = { \"kong-preset\": \"min_8\" }`  All values for kong-preset require the password to contain characters from at least three of the following categories:  1. Uppercase characters (A through Z)  2. Lowercase characters (a through z)  3. Base-10 digits (0 through 9)  4. Special characters (for example, &, $, #, %)  Supported preset rules: - `min_8`: minimum length of 8 - `min_12`: minimum length of 12 - `min_20`: minimum length of 20  To write your own rules, see https://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.  NOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.  Example:  `admin_gui_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`"
+    "description": "Kong Manager Authentication Password Complexity (JSON)\n\nWhen `admin_gui_auth = basic-auth`, this property defines\nthe rules required for Kong Manager passwords. Choose\nfrom preset rules or write your own.\n\nExample using preset rules:\n\n`admin_gui_auth_password_complexity = { \"kong-preset\": \"min_8\" }`\n\nAll values for kong-preset require the password to contain\ncharacters from at least three of the following categories:\n\n1. Uppercase characters (A through Z)\n\n2. Lowercase characters (a through z)\n\n3. Base-10 digits (0 through 9)\n\n4. Special characters (for example, &, $, #, %)\n\nSupported preset rules:\n- `min_8`: minimum length of 8\n- `min_12`: minimum length of 12\n- `min_20`: minimum length of 20\n\nTo write your own rules, see\nhttps://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.\n\nNOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.\n\nExample:\n\n`admin_gui_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`\n"
   },
   "admin_gui_session_conf": {
     "defaultValue": null,
-    "description": "Kong Manager Session Config (JSON)  Specifies the configuration for the Session plugin as used by Kong Manager.  For information about plugin configuration, consult the Kong Session plugin documentation.  Example: ``` admin_gui_session_conf = { \"cookie_name\": \"kookie\", \\                            \"secret\": \"changeme\" } ```"
+    "description": "Kong Manager Session Config (JSON)\n\nSpecifies the configuration for the Session plugin as\nused by Kong Manager.\n\nFor information about plugin configuration, consult\nthe Kong Session plugin documentation.\n\nExample:\n```\nadmin_gui_session_conf = { \"cookie_name\": \"kookie\", \\\n                           \"secret\": \"changeme\" }\n```\n"
   },
   "admin_gui_auth_header": {
     "defaultValue": "Kong-Admin-User",
-    "description": " Defines the name of the HTTP request header from which the Admin API will attempt to identify the Kong Admin user."
+    "description": "Defines the name of the HTTP request header from which\nthe Admin API will attempt to identify the Kong Admin\nuser.\n"
   },
   "admin_gui_auth_login_attempts": {
     "defaultValue": "0",
-    "description": " Number of times a user can attempt to login to Kong Manager. 0 means infinite attempts allowed."
+    "description": "Number of times a user can attempt to login to Kong\nManager. 0 means infinite attempts allowed.\n"
   },
   "admin_gui_header_txt": {
     "defaultValue": null,
-    "description": "Kong Manager Header Text Sets text for Kong Manager Header Banner. Header Banner is not shown if this config is empty."
+    "description": "Kong Manager Header Text\nSets text for Kong Manager Header Banner. Header Banner\nis not shown if this config is empty.\n"
   },
   "admin_gui_header_bg_color": {
     "defaultValue": null,
-    "description": "Kong Manager Header Background Color Sets background color for Kong Manager Header Banner Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Manager."
+    "description": "Kong Manager Header Background Color\nSets background color for Kong Manager Header Banner\nAccepts css color keyword, #-hexadecimal or rgb\nformat. Invalid values are ignored by Manager.\n"
   },
   "admin_gui_header_txt_color": {
     "defaultValue": null,
-    "description": "Kong Manager Header Text Color Sets text color for Kong Manager Header Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Kong Manager."
+    "description": "Kong Manager Header Text Color\nSets text color for Kong Manager Header Banner.\nAccepts css color keyword, #-hexadecimal or rgb\nformat. Invalid values are ignored by Kong Manager.\n"
   },
   "admin_gui_footer_txt": {
     "defaultValue": null,
-    "description": "Kong Manager Footer Text Sets text for Kong Manager Footer Banner. Footer Banner is not shown if this config is empty"
+    "description": "Kong Manager Footer Text\nSets text for Kong Manager Footer Banner. Footer Banner\nis not shown if this config is empty\n"
   },
   "admin_gui_footer_bg_color": {
     "defaultValue": null,
-    "description": "Kong Manager Footer Background Color Sets background color for Kong Manager Footer Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Manager."
+    "description": "Kong Manager Footer Background Color\nSets background color for Kong Manager Footer Banner.\nAccepts css color keyword, #-hexadecimal or rgb\nformat. Invalid values are ignored by Manager.\n"
   },
   "admin_gui_footer_txt_color": {
     "defaultValue": null,
-    "description": "Kong Manager Footer Text Color Sets text color for Kong Manager Footer Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Kong Manager."
+    "description": "Kong Manager Footer Text Color\nSets text color for Kong Manager Footer Banner.\nAccepts css color keyword, #-hexadecimal or rgb\nformat. Invalid values are ignored by Kong Manager.\n"
   },
   "admin_gui_login_banner_title": {
     "defaultValue": null,
-    "description": "Kong Manager Login Banner Title Text Sets title text for Kong Manager Login Banner. Login Banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+    "description": "Kong Manager Login Banner Title Text\nSets title text for Kong Manager Login Banner.\nLogin Banner is not shown if both\n`admin_gui_login_banner_title` and\n`admin_gui_login_banner_body` are empty.\n"
   },
   "admin_gui_login_banner_body": {
     "defaultValue": null,
-    "description": "Kong Manager Login Banner Body Text Sets body text for Kong Manager Login Banner. Login Banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+    "description": "Kong Manager Login Banner Body Text\nSets body text for Kong Manager Login Banner.\nLogin Banner is not shown if both\n`admin_gui_login_banner_title` and\n`admin_gui_login_banner_body` are empty.\n"
   },
   "konnect_mode": {
     "defaultValue": "off",
-    "description": "When enabled, the dataplane is connected to Konnect"
+    "description": "When enabled, the dataplane is connected to Konnect\n"
   },
   "analytics_flush_interval": {
     "defaultValue": "1",
-    "description": "Determine the frequency of flushing local data to Konnect in seconds."
+    "description": "Determine the frequency of flushing local data\nto Konnect in seconds.\n"
   },
   "analytics_buffer_size_limit": {
     "defaultValue": "100000",
-    "description": "Max number of messages can be buffered locally before dropping data in case there is no network connection to Konnect."
+    "description": "Max number of messages can be buffered locally\nbefore dropping data in case there is no\nnetwork connection to Konnect.\n"
   },
   "analytics_debug": {
     "defaultValue": "off",
-    "description": "Outputs analytics payload to Kong logs."
+    "description": "Outputs analytics payload to Kong logs.\n"
   },
   "admin_emails_from": {
     "defaultValue": "\"\"",
-    "description": "The email address for the `From` header for admin emails."
+    "description": "The email address for the `From` header\nfor admin emails.\n"
   },
   "admin_emails_reply_to": {
     "defaultValue": null,
-    "description": "Email address for the `Reply-To` header for admin emails."
+    "description": "Email address for the `Reply-To` header\nfor admin emails.\n"
   },
   "admin_invitation_expiry": {
     "defaultValue": "259200",
-    "description": "Expiration time for the admin invitation link (in seconds). 0 means no expiration.  Example, 72 hours: `72 * 60 * 60 = 259200`"
+    "description": "Expiration time for the admin invitation link\n(in seconds). 0 means no expiration.\n\nExample, 72 hours: `72 * 60 * 60 = 259200`\n"
   },
   "smtp_mock": {
     "defaultValue": "on",
-    "description": "This flag will mock the sending of emails. This can be used for testing before the SMTP client is fully configured."
+    "description": "This flag will mock the sending of emails. This can be\nused for testing before the SMTP client is fully\nconfigured.\n"
   },
   "smtp_host": {
     "defaultValue": "localhost",
-    "description": " The hostname of the SMTP server to connect to."
+    "description": "The hostname of the SMTP server to connect to.\n"
   },
   "smtp_port": {
     "defaultValue": "25",
-    "description": " The port number on the SMTP server to connect to."
+    "description": "The port number on the SMTP server to connect to.\n"
   },
   "smtp_starttls": {
     "defaultValue": "off",
-    "description": " When set to `on`, STARTTLS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 587."
+    "description": "When set to `on`, STARTTLS is used to encrypt\ncommunication with the SMTP server. This is normally\nused in conjunction with port 587.\n"
   },
   "smtp_username": {
     "defaultValue": null,
-    "description": "Username used for authentication with SMTP server"
+    "description": "Username used for authentication with SMTP server\n"
   },
   "smtp_password": {
     "defaultValue": null,
-    "description": "Password used for authentication with SMTP server"
+    "description": "Password used for authentication with SMTP server\n"
   },
   "smtp_ssl": {
     "defaultValue": "off",
-    "description": " When set to `on`, SMTPS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 465."
+    "description": "When set to `on`, SMTPS is used to encrypt\ncommunication with the SMTP server. This is normally\nused in conjunction with port 465.\n"
   },
   "smtp_auth_type": {
     "defaultValue": null,
-    "description": "The method used to authenticate with the SMTP server Valid options are `plain`, `login`, or `nil`"
+    "description": "The method used to authenticate with the SMTP server\nValid options are `plain`, `login`, or `nil`\n"
   },
   "smtp_domain": {
     "defaultValue": "localhost.localdomain",
-    "description": " The domain used in the `EHLO` connection and part of the `Message-ID` header"
+    "description": "The domain used in the `EHLO` connection and part of\nthe `Message-ID` header\n"
   },
   "smtp_timeout_connect": {
     "defaultValue": "60000",
-    "description": " The timeout (in milliseconds) for connecting to the SMTP server."
+    "description": "The timeout (in milliseconds) for connecting to the\nSMTP server.\n"
   },
   "smtp_timeout_send": {
     "defaultValue": "60000",
-    "description": " The timeout (in milliseconds) for sending data to the SMTP server."
+    "description": "The timeout (in milliseconds) for sending data to the\nSMTP server.\n"
   },
   "smtp_timeout_read": {
     "defaultValue": "60000",
-    "description": " The timeout (in milliseconds) for reading data from the SMTP server."
+    "description": "The timeout (in milliseconds) for reading data from\nthe SMTP server.\n"
   },
   "smtp_admin_emails": {
     "defaultValue": null,
-    "description": "Comma separated list of admin emails to receive notifications. Example `admin1@example.com, admin2@example.com`"
+    "description": "Comma separated list of admin emails to receive\nnotifications.\nExample `admin1@example.com, admin2@example.com`\n"
   },
   "audit_log": {
     "defaultValue": "off",
-    "description": "When enabled, Kong will log information about Admin API access and database row insertions, updates, and deletes."
+    "description": "When enabled, Kong will log information about\nAdmin API access and database row insertions,\nupdates, and deletes.\n"
   },
   "audit_log_ignore_methods": {
     "defaultValue": null,
-    "description": "Comma-separated list of HTTP methods that will not generate audit log entries. By default, all HTTP requests will be logged."
+    "description": "Comma-separated list of HTTP methods that\nwill not generate audit log entries. By\ndefault, all HTTP requests will be logged.\n"
   },
   "audit_log_ignore_paths": {
     "defaultValue": null,
-    "description": "Comma-separated list of request paths that will not generate audit log entries. By default, all HTTP requests will be logged."
+    "description": "Comma-separated list of request paths that\nwill not generate audit log entries. By\ndefault, all HTTP requests will be logged.\n"
   },
   "audit_log_ignore_tables": {
     "defaultValue": null,
-    "description": "Comma-separated list of database tables that will not generate audit log entries. By default, updates to all database tables will be logged (the term \"updates\" refers to the creation, update, or deletion of a row)."
+    "description": "Comma-separated list of database tables that\nwill not generate audit log entries. By\ndefault, updates to all database tables will\nbe logged (the term \"updates\" refers to the\ncreation, update, or deletion of a row).\n"
   },
   "audit_log_payload_exclude": {
     "defaultValue": [
@@ -1091,154 +1091,154 @@
       "secret",
       "password"
     ],
-    "description": " Comma-separated list of keys that will be filtered out of the payload. Keys that were filtered will be recorded in the audit log."
+    "description": "Comma-separated list of keys that will be\nfiltered out of the payload. Keys that were\nfiltered will be recorded in the audit log.\n"
   },
   "audit_log_record_ttl": {
     "defaultValue": "2592000",
-    "description": "Length, in seconds, of the TTL for audit log records. Records in the database older than their TTL are automatically purged.  Example, 30 days: `30 * 24 * 60 * 60 = 2592000`"
+    "description": "Length, in seconds, of the TTL for audit log\nrecords. Records in the database older than\ntheir TTL are automatically purged.\n\nExample, 30 days: `30 * 24 * 60 * 60 = 2592000`\n"
   },
   "audit_log_signing_key": {
     "defaultValue": null,
-    "description": "Defines the path to a private RSA signing key that can be used to insert a signature of audit records, adjacent to the record. The corresponding public key should be stored offline, and can be used the validate audit entries in the future. If this value is undefined, no signature will be generated."
+    "description": "Defines the path to a private RSA signing key\nthat can be used to insert a signature of\naudit records, adjacent to the record. The\ncorresponding public key should be stored\noffline, and can be used the validate audit\nentries in the future. If this value is\nundefined, no signature will be generated.\n"
   },
   "tracing": {
     "defaultValue": "off",
-    "description": "When enabled, Kong will generate granular debug data about various portions of the request lifecycle, such as DB or DNS queries, plugin execution, core handler timing, etc."
+    "description": "When enabled, Kong will generate granular\ndebug data about various portions of the\nrequest lifecycle, such as DB or DNS queries,\nplugin execution, core handler timing, etc.\n"
   },
   "tracing_write_strategy": {
     "defaultValue": "file",
-    "description": "Defines how Kong will write tracing data at the conclusion of the request. The default option, `file`, writes a human-readable depiction of tracing data to a configurable location on the node's file system. Other strategies write tracing data as a JSON document to the configured endpoint. Valid entries for this option are `file`, `file_raw`, `http`, `tcp`, `tls`, and `udp`."
+    "description": "Defines how Kong will write tracing data at\nthe conclusion of the request. The default\noption, `file`, writes a human-readable\ndepiction of tracing data to a configurable\nlocation on the node's file system. Other\nstrategies write tracing data as a JSON\ndocument to the configured endpoint. Valid\nentries for this option are `file`,\n`file_raw`, `http`, `tcp`, `tls`, and `udp`.\n"
   },
   "tracing_write_endpoint": {
     "defaultValue": null,
-    "description": "Defines the endpoint to which tracing data will be written.  - For the `file` and `file_raw` tracing write   strategies, this value must be a valid   location on the node's file system to which   Kong must have write access. - For the `tcp`, `tls`, and   `udp` strategies, this value is defined as a   string in the form of:  `<HOST>:<PORT>` - For the `http` strategy, this value is   defined in the form of:  `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`  Traces sent via HTTP are delivered via POST method with an `application/json` Content-Type."
+    "description": "Defines the endpoint to which tracing data\nwill be written.\n\n- For the `file` and `file_raw` tracing write\n  strategies, this value must be a valid\n  location on the node's file system to which\n  Kong must have write access.\n- For the `tcp`, `tls`, and\n  `udp` strategies, this value is defined as a\n  string in the form of:\n `<HOST>:<PORT>`\n- For the `http` strategy, this value is\n  defined in the form of:\n `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`\n\nTraces sent via HTTP are delivered via POST\nmethod with an `application/json`\nContent-Type.\n"
   },
   "tracing_time_threshold": {
     "defaultValue": "0",
-    "description": "The minimum time, in microseconds, over which a trace must execute in order to write the trace data to the configured endpoint. This configuration can be used to lower the noise present in trace data by removing trace objects that are not interesting from a timing perspective. The default value of `0` removes this limitation, causing traces of any duration to be written."
+    "description": "The minimum time, in microseconds, over which\na trace must execute in order to write the\ntrace data to the configured endpoint. This\nconfiguration can be used to lower the noise\npresent in trace data by removing trace\nobjects that are not interesting from a\ntiming perspective. The default value of `0`\nremoves this limitation, causing traces of\nany duration to be written.\n"
   },
   "tracing_types": {
     "defaultValue": "all",
-    "description": "Defines the types of traces that are written. Trace types not defined in this list are ignored, regardless of their lifetime. The default special value of `all` results in all trace types being written, regardless of type.  The following trace types are included:  - `query`: trace the database query - `legacy_query`: (deprecated) trace the    database query with legacy DAO - `router`: trace Kong routing the request;    internal routing time - `balancer`: trace the execution of the overall    balancer phase - `balancer.getPeer`: trace Kong selecting an    upstream peer from the ring-balancer - `balancer.toip`: trace balancer to resolve    peer's host to IP - `connect.toip`: trace cosocket to resolve    target's host to IP - `access.before`: trace the preprocessing of    access phase, like parameter parsing, route    matching, and balance preparation - `access.after`: trace the postprocess of    access phase, like balancer execution and    internal variable assigning - `plugin`: trace plugins phase handlers"
+    "description": "Defines the types of traces that are written.\nTrace types not defined in this list are\nignored, regardless of their lifetime. The\ndefault special value of `all` results in all\ntrace types being written, regardless of type.\n\nThe following trace types are included:\n\n- `query`: trace the database query\n- `legacy_query`: (deprecated) trace the\n   database query with legacy DAO\n- `router`: trace Kong routing the request;\n   internal routing time\n- `balancer`: trace the execution of the overall\n   balancer phase\n- `balancer.getPeer`: trace Kong selecting an\n   upstream peer from the ring-balancer\n- `balancer.toip`: trace balancer to resolve\n   peer's host to IP\n- `connect.toip`: trace cosocket to resolve\n   target's host to IP\n- `access.before`: trace the preprocessing of\n   access phase, like parameter parsing, route\n   matching, and balance preparation\n- `access.after`: trace the postprocess of\n   access phase, like balancer execution and\n   internal variable assigning\n- `plugin`: trace plugins phase handlers\n"
   },
   "tracing_debug_header": {
     "defaultValue": null,
-    "description": "Defines the name of the HTTP request header that must be present in order to generate traces within a request. Setting this value provides a mechanism to selectively generate request traces at the client's request. Note that the value of the header does not matter, only that the header is present in the request. When this value is not set and tracing is enabled, Kong will generate trace data for all requests flowing through the proxy and Admin API. Note that data from certificate handling phases is not logged when this setting is enabled."
+    "description": "Defines the name of the HTTP request header\nthat must be present in order to generate\ntraces within a request. Setting this value\nprovides a mechanism to selectively generate\nrequest traces at the client's request. Note\nthat the value of the header does not matter,\nonly that the header is present in the\nrequest. When this value is not set and\ntracing is enabled, Kong will generate trace\ndata for all requests flowing through the\nproxy and Admin API. Note that data from\ncertificate handling phases is not logged\nwhen this setting is enabled.\n"
   },
   "generate_trace_details": {
     "defaultValue": "off",
-    "description": "When enabled, Kong will write context- specific details into traces. Trace details offer more data about the context of the trace. This can significantly increase the size of trace reports. Note also that trace details may contain potentially sensitive information, such as raw SQL queries; care should be taken to store traces properly when this option is enabled."
+    "description": "When enabled, Kong will write context-\nspecific details into traces. Trace details\noffer more data about the context of the\ntrace. This can significantly increase the\nsize of trace reports. Note also that trace\ndetails may contain potentially sensitive\ninformation, such as raw SQL queries; care\nshould be taken to store traces properly when\nthis option is enabled.\n"
   },
   "route_validation_strategy": {
     "defaultValue": "smart",
-    "description": "The strategy used to validate routes when creating or updating them. Different strategies are available to tune how to enforce splitting traffic of workspaces. - `smart` is the default option and uses the   algorithm described in   https://docs.konghq.com/gateway/latest/admin-api/workspaces/examples/#important-note-conflicting-services-or-routes-in-workspaces. - `off` disables any check. - `path` enforces routes to comply with the pattern   described in config `enforce_route_path_pattern`. - `static` relies on the PostgreSQL database. Before creating a new route, it checks if the route is unique across all workspaces based on the following params: `paths`, `methods`, and `hosts`. If all fields of the new route overlap with an existing one, a 409 is returned with the route of the collision. The array order is not important for the overlap filter."
+    "description": "The strategy used to validate\nroutes when creating or updating them.\nDifferent strategies are available to tune\nhow to enforce splitting traffic of\nworkspaces.\n- `smart` is the default option and uses the\n  algorithm described in\n  https://docs.konghq.com/gateway/latest/admin-api/workspaces/examples/#important-note-conflicting-services-or-routes-in-workspaces.\n- `off` disables any check.\n- `path` enforces routes to comply with the pattern\n  described in config `enforce_route_path_pattern`.\n- `static` relies on the PostgreSQL database.\nBefore creating a new route, it checks if the\nroute is unique across all workspaces based on\nthe following params: `paths`, `methods`, and\n`hosts`. If all fields of the new route overlap\nwith an existing one, a 409 is returned with the\nroute of the collision. The array order is not\nimportant for the overlap filter.\n"
   },
   "enforce_route_path_pattern": {
     "defaultValue": null,
-    "description": "Specifies the Lua pattern which will be enforced on the `paths` attribute of a Route object. You can also add a placeholder for the workspace in the pattern, which will be rendered during runtime based on the workspace to which the `route` belongs. This setting is only relevant if `route_validation_strategy` is set to `path`.   Example For Pattern `/$(workspace)/v%d/.*` valid paths are:  1. `/group1/v1/` if route belongs to   workspace `group1`.  2. `/group2/v1/some_path` if route belongs to   workspace `group2`."
+    "description": "Specifies the Lua pattern which will\nbe enforced on the `paths` attribute of a\nRoute object. You can also add a placeholder\nfor the workspace in the pattern, which\nwill be rendered during runtime based on the\nworkspace to which the `route` belongs.\nThis setting is only relevant if\n`route_validation_strategy` is set to `path`.\n\n\nExample\nFor Pattern `/$(workspace)/v%d/.*` valid paths\nare:\n\n1. `/group1/v1/` if route belongs to\n  workspace `group1`.\n\n2. `/group2/v1/some_path` if route belongs to\n  workspace `group2`.\n"
   },
   "keyring_enabled": {
     "defaultValue": "off",
-    "description": "When enabled, Kong will encrypt sensitive field values before writing them to the database, and subsuquently decrypt them when retrieving data for the Admin API, Developer Portal, or proxy business logic. Symmetric encryption keys are managed based on the strategy defined below."
+    "description": "When enabled, Kong will encrypt sensitive\nfield values before writing them to the\ndatabase, and subsuquently decrypt them when\nretrieving data for the Admin API, Developer\nPortal, or proxy business logic. Symmetric\nencryption keys are managed based on the\nstrategy defined below.\n"
   },
   "keyring_strategy": {
     "defaultValue": "cluster",
-    "description": "Defines the strategy implementation by which Kong nodes will manage symmetric encryption keys. Please see the Kong Enterprise documentation for a detailed description of each strategies. Acceptable values for this option are 'cluster' and 'vault'."
+    "description": "Defines the strategy implementation by which\nKong nodes will manage symmetric encryption\nkeys. Please see the Kong Enterprise\ndocumentation for a detailed description of\neach strategies. Acceptable values for this\noption are 'cluster' and 'vault'.\n"
   },
   "keyring_public_key": {
     "defaultValue": null,
-    "description": "Defines the public key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  values: * absolute path to the public key * public key content * base64 encoded public key content"
+    "description": "Defines the public key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nvalues:\n* absolute path to the public key\n* public key content\n* base64 encoded public key content\n"
   },
   "keyring_private_key": {
     "defaultValue": null,
-    "description": "Defines the private key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  values: * absolute path to the private key * private key content * base64 encoded private key content"
+    "description": "Defines the private key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nvalues:\n* absolute path to the private key\n* private key content\n* base64 encoded private key content\n"
   },
   "keyring_blob_path": {
     "defaultValue": null,
-    "description": "Defines the filesystem path at which Kong will backup the initial keyring material. This option is useful largely for development purposes."
+    "description": "Defines the filesystem path at which Kong\nwill backup the initial keyring material.\nThis option is useful largely for development\npurposes.\n"
   },
   "keyring_vault_host": {
     "defaultValue": null,
-    "description": "Defines the Vault host at which Kong will fetch the encryption material. This value should be defined in the format:  `<scheme>://<IP / HOSTNAME>:<PORT>`"
+    "description": "Defines the Vault host at which Kong will\nfetch the encryption material. This value\nshould be defined in the format:\n\n`<scheme>://<IP / HOSTNAME>:<PORT>`\n"
   },
   "keyring_vault_mount": {
     "defaultValue": null,
-    "description": "Defines the name of the Vault v2 KV secrets engine at which symmetric keys are found."
+    "description": "Defines the name of the Vault v2 KV secrets\nengine at which symmetric keys are found.\n"
   },
   "keyring_vault_path": {
     "defaultValue": null,
-    "description": "Defines the names of the Vault v2 KV path at which symmetric keys are found."
+    "description": "Defines the names of the Vault v2 KV path\nat which symmetric keys are found.\n"
   },
   "keyring_vault_auth_method": {
     "defaultValue": "token",
-    "description": " Defines the authentication mechanism when connecting to the Hashicorp Vault service.  Accepted values are: `token`, or `kubernetes`:  * `token`: Uses the static token defined in            the `keyring_vault_token`            configuration property.  * `kubernetes`: Uses the Kubernetes authentication                 mechanism, with the running pod's                 mapped service account, to assume                 the Hashicorp Vault role name that is                 defined in the `keyring_vault_kube_role`                 configuration property."
+    "description": "Defines the authentication mechanism when\nconnecting to the Hashicorp Vault service.\n\nAccepted values are: `token`, or `kubernetes`:\n\n* `token`: Uses the static token defined in\n           the `keyring_vault_token`\n           configuration property.\n\n* `kubernetes`: Uses the Kubernetes authentication\n                mechanism, with the running pod's\n                mapped service account, to assume\n                the Hashicorp Vault role name that is\n                defined in the `keyring_vault_kube_role`\n                configuration property.\n"
   },
   "keyring_vault_token": {
     "defaultValue": null,
-    "description": "Defines the token value used to communicate with the v2 KV Vault HTTP(S) API."
+    "description": "Defines the token value used to communicate\nwith the v2 KV Vault HTTP(S) API.\n"
   },
   "keyring_vault_kube_role": {
     "defaultValue": "default",
-    "description": " Defines the Hashicorp Vault role that will be assumed using the Kubernetes service account of the running pod.  `keyring_vault_auth_method` must be set to `kubernetes` for this to activate."
+    "description": "Defines the Hashicorp Vault role that will be\nassumed using the Kubernetes service account of\nthe running pod.\n\n`keyring_vault_auth_method` must be set to `kubernetes`\nfor this to activate.\n"
   },
   "keyring_vault_kube_api_token_file": {
     "defaultValue": "/run/secrets/kubernetes.io/serviceaccount/token",
-    "description": " Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+    "description": "Defines where the Kubernetes service account token\nshould be read from the pod's filesystem, if using\na non-standard container platform setup.\n"
   },
   "untrusted_lua": {
     "defaultValue": "sandbox",
-    "description": " Controls loading of Lua functions from admin-supplied sources such as the Admin API. LuaJIT bytecode loading is always disabled.  **Warning:** LuaJIT is not designed as a secure runtime for running malicious code, therefore you should properly protect your Admin API endpoint even with sandboxing enabled. The sandbox only provides protection against trivial attackers or unintentional modification of the Kong global environment.  Accepted values are: `off`, `sandbox`, or `on`:  * `off`: Disallow loading of any arbitrary          Lua functions. The `off` option          disables any functionality that runs          arbitrary Lua code, including the          Serverless Functions plugins and any          transformation plugin that allows          custom Lua functions.  * `sandbox`: Allow loading of Lua functions,              but use a sandbox when executing              them. The sandboxed function has              restricted access to the global              environment and only has access              to standard Lua functions that              will generally not cause harm to              the Kong Gateway node.  * `on`: Functions have unrestricted         access to the global environment and         can load any Lua modules. This is         similar to the behavior in         Kong Gateway prior to 2.3.0.  The default `sandbox` environment does not allow importing other modules or libraries, or executing anything at the OS level (for example, file read/write). The global environment is also not accessible.  Examples of `untrusted_lua = sandbox` behavior:  * You can't access or change global values such as `kong.configuration.pg_password` * You can run harmless lua: `local foo = 1 + 1`. However, OS level functions are not allowed, like: `os.execute('rm -rf /*')`.  For a full allowed/disallowed list, see: https://github.com/kikito/sandbox.lua/blob/master/sandbox.lua  To customize the sandbox environment, use the `untrusted_lua_sandbox_requires` and `untrusted_lua_sandbox_environment` parameters below."
+    "description": "Controls loading of Lua functions from admin-supplied\nsources such as the Admin API. LuaJIT bytecode\nloading is always disabled.\n\n**Warning:** LuaJIT is not designed as a secure\nruntime for running malicious code, therefore\nyou should properly protect your Admin API endpoint\neven with sandboxing enabled. The sandbox only\nprovides protection against trivial attackers or\nunintentional modification of the Kong global\nenvironment.\n\nAccepted values are: `off`, `sandbox`, or\n`on`:\n\n* `off`: Disallow loading of any arbitrary\n         Lua functions. The `off` option\n         disables any functionality that runs\n         arbitrary Lua code, including the\n         Serverless Functions plugins and any\n         transformation plugin that allows\n         custom Lua functions.\n\n* `sandbox`: Allow loading of Lua functions,\n             but use a sandbox when executing\n             them. The sandboxed function has\n             restricted access to the global\n             environment and only has access\n             to standard Lua functions that\n             will generally not cause harm to\n             the Kong Gateway node.\n\n* `on`: Functions have unrestricted\n        access to the global environment and\n        can load any Lua modules. This is\n        similar to the behavior in\n        Kong Gateway prior to 2.3.0.\n\nThe default `sandbox` environment does not\nallow importing other modules or libraries,\nor executing anything at the OS level (for\nexample, file read/write). The global\nenvironment is also not accessible.\n\nExamples of `untrusted_lua = sandbox`\nbehavior:\n\n* You can't access or change global values\nsuch as `kong.configuration.pg_password`\n* You can run harmless lua:\n`local foo = 1 + 1`. However, OS level\nfunctions are not allowed, like:\n`os.execute('rm -rf /*')`.\n\nFor a full allowed/disallowed list, see:\nhttps://github.com/kikito/sandbox.lua/blob/master/sandbox.lua\n\nTo customize the sandbox environment, use\nthe `untrusted_lua_sandbox_requires` and\n`untrusted_lua_sandbox_environment`\nparameters below.\n"
   },
   "untrusted_lua_sandbox_requires": {
     "defaultValue": null,
-    "description": "Comma-separated list of modules allowed to be loaded with `require` inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  For example, say you have configured the Serverless pre-function plugin and it contains the following `requires`:  ``` local template = require \"resty.template\" local split = require \"kong.tools.utils\".split ```  To run the plugin, add the modules to the allowed list: ``` untrusted_lua_sandbox_requires = resty.template, kong.tools.utils ```  **Warning:** Allowing certain modules may create opportunities to escape the sandbox. For example, allowing `os` or `luaposix` may be unsafe."
+    "description": "Comma-separated list of modules allowed to\nbe loaded with `require` inside the\nsandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\nFor example, say you have configured the\nServerless pre-function plugin and it\ncontains the following `requires`:\n\n```\nlocal template = require \"resty.template\"\nlocal split = require \"kong.tools.utils\".split\n```\n\nTo run the plugin, add the modules to the\nallowed list:\n```\nuntrusted_lua_sandbox_requires = resty.template, kong.tools.utils\n```\n\n**Warning:** Allowing certain modules may\ncreate opportunities to escape the\nsandbox. For example, allowing `os` or\n`luaposix` may be unsafe.\n"
   },
   "untrusted_lua_sandbox_environment": {
     "defaultValue": null,
-    "description": "Comma-separated list of global Lua variables that should be made available inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  **Warning**: Certain variables, when made available, may create opportunities to escape the sandbox."
+    "description": "Comma-separated list of global Lua\nvariables that should be made available\ninside the sandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\n**Warning**: Certain variables, when made\navailable, may create opportunities to\nescape the sandbox.\n"
   },
   "openresty_path": {
     "defaultValue": null,
-    "description": "Path to the OpenResty installation that Kong will use. When this is empty (the default), Kong determines the OpenResty installation by searching for a system-installed OpenResty and falling back to searching $PATH for the nginx binary.  Setting this attribute disables the search behavior and explicitly instructs Kong which OpenResty installation to use."
+    "description": "Path to the OpenResty installation that Kong\nwill use. When this is empty (the default),\nKong determines the OpenResty installation\nby searching for a system-installed OpenResty\nand falling back to searching $PATH for the\nnginx binary.\n\nSetting this attribute disables the search\nbehavior and explicitly instructs Kong which\nOpenResty installation to use.\n"
   },
   "node_id": {
     "defaultValue": null,
-    "description": "Node ID for the Kong node. Every Kong node in a Kong cluster must have a unique and valid UUID. When empty, node ID is automatically generated."
+    "description": "Node ID for the Kong node. Every Kong node\nin a Kong cluster must have a unique and\nvalid UUID. When empty, node ID is\nautomatically generated.\n"
   },
   "cluster_fallback_config_import": {
     "defaultValue": "off",
-    "description": "Enable fallback configuration imports.  This should only be enabled for data planes."
+    "description": "Enable fallback configuration imports.\n\nThis should only be enabled for data planes.\n"
   },
   "cluster_fallback_config_storage": {
     "defaultValue": null,
-    "description": "Storage definition used by `cluster_fallback_config_import` and `cluster_fallback_config_export`.  Supported storage types: - S3-like storages - GCP storage service  To use S3 with a bucket named b and place all configs to with a key prefix named p, set it to: `s3://b/p` To use GCP for the same bucket and prefix, set it to: `gcs://b/p`  The credentials (and the endpoint URL for S3-like) for S3 are passed with environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where `AWS_CONFIG_STORAGE_ENDPOINT` is the endpoint that hosts S3-like storage.  The credentials for GCP are provided via the environment variable `GCP_SERVICE_ACCOUNT`."
+    "description": "Storage definition used by `cluster_fallback_config_import`\nand `cluster_fallback_config_export`.\n\nSupported storage types:\n- S3-like storages\n- GCP storage service\n\nTo use S3 with a bucket named b and place all configs\nto with a key prefix named p, set it to:\n`s3://b/p`\nTo use GCP for the same bucket and prefix, set it to:\n`gcs://b/p`\n\nThe credentials (and the endpoint URL for S3-like) for S3\nare passed with environment variables:\n`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,\nand `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where\n`AWS_CONFIG_STORAGE_ENDPOINT`\nis the endpoint that hosts S3-like storage.\n\nThe credentials for GCP are provided via the environment\nvariable `GCP_SERVICE_ACCOUNT`.\n"
   },
   "cluster_fallback_export_s3_config": {
     "defaultValue": null,
-    "description": "fallback config export S3 config This is used only when `cluster_fallback_config_storage` is S3-like schema. If set, it will add config table to kong exporter config S3 putObject request. The config table should be in JSON format and can be unserialized into a table. It should contain the necessary parameters as described in the documentation.  https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property. For example, if you want to set the ServerSideEncryption headers / KMS Key ID for the S3 putObject request, you can set the config table to: `{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"your-kms-key-id\"}`"
+    "description": "fallback config export S3 config\nThis is used only when `cluster_fallback_config_storage` is S3-like schema.\nIf set, it will add config table to kong exporter config S3 putObject request.\nThe config table should be in JSON format and can be unserialized into a table.\nIt should contain the necessary parameters as described in the documentation.\n https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property.\nFor example, if you want to set the ServerSideEncryption headers / KMS Key ID\nfor the S3 putObject request, you can set the config table to:\n`{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"your-kms-key-id\"}`\n"
   },
   "cluster_fallback_config_export": {
     "defaultValue": "off",
-    "description": "Enable fallback configuration exports."
+    "description": "Enable fallback configuration exports.\n"
   },
   "cluster_fallback_config_export_delay": {
     "defaultValue": "60",
-    "description": "The fallback configuration export interval.  If the interval is set to 60 and configuration A is exported and there are new configurations B, C, and D in the next 60 seconds, it will wait until 60 seconds passed and export D, skipping B and C."
+    "description": "The fallback configuration export interval.\n\nIf the interval is set to 60 and configuration A is exported\nand there are new configurations B, C, and D in the next 60 seconds,\nit will wait until 60 seconds passed and export D, skipping B and C.\n"
   },
   "wasm": {
     "defaultValue": "off",
-    "description": "Enable/disable wasm support. This must be enabled in order to use wasm filters and filter chains."
+    "description": "Enable/disable wasm support. This must be enabled in\norder to use wasm filters and filter chains.\n"
   },
   "wasm_filters_path": {
     "defaultValue": null,
-    "description": "Path to the directory containing wasm filter modules.  At startup, Kong discovers available wasm filters by scanning this directory for files with the `.wasm` file extension.  The name of a wasm filter module is derived from the filename itself, with the .wasm extension removed. So, given the following tree:  ``` /path/to/wasm_filters ├── my_module.wasm ├── my_other_module.wasm └── not_a_wasm_module.txt ```  The resulting filter modules available for use in Kong will be:  * `my_module` * `my_other_module`  Notes:  * No recursion is performed. Only .wasm files at the   top level are registered * This path _may_ be a symlink to a directory."
+    "description": "Path to the directory containing wasm filter modules.\n\nAt startup, Kong discovers available wasm filters by\nscanning this directory for files with the `.wasm`\nfile extension.\n\nThe name of a wasm filter module is derived from the\nfilename itself, with the .wasm extension removed. So,\ngiven the following tree:\n\n```\n/path/to/wasm_filters\n├── my_module.wasm\n├── my_other_module.wasm\n└── not_a_wasm_module.txt\n```\n\nThe resulting filter modules available for use in Kong\nwill be:\n\n* `my_module`\n* `my_other_module`\n\nNotes:\n\n* No recursion is performed. Only .wasm files at the\n  top level are registered\n* This path _may_ be a symlink to a directory.\n"
   },
   "request_debug": {
     "defaultValue": "on",
-    "description": "When enabled, Kong will provide detailed timing information for its components to the client and the error log if the following headers are present in the proxy request: - `X-Kong-Request-Debug`:   If the value is set to `*`,   timing information will be collected and exported for the current request.   If this header is not present or contains unknown value,   timing information will not be collected for the current request.   You can also specify a list of filters, separated by commas,   to filter the scope of the time information that is collected.   The following filters are supported:   - `rewrite`: Collect timing information from the `rewrite` phase.   - `access`: Collect timing information from the `access` phase.   - `balancer`: Collect timing information from the `balancer` phase.   - `response`: Collect timing information from the `response` phase.   - `header_filter`: Collect timing information from the `header_filter` phase.   - `body_filter`: Collect timing information from the `body_filter` phase.   - `log`: Collect timing information from the `log` phase.   - `upstream`: Collect timing information from the `upstream` phase.  - `X-Kong-Request-Debug-Log`:   If set to `true`, timing information will also be logged   in the Kong error log with a log level of `notice`.   Defaults to `false`.  - `X-Kong-Request-Debug-Token`:   Token for authenticating the client making the debug   request to prevent abuse. Debug requests originating from loopback   addresses do not require this header. "
+    "description": "When enabled, Kong will provide detailed timing information\nfor its components to the client and the error log\nif the following headers are present in the proxy request:\n- `X-Kong-Request-Debug`:\n  If the value is set to `*`,\n  timing information will be collected and exported for the current request.\n  If this header is not present or contains unknown value,\n  timing information will not be collected for the current request.\n  You can also specify a list of filters, separated by commas,\n  to filter the scope of the time information that is collected.\n  The following filters are supported:\n  - `rewrite`: Collect timing information from the `rewrite` phase.\n  - `access`: Collect timing information from the `access` phase.\n  - `balancer`: Collect timing information from the `balancer` phase.\n  - `response`: Collect timing information from the `response` phase.\n  - `header_filter`: Collect timing information from the `header_filter` phase.\n  - `body_filter`: Collect timing information from the `body_filter` phase.\n  - `log`: Collect timing information from the `log` phase.\n  - `upstream`: Collect timing information from the `upstream` phase.\n\n- `X-Kong-Request-Debug-Log`:\n  If set to `true`, timing information will also be logged\n  in the Kong error log with a log level of `notice`.\n  Defaults to `false`.\n\n- `X-Kong-Request-Debug-Token`:\n  Token for authenticating the client making the debug\n  request to prevent abuse. Debug requests originating from loopback\n  addresses do not require this header.\n\n"
   },
   "request_debug_token": {
     "defaultValue": "<random>",
-    "description": "The Request Debug Token is used in the `X-Kong-Request-Debug-Token` header to prevent abuse. If this value is not set (the default), a random token will be generated when Kong starts, restarts, or reloads. If a token is specified manually, then the provided token will be used.  You can locate the generated debug token in two locations: - Kong error log:   Debug token will be logged in the error log (notice level)   when Kong starts, restarts, or reloads.   The log line will have the: `[request-debug]` prefix to aid searching. - Filesystem:   Debug token will also be stored in a file located at   `{prefix}/.request_debug_token` and updated   when Kong starts, restarts, or reloads."
+    "description": "The Request Debug Token is used in the\n`X-Kong-Request-Debug-Token` header to prevent abuse.\nIf this value is not set (the default),\na random token will be generated\nwhen Kong starts, restarts, or reloads. If a token is\nspecified manually, then the provided token will be used.\n\nYou can locate the generated debug token in two locations:\n- Kong error log:\n  Debug token will be logged in the error log (notice level)\n  when Kong starts, restarts, or reloads.\n  The log line will have the: `[request-debug]` prefix to aid searching.\n- Filesystem:\n  Debug token will also be stored in a file located at\n  `{prefix}/.request_debug_token` and updated\n  when Kong starts, restarts, or reloads.\n"
   }
 }

--- a/app/_data/kong-conf/3.7.json
+++ b/app/_data/kong-conf/3.7.json
@@ -1,325 +1,325 @@
 {
   "prefix": {
     "defaultValue": "/usr/local/kong/",
-    "description": "Working directory. Equivalent to Nginx's prefix path, containing temporary files and logs. Each Kong process must have a separate working directory."
+    "description": "Working directory. Equivalent to Nginx's\nprefix path, containing temporary files\nand logs.\nEach Kong process must have a separate\nworking directory.\n"
   },
   "log_level": {
     "defaultValue": "notice",
-    "description": "Log level of the Nginx server. Logs are found at `<prefix>/logs/error.log`."
+    "description": "Log level of the Nginx server. Logs are\nfound at `<prefix>/logs/error.log`.\n"
   },
   "proxy_access_log": {
     "defaultValue": "logs/access.log",
-    "description": "Path for proxy port request access logs. Set this value to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for proxy port request access\nlogs. Set this value to `off` to\ndisable logging proxy requests.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n"
   },
   "proxy_error_log": {
     "defaultValue": "logs/error.log",
-    "description": "Path for proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for proxy port request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "proxy_stream_access_log": {
     "defaultValue": "logs/access.log basic",
-    "description": "Path for tcp streams proxy port access logs. Set this value to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location. `basic` is defined as `'$remote_addr [$time_local] ' '$protocol $status $bytes_sent $bytes_received ' '$session_time'`"
+    "description": "Path for tcp streams proxy port access\nlogs. Set this value to `off` to\ndisable logging proxy requests.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n`basic` is defined as `'$remote_addr [$time_local] '\n'$protocol $status $bytes_sent $bytes_received '\n'$session_time'`\n"
   },
   "proxy_stream_error_log": {
     "defaultValue": "logs/error.log",
-    "description": "Path for tcp streams proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for tcp streams proxy port request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "admin_access_log": {
     "defaultValue": "logs/admin_access.log",
-    "description": "Path for Admin API request access logs. If Hybrid Mode is enabled and the current node is set to be the Control Plane, then the connection requests from Data Planes are also written to this file with server name \"kong_cluster_listener\".  Set this value to `off` to disable logging Admin API requests. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for Admin API request access\nlogs. If Hybrid Mode is enabled\nand the current node is set to be\nthe Control Plane, then the\nconnection requests from Data Planes\nare also written to this file with\nserver name \"kong_cluster_listener\".\n\nSet this value to `off` to\ndisable logging Admin API requests.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n"
   },
   "admin_error_log": {
     "defaultValue": "logs/error.log",
-    "description": "Path for Admin API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for Admin API request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "status_access_log": {
     "defaultValue": "off",
-    "description": "Path for Status API request access logs. The default value of `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for Status API request access\nlogs. The default value of `off`\nimplies that logging for this API\nis disabled by default.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n"
   },
   "status_error_log": {
     "defaultValue": "logs/status_error.log",
-    "description": "Path for Status API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for Status API request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "debug_access_log": {
     "defaultValue": "off",
-    "description": "Path for Debug API request access logs. The default value of `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for Debug API request access\nlogs. The default value of `off`\nimplies that logging for this API\nis disabled by default.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n"
   },
   "debug_error_log": {
     "defaultValue": "logs/debug_error.log",
-    "description": "Path for Debug API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for Debug API request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "vaults": {
     "defaultValue": "bundled",
-    "description": "Comma-separated list of vaults this node should load. By default, all the bundled vaults are enabled.  The specified name(s) will be substituted as such in the Lua namespace: `kong.vaults.{name}.*`."
+    "description": "Comma-separated list of vaults this node\nshould load. By default, all the bundled\nvaults are enabled.\n\nThe specified name(s) will be substituted as\nsuch in the Lua namespace:\n`kong.vaults.{name}.*`.\n"
   },
   "opentelemetry_tracing": {
     "defaultValue": "off",
-    "description": "Deprecated: use tracing_instrumentations instead"
+    "description": "Deprecated: use tracing_instrumentations instead\n"
   },
   "tracing_instrumentations": {
     "defaultValue": "off",
-    "description": "Comma-separated list of tracing instrumentations this node should load. By default, no instrumentations are enabled.  Valid values to this setting are:  - `off`: do not enable instrumentations. - `request`: only enable request-level instrumentations. - `all`: enable all the following instrumentations. - `db_query`: trace database query - `dns_query`: trace DNS query. - `router`: trace router execution, including   router rebuilding. - `http_client`: trace OpenResty HTTP client requests. - `balancer`: trace balancer retries. - `plugin_rewrite`: trace plugins iterator   execution with rewrite phase. - `plugin_access`: trace plugins iterator   execution with access phase. - `plugin_header_filter`: trace plugins iterator   execution with header_filter phase.  **Note:** In the current implementation, tracing instrumentations are not enabled in stream mode."
+    "description": "Comma-separated list of tracing instrumentations\nthis node should load. By default, no instrumentations\nare enabled.\n\nValid values to this setting are:\n\n- `off`: do not enable instrumentations.\n- `request`: only enable request-level instrumentations.\n- `all`: enable all the following instrumentations.\n- `db_query`: trace database query\n- `dns_query`: trace DNS query.\n- `router`: trace router execution, including\n  router rebuilding.\n- `http_client`: trace OpenResty HTTP client requests.\n- `balancer`: trace balancer retries.\n- `plugin_rewrite`: trace plugins iterator\n  execution with rewrite phase.\n- `plugin_access`: trace plugins iterator\n  execution with access phase.\n- `plugin_header_filter`: trace plugins iterator\n  execution with header_filter phase.\n\n**Note:** In the current implementation,\ntracing instrumentations are not enabled in\nstream mode.\n"
   },
   "opentelemetry_tracing_sampling_rate": {
     "defaultValue": "1.0",
-    "description": "Deprecated: use tracing_sampling_rate instead"
+    "description": "Deprecated: use tracing_sampling_rate instead\n"
   },
   "tracing_sampling_rate": {
     "defaultValue": "0.01",
-    "description": "Tracing instrumentation sampling rate. Tracer samples a fixed percentage of all spans following the sampling rate.  Example: `0.25`, this should account for 25% of all traces."
+    "description": "Tracing instrumentation sampling rate.\nTracer samples a fixed percentage of all spans\nfollowing the sampling rate.\n\nExample: `0.25`, this should account for 25% of all traces.\n"
   },
   "plugins": {
     "defaultValue": "bundled",
-    "description": "Comma-separated list of plugins this node should load. By default, only plugins bundled in official distributions are loaded via the `bundled` keyword.  Loading a plugin does not enable it by default, but only instructs Kong to load its source code, and allows to configure the plugin via the various related Admin API endpoints.  The specified name(s) will be substituted as such in the Lua namespace: `kong.plugins.{name}.*`.  When the `off` keyword is specified as the only value, no plugins will be loaded.  `bundled` and plugin names can be mixed together, as the following examples suggest:  - `plugins = bundled,custom-auth,custom-log`   will include the bundled plugins plus two   custom ones - `plugins = custom-auth,custom-log` will   *only* include the `custom-auth` and   `custom-log` plugins. - `plugins = off` will not include any   plugins  **Note:** Kong will not start if some plugins were previously configured (i.e. have rows in the database) and are not specified in this list.  Before disabling a plugin, ensure all instances of it are removed before restarting Kong.  **Note:** Limiting the amount of available plugins can improve P99 latency when experiencing LRU churning in the database cache (i.e. when the configured `mem_cache_size`) is full."
+    "description": "Comma-separated list of plugins this node\nshould load. By default, only plugins\nbundled in official distributions are\nloaded via the `bundled` keyword.\n\nLoading a plugin does not enable it by\ndefault, but only instructs Kong to load its\nsource code, and allows to configure the\nplugin via the various related Admin API\nendpoints.\n\nThe specified name(s) will be substituted as\nsuch in the Lua namespace:\n`kong.plugins.{name}.*`.\n\nWhen the `off` keyword is specified as the\nonly value, no plugins will be loaded.\n\n`bundled` and plugin names can be mixed\ntogether, as the following examples suggest:\n\n- `plugins = bundled,custom-auth,custom-log`\n  will include the bundled plugins plus two\n  custom ones\n- `plugins = custom-auth,custom-log` will\n  *only* include the `custom-auth` and\n  `custom-log` plugins.\n- `plugins = off` will not include any\n  plugins\n\n**Note:** Kong will not start if some\nplugins were previously configured (i.e.\nhave rows in the database) and are not\nspecified in this list.  Before disabling a\nplugin, ensure all instances of it are\nremoved before restarting Kong.\n\n**Note:** Limiting the amount of available\nplugins can improve P99 latency when\nexperiencing LRU churning in the database\ncache (i.e. when the configured\n`mem_cache_size`) is full.\n"
   },
   "dedicated_config_processing": {
     "defaultValue": "on",
-    "description": "Enables or disables a special worker process for configuration processing. This process increases memory usage a little bit while allowing to reduce latencies by moving some background tasks, such as CP/DP connection handling, to an additional worker process specific to handling these background tasks. Currently this has effect only on data planes."
+    "description": "Enables or disables a special worker\nprocess for configuration processing. This process\nincreases memory usage a little bit while\nallowing to reduce latencies by moving some\nbackground tasks, such as CP/DP connection\nhandling, to an additional worker process specific\nto handling these background tasks.\nCurrently this has effect only on data planes.\n"
   },
   "pluginserver_names": {
     "defaultValue": null,
-    "description": "Comma-separated list of names for pluginserver processes.  The actual names are used for log messages and to relate the actual settings."
+    "description": "Comma-separated list of names for pluginserver\nprocesses.  The actual names are used for\nlog messages and to relate the actual settings.\n"
   },
   "pluginserver_XXX_socket": {
     "defaultValue": "<prefix>/<XXX>.socket",
-    "description": "Path to the unix socket used by the <XXX> pluginserver."
+    "description": "Path to the unix socket\nused by the <XXX> pluginserver.\n"
   },
   "pluginserver_XXX_start_cmd": {
     "defaultValue": "/usr/local/bin/<XXX>",
-    "description": "Full command (including any needed arguments) to start the <XXX> pluginserver"
+    "description": "Full command (including\nany needed arguments) to\nstart the <XXX> pluginserver\n"
   },
   "pluginserver_XXX_query_cmd": {
     "defaultValue": "/usr/local/bin/query_<XXX>",
-    "description": "Full command to \"query\" the <XXX> pluginserver.  Should produce a JSON with the dump info of all plugins it manages"
+    "description": "Full command to \"query\" the\n<XXX> pluginserver.  Should\nproduce a JSON with the\ndump info of all plugins it\nmanages\n"
   },
   "port_maps": {
     "defaultValue": null,
-    "description": "With this configuration parameter, you can let the Kong to know about the port from which the packets are forwarded to it. This is fairly common when running Kong in a containerized or virtualized environment. For example, `port_maps=80:8000, 443:8443` instructs Kong that the port 80 is mapped to 8000 (and the port 443 to 8443), where 8000 and 8443 are the ports that Kong is listening to.  This parameter helps Kong set a proper forwarded upstream HTTP request header or to get the proper forwarded port with the Kong PDK (in case other means determining it has failed). It changes routing by a destination port to route by a port from which packets are forwarded to Kong, and similarly it changes the default plugin log serializer to use the port according to this mapping instead of reporting the port Kong is listening to."
+    "description": "With this configuration parameter, you can\nlet the Kong to know about the port from\nwhich the packets are forwarded to it. This\nis fairly common when running Kong in a\ncontainerized or virtualized environment.\nFor example, `port_maps=80:8000, 443:8443`\ninstructs Kong that the port 80 is mapped\nto 8000 (and the port 443 to 8443), where\n8000 and 8443 are the ports that Kong is\nlistening to.\n\nThis parameter helps Kong set a proper\nforwarded upstream HTTP request header or to\nget the proper forwarded port with the Kong PDK\n(in case other means determining it has\nfailed). It changes routing by a destination\nport to route by a port from which packets\nare forwarded to Kong, and similarly it\nchanges the default plugin log serializer to\nuse the port according to this mapping\ninstead of reporting the port Kong is\nlistening to.\n"
   },
   "anonymous_reports": {
     "defaultValue": "on",
-    "description": "Send anonymous usage data such as error stack traces to help improve Kong."
+    "description": "Send anonymous usage data such as error\nstack traces to help improve Kong.\n"
   },
   "proxy_server": {
     "defaultValue": null,
-    "description": "Proxy server defined as a URL. Kong will only use this option if any component is explicitly configured to use proxy."
+    "description": "Proxy server defined as a URL. Kong will only use this\noption if any component is explicitly configured\nto use proxy.\n"
   },
   "proxy_server_ssl_verify": {
     "defaultValue": "off",
-    "description": "Toggles server certificate verification if `proxy_server` is in HTTPS. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+    "description": "Toggles server certificate verification if\n`proxy_server` is in HTTPS.\nSee the `lua_ssl_trusted_certificate`\nsetting to specify a certificate authority.\n"
   },
   "error_template_html": {
     "defaultValue": null,
-    "description": "Path to the custom html error template to override the default html kong error template.  The template may contain up to two `%s` placeholders. The first one will expand to the error message. The second one will expand to the request ID. Both placeholders are optional, but recommended. Adding more than two placeholders will result in a runtime error when trying to render the template: ``` <html>   <body>     <h1>My custom error template</h1>     <p>error: %s</p>     <p>request_id: %s</p>   </body> </html> ```"
+    "description": "Path to the custom html error template to\noverride the default html kong error\ntemplate.\n\nThe template may contain up to two `%s`\nplaceholders. The first one will expand to\nthe error message. The second one will\nexpand to the request ID. Both placeholders\nare optional, but recommended.\nAdding more than two placeholders will\nresult in a runtime error when trying to\nrender the template:\n```\n<html>\n  <body>\n    <h1>My custom error template</h1>\n    <p>error: %s</p>\n    <p>request_id: %s</p>\n  </body>\n</html>\n```\n"
   },
   "error_template_json": {
     "defaultValue": null,
-    "description": "Path to the custom json error template to override the default json kong error template.  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+    "description": "Path to the custom json error template to\noverride the default json kong error\ntemplate.\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n"
   },
   "error_template_xml": {
     "defaultValue": null,
-    "description": "Path to the custom xml error template to override the default xml kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+    "description": "Path to the custom xml error template to\noverride the default xml kong error template\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n"
   },
   "error_template_plain": {
     "defaultValue": null,
-    "description": "Path to the custom plain error template to override the default plain kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+    "description": "Path to the custom plain error template to\noverride the default plain kong error\ntemplate\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n"
   },
   "role": {
     "defaultValue": "traditional",
-    "description": "Use this setting to enable Hybrid Mode, This allows running some Kong nodes in a control plane role with a database and have them deliver configuration updates to other nodes running to DB-less running in a Data Plane role.  Valid values to this setting are:  - `traditional`: do not use Hybrid Mode. - `control_plane`: this node runs in a   control plane role. It can use a database   and will deliver configuration updates   to data plane nodes. - `data_plane`: this is a data plane node.   It runs DB-less and receives configuration   updates from a control plane node."
+    "description": "Use this setting to enable Hybrid Mode,\nThis allows running some Kong nodes in a\ncontrol plane role with a database and\nhave them deliver configuration updates\nto other nodes running to DB-less running in\na Data Plane role.\n\nValid values to this setting are:\n\n- `traditional`: do not use Hybrid Mode.\n- `control_plane`: this node runs in a\n  control plane role. It can use a database\n  and will deliver configuration updates\n  to data plane nodes.\n- `data_plane`: this is a data plane node.\n  It runs DB-less and receives configuration\n  updates from a control plane node.\n"
   },
   "cluster_mtls": {
     "defaultValue": "shared",
-    "description": "Sets the verification between nodes of the cluster.  Valid values to this setting are:  - `shared`: use a shared certificate/key   pair specified with the `cluster_cert`   and `cluster_cert_key` settings.   Note that CP and DP nodes have to present   the same certificate to establish mTLS   connections. - `pki`: use `cluster_ca_cert`,   `cluster_server_name` and `cluster_cert`   for verification.   These are different certificates for each   DP node, but issued by a cluster-wide   common CA certificate: `cluster_ca_cert`. - `pki_check_cn`: similar as `pki` but additionally   checks for Common Name of data plane certificate   specified in `cluster_allowed_common_names`."
+    "description": "Sets the verification between nodes of the\ncluster.\n\nValid values to this setting are:\n\n- `shared`: use a shared certificate/key\n  pair specified with the `cluster_cert`\n  and `cluster_cert_key` settings.\n  Note that CP and DP nodes have to present\n  the same certificate to establish mTLS\n  connections.\n- `pki`: use `cluster_ca_cert`,\n  `cluster_server_name` and `cluster_cert`\n  for verification.\n  These are different certificates for each\n  DP node, but issued by a cluster-wide\n  common CA certificate: `cluster_ca_cert`.\n- `pki_check_cn`: similar as `pki` but additionally\n  checks for Common Name of data plane certificate\n  specified in `cluster_allowed_common_names`.\n"
   },
   "cluster_cert": {
     "defaultValue": null,
-    "description": "Cluster certificate to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes.  Under `pki` mode it should be a different certificate for each DP node.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "Cluster certificate to use\nwhen establishing secure communication\nbetween control and data plane nodes.\nYou can use the `kong hybrid` command to\ngenerate the certificate/key pair.\nUnder `shared` mode, it must be the same\nfor all nodes.  Under `pki` mode it\nshould be a different certificate for each\nDP node.\n\nThe certificate can be configured on this\nproperty with either of the following values:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "cluster_cert_key": {
     "defaultValue": null,
-    "description": "Cluster certificate key to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes.  Under `pki` mode it should be a different certificate for each DP node.  The certificate key can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+    "description": "Cluster certificate key to\nuse when establishing secure communication\nbetween control and data plane nodes.\nYou can use the `kong hybrid` command to\ngenerate the certificate/key pair.\nUnder `shared` mode, it must be the same\nfor all nodes.  Under `pki` mode it\nshould be a different certificate for each\nDP node.\n\nThe certificate key can be configured on this\nproperty with either of the following values:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n"
   },
   "cluster_ca_cert": {
     "defaultValue": null,
-    "description": "The trusted CA certificate file in PEM format used for Control Plane to verify Data Plane's certificate and Data Plane to verify Control Plane's certificate. Required on data plane if `cluster_mtls` is set to `pki`. If Control Plane certificate is issued by a well known CA, user can set `lua_ssl_trusted_certificate=system` on Data Plane and leave this field empty.  This field is ignored if `cluster_mtls` is set to `shared`.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "The trusted CA certificate file in PEM\nformat used for Control Plane to verify\nData Plane's certificate and Data Plane\nto verify Control Plane's certificate.\nRequired on data plane if `cluster_mtls`\nis set to `pki`.\nIf Control Plane certificate is issued\nby a well known CA, user can set\n`lua_ssl_trusted_certificate=system`\non Data Plane and leave this field empty.\n\nThis field is ignored if `cluster_mtls` is\nset to `shared`.\n\nThe certificate can be configured on this property\nwith either of the following values:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "cluster_allowed_common_names": {
     "defaultValue": null,
-    "description": "The list of Common Names that are allowed to connect to control plane. Multiple entries may be supplied in a comma-separated string. When not set, Data Plane with same parent domain of Control Plane cert is allowed to connect.  This field is ignored if `cluster_mtls` is not set to `pki_check_cn`."
+    "description": "The list of Common Names that are allowed to\nconnect to control plane. Multiple entries may\nbe supplied in a comma-separated string. When not\nset, Data Plane with same parent domain of\nControl Plane cert is allowed to connect.\n\nThis field is ignored if `cluster_mtls` is\nnot set to `pki_check_cn`.\n"
   },
   "cluster_server_name": {
     "defaultValue": null,
-    "description": "The server name used in the SNI of the TLS connection from a DP node to a CP node. Must match the Common Name (CN) or Subject Alternative Name (SAN) found in the CP certificate. If `cluster_mtls` is set to `shared`, this setting is ignored and `kong_clustering` is used."
+    "description": "The server name used in the SNI of the TLS\nconnection from a DP node to a CP node.\nMust match the Common Name (CN) or Subject\nAlternative Name (SAN) found in the CP\ncertificate.\nIf `cluster_mtls` is set to\n`shared`, this setting is ignored and\n`kong_clustering` is used.\n"
   },
   "cluster_control_plane": {
     "defaultValue": null,
-    "description": "To be used by data plane nodes only: address of the control plane node from which configuration updates will be fetched, in `host:port` format."
+    "description": "To be used by data plane nodes only:\naddress of the control plane node from\nwhich configuration updates will be fetched,\nin `host:port` format.\n"
   },
   "cluster_telemetry_endpoint": {
     "defaultValue": null,
-    "description": "To be used by data plane nodes only: telemetry address of the control plane node to which telemetry updates will be posted in `host:port` format."
+    "description": "To be used by data plane nodes only:\ntelemetry address of the control plane node\nto which telemetry updates will be posted\nin `host:port` format.\n"
   },
   "cluster_telemetry_server_name": {
     "defaultValue": null,
-    "description": "The SNI (Server Name Indication extension) to use for Vitals telemetry data."
+    "description": "The SNI (Server Name Indication extension)\nto use for Vitals telemetry data.\n"
   },
   "cluster_dp_labels": {
     "defaultValue": null,
-    "description": "Comma separated list of Labels for the data plane. Labels are key-value pairs that provide additional context information for each DP. Each label must be configured as a string in the format `key:value`.  Labels are only compatible with hybrid mode deployments with Kong Konnect (SaaS), this configuration doesn't work with self-hosted deployments.  Keys and values follow the AIP standards: https://kong-aip.netlify.app/aip/129/  Example: `deployment:mycloud,region:us-east-1`"
+    "description": "Comma separated list of Labels for the data plane.\nLabels are key-value pairs that provide additional\ncontext information for each DP.\nEach label must be configured as a string in the\nformat `key:value`.\n\nLabels are only compatible with hybrid mode\ndeployments with Kong Konnect (SaaS),\nthis configuration doesn't work with\nself-hosted deployments.\n\nKeys and values follow the AIP standards:\nhttps://kong-aip.netlify.app/aip/129/\n\nExample:\n`deployment:mycloud,region:us-east-1`\n"
   },
   "cluster_listen": {
     "defaultValue": "0.0.0.0:8005",
-    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster. This port is mTLS protected to ensure end-to-end security and integrity.  This setting has no effect if `role` is not set to `control_plane`.  Connection made to this endpoint are logged to the same location as Admin API access logs. See `admin_access_log` config description for more information."
+    "description": "Comma-separated list of addresses and ports on\nwhich the cluster control plane server should listen\nfor data plane connections.\nThe cluster communication port of the control plane\nmust be accessible by all the data planes\nwithin the same cluster. This port is mTLS protected\nto ensure end-to-end security and integrity.\n\nThis setting has no effect if `role` is not set to\n`control_plane`.\n\nConnection made to this endpoint are logged\nto the same location as Admin API access logs.\nSee `admin_access_log` config description for more\ninformation.\n"
   },
   "cluster_telemetry_listen": {
     "defaultValue": "0.0.0.0:8006",
-    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane telemetry connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster.  This setting has no effect if `role` is not set to `control_plane`."
+    "description": "Comma-separated list of addresses and ports on\nwhich the cluster control plane server should listen\nfor data plane telemetry connections.\nThe cluster communication port of the control plane\nmust be accessible by all the data planes\nwithin the same cluster.\n\nThis setting has no effect if `role` is not set to\n`control_plane`.\n"
   },
   "cluster_data_plane_purge_delay": {
     "defaultValue": "1209600",
-    "description": " How many seconds must pass from the time a DP node becomes offline to the time its entry gets removed from the database, as returned by the /clustering/data-planes Admin API endpoint.  This is to prevent the cluster data plane table from growing indefinitely. The default is set to 14 days. That is, if CP haven't heard from a DP for 14 days, its entry will be removed."
+    "description": "How many seconds must pass from the time a DP node\nbecomes offline to the time its entry gets removed\nfrom the database, as returned by the\n/clustering/data-planes Admin API endpoint.\n\nThis is to prevent the cluster data plane table from\ngrowing indefinitely. The default is set to\n14 days. That is, if CP haven't heard from a DP for\n14 days, its entry will be removed.\n"
   },
   "cluster_ocsp": {
     "defaultValue": "off",
-    "description": " Whether to check for revocation status of DP certificates using OCSP (Online Certificate Status Protocol). If enabled, the DP certificate should contain the \"Certificate Authority Information Access\" extension and the OCSP method with URI of which the OCSP responder can be reached from CP.  OCSP checks are only performed on CP nodes, it has no effect on DP nodes.  Valid values to this setting are:  - `on`: OCSP revocation check is enabled and DP   must pass the check in order to establish   connection with CP. - `off`: OCSP revocation check is disabled. - `optional`: OCSP revocation check will be attempted,   however, if the required extension is not   found inside DP provided certificate   or communication with the OCSP responder   failed, then DP is still allowed through."
+    "description": "Whether to check for revocation status of DP\ncertificates using OCSP (Online Certificate Status Protocol).\nIf enabled, the DP certificate should contain the\n\"Certificate Authority Information Access\" extension\nand the OCSP method with URI of which the OCSP responder\ncan be reached from CP.\n\nOCSP checks are only performed on CP nodes, it has no\neffect on DP nodes.\n\nValid values to this setting are:\n\n- `on`: OCSP revocation check is enabled and DP\n  must pass the check in order to establish\n  connection with CP.\n- `off`: OCSP revocation check is disabled.\n- `optional`: OCSP revocation check will be attempted,\n  however, if the required extension is not\n  found inside DP provided certificate\n  or communication with the OCSP responder\n  failed, then DP is still allowed through.\n"
   },
   "cluster_use_proxy": {
     "defaultValue": "off",
-    "description": " Whether to turn on HTTP CONNECT proxy support for hybrid mode connections. `proxy_server` will be used for Hybrid mode connections if this option is turned on."
+    "description": "Whether to turn on HTTP CONNECT proxy support for\nhybrid mode connections. `proxy_server` will be used\nfor Hybrid mode connections if this option is turned on.\n"
   },
   "cluster_max_payload": {
     "defaultValue": "16777216",
-    "description": " This sets the maximum compressed payload size allowed to be sent across from CP to DP in Hybrid mode Default is 16MB - 16 * 1024 * 1024."
+    "description": "This sets the maximum compressed payload size allowed\nto be sent across from CP to DP in Hybrid mode\nDefault is 16MB - 16 * 1024 * 1024.\n"
   },
   "proxy_listen": {
     "defaultValue": [
       "0.0.0.0:8000 reuseport backlog=16384",
       "0.0.0.0:8443 http2 ssl reuseport backlog=16384"
     ],
-    "description": " Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. The proxy server is the public entry point of Kong, which proxies traffic from your consumers to your backend services. This value accepts IPv4, IPv6, and hostnames.  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the TCP_DEFER_ACCEPT socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  This value can be set to `off`, thus disabling the HTTP/HTTPS proxy port for this node. If stream_listen is also set to `off`, this enables 'control-plane' mode for this node (in which all traffic proxying capabilities are disabled). This node can then be used only to configure a cluster of Kong nodes connected to the same datastore.  Example: `proxy_listen = 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`  See http://nginx.org/en/docs/http/ngx_http_core_module.html#listen for a description of the accepted formats for this and other `*_listen` values.  See https://www.nginx.com/resources/admin-guide/proxy-protocol/ for more details about the `proxy_protocol` parameter.  Not all `*_listen` values accept all formats specified in nginx's documentation."
+    "description": "Comma-separated list of addresses and ports on\nwhich the proxy server should listen for\nHTTP/HTTPS traffic.\nThe proxy server is the public entry point of Kong,\nwhich proxies traffic from your consumers to your\nbackend services. This value accepts IPv4, IPv6, and\nhostnames.\n\nSome suffixes can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's proxy server.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `deferred` instructs to use a deferred accept on\n  Linux (the TCP_DEFER_ACCEPT socket option).\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process\n  allowing the Kernel to better distribute incoming\n  connections between worker processes\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small in order to prevent clients\n  seeing \"Connection refused\" error connecting to\n  a busy Kong instance.\n  **Note:** on Linux, this value is limited by the\n  setting of `net.core.somaxconn` Kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections\n- so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]\n  configures the “TCP keepalive” behavior for the listening\n  socket. If this parameter is omitted then the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value “on”, the SO_KEEPALIVE option is turned\n  on for the socket. If it is set to the value “off”, the\n  SO_KEEPALIVE option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,\n  and TCP_KEEPCNT socket options.\n\nThis value can be set to `off`, thus disabling\nthe HTTP/HTTPS proxy port for this node.\nIf stream_listen is also set to `off`, this enables\n'control-plane' mode for this node\n(in which all traffic proxying capabilities are\ndisabled). This node can then be used only to\nconfigure a cluster of Kong\nnodes connected to the same datastore.\n\nExample:\n`proxy_listen = 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`\n\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#listen\nfor a description of the accepted formats for this\nand other `*_listen` values.\n\nSee https://www.nginx.com/resources/admin-guide/proxy-protocol/\nfor more details about the `proxy_protocol`\nparameter.\n\nNot all `*_listen` values accept all formats\nspecified in nginx's documentation.\n"
   },
   "proxy_url": {
     "defaultValue": null,
-    "description": "Kong Proxy URL  The lookup, or balancer, address for your Kong Proxy nodes.  This value is commonly used in a microservices or service-mesh oriented architecture.  Accepted format (parts in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`  Examples:  - `<scheme>://<IP>:<PORT>` -> `proxy_url = http://127.0.0.1:8000` - `SSL <scheme>://<HOSTNAME>` -> `proxy_url = https://proxy.domain.tld` - `<scheme>://<HOSTNAME>/<PATH>` -> `proxy_url = http://dev-machine/dev-285`  By default, Kong Manager, and Kong Portal will use the window request host and append the resolved listener port depending on the requested protocol."
+    "description": "Kong Proxy URL\n\nThe lookup, or balancer, address for your Kong Proxy nodes.\n\nThis value is commonly used in a microservices\nor service-mesh oriented architecture.\n\nAccepted format (parts in parentheses are optional):\n\n  `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`\n\nExamples:\n\n- `<scheme>://<IP>:<PORT>` -> `proxy_url = http://127.0.0.1:8000`\n- `SSL <scheme>://<HOSTNAME>` -> `proxy_url = https://proxy.domain.tld`\n- `<scheme>://<HOSTNAME>/<PATH>` -> `proxy_url = http://dev-machine/dev-285`\n\nBy default, Kong Manager, and Kong Portal will use\nthe window request host and append the resolved\nlistener port depending on the requested protocol.\n"
   },
   "stream_listen": {
     "defaultValue": "off",
-    "description": " Comma-separated list of addresses and ports on which the stream mode should listen.  This value accepts IPv4, IPv6, and hostnames. Some suffixes can be specified for each pair: - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  Examples:  ``` stream_listen = 127.0.0.1:7000 reuseport backlog=16384 stream_listen = 0.0.0.0:989 reuseport backlog=65536, 0.0.0.0:20 stream_listen = [::1]:1234 backlog=16384 ```  By default this value is set to `off`, thus disabling the stream proxy port for this node."
+    "description": "Comma-separated list of addresses and ports on\nwhich the stream mode should listen.\n\nThis value accepts IPv4, IPv6, and hostnames.\nSome suffixes can be specified for each pair:\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process\n  allowing the Kernel to better distribute incoming\n  connections between worker processes\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small in order to prevent clients\n  seeing \"Connection refused\" error connecting to\n  a busy Kong instance.\n  **Note:** on Linux, this value is limited by the\n  setting of `net.core.somaxconn` Kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections\n- so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]\n  configures the “TCP keepalive” behavior for the listening\n  socket. If this parameter is omitted then the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value “on”, the SO_KEEPALIVE option is turned\n  on for the socket. If it is set to the value “off”, the\n  SO_KEEPALIVE option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,\n  and TCP_KEEPCNT socket options.\n\nExamples:\n\n```\nstream_listen = 127.0.0.1:7000 reuseport backlog=16384\nstream_listen = 0.0.0.0:989 reuseport backlog=65536, 0.0.0.0:20\nstream_listen = [::1]:1234 backlog=16384\n```\n\nBy default this value is set to `off`, thus\ndisabling the stream proxy port for this node.\n"
   },
   "admin_api_uri": {
     "defaultValue": null,
-    "description": "Deprecated: Use admin_gui_api_url instead"
+    "description": "Deprecated: Use admin_gui_api_url instead\n"
   },
   "admin_listen": {
     "defaultValue": [
       "127.0.0.1:8001 reuseport backlog=16384",
       "127.0.0.1:8444 http2 ssl reuseport backlog=16384"
     ],
-    "description": " Comma-separated list of addresses and ports on which the Admin interface should listen. The Admin interface is the API allowing you to configure and manage Kong. Access to this interface should be *restricted* to Kong administrators *only*. This value accepts IPv4, IPv6, and hostnames.  It is highly recommended to avoid exposing the Admin API to public interface(s), by using values such as 0.0.0.0:8001  See https://docs.konghq.com/gateway/latest/production/running-kong/secure-admin-api/ for more information about how to secure your Admin API  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the TCP_DEFER_ACCEPT socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  This value can be set to `off`, thus disabling the Admin interface for this node, enabling a 'data-plane' mode (without configuration capabilities) pulling its configuration changes from the database.  Example: `admin_listen = 127.0.0.1:8444 http2 ssl`"
+    "description": "Comma-separated list of addresses and ports on\nwhich the Admin interface should listen.\nThe Admin interface is the API allowing you to\nconfigure and manage Kong.\nAccess to this interface should be *restricted*\nto Kong administrators *only*. This value accepts\nIPv4, IPv6, and hostnames.\n\nIt is highly recommended to avoid exposing the Admin API to public\ninterface(s), by using values such as 0.0.0.0:8001\n\nSee https://docs.konghq.com/gateway/latest/production/running-kong/secure-admin-api/\nfor more information about how to secure your Admin API\n\nSome suffixes can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's proxy server.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `deferred` instructs to use a deferred accept on\n  Linux (the TCP_DEFER_ACCEPT socket option).\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process\n  allowing the Kernel to better distribute incoming\n  connections between worker processes\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small in order to prevent clients\n  seeing \"Connection refused\" error connecting to\n  a busy Kong instance.\n  **Note:** on Linux, this value is limited by the\n  setting of `net.core.somaxconn` Kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections\n- so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]\n  configures the “TCP keepalive” behavior for the listening\n  socket. If this parameter is omitted then the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value “on”, the SO_KEEPALIVE option is turned\n  on for the socket. If it is set to the value “off”, the\n  SO_KEEPALIVE option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,\n  and TCP_KEEPCNT socket options.\n\nThis value can be set to `off`, thus disabling\nthe Admin interface for this node, enabling a\n'data-plane' mode (without configuration\ncapabilities) pulling its configuration changes\nfrom the database.\n\nExample: `admin_listen = 127.0.0.1:8444 http2 ssl`\n"
   },
   "status_listen": {
     "defaultValue": "127.0.0.1:8007 reuseport backlog=16384",
-    "description": " Comma-separated list of addresses and ports on which the Status API should listen. The Status API is a read-only endpoint allowing monitoring tools to retrieve metrics, healthiness, and other non-sensitive information of the current Kong node.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Status API server. - `proxy_protocol` will enable usage of the PROXY protocol.  This value can be set to `off`, disabling the Status API for this node.  Example: `status_listen = 0.0.0.0:8100 ssl http2`"
+    "description": "Comma-separated list of addresses and ports on\nwhich the Status API should listen.\nThe Status API is a read-only endpoint\nallowing monitoring tools to retrieve metrics,\nhealthiness, and other non-sensitive information\nof the current Kong node.\n\nThe following suffix can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's Status API server.\n- `proxy_protocol` will enable usage of the PROXY protocol.\n\nThis value can be set to `off`, disabling\nthe Status API for this node.\n\nExample: `status_listen = 0.0.0.0:8100 ssl http2`\n"
   },
   "debug_listen": {
     "defaultValue": "off",
-    "description": "Comma-separated list of addresses and ports on which the Debug API should listen.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Debug API server.  This value can be set to `off`, disabling the Debug API for this node.  Example: `debug_listen = 0.0.0.0:8200 ssl http2`"
+    "description": "Comma-separated list of addresses and ports on\nwhich the Debug API should listen.\n\nThe following suffix can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's Debug API server.\n\nThis value can be set to `off`, disabling\nthe Debug API for this node.\n\nExample: `debug_listen = 0.0.0.0:8200 ssl http2`\n"
   },
   "debug_listen_local": {
     "defaultValue": "on",
-    "description": "Expose `debug_listen` functionalities via a Unix domain socket under the Kong prefix.  This option allows local user to use \"kong debug\" command to invoke various debug functionalities without needing to enable `debug_listen` ahead of time."
+    "description": "Expose `debug_listen` functionalities via a\nUnix domain socket under the Kong prefix.\n\nThis option allows local user to use \"kong debug\" command\nto invoke various debug functionalities without needing to\nenable `debug_listen` ahead of time.\n"
   },
   "nginx_user": {
     "defaultValue": "kong kong",
-    "description": "Defines user and group credentials used by worker processes. If group is omitted, a group whose name equals that of user is used.  Example: `nginx_user = nginx www`  **Note**: If the `kong` user and the `kong` group are not available, the default user and group credentials will be `nobody nobody`."
+    "description": "Defines user and group credentials used by\nworker processes. If group is omitted, a\ngroup whose name equals that of user is\nused.\n\nExample: `nginx_user = nginx www`\n\n**Note**: If the `kong` user and the `kong`\ngroup are not available, the default user\nand group credentials will be\n`nobody nobody`.\n"
   },
   "nginx_worker_processes": {
     "defaultValue": "auto",
-    "description": "Determines the number of worker processes spawned by Nginx.  See http://nginx.org/en/docs/ngx_core_module.html#worker_processes for detailed usage of the equivalent Nginx directive and a description of accepted values."
+    "description": "Determines the number of worker processes\nspawned by Nginx.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_processes\nfor detailed usage of the equivalent Nginx\ndirective and a description of accepted\nvalues.\n"
   },
   "nginx_daemon": {
     "defaultValue": "on",
-    "description": "Determines whether Nginx will run as a daemon or as a foreground process. Mainly useful for development or when running Kong inside a Docker environment.  See http://nginx.org/en/docs/ngx_core_module.html#daemon."
+    "description": "Determines whether Nginx will run as a daemon\nor as a foreground process. Mainly useful\nfor development or when running Kong inside\na Docker environment.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#daemon.\n"
   },
   "mem_cache_size": {
     "defaultValue": "128m",
-    "description": "Size of each of the two shared memory caches for traditional mode database entities and runtime data, `kong_core_cache` and `kong_cache`.  The accepted units are `k` and `m`, with a minimum recommended value of a few MBs.  **Note**: As this option controls the size of two different cache zones, the total memory Kong uses to cache entities might be double this value. The created zones are shared by all worker processes and do not become larger when more worker is used."
+    "description": "Size of each of the two shared memory caches\nfor traditional mode database entities\nand runtime data, `kong_core_cache` and\n`kong_cache`.\n\nThe accepted units are `k` and `m`, with a minimum\nrecommended value of a few MBs.\n\n**Note**: As this option controls the size of two\ndifferent cache zones, the total memory Kong\nuses to cache entities might be double this value.\nThe created zones are shared by all worker\nprocesses and do not become larger when more\nworker is used.\n"
   },
   "ssl_cipher_suite": {
     "defaultValue": "intermediate",
-    "description": "Defines the TLS ciphers served by Nginx. Accepted values are `modern`, `intermediate`, `old`, `fips` or `custom`. If you want to enable TLSv1.1, this value has to be `old`.  See https://wiki.mozilla.org/Security/Server_Side_TLS for detailed descriptions of each cipher suite. `fips` cipher suites are as described in https://wiki.openssl.org/index.php/FIPS_mode_and_TLS."
+    "description": "Defines the TLS ciphers served by Nginx.\nAccepted values are `modern`,\n`intermediate`, `old`, `fips` or `custom`.\nIf you want to enable TLSv1.1, this value has to be `old`.\n\nSee https://wiki.mozilla.org/Security/Server_Side_TLS\nfor detailed descriptions of each cipher\nsuite. `fips` cipher suites are as described in\nhttps://wiki.openssl.org/index.php/FIPS_mode_and_TLS.\n"
   },
   "ssl_ciphers": {
     "defaultValue": null,
-    "description": "Defines a custom list of TLS ciphers to be served by Nginx. This list must conform to the pattern defined by `openssl ciphers`. This value is ignored if `ssl_cipher_suite` is not `custom`. If you use DHE ciphers, you must also configure the `ssl_dhparam` parameter."
+    "description": "Defines a custom list of TLS ciphers to be\nserved by Nginx. This list must conform to\nthe pattern defined by `openssl ciphers`.\nThis value is ignored if `ssl_cipher_suite`\nis not `custom`.\nIf you use DHE ciphers, you must also\nconfigure the `ssl_dhparam` parameter.\n"
   },
   "ssl_protocols": {
     "defaultValue": "TLSv1.2 TLSv1.3",
-    "description": " Enables the specified protocols for client-side connections. The set of supported protocol versions also depends on the version of OpenSSL Kong was built with. This value is ignored if `ssl_cipher_suite` is not `custom`. If you want to enable TLSv1.1, you should set `ssl_cipher_suite` to `old`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols"
+    "description": "Enables the specified protocols for\nclient-side connections. The set of\nsupported protocol versions also depends\non the version of OpenSSL Kong was built\nwith. This value is ignored if\n`ssl_cipher_suite` is not `custom`.\nIf you want to enable TLSv1.1, you should\nset `ssl_cipher_suite` to `old`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols\n"
   },
   "ssl_prefer_server_ciphers": {
     "defaultValue": "on",
-    "description": "Specifies that server ciphers should be preferred over client ciphers when using the SSLv3 and TLS protocols. This value is ignored if `ssl_cipher_suite` is not `custom`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers"
+    "description": "Specifies that server ciphers should be\npreferred over client ciphers when using\nthe SSLv3 and TLS protocols. This value is\nignored if `ssl_cipher_suite` is not `custom`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers\n"
   },
   "ssl_dhparam": {
     "defaultValue": null,
-    "description": "Defines DH parameters for DHE ciphers from the predefined groups: `ffdhe2048`, `ffdhe3072`, `ffdhe4096`, `ffdhe6144`, `ffdhe8192`, from the absolute path to a parameters file, or directly from the parameters content.  This value is ignored if `ssl_cipher_suite` is `modern` or `intermediate`. The reason is that `modern` has no ciphers that needs this, and `intermediate` uses `ffdhe2048`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam"
+    "description": "Defines DH parameters for DHE ciphers from the\npredefined groups: `ffdhe2048`, `ffdhe3072`,\n`ffdhe4096`, `ffdhe6144`, `ffdhe8192`,\nfrom the absolute path to a parameters file, or\ndirectly from the parameters content.\n\nThis value is ignored if `ssl_cipher_suite`\nis `modern` or `intermediate`. The reason is\nthat `modern` has no ciphers that needs this,\nand `intermediate` uses `ffdhe2048`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam\n"
   },
   "ssl_session_tickets": {
     "defaultValue": "on",
-    "description": "Enables or disables session resumption through TLS session tickets. This has no impact when used with TLSv1.3.  Kong enables this by default for performance reasons, but it has security implications: https://github.com/mozilla/server-side-tls/issues/135  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets"
+    "description": "Enables or disables session resumption through\nTLS session tickets. This has no impact when\nused with TLSv1.3.\n\nKong enables this by default for performance\nreasons, but it has security implications:\nhttps://github.com/mozilla/server-side-tls/issues/135\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets\n"
   },
   "ssl_session_timeout": {
     "defaultValue": "1d",
-    "description": "Specifies a time during which a client may reuse the session parameters. See the rationale: https://github.com/mozilla/server-side-tls/issues/198  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout"
+    "description": "Specifies a time during which a client may\nreuse the session parameters. See the rationale:\nhttps://github.com/mozilla/server-side-tls/issues/198\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout\n"
   },
   "ssl_session_cache_size": {
     "defaultValue": "10m",
-    "description": "Sets the size of the caches that store session parameters  See https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache"
+    "description": "Sets the size of the caches that store session parameters\n\nSee https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache\n"
   },
   "ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `proxy_listen` values with TLS enabled.  If more than one certificates are specified, it can be used to provide alternate type of certificate (for example, ECC certificate) that will be served to clients that supports them. Note to properly serve using ECC certificates, it is recommended to also set `ssl_cipher_suite` to `modern` or `intermediate`.  Unless this option is explicitly set, Kong will auto-generate a pair of default certificates (RSA + ECC) first time it starts up and use it for serving TLS requests.  Certificates can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "Comma-separated list of certificates for `proxy_listen` values with TLS enabled.\n\nIf more than one certificates are specified, it can be used to provide\nalternate type of certificate (for example, ECC certificate) that will be served\nto clients that supports them. Note to properly serve using ECC certificates,\nit is recommended to also set `ssl_cipher_suite` to\n`modern` or `intermediate`.\n\nUnless this option is explicitly set, Kong will auto-generate\na pair of default certificates (RSA + ECC) first time it starts up and use\nit for serving TLS requests.\n\nCertificates can be configured on this property with either of the following\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `proxy_listen` values with TLS enabled.  If more than one certificate was specified for `ssl_cert`, then this option should contain the corresponding key for all certificates provided in the same order.  Unless this option is explicitly set, Kong will auto-generate a pair of default private keys (RSA + ECC) first time it starts up and use it for serving TLS requests.  Keys can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+    "description": "Comma-separated list of keys for `proxy_listen` values with TLS enabled.\n\nIf more than one certificate was specified for `ssl_cert`, then this\noption should contain the corresponding key for all certificates\nprovided in the same order.\n\nUnless this option is explicitly set, Kong will auto-generate\na pair of default private keys (RSA + ECC) first time it starts up and use\nit for serving TLS requests.\n\nKeys can be configured on this property with either of the following\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n"
   },
   "client_ssl": {
     "defaultValue": "off",
-    "description": "Determines if Nginx should attempt to send client-side TLS certificates and perform Mutual TLS Authentication with upstream service when proxying requests."
+    "description": "Determines if Nginx should attempt to send client-side\nTLS certificates and perform Mutual TLS Authentication\nwith upstream service when proxying requests.\n"
   },
   "client_ssl_cert": {
     "defaultValue": null,
-    "description": "If `client_ssl` is enabled, the client certificate for the `proxy_ssl_certificate` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "If `client_ssl` is enabled, the client certificate\nfor the `proxy_ssl_certificate` directive.\n\nThis value can be overwritten dynamically with the `client_certificate`\nattribute of the `Service` object.\n\nThe certificate can be configured on this property with either of the following\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "client_ssl_cert_key": {
     "defaultValue": null,
-    "description": "If `client_ssl` is enabled, the client TLS key for the `proxy_ssl_certificate_key` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate key can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+    "description": "If `client_ssl` is enabled, the client TLS key\nfor the `proxy_ssl_certificate_key` directive.\n\nThis value can be overwritten dynamically with the `client_certificate`\nattribute of the `Service` object.\n\nThe certificate key can be configured on this property with either of the following\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n"
   },
   "admin_ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `admin_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+    "description": "Comma-separated list of certificates for `admin_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n"
   },
   "admin_ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `admin_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+    "description": "Comma-separated list of keys for `admin_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n"
   },
   "status_ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `status_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+    "description": "Comma-separated list of certificates for `status_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n"
   },
   "status_ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `status_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+    "description": "Comma-separated list of keys for `status_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n"
   },
   "debug_ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `debug_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+    "description": "Comma-separated list of certificates for `debug_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n"
   },
   "debug_ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `debug_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+    "description": "Comma-separated list of keys for `debug_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n"
   },
   "headers": {
     "defaultValue": [
@@ -327,311 +327,311 @@
       "latency_tokens",
       "X-Kong-Request-Id"
     ],
-    "description": " Comma-separated list of headers Kong should inject in client responses.  Accepted values are: - `Server`: Injects `Server: kong/x.y.z`   on Kong-produced response (e.g. Admin   API, rejected requests from auth plugin). - `Via`: Injects `Via: kong/x.y.z` for   successfully proxied requests. - `X-Kong-Proxy-Latency`: Time taken   (in milliseconds) by Kong to process   a request and run all plugins before   proxying the request upstream. - `X-Kong-Response-Latency`: time taken   (in millisecond) by Kong to produce   a response in case of e.g. plugin   short-circuiting the request, or in   in case of an error. - `X-Kong-Upstream-Latency`: Time taken   (in milliseconds) by the upstream   service to send response headers. - `X-Kong-Admin-Latency`: Time taken   (in milliseconds) by Kong to process   an Admin API request. - `X-Kong-Upstream-Status`: The HTTP status   code returned by the upstream service.   This is particularly useful for clients to   distinguish upstream statuses if the   response is rewritten by a plugin. - `X-Kong-Request-Id`: Unique identifier of   the request. - `server_tokens`: Same as specifying both   `Server` and `Via`. - `latency_tokens`: Same as specifying   `X-Kong-Proxy-Latency`,   `X-Kong-Response-Latency`,   `X-Kong-Admin-Latency` and   `X-Kong-Upstream-Latency`  In addition to those, this value can be set to `off`, which prevents Kong from injecting any of the above headers. Note that this does not prevent plugins from injecting headers of their own.  Example: `headers = via, latency_tokens`"
+    "description": "Comma-separated list of headers Kong should\ninject in client responses.\n\nAccepted values are:\n- `Server`: Injects `Server: kong/x.y.z`\n  on Kong-produced response (e.g. Admin\n  API, rejected requests from auth plugin).\n- `Via`: Injects `Via: kong/x.y.z` for\n  successfully proxied requests.\n- `X-Kong-Proxy-Latency`: Time taken\n  (in milliseconds) by Kong to process\n  a request and run all plugins before\n  proxying the request upstream.\n- `X-Kong-Response-Latency`: time taken\n  (in millisecond) by Kong to produce\n  a response in case of e.g. plugin\n  short-circuiting the request, or in\n  in case of an error.\n- `X-Kong-Upstream-Latency`: Time taken\n  (in milliseconds) by the upstream\n  service to send response headers.\n- `X-Kong-Admin-Latency`: Time taken\n  (in milliseconds) by Kong to process\n  an Admin API request.\n- `X-Kong-Upstream-Status`: The HTTP status\n  code returned by the upstream service.\n  This is particularly useful for clients to\n  distinguish upstream statuses if the\n  response is rewritten by a plugin.\n- `X-Kong-Request-Id`: Unique identifier of\n  the request.\n- `server_tokens`: Same as specifying both\n  `Server` and `Via`.\n- `latency_tokens`: Same as specifying\n  `X-Kong-Proxy-Latency`,\n  `X-Kong-Response-Latency`,\n  `X-Kong-Admin-Latency` and\n  `X-Kong-Upstream-Latency`\n\nIn addition to those, this value can be set\nto `off`, which prevents Kong from injecting\nany of the above headers. Note that this\ndoes not prevent plugins from injecting\nheaders of their own.\n\nExample: `headers = via, latency_tokens`\n"
   },
   "headers_upstream": {
     "defaultValue": "X-Kong-Request-Id",
-    "description": " Comma-separated list of headers Kong should inject in requests to upstream.  At this time, the only accepted value is: - `X-Kong-Request-Id`: Unique identifier of   the request.  In addition, this value can be set to `off`, which prevents Kong from injecting the above header. Note that this does not prevent plugins from injecting headers of their own."
+    "description": "Comma-separated list of headers Kong should\ninject in requests to upstream.\n\nAt this time, the only accepted value is:\n- `X-Kong-Request-Id`: Unique identifier of\n  the request.\n\nIn addition, this value can be set\nto `off`, which prevents Kong from injecting\nthe above header. Note that this\ndoes not prevent plugins from injecting\nheaders of their own.\n"
   },
   "trusted_ips": {
     "defaultValue": null,
-    "description": "Defines trusted IP addresses blocks that are known to send correct `X-Forwarded-*` headers. Requests from trusted IPs make Kong forward their `X-Forwarded-*` headers upstream. Non-trusted requests make Kong insert its own `X-Forwarded-*` headers.  This property also sets the `set_real_ip_from` directive(s) in the Nginx configuration. It accepts the same type of values (CIDR blocks) but as a comma-separated list.  To trust *all* /!\\ IPs, set this value to `0.0.0.0/0,::/0`.  If the special value `unix:` is specified, all UNIX-domain sockets will be trusted.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from for examples of accepted values."
+    "description": "Defines trusted IP addresses blocks that are\nknown to send correct `X-Forwarded-*`\nheaders.\nRequests from trusted IPs make Kong forward\ntheir `X-Forwarded-*` headers upstream.\nNon-trusted requests make Kong insert its\nown `X-Forwarded-*` headers.\n\nThis property also sets the\n`set_real_ip_from` directive(s) in the Nginx\nconfiguration. It accepts the same type of\nvalues (CIDR blocks) but as a\ncomma-separated list.\n\nTo trust *all* /!\\ IPs, set this value to\n`0.0.0.0/0,::/0`.\n\nIf the special value `unix:` is specified,\nall UNIX-domain sockets will be trusted.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from\nfor examples of accepted values.\n"
   },
   "real_ip_header": {
     "defaultValue": "X-Real-IP",
-    "description": "Defines the request header field whose value will be used to replace the client address. This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  If this value receives `proxy_protocol`:  - at least one of the `proxy_listen` entries   must have the `proxy_protocol` flag   enabled. - the `proxy_protocol` parameter will be   appended to the `listen` directive of the   Nginx template.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header for a description of this directive."
+    "description": "Defines the request header field whose value\nwill be used to replace the client address.\nThis value sets the `ngx_http_realip_module`\ndirective of the same name in the Nginx\nconfiguration.\n\nIf this value receives `proxy_protocol`:\n\n- at least one of the `proxy_listen` entries\n  must have the `proxy_protocol` flag\n  enabled.\n- the `proxy_protocol` parameter will be\n  appended to the `listen` directive of the\n  Nginx template.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header\nfor a description of this directive.\n"
   },
   "real_ip_recursive": {
     "defaultValue": "off",
-    "description": "This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive for a description of this directive."
+    "description": "This value sets the `ngx_http_realip_module`\ndirective of the same name in the Nginx\nconfiguration.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive\nfor a description of this directive.\n"
   },
   "error_default_type": {
     "defaultValue": "text/plain",
-    "description": "Default MIME type to use when the request `Accept` header is missing and Nginx is returning an error for the request. Accepted values are `text/plain`, `text/html`, `application/json`, and `application/xml`."
+    "description": "Default MIME type to use when the request\n`Accept` header is missing and Nginx\nis returning an error for the request.\nAccepted values are `text/plain`,\n`text/html`, `application/json`, and\n`application/xml`.\n"
   },
   "upstream_keepalive_pool_size": {
     "defaultValue": "512",
-    "description": "Sets the default size of the upstream keepalive connection pools. Upstream keepalive connection pools are segmented by the `dst ip/dst port/SNI` attributes of a connection. A value of `0` will disable upstream keepalive connections by default, forcing each upstream request to open a new connection."
+    "description": "Sets the default size of the upstream\nkeepalive connection pools.\nUpstream keepalive connection pools\nare segmented by the `dst ip/dst\nport/SNI` attributes of a connection.\nA value of `0` will disable upstream\nkeepalive connections by default, forcing\neach upstream request to open a new\nconnection.\n"
   },
   "upstream_keepalive_max_requests": {
     "defaultValue": "10000",
-    "description": "Sets the default maximum number of requests than can be proxied upstream through one keepalive connection. After the maximum number of requests is reached, the connection will be closed. A value of `0` will disable this behavior, and a keepalive connection can be used to proxy an indefinite number of requests."
+    "description": "Sets the default maximum number of\nrequests than can be proxied upstream\nthrough one keepalive connection.\nAfter the maximum number of requests\nis reached, the connection will be\nclosed.\nA value of `0` will disable this\nbehavior, and a keepalive connection\ncan be used to proxy an indefinite\nnumber of requests.\n"
   },
   "upstream_keepalive_idle_timeout": {
     "defaultValue": "60",
-    "description": "Sets the default timeout (in seconds) for which an upstream keepalive connection should be kept open. When the timeout is reached while the connection has not been reused, it will be closed. A value of `0` will disable this behavior, and an idle keepalive connection may be kept open indefinitely."
+    "description": "Sets the default timeout (in seconds)\nfor which an upstream keepalive\nconnection should be kept open. When\nthe timeout is reached while the\nconnection has not been reused, it\nwill be closed.\nA value of `0` will disable this\nbehavior, and an idle keepalive\nconnection may be kept open\nindefinitely.\n"
   },
   "allow_debug_header": {
     "defaultValue": "off",
-    "description": "Enable the `Kong-Debug` header function. if it is `on`, kong will add `Kong-Route-Id` `Kong-Route-Name` `Kong-Service-Id` `Kong-Service-Name` debug headers to response when the client request header `Kong-Debug: 1` is present."
+    "description": "Enable the `Kong-Debug` header function.\nif it is `on`, kong will add\n`Kong-Route-Id` `Kong-Route-Name` `Kong-Service-Id`\n`Kong-Service-Name` debug headers to response when\nthe client request header `Kong-Debug: 1` is present.\n"
   },
   "nginx_main_worker_rlimit_nofile": {
     "defaultValue": "auto",
-    "description": " Changes the limit on the maximum number of open files for worker processes.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile"
+    "description": "Changes the limit on the maximum number of open files\nfor worker processes.\n\nThe special and default value of `auto` sets this\nvalue to `ulimit -n` with the upper bound limited to\n16384 as a measure to protect against excess memory use,\nand the lower bound of 1024 as a good default.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile\n"
   },
   "nginx_events_worker_connections": {
     "defaultValue": "auto",
-    "description": " Sets the maximum number of simultaneous connections that can be opened by a worker process.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_connections"
+    "description": "Sets the maximum number of simultaneous\nconnections that can be opened by a worker process.\n\nThe special and default value of `auto` sets this\nvalue to `ulimit -n` with the upper bound limited to\n16384 as a measure to protect against excess memory use,\nand the lower bound of 1024 as a good default.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_connections\n"
   },
   "nginx_http_client_header_buffer_size": {
     "defaultValue": "1k",
-    "description": "Sets buffer size for reading the client request headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size"
+    "description": "Sets buffer size for reading the\nclient request headers.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size\n"
   },
   "nginx_http_large_client_header_buffers": {
     "defaultValue": "4 8k",
-    "description": "Sets the maximum number and size of buffers used for reading large clients requests headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers"
+    "description": "Sets the maximum number and\nsize of buffers used for\nreading large clients\nrequests headers.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers\n"
   },
   "nginx_http_client_max_body_size": {
     "defaultValue": "0",
-    "description": "Defines the maximum request body size allowed by requests proxied by Kong, specified in the Content-Length request header. If a request exceeds this limit, Kong will respond with a 413 (Request Entity Too Large). Setting this value to 0 disables checking the request body size. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size"
+    "description": "Defines the maximum request body size\nallowed by requests proxied by Kong,\nspecified in the Content-Length request\nheader. If a request exceeds this\nlimit, Kong will respond with a 413\n(Request Entity Too Large). Setting\nthis value to 0 disables checking the\nrequest body size.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size\n"
   },
   "nginx_admin_client_max_body_size": {
     "defaultValue": "10m",
-    "description": "Defines the maximum request body size for Admin API."
+    "description": "Defines the maximum request body size for\nAdmin API.\n"
   },
   "nginx_http_charset": {
     "defaultValue": "UTF-8",
-    "description": "Adds the specified charset to the “Content-Type” response header field. If this charset is different from the charset specified in the source_charset directive, a conversion is performed.  The parameter `off` cancels the addition of charset to the “Content-Type” response header field. See http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset"
+    "description": "Adds the specified charset to the “Content-Type”\nresponse header field. If this charset is different\nfrom the charset specified in the source_charset\ndirective, a conversion is performed.\n\nThe parameter `off` cancels the addition of\ncharset to the “Content-Type” response header field.\nSee http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset\n"
   },
   "nginx_http_client_body_buffer_size": {
     "defaultValue": "8k",
-    "description": "Defines the buffer size for reading the request body. If the client request body is larger than this value, the body will be buffered to disk. Note that when the body is buffered to disk, Kong plugins that access or manipulate the request body may not work, so it is advisable to set this value as high as possible (e.g., set it as high as `client_max_body_size` to force request bodies to be kept in memory). Do note that high-concurrency environments will require significant memory allocations to process many concurrent large request bodies. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size"
+    "description": "Defines the buffer size for reading\nthe request body. If the client\nrequest body is larger than this\nvalue, the body will be buffered to\ndisk. Note that when the body is\nbuffered to disk, Kong plugins that\naccess or manipulate the request\nbody may not work, so it is\nadvisable to set this value as high\nas possible (e.g., set it as high\nas `client_max_body_size` to force\nrequest bodies to be kept in\nmemory). Do note that\nhigh-concurrency environments will\nrequire significant memory\nallocations to process many\nconcurrent large request bodies.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size\n"
   },
   "nginx_admin_client_body_buffer_size": {
     "defaultValue": "10m",
-    "description": "Defines the buffer size for reading the request body on Admin API."
+    "description": "Defines the buffer size for reading\nthe request body on Admin API.\n"
   },
   "nginx_http_lua_regex_match_limit": {
     "defaultValue": "100000",
-    "description": "Global `MATCH_LIMIT` for PCRE regex matching. The default of `100000` should ensure at worst any regex Kong executes could finish within roughly 2 seconds."
+    "description": "Global `MATCH_LIMIT` for PCRE\nregex matching. The default of `100000` should ensure\nat worst any regex Kong executes could finish within\nroughly 2 seconds.\n"
   },
   "nginx_http_lua_regex_cache_max_entries": {
     "defaultValue": "8192",
-    "description": "Specifies the maximum number of entries allowed in the worker process level PCRE JIT compiled regex cache. It is recommended to set it to at least (number of regex paths * 2) to avoid high CPU usages if you manually specified `router_flavor` to `traditional`. `expressions` and `traditional_compat` router does not make use of the PCRE library and their behavior is unaffected by this setting."
+    "description": "Specifies the maximum number of entries allowed\nin the worker process level PCRE JIT compiled regex cache.\nIt is recommended to set it to at least (number of regex paths * 2)\nto avoid high CPU usages if you manually specified `router_flavor` to\n`traditional`. `expressions` and `traditional_compat` router does\nnot make use of the PCRE library and their behavior\nis unaffected by this setting.\n"
   },
   "nginx_http_keepalive_requests": {
     "defaultValue": "10000",
-    "description": "Sets the maximum number of client requests that can be served through one keep-alive connection. After the maximum number of requests are made, the connection is closed. Closing connections periodically is necessary to free per-connection memory allocations. Therefore, using too high maximum number of requests could result in excessive memory usage and not recommended. See: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests"
+    "description": "Sets the maximum number of client requests that can be served through one\nkeep-alive connection. After the maximum number of requests are made,\nthe connection is closed.\nClosing connections periodically is necessary to free per-connection\nmemory allocations. Therefore, using too high maximum number of requests\ncould result in excessive memory usage and not recommended.\nSee: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests\n"
   },
   "database": {
     "defaultValue": "postgres",
-    "description": "Determines the database (or no database) for this node Accepted values are `postgres` and `off`."
+    "description": "Determines the database (or no database) for\nthis node\nAccepted values are `postgres` and `off`.\n"
   },
   "pg_host": {
     "defaultValue": "127.0.0.1",
-    "description": "Host of the Postgres server."
+    "description": "Host of the Postgres server.\n"
   },
   "pg_port": {
     "defaultValue": "5432",
-    "description": "Port of the Postgres server."
+    "description": "Port of the Postgres server.\n"
   },
   "pg_timeout": {
     "defaultValue": "5000",
-    "description": "Defines the timeout (in ms), for connecting, reading and writing."
+    "description": "Defines the timeout (in ms), for connecting,\nreading and writing.\n"
   },
   "pg_user": {
     "defaultValue": "kong",
-    "description": "Postgres user."
+    "description": "Postgres user.\n"
   },
   "pg_password": {
     "defaultValue": null,
-    "description": "Postgres user's password."
+    "description": "Postgres user's password.\n"
   },
   "pg_iam_auth": {
     "defaultValue": "off",
-    "description": "Determines whether the AWS IAM database Authentication will be used. When switch to `on`, the username defined in `pg_user` will be used as the database account, and the database connection will be forced to using TLS. `pg_password` will not be used when the switch is `on`. Note that the corresponding IAM policy must be correct, otherwise connecting will fail."
+    "description": "Determines whether the AWS IAM database\nAuthentication will be used. When switch to\n`on`, the username defined in `pg_user` will\nbe used as the database account, and the\ndatabase connection will be forced to using\nTLS. `pg_password` will not be used when\nthe switch is `on`. Note that the corresponding\nIAM policy must be correct, otherwise connecting\nwill fail.\n"
   },
   "pg_iam_auth_assume_role_arn": {
     "defaultValue": null,
-    "description": "The target AWS IAM role ARN that will be assumed when using AWS IAM database authentication. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+    "description": "The target AWS IAM role ARN that will be\nassumed when using AWS IAM database\nauthentication. Typically this is used\nfor operating between multiple roles\nor cross-accounts.\nIf you are not using assume role\nyou should not specify this value.\n"
   },
   "pg_iam_auth_role_session_name": {
     "defaultValue": "KongPostgres",
-    "description": "The role session name used for role assuming in AWS IAM Database Authentication. The default value is `KongPostgres`."
+    "description": "The role session name used for role\nassuming in AWS IAM Database\nAuthentication. The default value is\n`KongPostgres`.\n"
   },
   "pg_iam_auth_sts_endpoint_url": {
     "defaultValue": null,
-    "description": "The custom STS endpoint URL used for role assuming in AWS IAM Database Authentication.  Note that this value will override the default STS endpoint URL(which should be `https://sts.amazonaws.com`, or `https://sts.<region>.amazonaws.com` if you have `AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).  If you are not using private VPC endpoint for STS service, you should not specify this value."
+    "description": "The custom STS endpoint URL used for role assuming\nin AWS IAM Database Authentication.\n\nNote that this value will override the default\nSTS endpoint URL(which should be\n`https://sts.amazonaws.com`, or\n`https://sts.<region>.amazonaws.com` if you have\n`AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).\n\nIf you are not using private VPC endpoint for STS\nservice, you should not specify this value.\n"
   },
   "pg_database": {
     "defaultValue": "kong",
-    "description": "The database name to connect to."
+    "description": "The database name to connect to.\n"
   },
   "pg_schema": {
     "defaultValue": null,
-    "description": "The database schema to use. If unspecified, Kong will respect the `search_path` value of your PostgreSQL instance."
+    "description": "The database schema to use. If unspecified,\nKong will respect the `search_path` value of\nyour PostgreSQL instance.\n"
   },
   "pg_ssl": {
     "defaultValue": "off",
-    "description": "Toggles client-server TLS connections between Kong and PostgreSQL. Because PostgreSQL uses the same port for TLS and non-TLS, this is only a hint. If the server does not support TLS, the established connection will be a plain one."
+    "description": "Toggles client-server TLS connections\nbetween Kong and PostgreSQL.\nBecause PostgreSQL uses the same port for TLS\nand non-TLS, this is only a hint. If the\nserver does not support TLS, the established\nconnection will be a plain one.\n"
   },
   "pg_ssl_version": {
     "defaultValue": "tlsv1_2",
-    "description": "When using ssl between Kong and PostgreSQL, the version of tls to use. Accepted values are `tlsv1_1`, `tlsv1_2`, `tlsv1_3`, or 'any'. When `any` is set, the client negotiates the highest version with the server which can't be lower than `tlsv1_1`."
+    "description": "When using ssl between Kong and PostgreSQL,\nthe version of tls to use. Accepted values are\n`tlsv1_1`, `tlsv1_2`, `tlsv1_3`, or 'any'. When\n`any` is set, the client negotiates the highest\nversion with the server which can't be lower\nthan `tlsv1_1`.\n"
   },
   "pg_ssl_required": {
     "defaultValue": "off",
-    "description": "When `pg_ssl` is on this determines if TLS must be used between Kong and PostgreSQL. It aborts the connection if the server does not support SSL connections."
+    "description": "When `pg_ssl` is on this determines if\nTLS must be used between Kong and PostgreSQL.\nIt aborts the connection if the server does\nnot support SSL connections.\n"
   },
   "pg_ssl_verify": {
     "defaultValue": "off",
-    "description": "Toggles server certificate verification if `pg_ssl` is enabled. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+    "description": "Toggles server certificate verification if\n`pg_ssl` is enabled.\nSee the `lua_ssl_trusted_certificate`\nsetting to specify a certificate authority.\n"
   },
   "pg_ssl_cert": {
     "defaultValue": null,
-    "description": "The absolute path to the PEM encoded client TLS certificate for the PostgreSQL connection. Mutual TLS authentication against PostgreSQL is only enabled if this value is set."
+    "description": "The absolute path to the PEM encoded client\nTLS certificate for the PostgreSQL connection.\nMutual TLS authentication against\nPostgreSQL is only enabled if this value is set.\n"
   },
   "pg_ssl_cert_key": {
     "defaultValue": null,
-    "description": "If `pg_ssl_cert` is set, the absolute path to the PEM encoded client TLS private key for the PostgreSQL connection."
+    "description": "If `pg_ssl_cert` is set, the absolute path to\nthe PEM encoded client TLS private key for the\nPostgreSQL connection.\n"
   },
   "pg_max_concurrent_queries": {
     "defaultValue": "0",
-    "description": "Sets the maximum number of concurrent queries that can be executing at any given time. This limit is enforced per worker process; the total number of concurrent queries for this node will be will be: `pg_max_concurrent_queries * nginx_worker_processes`.  The default value of 0 removes this concurrency limitation."
+    "description": "Sets the maximum number of concurrent queries\nthat can be executing at any given time. This\nlimit is enforced per worker process; the\ntotal number of concurrent queries for this\nnode will be will be:\n`pg_max_concurrent_queries * nginx_worker_processes`.\n\nThe default value of 0 removes this\nconcurrency limitation.\n"
   },
   "pg_semaphore_timeout": {
     "defaultValue": "60000",
-    "description": "Defines the timeout (in ms) after which PostgreSQL query semaphore resource acquisition attempts will fail. Such failures will generally result in the associated proxy or Admin API request failing with an HTTP 500 status code. Detailed discussion of this behavior is available in the online documentation."
+    "description": "Defines the timeout (in ms) after which\nPostgreSQL query semaphore resource\nacquisition attempts will fail. Such\nfailures will generally result in the\nassociated proxy or Admin API request\nfailing with an HTTP 500 status code.\nDetailed discussion of this behavior is\navailable in the online documentation.\n"
   },
   "pg_keepalive_timeout": {
     "defaultValue": null,
-    "description": "Specify the maximal idle timeout (in ms) for the postgres connections in the pool. If this value is set to 0 then the timeout interval is unlimited.  If not specified this value will be same as `lua_socket_keepalive_timeout`"
+    "description": "Specify the maximal idle timeout (in ms)\nfor the postgres connections in the pool.\nIf this value is set to 0 then the timeout interval\nis unlimited.\n\nIf not specified this value will be same as\n`lua_socket_keepalive_timeout`\n"
   },
   "pg_pool_size": {
     "defaultValue": null,
-    "description": "Specifies the size limit (in terms of connection count) for the Postgres server. Note that this connection pool is intended per Nginx worker rather than per Kong instance.  If not specified, the default value is the same as `lua_socket_pool_size`"
+    "description": "Specifies the size limit (in terms of connection\ncount) for the Postgres server.\nNote that this connection pool is intended\nper Nginx worker rather than per Kong instance.\n\nIf not specified, the default value is the same as\n`lua_socket_pool_size`\n"
   },
   "pg_backlog": {
     "defaultValue": null,
-    "description": "If specified, this value will limit the total number of open connections to the Postgres server to `pg_pool_size`. If the connection pool is full, subsequent connect operations will be inserted in a queue with size equal to this option's value.  If the number of queued connect operations reaches `pg_backlog`, exceeding connections will fail.  If not specified, then number of open connections to the Postgres server is not limited."
+    "description": "If specified, this value will limit the total\nnumber of open connections to the Postgres\nserver to `pg_pool_size`. If the connection\npool is full, subsequent connect operations\nwill be inserted in a queue with size equal\nto this option's value.\n\nIf the number of queued connect operations\nreaches `pg_backlog`, exceeding connections will fail.\n\nIf not specified, then number of open connections\nto the Postgres server is not limited.\n"
   },
   "pg_ro_host": {
     "defaultValue": null,
-    "description": "Same as `pg_host`, but for the read-only connection. **Note:** Refer to the documentation section above for detailed usage."
+    "description": "Same as `pg_host`, but for the\nread-only connection.\n**Note:** Refer to the documentation\nsection above for detailed usage.\n"
   },
   "pg_ro_port": {
     "defaultValue": "<pg_port>",
-    "description": "Same as `pg_port`, but for the read-only connection."
+    "description": "Same as `pg_port`, but for the\nread-only connection.\n"
   },
   "pg_ro_timeout": {
     "defaultValue": "<pg_timeout>",
-    "description": "Same as `pg_timeout`, but for the read-only connection."
+    "description": "Same as `pg_timeout`, but for the\nread-only connection.\n"
   },
   "pg_ro_user": {
     "defaultValue": "<pg_user>",
-    "description": "Same as `pg_user`, but for the read-only connection."
+    "description": "Same as `pg_user`, but for the\nread-only connection.\n"
   },
   "pg_ro_password": {
     "defaultValue": "<pg_password>",
-    "description": "Same as `pg_password`, but for the read-only connection."
+    "description": "Same as `pg_password`, but for the\nread-only connection.\n"
   },
   "pg_ro_iam_auth": {
     "defaultValue": "<pg_iam_auth>",
-    "description": "Same as `pg_iam_auth`, but for the read-only connection."
+    "description": "Same as `pg_iam_auth`, but for the\nread-only connection.\n"
   },
   "pg_ro_iam_auth_assume_role_arn": {
     "defaultValue": null,
-    "description": "Same as `pg_iam_auth_assume_role_arn', but for the read-only connection."
+    "description": "Same as `pg_iam_auth_assume_role_arn',\nbut for the read-only connection.\n"
   },
   "pg_ro_iam_auth_role_session_name": {
     "defaultValue": "KongPostgres",
-    "description": "Same as `pg_iam_auth_role_session_name`, but for the read-only connection."
+    "description": "Same as `pg_iam_auth_role_session_name`,\nbut for the read-only connection.\n"
   },
   "pg_ro_iam_auth_sts_endpoint_url": {
     "defaultValue": null,
-    "description": "Same as `pg_iam_auth_sts_endpoint_url`, but for the read-only connection."
+    "description": "Same as `pg_iam_auth_sts_endpoint_url`,\nbut for the read-only connection.\n"
   },
   "pg_ro_database": {
     "defaultValue": "<pg_database>",
-    "description": "Same as `pg_database`, but for the read-only connection."
+    "description": "Same as `pg_database`, but for the\nread-only connection.\n"
   },
   "pg_ro_schema": {
     "defaultValue": "<pg_schema>",
-    "description": "Same as `pg_schema`, but for the read-only connection."
+    "description": "Same as `pg_schema`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl": {
     "defaultValue": "<pg_ssl>",
-    "description": "Same as `pg_ssl`, but for the read-only connection."
+    "description": "Same as `pg_ssl`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl_required": {
     "defaultValue": "<pg_ssl_required>",
-    "description": " Same as `pg_ssl_required`, but for the read-only connection."
+    "description": "Same as `pg_ssl_required`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl_verify": {
     "defaultValue": "<pg_ssl_verify>",
-    "description": " Same as `pg_ssl_verify`, but for the read-only connection."
+    "description": "Same as `pg_ssl_verify`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl_version": {
     "defaultValue": "<pg_ssl_version>",
-    "description": " Same as `pg_ssl_version`, but for the read-only connection."
+    "description": "Same as `pg_ssl_version`, but for the\nread-only connection.\n"
   },
   "pg_ro_max_concurrent_queries": {
     "defaultValue": "<pg_max_concurrent_queries>",
-    "description": " Same as `pg_max_concurrent_queries`, but for the read-only connection. Note: read-only concurrency is not shared with the main (read-write) connection."
+    "description": "Same as `pg_max_concurrent_queries`, but for\nthe read-only connection.\nNote: read-only concurrency is not shared\nwith the main (read-write) connection.\n"
   },
   "pg_ro_semaphore_timeout": {
     "defaultValue": "<pg_semaphore_timeout>",
-    "description": " Same as `pg_semaphore_timeout`, but for the read-only connection."
+    "description": "Same as `pg_semaphore_timeout`, but for the\nread-only connection.\n"
   },
   "pg_ro_keepalive_timeout": {
     "defaultValue": "<pg_keepalive_timeout>",
-    "description": " Same as `pg_keepalive_timeout`, but for the read-only connection."
+    "description": "Same as `pg_keepalive_timeout`, but for the\nread-only connection.\n"
   },
   "pg_ro_pool_size": {
     "defaultValue": "<pg_pool_size>",
-    "description": " Same as `pg_pool_size`, but for the read-only connection."
+    "description": "Same as `pg_pool_size`, but for the\nread-only connection.\n"
   },
   "pg_ro_backlog": {
     "defaultValue": "<pg_backlog>",
-    "description": " Same as `pg_backlog`, but for the read-only connection."
+    "description": "Same as `pg_backlog`, but for the\nread-only connection.\n"
   },
   "declarative_config": {
     "defaultValue": null,
-    "description": "The path to the declarative configuration file which holds the specification of all entities (Routes, Services, Consumers, etc.) to be used when the `database` is set to `off`.  Entities are stored in Kong's LMDB cache, so you must ensure that enough headroom is allocated to it via the `lmdb_map_size` property.  If the Hybrid mode `role` is set to `data_plane` and there's no configuration cache file, this configuration is used before connecting to the Control Plane node as a user-controlled fallback."
+    "description": "The path to the declarative configuration\nfile which holds the specification of all\nentities (Routes, Services, Consumers, etc.)\nto be used when the `database` is set to\n`off`.\n\nEntities are stored in Kong's LMDB cache,\nso you must ensure that enough headroom is\nallocated to it via the `lmdb_map_size`\nproperty.\n\nIf the Hybrid mode `role` is set to `data_plane`\nand there's no configuration cache file,\nthis configuration is used before connecting\nto the Control Plane node as a user-controlled\nfallback.\n"
   },
   "declarative_config_string": {
     "defaultValue": null,
-    "description": "The declarative configuration as a string"
+    "description": "The declarative configuration as a string\n"
   },
   "lmdb_environment_path": {
     "defaultValue": "dbless.lmdb",
-    "description": "Directory where the LMDB database files used by DB-less and Hybrid mode to store Kong configurations reside.  This path is relative under the Kong `prefix`."
+    "description": "Directory where the LMDB database files used by\nDB-less and Hybrid mode to store Kong\nconfigurations reside.\n\nThis path is relative under the Kong `prefix`.\n"
   },
   "lmdb_map_size": {
     "defaultValue": "2048m",
-    "description": "Maximum size of the LMDB memory map, used to store the DB-less and Hybird mode configurations. Default is 2048m.  This config defines the limit of LMDB file size, the actual file size growth will be on-demand and proportional to the actual config size.  Note this value can be set very large, say a couple of GBs to accommodate future database growth and Multi Version Concurrency Control (MVCC) headroom needs. The file size of the LMDB database file should stabilize after a few config reload/Hybrid mode syncs and the actual memory used by the LMDB database will be smaller than the file size due to dynamic swapping of database pages by the OS."
+    "description": "Maximum size of the LMDB memory map, used to store the\nDB-less and Hybird mode configurations. Default is 2048m.\n\nThis config defines the limit of LMDB file size, the\nactual file size growth will be on-demand and\nproportional to the actual config size.\n\nNote this value can be set very large, say a couple of GBs\nto accommodate future database growth and\nMulti Version Concurrency Control (MVCC) headroom needs.\nThe file size of the LMDB database file should stabilize\nafter a few config reload/Hybrid mode syncs and the actual\nmemory used by the LMDB database will be smaller than\nthe file size due to dynamic swapping of database pages by\nthe OS.\n"
   },
   "db_update_frequency": {
     "defaultValue": "5",
-    "description": "Frequency (in seconds) at which to check for updated entities with the datastore.  When a node creates, updates, or deletes an entity via the Admin API, other nodes need to wait for the next poll (configured by this value) to eventually purge the old cached entity and start using the new one."
+    "description": "Frequency (in seconds) at which to check for\nupdated entities with the datastore.\n\nWhen a node creates, updates, or deletes an\nentity via the Admin API, other nodes need\nto wait for the next poll (configured by\nthis value) to eventually purge the old\ncached entity and start using the new one.\n"
   },
   "db_update_propagation": {
     "defaultValue": "0",
-    "description": "Time (in seconds) taken for an entity in the datastore to be propagated to replica nodes of another datacenter.  When set, this property will increase the time taken by Kong to propagate the change of an entity.  Single-datacenter setups or PostgreSQL servers should suffer no such delays, and this value can be safely set to 0. Postgres setups with read replicas should set this value to maximum expected replication lag between the writer and reader instances."
+    "description": "Time (in seconds) taken for an entity in the\ndatastore to be propagated to replica nodes\nof another datacenter.\n\nWhen set, this property will increase the\ntime taken by Kong to propagate the change\nof an entity.\n\nSingle-datacenter setups or PostgreSQL\nservers should suffer no such delays, and\nthis value can be safely set to 0.\nPostgres setups with read replicas should\nset this value to maximum expected replication\nlag between the writer and reader instances.\n"
   },
   "db_cache_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of an entity from the datastore when cached by this node.  Database misses (no entity) are also cached according to this setting if you do not configure `db_cache_neg_ttl`.  If set to 0 (default), such cached entities or misses never expire."
+    "description": "Time-to-live (in seconds) of an entity from\nthe datastore when cached by this node.\n\nDatabase misses (no entity) are also cached\naccording to this setting if you do not\nconfigure `db_cache_neg_ttl`.\n\nIf set to 0 (default), such cached entities\nor misses never expire.\n"
   },
   "db_cache_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a datastore miss (no entity).  If not specified (default), `db_cache_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a datastore\nmiss (no entity).\n\nIf not specified (default), `db_cache_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "db_resurrect_ttl": {
     "defaultValue": "30",
-    "description": "Time (in seconds) for which stale entities from the datastore should be resurrected for when they cannot be refreshed (e.g., the datastore is unreachable). When this TTL expires, a new attempt to refresh the stale entities will be made."
+    "description": "Time (in seconds) for which stale entities\nfrom the datastore should be resurrected for\nwhen they cannot be refreshed (e.g., the\ndatastore is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nentities will be made.\n"
   },
   "db_cache_warmup_entities": {
     "defaultValue": "services",
-    "description": " Entities to be pre-loaded from the datastore into the in-memory cache at Kong start-up. This speeds up the first access of endpoints that use the given entities.  When the `services` entity is configured for warmup, the DNS entries for values in its `host` attribute are pre-resolved asynchronously as well.  Cache size set in `mem_cache_size` should be set to a value large enough to hold all instances of the specified entities. If the size is insufficient, Kong will log a warning."
+    "description": "Entities to be pre-loaded from the datastore\ninto the in-memory cache at Kong start-up.\nThis speeds up the first access of endpoints\nthat use the given entities.\n\nWhen the `services` entity is configured\nfor warmup, the DNS entries for values in\nits `host` attribute are pre-resolved\nasynchronously as well.\n\nCache size set in `mem_cache_size` should\nbe set to a value large enough to hold all\ninstances of the specified entities.\nIf the size is insufficient, Kong will log\na warning.\n"
   },
   "dns_resolver": {
     "defaultValue": null,
-    "description": "Comma separated list of nameservers, each entry in `ip[:port]` format to be used by Kong. If not specified the nameservers in the local `resolv.conf` file will be used. Port defaults to 53 if omitted. Accepts both IPv4 and IPv6 addresses."
+    "description": "Comma separated list of nameservers, each\nentry in `ip[:port]` format to be used by\nKong. If not specified the nameservers in\nthe local `resolv.conf` file will be used.\nPort defaults to 53 if omitted. Accepts\nboth IPv4 and IPv6 addresses.\n"
   },
   "dns_hostsfile": {
     "defaultValue": "/etc/hosts",
-    "description": "The hosts file to use. This file is read once and its content is static in memory. To read the file again after modifying it, Kong must be reloaded."
+    "description": "The hosts file to use. This file is read\nonce and its content is static in memory.\nTo read the file again after modifying it,\nKong must be reloaded.\n"
   },
   "dns_order": {
     "defaultValue": [
@@ -640,450 +640,450 @@
       "A",
       "CNAME"
     ],
-    "description": "The order in which to resolve different record types. The `LAST` type means the type of the last successful lookup (for the specified name). The format is a (case insensitive) comma separated list."
+    "description": "The order in which to resolve different\nrecord types. The `LAST` type means the\ntype of the last successful lookup (for the\nspecified name). The format is a (case\ninsensitive) comma separated list.\n"
   },
   "dns_valid_ttl": {
     "defaultValue": null,
-    "description": "By default, DNS records are cached using the TTL value of a response. If this property receives a value (in seconds), it will override the TTL for all records."
+    "description": "By default, DNS records are cached using\nthe TTL value of a response. If this\nproperty receives a value (in seconds), it\nwill override the TTL for all records.\n"
   },
   "dns_stale_ttl": {
     "defaultValue": "3600",
-    "description": "Defines, in seconds, how long a record will remain in cache past its TTL. This value will be used while the new DNS record is fetched in the background. Stale data will be used from expiry of a record until either the refresh query completes, or the `dns_stale_ttl` number of seconds have passed. This configuration enables Kong to be more resilient during resolver downtime."
+    "description": "Defines, in seconds, how long a record will\nremain in cache past its TTL. This value\nwill be used while the new DNS record is\nfetched in the background.\nStale data will be used from expiry of a\nrecord until either the refresh query\ncompletes, or the `dns_stale_ttl` number of\nseconds have passed.\nThis configuration enables Kong to be more\nresilient during resolver downtime.\n"
   },
   "dns_cache_size": {
     "defaultValue": "10000",
-    "description": "Defines the maximum allowed number of DNS records stored in memory cache. Least recently used DNS records are discarded from cache if it is full. Both errors and data are cached, therefore a single name query can easily take up 10-15 slots."
+    "description": "Defines the maximum allowed number of\nDNS records stored in memory cache.\nLeast recently used DNS records are discarded\nfrom cache if it is full. Both errors and\ndata are cached, therefore a single name query\ncan easily take up 10-15 slots.\n"
   },
   "dns_not_found_ttl": {
     "defaultValue": "30",
-    "description": "TTL in seconds for empty DNS responses and \"(3) name error\" responses."
+    "description": "TTL in seconds for empty DNS responses and\n\"(3) name error\" responses.\n"
   },
   "dns_error_ttl": {
     "defaultValue": "1",
-    "description": "TTL in seconds for error responses."
+    "description": "TTL in seconds for error responses.\n"
   },
   "dns_no_sync": {
     "defaultValue": "off",
-    "description": "If enabled, then upon a cache-miss every request will trigger its own dns query. When disabled multiple requests for the same name/type will be synchronised to a single query."
+    "description": "If enabled, then upon a cache-miss every\nrequest will trigger its own dns query.\nWhen disabled multiple requests for the\nsame name/type will be synchronised to a\nsingle query.\n"
   },
   "vault_env_prefix": {
     "defaultValue": null,
-    "description": "Defines the environment variable vault's default prefix. For example if you have all your secrets stored in environment variables prefixed with `SECRETS_`, it can be configured here so that it isn't necessary to repeat them in Vault references."
+    "description": "Defines the environment variable vault's\ndefault prefix. For example if you have\nall your secrets stored in environment\nvariables prefixed with `SECRETS_`, it\ncan be configured here so that it isn't\nnecessary to repeat them in Vault\nreferences.\n"
   },
   "vault_aws_region": {
     "defaultValue": null,
-    "description": "The AWS region your vault is located in."
+    "description": "The AWS region your vault is located in.\n"
   },
   "vault_aws_endpoint_url": {
     "defaultValue": null,
-    "description": "The AWS SecretsManager service endpoint url. If not specified, the value used by vault will be the official AWS SecretsManager service url which is `https://secretsmanager.<region>.amazonaws.com` You can specify a complete URL(including the \"http/https\" scheme) to override the endpoint that vault will connect to."
+    "description": "The AWS SecretsManager service endpoint url.\nIf not specified, the value used by vault will\nbe the official AWS SecretsManager service url\nwhich is\n`https://secretsmanager.<region>.amazonaws.com`\nYou can specify a complete URL(including\nthe \"http/https\" scheme) to override the\nendpoint that vault will connect to.\n"
   },
   "vault_aws_assume_role_arn": {
     "defaultValue": null,
-    "description": "The target AWS IAM role ARN that will be assumed. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+    "description": "The target AWS IAM role ARN that will be\nassumed. Typically this is used for\noperating between multiple roles\nor cross-accounts.\nIf you are not using assume role\nyou should not specify this value.\n"
   },
   "vault_aws_role_session_name": {
     "defaultValue": "KongVault",
-    "description": "The role session name used for role assuming. The default value is `KongVault`."
+    "description": "The role session name used for role\nassuming. The default value is\n`KongVault`.\n"
   },
   "vault_aws_sts_endpoint_url": {
     "defaultValue": null,
-    "description": "The custom STS endpoint URL used for role assuming in AWS Vault.  Note that this value will override the default STS endpoint URL(which should be `https://sts.amazonaws.com`, or `https://sts.<region>.amazonaws.com` if you have `AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).  If you are not using private VPC endpoint for STS service, you should not specify this value."
+    "description": "The custom STS endpoint URL used for role assuming\nin AWS Vault.\n\nNote that this value will override the default\nSTS endpoint URL(which should be\n`https://sts.amazonaws.com`, or\n`https://sts.<region>.amazonaws.com` if you have\n`AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).\n\nIf you are not using private VPC endpoint for STS\nservice, you should not specify this value.\n"
   },
   "vault_aws_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the AWS vault when cached by this node.  AWS vault misses (no secret) are also cached according to this setting if you do not configure `vault_aws_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe AWS vault when cached by this node.\n\nAWS vault misses (no secret) are also cached\naccording to this setting if you do not\nconfigure `vault_aws_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_aws_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_aws_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a AWS vault\nmiss (no secret).\n\nIf not specified (default), `vault_aws_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_aws_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the AWS vault should be resurrected for when they cannot be refreshed (e.g., the AWS vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the AWS vault should be resurrected for\nwhen they cannot be refreshed (e.g., the\nAWS vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "vault_gcp_project_id": {
     "defaultValue": null,
-    "description": "The project ID from your Google API Console."
+    "description": "The project ID from your Google API Console.\n"
   },
   "vault_gcp_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the GCP vault when cached by this node.  GCP vault misses (no secret) are also cached according to this setting if you do not configure `vault_gcp_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe GCP vault when cached by this node.\n\nGCP vault misses (no secret) are also cached\naccording to this setting if you do not\nconfigure `vault_gcp_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_gcp_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_gcp_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a AWS vault\nmiss (no secret).\n\nIf not specified (default), `vault_gcp_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_gcp_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the GCP vault should be resurrected for when they cannot be refreshed (e.g., the GCP vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the GCP vault should be resurrected for\nwhen they cannot be refreshed (e.g., the\nGCP vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "vault_hcv_protocol": {
     "defaultValue": "http",
-    "description": "The protocol to connect with. Accepts one of `http` or `https`."
+    "description": "The protocol to connect with. Accepts one of\n`http` or `https`.\n"
   },
   "vault_hcv_host": {
     "defaultValue": "127.0.0.1",
-    "description": "The hostname of your HashiCorp vault."
+    "description": "The hostname of your HashiCorp vault.\n"
   },
   "vault_hcv_port": {
     "defaultValue": "8200",
-    "description": "The port number of your HashiCorp vault."
+    "description": "The port number of your HashiCorp vault.\n"
   },
   "vault_hcv_namespace": {
     "defaultValue": null,
-    "description": "Namespace for the HashiCorp Vault. Vault Enterprise requires a namespace to successfully connect to it."
+    "description": "Namespace for the HashiCorp Vault. Vault\nEnterprise requires a namespace to\nsuccessfully connect to it.\n"
   },
   "vault_hcv_mount": {
     "defaultValue": "secret",
-    "description": "The mount point."
+    "description": "The mount point.\n"
   },
   "vault_hcv_kv": {
     "defaultValue": "v1",
-    "description": "The secrets engine version. Accepts `v1` or `v2`."
+    "description": "The secrets engine version. Accepts `v1` or\n`v2`.\n"
   },
   "vault_hcv_token": {
     "defaultValue": null,
-    "description": "A token string."
+    "description": "A token string.\n"
   },
   "vault_hcv_auth_method": {
     "defaultValue": "token",
-    "description": "Defines the authentication mechanism when connecting to the Hashicorp Vault service. Accepted values are: `token`, `kubernetes` or `approle`."
+    "description": "Defines the authentication mechanism when\nconnecting to the Hashicorp Vault service.\nAccepted values are: `token`,\n`kubernetes` or `approle`.\n"
   },
   "vault_hcv_kube_role": {
     "defaultValue": null,
-    "description": "Defines the HashiCorp Vault role for the Kubernetes service account of the running pod. `vault_hcv_auth_method` must be set to `kubernetes` for this to activate."
+    "description": "Defines the HashiCorp Vault role for the\nKubernetes service account of the running\npod. `vault_hcv_auth_method` must be\nset to `kubernetes` for this to activate.\n"
   },
   "vault_hcv_kube_auth_path": {
     "defaultValue": "kubernetes",
-    "description": " Place where the Kubernetes auth method will be accessible: /v1/auth/<vault_hcv_kube_auth_path>"
+    "description": "Place where the Kubernetes auth method will be\naccessible: /v1/auth/<vault_hcv_kube_auth_path>\n"
   },
   "vault_hcv_kube_api_token_file": {
     "defaultValue": null,
-    "description": "Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+    "description": "Defines where the Kubernetes service account\ntoken should be read from the pod's\nfilesystem, if using a non-standard\ncontainer platform setup.\n"
   },
   "vault_hcv_approle_auth_path": {
     "defaultValue": "approle",
-    "description": " Place where the Approle auth method will be accessible: /v1/auth/<vault_hcv_approle_auth_path>"
+    "description": "Place where the Approle auth method will be\naccessible: /v1/auth/<vault_hcv_approle_auth_path>\n"
   },
   "vault_hcv_approle_role_id": {
     "defaultValue": null,
-    "description": "The Role ID of the Approle in HashiCorp Vault."
+    "description": "The Role ID of the Approle in HashiCorp Vault.\n"
   },
   "vault_hcv_approle_secret_id": {
     "defaultValue": null,
-    "description": "The Secret ID of the Approle in HashiCorp Vault."
+    "description": "The Secret ID of the Approle in HashiCorp Vault.\n"
   },
   "vault_hcv_approle_secret_id_file": {
     "defaultValue": null,
-    "description": "Defines where the Secret ID should be read from the pod's filesystem. This is usually used with HashiCorp Vault's response wrapping."
+    "description": "Defines where the Secret ID should be read from\nthe pod's filesystem. This is usually used with\nHashiCorp Vault's response wrapping.\n"
   },
   "vault_hcv_approle_response_wrapping": {
     "defaultValue": "false",
-    "description": "Defines whether the Secret ID read from configuration or file is actually a response-wrapping token instead of a real Secret ID."
+    "description": "Defines whether the Secret ID read from configuration\nor file is actually a response-wrapping token instead\nof a real Secret ID.\n"
   },
   "vault_hcv_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the HashiCorp vault when cached by this node.  HashiCorp vault misses (no secret) are also cached according to this setting if you do not configure `vault_hcv_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe HashiCorp vault when cached by this node.\n\nHashiCorp vault misses (no secret) are also\ncached according to this setting if you do not\nconfigure `vault_hcv_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_hcv_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a HashiCorp vault miss (no secret).  If not specified (default), `vault_hcv_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a HashiCorp vault\nmiss (no secret).\n\nIf not specified (default), `vault_hcv_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_hcv_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the HashiCorp vault should be resurrected for when they cannot be refreshed (e.g., the HashiCorp vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the HashiCorp vault should be resurrected\nfor when they cannot be refreshed (e.g., the\nHashiCorp vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "vault_azure_vault_uri": {
     "defaultValue": null,
-    "description": "The URI the vault is reachable from."
+    "description": "The URI the vault is reachable from.\n"
   },
   "vault_azure_client_id": {
     "defaultValue": null,
-    "description": "The client ID from your registered Application. Visit your Azure Dashboard and select *App Registrations* to check your client ID."
+    "description": "The client ID from your registered Application. Visit your Azure Dashboard and select *App Registrations* to check your client ID.\n"
   },
   "vault_azure_tenant_id": {
     "defaultValue": null,
-    "description": "The DirectoryId and TenantId both equate to the GUID representing the ActiveDirectory Tenant. Depending on context, either term may be used by Microsoft documentation and products, which can be confusing. In other words, the \"Tenant ID\" IS the \"Directory ID\""
+    "description": "The DirectoryId and TenantId both equate to the GUID representing the ActiveDirectory Tenant. Depending on context, either term may be used by Microsoft documentation and products, which can be confusing. In other words, the \"Tenant ID\" IS the \"Directory ID\"\n"
   },
   "vault_azure_type": {
     "defaultValue": "secrets",
-    "description": "Azure Key Vault enables Microsoft Azure applications and users to store and use several types of secret/key data: keys, secrets, and certificates. Kong currently only supports the `Secrets`"
+    "description": "Azure Key Vault enables Microsoft Azure applications and users to store and use several types of secret/key data: keys, secrets, and certificates. Kong currently only supports the `Secrets`\n"
   },
   "vault_azure_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the Azure Key Vault when cached by this node.  Key Vault misses (no secret) are also cached according to this setting if you do not configure `vault_azure_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe Azure Key Vault when cached by this node.\n\nKey Vault misses (no secret) are also\ncached according to this setting if you do not\nconfigure `vault_azure_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_azure_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a Azure Key Vault miss (no secret).  If not specified (default), `vault_azure_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a Azure Key Vault\nmiss (no secret).\n\nIf not specified (default), `vault_azure_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_azure_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the Azure Key Vault should be resurrected for when they cannot be refreshed (e.g., the the vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the Azure Key Vault should be resurrected\nfor when they cannot be refreshed (e.g., the\nthe vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "worker_consistency": {
     "defaultValue": "eventual",
-    "description": " Defines whether this node should rebuild its state synchronously or asynchronously (the balancers and the router are rebuilt on updates that affects them, e.g., updates to Routes, Services or Upstreams, via the Admin API or loading a declarative configuration file). (This option is deprecated and will be removed in future releases. The new default is `eventual`.)  Accepted values are:  - `strict`: the router will be rebuilt   synchronously, causing incoming requests to   be delayed until the rebuild is finished.   (This option is deprecated and will be removed    in future releases. The new default is `eventual`) - `eventual`: the router will be rebuilt   asynchronously via a recurring background   job running every second inside of each   worker.  Note that `strict` ensures that all workers of a given node will always proxy requests with an identical router, but that increased long tail latency can be observed if frequent Routes and Services updates are expected. Using `eventual` will help preventing long tail latency issues in such cases, but may cause workers to route requests differently for a short period of time after Routes and Services updates."
+    "description": "Defines whether this node should rebuild its\nstate synchronously or asynchronously (the\nbalancers and the router are rebuilt on\nupdates that affects them, e.g., updates to\nRoutes, Services or Upstreams, via the Admin\nAPI or loading a declarative configuration\nfile). (This option is deprecated and will be\nremoved in future releases. The new default\nis `eventual`.)\n\nAccepted values are:\n\n- `strict`: the router will be rebuilt\n  synchronously, causing incoming requests to\n  be delayed until the rebuild is finished.\n  (This option is deprecated and will be removed\n   in future releases. The new default is `eventual`)\n- `eventual`: the router will be rebuilt\n  asynchronously via a recurring background\n  job running every second inside of each\n  worker.\n\nNote that `strict` ensures that all workers\nof a given node will always proxy requests\nwith an identical router, but that increased\nlong tail latency can be observed if\nfrequent Routes and Services updates are\nexpected.\nUsing `eventual` will help preventing long\ntail latency issues in such cases, but may\ncause workers to route requests differently\nfor a short period of time after Routes and\nServices updates.\n"
   },
   "worker_state_update_frequency": {
     "defaultValue": "5",
-    "description": " Defines how often the worker state changes are checked with a background job. When a change is detected, a new router or balancer will be built, as needed. Raising this value will decrease the load on database servers and result in less jitter in proxy latency, but it might take more time to propagate changes to each individual worker."
+    "description": "Defines how often the worker state changes are\nchecked with a background job. When a change\nis detected, a new router or balancer will be\nbuilt, as needed. Raising this value will\ndecrease the load on database servers and\nresult in less jitter in proxy latency, but\nit might take more time to propagate changes\nto each individual worker.\n"
   },
   "router_flavor": {
     "defaultValue": "traditional_compatible",
-    "description": " Selects the router implementation to use when performing request routing. Incremental router rebuild is available when the flavor is set to either `expressions` or `traditional_compatible` which could significantly shorten rebuild time for large number of routes.  Accepted values are:  - `traditional_compatible`: the DSL based expression   router engine will be used under the hood. However   the router config interface will be the same   as `traditional` and expressions are   automatically generated at router build time.   The `expression` field on the `Route` object   is not visible. - `expressions`: the DSL based expression router engine   will be used under the hood. Traditional router   config interface is still visible, and you could also write   Router Expression manually and provide them in the   `expression` field on the `Route` object. - `traditional`: the pre-3.0 Router engine will be   used. Config interface will be the same as   pre-3.0 Kong and the `expression` field on the   `Route` object is not visible.    Deprecation warning: In Kong 3.0, `traditional`   mode should be avoided and only be used in case   `traditional_compatible` did not work as expected.   This flavor of router will be removed in the next   major release of Kong."
+    "description": "Selects the router implementation to use when\nperforming request routing. Incremental router\nrebuild is available when the flavor is set\nto either `expressions` or\n`traditional_compatible` which could\nsignificantly shorten rebuild time for large\nnumber of routes.\n\nAccepted values are:\n\n- `traditional_compatible`: the DSL based expression\n  router engine will be used under the hood. However\n  the router config interface will be the same\n  as `traditional` and expressions are\n  automatically generated at router build time.\n  The `expression` field on the `Route` object\n  is not visible.\n- `expressions`: the DSL based expression router engine\n  will be used under the hood. Traditional router\n  config interface is still visible, and you could also write\n  Router Expression manually and provide them in the\n  `expression` field on the `Route` object.\n- `traditional`: the pre-3.0 Router engine will be\n  used. Config interface will be the same as\n  pre-3.0 Kong and the `expression` field on the\n  `Route` object is not visible.\n\n  Deprecation warning: In Kong 3.0, `traditional`\n  mode should be avoided and only be used in case\n  `traditional_compatible` did not work as expected.\n  This flavor of router will be removed in the next\n  major release of Kong.\n"
   },
   "lua_max_req_headers": {
     "defaultValue": "100",
-    "description": "Maximum number of request headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying the Kong sends all the request headers and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many request headers."
+    "description": "Maximum number of request headers to parse by default.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying the Kong sends all the request headers\nand this setting does not have any effect. It is used\nto limit Kong and its plugins from reading too many\nrequest headers.\n"
   },
   "lua_max_resp_headers": {
     "defaultValue": "100",
-    "description": "Maximum number of response headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong returns all the response headers and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many response headers."
+    "description": "Maximum number of response headers to parse by default.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong returns all the response headers\nand this setting does not have any effect. It is used\nto limit Kong and its plugins from reading too many\nresponse headers.\n"
   },
   "lua_max_uri_args": {
     "defaultValue": "100",
-    "description": "Maximum number of request uri arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request query arguments and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many query arguments."
+    "description": "Maximum number of request uri arguments to parse by\ndefault.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request query\narguments and this setting does not have any effect.\nIt is used to limit Kong and its plugins from reading\ntoo many query arguments.\n"
   },
   "lua_max_post_args": {
     "defaultValue": "100",
-    "description": "Maximum number of request post arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request post arguments and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many post arguments."
+    "description": "Maximum number of request post arguments to parse by\ndefault.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request post\narguments and this setting does not have any effect.\nIt is used to limit Kong and its plugins from reading\ntoo many post arguments.\n"
   },
   "lua_ssl_trusted_certificate": {
     "defaultValue": "system",
-    "description": "Comma-separated list of certificate authorities for Lua cosockets in PEM format.  The special value `system` attempts to search for the \"usual default\" provided by each distro, according to an arbitrary heuristic. In the current implementation, The following pathnames will be tested in order, and the first one found will be used:  - /etc/ssl/certs/ca-certificates.crt (Debian/Ubuntu/Gentoo) - /etc/pki/tls/certs/ca-bundle.crt (Fedora/RHEL 6) - /etc/ssl/ca-bundle.pem (OpenSUSE) - /etc/pki/tls/cacert.pem (OpenELEC) - /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem (CentOS/RHEL 7) - /etc/ssl/cert.pem (OpenBSD, Alpine)  `system` can be used by itself or in conjunction with other CA filepaths.  When `pg_ssl_verify` is enabled, these certificate authority files will be used for verifying Kong's database connections.  Certificates can be configured on this property with either of the following values: * `system` * absolute path to the certificate * certificate content * base64 encoded certificate content  See https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate"
+    "description": "Comma-separated list of certificate authorities\nfor Lua cosockets in PEM format.\n\nThe special value `system` attempts to search for the\n\"usual default\" provided by each distro, according\nto an arbitrary heuristic. In the current implementation,\nThe following pathnames will be tested in order,\nand the first one found will be used:\n\n- /etc/ssl/certs/ca-certificates.crt (Debian/Ubuntu/Gentoo)\n- /etc/pki/tls/certs/ca-bundle.crt (Fedora/RHEL 6)\n- /etc/ssl/ca-bundle.pem (OpenSUSE)\n- /etc/pki/tls/cacert.pem (OpenELEC)\n- /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem (CentOS/RHEL 7)\n- /etc/ssl/cert.pem (OpenBSD, Alpine)\n\n`system` can be used by itself or in conjunction with other\nCA filepaths.\n\nWhen `pg_ssl_verify` is enabled, these\ncertificate authority files will be\nused for verifying Kong's database connections.\n\nCertificates can be configured on this property\nwith either of the following values:\n* `system`\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n\nSee https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate\n"
   },
   "lua_ssl_verify_depth": {
     "defaultValue": "1",
-    "description": "Sets the verification depth in the server certificates chain used by Lua cosockets, set by `lua_ssl_trusted_certificate`. This includes the certificates configured for Kong's database connections. If the maximum depth is reached before reaching the end of the chain, verification will fail. This helps mitigate certificate based DoS attacks.  See https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth"
+    "description": "Sets the verification depth in the server\ncertificates chain used by Lua cosockets,\nset by `lua_ssl_trusted_certificate`.\nThis includes the certificates configured\nfor Kong's database connections.\nIf the maximum depth is reached before\nreaching the end of the chain, verification\nwill fail. This helps mitigate certificate\nbased DoS attacks.\n\nSee https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth\n"
   },
   "lua_ssl_protocols": {
     "defaultValue": "TLSv1.2 TLSv1.3",
-    "description": "Defines the TLS versions supported when handshaking with OpenResty's TCP cosocket APIs.  This affects connections made by Lua code, such as connections to the database Kong uses, or when sending logs using a logging plugin. It does *not* affect connections made to the upstream Service or from downstream clients."
+    "description": "Defines the TLS versions supported\nwhen handshaking with OpenResty's\nTCP cosocket APIs.\n\nThis affects connections made by Lua\ncode, such as connections to the\ndatabase Kong uses, or when sending logs\nusing a logging plugin. It does *not*\naffect connections made to the upstream\nService or from downstream clients.\n"
   },
   "lua_package_path": {
     "defaultValue": "./?.lua;./?/init.lua;",
-    "description": "Sets the Lua module search path (LUA_PATH). Useful when developing or using custom plugins not stored in the default search path.  See https://github.com/openresty/lua-nginx-module#lua_package_path"
+    "description": "Sets the Lua module search path\n(LUA_PATH). Useful when developing\nor using custom plugins not stored\nin the default search path.\n\nSee https://github.com/openresty/lua-nginx-module#lua_package_path\n"
   },
   "lua_package_cpath": {
     "defaultValue": null,
-    "description": "Sets the Lua C module search path (LUA_CPATH).  See https://github.com/openresty/lua-nginx-module#lua_package_cpath"
+    "description": "Sets the Lua C module search path\n(LUA_CPATH).\n\nSee https://github.com/openresty/lua-nginx-module#lua_package_cpath\n"
   },
   "lua_socket_pool_size": {
     "defaultValue": "256",
-    "description": "Specifies the size limit for every cosocket connection pool associated with every remote server.  See https://github.com/openresty/lua-nginx-module#lua_socket_pool_size"
+    "description": "Specifies the size limit for every cosocket\nconnection pool associated with every remote\nserver.\n\nSee https://github.com/openresty/lua-nginx-module#lua_socket_pool_size\n"
   },
   "enforce_rbac": {
     "defaultValue": "off",
-    "description": "Specifies whether Admin API RBAC is enforced. Accepts one of `entity`, `both`, `on`, or `off`.  - `on`: only endpoint-level authorization   is enforced. - `entity`: entity-level authorization   applies. - `both`: enables both endpoint and   entity-level authorization. - `off`: disables both endpoint and   entity-level authorization.  When enabled, Kong will deny requests to the Admin API when a nonexistent or invalid RBAC authorization token is passed, or the RBAC user with which the token is associated does not have permissions to access/modify the requested resource."
+    "description": "Specifies whether Admin API RBAC is enforced.\nAccepts one of `entity`, `both`, `on`, or\n`off`.\n\n- `on`: only endpoint-level authorization\n  is enforced.\n- `entity`: entity-level authorization\n  applies.\n- `both`: enables both endpoint and\n  entity-level authorization.\n- `off`: disables both endpoint and\n  entity-level authorization.\n\nWhen enabled, Kong will deny requests to the\nAdmin API when a nonexistent or invalid RBAC\nauthorization token is passed, or the RBAC\nuser with which the token is associated does\nnot have permissions to access/modify the\nrequested resource.\n"
   },
   "rbac_auth_header": {
     "defaultValue": "Kong-Admin-Token",
-    "description": "Defines the name of the HTTP request header from which the Admin API will attempt to authenticate the RBAC user."
+    "description": "Defines the name of the HTTP request\nheader from which the Admin API will\nattempt to authenticate the RBAC user.\n"
   },
   "event_hooks_enabled": {
     "defaultValue": "on",
-    "description": "When enabled, event hook entities represent a relationship between an event (source and event) and an action (handler). Similar to web hooks, event hooks can be used to communicate Kong Gateway service events. When a particular event happens on a service, the event hook calls a URL with information about that event. Event hook configurations differ depending on the handler. The events that are triggered send associated data.  See: https://docs.konghq.com/enterprise/latest/admin-api/event-hooks/reference/"
+    "description": "When enabled, event hook entities represent a relationship\nbetween an event (source and event) and an action\n(handler). Similar to web hooks, event hooks can be used to\ncommunicate Kong Gateway service events. When a particular\nevent happens on a service, the event hook calls a URL with\ninformation about that event. Event hook configurations\ndiffer depending on the handler. The events that are\ntriggered send associated data.\n\nSee: https://docs.konghq.com/enterprise/latest/admin-api/event-hooks/reference/\n"
   },
   "fips": {
     "defaultValue": "off",
-    "description": "Turn on FIPS mode; this mode is only available on a FIPS build."
+    "description": "Turn on FIPS mode; this mode is only available on a FIPS build.\n"
   },
   "admin_gui_listen": {
     "defaultValue": [
       "0.0.0.0:8002",
       "0.0.0.0:8445 ssl"
     ],
-    "description": " Kong Manager Listeners  Comma-separated list of addresses and ports on which Kong will expose Kong Manager. This web application lets you configure and manage Kong, and therefore should be kept secured.  Suffixes can be specified for each pair, similarly to the `admin_listen` directive."
+    "description": "Kong Manager Listeners\n\nComma-separated list of addresses and ports on which\nKong will expose Kong Manager. This web application\nlets you configure and manage Kong, and therefore\nshould be kept secured.\n\nSuffixes can be specified for each pair, similarly to\nthe `admin_listen` directive.\n"
   },
   "admin_gui_url": {
     "defaultValue": null,
-    "description": "Kong Manager URL  The lookup, or balancer, address for Kong Manager.  Accepted format (items in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>)`  Examples:  - `http://127.0.0.1:8003` - `https://kong-admin.test` - `http://dev-machine`  By default, Kong Manager will use the window request host and append the resolved listener port depending on the requested protocol."
+    "description": "Kong Manager URL\n\nThe lookup, or balancer, address for Kong Manager.\n\nAccepted format (items in parentheses are optional):\n\n  `<scheme>://<IP / HOSTNAME>(:<PORT>)`\n\nExamples:\n\n- `http://127.0.0.1:8003`\n- `https://kong-admin.test`\n- `http://dev-machine`\n\nBy default, Kong Manager will use the window request\nhost and append the resolved listener port depending\non the requested protocol.\n"
   },
   "admin_gui_path": {
     "defaultValue": "/",
-    "description": "Kong Manager base path  This configuration parameter allows the user to customize the path prefix where Kong Manager is served. When updating this parameter, it's recommended to update the path in `admin_gui_url` as well.  Accepted format:  - Path must start with a `/` - Path must not end with a `/` (except for the `/`) - Path can only contain letters, digits, hyphens (`-`), underscores (`_`), and slashes (`/`) - Path must not contain continuous slashes (e.g., `//` and `///`)  Examples:  - `/` - `/manager` - `/kong-manager` - `/kong/manager`"
+    "description": "Kong Manager base path\n\nThis configuration parameter allows the user to customize\nthe path prefix where Kong Manager is served. When updating\nthis parameter, it's recommended to update the path in `admin_gui_url`\nas well.\n\nAccepted format:\n\n- Path must start with a `/`\n- Path must not end with a `/` (except for the `/`)\n- Path can only contain letters, digits, hyphens (`-`),\nunderscores (`_`), and slashes (`/`)\n- Path must not contain continuous slashes (e.g., `//` and `///`)\n\nExamples:\n\n- `/`\n- `/manager`\n- `/kong-manager`\n- `/kong/manager`\n"
   },
   "admin_gui_api_url": {
     "defaultValue": null,
-    "description": "Hierarchical part of a URI which is composed optionally of a host, port, and path at which the Admin API accepts HTTP or HTTPS traffic. When this config is disabled, Kong Manager will use the window protocol + host and append the resolved admin_listen HTTP/HTTPS port."
+    "description": "Hierarchical part of a URI which is composed\noptionally of a host, port, and path at which the\nAdmin API accepts HTTP or HTTPS traffic. When\nthis config is disabled, Kong Manager will\nuse the window protocol + host and append the\nresolved admin_listen HTTP/HTTPS port.\n"
   },
   "admin_gui_ssl_protocols": {
     "defaultValue": "TLSv1.2 TLSv1.3",
-    "description": " Defines the TLS versions supported for Kong Manager"
+    "description": "Defines the TLS versions supported\nfor Kong Manager\n"
   },
   "admin_gui_ssl_cert": {
     "defaultValue": null,
-    "description": "The SSL certificate for `admin_gui_listen` values with SSL enabled.  values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+    "description": "The SSL certificate for `admin_gui_listen` values\nwith SSL enabled.\n\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n"
   },
   "admin_gui_ssl_cert_key": {
     "defaultValue": null,
-    "description": "The SSL key for `admin_gui_listen` values with SSL enabled.  values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+    "description": "The SSL key for `admin_gui_listen` values with SSL\nenabled.\n\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n"
   },
   "admin_gui_flags": {
     "defaultValue": "{}",
-    "description": " Alters the layout Admin GUI (JSON) The only supported value is `{ \"IMMUNITY_ENABLED\": true }` to enable Kong Immunity in the Admin GUI."
+    "description": "Alters the layout Admin GUI (JSON)\nThe only supported value is `{ \"IMMUNITY_ENABLED\": true }`\nto enable Kong Immunity in the Admin GUI.\n"
   },
   "admin_gui_access_log": {
     "defaultValue": "logs/admin_gui_access.log",
-    "description": " Kong Manager Access Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables access logs for Kong Manager."
+    "description": "Kong Manager Access Logs\n\nHere you can set an absolute or relative path for Kong\nManager access logs. When the path is relative,\nlogs are placed in the `prefix` location.\n\nSetting this value to `off` disables access logs\nfor Kong Manager.\n"
   },
   "admin_gui_error_log": {
     "defaultValue": "logs/admin_gui_error.log",
-    "description": " Kong Manager Error Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables error logs for Kong Manager.  Granularity can be adjusted through the `log_level` directive."
+    "description": "Kong Manager Error Logs\n\nHere you can set an absolute or relative path for Kong\nManager access logs. When the path is relative,\nlogs are placed in the `prefix` location.\n\nSetting this value to `off` disables error logs for\nKong Manager.\n\nGranularity can be adjusted through the `log_level`\ndirective.\n"
   },
   "admin_gui_auth": {
     "defaultValue": null,
-    "description": "Kong Manager Authentication Plugin Name  Secures access to Kong Manager by specifying an authentication plugin to use.  Supported Plugins:  - `basic-auth`: Basic Authentication plugin - `ldap-auth-advanced`: LDAP Authentication plugin - `openid-connect`: OpenID Connect Authentication   plugin"
+    "description": "Kong Manager Authentication Plugin Name\n\nSecures access to Kong Manager by specifying an\nauthentication plugin to use.\n\nSupported Plugins:\n\n- `basic-auth`: Basic Authentication plugin\n- `ldap-auth-advanced`: LDAP Authentication plugin\n- `openid-connect`: OpenID Connect Authentication\n  plugin\n"
   },
   "admin_gui_auth_conf": {
     "defaultValue": null,
-    "description": "Kong Manager Authentication Plugin Config (JSON)  Specifies the configuration for the authentication plugin specified in `admin_gui_auth`.  For information about Plugin Configuration consult the associated plugin documentation.  Example for `basic-auth`:  `admin_gui_auth_conf = { \"hide_credentials\": true }`"
+    "description": "Kong Manager Authentication Plugin Config (JSON)\n\nSpecifies the configuration for the authentication\nplugin specified in `admin_gui_auth`.\n\nFor information about Plugin Configuration\nconsult the associated plugin documentation.\n\nExample for `basic-auth`:\n\n`admin_gui_auth_conf = { \"hide_credentials\": true }`\n"
   },
   "admin_gui_auth_password_complexity": {
     "defaultValue": null,
-    "description": "Kong Manager Authentication Password Complexity (JSON)  When `admin_gui_auth = basic-auth`, this property defines the rules required for Kong Manager passwords. Choose from preset rules or write your own.  Example using preset rules:  `admin_gui_auth_password_complexity = { \"kong-preset\": \"min_8\" }`  All values for kong-preset require the password to contain characters from at least three of the following categories:  1. Uppercase characters (A through Z)  2. Lowercase characters (a through z)  3. Base-10 digits (0 through 9)  4. Special characters (for example, &, $, #, %)  Supported preset rules: - `min_8`: minimum length of 8 - `min_12`: minimum length of 12 - `min_20`: minimum length of 20  To write your own rules, see https://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.  NOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.  Example:  `admin_gui_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`"
+    "description": "Kong Manager Authentication Password Complexity (JSON)\n\nWhen `admin_gui_auth = basic-auth`, this property defines\nthe rules required for Kong Manager passwords. Choose\nfrom preset rules or write your own.\n\nExample using preset rules:\n\n`admin_gui_auth_password_complexity = { \"kong-preset\": \"min_8\" }`\n\nAll values for kong-preset require the password to contain\ncharacters from at least three of the following categories:\n\n1. Uppercase characters (A through Z)\n\n2. Lowercase characters (a through z)\n\n3. Base-10 digits (0 through 9)\n\n4. Special characters (for example, &, $, #, %)\n\nSupported preset rules:\n- `min_8`: minimum length of 8\n- `min_12`: minimum length of 12\n- `min_20`: minimum length of 20\n\nTo write your own rules, see\nhttps://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.\n\nNOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.\n\nExample:\n\n`admin_gui_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`\n"
   },
   "admin_gui_session_conf": {
     "defaultValue": null,
-    "description": "Kong Manager Session Config (JSON)  Specifies the configuration for the Session plugin as used by Kong Manager.  For information about plugin configuration, consult the Kong Session plugin documentation.  Example: ``` admin_gui_session_conf = { \"cookie_name\": \"kookie\", \\                            \"secret\": \"changeme\" } ```"
+    "description": "Kong Manager Session Config (JSON)\n\nSpecifies the configuration for the Session plugin as\nused by Kong Manager.\n\nFor information about plugin configuration, consult\nthe Kong Session plugin documentation.\n\nExample:\n```\nadmin_gui_session_conf = { \"cookie_name\": \"kookie\", \\\n                           \"secret\": \"changeme\" }\n```\n"
   },
   "admin_gui_auth_header": {
     "defaultValue": "Kong-Admin-User",
-    "description": " Defines the name of the HTTP request header from which the Admin API will attempt to identify the Kong Admin user."
+    "description": "Defines the name of the HTTP request header from which\nthe Admin API will attempt to identify the Kong Admin\nuser.\n"
   },
   "admin_gui_auth_login_attempts": {
     "defaultValue": "0",
-    "description": " Number of times a user can attempt to login to Kong Manager. 0 means infinite attempts allowed."
+    "description": "Number of times a user can attempt to login to Kong\nManager. 0 means infinite attempts allowed.\n"
   },
   "admin_gui_header_txt": {
     "defaultValue": null,
-    "description": "Kong Manager Header Text Sets text for Kong Manager Header Banner. Header Banner is not shown if this config is empty."
+    "description": "Kong Manager Header Text\nSets text for Kong Manager Header Banner. Header Banner\nis not shown if this config is empty.\n"
   },
   "admin_gui_header_bg_color": {
     "defaultValue": null,
-    "description": "Kong Manager Header Background Color Sets background color for Kong Manager Header Banner Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Manager."
+    "description": "Kong Manager Header Background Color\nSets background color for Kong Manager Header Banner\nAccepts css color keyword, #-hexadecimal or rgb\nformat. Invalid values are ignored by Manager.\n"
   },
   "admin_gui_header_txt_color": {
     "defaultValue": null,
-    "description": "Kong Manager Header Text Color Sets text color for Kong Manager Header Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Kong Manager."
+    "description": "Kong Manager Header Text Color\nSets text color for Kong Manager Header Banner.\nAccepts css color keyword, #-hexadecimal or rgb\nformat. Invalid values are ignored by Kong Manager.\n"
   },
   "admin_gui_footer_txt": {
     "defaultValue": null,
-    "description": "Kong Manager Footer Text Sets text for Kong Manager Footer Banner. Footer Banner is not shown if this config is empty"
+    "description": "Kong Manager Footer Text\nSets text for Kong Manager Footer Banner. Footer Banner\nis not shown if this config is empty\n"
   },
   "admin_gui_footer_bg_color": {
     "defaultValue": null,
-    "description": "Kong Manager Footer Background Color Sets background color for Kong Manager Footer Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Manager."
+    "description": "Kong Manager Footer Background Color\nSets background color for Kong Manager Footer Banner.\nAccepts css color keyword, #-hexadecimal or rgb\nformat. Invalid values are ignored by Manager.\n"
   },
   "admin_gui_footer_txt_color": {
     "defaultValue": null,
-    "description": "Kong Manager Footer Text Color Sets text color for Kong Manager Footer Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Kong Manager."
+    "description": "Kong Manager Footer Text Color\nSets text color for Kong Manager Footer Banner.\nAccepts css color keyword, #-hexadecimal or rgb\nformat. Invalid values are ignored by Kong Manager.\n"
   },
   "admin_gui_login_banner_title": {
     "defaultValue": null,
-    "description": "Kong Manager Login Banner Title Text Sets title text for Kong Manager Login Banner. Login Banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+    "description": "Kong Manager Login Banner Title Text\nSets title text for Kong Manager Login Banner.\nLogin Banner is not shown if both\n`admin_gui_login_banner_title` and\n`admin_gui_login_banner_body` are empty.\n"
   },
   "admin_gui_login_banner_body": {
     "defaultValue": null,
-    "description": "Kong Manager Login Banner Body Text Sets body text for Kong Manager Login Banner. Login Banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+    "description": "Kong Manager Login Banner Body Text\nSets body text for Kong Manager Login Banner.\nLogin Banner is not shown if both\n`admin_gui_login_banner_title` and\n`admin_gui_login_banner_body` are empty.\n"
   },
   "konnect_mode": {
     "defaultValue": "off",
-    "description": "When enabled, the dataplane is connected to Konnect"
+    "description": "When enabled, the dataplane is connected to Konnect\n"
   },
   "analytics_flush_interval": {
     "defaultValue": "1",
-    "description": "Determine the frequency of flushing local data to Konnect in seconds."
+    "description": "Determine the frequency of flushing local data\nto Konnect in seconds.\n"
   },
   "analytics_buffer_size_limit": {
     "defaultValue": "100000",
-    "description": "Max number of messages can be buffered locally before dropping data in case there is no network connection to Konnect."
+    "description": "Max number of messages can be buffered locally\nbefore dropping data in case there is no\nnetwork connection to Konnect.\n"
   },
   "analytics_debug": {
     "defaultValue": "off",
-    "description": "Outputs analytics payload to Kong logs."
+    "description": "Outputs analytics payload to Kong logs.\n"
   },
   "admin_emails_from": {
     "defaultValue": "\"\"",
-    "description": "The email address for the `From` header for admin emails."
+    "description": "The email address for the `From` header\nfor admin emails.\n"
   },
   "admin_emails_reply_to": {
     "defaultValue": null,
-    "description": "Email address for the `Reply-To` header for admin emails."
+    "description": "Email address for the `Reply-To` header\nfor admin emails.\n"
   },
   "admin_invitation_expiry": {
     "defaultValue": "259200",
-    "description": "Expiration time for the admin invitation link (in seconds). 0 means no expiration.  Example, 72 hours: `72 * 60 * 60 = 259200`"
+    "description": "Expiration time for the admin invitation link\n(in seconds). 0 means no expiration.\n\nExample, 72 hours: `72 * 60 * 60 = 259200`\n"
   },
   "smtp_mock": {
     "defaultValue": "on",
-    "description": "This flag will mock the sending of emails. This can be used for testing before the SMTP client is fully configured."
+    "description": "This flag will mock the sending of emails. This can be\nused for testing before the SMTP client is fully\nconfigured.\n"
   },
   "smtp_host": {
     "defaultValue": "localhost",
-    "description": " The hostname of the SMTP server to connect to."
+    "description": "The hostname of the SMTP server to connect to.\n"
   },
   "smtp_port": {
     "defaultValue": "25",
-    "description": " The port number on the SMTP server to connect to."
+    "description": "The port number on the SMTP server to connect to.\n"
   },
   "smtp_starttls": {
     "defaultValue": "off",
-    "description": " When set to `on`, STARTTLS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 587."
+    "description": "When set to `on`, STARTTLS is used to encrypt\ncommunication with the SMTP server. This is normally\nused in conjunction with port 587.\n"
   },
   "smtp_username": {
     "defaultValue": null,
-    "description": "Username used for authentication with SMTP server"
+    "description": "Username used for authentication with SMTP server\n"
   },
   "smtp_password": {
     "defaultValue": null,
-    "description": "Password used for authentication with SMTP server"
+    "description": "Password used for authentication with SMTP server\n"
   },
   "smtp_ssl": {
     "defaultValue": "off",
-    "description": " When set to `on`, SMTPS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 465."
+    "description": "When set to `on`, SMTPS is used to encrypt\ncommunication with the SMTP server. This is normally\nused in conjunction with port 465.\n"
   },
   "smtp_auth_type": {
     "defaultValue": null,
-    "description": "The method used to authenticate with the SMTP server Valid options are `plain`, `login`, or `nil`"
+    "description": "The method used to authenticate with the SMTP server\nValid options are `plain`, `login`, or `nil`\n"
   },
   "smtp_domain": {
     "defaultValue": "localhost.localdomain",
-    "description": " The domain used in the `EHLO` connection and part of the `Message-ID` header"
+    "description": "The domain used in the `EHLO` connection and part of\nthe `Message-ID` header\n"
   },
   "smtp_timeout_connect": {
     "defaultValue": "60000",
-    "description": " The timeout (in milliseconds) for connecting to the SMTP server."
+    "description": "The timeout (in milliseconds) for connecting to the\nSMTP server.\n"
   },
   "smtp_timeout_send": {
     "defaultValue": "60000",
-    "description": " The timeout (in milliseconds) for sending data to the SMTP server."
+    "description": "The timeout (in milliseconds) for sending data to the\nSMTP server.\n"
   },
   "smtp_timeout_read": {
     "defaultValue": "60000",
-    "description": " The timeout (in milliseconds) for reading data from the SMTP server."
+    "description": "The timeout (in milliseconds) for reading data from\nthe SMTP server.\n"
   },
   "smtp_admin_emails": {
     "defaultValue": null,
-    "description": "Comma separated list of admin emails to receive notifications. Example `admin1@example.com, admin2@example.com`"
+    "description": "Comma separated list of admin emails to receive\nnotifications.\nExample `admin1@example.com, admin2@example.com`\n"
   },
   "audit_log": {
     "defaultValue": "off",
-    "description": "When enabled, Kong will log information about Admin API access and database row insertions, updates, and deletes."
+    "description": "When enabled, Kong will log information about\nAdmin API access and database row insertions,\nupdates, and deletes.\n"
   },
   "audit_log_ignore_methods": {
     "defaultValue": null,
-    "description": "Comma-separated list of HTTP methods that will not generate audit log entries. By default, all HTTP requests will be logged."
+    "description": "Comma-separated list of HTTP methods that\nwill not generate audit log entries. By\ndefault, all HTTP requests will be logged.\n"
   },
   "audit_log_ignore_paths": {
     "defaultValue": null,
-    "description": "Comma-separated list of request paths that will not generate audit log entries. By default, all HTTP requests will be logged."
+    "description": "Comma-separated list of request paths that\nwill not generate audit log entries. By\ndefault, all HTTP requests will be logged.\n"
   },
   "audit_log_ignore_tables": {
     "defaultValue": null,
-    "description": "Comma-separated list of database tables that will not generate audit log entries. By default, updates to all database tables will be logged (the term \"updates\" refers to the creation, update, or deletion of a row)."
+    "description": "Comma-separated list of database tables that\nwill not generate audit log entries. By\ndefault, updates to all database tables will\nbe logged (the term \"updates\" refers to the\ncreation, update, or deletion of a row).\n"
   },
   "audit_log_payload_exclude": {
     "defaultValue": [
@@ -1091,133 +1091,133 @@
       "secret",
       "password"
     ],
-    "description": " Comma-separated list of keys that will be filtered out of the payload. Keys that were filtered will be recorded in the audit log."
+    "description": "Comma-separated list of keys that will be\nfiltered out of the payload. Keys that were\nfiltered will be recorded in the audit log.\n"
   },
   "audit_log_record_ttl": {
     "defaultValue": "2592000",
-    "description": "Length, in seconds, of the TTL for audit log records. Records in the database older than their TTL are automatically purged.  Example, 30 days: `30 * 24 * 60 * 60 = 2592000`"
+    "description": "Length, in seconds, of the TTL for audit log\nrecords. Records in the database older than\ntheir TTL are automatically purged.\n\nExample, 30 days: `30 * 24 * 60 * 60 = 2592000`\n"
   },
   "audit_log_signing_key": {
     "defaultValue": null,
-    "description": "Defines the path to a private RSA signing key that can be used to insert a signature of audit records, adjacent to the record. The corresponding public key should be stored offline, and can be used the validate audit entries in the future. If this value is undefined, no signature will be generated."
+    "description": "Defines the path to a private RSA signing key\nthat can be used to insert a signature of\naudit records, adjacent to the record. The\ncorresponding public key should be stored\noffline, and can be used the validate audit\nentries in the future. If this value is\nundefined, no signature will be generated.\n"
   },
   "route_validation_strategy": {
     "defaultValue": "smart",
-    "description": "The strategy used to validate routes when creating or updating them. Different strategies are available to tune how to enforce splitting traffic of workspaces. - `smart` is the default option and uses the   algorithm described in   https://docs.konghq.com/gateway/latest/kong-enterprise/workspaces/. - `off` disables any check. - `path` enforces routes to comply with the pattern   described in config `enforce_route_path_pattern`. - `static` relies on the PostgreSQL database. Before creating a new route, it checks if the route is unique across all workspaces based on the following params: `paths`, `methods`, and `hosts`. If all fields of the new route overlap with an existing one, a 409 is returned with the route of the collision. The array order is not important for the overlap filter."
+    "description": "The strategy used to validate\nroutes when creating or updating them.\nDifferent strategies are available to tune\nhow to enforce splitting traffic of\nworkspaces.\n- `smart` is the default option and uses the\n  algorithm described in\n  https://docs.konghq.com/gateway/latest/kong-enterprise/workspaces/.\n- `off` disables any check.\n- `path` enforces routes to comply with the pattern\n  described in config `enforce_route_path_pattern`.\n- `static` relies on the PostgreSQL database.\nBefore creating a new route, it checks if the\nroute is unique across all workspaces based on\nthe following params: `paths`, `methods`, and\n`hosts`. If all fields of the new route overlap\nwith an existing one, a 409 is returned with the\nroute of the collision. The array order is not\nimportant for the overlap filter.\n"
   },
   "enforce_route_path_pattern": {
     "defaultValue": null,
-    "description": "Specifies the Lua pattern which will be enforced on the `paths` attribute of a Route object. You can also add a placeholder for the workspace in the pattern, which will be rendered during runtime based on the workspace to which the `route` belongs. This setting is only relevant if `route_validation_strategy` is set to `path`.   Example For Pattern `/$(workspace)/v%d/.*` valid paths are:  1. `/group1/v1/` if route belongs to   workspace `group1`.  2. `/group2/v1/some_path` if route belongs to   workspace `group2`."
+    "description": "Specifies the Lua pattern which will\nbe enforced on the `paths` attribute of a\nRoute object. You can also add a placeholder\nfor the workspace in the pattern, which\nwill be rendered during runtime based on the\nworkspace to which the `route` belongs.\nThis setting is only relevant if\n`route_validation_strategy` is set to `path`.\n\n\nExample\nFor Pattern `/$(workspace)/v%d/.*` valid paths\nare:\n\n1. `/group1/v1/` if route belongs to\n  workspace `group1`.\n\n2. `/group2/v1/some_path` if route belongs to\n  workspace `group2`.\n"
   },
   "keyring_enabled": {
     "defaultValue": "off",
-    "description": "When enabled, Kong will encrypt sensitive field values before writing them to the database, and subsuquently decrypt them when retrieving data for the Admin API, Developer Portal, or proxy business logic. Symmetric encryption keys are managed based on the strategy defined below."
+    "description": "When enabled, Kong will encrypt sensitive\nfield values before writing them to the\ndatabase, and subsuquently decrypt them when\nretrieving data for the Admin API, Developer\nPortal, or proxy business logic. Symmetric\nencryption keys are managed based on the\nstrategy defined below.\n"
   },
   "keyring_strategy": {
     "defaultValue": "cluster",
-    "description": "Defines the strategy implementation by which Kong nodes will manage symmetric encryption keys. Please see the Kong Enterprise documentation for a detailed description of each strategies. Acceptable values for this option are 'cluster' and 'vault'."
+    "description": "Defines the strategy implementation by which\nKong nodes will manage symmetric encryption\nkeys. Please see the Kong Enterprise\ndocumentation for a detailed description of\neach strategies. Acceptable values for this\noption are 'cluster' and 'vault'.\n"
   },
   "keyring_public_key": {
     "defaultValue": null,
-    "description": "Defines the public key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  values: * absolute path to the public key * public key content * base64 encoded public key content"
+    "description": "Defines the public key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nvalues:\n* absolute path to the public key\n* public key content\n* base64 encoded public key content\n"
   },
   "keyring_private_key": {
     "defaultValue": null,
-    "description": "Defines the private key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  values: * absolute path to the private key * private key content * base64 encoded private key content"
+    "description": "Defines the private key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nvalues:\n* absolute path to the private key\n* private key content\n* base64 encoded private key content\n"
   },
   "keyring_blob_path": {
     "defaultValue": null,
-    "description": "Defines the filesystem path at which Kong will backup the initial keyring material. This option is useful largely for development purposes."
+    "description": "Defines the filesystem path at which Kong\nwill backup the initial keyring material.\nThis option is useful largely for development\npurposes.\n"
   },
   "keyring_vault_host": {
     "defaultValue": null,
-    "description": "Defines the Vault host at which Kong will fetch the encryption material. This value should be defined in the format:  `<scheme>://<IP / HOSTNAME>:<PORT>`"
+    "description": "Defines the Vault host at which Kong will\nfetch the encryption material. This value\nshould be defined in the format:\n\n`<scheme>://<IP / HOSTNAME>:<PORT>`\n"
   },
   "keyring_vault_mount": {
     "defaultValue": null,
-    "description": "Defines the name of the Vault v2 KV secrets engine at which symmetric keys are found."
+    "description": "Defines the name of the Vault v2 KV secrets\nengine at which symmetric keys are found.\n"
   },
   "keyring_vault_path": {
     "defaultValue": null,
-    "description": "Defines the names of the Vault v2 KV path at which symmetric keys are found."
+    "description": "Defines the names of the Vault v2 KV path\nat which symmetric keys are found.\n"
   },
   "keyring_vault_auth_method": {
     "defaultValue": "token",
-    "description": " Defines the authentication mechanism when connecting to the Hashicorp Vault service.  Accepted values are: `token`, or `kubernetes`:  * `token`: Uses the static token defined in            the `keyring_vault_token`            configuration property.  * `kubernetes`: Uses the Kubernetes authentication                 mechanism, with the running pod's                 mapped service account, to assume                 the Hashicorp Vault role name that is                 defined in the `keyring_vault_kube_role`                 configuration property."
+    "description": "Defines the authentication mechanism when\nconnecting to the Hashicorp Vault service.\n\nAccepted values are: `token`, or `kubernetes`:\n\n* `token`: Uses the static token defined in\n           the `keyring_vault_token`\n           configuration property.\n\n* `kubernetes`: Uses the Kubernetes authentication\n                mechanism, with the running pod's\n                mapped service account, to assume\n                the Hashicorp Vault role name that is\n                defined in the `keyring_vault_kube_role`\n                configuration property.\n"
   },
   "keyring_vault_token": {
     "defaultValue": null,
-    "description": "Defines the token value used to communicate with the v2 KV Vault HTTP(S) API."
+    "description": "Defines the token value used to communicate\nwith the v2 KV Vault HTTP(S) API.\n"
   },
   "keyring_vault_kube_role": {
     "defaultValue": "default",
-    "description": " Defines the Hashicorp Vault role that will be assumed using the Kubernetes service account of the running pod.  `keyring_vault_auth_method` must be set to `kubernetes` for this to activate."
+    "description": "Defines the Hashicorp Vault role that will be\nassumed using the Kubernetes service account of\nthe running pod.\n\n`keyring_vault_auth_method` must be set to `kubernetes`\nfor this to activate.\n"
   },
   "keyring_vault_kube_api_token_file": {
     "defaultValue": "/run/secrets/kubernetes.io/serviceaccount/token",
-    "description": " Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+    "description": "Defines where the Kubernetes service account token\nshould be read from the pod's filesystem, if using\na non-standard container platform setup.\n"
   },
   "untrusted_lua": {
     "defaultValue": "sandbox",
-    "description": " Controls loading of Lua functions from admin-supplied sources such as the Admin API. LuaJIT bytecode loading is always disabled.  **Warning:** LuaJIT is not designed as a secure runtime for running malicious code, therefore you should properly protect your Admin API endpoint even with sandboxing enabled. The sandbox only provides protection against trivial attackers or unintentional modification of the Kong global environment.  Accepted values are: `off`, `sandbox`, or `on`:  * `off`: Disallow loading of any arbitrary          Lua functions. The `off` option          disables any functionality that runs          arbitrary Lua code, including the          Serverless Functions plugins and any          transformation plugin that allows          custom Lua functions.  * `sandbox`: Allow loading of Lua functions,              but use a sandbox when executing              them. The sandboxed function has              restricted access to the global              environment and only has access              to standard Lua functions that              will generally not cause harm to              the Kong Gateway node.  * `on`: Functions have unrestricted         access to the global environment and         can load any Lua modules. This is         similar to the behavior in         Kong Gateway prior to 2.3.0.  The default `sandbox` environment does not allow importing other modules or libraries, or executing anything at the OS level (for example, file read/write). The global environment is also not accessible.  Examples of `untrusted_lua = sandbox` behavior:  * You can't access or change global values such as `kong.configuration.pg_password` * You can run harmless lua: `local foo = 1 + 1`. However, OS level functions are not allowed, like: `os.execute('rm -rf /*')`.  For a full allowed/disallowed list, see: https://github.com/kikito/sandbox.lua/blob/master/sandbox.lua  To customize the sandbox environment, use the `untrusted_lua_sandbox_requires` and `untrusted_lua_sandbox_environment` parameters below."
+    "description": "Controls loading of Lua functions from admin-supplied\nsources such as the Admin API. LuaJIT bytecode\nloading is always disabled.\n\n**Warning:** LuaJIT is not designed as a secure\nruntime for running malicious code, therefore\nyou should properly protect your Admin API endpoint\neven with sandboxing enabled. The sandbox only\nprovides protection against trivial attackers or\nunintentional modification of the Kong global\nenvironment.\n\nAccepted values are: `off`, `sandbox`, or\n`on`:\n\n* `off`: Disallow loading of any arbitrary\n         Lua functions. The `off` option\n         disables any functionality that runs\n         arbitrary Lua code, including the\n         Serverless Functions plugins and any\n         transformation plugin that allows\n         custom Lua functions.\n\n* `sandbox`: Allow loading of Lua functions,\n             but use a sandbox when executing\n             them. The sandboxed function has\n             restricted access to the global\n             environment and only has access\n             to standard Lua functions that\n             will generally not cause harm to\n             the Kong Gateway node.\n\n* `on`: Functions have unrestricted\n        access to the global environment and\n        can load any Lua modules. This is\n        similar to the behavior in\n        Kong Gateway prior to 2.3.0.\n\nThe default `sandbox` environment does not\nallow importing other modules or libraries,\nor executing anything at the OS level (for\nexample, file read/write). The global\nenvironment is also not accessible.\n\nExamples of `untrusted_lua = sandbox`\nbehavior:\n\n* You can't access or change global values\nsuch as `kong.configuration.pg_password`\n* You can run harmless lua:\n`local foo = 1 + 1`. However, OS level\nfunctions are not allowed, like:\n`os.execute('rm -rf /*')`.\n\nFor a full allowed/disallowed list, see:\nhttps://github.com/kikito/sandbox.lua/blob/master/sandbox.lua\n\nTo customize the sandbox environment, use\nthe `untrusted_lua_sandbox_requires` and\n`untrusted_lua_sandbox_environment`\nparameters below.\n"
   },
   "untrusted_lua_sandbox_requires": {
     "defaultValue": null,
-    "description": "Comma-separated list of modules allowed to be loaded with `require` inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  For example, say you have configured the Serverless pre-function plugin and it contains the following `requires`:  ``` local template = require \"resty.template\" local split = require \"kong.tools.utils\".split ```  To run the plugin, add the modules to the allowed list: ``` untrusted_lua_sandbox_requires = resty.template, kong.tools.utils ```  **Warning:** Allowing certain modules may create opportunities to escape the sandbox. For example, allowing `os` or `luaposix` may be unsafe."
+    "description": "Comma-separated list of modules allowed to\nbe loaded with `require` inside the\nsandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\nFor example, say you have configured the\nServerless pre-function plugin and it\ncontains the following `requires`:\n\n```\nlocal template = require \"resty.template\"\nlocal split = require \"kong.tools.utils\".split\n```\n\nTo run the plugin, add the modules to the\nallowed list:\n```\nuntrusted_lua_sandbox_requires = resty.template, kong.tools.utils\n```\n\n**Warning:** Allowing certain modules may\ncreate opportunities to escape the\nsandbox. For example, allowing `os` or\n`luaposix` may be unsafe.\n"
   },
   "untrusted_lua_sandbox_environment": {
     "defaultValue": null,
-    "description": "Comma-separated list of global Lua variables that should be made available inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  **Warning**: Certain variables, when made available, may create opportunities to escape the sandbox."
+    "description": "Comma-separated list of global Lua\nvariables that should be made available\ninside the sandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\n**Warning**: Certain variables, when made\navailable, may create opportunities to\nescape the sandbox.\n"
   },
   "openresty_path": {
     "defaultValue": null,
-    "description": "Path to the OpenResty installation that Kong will use. When this is empty (the default), Kong determines the OpenResty installation by searching for a system-installed OpenResty and falling back to searching $PATH for the nginx binary.  Setting this attribute disables the search behavior and explicitly instructs Kong which OpenResty installation to use."
+    "description": "Path to the OpenResty installation that Kong\nwill use. When this is empty (the default),\nKong determines the OpenResty installation\nby searching for a system-installed OpenResty\nand falling back to searching $PATH for the\nnginx binary.\n\nSetting this attribute disables the search\nbehavior and explicitly instructs Kong which\nOpenResty installation to use.\n"
   },
   "node_id": {
     "defaultValue": null,
-    "description": "Node ID for the Kong node. Every Kong node in a Kong cluster must have a unique and valid UUID. When empty, node ID is automatically generated."
+    "description": "Node ID for the Kong node. Every Kong node\nin a Kong cluster must have a unique and\nvalid UUID. When empty, node ID is\nautomatically generated.\n"
   },
   "cluster_fallback_config_import": {
     "defaultValue": "off",
-    "description": "Enable fallback configuration imports.  This should only be enabled for data planes."
+    "description": "Enable fallback configuration imports.\n\nThis should only be enabled for data planes.\n"
   },
   "cluster_fallback_config_storage": {
     "defaultValue": null,
-    "description": "Storage definition used by `cluster_fallback_config_import` and `cluster_fallback_config_export`.  Supported storage types: - S3-like storages - GCP storage service  To use S3 with a bucket named b and place all configs to with a key prefix named p, set it to: `s3://b/p` To use GCP for the same bucket and prefix, set it to: `gcs://b/p`  The credentials (and the endpoint URL for S3-like) for S3 are passed with environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where `AWS_CONFIG_STORAGE_ENDPOINT` is the endpoint that hosts S3-like storage.  The credentials for GCP are provided via the environment variable `GCP_SERVICE_ACCOUNT`."
+    "description": "Storage definition used by `cluster_fallback_config_import`\nand `cluster_fallback_config_export`.\n\nSupported storage types:\n- S3-like storages\n- GCP storage service\n\nTo use S3 with a bucket named b and place all configs\nto with a key prefix named p, set it to:\n`s3://b/p`\nTo use GCP for the same bucket and prefix, set it to:\n`gcs://b/p`\n\nThe credentials (and the endpoint URL for S3-like) for S3\nare passed with environment variables:\n`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,\nand `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where\n`AWS_CONFIG_STORAGE_ENDPOINT`\nis the endpoint that hosts S3-like storage.\n\nThe credentials for GCP are provided via the environment\nvariable `GCP_SERVICE_ACCOUNT`.\n"
   },
   "cluster_fallback_export_s3_config": {
     "defaultValue": null,
-    "description": "fallback config export S3 config This is used only when `cluster_fallback_config_storage` is S3-like schema. If set, it will add config table to kong exporter config S3 putObject request. The config table should be in JSON format and can be unserialized into a table. It should contain the necessary parameters as described in the documentation.  https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property. For example, if you want to set the ServerSideEncryption headers / KMS Key ID for the S3 putObject request, you can set the config table to: `{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"your-kms-key-id\"}`"
+    "description": "fallback config export S3 config\nThis is used only when `cluster_fallback_config_storage` is S3-like schema.\nIf set, it will add config table to kong exporter config S3 putObject request.\nThe config table should be in JSON format and can be unserialized into a table.\nIt should contain the necessary parameters as described in the documentation.\n https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property.\nFor example, if you want to set the ServerSideEncryption headers / KMS Key ID\nfor the S3 putObject request, you can set the config table to:\n`{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"your-kms-key-id\"}`\n"
   },
   "cluster_fallback_config_export": {
     "defaultValue": "off",
-    "description": "Enable fallback configuration exports."
+    "description": "Enable fallback configuration exports.\n"
   },
   "cluster_fallback_config_export_delay": {
     "defaultValue": "60",
-    "description": "The fallback configuration export interval.  If the interval is set to 60 and configuration A is exported and there are new configurations B, C, and D in the next 60 seconds, it will wait until 60 seconds passed and export D, skipping B and C."
+    "description": "The fallback configuration export interval.\n\nIf the interval is set to 60 and configuration A is exported\nand there are new configurations B, C, and D in the next 60 seconds,\nit will wait until 60 seconds passed and export D, skipping B and C.\n"
   },
   "wasm": {
     "defaultValue": "off",
-    "description": "Enable/disable wasm support. This must be enabled in order to use wasm filters and filter chains."
+    "description": "Enable/disable wasm support. This must be enabled in\norder to use wasm filters and filter chains.\n"
   },
   "wasm_filters_path": {
     "defaultValue": null,
-    "description": "Path to the directory containing wasm filter modules.  At startup, Kong discovers available wasm filters by scanning this directory for files with the `.wasm` file extension.  The name of a wasm filter module is derived from the filename itself, with the .wasm extension removed. So, given the following tree:  ``` /path/to/wasm_filters ├── my_module.wasm ├── my_other_module.wasm └── not_a_wasm_module.txt ```  The resulting filter modules available for use in Kong will be:  * `my_module` * `my_other_module`  Notes:  * No recursion is performed. Only .wasm files at the   top level are registered * This path _may_ be a symlink to a directory."
+    "description": "Path to the directory containing wasm filter modules.\n\nAt startup, Kong discovers available wasm filters by\nscanning this directory for files with the `.wasm`\nfile extension.\n\nThe name of a wasm filter module is derived from the\nfilename itself, with the .wasm extension removed. So,\ngiven the following tree:\n\n```\n/path/to/wasm_filters\n├── my_module.wasm\n├── my_other_module.wasm\n└── not_a_wasm_module.txt\n```\n\nThe resulting filter modules available for use in Kong\nwill be:\n\n* `my_module`\n* `my_other_module`\n\nNotes:\n\n* No recursion is performed. Only .wasm files at the\n  top level are registered\n* This path _may_ be a symlink to a directory.\n"
   },
   "wasm_filters": {
     "defaultValue": [
       "bundled",
       "user"
     ],
-    "description": "Comma-separated list of Wasm filters to be made available for use in filter chains.  When the `off` keyword is specified as the only value, no filters will be available for use.  When the `bundled` keyword is specified, all filters bundled with Kong will be available.  When the `user` keyword is specified, all filters within the `wasm_filters_path` will be available.  **Examples:**  - `wasm_filters = bundled,user` enables _all_ bundled   and user-supplied filters - `wasm_filters = user` enables _only_ user-supplied   filters - `wasm_filters = filter-a,filter-b` enables _only_   filters named `filter-a` or `filter-b` (whether   bundled _or_ user-suppplied)  If a conflict occurs where a bundled filter and a user-supplied filter share the same name, a warning will be logged, and the user-supplied filter will be used instead."
+    "description": "Comma-separated list of Wasm filters to be made\navailable for use in filter chains.\n\nWhen the `off` keyword is specified as the\nonly value, no filters will be available for use.\n\nWhen the `bundled` keyword is specified, all filters\nbundled with Kong will be available.\n\nWhen the `user` keyword is specified, all filters\nwithin the `wasm_filters_path` will be available.\n\n**Examples:**\n\n- `wasm_filters = bundled,user` enables _all_ bundled\n  and user-supplied filters\n- `wasm_filters = user` enables _only_ user-supplied\n  filters\n- `wasm_filters = filter-a,filter-b` enables _only_\n  filters named `filter-a` or `filter-b` (whether\n  bundled _or_ user-suppplied)\n\nIf a conflict occurs where a bundled filter and a\nuser-supplied filter share the same name, a warning\nwill be logged, and the user-supplied filter will\nbe used instead.\n"
   },
   "request_debug": {
     "defaultValue": "on",
-    "description": "When enabled, Kong will provide detailed timing information for its components to the client and the error log if the following headers are present in the proxy request: - `X-Kong-Request-Debug`:   If the value is set to `*`,   timing information will be collected and exported for the current request.   If this header is not present or contains unknown value,   timing information will not be collected for the current request.   You can also specify a list of filters, separated by commas,   to filter the scope of the time information that is collected.   The following filters are supported:   - `rewrite`: Collect timing information from the `rewrite` phase.   - `access`: Collect timing information from the `access` phase.   - `balancer`: Collect timing information from the `balancer` phase.   - `response`: Collect timing information from the `response` phase.   - `header_filter`: Collect timing information from the `header_filter` phase.   - `body_filter`: Collect timing information from the `body_filter` phase.   - `log`: Collect timing information from the `log` phase.   - `upstream`: Collect timing information from the `upstream` phase.  - `X-Kong-Request-Debug-Log`:   If set to `true`, timing information will also be logged   in the Kong error log with a log level of `notice`.   Defaults to `false`.  - `X-Kong-Request-Debug-Token`:   Token for authenticating the client making the debug   request to prevent abuse. Debug requests originating from loopback   addresses do not require this header. "
+    "description": "When enabled, Kong will provide detailed timing information\nfor its components to the client and the error log\nif the following headers are present in the proxy request:\n- `X-Kong-Request-Debug`:\n  If the value is set to `*`,\n  timing information will be collected and exported for the current request.\n  If this header is not present or contains unknown value,\n  timing information will not be collected for the current request.\n  You can also specify a list of filters, separated by commas,\n  to filter the scope of the time information that is collected.\n  The following filters are supported:\n  - `rewrite`: Collect timing information from the `rewrite` phase.\n  - `access`: Collect timing information from the `access` phase.\n  - `balancer`: Collect timing information from the `balancer` phase.\n  - `response`: Collect timing information from the `response` phase.\n  - `header_filter`: Collect timing information from the `header_filter` phase.\n  - `body_filter`: Collect timing information from the `body_filter` phase.\n  - `log`: Collect timing information from the `log` phase.\n  - `upstream`: Collect timing information from the `upstream` phase.\n\n- `X-Kong-Request-Debug-Log`:\n  If set to `true`, timing information will also be logged\n  in the Kong error log with a log level of `notice`.\n  Defaults to `false`.\n\n- `X-Kong-Request-Debug-Token`:\n  Token for authenticating the client making the debug\n  request to prevent abuse. Debug requests originating from loopback\n  addresses do not require this header.\n\n"
   },
   "request_debug_token": {
     "defaultValue": "<random>",
-    "description": "The Request Debug Token is used in the `X-Kong-Request-Debug-Token` header to prevent abuse. If this value is not set (the default), a random token will be generated when Kong starts, restarts, or reloads. If a token is specified manually, then the provided token will be used.  You can locate the generated debug token in two locations: - Kong error log:   Debug token will be logged in the error log (notice level)   when Kong starts, restarts, or reloads.   The log line will have the: `[request-debug]` prefix to aid searching. - Filesystem:   Debug token will also be stored in a file located at   `{prefix}/.request_debug_token` and updated   when Kong starts, restarts, or reloads."
+    "description": "The Request Debug Token is used in the\n`X-Kong-Request-Debug-Token` header to prevent abuse.\nIf this value is not set (the default),\na random token will be generated\nwhen Kong starts, restarts, or reloads. If a token is\nspecified manually, then the provided token will be used.\n\nYou can locate the generated debug token in two locations:\n- Kong error log:\n  Debug token will be logged in the error log (notice level)\n  when Kong starts, restarts, or reloads.\n  The log line will have the: `[request-debug]` prefix to aid searching.\n- Filesystem:\n  Debug token will also be stored in a file located at\n  `{prefix}/.request_debug_token` and updated\n  when Kong starts, restarts, or reloads.\n"
   }
 }

--- a/app/_data/kong-conf/3.7.json
+++ b/app/_data/kong-conf/3.7.json
@@ -1,0 +1,1223 @@
+{
+  "prefix": {
+    "defaultValue": "/usr/local/kong/",
+    "description": "Working directory. Equivalent to Nginx's prefix path, containing temporary files and logs. Each Kong process must have a separate working directory."
+  },
+  "log_level": {
+    "defaultValue": "notice",
+    "description": "Log level of the Nginx server. Logs are found at `<prefix>/logs/error.log`."
+  },
+  "proxy_access_log": {
+    "defaultValue": "logs/access.log",
+    "description": "Path for proxy port request access logs. Set this value to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "proxy_error_log": {
+    "defaultValue": "logs/error.log",
+    "description": "Path for proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "proxy_stream_access_log": {
+    "defaultValue": "logs/access.log basic",
+    "description": "Path for tcp streams proxy port access logs. Set this value to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location. `basic` is defined as `'$remote_addr [$time_local] ' '$protocol $status $bytes_sent $bytes_received ' '$session_time'`"
+  },
+  "proxy_stream_error_log": {
+    "defaultValue": "logs/error.log",
+    "description": "Path for tcp streams proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "admin_access_log": {
+    "defaultValue": "logs/admin_access.log",
+    "description": "Path for Admin API request access logs. If Hybrid Mode is enabled and the current node is set to be the Control Plane, then the connection requests from Data Planes are also written to this file with server name \"kong_cluster_listener\".  Set this value to `off` to disable logging Admin API requests. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "admin_error_log": {
+    "defaultValue": "logs/error.log",
+    "description": "Path for Admin API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "status_access_log": {
+    "defaultValue": "off",
+    "description": "Path for Status API request access logs. The default value of `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "status_error_log": {
+    "defaultValue": "logs/status_error.log",
+    "description": "Path for Status API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "debug_access_log": {
+    "defaultValue": "off",
+    "description": "Path for Debug API request access logs. The default value of `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "debug_error_log": {
+    "defaultValue": "logs/debug_error.log",
+    "description": "Path for Debug API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "vaults": {
+    "defaultValue": "bundled",
+    "description": "Comma-separated list of vaults this node should load. By default, all the bundled vaults are enabled.  The specified name(s) will be substituted as such in the Lua namespace: `kong.vaults.{name}.*`."
+  },
+  "opentelemetry_tracing": {
+    "defaultValue": "off",
+    "description": "Deprecated: use tracing_instrumentations instead"
+  },
+  "tracing_instrumentations": {
+    "defaultValue": "off",
+    "description": "Comma-separated list of tracing instrumentations this node should load. By default, no instrumentations are enabled.  Valid values to this setting are:  - `off`: do not enable instrumentations. - `request`: only enable request-level instrumentations. - `all`: enable all the following instrumentations. - `db_query`: trace database query - `dns_query`: trace DNS query. - `router`: trace router execution, including   router rebuilding. - `http_client`: trace OpenResty HTTP client requests. - `balancer`: trace balancer retries. - `plugin_rewrite`: trace plugins iterator   execution with rewrite phase. - `plugin_access`: trace plugins iterator   execution with access phase. - `plugin_header_filter`: trace plugins iterator   execution with header_filter phase.  **Note:** In the current implementation, tracing instrumentations are not enabled in stream mode."
+  },
+  "opentelemetry_tracing_sampling_rate": {
+    "defaultValue": "1.0",
+    "description": "Deprecated: use tracing_sampling_rate instead"
+  },
+  "tracing_sampling_rate": {
+    "defaultValue": "0.01",
+    "description": "Tracing instrumentation sampling rate. Tracer samples a fixed percentage of all spans following the sampling rate.  Example: `0.25`, this should account for 25% of all traces."
+  },
+  "plugins": {
+    "defaultValue": "bundled",
+    "description": "Comma-separated list of plugins this node should load. By default, only plugins bundled in official distributions are loaded via the `bundled` keyword.  Loading a plugin does not enable it by default, but only instructs Kong to load its source code, and allows to configure the plugin via the various related Admin API endpoints.  The specified name(s) will be substituted as such in the Lua namespace: `kong.plugins.{name}.*`.  When the `off` keyword is specified as the only value, no plugins will be loaded.  `bundled` and plugin names can be mixed together, as the following examples suggest:  - `plugins = bundled,custom-auth,custom-log`   will include the bundled plugins plus two   custom ones - `plugins = custom-auth,custom-log` will   *only* include the `custom-auth` and   `custom-log` plugins. - `plugins = off` will not include any   plugins  **Note:** Kong will not start if some plugins were previously configured (i.e. have rows in the database) and are not specified in this list.  Before disabling a plugin, ensure all instances of it are removed before restarting Kong.  **Note:** Limiting the amount of available plugins can improve P99 latency when experiencing LRU churning in the database cache (i.e. when the configured `mem_cache_size`) is full."
+  },
+  "dedicated_config_processing": {
+    "defaultValue": "on",
+    "description": "Enables or disables a special worker process for configuration processing. This process increases memory usage a little bit while allowing to reduce latencies by moving some background tasks, such as CP/DP connection handling, to an additional worker process specific to handling these background tasks. Currently this has effect only on data planes."
+  },
+  "pluginserver_names": {
+    "defaultValue": null,
+    "description": "Comma-separated list of names for pluginserver processes.  The actual names are used for log messages and to relate the actual settings."
+  },
+  "pluginserver_XXX_socket": {
+    "defaultValue": "<prefix>/<XXX>.socket",
+    "description": "Path to the unix socket used by the <XXX> pluginserver."
+  },
+  "pluginserver_XXX_start_cmd": {
+    "defaultValue": "/usr/local/bin/<XXX>",
+    "description": "Full command (including any needed arguments) to start the <XXX> pluginserver"
+  },
+  "pluginserver_XXX_query_cmd": {
+    "defaultValue": "/usr/local/bin/query_<XXX>",
+    "description": "Full command to \"query\" the <XXX> pluginserver.  Should produce a JSON with the dump info of all plugins it manages"
+  },
+  "port_maps": {
+    "defaultValue": null,
+    "description": "With this configuration parameter, you can let the Kong to know about the port from which the packets are forwarded to it. This is fairly common when running Kong in a containerized or virtualized environment. For example, `port_maps=80:8000, 443:8443` instructs Kong that the port 80 is mapped to 8000 (and the port 443 to 8443), where 8000 and 8443 are the ports that Kong is listening to.  This parameter helps Kong set a proper forwarded upstream HTTP request header or to get the proper forwarded port with the Kong PDK (in case other means determining it has failed). It changes routing by a destination port to route by a port from which packets are forwarded to Kong, and similarly it changes the default plugin log serializer to use the port according to this mapping instead of reporting the port Kong is listening to."
+  },
+  "anonymous_reports": {
+    "defaultValue": "on",
+    "description": "Send anonymous usage data such as error stack traces to help improve Kong."
+  },
+  "proxy_server": {
+    "defaultValue": null,
+    "description": "Proxy server defined as a URL. Kong will only use this option if any component is explicitly configured to use proxy."
+  },
+  "proxy_server_ssl_verify": {
+    "defaultValue": "off",
+    "description": "Toggles server certificate verification if `proxy_server` is in HTTPS. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+  },
+  "error_template_html": {
+    "defaultValue": null,
+    "description": "Path to the custom html error template to override the default html kong error template.  The template may contain up to two `%s` placeholders. The first one will expand to the error message. The second one will expand to the request ID. Both placeholders are optional, but recommended. Adding more than two placeholders will result in a runtime error when trying to render the template: ``` <html>   <body>     <h1>My custom error template</h1>     <p>error: %s</p>     <p>request_id: %s</p>   </body> </html> ```"
+  },
+  "error_template_json": {
+    "defaultValue": null,
+    "description": "Path to the custom json error template to override the default json kong error template.  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+  },
+  "error_template_xml": {
+    "defaultValue": null,
+    "description": "Path to the custom xml error template to override the default xml kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+  },
+  "error_template_plain": {
+    "defaultValue": null,
+    "description": "Path to the custom plain error template to override the default plain kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+  },
+  "role": {
+    "defaultValue": "traditional",
+    "description": "Use this setting to enable Hybrid Mode, This allows running some Kong nodes in a control plane role with a database and have them deliver configuration updates to other nodes running to DB-less running in a Data Plane role.  Valid values to this setting are:  - `traditional`: do not use Hybrid Mode. - `control_plane`: this node runs in a   control plane role. It can use a database   and will deliver configuration updates   to data plane nodes. - `data_plane`: this is a data plane node.   It runs DB-less and receives configuration   updates from a control plane node."
+  },
+  "cluster_mtls": {
+    "defaultValue": "shared",
+    "description": "Sets the verification between nodes of the cluster.  Valid values to this setting are:  - `shared`: use a shared certificate/key   pair specified with the `cluster_cert`   and `cluster_cert_key` settings.   Note that CP and DP nodes have to present   the same certificate to establish mTLS   connections. - `pki`: use `cluster_ca_cert`,   `cluster_server_name` and `cluster_cert`   for verification.   These are different certificates for each   DP node, but issued by a cluster-wide   common CA certificate: `cluster_ca_cert`. - `pki_check_cn`: similar as `pki` but additionally   checks for Common Name of data plane certificate   specified in `cluster_allowed_common_names`."
+  },
+  "cluster_cert": {
+    "defaultValue": null,
+    "description": "Cluster certificate to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes.  Under `pki` mode it should be a different certificate for each DP node.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "cluster_cert_key": {
+    "defaultValue": null,
+    "description": "Cluster certificate key to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes.  Under `pki` mode it should be a different certificate for each DP node.  The certificate key can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+  },
+  "cluster_ca_cert": {
+    "defaultValue": null,
+    "description": "The trusted CA certificate file in PEM format used for Control Plane to verify Data Plane's certificate and Data Plane to verify Control Plane's certificate. Required on data plane if `cluster_mtls` is set to `pki`. If Control Plane certificate is issued by a well known CA, user can set `lua_ssl_trusted_certificate=system` on Data Plane and leave this field empty.  This field is ignored if `cluster_mtls` is set to `shared`.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "cluster_allowed_common_names": {
+    "defaultValue": null,
+    "description": "The list of Common Names that are allowed to connect to control plane. Multiple entries may be supplied in a comma-separated string. When not set, Data Plane with same parent domain of Control Plane cert is allowed to connect.  This field is ignored if `cluster_mtls` is not set to `pki_check_cn`."
+  },
+  "cluster_server_name": {
+    "defaultValue": null,
+    "description": "The server name used in the SNI of the TLS connection from a DP node to a CP node. Must match the Common Name (CN) or Subject Alternative Name (SAN) found in the CP certificate. If `cluster_mtls` is set to `shared`, this setting is ignored and `kong_clustering` is used."
+  },
+  "cluster_control_plane": {
+    "defaultValue": null,
+    "description": "To be used by data plane nodes only: address of the control plane node from which configuration updates will be fetched, in `host:port` format."
+  },
+  "cluster_telemetry_endpoint": {
+    "defaultValue": null,
+    "description": "To be used by data plane nodes only: telemetry address of the control plane node to which telemetry updates will be posted in `host:port` format."
+  },
+  "cluster_telemetry_server_name": {
+    "defaultValue": null,
+    "description": "The SNI (Server Name Indication extension) to use for Vitals telemetry data."
+  },
+  "cluster_dp_labels": {
+    "defaultValue": null,
+    "description": "Comma separated list of Labels for the data plane. Labels are key-value pairs that provide additional context information for each DP. Each label must be configured as a string in the format `key:value`.  Labels are only compatible with hybrid mode deployments with Kong Konnect (SaaS), this configuration doesn't work with self-hosted deployments.  Keys and values follow the AIP standards: https://kong-aip.netlify.app/aip/129/  Example: `deployment:mycloud,region:us-east-1`"
+  },
+  "cluster_listen": {
+    "defaultValue": "0.0.0.0:8005",
+    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster. This port is mTLS protected to ensure end-to-end security and integrity.  This setting has no effect if `role` is not set to `control_plane`.  Connection made to this endpoint are logged to the same location as Admin API access logs. See `admin_access_log` config description for more information."
+  },
+  "cluster_telemetry_listen": {
+    "defaultValue": "0.0.0.0:8006",
+    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane telemetry connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster.  This setting has no effect if `role` is not set to `control_plane`."
+  },
+  "cluster_data_plane_purge_delay": {
+    "defaultValue": "1209600",
+    "description": " How many seconds must pass from the time a DP node becomes offline to the time its entry gets removed from the database, as returned by the /clustering/data-planes Admin API endpoint.  This is to prevent the cluster data plane table from growing indefinitely. The default is set to 14 days. That is, if CP haven't heard from a DP for 14 days, its entry will be removed."
+  },
+  "cluster_ocsp": {
+    "defaultValue": "off",
+    "description": " Whether to check for revocation status of DP certificates using OCSP (Online Certificate Status Protocol). If enabled, the DP certificate should contain the \"Certificate Authority Information Access\" extension and the OCSP method with URI of which the OCSP responder can be reached from CP.  OCSP checks are only performed on CP nodes, it has no effect on DP nodes.  Valid values to this setting are:  - `on`: OCSP revocation check is enabled and DP   must pass the check in order to establish   connection with CP. - `off`: OCSP revocation check is disabled. - `optional`: OCSP revocation check will be attempted,   however, if the required extension is not   found inside DP provided certificate   or communication with the OCSP responder   failed, then DP is still allowed through."
+  },
+  "cluster_use_proxy": {
+    "defaultValue": "off",
+    "description": " Whether to turn on HTTP CONNECT proxy support for hybrid mode connections. `proxy_server` will be used for Hybrid mode connections if this option is turned on."
+  },
+  "cluster_max_payload": {
+    "defaultValue": "16777216",
+    "description": " This sets the maximum compressed payload size allowed to be sent across from CP to DP in Hybrid mode Default is 16MB - 16 * 1024 * 1024."
+  },
+  "proxy_listen": {
+    "defaultValue": [
+      "0.0.0.0:8000 reuseport backlog=16384",
+      "0.0.0.0:8443 http2 ssl reuseport backlog=16384"
+    ],
+    "description": " Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. The proxy server is the public entry point of Kong, which proxies traffic from your consumers to your backend services. This value accepts IPv4, IPv6, and hostnames.  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the TCP_DEFER_ACCEPT socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  This value can be set to `off`, thus disabling the HTTP/HTTPS proxy port for this node. If stream_listen is also set to `off`, this enables 'control-plane' mode for this node (in which all traffic proxying capabilities are disabled). This node can then be used only to configure a cluster of Kong nodes connected to the same datastore.  Example: `proxy_listen = 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`  See http://nginx.org/en/docs/http/ngx_http_core_module.html#listen for a description of the accepted formats for this and other `*_listen` values.  See https://www.nginx.com/resources/admin-guide/proxy-protocol/ for more details about the `proxy_protocol` parameter.  Not all `*_listen` values accept all formats specified in nginx's documentation."
+  },
+  "proxy_url": {
+    "defaultValue": null,
+    "description": "Kong Proxy URL  The lookup, or balancer, address for your Kong Proxy nodes.  This value is commonly used in a microservices or service-mesh oriented architecture.  Accepted format (parts in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`  Examples:  - `<scheme>://<IP>:<PORT>` -> `proxy_url = http://127.0.0.1:8000` - `SSL <scheme>://<HOSTNAME>` -> `proxy_url = https://proxy.domain.tld` - `<scheme>://<HOSTNAME>/<PATH>` -> `proxy_url = http://dev-machine/dev-285`  By default, Kong Manager, and Kong Portal will use the window request host and append the resolved listener port depending on the requested protocol."
+  },
+  "stream_listen": {
+    "defaultValue": "off",
+    "description": " Comma-separated list of addresses and ports on which the stream mode should listen.  This value accepts IPv4, IPv6, and hostnames. Some suffixes can be specified for each pair: - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  Examples:  ``` stream_listen = 127.0.0.1:7000 reuseport backlog=16384 stream_listen = 0.0.0.0:989 reuseport backlog=65536, 0.0.0.0:20 stream_listen = [::1]:1234 backlog=16384 ```  By default this value is set to `off`, thus disabling the stream proxy port for this node."
+  },
+  "admin_api_uri": {
+    "defaultValue": null,
+    "description": "Deprecated: Use admin_gui_api_url instead"
+  },
+  "admin_listen": {
+    "defaultValue": [
+      "127.0.0.1:8001 reuseport backlog=16384",
+      "127.0.0.1:8444 http2 ssl reuseport backlog=16384"
+    ],
+    "description": " Comma-separated list of addresses and ports on which the Admin interface should listen. The Admin interface is the API allowing you to configure and manage Kong. Access to this interface should be *restricted* to Kong administrators *only*. This value accepts IPv4, IPv6, and hostnames.  It is highly recommended to avoid exposing the Admin API to public interface(s), by using values such as 0.0.0.0:8001  See https://docs.konghq.com/gateway/latest/production/running-kong/secure-admin-api/ for more information about how to secure your Admin API  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the TCP_DEFER_ACCEPT socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process   allowing the Kernel to better distribute incoming   connections between worker processes - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small in order to prevent clients   seeing \"Connection refused\" error connecting to   a busy Kong instance.   **Note:** on Linux, this value is limited by the   setting of `net.core.somaxconn` Kernel parameter.   In order for the larger `backlog` set here to take   effect it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value “on”, the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value “off”, the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the TCP_KEEPIDLE, TCP_KEEPINTVL,   and TCP_KEEPCNT socket options.  This value can be set to `off`, thus disabling the Admin interface for this node, enabling a 'data-plane' mode (without configuration capabilities) pulling its configuration changes from the database.  Example: `admin_listen = 127.0.0.1:8444 http2 ssl`"
+  },
+  "status_listen": {
+    "defaultValue": "127.0.0.1:8007 reuseport backlog=16384",
+    "description": " Comma-separated list of addresses and ports on which the Status API should listen. The Status API is a read-only endpoint allowing monitoring tools to retrieve metrics, healthiness, and other non-sensitive information of the current Kong node.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Status API server. - `proxy_protocol` will enable usage of the PROXY protocol.  This value can be set to `off`, disabling the Status API for this node.  Example: `status_listen = 0.0.0.0:8100 ssl http2`"
+  },
+  "debug_listen": {
+    "defaultValue": "off",
+    "description": "Comma-separated list of addresses and ports on which the Debug API should listen.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Debug API server.  This value can be set to `off`, disabling the Debug API for this node.  Example: `debug_listen = 0.0.0.0:8200 ssl http2`"
+  },
+  "debug_listen_local": {
+    "defaultValue": "on",
+    "description": "Expose `debug_listen` functionalities via a Unix domain socket under the Kong prefix.  This option allows local user to use \"kong debug\" command to invoke various debug functionalities without needing to enable `debug_listen` ahead of time."
+  },
+  "nginx_user": {
+    "defaultValue": "kong kong",
+    "description": "Defines user and group credentials used by worker processes. If group is omitted, a group whose name equals that of user is used.  Example: `nginx_user = nginx www`  **Note**: If the `kong` user and the `kong` group are not available, the default user and group credentials will be `nobody nobody`."
+  },
+  "nginx_worker_processes": {
+    "defaultValue": "auto",
+    "description": "Determines the number of worker processes spawned by Nginx.  See http://nginx.org/en/docs/ngx_core_module.html#worker_processes for detailed usage of the equivalent Nginx directive and a description of accepted values."
+  },
+  "nginx_daemon": {
+    "defaultValue": "on",
+    "description": "Determines whether Nginx will run as a daemon or as a foreground process. Mainly useful for development or when running Kong inside a Docker environment.  See http://nginx.org/en/docs/ngx_core_module.html#daemon."
+  },
+  "mem_cache_size": {
+    "defaultValue": "128m",
+    "description": "Size of each of the two shared memory caches for traditional mode database entities and runtime data, `kong_core_cache` and `kong_cache`.  The accepted units are `k` and `m`, with a minimum recommended value of a few MBs.  **Note**: As this option controls the size of two different cache zones, the total memory Kong uses to cache entities might be double this value. The created zones are shared by all worker processes and do not become larger when more worker is used."
+  },
+  "ssl_cipher_suite": {
+    "defaultValue": "intermediate",
+    "description": "Defines the TLS ciphers served by Nginx. Accepted values are `modern`, `intermediate`, `old`, `fips` or `custom`. If you want to enable TLSv1.1, this value has to be `old`.  See https://wiki.mozilla.org/Security/Server_Side_TLS for detailed descriptions of each cipher suite. `fips` cipher suites are as described in https://wiki.openssl.org/index.php/FIPS_mode_and_TLS."
+  },
+  "ssl_ciphers": {
+    "defaultValue": null,
+    "description": "Defines a custom list of TLS ciphers to be served by Nginx. This list must conform to the pattern defined by `openssl ciphers`. This value is ignored if `ssl_cipher_suite` is not `custom`. If you use DHE ciphers, you must also configure the `ssl_dhparam` parameter."
+  },
+  "ssl_protocols": {
+    "defaultValue": "TLSv1.2 TLSv1.3",
+    "description": " Enables the specified protocols for client-side connections. The set of supported protocol versions also depends on the version of OpenSSL Kong was built with. This value is ignored if `ssl_cipher_suite` is not `custom`. If you want to enable TLSv1.1, you should set `ssl_cipher_suite` to `old`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols"
+  },
+  "ssl_prefer_server_ciphers": {
+    "defaultValue": "on",
+    "description": "Specifies that server ciphers should be preferred over client ciphers when using the SSLv3 and TLS protocols. This value is ignored if `ssl_cipher_suite` is not `custom`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers"
+  },
+  "ssl_dhparam": {
+    "defaultValue": null,
+    "description": "Defines DH parameters for DHE ciphers from the predefined groups: `ffdhe2048`, `ffdhe3072`, `ffdhe4096`, `ffdhe6144`, `ffdhe8192`, from the absolute path to a parameters file, or directly from the parameters content.  This value is ignored if `ssl_cipher_suite` is `modern` or `intermediate`. The reason is that `modern` has no ciphers that needs this, and `intermediate` uses `ffdhe2048`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam"
+  },
+  "ssl_session_tickets": {
+    "defaultValue": "on",
+    "description": "Enables or disables session resumption through TLS session tickets. This has no impact when used with TLSv1.3.  Kong enables this by default for performance reasons, but it has security implications: https://github.com/mozilla/server-side-tls/issues/135  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets"
+  },
+  "ssl_session_timeout": {
+    "defaultValue": "1d",
+    "description": "Specifies a time during which a client may reuse the session parameters. See the rationale: https://github.com/mozilla/server-side-tls/issues/198  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout"
+  },
+  "ssl_session_cache_size": {
+    "defaultValue": "10m",
+    "description": "Sets the size of the caches that store session parameters  See https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache"
+  },
+  "ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `proxy_listen` values with TLS enabled.  If more than one certificates are specified, it can be used to provide alternate type of certificate (for example, ECC certificate) that will be served to clients that supports them. Note to properly serve using ECC certificates, it is recommended to also set `ssl_cipher_suite` to `modern` or `intermediate`.  Unless this option is explicitly set, Kong will auto-generate a pair of default certificates (RSA + ECC) first time it starts up and use it for serving TLS requests.  Certificates can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `proxy_listen` values with TLS enabled.  If more than one certificate was specified for `ssl_cert`, then this option should contain the corresponding key for all certificates provided in the same order.  Unless this option is explicitly set, Kong will auto-generate a pair of default private keys (RSA + ECC) first time it starts up and use it for serving TLS requests.  Keys can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+  },
+  "client_ssl": {
+    "defaultValue": "off",
+    "description": "Determines if Nginx should attempt to send client-side TLS certificates and perform Mutual TLS Authentication with upstream service when proxying requests."
+  },
+  "client_ssl_cert": {
+    "defaultValue": null,
+    "description": "If `client_ssl` is enabled, the client certificate for the `proxy_ssl_certificate` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate can be configured on this property with either of the following values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "client_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "If `client_ssl` is enabled, the client TLS key for the `proxy_ssl_certificate_key` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate key can be configured on this property with either of the following values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+  },
+  "admin_ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `admin_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+  },
+  "admin_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `admin_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+  },
+  "status_ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `status_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+  },
+  "status_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `status_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+  },
+  "debug_ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `debug_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+  },
+  "debug_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `debug_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+  },
+  "headers": {
+    "defaultValue": [
+      "server_tokens",
+      "latency_tokens",
+      "X-Kong-Request-Id"
+    ],
+    "description": " Comma-separated list of headers Kong should inject in client responses.  Accepted values are: - `Server`: Injects `Server: kong/x.y.z`   on Kong-produced response (e.g. Admin   API, rejected requests from auth plugin). - `Via`: Injects `Via: kong/x.y.z` for   successfully proxied requests. - `X-Kong-Proxy-Latency`: Time taken   (in milliseconds) by Kong to process   a request and run all plugins before   proxying the request upstream. - `X-Kong-Response-Latency`: time taken   (in millisecond) by Kong to produce   a response in case of e.g. plugin   short-circuiting the request, or in   in case of an error. - `X-Kong-Upstream-Latency`: Time taken   (in milliseconds) by the upstream   service to send response headers. - `X-Kong-Admin-Latency`: Time taken   (in milliseconds) by Kong to process   an Admin API request. - `X-Kong-Upstream-Status`: The HTTP status   code returned by the upstream service.   This is particularly useful for clients to   distinguish upstream statuses if the   response is rewritten by a plugin. - `X-Kong-Request-Id`: Unique identifier of   the request. - `server_tokens`: Same as specifying both   `Server` and `Via`. - `latency_tokens`: Same as specifying   `X-Kong-Proxy-Latency`,   `X-Kong-Response-Latency`,   `X-Kong-Admin-Latency` and   `X-Kong-Upstream-Latency`  In addition to those, this value can be set to `off`, which prevents Kong from injecting any of the above headers. Note that this does not prevent plugins from injecting headers of their own.  Example: `headers = via, latency_tokens`"
+  },
+  "headers_upstream": {
+    "defaultValue": "X-Kong-Request-Id",
+    "description": " Comma-separated list of headers Kong should inject in requests to upstream.  At this time, the only accepted value is: - `X-Kong-Request-Id`: Unique identifier of   the request.  In addition, this value can be set to `off`, which prevents Kong from injecting the above header. Note that this does not prevent plugins from injecting headers of their own."
+  },
+  "trusted_ips": {
+    "defaultValue": null,
+    "description": "Defines trusted IP addresses blocks that are known to send correct `X-Forwarded-*` headers. Requests from trusted IPs make Kong forward their `X-Forwarded-*` headers upstream. Non-trusted requests make Kong insert its own `X-Forwarded-*` headers.  This property also sets the `set_real_ip_from` directive(s) in the Nginx configuration. It accepts the same type of values (CIDR blocks) but as a comma-separated list.  To trust *all* /!\\ IPs, set this value to `0.0.0.0/0,::/0`.  If the special value `unix:` is specified, all UNIX-domain sockets will be trusted.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from for examples of accepted values."
+  },
+  "real_ip_header": {
+    "defaultValue": "X-Real-IP",
+    "description": "Defines the request header field whose value will be used to replace the client address. This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  If this value receives `proxy_protocol`:  - at least one of the `proxy_listen` entries   must have the `proxy_protocol` flag   enabled. - the `proxy_protocol` parameter will be   appended to the `listen` directive of the   Nginx template.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header for a description of this directive."
+  },
+  "real_ip_recursive": {
+    "defaultValue": "off",
+    "description": "This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive for a description of this directive."
+  },
+  "error_default_type": {
+    "defaultValue": "text/plain",
+    "description": "Default MIME type to use when the request `Accept` header is missing and Nginx is returning an error for the request. Accepted values are `text/plain`, `text/html`, `application/json`, and `application/xml`."
+  },
+  "upstream_keepalive_pool_size": {
+    "defaultValue": "512",
+    "description": "Sets the default size of the upstream keepalive connection pools. Upstream keepalive connection pools are segmented by the `dst ip/dst port/SNI` attributes of a connection. A value of `0` will disable upstream keepalive connections by default, forcing each upstream request to open a new connection."
+  },
+  "upstream_keepalive_max_requests": {
+    "defaultValue": "10000",
+    "description": "Sets the default maximum number of requests than can be proxied upstream through one keepalive connection. After the maximum number of requests is reached, the connection will be closed. A value of `0` will disable this behavior, and a keepalive connection can be used to proxy an indefinite number of requests."
+  },
+  "upstream_keepalive_idle_timeout": {
+    "defaultValue": "60",
+    "description": "Sets the default timeout (in seconds) for which an upstream keepalive connection should be kept open. When the timeout is reached while the connection has not been reused, it will be closed. A value of `0` will disable this behavior, and an idle keepalive connection may be kept open indefinitely."
+  },
+  "allow_debug_header": {
+    "defaultValue": "off",
+    "description": "Enable the `Kong-Debug` header function. if it is `on`, kong will add `Kong-Route-Id` `Kong-Route-Name` `Kong-Service-Id` `Kong-Service-Name` debug headers to response when the client request header `Kong-Debug: 1` is present."
+  },
+  "nginx_main_worker_rlimit_nofile": {
+    "defaultValue": "auto",
+    "description": " Changes the limit on the maximum number of open files for worker processes.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile"
+  },
+  "nginx_events_worker_connections": {
+    "defaultValue": "auto",
+    "description": " Sets the maximum number of simultaneous connections that can be opened by a worker process.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_connections"
+  },
+  "nginx_http_client_header_buffer_size": {
+    "defaultValue": "1k",
+    "description": "Sets buffer size for reading the client request headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size"
+  },
+  "nginx_http_large_client_header_buffers": {
+    "defaultValue": "4 8k",
+    "description": "Sets the maximum number and size of buffers used for reading large clients requests headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers"
+  },
+  "nginx_http_client_max_body_size": {
+    "defaultValue": "0",
+    "description": "Defines the maximum request body size allowed by requests proxied by Kong, specified in the Content-Length request header. If a request exceeds this limit, Kong will respond with a 413 (Request Entity Too Large). Setting this value to 0 disables checking the request body size. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size"
+  },
+  "nginx_admin_client_max_body_size": {
+    "defaultValue": "10m",
+    "description": "Defines the maximum request body size for Admin API."
+  },
+  "nginx_http_charset": {
+    "defaultValue": "UTF-8",
+    "description": "Adds the specified charset to the “Content-Type” response header field. If this charset is different from the charset specified in the source_charset directive, a conversion is performed.  The parameter `off` cancels the addition of charset to the “Content-Type” response header field. See http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset"
+  },
+  "nginx_http_client_body_buffer_size": {
+    "defaultValue": "8k",
+    "description": "Defines the buffer size for reading the request body. If the client request body is larger than this value, the body will be buffered to disk. Note that when the body is buffered to disk, Kong plugins that access or manipulate the request body may not work, so it is advisable to set this value as high as possible (e.g., set it as high as `client_max_body_size` to force request bodies to be kept in memory). Do note that high-concurrency environments will require significant memory allocations to process many concurrent large request bodies. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size"
+  },
+  "nginx_admin_client_body_buffer_size": {
+    "defaultValue": "10m",
+    "description": "Defines the buffer size for reading the request body on Admin API."
+  },
+  "nginx_http_lua_regex_match_limit": {
+    "defaultValue": "100000",
+    "description": "Global `MATCH_LIMIT` for PCRE regex matching. The default of `100000` should ensure at worst any regex Kong executes could finish within roughly 2 seconds."
+  },
+  "nginx_http_lua_regex_cache_max_entries": {
+    "defaultValue": "8192",
+    "description": "Specifies the maximum number of entries allowed in the worker process level PCRE JIT compiled regex cache. It is recommended to set it to at least (number of regex paths * 2) to avoid high CPU usages if you manually specified `router_flavor` to `traditional`. `expressions` and `traditional_compat` router does not make use of the PCRE library and their behavior is unaffected by this setting."
+  },
+  "nginx_http_keepalive_requests": {
+    "defaultValue": "10000",
+    "description": "Sets the maximum number of client requests that can be served through one keep-alive connection. After the maximum number of requests are made, the connection is closed. Closing connections periodically is necessary to free per-connection memory allocations. Therefore, using too high maximum number of requests could result in excessive memory usage and not recommended. See: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests"
+  },
+  "database": {
+    "defaultValue": "postgres",
+    "description": "Determines the database (or no database) for this node Accepted values are `postgres` and `off`."
+  },
+  "pg_host": {
+    "defaultValue": "127.0.0.1",
+    "description": "Host of the Postgres server."
+  },
+  "pg_port": {
+    "defaultValue": "5432",
+    "description": "Port of the Postgres server."
+  },
+  "pg_timeout": {
+    "defaultValue": "5000",
+    "description": "Defines the timeout (in ms), for connecting, reading and writing."
+  },
+  "pg_user": {
+    "defaultValue": "kong",
+    "description": "Postgres user."
+  },
+  "pg_password": {
+    "defaultValue": null,
+    "description": "Postgres user's password."
+  },
+  "pg_iam_auth": {
+    "defaultValue": "off",
+    "description": "Determines whether the AWS IAM database Authentication will be used. When switch to `on`, the username defined in `pg_user` will be used as the database account, and the database connection will be forced to using TLS. `pg_password` will not be used when the switch is `on`. Note that the corresponding IAM policy must be correct, otherwise connecting will fail."
+  },
+  "pg_iam_auth_assume_role_arn": {
+    "defaultValue": null,
+    "description": "The target AWS IAM role ARN that will be assumed when using AWS IAM database authentication. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+  },
+  "pg_iam_auth_role_session_name": {
+    "defaultValue": "KongPostgres",
+    "description": "The role session name used for role assuming in AWS IAM Database Authentication. The default value is `KongPostgres`."
+  },
+  "pg_iam_auth_sts_endpoint_url": {
+    "defaultValue": null,
+    "description": "The custom STS endpoint URL used for role assuming in AWS IAM Database Authentication.  Note that this value will override the default STS endpoint URL(which should be `https://sts.amazonaws.com`, or `https://sts.<region>.amazonaws.com` if you have `AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).  If you are not using private VPC endpoint for STS service, you should not specify this value."
+  },
+  "pg_database": {
+    "defaultValue": "kong",
+    "description": "The database name to connect to."
+  },
+  "pg_schema": {
+    "defaultValue": null,
+    "description": "The database schema to use. If unspecified, Kong will respect the `search_path` value of your PostgreSQL instance."
+  },
+  "pg_ssl": {
+    "defaultValue": "off",
+    "description": "Toggles client-server TLS connections between Kong and PostgreSQL. Because PostgreSQL uses the same port for TLS and non-TLS, this is only a hint. If the server does not support TLS, the established connection will be a plain one."
+  },
+  "pg_ssl_version": {
+    "defaultValue": "tlsv1_2",
+    "description": "When using ssl between Kong and PostgreSQL, the version of tls to use. Accepted values are `tlsv1_1`, `tlsv1_2`, `tlsv1_3`, or 'any'. When `any` is set, the client negotiates the highest version with the server which can't be lower than `tlsv1_1`."
+  },
+  "pg_ssl_required": {
+    "defaultValue": "off",
+    "description": "When `pg_ssl` is on this determines if TLS must be used between Kong and PostgreSQL. It aborts the connection if the server does not support SSL connections."
+  },
+  "pg_ssl_verify": {
+    "defaultValue": "off",
+    "description": "Toggles server certificate verification if `pg_ssl` is enabled. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+  },
+  "pg_ssl_cert": {
+    "defaultValue": null,
+    "description": "The absolute path to the PEM encoded client TLS certificate for the PostgreSQL connection. Mutual TLS authentication against PostgreSQL is only enabled if this value is set."
+  },
+  "pg_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "If `pg_ssl_cert` is set, the absolute path to the PEM encoded client TLS private key for the PostgreSQL connection."
+  },
+  "pg_max_concurrent_queries": {
+    "defaultValue": "0",
+    "description": "Sets the maximum number of concurrent queries that can be executing at any given time. This limit is enforced per worker process; the total number of concurrent queries for this node will be will be: `pg_max_concurrent_queries * nginx_worker_processes`.  The default value of 0 removes this concurrency limitation."
+  },
+  "pg_semaphore_timeout": {
+    "defaultValue": "60000",
+    "description": "Defines the timeout (in ms) after which PostgreSQL query semaphore resource acquisition attempts will fail. Such failures will generally result in the associated proxy or Admin API request failing with an HTTP 500 status code. Detailed discussion of this behavior is available in the online documentation."
+  },
+  "pg_keepalive_timeout": {
+    "defaultValue": null,
+    "description": "Specify the maximal idle timeout (in ms) for the postgres connections in the pool. If this value is set to 0 then the timeout interval is unlimited.  If not specified this value will be same as `lua_socket_keepalive_timeout`"
+  },
+  "pg_pool_size": {
+    "defaultValue": null,
+    "description": "Specifies the size limit (in terms of connection count) for the Postgres server. Note that this connection pool is intended per Nginx worker rather than per Kong instance.  If not specified, the default value is the same as `lua_socket_pool_size`"
+  },
+  "pg_backlog": {
+    "defaultValue": null,
+    "description": "If specified, this value will limit the total number of open connections to the Postgres server to `pg_pool_size`. If the connection pool is full, subsequent connect operations will be inserted in a queue with size equal to this option's value.  If the number of queued connect operations reaches `pg_backlog`, exceeding connections will fail.  If not specified, then number of open connections to the Postgres server is not limited."
+  },
+  "pg_ro_host": {
+    "defaultValue": null,
+    "description": "Same as `pg_host`, but for the read-only connection. **Note:** Refer to the documentation section above for detailed usage."
+  },
+  "pg_ro_port": {
+    "defaultValue": "<pg_port>",
+    "description": "Same as `pg_port`, but for the read-only connection."
+  },
+  "pg_ro_timeout": {
+    "defaultValue": "<pg_timeout>",
+    "description": "Same as `pg_timeout`, but for the read-only connection."
+  },
+  "pg_ro_user": {
+    "defaultValue": "<pg_user>",
+    "description": "Same as `pg_user`, but for the read-only connection."
+  },
+  "pg_ro_password": {
+    "defaultValue": "<pg_password>",
+    "description": "Same as `pg_password`, but for the read-only connection."
+  },
+  "pg_ro_iam_auth": {
+    "defaultValue": "<pg_iam_auth>",
+    "description": "Same as `pg_iam_auth`, but for the read-only connection."
+  },
+  "pg_ro_iam_auth_assume_role_arn": {
+    "defaultValue": null,
+    "description": "Same as `pg_iam_auth_assume_role_arn', but for the read-only connection."
+  },
+  "pg_ro_iam_auth_role_session_name": {
+    "defaultValue": "KongPostgres",
+    "description": "Same as `pg_iam_auth_role_session_name`, but for the read-only connection."
+  },
+  "pg_ro_iam_auth_sts_endpoint_url": {
+    "defaultValue": null,
+    "description": "Same as `pg_iam_auth_sts_endpoint_url`, but for the read-only connection."
+  },
+  "pg_ro_database": {
+    "defaultValue": "<pg_database>",
+    "description": "Same as `pg_database`, but for the read-only connection."
+  },
+  "pg_ro_schema": {
+    "defaultValue": "<pg_schema>",
+    "description": "Same as `pg_schema`, but for the read-only connection."
+  },
+  "pg_ro_ssl": {
+    "defaultValue": "<pg_ssl>",
+    "description": "Same as `pg_ssl`, but for the read-only connection."
+  },
+  "pg_ro_ssl_required": {
+    "defaultValue": "<pg_ssl_required>",
+    "description": " Same as `pg_ssl_required`, but for the read-only connection."
+  },
+  "pg_ro_ssl_verify": {
+    "defaultValue": "<pg_ssl_verify>",
+    "description": " Same as `pg_ssl_verify`, but for the read-only connection."
+  },
+  "pg_ro_ssl_version": {
+    "defaultValue": "<pg_ssl_version>",
+    "description": " Same as `pg_ssl_version`, but for the read-only connection."
+  },
+  "pg_ro_max_concurrent_queries": {
+    "defaultValue": "<pg_max_concurrent_queries>",
+    "description": " Same as `pg_max_concurrent_queries`, but for the read-only connection. Note: read-only concurrency is not shared with the main (read-write) connection."
+  },
+  "pg_ro_semaphore_timeout": {
+    "defaultValue": "<pg_semaphore_timeout>",
+    "description": " Same as `pg_semaphore_timeout`, but for the read-only connection."
+  },
+  "pg_ro_keepalive_timeout": {
+    "defaultValue": "<pg_keepalive_timeout>",
+    "description": " Same as `pg_keepalive_timeout`, but for the read-only connection."
+  },
+  "pg_ro_pool_size": {
+    "defaultValue": "<pg_pool_size>",
+    "description": " Same as `pg_pool_size`, but for the read-only connection."
+  },
+  "pg_ro_backlog": {
+    "defaultValue": "<pg_backlog>",
+    "description": " Same as `pg_backlog`, but for the read-only connection."
+  },
+  "declarative_config": {
+    "defaultValue": null,
+    "description": "The path to the declarative configuration file which holds the specification of all entities (Routes, Services, Consumers, etc.) to be used when the `database` is set to `off`.  Entities are stored in Kong's LMDB cache, so you must ensure that enough headroom is allocated to it via the `lmdb_map_size` property.  If the Hybrid mode `role` is set to `data_plane` and there's no configuration cache file, this configuration is used before connecting to the Control Plane node as a user-controlled fallback."
+  },
+  "declarative_config_string": {
+    "defaultValue": null,
+    "description": "The declarative configuration as a string"
+  },
+  "lmdb_environment_path": {
+    "defaultValue": "dbless.lmdb",
+    "description": "Directory where the LMDB database files used by DB-less and Hybrid mode to store Kong configurations reside.  This path is relative under the Kong `prefix`."
+  },
+  "lmdb_map_size": {
+    "defaultValue": "2048m",
+    "description": "Maximum size of the LMDB memory map, used to store the DB-less and Hybird mode configurations. Default is 2048m.  This config defines the limit of LMDB file size, the actual file size growth will be on-demand and proportional to the actual config size.  Note this value can be set very large, say a couple of GBs to accommodate future database growth and Multi Version Concurrency Control (MVCC) headroom needs. The file size of the LMDB database file should stabilize after a few config reload/Hybrid mode syncs and the actual memory used by the LMDB database will be smaller than the file size due to dynamic swapping of database pages by the OS."
+  },
+  "db_update_frequency": {
+    "defaultValue": "5",
+    "description": "Frequency (in seconds) at which to check for updated entities with the datastore.  When a node creates, updates, or deletes an entity via the Admin API, other nodes need to wait for the next poll (configured by this value) to eventually purge the old cached entity and start using the new one."
+  },
+  "db_update_propagation": {
+    "defaultValue": "0",
+    "description": "Time (in seconds) taken for an entity in the datastore to be propagated to replica nodes of another datacenter.  When set, this property will increase the time taken by Kong to propagate the change of an entity.  Single-datacenter setups or PostgreSQL servers should suffer no such delays, and this value can be safely set to 0. Postgres setups with read replicas should set this value to maximum expected replication lag between the writer and reader instances."
+  },
+  "db_cache_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of an entity from the datastore when cached by this node.  Database misses (no entity) are also cached according to this setting if you do not configure `db_cache_neg_ttl`.  If set to 0 (default), such cached entities or misses never expire."
+  },
+  "db_cache_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a datastore miss (no entity).  If not specified (default), `db_cache_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "db_resurrect_ttl": {
+    "defaultValue": "30",
+    "description": "Time (in seconds) for which stale entities from the datastore should be resurrected for when they cannot be refreshed (e.g., the datastore is unreachable). When this TTL expires, a new attempt to refresh the stale entities will be made."
+  },
+  "db_cache_warmup_entities": {
+    "defaultValue": "services",
+    "description": " Entities to be pre-loaded from the datastore into the in-memory cache at Kong start-up. This speeds up the first access of endpoints that use the given entities.  When the `services` entity is configured for warmup, the DNS entries for values in its `host` attribute are pre-resolved asynchronously as well.  Cache size set in `mem_cache_size` should be set to a value large enough to hold all instances of the specified entities. If the size is insufficient, Kong will log a warning."
+  },
+  "dns_resolver": {
+    "defaultValue": null,
+    "description": "Comma separated list of nameservers, each entry in `ip[:port]` format to be used by Kong. If not specified the nameservers in the local `resolv.conf` file will be used. Port defaults to 53 if omitted. Accepts both IPv4 and IPv6 addresses."
+  },
+  "dns_hostsfile": {
+    "defaultValue": "/etc/hosts",
+    "description": "The hosts file to use. This file is read once and its content is static in memory. To read the file again after modifying it, Kong must be reloaded."
+  },
+  "dns_order": {
+    "defaultValue": [
+      "LAST",
+      "SRV",
+      "A",
+      "CNAME"
+    ],
+    "description": "The order in which to resolve different record types. The `LAST` type means the type of the last successful lookup (for the specified name). The format is a (case insensitive) comma separated list."
+  },
+  "dns_valid_ttl": {
+    "defaultValue": null,
+    "description": "By default, DNS records are cached using the TTL value of a response. If this property receives a value (in seconds), it will override the TTL for all records."
+  },
+  "dns_stale_ttl": {
+    "defaultValue": "3600",
+    "description": "Defines, in seconds, how long a record will remain in cache past its TTL. This value will be used while the new DNS record is fetched in the background. Stale data will be used from expiry of a record until either the refresh query completes, or the `dns_stale_ttl` number of seconds have passed. This configuration enables Kong to be more resilient during resolver downtime."
+  },
+  "dns_cache_size": {
+    "defaultValue": "10000",
+    "description": "Defines the maximum allowed number of DNS records stored in memory cache. Least recently used DNS records are discarded from cache if it is full. Both errors and data are cached, therefore a single name query can easily take up 10-15 slots."
+  },
+  "dns_not_found_ttl": {
+    "defaultValue": "30",
+    "description": "TTL in seconds for empty DNS responses and \"(3) name error\" responses."
+  },
+  "dns_error_ttl": {
+    "defaultValue": "1",
+    "description": "TTL in seconds for error responses."
+  },
+  "dns_no_sync": {
+    "defaultValue": "off",
+    "description": "If enabled, then upon a cache-miss every request will trigger its own dns query. When disabled multiple requests for the same name/type will be synchronised to a single query."
+  },
+  "vault_env_prefix": {
+    "defaultValue": null,
+    "description": "Defines the environment variable vault's default prefix. For example if you have all your secrets stored in environment variables prefixed with `SECRETS_`, it can be configured here so that it isn't necessary to repeat them in Vault references."
+  },
+  "vault_aws_region": {
+    "defaultValue": null,
+    "description": "The AWS region your vault is located in."
+  },
+  "vault_aws_endpoint_url": {
+    "defaultValue": null,
+    "description": "The AWS SecretsManager service endpoint url. If not specified, the value used by vault will be the official AWS SecretsManager service url which is `https://secretsmanager.<region>.amazonaws.com` You can specify a complete URL(including the \"http/https\" scheme) to override the endpoint that vault will connect to."
+  },
+  "vault_aws_assume_role_arn": {
+    "defaultValue": null,
+    "description": "The target AWS IAM role ARN that will be assumed. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+  },
+  "vault_aws_role_session_name": {
+    "defaultValue": "KongVault",
+    "description": "The role session name used for role assuming. The default value is `KongVault`."
+  },
+  "vault_aws_sts_endpoint_url": {
+    "defaultValue": null,
+    "description": "The custom STS endpoint URL used for role assuming in AWS Vault.  Note that this value will override the default STS endpoint URL(which should be `https://sts.amazonaws.com`, or `https://sts.<region>.amazonaws.com` if you have `AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).  If you are not using private VPC endpoint for STS service, you should not specify this value."
+  },
+  "vault_aws_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the AWS vault when cached by this node.  AWS vault misses (no secret) are also cached according to this setting if you do not configure `vault_aws_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_aws_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_aws_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_aws_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the AWS vault should be resurrected for when they cannot be refreshed (e.g., the AWS vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "vault_gcp_project_id": {
+    "defaultValue": null,
+    "description": "The project ID from your Google API Console."
+  },
+  "vault_gcp_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the GCP vault when cached by this node.  GCP vault misses (no secret) are also cached according to this setting if you do not configure `vault_gcp_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_gcp_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_gcp_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_gcp_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the GCP vault should be resurrected for when they cannot be refreshed (e.g., the GCP vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "vault_hcv_protocol": {
+    "defaultValue": "http",
+    "description": "The protocol to connect with. Accepts one of `http` or `https`."
+  },
+  "vault_hcv_host": {
+    "defaultValue": "127.0.0.1",
+    "description": "The hostname of your HashiCorp vault."
+  },
+  "vault_hcv_port": {
+    "defaultValue": "8200",
+    "description": "The port number of your HashiCorp vault."
+  },
+  "vault_hcv_namespace": {
+    "defaultValue": null,
+    "description": "Namespace for the HashiCorp Vault. Vault Enterprise requires a namespace to successfully connect to it."
+  },
+  "vault_hcv_mount": {
+    "defaultValue": "secret",
+    "description": "The mount point."
+  },
+  "vault_hcv_kv": {
+    "defaultValue": "v1",
+    "description": "The secrets engine version. Accepts `v1` or `v2`."
+  },
+  "vault_hcv_token": {
+    "defaultValue": null,
+    "description": "A token string."
+  },
+  "vault_hcv_auth_method": {
+    "defaultValue": "token",
+    "description": "Defines the authentication mechanism when connecting to the Hashicorp Vault service. Accepted values are: `token`, `kubernetes` or `approle`."
+  },
+  "vault_hcv_kube_role": {
+    "defaultValue": null,
+    "description": "Defines the HashiCorp Vault role for the Kubernetes service account of the running pod. `vault_hcv_auth_method` must be set to `kubernetes` for this to activate."
+  },
+  "vault_hcv_kube_auth_path": {
+    "defaultValue": "kubernetes",
+    "description": " Place where the Kubernetes auth method will be accessible: /v1/auth/<vault_hcv_kube_auth_path>"
+  },
+  "vault_hcv_kube_api_token_file": {
+    "defaultValue": null,
+    "description": "Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+  },
+  "vault_hcv_approle_auth_path": {
+    "defaultValue": "approle",
+    "description": " Place where the Approle auth method will be accessible: /v1/auth/<vault_hcv_approle_auth_path>"
+  },
+  "vault_hcv_approle_role_id": {
+    "defaultValue": null,
+    "description": "The Role ID of the Approle in HashiCorp Vault."
+  },
+  "vault_hcv_approle_secret_id": {
+    "defaultValue": null,
+    "description": "The Secret ID of the Approle in HashiCorp Vault."
+  },
+  "vault_hcv_approle_secret_id_file": {
+    "defaultValue": null,
+    "description": "Defines where the Secret ID should be read from the pod's filesystem. This is usually used with HashiCorp Vault's response wrapping."
+  },
+  "vault_hcv_approle_response_wrapping": {
+    "defaultValue": "false",
+    "description": "Defines whether the Secret ID read from configuration or file is actually a response-wrapping token instead of a real Secret ID."
+  },
+  "vault_hcv_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the HashiCorp vault when cached by this node.  HashiCorp vault misses (no secret) are also cached according to this setting if you do not configure `vault_hcv_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_hcv_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a HashiCorp vault miss (no secret).  If not specified (default), `vault_hcv_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_hcv_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the HashiCorp vault should be resurrected for when they cannot be refreshed (e.g., the HashiCorp vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "vault_azure_vault_uri": {
+    "defaultValue": null,
+    "description": "The URI the vault is reachable from."
+  },
+  "vault_azure_client_id": {
+    "defaultValue": null,
+    "description": "The client ID from your registered Application. Visit your Azure Dashboard and select *App Registrations* to check your client ID."
+  },
+  "vault_azure_tenant_id": {
+    "defaultValue": null,
+    "description": "The DirectoryId and TenantId both equate to the GUID representing the ActiveDirectory Tenant. Depending on context, either term may be used by Microsoft documentation and products, which can be confusing. In other words, the \"Tenant ID\" IS the \"Directory ID\""
+  },
+  "vault_azure_type": {
+    "defaultValue": "secrets",
+    "description": "Azure Key Vault enables Microsoft Azure applications and users to store and use several types of secret/key data: keys, secrets, and certificates. Kong currently only supports the `Secrets`"
+  },
+  "vault_azure_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the Azure Key Vault when cached by this node.  Key Vault misses (no secret) are also cached according to this setting if you do not configure `vault_azure_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_azure_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a Azure Key Vault miss (no secret).  If not specified (default), `vault_azure_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_azure_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the Azure Key Vault should be resurrected for when they cannot be refreshed (e.g., the the vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "worker_consistency": {
+    "defaultValue": "eventual",
+    "description": " Defines whether this node should rebuild its state synchronously or asynchronously (the balancers and the router are rebuilt on updates that affects them, e.g., updates to Routes, Services or Upstreams, via the Admin API or loading a declarative configuration file). (This option is deprecated and will be removed in future releases. The new default is `eventual`.)  Accepted values are:  - `strict`: the router will be rebuilt   synchronously, causing incoming requests to   be delayed until the rebuild is finished.   (This option is deprecated and will be removed    in future releases. The new default is `eventual`) - `eventual`: the router will be rebuilt   asynchronously via a recurring background   job running every second inside of each   worker.  Note that `strict` ensures that all workers of a given node will always proxy requests with an identical router, but that increased long tail latency can be observed if frequent Routes and Services updates are expected. Using `eventual` will help preventing long tail latency issues in such cases, but may cause workers to route requests differently for a short period of time after Routes and Services updates."
+  },
+  "worker_state_update_frequency": {
+    "defaultValue": "5",
+    "description": " Defines how often the worker state changes are checked with a background job. When a change is detected, a new router or balancer will be built, as needed. Raising this value will decrease the load on database servers and result in less jitter in proxy latency, but it might take more time to propagate changes to each individual worker."
+  },
+  "router_flavor": {
+    "defaultValue": "traditional_compatible",
+    "description": " Selects the router implementation to use when performing request routing. Incremental router rebuild is available when the flavor is set to either `expressions` or `traditional_compatible` which could significantly shorten rebuild time for large number of routes.  Accepted values are:  - `traditional_compatible`: the DSL based expression   router engine will be used under the hood. However   the router config interface will be the same   as `traditional` and expressions are   automatically generated at router build time.   The `expression` field on the `Route` object   is not visible. - `expressions`: the DSL based expression router engine   will be used under the hood. Traditional router   config interface is still visible, and you could also write   Router Expression manually and provide them in the   `expression` field on the `Route` object. - `traditional`: the pre-3.0 Router engine will be   used. Config interface will be the same as   pre-3.0 Kong and the `expression` field on the   `Route` object is not visible.    Deprecation warning: In Kong 3.0, `traditional`   mode should be avoided and only be used in case   `traditional_compatible` did not work as expected.   This flavor of router will be removed in the next   major release of Kong."
+  },
+  "lua_max_req_headers": {
+    "defaultValue": "100",
+    "description": "Maximum number of request headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying the Kong sends all the request headers and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many request headers."
+  },
+  "lua_max_resp_headers": {
+    "defaultValue": "100",
+    "description": "Maximum number of response headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong returns all the response headers and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many response headers."
+  },
+  "lua_max_uri_args": {
+    "defaultValue": "100",
+    "description": "Maximum number of request uri arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request query arguments and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many query arguments."
+  },
+  "lua_max_post_args": {
+    "defaultValue": "100",
+    "description": "Maximum number of request post arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request post arguments and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many post arguments."
+  },
+  "lua_ssl_trusted_certificate": {
+    "defaultValue": "system",
+    "description": "Comma-separated list of certificate authorities for Lua cosockets in PEM format.  The special value `system` attempts to search for the \"usual default\" provided by each distro, according to an arbitrary heuristic. In the current implementation, The following pathnames will be tested in order, and the first one found will be used:  - /etc/ssl/certs/ca-certificates.crt (Debian/Ubuntu/Gentoo) - /etc/pki/tls/certs/ca-bundle.crt (Fedora/RHEL 6) - /etc/ssl/ca-bundle.pem (OpenSUSE) - /etc/pki/tls/cacert.pem (OpenELEC) - /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem (CentOS/RHEL 7) - /etc/ssl/cert.pem (OpenBSD, Alpine)  `system` can be used by itself or in conjunction with other CA filepaths.  When `pg_ssl_verify` is enabled, these certificate authority files will be used for verifying Kong's database connections.  Certificates can be configured on this property with either of the following values: * `system` * absolute path to the certificate * certificate content * base64 encoded certificate content  See https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate"
+  },
+  "lua_ssl_verify_depth": {
+    "defaultValue": "1",
+    "description": "Sets the verification depth in the server certificates chain used by Lua cosockets, set by `lua_ssl_trusted_certificate`. This includes the certificates configured for Kong's database connections. If the maximum depth is reached before reaching the end of the chain, verification will fail. This helps mitigate certificate based DoS attacks.  See https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth"
+  },
+  "lua_ssl_protocols": {
+    "defaultValue": "TLSv1.2 TLSv1.3",
+    "description": "Defines the TLS versions supported when handshaking with OpenResty's TCP cosocket APIs.  This affects connections made by Lua code, such as connections to the database Kong uses, or when sending logs using a logging plugin. It does *not* affect connections made to the upstream Service or from downstream clients."
+  },
+  "lua_package_path": {
+    "defaultValue": "./?.lua;./?/init.lua;",
+    "description": "Sets the Lua module search path (LUA_PATH). Useful when developing or using custom plugins not stored in the default search path.  See https://github.com/openresty/lua-nginx-module#lua_package_path"
+  },
+  "lua_package_cpath": {
+    "defaultValue": null,
+    "description": "Sets the Lua C module search path (LUA_CPATH).  See https://github.com/openresty/lua-nginx-module#lua_package_cpath"
+  },
+  "lua_socket_pool_size": {
+    "defaultValue": "256",
+    "description": "Specifies the size limit for every cosocket connection pool associated with every remote server.  See https://github.com/openresty/lua-nginx-module#lua_socket_pool_size"
+  },
+  "enforce_rbac": {
+    "defaultValue": "off",
+    "description": "Specifies whether Admin API RBAC is enforced. Accepts one of `entity`, `both`, `on`, or `off`.  - `on`: only endpoint-level authorization   is enforced. - `entity`: entity-level authorization   applies. - `both`: enables both endpoint and   entity-level authorization. - `off`: disables both endpoint and   entity-level authorization.  When enabled, Kong will deny requests to the Admin API when a nonexistent or invalid RBAC authorization token is passed, or the RBAC user with which the token is associated does not have permissions to access/modify the requested resource."
+  },
+  "rbac_auth_header": {
+    "defaultValue": "Kong-Admin-Token",
+    "description": "Defines the name of the HTTP request header from which the Admin API will attempt to authenticate the RBAC user."
+  },
+  "event_hooks_enabled": {
+    "defaultValue": "on",
+    "description": "When enabled, event hook entities represent a relationship between an event (source and event) and an action (handler). Similar to web hooks, event hooks can be used to communicate Kong Gateway service events. When a particular event happens on a service, the event hook calls a URL with information about that event. Event hook configurations differ depending on the handler. The events that are triggered send associated data.  See: https://docs.konghq.com/enterprise/latest/admin-api/event-hooks/reference/"
+  },
+  "fips": {
+    "defaultValue": "off",
+    "description": "Turn on FIPS mode; this mode is only available on a FIPS build."
+  },
+  "admin_gui_listen": {
+    "defaultValue": [
+      "0.0.0.0:8002",
+      "0.0.0.0:8445 ssl"
+    ],
+    "description": " Kong Manager Listeners  Comma-separated list of addresses and ports on which Kong will expose Kong Manager. This web application lets you configure and manage Kong, and therefore should be kept secured.  Suffixes can be specified for each pair, similarly to the `admin_listen` directive."
+  },
+  "admin_gui_url": {
+    "defaultValue": null,
+    "description": "Kong Manager URL  The lookup, or balancer, address for Kong Manager.  Accepted format (items in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>)`  Examples:  - `http://127.0.0.1:8003` - `https://kong-admin.test` - `http://dev-machine`  By default, Kong Manager will use the window request host and append the resolved listener port depending on the requested protocol."
+  },
+  "admin_gui_path": {
+    "defaultValue": "/",
+    "description": "Kong Manager base path  This configuration parameter allows the user to customize the path prefix where Kong Manager is served. When updating this parameter, it's recommended to update the path in `admin_gui_url` as well.  Accepted format:  - Path must start with a `/` - Path must not end with a `/` (except for the `/`) - Path can only contain letters, digits, hyphens (`-`), underscores (`_`), and slashes (`/`) - Path must not contain continuous slashes (e.g., `//` and `///`)  Examples:  - `/` - `/manager` - `/kong-manager` - `/kong/manager`"
+  },
+  "admin_gui_api_url": {
+    "defaultValue": null,
+    "description": "Hierarchical part of a URI which is composed optionally of a host, port, and path at which the Admin API accepts HTTP or HTTPS traffic. When this config is disabled, Kong Manager will use the window protocol + host and append the resolved admin_listen HTTP/HTTPS port."
+  },
+  "admin_gui_ssl_protocols": {
+    "defaultValue": "TLSv1.2 TLSv1.3",
+    "description": " Defines the TLS versions supported for Kong Manager"
+  },
+  "admin_gui_ssl_cert": {
+    "defaultValue": null,
+    "description": "The SSL certificate for `admin_gui_listen` values with SSL enabled.  values: * absolute path to the certificate * certificate content * base64 encoded certificate content"
+  },
+  "admin_gui_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "The SSL key for `admin_gui_listen` values with SSL enabled.  values: * absolute path to the certificate key * certificate key content * base64 encoded certificate key content"
+  },
+  "admin_gui_flags": {
+    "defaultValue": "{}",
+    "description": " Alters the layout Admin GUI (JSON) The only supported value is `{ \"IMMUNITY_ENABLED\": true }` to enable Kong Immunity in the Admin GUI."
+  },
+  "admin_gui_access_log": {
+    "defaultValue": "logs/admin_gui_access.log",
+    "description": " Kong Manager Access Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables access logs for Kong Manager."
+  },
+  "admin_gui_error_log": {
+    "defaultValue": "logs/admin_gui_error.log",
+    "description": " Kong Manager Error Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables error logs for Kong Manager.  Granularity can be adjusted through the `log_level` directive."
+  },
+  "admin_gui_auth": {
+    "defaultValue": null,
+    "description": "Kong Manager Authentication Plugin Name  Secures access to Kong Manager by specifying an authentication plugin to use.  Supported Plugins:  - `basic-auth`: Basic Authentication plugin - `ldap-auth-advanced`: LDAP Authentication plugin - `openid-connect`: OpenID Connect Authentication   plugin"
+  },
+  "admin_gui_auth_conf": {
+    "defaultValue": null,
+    "description": "Kong Manager Authentication Plugin Config (JSON)  Specifies the configuration for the authentication plugin specified in `admin_gui_auth`.  For information about Plugin Configuration consult the associated plugin documentation.  Example for `basic-auth`:  `admin_gui_auth_conf = { \"hide_credentials\": true }`"
+  },
+  "admin_gui_auth_password_complexity": {
+    "defaultValue": null,
+    "description": "Kong Manager Authentication Password Complexity (JSON)  When `admin_gui_auth = basic-auth`, this property defines the rules required for Kong Manager passwords. Choose from preset rules or write your own.  Example using preset rules:  `admin_gui_auth_password_complexity = { \"kong-preset\": \"min_8\" }`  All values for kong-preset require the password to contain characters from at least three of the following categories:  1. Uppercase characters (A through Z)  2. Lowercase characters (a through z)  3. Base-10 digits (0 through 9)  4. Special characters (for example, &, $, #, %)  Supported preset rules: - `min_8`: minimum length of 8 - `min_12`: minimum length of 12 - `min_20`: minimum length of 20  To write your own rules, see https://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.  NOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.  Example:  `admin_gui_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`"
+  },
+  "admin_gui_session_conf": {
+    "defaultValue": null,
+    "description": "Kong Manager Session Config (JSON)  Specifies the configuration for the Session plugin as used by Kong Manager.  For information about plugin configuration, consult the Kong Session plugin documentation.  Example: ``` admin_gui_session_conf = { \"cookie_name\": \"kookie\", \\                            \"secret\": \"changeme\" } ```"
+  },
+  "admin_gui_auth_header": {
+    "defaultValue": "Kong-Admin-User",
+    "description": " Defines the name of the HTTP request header from which the Admin API will attempt to identify the Kong Admin user."
+  },
+  "admin_gui_auth_login_attempts": {
+    "defaultValue": "0",
+    "description": " Number of times a user can attempt to login to Kong Manager. 0 means infinite attempts allowed."
+  },
+  "admin_gui_header_txt": {
+    "defaultValue": null,
+    "description": "Kong Manager Header Text Sets text for Kong Manager Header Banner. Header Banner is not shown if this config is empty."
+  },
+  "admin_gui_header_bg_color": {
+    "defaultValue": null,
+    "description": "Kong Manager Header Background Color Sets background color for Kong Manager Header Banner Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Manager."
+  },
+  "admin_gui_header_txt_color": {
+    "defaultValue": null,
+    "description": "Kong Manager Header Text Color Sets text color for Kong Manager Header Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Kong Manager."
+  },
+  "admin_gui_footer_txt": {
+    "defaultValue": null,
+    "description": "Kong Manager Footer Text Sets text for Kong Manager Footer Banner. Footer Banner is not shown if this config is empty"
+  },
+  "admin_gui_footer_bg_color": {
+    "defaultValue": null,
+    "description": "Kong Manager Footer Background Color Sets background color for Kong Manager Footer Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Manager."
+  },
+  "admin_gui_footer_txt_color": {
+    "defaultValue": null,
+    "description": "Kong Manager Footer Text Color Sets text color for Kong Manager Footer Banner. Accepts css color keyword, #-hexadecimal or rgb format. Invalid values are ignored by Kong Manager."
+  },
+  "admin_gui_login_banner_title": {
+    "defaultValue": null,
+    "description": "Kong Manager Login Banner Title Text Sets title text for Kong Manager Login Banner. Login Banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+  },
+  "admin_gui_login_banner_body": {
+    "defaultValue": null,
+    "description": "Kong Manager Login Banner Body Text Sets body text for Kong Manager Login Banner. Login Banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+  },
+  "konnect_mode": {
+    "defaultValue": "off",
+    "description": "When enabled, the dataplane is connected to Konnect"
+  },
+  "analytics_flush_interval": {
+    "defaultValue": "1",
+    "description": "Determine the frequency of flushing local data to Konnect in seconds."
+  },
+  "analytics_buffer_size_limit": {
+    "defaultValue": "100000",
+    "description": "Max number of messages can be buffered locally before dropping data in case there is no network connection to Konnect."
+  },
+  "analytics_debug": {
+    "defaultValue": "off",
+    "description": "Outputs analytics payload to Kong logs."
+  },
+  "admin_emails_from": {
+    "defaultValue": "\"\"",
+    "description": "The email address for the `From` header for admin emails."
+  },
+  "admin_emails_reply_to": {
+    "defaultValue": null,
+    "description": "Email address for the `Reply-To` header for admin emails."
+  },
+  "admin_invitation_expiry": {
+    "defaultValue": "259200",
+    "description": "Expiration time for the admin invitation link (in seconds). 0 means no expiration.  Example, 72 hours: `72 * 60 * 60 = 259200`"
+  },
+  "smtp_mock": {
+    "defaultValue": "on",
+    "description": "This flag will mock the sending of emails. This can be used for testing before the SMTP client is fully configured."
+  },
+  "smtp_host": {
+    "defaultValue": "localhost",
+    "description": " The hostname of the SMTP server to connect to."
+  },
+  "smtp_port": {
+    "defaultValue": "25",
+    "description": " The port number on the SMTP server to connect to."
+  },
+  "smtp_starttls": {
+    "defaultValue": "off",
+    "description": " When set to `on`, STARTTLS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 587."
+  },
+  "smtp_username": {
+    "defaultValue": null,
+    "description": "Username used for authentication with SMTP server"
+  },
+  "smtp_password": {
+    "defaultValue": null,
+    "description": "Password used for authentication with SMTP server"
+  },
+  "smtp_ssl": {
+    "defaultValue": "off",
+    "description": " When set to `on`, SMTPS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 465."
+  },
+  "smtp_auth_type": {
+    "defaultValue": null,
+    "description": "The method used to authenticate with the SMTP server Valid options are `plain`, `login`, or `nil`"
+  },
+  "smtp_domain": {
+    "defaultValue": "localhost.localdomain",
+    "description": " The domain used in the `EHLO` connection and part of the `Message-ID` header"
+  },
+  "smtp_timeout_connect": {
+    "defaultValue": "60000",
+    "description": " The timeout (in milliseconds) for connecting to the SMTP server."
+  },
+  "smtp_timeout_send": {
+    "defaultValue": "60000",
+    "description": " The timeout (in milliseconds) for sending data to the SMTP server."
+  },
+  "smtp_timeout_read": {
+    "defaultValue": "60000",
+    "description": " The timeout (in milliseconds) for reading data from the SMTP server."
+  },
+  "smtp_admin_emails": {
+    "defaultValue": null,
+    "description": "Comma separated list of admin emails to receive notifications. Example `admin1@example.com, admin2@example.com`"
+  },
+  "audit_log": {
+    "defaultValue": "off",
+    "description": "When enabled, Kong will log information about Admin API access and database row insertions, updates, and deletes."
+  },
+  "audit_log_ignore_methods": {
+    "defaultValue": null,
+    "description": "Comma-separated list of HTTP methods that will not generate audit log entries. By default, all HTTP requests will be logged."
+  },
+  "audit_log_ignore_paths": {
+    "defaultValue": null,
+    "description": "Comma-separated list of request paths that will not generate audit log entries. By default, all HTTP requests will be logged."
+  },
+  "audit_log_ignore_tables": {
+    "defaultValue": null,
+    "description": "Comma-separated list of database tables that will not generate audit log entries. By default, updates to all database tables will be logged (the term \"updates\" refers to the creation, update, or deletion of a row)."
+  },
+  "audit_log_payload_exclude": {
+    "defaultValue": [
+      "token",
+      "secret",
+      "password"
+    ],
+    "description": " Comma-separated list of keys that will be filtered out of the payload. Keys that were filtered will be recorded in the audit log."
+  },
+  "audit_log_record_ttl": {
+    "defaultValue": "2592000",
+    "description": "Length, in seconds, of the TTL for audit log records. Records in the database older than their TTL are automatically purged.  Example, 30 days: `30 * 24 * 60 * 60 = 2592000`"
+  },
+  "audit_log_signing_key": {
+    "defaultValue": null,
+    "description": "Defines the path to a private RSA signing key that can be used to insert a signature of audit records, adjacent to the record. The corresponding public key should be stored offline, and can be used the validate audit entries in the future. If this value is undefined, no signature will be generated."
+  },
+  "route_validation_strategy": {
+    "defaultValue": "smart",
+    "description": "The strategy used to validate routes when creating or updating them. Different strategies are available to tune how to enforce splitting traffic of workspaces. - `smart` is the default option and uses the   algorithm described in   https://docs.konghq.com/gateway/latest/kong-enterprise/workspaces/. - `off` disables any check. - `path` enforces routes to comply with the pattern   described in config `enforce_route_path_pattern`. - `static` relies on the PostgreSQL database. Before creating a new route, it checks if the route is unique across all workspaces based on the following params: `paths`, `methods`, and `hosts`. If all fields of the new route overlap with an existing one, a 409 is returned with the route of the collision. The array order is not important for the overlap filter."
+  },
+  "enforce_route_path_pattern": {
+    "defaultValue": null,
+    "description": "Specifies the Lua pattern which will be enforced on the `paths` attribute of a Route object. You can also add a placeholder for the workspace in the pattern, which will be rendered during runtime based on the workspace to which the `route` belongs. This setting is only relevant if `route_validation_strategy` is set to `path`.   Example For Pattern `/$(workspace)/v%d/.*` valid paths are:  1. `/group1/v1/` if route belongs to   workspace `group1`.  2. `/group2/v1/some_path` if route belongs to   workspace `group2`."
+  },
+  "keyring_enabled": {
+    "defaultValue": "off",
+    "description": "When enabled, Kong will encrypt sensitive field values before writing them to the database, and subsuquently decrypt them when retrieving data for the Admin API, Developer Portal, or proxy business logic. Symmetric encryption keys are managed based on the strategy defined below."
+  },
+  "keyring_strategy": {
+    "defaultValue": "cluster",
+    "description": "Defines the strategy implementation by which Kong nodes will manage symmetric encryption keys. Please see the Kong Enterprise documentation for a detailed description of each strategies. Acceptable values for this option are 'cluster' and 'vault'."
+  },
+  "keyring_public_key": {
+    "defaultValue": null,
+    "description": "Defines the public key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  values: * absolute path to the public key * public key content * base64 encoded public key content"
+  },
+  "keyring_private_key": {
+    "defaultValue": null,
+    "description": "Defines the private key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  values: * absolute path to the private key * private key content * base64 encoded private key content"
+  },
+  "keyring_blob_path": {
+    "defaultValue": null,
+    "description": "Defines the filesystem path at which Kong will backup the initial keyring material. This option is useful largely for development purposes."
+  },
+  "keyring_vault_host": {
+    "defaultValue": null,
+    "description": "Defines the Vault host at which Kong will fetch the encryption material. This value should be defined in the format:  `<scheme>://<IP / HOSTNAME>:<PORT>`"
+  },
+  "keyring_vault_mount": {
+    "defaultValue": null,
+    "description": "Defines the name of the Vault v2 KV secrets engine at which symmetric keys are found."
+  },
+  "keyring_vault_path": {
+    "defaultValue": null,
+    "description": "Defines the names of the Vault v2 KV path at which symmetric keys are found."
+  },
+  "keyring_vault_auth_method": {
+    "defaultValue": "token",
+    "description": " Defines the authentication mechanism when connecting to the Hashicorp Vault service.  Accepted values are: `token`, or `kubernetes`:  * `token`: Uses the static token defined in            the `keyring_vault_token`            configuration property.  * `kubernetes`: Uses the Kubernetes authentication                 mechanism, with the running pod's                 mapped service account, to assume                 the Hashicorp Vault role name that is                 defined in the `keyring_vault_kube_role`                 configuration property."
+  },
+  "keyring_vault_token": {
+    "defaultValue": null,
+    "description": "Defines the token value used to communicate with the v2 KV Vault HTTP(S) API."
+  },
+  "keyring_vault_kube_role": {
+    "defaultValue": "default",
+    "description": " Defines the Hashicorp Vault role that will be assumed using the Kubernetes service account of the running pod.  `keyring_vault_auth_method` must be set to `kubernetes` for this to activate."
+  },
+  "keyring_vault_kube_api_token_file": {
+    "defaultValue": "/run/secrets/kubernetes.io/serviceaccount/token",
+    "description": " Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+  },
+  "untrusted_lua": {
+    "defaultValue": "sandbox",
+    "description": " Controls loading of Lua functions from admin-supplied sources such as the Admin API. LuaJIT bytecode loading is always disabled.  **Warning:** LuaJIT is not designed as a secure runtime for running malicious code, therefore you should properly protect your Admin API endpoint even with sandboxing enabled. The sandbox only provides protection against trivial attackers or unintentional modification of the Kong global environment.  Accepted values are: `off`, `sandbox`, or `on`:  * `off`: Disallow loading of any arbitrary          Lua functions. The `off` option          disables any functionality that runs          arbitrary Lua code, including the          Serverless Functions plugins and any          transformation plugin that allows          custom Lua functions.  * `sandbox`: Allow loading of Lua functions,              but use a sandbox when executing              them. The sandboxed function has              restricted access to the global              environment and only has access              to standard Lua functions that              will generally not cause harm to              the Kong Gateway node.  * `on`: Functions have unrestricted         access to the global environment and         can load any Lua modules. This is         similar to the behavior in         Kong Gateway prior to 2.3.0.  The default `sandbox` environment does not allow importing other modules or libraries, or executing anything at the OS level (for example, file read/write). The global environment is also not accessible.  Examples of `untrusted_lua = sandbox` behavior:  * You can't access or change global values such as `kong.configuration.pg_password` * You can run harmless lua: `local foo = 1 + 1`. However, OS level functions are not allowed, like: `os.execute('rm -rf /*')`.  For a full allowed/disallowed list, see: https://github.com/kikito/sandbox.lua/blob/master/sandbox.lua  To customize the sandbox environment, use the `untrusted_lua_sandbox_requires` and `untrusted_lua_sandbox_environment` parameters below."
+  },
+  "untrusted_lua_sandbox_requires": {
+    "defaultValue": null,
+    "description": "Comma-separated list of modules allowed to be loaded with `require` inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  For example, say you have configured the Serverless pre-function plugin and it contains the following `requires`:  ``` local template = require \"resty.template\" local split = require \"kong.tools.utils\".split ```  To run the plugin, add the modules to the allowed list: ``` untrusted_lua_sandbox_requires = resty.template, kong.tools.utils ```  **Warning:** Allowing certain modules may create opportunities to escape the sandbox. For example, allowing `os` or `luaposix` may be unsafe."
+  },
+  "untrusted_lua_sandbox_environment": {
+    "defaultValue": null,
+    "description": "Comma-separated list of global Lua variables that should be made available inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  **Warning**: Certain variables, when made available, may create opportunities to escape the sandbox."
+  },
+  "openresty_path": {
+    "defaultValue": null,
+    "description": "Path to the OpenResty installation that Kong will use. When this is empty (the default), Kong determines the OpenResty installation by searching for a system-installed OpenResty and falling back to searching $PATH for the nginx binary.  Setting this attribute disables the search behavior and explicitly instructs Kong which OpenResty installation to use."
+  },
+  "node_id": {
+    "defaultValue": null,
+    "description": "Node ID for the Kong node. Every Kong node in a Kong cluster must have a unique and valid UUID. When empty, node ID is automatically generated."
+  },
+  "cluster_fallback_config_import": {
+    "defaultValue": "off",
+    "description": "Enable fallback configuration imports.  This should only be enabled for data planes."
+  },
+  "cluster_fallback_config_storage": {
+    "defaultValue": null,
+    "description": "Storage definition used by `cluster_fallback_config_import` and `cluster_fallback_config_export`.  Supported storage types: - S3-like storages - GCP storage service  To use S3 with a bucket named b and place all configs to with a key prefix named p, set it to: `s3://b/p` To use GCP for the same bucket and prefix, set it to: `gcs://b/p`  The credentials (and the endpoint URL for S3-like) for S3 are passed with environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where `AWS_CONFIG_STORAGE_ENDPOINT` is the endpoint that hosts S3-like storage.  The credentials for GCP are provided via the environment variable `GCP_SERVICE_ACCOUNT`."
+  },
+  "cluster_fallback_export_s3_config": {
+    "defaultValue": null,
+    "description": "fallback config export S3 config This is used only when `cluster_fallback_config_storage` is S3-like schema. If set, it will add config table to kong exporter config S3 putObject request. The config table should be in JSON format and can be unserialized into a table. It should contain the necessary parameters as described in the documentation.  https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property. For example, if you want to set the ServerSideEncryption headers / KMS Key ID for the S3 putObject request, you can set the config table to: `{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"your-kms-key-id\"}`"
+  },
+  "cluster_fallback_config_export": {
+    "defaultValue": "off",
+    "description": "Enable fallback configuration exports."
+  },
+  "cluster_fallback_config_export_delay": {
+    "defaultValue": "60",
+    "description": "The fallback configuration export interval.  If the interval is set to 60 and configuration A is exported and there are new configurations B, C, and D in the next 60 seconds, it will wait until 60 seconds passed and export D, skipping B and C."
+  },
+  "wasm": {
+    "defaultValue": "off",
+    "description": "Enable/disable wasm support. This must be enabled in order to use wasm filters and filter chains."
+  },
+  "wasm_filters_path": {
+    "defaultValue": null,
+    "description": "Path to the directory containing wasm filter modules.  At startup, Kong discovers available wasm filters by scanning this directory for files with the `.wasm` file extension.  The name of a wasm filter module is derived from the filename itself, with the .wasm extension removed. So, given the following tree:  ``` /path/to/wasm_filters ├── my_module.wasm ├── my_other_module.wasm └── not_a_wasm_module.txt ```  The resulting filter modules available for use in Kong will be:  * `my_module` * `my_other_module`  Notes:  * No recursion is performed. Only .wasm files at the   top level are registered * This path _may_ be a symlink to a directory."
+  },
+  "wasm_filters": {
+    "defaultValue": [
+      "bundled",
+      "user"
+    ],
+    "description": "Comma-separated list of Wasm filters to be made available for use in filter chains.  When the `off` keyword is specified as the only value, no filters will be available for use.  When the `bundled` keyword is specified, all filters bundled with Kong will be available.  When the `user` keyword is specified, all filters within the `wasm_filters_path` will be available.  **Examples:**  - `wasm_filters = bundled,user` enables _all_ bundled   and user-supplied filters - `wasm_filters = user` enables _only_ user-supplied   filters - `wasm_filters = filter-a,filter-b` enables _only_   filters named `filter-a` or `filter-b` (whether   bundled _or_ user-suppplied)  If a conflict occurs where a bundled filter and a user-supplied filter share the same name, a warning will be logged, and the user-supplied filter will be used instead."
+  },
+  "request_debug": {
+    "defaultValue": "on",
+    "description": "When enabled, Kong will provide detailed timing information for its components to the client and the error log if the following headers are present in the proxy request: - `X-Kong-Request-Debug`:   If the value is set to `*`,   timing information will be collected and exported for the current request.   If this header is not present or contains unknown value,   timing information will not be collected for the current request.   You can also specify a list of filters, separated by commas,   to filter the scope of the time information that is collected.   The following filters are supported:   - `rewrite`: Collect timing information from the `rewrite` phase.   - `access`: Collect timing information from the `access` phase.   - `balancer`: Collect timing information from the `balancer` phase.   - `response`: Collect timing information from the `response` phase.   - `header_filter`: Collect timing information from the `header_filter` phase.   - `body_filter`: Collect timing information from the `body_filter` phase.   - `log`: Collect timing information from the `log` phase.   - `upstream`: Collect timing information from the `upstream` phase.  - `X-Kong-Request-Debug-Log`:   If set to `true`, timing information will also be logged   in the Kong error log with a log level of `notice`.   Defaults to `false`.  - `X-Kong-Request-Debug-Token`:   Token for authenticating the client making the debug   request to prevent abuse. Debug requests originating from loopback   addresses do not require this header. "
+  },
+  "request_debug_token": {
+    "defaultValue": "<random>",
+    "description": "The Request Debug Token is used in the `X-Kong-Request-Debug-Token` header to prevent abuse. If this value is not set (the default), a random token will be generated when Kong starts, restarts, or reloads. If a token is specified manually, then the provided token will be used.  You can locate the generated debug token in two locations: - Kong error log:   Debug token will be logged in the error log (notice level)   when Kong starts, restarts, or reloads.   The log line will have the: `[request-debug]` prefix to aid searching. - Filesystem:   Debug token will also be stored in a file located at   `{prefix}/.request_debug_token` and updated   when Kong starts, restarts, or reloads."
+  }
+}

--- a/app/_data/kong-conf/3.8.json
+++ b/app/_data/kong-conf/3.8.json
@@ -1,0 +1,1282 @@
+{
+  "prefix": {
+    "defaultValue": "/usr/local/kong/",
+    "description": "Working directory. Equivalent to Nginx's prefix path, containing temporary files and logs. Each Kong process must have a separate working directory."
+  },
+  "log_level": {
+    "defaultValue": "notice",
+    "description": "Log level of the Nginx server. Logs are found at `<prefix>/logs/error.log`."
+  },
+  "proxy_access_log": {
+    "defaultValue": "logs/access.log",
+    "description": "Path for proxy port request access logs. Set this value to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "proxy_error_log": {
+    "defaultValue": "logs/error.log",
+    "description": "Path for proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "proxy_stream_access_log": {
+    "defaultValue": "logs/access.log basic",
+    "description": "Path for TCP streams proxy port access logs. Set to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location. `basic` is defined as `'$remote_addr [$time_local] ' '$protocol $status $bytes_sent $bytes_received ' '$session_time'`"
+  },
+  "proxy_stream_error_log": {
+    "defaultValue": "logs/error.log",
+    "description": "Path for tcp streams proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "admin_access_log": {
+    "defaultValue": "logs/admin_access.log",
+    "description": "Path for Admin API request access logs. If hybrid mode is enabled and the current node is set to be the control plane, then the connection requests from data planes are also written to this file with server name \"kong_cluster_listener\".  Set this value to `off` to disable logging Admin API requests. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "admin_error_log": {
+    "defaultValue": "logs/error.log",
+    "description": "Path for Admin API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "status_access_log": {
+    "defaultValue": "off",
+    "description": "Path for Status API request access logs. The default value of `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "status_error_log": {
+    "defaultValue": "logs/status_error.log",
+    "description": "Path for Status API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "debug_access_log": {
+    "defaultValue": "off",
+    "description": "Path for Debug API request access logs. The default value `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "debug_error_log": {
+    "defaultValue": "logs/debug_error.log",
+    "description": "Path for Debug API request error logs. The granularity of these logs is adjusted using the `log_level` property."
+  },
+  "vaults": {
+    "defaultValue": "bundled",
+    "description": "Comma-separated list of vaults this node should load. By default, all the bundled vaults are enabled.  The specified name(s) will be substituted as such in the Lua namespace: `kong.vaults.{name}.*`."
+  },
+  "opentelemetry_tracing": {
+    "defaultValue": "off",
+    "description": "Deprecated: use `tracing_instrumentations` instead."
+  },
+  "tracing_instrumentations": {
+    "defaultValue": "off",
+    "description": "Comma-separated list of tracing instrumentations this node should load. By default, no instrumentations are enabled.  Valid values for this setting are:  - `off`: do not enable instrumentations. - `request`: only enable request-level instrumentations. - `all`: enable all the following instrumentations. - `db_query`: trace database queries. - `dns_query`: trace DNS queries. - `router`: trace router execution, including router rebuilding. - `http_client`: trace OpenResty HTTP client requests. - `balancer`: trace balancer retries. - `plugin_rewrite`: trace plugin iterator execution with rewrite phase. - `plugin_access`: trace plugin iterator execution with access phase. - `plugin_header_filter`: trace plugin iterator execution with header_filter phase.  **Note:** In the current implementation, tracing instrumentations are not enabled in stream mode."
+  },
+  "opentelemetry_tracing_sampling_rate": {
+    "defaultValue": "1.0",
+    "description": "Deprecated: use `tracing_sampling_rate` instead."
+  },
+  "tracing_sampling_rate": {
+    "defaultValue": "0.01",
+    "description": "Tracing instrumentation sampling rate. Tracer samples a fixed percentage of all spans following the sampling rate.  Example: `0.25`, this accounts for 25% of all traces."
+  },
+  "plugins": {
+    "defaultValue": "bundled",
+    "description": "Comma-separated list of plugins this node should load. By default, only plugins bundled in official distributions are loaded via the `bundled` keyword.  Loading a plugin does not enable it by default, but only instructs Kong to load its source code and allows configuration via the various related Admin API endpoints.  The specified name(s) will be substituted as such in the Lua namespace: `kong.plugins.{name}.*`.  When the `off` keyword is specified as the only value, no plugins will be loaded.  `bundled` and plugin names can be mixed together, as the following examples suggest:  - `plugins = bundled,custom-auth,custom-log`   will include the bundled plugins plus two custom ones. - `plugins = custom-auth,custom-log` will   *only* include the `custom-auth` and `custom-log` plugins. - `plugins = off` will not include any plugins.  **Note:** Kong will not start if some plugins were previously configured (i.e. have rows in the database) and are not specified in this list. Before disabling a plugin, ensure all instances of it are removed before restarting Kong.  **Note:** Limiting the amount of available plugins can improve P99 latency when experiencing LRU churning in the database cache (i.e. when the configured `mem_cache_size`) is full."
+  },
+  "dedicated_config_processing": {
+    "defaultValue": "on",
+    "description": "Enables or disables a special worker process for configuration processing. This process increases memory usage a little bit while allowing to reduce latencies by moving some background tasks, such as CP/DP connection handling, to an additional worker process specific to handling these background tasks. Currently this has effect only on data planes."
+  },
+  "pluginserver_names": {
+    "defaultValue": null,
+    "description": "Comma-separated list of names for pluginserver processes. The actual names are used for log messages and to relate the actual settings."
+  },
+  "pluginserver_XXX_socket": {
+    "defaultValue": "<prefix>/<XXX>.socket",
+    "description": "Path to the unix socket used by the <XXX> pluginserver."
+  },
+  "pluginserver_XXX_start_cmd": {
+    "defaultValue": "/usr/local/bin/<XXX>",
+    "description": "Full command (including any needed arguments) to start the <XXX> pluginserver"
+  },
+  "pluginserver_XXX_query_cmd": {
+    "defaultValue": "/usr/local/bin/query_<XXX>",
+    "description": "Full command to \"query\" the <XXX> pluginserver.  Should produce a JSON with the dump info of all plugins it manages"
+  },
+  "port_maps": {
+    "defaultValue": null,
+    "description": "With this configuration parameter, you can let Kong Gateway know the port from which the packets are forwarded to it. This is fairly common when running Kong in a containerized or virtualized environment. For example, `port_maps=80:8000, 443:8443` instructs Kong that the port 80 is mapped to 8000 (and the port 443 to 8443), where 8000 and 8443 are the ports that Kong is listening to.  This parameter helps Kong set a proper forwarded upstream HTTP request header or to get the proper forwarded port with the Kong PDK (in case other means determining it has failed). It changes routing by a destination port to route by a port from which packets are forwarded to Kong, and similarly it changes the default plugin log serializer to use the port according to this mapping instead of reporting the port Kong is listening to."
+  },
+  "anonymous_reports": {
+    "defaultValue": "on",
+    "description": "Send anonymous usage data such as error stack traces to help improve Kong."
+  },
+  "proxy_server": {
+    "defaultValue": null,
+    "description": "Proxy server defined as an encoded URL. Kong will only use this option if a component is explicitly configured to use a proxy."
+  },
+  "proxy_server_ssl_verify": {
+    "defaultValue": "off",
+    "description": "Toggles server certificate verification if `proxy_server` is in HTTPS. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+  },
+  "error_template_html": {
+    "defaultValue": null,
+    "description": "Path to the custom html error template to override the default html kong error template.  The template may contain up to two `%s` placeholders. The first one will expand to the error message. The second one will expand to the request ID. Both placeholders are optional, but recommended. Adding more than two placeholders will result in a runtime error when trying to render the template: ``` <html>   <body>     <h1>My custom error template</h1>     <p>error: %s</p>     <p>request_id: %s</p>   </body> </html> ```"
+  },
+  "error_template_json": {
+    "defaultValue": null,
+    "description": "Path to the custom json error template to override the default json kong error template.  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+  },
+  "error_template_xml": {
+    "defaultValue": null,
+    "description": "Path to the custom xml error template to override the default xml kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+  },
+  "error_template_plain": {
+    "defaultValue": null,
+    "description": "Path to the custom plain error template to override the default plain kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+  },
+  "role": {
+    "defaultValue": "traditional",
+    "description": "Use this setting to enable hybrid mode, This allows running some Kong nodes in a control plane role with a database and have them deliver configuration updates to other nodes running to DB-less running in a data plane role.  Valid values for this setting are:  - `traditional`: do not use hybrid mode. - `control_plane`: this node runs in a   control plane role. It can use a database   and will deliver configuration updates   to data plane nodes. - `data_plane`: this is a data plane node.   It runs DB-less and receives configuration   updates from a control plane node."
+  },
+  "cluster_mtls": {
+    "defaultValue": "shared",
+    "description": "Sets the verification method between nodes of the cluster.  Valid values for this setting are:  - `shared`: use a shared certificate/key pair specified with   the `cluster_cert` and `cluster_cert_key` settings.   Note that CP and DP nodes must present the same certificate   to establish mTLS connections. - `pki`: use `cluster_ca_cert`, `cluster_server_name`, and   `cluster_cert` for verification. These are different   certificates for each DP node, but issued by a cluster-wide   common CA certificate: `cluster_ca_cert`. - `pki_check_cn`: similar to `pki` but additionally checks   for the common name of the data plane certificate specified   in `cluster_allowed_common_names`."
+  },
+  "cluster_cert": {
+    "defaultValue": null,
+    "description": "Cluster certificate to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes. Under `pki` mode, it should be a different certificate for each DP node.  The certificate can be configured on this property with any of the following values: - absolute path to the certificate - certificate content - base64 encoded certificate content"
+  },
+  "cluster_cert_key": {
+    "defaultValue": null,
+    "description": "Cluster certificate key to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes.  Under `pki` mode it should be a different certificate for each DP node.  The certificate key can be configured on this property with either of the following values: - absolute path to the certificate key - certificate key content - base64 encoded certificate key content"
+  },
+  "cluster_ca_cert": {
+    "defaultValue": null,
+    "description": "The trusted CA certificate file in PEM format used for: - Control plane to verify data plane's certificate - Data plane to verify control plane's certificate  Required on data plane if `cluster_mtls` is set to `pki`. If the control plane certificate is issued by a well-known CA, set `lua_ssl_trusted_certificate=system` on the data plane and leave this field empty.  This field is ignored if `cluster_mtls` is set to `shared`.  The certificate can be configured on this property with any of the following values: - absolute path to the certificate - certificate content - base64 encoded certificate content"
+  },
+  "cluster_allowed_common_names": {
+    "defaultValue": null,
+    "description": "The list of Common Names that are allowed to connect to control plane. Multiple entries may be supplied in a comma-separated string. When not set, only data plane with the same parent domain as the control plane cert is allowed to connect.  This field is ignored if `cluster_mtls` is not set to `pki_check_cn`."
+  },
+  "cluster_server_name": {
+    "defaultValue": null,
+    "description": "The server name used in the SNI of the TLS connection from a DP node to a CP node. Must match the Common Name (CN) or Subject Alternative Name (SAN) found in the CP certificate. If `cluster_mtls` is set to `shared`, this setting is ignored and `kong_clustering` is used."
+  },
+  "cluster_control_plane": {
+    "defaultValue": null,
+    "description": "To be used by data plane nodes only: address of the control plane node from which configuration updates will be fetched, in `host:port` format."
+  },
+  "cluster_telemetry_endpoint": {
+    "defaultValue": null,
+    "description": "To be used by data plane nodes only: telemetry address of the control plane node to which telemetry updates will be posted in `host:port` format."
+  },
+  "cluster_telemetry_server_name": {
+    "defaultValue": null,
+    "description": "The SNI (Server Name Indication extension) to use for Vitals telemetry data."
+  },
+  "cluster_dp_labels": {
+    "defaultValue": null,
+    "description": "Comma-separated list of labels for the data plane. Labels are key-value pairs that provide additional context information for each DP. Each label must be configured as a string in the format `key:value`.  Labels are only compatible with hybrid mode deployments with Kong Konnect (SaaS). This configuration doesn't work with self-hosted deployments.  Keys and values follow the AIP standards: https://kong-aip.netlify.app/aip/129/  Example: `deployment:mycloud,region:us-east-1`"
+  },
+  "cluster_listen": {
+    "defaultValue": "0.0.0.0:8005",
+    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster. This port is mTLS protected to ensure end-to-end security and integrity.  This setting has no effect if `role` is not set to `control_plane`.  Connections made to this endpoint are logged to the same location as Admin API access logs. See `admin_access_log` config description for more information."
+  },
+  "cluster_telemetry_listen": {
+    "defaultValue": "0.0.0.0:8006",
+    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane telemetry connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster.  This setting has no effect if `role` is not set to `control_plane`."
+  },
+  "cluster_data_plane_purge_delay": {
+    "defaultValue": "1209600",
+    "description": " How many seconds must pass from the time a DP node becomes offline to the time its entry gets removed from the database, as returned by the /clustering/data-planes Admin API endpoint.  This is to prevent the cluster data plane table from growing indefinitely. The default is set to 14 days. That is, if the CP hasn't heard from a DP for 14 days, its entry will be removed."
+  },
+  "cluster_ocsp": {
+    "defaultValue": "off",
+    "description": " Whether to check for revocation status of DP certificates using OCSP (Online Certificate Status Protocol). If enabled, the DP certificate should contain the \"Certificate Authority Information Access\" extension and the OCSP method with URI of which the OCSP responder can be reached from CP.  OCSP checks are only performed on CP nodes, it has no effect on DP nodes.  Valid values for this setting are:  - `on`: OCSP revocation check is enabled and DP   must pass the check in order to establish   connection with CP. - `off`: OCSP revocation check is disabled. - `optional`: OCSP revocation check will be attempted,   however, if the required extension is not   found inside DP-provided certificate   or communication with the OCSP responder   failed, then DP is still allowed through."
+  },
+  "cluster_use_proxy": {
+    "defaultValue": "off",
+    "description": " Whether to turn on HTTP CONNECT proxy support for hybrid mode connections. `proxy_server` will be used for hybrid mode connections if this option is turned on."
+  },
+  "cluster_max_payload": {
+    "defaultValue": "16777216",
+    "description": " This sets the maximum compressed payload size allowed to be sent from CP to DP in hybrid mode. Default is 16MB - 16 * 1024 * 1024."
+  },
+  "proxy_listen": {
+    "defaultValue": [
+      "0.0.0.0:8000 reuseport backlog=16384",
+      "0.0.0.0:8443 http2 ssl reuseport backlog=16384"
+    ],
+    "description": " Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. The proxy server is the public entry point of Kong, which proxies traffic from your consumers to your backend services. This value accepts IPv4, IPv6, and hostnames.  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the `TCP_DEFER_ACCEPT` socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process,   allowing the kernel to better distribute incoming   connections between worker processes. - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small to prevent clients   seeing \"Connection refused\" errors when connecting to   a busy Kong instance.   **Note:** On Linux, this value is limited by the   setting of the `net.core.somaxconn` kernel parameter.   In order for the larger `backlog` set here to take   effect, it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` specifies whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections. - `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]`   configures the TCP keepalive behavior for the listening   socket. If this parameter is omitted, the operating   system’s settings will be in effect for the socket. If it   is set to the value `on`, the `SO_KEEPALIVE` option is turned   on for the socket. If it is set to the value `off`, the   `SO_KEEPALIVE` option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the `TCP_KEEPIDLE`,` TCP_KEEPINTVL`,   and `TCP_KEEPCNT` socket options.  This value can be set to `off`, thus disabling the HTTP/HTTPS proxy port for this node. If `stream_listen` is also set to `off`, this enables control plane mode for this node (in which all traffic proxying capabilities are disabled). This node can then be used only to configure a cluster of Kong nodes connected to the same datastore.  Example: `proxy_listen = 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`  See http://nginx.org/en/docs/http/ngx_http_core_module.html#listen for a description of the accepted formats for this and other `*_listen` values.  See https://www.nginx.com/resources/admin-guide/proxy-protocol/ for more details about the `proxy_protocol` parameter.  Not all `*_listen` values accept all formats specified in nginx's documentation."
+  },
+  "proxy_url": {
+    "defaultValue": null,
+    "description": "Kong Proxy URL  The lookup, or balancer, address for your Kong Proxy nodes.  This value is commonly used in a microservices or service-mesh oriented architecture.  Accepted format (parts in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`  Examples:  - `<scheme>://<IP>:<PORT>` -> `proxy_url = http://127.0.0.1:8000` - `SSL <scheme>://<HOSTNAME>` -> `proxy_url = https://proxy.domain.tld` - `<scheme>://<HOSTNAME>/<PATH>` -> `proxy_url = http://dev-machine/dev-285`  By default, Kong Manager and Kong Portal will use the window request host and append the resolved listener port depending on the requested protocol."
+  },
+  "stream_listen": {
+    "defaultValue": "off",
+    "description": " Comma-separated list of addresses and ports on which the stream mode should listen.  This value accepts IPv4, IPv6, and hostnames. Some suffixes can be specified for each pair: - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process,   allowing the kernel to better distribute incoming   connections between worker processes. - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small to prevent clients   seeing \"Connection refused\" errors when connecting to   a busy Kong instance.   **Note:** On Linux, this value is limited by the   setting of the `net.core.somaxconn` kernel parameter.   In order for the larger `backlog` set here to take   effect, it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` specifies whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the \"TCP keepalive\" behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value \"on\", the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value \"off\", the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the` TCP_KEEPIDLE`, `TCP_KEEPINTVL`,   and `TCP_KEEPCNT` socket options.  Examples:  ``` stream_listen = 127.0.0.1:7000 reuseport backlog=16384 stream_listen = 0.0.0.0:989 reuseport backlog=65536, 0.0.0.0:20 stream_listen = [::1]:1234 backlog=16384 ```  By default, this value is set to `off`, thus disabling the stream proxy port for this node."
+  },
+  "admin_api_uri": {
+    "defaultValue": null,
+    "description": "Deprecated: Use admin_gui_api_url instead"
+  },
+  "admin_listen": {
+    "defaultValue": [
+      "127.0.0.1:8001 reuseport backlog=16384",
+      "127.0.0.1:8444 http2 ssl reuseport backlog=16384"
+    ],
+    "description": " Comma-separated list of addresses and ports on which the Admin interface should listen. The Admin interface is the API allowing you to configure and manage Kong. Access to this interface should be *restricted* to Kong administrators *only*. This value accepts IPv4, IPv6, and hostnames.  It is highly recommended to avoid exposing the Admin API to public interfaces, by using values such as `0.0.0.0:8001`  See https://docs.konghq.com/gateway/latest/production/running-kong/secure-admin-api/ for more information about how to secure your Admin API.  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the `TCP_DEFER_ACCEPT` socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process,   allowing the Kernel to better distribute incoming   connections between worker processes. - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small to prevent clients   seeing \"Connection refused\" errors when connecting to   a busy Kong instance.   **Note:** On Linux, this value is limited by the   setting of the `net.core.somaxconn` kernel parameter.   In order for the larger `backlog` set here to take   effect, it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` specifies whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections. - `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]`   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted, the operating   system’s settings will be in effect for the socket. If it   is set to the value `on`, the `SO_KEEPALIVE` option is turned   on for the socket. If it is set to the value `off`, the   `SO_KEEPALIVE` option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the `TCP_KEEPIDLE`, `TCP_KEEPINTVL`,   and `TCP_KEEPCNT` socket options.  This value can be set to `off`, thus disabling the Admin interface for this node, enabling a data plane mode (without configuration capabilities) pulling its configuration changes from the database.  Example: `admin_listen = 127.0.0.1:8444 http2 ssl`"
+  },
+  "status_listen": {
+    "defaultValue": "127.0.0.1:8007 reuseport backlog=16384",
+    "description": " Comma-separated list of addresses and ports on which the Status API should listen. The Status API is a read-only endpoint allowing monitoring tools to retrieve metrics, healthiness, and other non-sensitive information of the current Kong node.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Status API server. - `proxy_protocol` will enable usage of the PROXY protocol.  This value can be set to `off`, disabling the Status API for this node.  Example: `status_listen = 0.0.0.0:8100 ssl http2`"
+  },
+  "debug_listen": {
+    "defaultValue": "off",
+    "description": "Comma-separated list of addresses and ports on which the Debug API should listen.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Debug API server.  This value can be set to `off`, disabling the Debug API for this node.  Example: `debug_listen = 0.0.0.0:8200 ssl http2`"
+  },
+  "debug_listen_local": {
+    "defaultValue": "on",
+    "description": "Expose `debug_listen` functionalities via a Unix domain socket under the Kong prefix.  This option allows local users to use `kong debug` command to invoke various debug functionalities without needing to enable `debug_listen` ahead of time."
+  },
+  "nginx_user": {
+    "defaultValue": "kong kong",
+    "description": "Defines user and group credentials used by worker processes. If group is omitted, a group whose name equals that of user is used.  Example: `nginx_user = nginx www`  **Note**: If the `kong` user and the `kong` group are not available, the default user and group credentials will be `nobody nobody`."
+  },
+  "nginx_worker_processes": {
+    "defaultValue": "auto",
+    "description": "Determines the number of worker processes spawned by Nginx.  See http://nginx.org/en/docs/ngx_core_module.html#worker_processes for detailed usage of the equivalent Nginx directive and a description of accepted values."
+  },
+  "nginx_daemon": {
+    "defaultValue": "on",
+    "description": "Determines whether Nginx will run as a daemon or as a foreground process. Mainly useful for development or when running Kong inside a Docker environment.  See http://nginx.org/en/docs/ngx_core_module.html#daemon."
+  },
+  "mem_cache_size": {
+    "defaultValue": "128m",
+    "description": "Size of each of the two shared memory caches for traditional mode database entities and runtime data, `kong_core_cache` and `kong_cache`.  The accepted units are `k` and `m`, with a minimum recommended value of a few MBs.  **Note**: As this option controls the size of two different cache zones, the total memory Kong uses to cache entities might be double this value. The created zones are shared by all worker processes and do not become larger when more workers are used."
+  },
+  "ssl_cipher_suite": {
+    "defaultValue": "intermediate",
+    "description": "Defines the TLS ciphers served by Nginx. Accepted values are `modern`, `intermediate`, `old`, `fips` or `custom`. If you want to enable TLSv1.1, this value has to be `old`.  See https://wiki.mozilla.org/Security/Server_Side_TLS for detailed descriptions of each cipher suite. `fips` cipher suites are as described in https://wiki.openssl.org/index.php/FIPS_mode_and_TLS."
+  },
+  "ssl_ciphers": {
+    "defaultValue": null,
+    "description": "Defines a custom list of TLS ciphers to be served by Nginx. This list must conform to the pattern defined by `openssl ciphers`. This value is ignored if `ssl_cipher_suite` is not `custom`. If you use DHE ciphers, you must also configure the `ssl_dhparam` parameter."
+  },
+  "ssl_protocols": {
+    "defaultValue": "TLSv1.2 TLSv1.3",
+    "description": " Enables the specified protocols for client-side connections. The set of supported protocol versions also depends on the version of OpenSSL Kong was built with. This value is ignored if `ssl_cipher_suite` is not `custom`. If you want to enable TLSv1.1, you should set `ssl_cipher_suite` to `old`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols"
+  },
+  "ssl_prefer_server_ciphers": {
+    "defaultValue": "on",
+    "description": "Specifies that server ciphers should be preferred over client ciphers when using the SSLv3 and TLS protocols. This value is ignored if `ssl_cipher_suite` is not `custom`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers"
+  },
+  "ssl_dhparam": {
+    "defaultValue": null,
+    "description": "Defines DH parameters for DHE ciphers from the predefined groups: `ffdhe2048`, `ffdhe3072`, `ffdhe4096`, `ffdhe6144`, `ffdhe8192`, from the absolute path to a parameters file, or directly from the parameters content.  This value is ignored if `ssl_cipher_suite` is `modern` or `intermediate`. The reason is that `modern` has no ciphers that need this, and `intermediate` uses `ffdhe2048`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam"
+  },
+  "ssl_session_tickets": {
+    "defaultValue": "on",
+    "description": "Enables or disables session resumption through TLS session tickets. This has no impact when used with TLSv1.3.  Kong enables this by default for performance reasons, but it has security implications: https://github.com/mozilla/server-side-tls/issues/135  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets"
+  },
+  "ssl_session_timeout": {
+    "defaultValue": "1d",
+    "description": "Specifies a time during which a client may reuse the session parameters. See the rationale: https://github.com/mozilla/server-side-tls/issues/198  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout"
+  },
+  "ssl_session_cache_size": {
+    "defaultValue": "10m",
+    "description": "Sets the size of the caches that store session parameters.  See https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache"
+  },
+  "ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `proxy_listen` values with TLS enabled.  If more than one certificate is specified, it can be used to provide alternate types of certificates (for example, ECC certificates) that will be served to clients that support them. Note that to properly serve using ECC certificates, it is recommended to also set `ssl_cipher_suite` to `modern` or `intermediate`.  Unless this option is explicitly set, Kong will auto-generate a pair of default certificates (RSA + ECC) the first time it starts up and use them for serving TLS requests.  Certificates can be configured on this property with any of the following values: - absolute path to the certificate - certificate content - base64 encoded certificate content"
+  },
+  "ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `proxy_listen` values with TLS enabled.  If more than one certificate was specified for `ssl_cert`, then this option should contain the corresponding key for all certificates provided in the same order.  Unless this option is explicitly set, Kong will auto-generate a pair of default private keys (RSA + ECC) the first time it starts up and use them for serving TLS requests.  Keys can be configured on this property with any of the following values: - absolute path to the certificate key - certificate key content - base64 encoded certificate key content"
+  },
+  "client_ssl": {
+    "defaultValue": "off",
+    "description": "Determines if Nginx should attempt to send client-side TLS certificates and perform Mutual TLS Authentication with upstream service when proxying requests."
+  },
+  "client_ssl_cert": {
+    "defaultValue": null,
+    "description": "If `client_ssl` is enabled, the client certificate for the `proxy_ssl_certificate` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate can be configured on this property with any of the following values: - absolute path to the certificate - certificate content - base64 encoded certificate content"
+  },
+  "client_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "If `client_ssl` is enabled, the client TLS key for the `proxy_ssl_certificate_key` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate key can be configured on this property with any of the following values: - absolute path to the certificate key - certificate key content - base64 encoded certificate key content"
+  },
+  "admin_ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `admin_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+  },
+  "admin_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `admin_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+  },
+  "status_ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `status_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+  },
+  "status_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `status_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+  },
+  "debug_ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `debug_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+  },
+  "debug_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `debug_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+  },
+  "headers": {
+    "defaultValue": [
+      "server_tokens",
+      "latency_tokens",
+      "X-Kong-Request-Id"
+    ],
+    "description": " Comma-separated list of headers Kong should inject in client responses.  Accepted values are: - `Server`: Injects `Server: kong/x.y.z`   on Kong-produced responses (e.g., Admin   API, rejected requests from auth plugin). - `Via`: Injects `Via: kong/x.y.z` for   successfully proxied requests. - `X-Kong-Proxy-Latency`: Time taken   (in milliseconds) by Kong to process   a request and run all plugins before   proxying the request upstream. - `X-Kong-Response-Latency`: Time taken   (in milliseconds) by Kong to produce   a response in case of, e.g., a plugin   short-circuiting the request, or in   case of an error. - `X-Kong-Upstream-Latency`: Time taken   (in milliseconds) by the upstream   service to send response headers. - `X-Kong-Admin-Latency`: Time taken   (in milliseconds) by Kong to process   an Admin API request. - `X-Kong-Upstream-Status`: The HTTP status   code returned by the upstream service.   This is particularly useful for clients to   distinguish upstream statuses if the   response is rewritten by a plugin. - `X-Kong-Request-Id`: Unique identifier of   the request. - `server_tokens`: Same as specifying both   `Server` and `Via`. - `latency_tokens`: Same as specifying   `X-Kong-Proxy-Latency`,   `X-Kong-Response-Latency`,   `X-Kong-Admin-Latency`, and   `X-Kong-Upstream-Latency`.  In addition to these, this value can be set to `off`, which prevents Kong from injecting any of the above headers. Note that this does not prevent plugins from injecting headers of their own.  Example: `headers = via, latency_tokens`"
+  },
+  "headers_upstream": {
+    "defaultValue": "X-Kong-Request-Id",
+    "description": " Comma-separated list of headers Kong should inject in requests to upstream.  At this time, the only accepted value is: - `X-Kong-Request-Id`: Unique identifier of   the request.  In addition, this value can be set to `off`, which prevents Kong from injecting the above header. Note that this does not prevent plugins from injecting headers of their own."
+  },
+  "trusted_ips": {
+    "defaultValue": null,
+    "description": "Defines trusted IP address blocks that are known to send correct `X-Forwarded-*` headers. Requests from trusted IPs make Kong forward their `X-Forwarded-*` headers upstream. Non-trusted requests make Kong insert its own `X-Forwarded-*` headers.  This property also sets the `set_real_ip_from` directive(s) in the Nginx configuration. It accepts the same type of values (CIDR blocks) but as a comma-separated list.  To trust *all* IPs, set this value to `0.0.0.0/0,::/0`.  If the special value `unix:` is specified, all UNIX-domain sockets will be trusted.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from for examples of accepted values."
+  },
+  "real_ip_header": {
+    "defaultValue": "X-Real-IP",
+    "description": "Defines the request header field whose value will be used to replace the client address. This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  If this value receives `proxy_protocol`:  - at least one of the `proxy_listen` entries   must have the `proxy_protocol` flag   enabled. - the `proxy_protocol` parameter will be   appended to the `listen` directive of the   Nginx template.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header for a description of this directive."
+  },
+  "real_ip_recursive": {
+    "defaultValue": "off",
+    "description": "This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive for a description of this directive."
+  },
+  "error_default_type": {
+    "defaultValue": "text/plain",
+    "description": "Default MIME type to use when the request `Accept` header is missing and Nginx is returning an error for the request. Accepted values are `text/plain`, `text/html`, `application/json`, and `application/xml`."
+  },
+  "upstream_keepalive_pool_size": {
+    "defaultValue": "512",
+    "description": "Sets the default size of the upstream keepalive connection pools. Upstream keepalive connection pools are segmented by the `dst ip/dst port/SNI` attributes of a connection. A value of `0` will disable upstream keepalive connections by default, forcing each upstream request to open a new connection."
+  },
+  "upstream_keepalive_max_requests": {
+    "defaultValue": "10000",
+    "description": "Sets the default maximum number of requests that can be proxied upstream through one keepalive connection. After the maximum number of requests is reached, the connection will be closed. A value of `0` will disable this behavior, and a keepalive connection can be used to proxy an indefinite number of requests."
+  },
+  "upstream_keepalive_idle_timeout": {
+    "defaultValue": "60",
+    "description": "Sets the default timeout (in seconds) for which an upstream keepalive connection should be kept open. When the timeout is reached while the connection has not been reused, it will be closed. A value of `0` will disable this behavior, and an idle keepalive connection may be kept open indefinitely."
+  },
+  "allow_debug_header": {
+    "defaultValue": "off",
+    "description": "Enable the `Kong-Debug` header function. If it is `on`, Kong will add `Kong-Route-Id`, `Kong-Route-Name`, `Kong-Service-Id`, and `Kong-Service-Name` debug headers to the response when the client request header `Kong-Debug: 1` is present."
+  },
+  "nginx_main_worker_rlimit_nofile": {
+    "defaultValue": "auto",
+    "description": " Changes the limit on the maximum number of open files for worker processes.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile"
+  },
+  "nginx_events_worker_connections": {
+    "defaultValue": "auto",
+    "description": " Sets the maximum number of simultaneous connections that can be opened by a worker process.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_connections"
+  },
+  "nginx_http_client_header_buffer_size": {
+    "defaultValue": "1k",
+    "description": "Sets buffer size for reading the client request headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size"
+  },
+  "nginx_http_large_client_header_buffers": {
+    "defaultValue": "4 8k",
+    "description": "Sets the maximum number and size of buffers used for reading large client request headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers"
+  },
+  "nginx_http_client_max_body_size": {
+    "defaultValue": "0",
+    "description": "Defines the maximum request body size allowed by requests proxied by Kong, specified in the Content-Length request header. If a request exceeds this limit, Kong will respond with a 413 (Request Entity Too Large). Setting this value to 0 disables checking the request body size. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size"
+  },
+  "nginx_admin_client_max_body_size": {
+    "defaultValue": "10m",
+    "description": "Defines the maximum request body size for Admin API."
+  },
+  "nginx_http_charset": {
+    "defaultValue": "UTF-8",
+    "description": "Adds the specified charset to the \"Content-Type\" response header field. If this charset is different from the charset specified in the `source_charset` directive, a conversion is performed.  The parameter `off` cancels the addition of charset to the \"Content-Type\" response header field. See http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset"
+  },
+  "nginx_http_client_body_buffer_size": {
+    "defaultValue": "8k",
+    "description": "Defines the buffer size for reading the request body. If the client request body is larger than this value, the body will be buffered to disk. Note that when the body is buffered to disk, Kong plugins that access or manipulate the request body may not work, so it is advisable to set this value as high as possible (e.g., set it as high as `client_max_body_size` to force request bodies to be kept in memory). Do note that high-concurrency environments will require significant memory allocations to process many concurrent large request bodies. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size"
+  },
+  "nginx_admin_client_body_buffer_size": {
+    "defaultValue": "10m",
+    "description": "Defines the buffer size for reading the request body on Admin API."
+  },
+  "nginx_http_lua_regex_match_limit": {
+    "defaultValue": "100000",
+    "description": "Global `MATCH_LIMIT` for PCRE regex matching. The default of `100000` should ensure at worst any regex Kong executes could finish within roughly 2 seconds."
+  },
+  "nginx_http_lua_regex_cache_max_entries": {
+    "defaultValue": "8192",
+    "description": "Specifies the maximum number of entries allowed in the worker process level PCRE JIT compiled regex cache. It is recommended to set it to at least (number of regex paths * 2) to avoid high CPU usages if you manually specified `router_flavor` to `traditional`. `expressions` and `traditional_compat` router do not make use of the PCRE library and their behavior is unaffected by this setting."
+  },
+  "nginx_http_keepalive_requests": {
+    "defaultValue": "10000",
+    "description": "Sets the maximum number of client requests that can be served through one keep-alive connection. After the maximum number of requests are made, the connection is closed. Closing connections periodically is necessary to free per-connection memory allocations. Therefore, using too high a maximum number of requests could result in excessive memory usage and is not recommended. See: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests"
+  },
+  "database": {
+    "defaultValue": "postgres",
+    "description": "Determines the database (or no database) for this node Accepted values are `postgres` and `off`."
+  },
+  "pg_host": {
+    "defaultValue": "127.0.0.1",
+    "description": "Host of the Postgres server."
+  },
+  "pg_port": {
+    "defaultValue": "5432",
+    "description": "Port of the Postgres server."
+  },
+  "pg_timeout": {
+    "defaultValue": "5000",
+    "description": "Defines the timeout (in ms), for connecting, reading and writing."
+  },
+  "pg_user": {
+    "defaultValue": "kong",
+    "description": "Postgres user."
+  },
+  "pg_password": {
+    "defaultValue": null,
+    "description": "Postgres user's password."
+  },
+  "pg_iam_auth": {
+    "defaultValue": "off",
+    "description": "Determines whether the AWS IAM database Authentication will be used. When switch to `on`, the username defined in `pg_user` will be used as the database account, and the database connection will be forced to using TLS. `pg_password` will not be used when the switch is `on`. Note that the corresponding IAM policy must be correct, otherwise connecting will fail."
+  },
+  "pg_iam_auth_assume_role_arn": {
+    "defaultValue": null,
+    "description": "The target AWS IAM role ARN that will be assumed when using AWS IAM database authentication. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+  },
+  "pg_iam_auth_role_session_name": {
+    "defaultValue": "KongPostgres",
+    "description": "The role session name used for role assuming in AWS IAM Database Authentication. The default value is `KongPostgres`."
+  },
+  "pg_iam_auth_sts_endpoint_url": {
+    "defaultValue": null,
+    "description": "The custom STS endpoint URL used for role assuming in AWS IAM Database Authentication.  Note that this value will override the default STS endpoint URL(which should be `https://sts.amazonaws.com`, or `https://sts.<region>.amazonaws.com` if you have `AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).  If you are not using private VPC endpoint for STS service, you should not specify this value."
+  },
+  "pg_database": {
+    "defaultValue": "kong",
+    "description": "The database name to connect to."
+  },
+  "pg_schema": {
+    "defaultValue": null,
+    "description": "The database schema to use. If unspecified, Kong will respect the `search_path` value of your PostgreSQL instance."
+  },
+  "pg_ssl": {
+    "defaultValue": "off",
+    "description": "Toggles client-server TLS connections between Kong and PostgreSQL. Because PostgreSQL uses the same port for TLS and non-TLS, this is only a hint. If the server does not support TLS, the established connection will be a plain one."
+  },
+  "pg_ssl_version": {
+    "defaultValue": "tlsv1_2",
+    "description": "When using ssl between Kong and PostgreSQL, the version of tls to use. Accepted values are `tlsv1_1`, `tlsv1_2`, `tlsv1_3`, or 'any'. When `any` is set, the client negotiates the highest version with the server which can't be lower than `tlsv1_1`."
+  },
+  "pg_ssl_required": {
+    "defaultValue": "off",
+    "description": "When `pg_ssl` is on this determines if TLS must be used between Kong and PostgreSQL. It aborts the connection if the server does not support SSL connections."
+  },
+  "pg_ssl_verify": {
+    "defaultValue": "off",
+    "description": "Toggles server certificate verification if `pg_ssl` is enabled. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+  },
+  "pg_ssl_cert": {
+    "defaultValue": null,
+    "description": "The absolute path to the PEM encoded client TLS certificate for the PostgreSQL connection. Mutual TLS authentication against PostgreSQL is only enabled if this value is set."
+  },
+  "pg_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "If `pg_ssl_cert` is set, the absolute path to the PEM encoded client TLS private key for the PostgreSQL connection."
+  },
+  "pg_max_concurrent_queries": {
+    "defaultValue": "0",
+    "description": "Sets the maximum number of concurrent queries that can be executing at any given time. This limit is enforced per worker process; the total number of concurrent queries for this node will be will be: `pg_max_concurrent_queries * nginx_worker_processes`.  The default value of 0 removes this concurrency limitation."
+  },
+  "pg_semaphore_timeout": {
+    "defaultValue": "60000",
+    "description": "Defines the timeout (in ms) after which PostgreSQL query semaphore resource acquisition attempts will fail. Such failures will generally result in the associated proxy or Admin API request failing with an HTTP 500 status code. Detailed discussion of this behavior is available in the online documentation."
+  },
+  "pg_keepalive_timeout": {
+    "defaultValue": null,
+    "description": "Specify the maximal idle timeout (in ms) for the postgres connections in the pool. If this value is set to 0 then the timeout interval is unlimited.  If not specified this value will be same as `lua_socket_keepalive_timeout`"
+  },
+  "pg_pool_size": {
+    "defaultValue": null,
+    "description": "Specifies the size limit (in terms of connection count) for the Postgres server. Note that this connection pool is intended per Nginx worker rather than per Kong instance.  If not specified, the default value is the same as `lua_socket_pool_size`"
+  },
+  "pg_backlog": {
+    "defaultValue": null,
+    "description": "If specified, this value will limit the total number of open connections to the Postgres server to `pg_pool_size`. If the connection pool is full, subsequent connect operations will be inserted in a queue with size equal to this option's value.  If the number of queued connect operations reaches `pg_backlog`, exceeding connections will fail.  If not specified, then number of open connections to the Postgres server is not limited."
+  },
+  "pg_ro_host": {
+    "defaultValue": null,
+    "description": "Same as `pg_host`, but for the read-only connection. **Note:** Refer to the documentation section above for detailed usage."
+  },
+  "pg_ro_port": {
+    "defaultValue": "<pg_port>",
+    "description": "Same as `pg_port`, but for the read-only connection."
+  },
+  "pg_ro_timeout": {
+    "defaultValue": "<pg_timeout>",
+    "description": "Same as `pg_timeout`, but for the read-only connection."
+  },
+  "pg_ro_user": {
+    "defaultValue": "<pg_user>",
+    "description": "Same as `pg_user`, but for the read-only connection."
+  },
+  "pg_ro_password": {
+    "defaultValue": "<pg_password>",
+    "description": "Same as `pg_password`, but for the read-only connection."
+  },
+  "pg_ro_iam_auth": {
+    "defaultValue": "<pg_iam_auth>",
+    "description": "Same as `pg_iam_auth`, but for the read-only connection."
+  },
+  "pg_ro_iam_auth_assume_role_arn": {
+    "defaultValue": null,
+    "description": "Same as `pg_iam_auth_assume_role_arn', but for the read-only connection."
+  },
+  "pg_ro_iam_auth_role_session_name": {
+    "defaultValue": "KongPostgres",
+    "description": "Same as `pg_iam_auth_role_session_name`, but for the read-only connection."
+  },
+  "pg_ro_iam_auth_sts_endpoint_url": {
+    "defaultValue": null,
+    "description": "Same as `pg_iam_auth_sts_endpoint_url`, but for the read-only connection."
+  },
+  "pg_ro_database": {
+    "defaultValue": "<pg_database>",
+    "description": "Same as `pg_database`, but for the read-only connection."
+  },
+  "pg_ro_schema": {
+    "defaultValue": "<pg_schema>",
+    "description": "Same as `pg_schema`, but for the read-only connection."
+  },
+  "pg_ro_ssl": {
+    "defaultValue": "<pg_ssl>",
+    "description": "Same as `pg_ssl`, but for the read-only connection."
+  },
+  "pg_ro_ssl_required": {
+    "defaultValue": "<pg_ssl_required>",
+    "description": " Same as `pg_ssl_required`, but for the read-only connection."
+  },
+  "pg_ro_ssl_verify": {
+    "defaultValue": "<pg_ssl_verify>",
+    "description": " Same as `pg_ssl_verify`, but for the read-only connection."
+  },
+  "pg_ro_ssl_version": {
+    "defaultValue": "<pg_ssl_version>",
+    "description": " Same as `pg_ssl_version`, but for the read-only connection."
+  },
+  "pg_ro_max_concurrent_queries": {
+    "defaultValue": "<pg_max_concurrent_queries>",
+    "description": " Same as `pg_max_concurrent_queries`, but for the read-only connection. Note: read-only concurrency is not shared with the main (read-write) connection."
+  },
+  "pg_ro_semaphore_timeout": {
+    "defaultValue": "<pg_semaphore_timeout>",
+    "description": " Same as `pg_semaphore_timeout`, but for the read-only connection."
+  },
+  "pg_ro_keepalive_timeout": {
+    "defaultValue": "<pg_keepalive_timeout>",
+    "description": " Same as `pg_keepalive_timeout`, but for the read-only connection."
+  },
+  "pg_ro_pool_size": {
+    "defaultValue": "<pg_pool_size>",
+    "description": " Same as `pg_pool_size`, but for the read-only connection."
+  },
+  "pg_ro_backlog": {
+    "defaultValue": "<pg_backlog>",
+    "description": " Same as `pg_backlog`, but for the read-only connection."
+  },
+  "declarative_config": {
+    "defaultValue": null,
+    "description": "The path to the declarative configuration file which holds the specification of all entities (routes, services, consumers, etc.) to be used when the `database` is set to `off`.  Entities are stored in Kong's LMDB cache, so you must ensure that enough headroom is allocated to it via the `lmdb_map_size` property.  If the hybrid mode `role` is set to `data_plane` and there's no configuration cache file, this configuration is used before connecting to the control plane node as a user-controlled fallback."
+  },
+  "declarative_config_string": {
+    "defaultValue": null,
+    "description": "The declarative configuration as a string"
+  },
+  "lmdb_environment_path": {
+    "defaultValue": "dbless.lmdb",
+    "description": "Directory where the LMDB database files used by DB-less and hybrid mode to store Kong configurations reside.  This path is relative under the Kong `prefix`."
+  },
+  "lmdb_map_size": {
+    "defaultValue": "2048m",
+    "description": "Maximum size of the LMDB memory map, used to store the DB-less and hybrid mode configurations. Default is 2048m.  This config defines the limit of LMDB file size; the actual file size growth will be on-demand and proportional to the actual config size.  Note this value can be set very large, say a couple of GBs, to accommodate future database growth and Multi-Version Concurrency Control (MVCC) headroom needs. The file size of the LMDB database file should stabilize after a few config reloads/hybrid mode syncs, and the actual memory used by the LMDB database will be smaller than the file size due to dynamic swapping of database pages by the OS."
+  },
+  "db_update_frequency": {
+    "defaultValue": "5",
+    "description": "Frequency (in seconds) at which to check for updated entities with the datastore.  When a node creates, updates, or deletes an entity via the Admin API, other nodes need to wait for the next poll (configured by this value) to eventually purge the old cached entity and start using the new one."
+  },
+  "db_update_propagation": {
+    "defaultValue": "0",
+    "description": "Time (in seconds) taken for an entity in the datastore to be propagated to replica nodes of another datacenter.  When set, this property will increase the time taken by Kong to propagate the change of an entity.  Single-datacenter setups or PostgreSQL servers should suffer no such delays, and this value can be safely set to 0. Postgres setups with read replicas should set this value to the maximum expected replication lag between the writer and reader instances."
+  },
+  "db_cache_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of an entity from the datastore when cached by this node.  Database misses (no entity) are also cached according to this setting if you do not configure `db_cache_neg_ttl`.  If set to 0 (default), such cached entities or misses never expire."
+  },
+  "db_cache_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a datastore miss (no entity).  If not specified (default), `db_cache_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "db_resurrect_ttl": {
+    "defaultValue": "30",
+    "description": "Time (in seconds) for which stale entities from the datastore should be resurrected when they cannot be refreshed (e.g., the datastore is unreachable). When this TTL expires, a new attempt to refresh the stale entities will be made."
+  },
+  "db_cache_warmup_entities": {
+    "defaultValue": "services",
+    "description": " Entities to be pre-loaded from the datastore into the in-memory cache at Kong start-up. This speeds up the first access of endpoints that use the given entities.  When the `services` entity is configured for warmup, the DNS entries for values in its `host` attribute are pre-resolved asynchronously as well.  Cache size set in `mem_cache_size` should be set to a value large enough to hold all instances of the specified entities. If the size is insufficient, Kong will log a warning."
+  },
+  "dns_resolver": {
+    "defaultValue": null,
+    "description": "Comma-separated list of nameservers, each entry in `ip[:port]` format to be used by Kong. If not specified, the nameservers in the local `resolv.conf` file will be used. Port defaults to 53 if omitted. Accepts both IPv4 and IPv6 addresses."
+  },
+  "dns_hostsfile": {
+    "defaultValue": "/etc/hosts",
+    "description": "The hosts file to use. This file is read once and its content is static in memory. To read the file again after modifying it, Kong must be reloaded."
+  },
+  "dns_order": {
+    "defaultValue": [
+      "LAST",
+      "SRV",
+      "A",
+      "CNAME"
+    ],
+    "description": "The order in which to resolve different record types. The `LAST` type means the type of the last successful lookup (for the specified name). The format is a (case insensitive) comma-separated list."
+  },
+  "dns_valid_ttl": {
+    "defaultValue": null,
+    "description": "By default, DNS records are cached using the TTL value of a response. If this property receives a value (in seconds), it will override the TTL for all records."
+  },
+  "dns_stale_ttl": {
+    "defaultValue": "3600",
+    "description": "Defines, in seconds, how long a record will remain in cache past its TTL. This value will be used while the new DNS record is fetched in the background. Stale data will be used from expiry of a record until either the refresh query completes, or the `dns_stale_ttl` number of seconds have passed. This configuration enables Kong to be more resilient during resolver downtime."
+  },
+  "dns_cache_size": {
+    "defaultValue": "10000",
+    "description": "Defines the maximum allowed number of DNS records stored in memory cache. Least recently used DNS records are discarded from cache if it is full. Both errors and data are cached; therefore, a single name query can easily take up 10-15 slots."
+  },
+  "dns_not_found_ttl": {
+    "defaultValue": "30",
+    "description": "TTL in seconds for empty DNS responses and \"(3) name error\" responses."
+  },
+  "dns_error_ttl": {
+    "defaultValue": "1",
+    "description": "TTL in seconds for error responses."
+  },
+  "dns_no_sync": {
+    "defaultValue": "off",
+    "description": "If enabled, then upon a cache-miss every request will trigger its own DNS query. When disabled, multiple requests for the same name/type will be synchronized to a single query."
+  },
+  "new_dns_client": {
+    "defaultValue": "off",
+    "description": "Enable or disable the new DNS resolver"
+  },
+  "resolver_address": {
+    "defaultValue": "<name servers parsed from resolv.conf>",
+    "description": " Comma-separated list of nameservers, each entry in `ip[:port]` format to be used by Kong. If not specified, the nameservers in the local `resolv.conf` file will be used. Port defaults to 53 if omitted. Accepts both IPv4 and IPv6 addresses.  Examples:  ``` resolver_address = 8.8.8.8 resolver_address = 8.8.8.8, [::1] resolver_address = 8.8.8.8:53, [::1]:53 ```"
+  },
+  "resolver_hosts_file": {
+    "defaultValue": "/etc/hosts",
+    "description": " The hosts file to use. This file is read once and its content is static in memory. To read the file again after modifying it, Kong must be reloaded."
+  },
+  "resolver_family": {
+    "defaultValue": [
+      "A",
+      "SRV"
+    ],
+    "description": "The supported query types.  For a domain name, Kong will only query either IP addresses (A or AAAA) or SRV records, but not both.  It will query SRV records only when the domain matches the \"_<proto>._<service>.<name>\" format, for example, \"_ldap._tcp.example.com\".  For IP addresses (A or AAAA) resolution, it first attempts IPv4 (A) and then queries IPv6 (AAAA)."
+  },
+  "resolver_valid_ttl": {
+    "defaultValue": "<TTL from responses>",
+    "description": " By default, DNS records are cached using the TTL value of a response. This optional parameter (in seconds) allows overriding it."
+  },
+  "resolver_error_ttl": {
+    "defaultValue": "1",
+    "description": "TTL in seconds for error responses and empty responses."
+  },
+  "resolver_stale_ttl": {
+    "defaultValue": "3600",
+    "description": "Defines, in seconds, how long a record will remain in cache past its TTL. This value will be used while the new DNS record is fetched in the background.  Stale data will be used from expiry of a record until either the refresh query completes, or the `resolver_stale_ttl` number of seconds have passed.  This configuration enables Kong to be more resilient during the DNS server downtime."
+  },
+  "resolver_lru_cache_size": {
+    "defaultValue": "10000",
+    "description": "The DNS client uses a two-layer cache system: L1 - worker-level LRU Lua VM cache L2 - across-workers shared memory cache  This value specifies the maximum allowed number of DNS responses stored in the L1 LRU lua VM cache.  A single name query can easily take up 1~10 slots, depending on attempted query types and extended domains from /etc/resolv.conf options `domain` or `search`."
+  },
+  "resolver_mem_cache_size": {
+    "defaultValue": "5m",
+    "description": "This value specifies the size of the L2 shared memory cache for DNS responses, `kong_dns_cache`.  Accepted units are `k` and `m`, with a minimum recommended value of a few MBs.  5MB shared memory size could store ~20000 DNS responeses with single A record or ~10000 DNS responeses with 2~3 A records.  10MB shared memory size could store ~40000 DNS responeses with single A record or ~20000 DNS responeses with 2~3 A records."
+  },
+  "vault_env_prefix": {
+    "defaultValue": null,
+    "description": "Defines the environment variable vault's default prefix. For example if you have all your secrets stored in environment variables prefixed with `SECRETS_`, it can be configured here so that it isn't necessary to repeat them in Vault references."
+  },
+  "vault_aws_region": {
+    "defaultValue": null,
+    "description": "The AWS region your vault is located in."
+  },
+  "vault_aws_endpoint_url": {
+    "defaultValue": null,
+    "description": "The AWS SecretsManager service endpoint url. If not specified, the value used by vault will be the official AWS SecretsManager service url which is `https://secretsmanager.<region>.amazonaws.com` You can specify a complete URL(including the \"http/https\" scheme) to override the endpoint that vault will connect to."
+  },
+  "vault_aws_assume_role_arn": {
+    "defaultValue": null,
+    "description": "The target AWS IAM role ARN that will be assumed. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+  },
+  "vault_aws_role_session_name": {
+    "defaultValue": "KongVault",
+    "description": "The role session name used for role assuming. The default value is `KongVault`."
+  },
+  "vault_aws_sts_endpoint_url": {
+    "defaultValue": null,
+    "description": "The custom STS endpoint URL used for role assuming in AWS Vault.  Note that this value will override the default STS endpoint URL(which should be `https://sts.amazonaws.com`, or `https://sts.<region>.amazonaws.com` if you have `AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).  If you are not using private VPC endpoint for STS service, you should not specify this value."
+  },
+  "vault_aws_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the AWS vault when cached by this node.  AWS vault misses (no secret) are also cached according to this setting if you do not configure `vault_aws_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_aws_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_aws_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_aws_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the AWS vault should be resurrected for when they cannot be refreshed (e.g., the AWS vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "vault_gcp_project_id": {
+    "defaultValue": null,
+    "description": "The project ID from your Google API Console."
+  },
+  "vault_gcp_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the GCP vault when cached by this node.  GCP vault misses (no secret) are also cached according to this setting if you do not configure `vault_gcp_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_gcp_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_gcp_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_gcp_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the GCP vault should be resurrected for when they cannot be refreshed (e.g., the GCP vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "vault_hcv_protocol": {
+    "defaultValue": "http",
+    "description": "The protocol to connect with. Accepts one of `http` or `https`."
+  },
+  "vault_hcv_host": {
+    "defaultValue": "127.0.0.1",
+    "description": "The hostname of your HashiCorp vault."
+  },
+  "vault_hcv_port": {
+    "defaultValue": "8200",
+    "description": "The port number of your HashiCorp vault."
+  },
+  "vault_hcv_namespace": {
+    "defaultValue": null,
+    "description": "Namespace for the HashiCorp Vault. Vault Enterprise requires a namespace to successfully connect to it."
+  },
+  "vault_hcv_mount": {
+    "defaultValue": "secret",
+    "description": "The mount point."
+  },
+  "vault_hcv_kv": {
+    "defaultValue": "v1",
+    "description": "The secrets engine version. Accepts `v1` or `v2`."
+  },
+  "vault_hcv_token": {
+    "defaultValue": null,
+    "description": "A token string."
+  },
+  "vault_hcv_auth_method": {
+    "defaultValue": "token",
+    "description": "Defines the authentication mechanism when connecting to the Hashicorp Vault service. Accepted values are: `token`, `kubernetes` or `approle`."
+  },
+  "vault_hcv_kube_role": {
+    "defaultValue": null,
+    "description": "Defines the HashiCorp Vault role for the Kubernetes service account of the running pod. `vault_hcv_auth_method` must be set to `kubernetes` for this to activate."
+  },
+  "vault_hcv_kube_auth_path": {
+    "defaultValue": "kubernetes",
+    "description": " Place where the Kubernetes auth method will be accessible: `/v1/auth/<vault_hcv_kube_auth_path>`"
+  },
+  "vault_hcv_kube_api_token_file": {
+    "defaultValue": null,
+    "description": "Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+  },
+  "vault_hcv_approle_auth_path": {
+    "defaultValue": "approle",
+    "description": " Place where the Approle auth method will be accessible: `/v1/auth/<vault_hcv_approle_auth_path>`"
+  },
+  "vault_hcv_approle_role_id": {
+    "defaultValue": null,
+    "description": "The Role ID of the Approle in HashiCorp Vault."
+  },
+  "vault_hcv_approle_secret_id": {
+    "defaultValue": null,
+    "description": "The Secret ID of the Approle in HashiCorp Vault."
+  },
+  "vault_hcv_approle_secret_id_file": {
+    "defaultValue": null,
+    "description": "Defines where the Secret ID should be read from the pod's filesystem. This is usually used with HashiCorp Vault's response wrapping."
+  },
+  "vault_hcv_approle_response_wrapping": {
+    "defaultValue": "false",
+    "description": "Defines whether the Secret ID read from configuration or file is actually a response-wrapping token instead of a real Secret ID."
+  },
+  "vault_hcv_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the HashiCorp vault when cached by this node.  HashiCorp vault misses (no secret) are also cached according to this setting if you do not configure `vault_hcv_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_hcv_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a HashiCorp vault miss (no secret).  If not specified (default), `vault_hcv_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_hcv_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the HashiCorp vault should be resurrected for when they cannot be refreshed (e.g., the HashiCorp vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "vault_azure_vault_uri": {
+    "defaultValue": null,
+    "description": "The URI the vault is reachable from."
+  },
+  "vault_azure_client_id": {
+    "defaultValue": null,
+    "description": "The client ID from your registered Application. Visit your Azure Dashboard and select *App Registrations* to check your client ID."
+  },
+  "vault_azure_tenant_id": {
+    "defaultValue": null,
+    "description": "The DirectoryId and TenantId both equate to the GUID representing the ActiveDirectory Tenant. Depending on context, either term may be used by Microsoft documentation and products, which can be confusing. In other words, the \"Tenant ID\" IS the \"Directory ID\""
+  },
+  "vault_azure_type": {
+    "defaultValue": "secrets",
+    "description": "Azure Key Vault enables Microsoft Azure applications and users to store and use several types of secret/key data: keys, secrets, and certificates. Kong currently only supports the `Secrets`"
+  },
+  "vault_azure_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the Azure Key Vault when cached by this node.  Key Vault misses (no secret) are also cached according to this setting if you do not configure `vault_azure_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_azure_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a Azure Key Vault miss (no secret).  If not specified (default), `vault_azure_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_azure_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the Azure Key Vault should be resurrected for when they cannot be refreshed (e.g., the the vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "worker_consistency": {
+    "defaultValue": "eventual",
+    "description": " Defines whether this node should rebuild its state synchronously or asynchronously (the balancers and the router are rebuilt on updates that affect them, e.g., updates to routes, services, or upstreams via the admin API or loading a declarative configuration file). (This option is deprecated and will be removed in future releases. The new default is `eventual`.)  Accepted values are:  - `strict`: the router will be rebuilt   synchronously, causing incoming requests to   be delayed until the rebuild is finished.   (This option is deprecated and will be removed    in future releases. The new default is `eventual`) - `eventual`: the router will be rebuilt   asynchronously via a recurring background   job running every second inside of each   worker.  Note that `strict` ensures that all workers of a given node will always proxy requests with an identical router, but increased long-tail latency can be observed if frequent routes and services updates are expected. Using `eventual` will help prevent long-tail latency issues in such cases, but may cause workers to route requests differently for a short period of time after routes and services updates."
+  },
+  "worker_state_update_frequency": {
+    "defaultValue": "5",
+    "description": " Defines how often the worker state changes are checked with a background job. When a change is detected, a new router or balancer will be built, as needed. Raising this value will decrease the load on database servers and result in less jitter in proxy latency, but it might take more time to propagate changes to each individual worker."
+  },
+  "router_flavor": {
+    "defaultValue": "traditional_compatible",
+    "description": " Selects the router implementation to use when performing request routing. Incremental router rebuild is available when the flavor is set to either `expressions` or `traditional_compatible`, which could significantly shorten rebuild time for a large number of routes.  Accepted values are:  - `traditional_compatible`: the DSL-based expression   router engine will be used under the hood. However,   the router config interface will be the same   as `traditional`, and expressions are   automatically generated at router build time.   The `expression` field on the `route` object   is not visible. - `expressions`: the DSL-based expression router engine   will be used under the hood. The traditional router   config interface is still visible, and you can also write   router Expressions manually and provide them in the   `expression` field on the `route` object. - `traditional`: the pre-3.0 router engine will be   used. The config interface will be the same as   pre-3.0 Kong, and the `expression` field on the   `route` object is not visible.    Deprecation warning: In Kong 3.0, `traditional`   mode should be avoided and only be used if   `traditional_compatible` does not work as expected.   This flavor of the router will be removed in the next   major release of Kong."
+  },
+  "lua_max_req_headers": {
+    "defaultValue": "100",
+    "description": "Maximum number of request headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request headers, and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many request headers."
+  },
+  "lua_max_resp_headers": {
+    "defaultValue": "100",
+    "description": "Maximum number of response headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong returns all the response headers, and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many response headers."
+  },
+  "lua_max_uri_args": {
+    "defaultValue": "100",
+    "description": "Maximum number of request URI arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request query arguments, and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many query arguments."
+  },
+  "lua_max_post_args": {
+    "defaultValue": "100",
+    "description": "Maximum number of request post arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request post arguments, and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many post arguments."
+  },
+  "lua_ssl_trusted_certificate": {
+    "defaultValue": "system",
+    "description": "Comma-separated list of certificate authorities for Lua cosockets in PEM format.  The special value `system` attempts to search for the \"usual default\" provided by each distro, according to an arbitrary heuristic. In the current implementation, the following pathnames will be tested in order, and the first one found will be used:  - `/etc/ssl/certs/ca-certificates.crt` (Debian/Ubuntu/Gentoo) - `/etc/pki/tls/certs/ca-bundle.crt` (Fedora/RHEL 6) - `/etc/ssl/ca-bundle.pem` (OpenSUSE) - `/etc/pki/tls/cacert.pem` (OpenELEC) - `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` (CentOS/RHEL 7) - `/etc/ssl/cert.pem` (OpenBSD, Alpine)  `system` can be used by itself or in conjunction with other CA file paths.  When `pg_ssl_verify` is enabled, these certificate authority files will be used for verifying Kong's database connections.  Certificates can be configured on this property with any of the following values: - `system` - absolute path to the certificate - certificate content - base64 encoded certificate content  See https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate"
+  },
+  "lua_ssl_verify_depth": {
+    "defaultValue": "1",
+    "description": "Sets the verification depth in the server certificates chain used by Lua cosockets, set by `lua_ssl_trusted_certificate`. This includes the certificates configured for Kong's database connections. If the maximum depth is reached before reaching the end of the chain, verification will fail. This helps mitigate certificate based DoS attacks.  See https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth"
+  },
+  "lua_ssl_protocols": {
+    "defaultValue": "TLSv1.2 TLSv1.3",
+    "description": "Defines the TLS versions supported when handshaking with OpenResty's TCP cosocket APIs.  This affects connections made by Lua code, such as connections to the database Kong uses, or when sending logs using a logging plugin. It does *not* affect connections made to the upstream Service or from downstream clients."
+  },
+  "lua_package_path": {
+    "defaultValue": "./?.lua;./?/init.lua;",
+    "description": "Sets the Lua module search path (LUA_PATH). Useful when developing or using custom plugins not stored in the default search path.  See https://github.com/openresty/lua-nginx-module#lua_package_path"
+  },
+  "lua_package_cpath": {
+    "defaultValue": null,
+    "description": "Sets the Lua C module search path (LUA_CPATH).  See https://github.com/openresty/lua-nginx-module#lua_package_cpath"
+  },
+  "lua_socket_pool_size": {
+    "defaultValue": "256",
+    "description": "Specifies the size limit for every cosocket connection pool associated with every remote server.  See https://github.com/openresty/lua-nginx-module#lua_socket_pool_size"
+  },
+  "enforce_rbac": {
+    "defaultValue": "off",
+    "description": "Specifies whether Admin API RBAC is enforced. Accepts one of `entity`, `both`, `on`, or `off`.  - `on`: only endpoint-level authorization   is enforced. - `entity`: entity-level authorization   applies. - `both`: enables both endpoint and   entity-level authorization. - `off`: disables both endpoint and   entity-level authorization.  When enabled, Kong will deny requests to the Admin API when a nonexistent or invalid RBAC authorization token is passed, or the RBAC user with which the token is associated does not have permissions to access/modify the requested resource."
+  },
+  "rbac_auth_header": {
+    "defaultValue": "Kong-Admin-Token",
+    "description": "Defines the name of the HTTP request header from which the Admin API will attempt to authenticate the RBAC user."
+  },
+  "event_hooks_enabled": {
+    "defaultValue": "on",
+    "description": "When enabled, event hook entities represent a relationship between an event (source and event) and an action (handler). Similar to web hooks, event hooks can be used to communicate Kong Gateway service events. When a particular event happens on a service, the event hook calls a URL with information about that event. Event hook configurations differ depending on the handler. The events that are triggered send associated data.  See: https://docs.konghq.com/gateway/api/admin-ee/latest/#/Event-hooks/get-event-hooks"
+  },
+  "fips": {
+    "defaultValue": "off",
+    "description": "Turn on FIPS mode; this mode is only available on a FIPS build."
+  },
+  "admin_gui_listen": {
+    "defaultValue": [
+      "0.0.0.0:8002",
+      "0.0.0.0:8445 ssl"
+    ],
+    "description": " Kong Manager Listeners  Comma-separated list of addresses and ports on which Kong will expose Kong Manager. This web application lets you configure and manage Kong, and therefore should be kept secured.  Suffixes can be specified for each pair, similarly to the `admin_listen` directive."
+  },
+  "admin_gui_url": {
+    "defaultValue": null,
+    "description": "Kong Manager URL  The lookup, or balancer, address for Kong Manager.  Accepted format (items in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>)`  Examples:  - `http://127.0.0.1:8003` - `https://kong-admin.test` - `http://dev-machine`  By default, Kong Manager will use the window request host and append the resolved listener port depending on the requested protocol."
+  },
+  "admin_gui_path": {
+    "defaultValue": "/",
+    "description": "Kong Manager base path  This configuration parameter allows the user to customize the path prefix where Kong Manager is served. When updating this parameter, it's recommended to update the path in `admin_gui_url` as well.  Accepted format:  - Path must start with a `/` - Path must not end with a `/` (except for the `/`) - Path can only contain letters, digits, hyphens (`-`), underscores (`_`), and slashes (`/`) - Path must not contain continuous slashes (e.g., `//` and `///`)  Examples:  - `/` - `/manager` - `/kong-manager` - `/kong/manager`"
+  },
+  "admin_gui_api_url": {
+    "defaultValue": null,
+    "description": "Hierarchical part of a URI which is composed optionally of a host, port, and path at which the Admin API accepts HTTP or HTTPS traffic. When this config is disabled, Kong Manager will use the window protocol + host and append the resolved admin_listen HTTP/HTTPS port."
+  },
+  "admin_gui_ssl_protocols": {
+    "defaultValue": "TLSv1.2 TLSv1.3",
+    "description": " Defines the TLS versions supported for Kong Manager"
+  },
+  "admin_gui_ssl_cert": {
+    "defaultValue": null,
+    "description": "The SSL certificate for `admin_gui_listen` values with SSL enabled.  values: - absolute path to the certificate - certificate content - base64 encoded certificate content"
+  },
+  "admin_gui_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "The SSL key for `admin_gui_listen` values with SSL enabled.  values: - absolute path to the certificate key - certificate key content - base64 encoded certificate key content"
+  },
+  "admin_gui_flags": {
+    "defaultValue": "{}",
+    "description": " Alters the layout Admin GUI (JSON) to enable Kong Immunity in the Admin GUI."
+  },
+  "admin_gui_access_log": {
+    "defaultValue": "logs/admin_gui_access.log",
+    "description": " Kong Manager Access Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables access logs for Kong Manager."
+  },
+  "admin_gui_error_log": {
+    "defaultValue": "logs/admin_gui_error.log",
+    "description": " Kong Manager Error Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables error logs for Kong Manager.  Granularity can be adjusted through the `log_level` directive."
+  },
+  "admin_gui_auth": {
+    "defaultValue": null,
+    "description": "Kong Manager Authentication Plugin Name  Secures access to Kong Manager by specifying an authentication plugin to use.  Supported Plugins:  - `basic-auth`: Basic Authentication plugin - `ldap-auth-advanced`: LDAP Authentication plugin - `openid-connect`: OpenID Connect Authentication   plugin"
+  },
+  "admin_gui_auth_conf": {
+    "defaultValue": null,
+    "description": "Kong Manager Authentication Plugin Config (JSON)  Specifies the configuration for the authentication plugin specified in `admin_gui_auth`.  For information about Plugin Configuration consult the associated plugin documentation.  Example for `basic-auth`:  `admin_gui_auth_conf = { \"hide_credentials\": true }`"
+  },
+  "admin_gui_auth_password_complexity": {
+    "defaultValue": null,
+    "description": "Kong Manager Authentication Password Complexity (JSON)  When `admin_gui_auth = basic-auth`, this property defines the rules required for Kong Manager passwords. Choose from preset rules or write your own.  Example using preset rules:  `admin_gui_auth_password_complexity = { \"kong-preset\": \"min_8\" }`  All values for kong-preset require the password to contain characters from at least three of the following categories:  1. Uppercase characters (A through Z)  2. Lowercase characters (a through z)  3. Base-10 digits (0 through 9)  4. Special characters (for example, &, $, #, %)  Supported preset rules: - `min_8`: minimum length of 8 - `min_12`: minimum length of 12 - `min_20`: minimum length of 20  To write your own rules, see https://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.  NOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.  Example:  `admin_gui_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`"
+  },
+  "admin_gui_session_conf": {
+    "defaultValue": null,
+    "description": "Kong Manager Session Config (JSON)  Specifies the configuration for the Session plugin as used by Kong Manager.  For information about plugin configuration, consult the Kong Session plugin documentation.  Example: ``` admin_gui_session_conf = { \"cookie_name\": \"kookie\", \\                            \"secret\": \"changeme\" } ```"
+  },
+  "admin_gui_auth_header": {
+    "defaultValue": "Kong-Admin-User",
+    "description": " Defines the name of the HTTP request header from which the Admin API will attempt to identify the Kong Admin user."
+  },
+  "admin_gui_auth_login_attempts": {
+    "defaultValue": "0",
+    "description": " Number of times a user can attempt to login to Kong Manager. 0 means infinite attempts allowed."
+  },
+  "admin_gui_auth_change_password_attempts": {
+    "defaultValue": "0",
+    "description": " Number of times a user can attempt to change password. 0 means infinite attempts allowed."
+  },
+  "admin_gui_auth_change_password_ttl": {
+    "defaultValue": "86400",
+    "description": " Length, in seconds, of the TTL for changing password attempts records. Records in the database older than their TTL are automatically purged.  Example, 1 days: `1 * 24 * 60 * 60 = 86400.`"
+  },
+  "admin_gui_header_txt": {
+    "defaultValue": null,
+    "description": "Sets the text for the Kong Manager header banner. Header banner is not shown if this config is empty."
+  },
+  "admin_gui_header_bg_color": {
+    "defaultValue": null,
+    "description": "Sets the background color for the Kong Manager header banner. Accepts CSS color keyword, #-hexadecimal, or RGB format. Invalid values are ignored by Manager."
+  },
+  "admin_gui_header_txt_color": {
+    "defaultValue": null,
+    "description": "Sets the text color for the Kong Manager header banner. Accepts CSS color keyword, #-hexadecimal, or RGB format. Invalid values are ignored by Kong Manager."
+  },
+  "admin_gui_footer_txt": {
+    "defaultValue": null,
+    "description": "Sets the text for the Kong Manager footer banner. Footer banner is not shown if this config is empty."
+  },
+  "admin_gui_footer_bg_color": {
+    "defaultValue": null,
+    "description": "Sets the background color for the Kong Manager footer banner. Accepts CSS color keyword, #-hexadecimal, or RGB format. Invalid values are ignored by manager."
+  },
+  "admin_gui_footer_txt_color": {
+    "defaultValue": null,
+    "description": "Sets the text color for the Kong Manager footer banner. Accepts CSS color keyword, #-hexadecimal, or RGB format. Invalid values are ignored by Kong Manager."
+  },
+  "admin_gui_login_banner_title": {
+    "defaultValue": null,
+    "description": "Sets the title text for the Kong Manager login banner. Login banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+  },
+  "admin_gui_login_banner_body": {
+    "defaultValue": null,
+    "description": "Sets the body text for the Kong Manager login banner. Login banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+  },
+  "konnect_mode": {
+    "defaultValue": "off",
+    "description": "When enabled, the dataplane is connected to Konnect"
+  },
+  "analytics_flush_interval": {
+    "defaultValue": "1",
+    "description": "Specify the maximum frequency, in seconds, at which local analytics and licensing data are flushed to the database or Konnect, depending on the installation mode. Kong also triggers a flush when the number of messages in the buffer is less than `analytics_buffer_size_limit`, regardless of whether the specified time interval has elapsed."
+  },
+  "analytics_buffer_size_limit": {
+    "defaultValue": "100000",
+    "description": "Max number of messages can be buffered locally before dropping data in case there is no network connection to Konnect."
+  },
+  "analytics_debug": {
+    "defaultValue": "off",
+    "description": "Outputs analytics payload to Kong logs."
+  },
+  "admin_emails_from": {
+    "defaultValue": "\"\"",
+    "description": "The email address for the `From` header for admin emails."
+  },
+  "admin_emails_reply_to": {
+    "defaultValue": null,
+    "description": "Email address for the `Reply-To` header for admin emails."
+  },
+  "admin_invitation_expiry": {
+    "defaultValue": "259200",
+    "description": "Expiration time for the admin invitation link (in seconds). 0 means no expiration.  Example, 72 hours: `72 * 60 * 60 = 259200`"
+  },
+  "smtp_mock": {
+    "defaultValue": "on",
+    "description": "This flag will mock the sending of emails. This can be used for testing before the SMTP client is fully configured."
+  },
+  "smtp_host": {
+    "defaultValue": "localhost",
+    "description": " The hostname of the SMTP server to connect to."
+  },
+  "smtp_port": {
+    "defaultValue": "25",
+    "description": " The port number on the SMTP server to connect to."
+  },
+  "smtp_starttls": {
+    "defaultValue": "off",
+    "description": " When set to `on`, STARTTLS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 587."
+  },
+  "smtp_username": {
+    "defaultValue": null,
+    "description": "Username used for authentication with SMTP server"
+  },
+  "smtp_password": {
+    "defaultValue": null,
+    "description": "Password used for authentication with SMTP server"
+  },
+  "smtp_ssl": {
+    "defaultValue": "off",
+    "description": " When set to `on`, SMTPS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 465."
+  },
+  "smtp_auth_type": {
+    "defaultValue": null,
+    "description": "The method used to authenticate with the SMTP server Valid options are `plain`, `login`, or `nil`"
+  },
+  "smtp_domain": {
+    "defaultValue": "localhost.localdomain",
+    "description": " The domain used in the `EHLO` connection and part of the `Message-ID` header"
+  },
+  "smtp_timeout_connect": {
+    "defaultValue": "60000",
+    "description": " The timeout (in milliseconds) for connecting to the SMTP server."
+  },
+  "smtp_timeout_send": {
+    "defaultValue": "60000",
+    "description": " The timeout (in milliseconds) for sending data to the SMTP server."
+  },
+  "smtp_timeout_read": {
+    "defaultValue": "60000",
+    "description": " The timeout (in milliseconds) for reading data from the SMTP server."
+  },
+  "smtp_admin_emails": {
+    "defaultValue": null,
+    "description": "Comma separated list of admin emails to receive notifications. Example `admin1@example.com, admin2@example.com`"
+  },
+  "audit_log": {
+    "defaultValue": "off",
+    "description": "When enabled, Kong will log information about Admin API access and database row insertions, updates, and deletions."
+  },
+  "audit_log_ignore_methods": {
+    "defaultValue": null,
+    "description": "Comma-separated list of HTTP methods that will not generate audit log entries. By default, all HTTP requests will be logged."
+  },
+  "audit_log_ignore_paths": {
+    "defaultValue": null,
+    "description": "Comma-separated list of request paths that will not generate audit log entries. By default, all HTTP requests will be logged."
+  },
+  "audit_log_ignore_tables": {
+    "defaultValue": null,
+    "description": "Comma-separated list of database tables that will not generate audit log entries. By default, updates to all database tables will be logged (the term \"updates\" refers to the creation, update, or deletion of a row)."
+  },
+  "audit_log_payload_exclude": {
+    "defaultValue": [
+      "token",
+      "secret",
+      "password"
+    ],
+    "description": " Comma-separated list of keys that will be filtered out of the payload. Keys that were filtered will be recorded in the audit log."
+  },
+  "audit_log_record_ttl": {
+    "defaultValue": "2592000",
+    "description": "Length, in seconds, of the TTL for audit log records. Records in the database older than their TTL are automatically purged.  Example, 30 days: `30 * 24 * 60 * 60 = 2592000`"
+  },
+  "audit_log_signing_key": {
+    "defaultValue": null,
+    "description": "Defines the path to a private RSA signing key that can be used to insert a signature of audit records, adjacent to the record. The corresponding public key should be stored offline, and can be used to validate audit entries in the future. If this value is undefined, no signature will be generated."
+  },
+  "route_validation_strategy": {
+    "defaultValue": "smart",
+    "description": "The strategy used to validate routes when creating or updating them. Different strategies are available to tune how to enforce splitting traffic of workspaces. - `smart` is the default option and uses the   algorithm described in   https://docs.konghq.com/gateway/latest/kong-enterprise/workspaces/. - `off` disables any check. - `path` enforces routes to comply with the pattern   described in config `enforce_route_path_pattern`. - `static` relies on the PostgreSQL database. Before creating a new route, it checks if the route is unique across all workspaces based on the following params: `paths`, `methods`, and `hosts`. If all fields of the new route overlap with an existing one, a 409 is returned with the route of the collision. The array order is not important for the overlap filter."
+  },
+  "enforce_route_path_pattern": {
+    "defaultValue": null,
+    "description": "Specifies the Lua pattern which will be enforced on the `paths` attribute of a route object. You can also add a placeholder for the workspace in the pattern, which will be rendered during runtime based on the workspace to which the `route` belongs. This setting is only relevant if `route_validation_strategy` is set to `path`.   Example For Pattern `/$(workspace)/v%d/.*` valid paths are:  1. `/group1/v1/` if route belongs to   workspace `group1`.  2. `/group2/v1/some_path` if route belongs to   workspace `group2`."
+  },
+  "keyring_enabled": {
+    "defaultValue": "off",
+    "description": "When enabled, Kong will encrypt sensitive field values before writing them to the database, and subsequently decrypt them when retrieving data for the Admin API, Developer Portal, or proxy business logic. Symmetric encryption keys are managed based on the strategy defined below."
+  },
+  "keyring_strategy": {
+    "defaultValue": "cluster",
+    "description": "Defines the strategy implementation by which Kong nodes will manage symmetric encryption keys. Please see the Kong Enterprise documentation for a detailed description of each strategy. Acceptable values for this option are `cluster` and `vault`."
+  },
+  "keyring_public_key": {
+    "defaultValue": null,
+    "description": "Defines the public key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  Values: - absolute path to the public key - public key content - base64 encoded public key content"
+  },
+  "keyring_private_key": {
+    "defaultValue": null,
+    "description": "Defines the private key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  Values: - absolute path to the private key - private key content - base64 encoded private key content"
+  },
+  "keyring_recovery_public_key": {
+    "defaultValue": null,
+    "description": "Defines the public key to optionally encrypt all keyring materials and back them up in the database.  Values: - absolute path to the public key - public key content - base64 encoded public key content"
+  },
+  "keyring_blob_path": {
+    "defaultValue": null,
+    "description": "Defines the filesystem path at which Kong will back up the initial keyring material. This option is useful largely for development purposes."
+  },
+  "keyring_vault_host": {
+    "defaultValue": null,
+    "description": "Defines the Vault host at which Kong will fetch the encryption material. This value should be defined in the format:  `<scheme>://<IP / HOSTNAME>:<PORT>`"
+  },
+  "keyring_vault_mount": {
+    "defaultValue": null,
+    "description": "Defines the name of the Vault v2 KV secrets engine at which symmetric keys are found."
+  },
+  "keyring_vault_path": {
+    "defaultValue": null,
+    "description": "Defines the name of the Vault v2 KV path at which symmetric keys are found."
+  },
+  "keyring_vault_auth_method": {
+    "defaultValue": "token",
+    "description": " Defines the authentication mechanism when connecting to the Hashicorp Vault service.  Accepted values are: `token`, or `kubernetes`:  - `token`: Uses the static token defined in            the `keyring_vault_token`            configuration property.  - `kubernetes`: Uses the Kubernetes authentication                 mechanism, with the running pod's                 mapped service account, to assume                 the Hashicorp Vault role name that is                 defined in the `keyring_vault_kube_role`                 configuration property."
+  },
+  "keyring_vault_token": {
+    "defaultValue": null,
+    "description": "Defines the token value used to communicate with the v2 KV Vault HTTP(S) API."
+  },
+  "keyring_vault_kube_role": {
+    "defaultValue": "default",
+    "description": " Defines the Hashicorp Vault role that will be assumed using the Kubernetes service account of the running pod.  `keyring_vault_auth_method` must be set to `kubernetes` for this to activate."
+  },
+  "keyring_vault_kube_api_token_file": {
+    "defaultValue": "/run/secrets/kubernetes.io/serviceaccount/token",
+    "description": " Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+  },
+  "keyring_encrypt_license": {
+    "defaultValue": "off",
+    "description": " Enables keyring encryption for license payloads stored in the database.  **Warning:** For Kong deployments that rely entirely on the database for license provisioning (i.e. not using `KONG_LICENSE_DATA` or `KONG_LICENSE_PATH`), enabling this option will delay license activation until after the node's keyring has been activated."
+  },
+  "untrusted_lua": {
+    "defaultValue": "sandbox",
+    "description": " Controls loading of Lua functions from admin-supplied sources such as the Admin API. LuaJIT bytecode loading is always disabled.  **Warning:** LuaJIT is not designed as a secure runtime for running malicious code, therefore you should properly protect your Admin API endpoint even with sandboxing enabled. The sandbox only provides protection against trivial attackers or unintentional modification of the Kong global environment.  Accepted values are: `off`, `sandbox`, or `on`:  - `off`: Disallow loading of any arbitrary          Lua functions. The `off` option          disables any functionality that runs          arbitrary Lua code, including the          Serverless Functions plugins and any          transformation plugin that allows          custom Lua functions.  - `sandbox`: Allow loading of Lua functions,              but use a sandbox when executing              them. The sandboxed function has              restricted access to the global              environment and only has access              to standard Lua functions that              will generally not cause harm to              the Kong Gateway node.  - `on`: Functions have unrestricted         access to the global environment and         can load any Lua modules. This is         similar to the behavior in         Kong Gateway prior to 2.3.0.  The default `sandbox` environment does not allow importing other modules or libraries, or executing anything at the OS level (for example, file read/write). The global environment is also not accessible.  Examples of `untrusted_lua = sandbox` behavior:  - You can't access or change global values   such as `kong.configuration.pg_password` - You can run harmless Lua:   `local foo = 1 + 1`. However, OS level   functions are not allowed, like:   `os.execute(`rm -rf /*`)`.  For a full allowed/disallowed list, see: https://github.com/kikito/sandbox.lua/blob/master/sandbox.lua  To customize the sandbox environment, use the `untrusted_lua_sandbox_requires` and `untrusted_lua_sandbox_environment` parameters below."
+  },
+  "untrusted_lua_sandbox_requires": {
+    "defaultValue": null,
+    "description": "Comma-separated list of modules allowed to be loaded with `require` inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  For example, say you have configured the Serverless pre-function plugin and it contains the following `requires`:  ``` local template = require \"resty.template\" local split = require \"kong.tools.string\".split ```  To run the plugin, add the modules to the allowed list: ``` untrusted_lua_sandbox_requires = resty.template, kong.tools.utils ```  **Warning:** Allowing certain modules may create opportunities to escape the sandbox. For example, allowing `os` or `luaposix` may be unsafe."
+  },
+  "untrusted_lua_sandbox_environment": {
+    "defaultValue": null,
+    "description": "Comma-separated list of global Lua variables that should be made available inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  **Warning**: Certain variables, when made available, may create opportunities to escape the sandbox."
+  },
+  "openresty_path": {
+    "defaultValue": null,
+    "description": "Path to the OpenResty installation that Kong will use. When this is empty (the default), Kong determines the OpenResty installation by searching for a system-installed OpenResty and falling back to searching $PATH for the nginx binary.  Setting this attribute disables the search behavior and explicitly instructs Kong which OpenResty installation to use."
+  },
+  "node_id": {
+    "defaultValue": null,
+    "description": "Node ID for the Kong node. Every Kong node in a Kong cluster must have a unique and valid UUID. When empty, node ID is automatically generated."
+  },
+  "cluster_fallback_config_import": {
+    "defaultValue": "off",
+    "description": "Enable fallback configuration imports.  This should only be enabled for data planes."
+  },
+  "cluster_fallback_config_storage": {
+    "defaultValue": null,
+    "description": "Storage definition used by `cluster_fallback_config_import` and `cluster_fallback_config_export`.  Supported storage types: - S3-like storages - GCP storage service  To use S3 with a bucket named b and place all configs to with a key prefix named p, set it to: `s3://b/p` To use GCP for the same bucket and prefix, set it to: `gcs://b/p`  The credentials (and the endpoint URL for S3-like) for S3 are passed with environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where `AWS_CONFIG_STORAGE_ENDPOINT` is the endpoint that hosts S3-like storage.  The credentials for GCP are provided via the environment variable `GCP_SERVICE_ACCOUNT`."
+  },
+  "cluster_fallback_export_s3_config": {
+    "defaultValue": null,
+    "description": "Fallback config export S3 configuration. This is used only when `cluster_fallback_config_storage` is an S3-like schema. If set, it will add the config table to the Kong exporter config S3 putObject request. The config table should be in JSON format and can be unserialized into a table. It should contain the necessary parameters as described in the documentation: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property. For example, if you want to set the ServerSideEncryption headers/KMS Key ID for the S3 putObject request, you can set the config table to: `{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"your-kms-key-id\"}`"
+  },
+  "cluster_fallback_config_export": {
+    "defaultValue": "off",
+    "description": "Enable fallback configuration exports."
+  },
+  "cluster_fallback_config_export_delay": {
+    "defaultValue": "60",
+    "description": "The fallback configuration export interval.  If the interval is set to 60 and configuration A is exported and there are new configurations B, C, and D in the next 60 seconds, it will wait until 60 seconds passed and export D, skipping B and C."
+  },
+  "wasm": {
+    "defaultValue": "off",
+    "description": "Enable/disable wasm support. This must be enabled in order to use wasm filters and filter chains."
+  },
+  "wasm_filters_path": {
+    "defaultValue": null,
+    "description": "Path to the directory containing wasm filter modules.  At startup, Kong discovers available wasm filters by scanning this directory for files with the `.wasm` file extension.  The name of a wasm filter module is derived from the filename itself, with the .wasm extension removed. So, given the following tree:  ``` /path/to/wasm_filters ├── my_module.wasm ├── my_other_module.wasm └── not_a_wasm_module.txt ```  The resulting filter modules available for use in Kong will be:  - `my_module` - `my_other_module`  Notes:  - No recursion is performed. Only .wasm files at the   top level are registered. - This path _may_ be a symlink to a directory."
+  },
+  "wasm_filters": {
+    "defaultValue": [
+      "bundled",
+      "user"
+    ],
+    "description": "Comma-separated list of Wasm filters to be made available for use in filter chains.  When the `off` keyword is specified as the only value, no filters will be available for use.  When the `bundled` keyword is specified, all filters bundled with Kong will be available.  When the `user` keyword is specified, all filters within the `wasm_filters_path` will be available.  **Examples:**  - `wasm_filters = bundled,user` enables _all_ bundled   and user-supplied filters - `wasm_filters = user` enables _only_ user-supplied   filters - `wasm_filters = filter-a,filter-b` enables _only_   filters named `filter-a` or `filter-b` (whether   bundled _or_ user-supplied)  If a conflict occurs where a bundled filter and a user-supplied filter share the same name, a warning will be logged, and the user-supplied filter will be used instead."
+  },
+  "test": {
+    "defaultValue": "on",
+    "description": "test"
+  },
+  "request_debug": {
+    "defaultValue": "on",
+    "description": "When enabled, Kong will provide detailed timing information for its components to the client and the error log if the following headers are present in the proxy request: - `X-Kong-Request-Debug`:   If the value is set to `*`,   timing information will be collected and exported for the current request.   If this header is not present or contains an unknown value,   timing information will not be collected for the current request.   You can also specify a list of filters, separated by commas,   to filter the scope of the time information that is collected. The following filters are supported for `X-Kong-Request-Debug`: - `rewrite`: Collect timing information from the `rewrite` phase. - `access`: Collect timing information from the `access` phase. - `balancer`: Collect timing information from the `balancer` phase. - `response`: Collect timing information from the `response` phase. - `header_filter`: Collect timing information from the `header_filter` phase. - `body_filter`: Collect timing information from the `body_filter` phase. - `log`: Collect timing information from the `log` phase. - `upstream`: Collect timing information from the `upstream` phase.  - `X-Kong-Request-Debug-Log`:   If set to `true`, timing information will also be logged   in the Kong error log with a log level of `notice`.   Defaults to `false`.  - `X-Kong-Request-Debug-Token`:   Token for authenticating the client making the debug   request to prevent abuse. Debug requests originating from loopback   addresses do not require this header. "
+  },
+  "request_debug_token": {
+    "defaultValue": "<random>",
+    "description": "The Request Debug Token is used in the `X-Kong-Request-Debug-Token` header to prevent abuse. If this value is not set (the default), a random token will be generated when Kong starts, restarts, or reloads. If a token is specified manually, then the provided token will be used.  You can locate the generated debug token in two locations: - Kong error log:   Debug token will be logged in the error log (notice level)   when Kong starts, restarts, or reloads.   The log line will have the: `[request-debug]` prefix to aid searching. - Filesystem:   Debug token will also be stored in a file located at   `{prefix}/.request_debug_token` and updated   when Kong starts, restarts, or reloads."
+  }
+}

--- a/app/_data/kong-conf/3.8.json
+++ b/app/_data/kong-conf/3.8.json
@@ -1,325 +1,325 @@
 {
   "prefix": {
     "defaultValue": "/usr/local/kong/",
-    "description": "Working directory. Equivalent to Nginx's prefix path, containing temporary files and logs. Each Kong process must have a separate working directory."
+    "description": "Working directory. Equivalent to Nginx's\nprefix path, containing temporary files\nand logs.\nEach Kong process must have a separate\nworking directory.\n"
   },
   "log_level": {
     "defaultValue": "notice",
-    "description": "Log level of the Nginx server. Logs are found at `<prefix>/logs/error.log`."
+    "description": "Log level of the Nginx server. Logs are\nfound at `<prefix>/logs/error.log`.\n"
   },
   "proxy_access_log": {
     "defaultValue": "logs/access.log",
-    "description": "Path for proxy port request access logs. Set this value to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for proxy port request access\nlogs. Set this value to `off` to\ndisable logging proxy requests.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n"
   },
   "proxy_error_log": {
     "defaultValue": "logs/error.log",
-    "description": "Path for proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for proxy port request error logs.\nThe granularity of these logs is adjusted by the `log_level` property.\n"
   },
   "proxy_stream_access_log": {
     "defaultValue": "logs/access.log basic",
-    "description": "Path for TCP streams proxy port access logs. Set to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location. `basic` is defined as `'$remote_addr [$time_local] ' '$protocol $status $bytes_sent $bytes_received ' '$session_time'`"
+    "description": "Path for TCP streams proxy port access logs.\nSet to `off` to disable logging proxy requests.\nIf this value is a relative path, it will be placed under the `prefix` location.\n`basic` is defined as `'$remote_addr [$time_local] '\n'$protocol $status $bytes_sent $bytes_received '\n'$session_time'`\n"
   },
   "proxy_stream_error_log": {
     "defaultValue": "logs/error.log",
-    "description": "Path for tcp streams proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for tcp streams proxy port request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "admin_access_log": {
     "defaultValue": "logs/admin_access.log",
-    "description": "Path for Admin API request access logs. If hybrid mode is enabled and the current node is set to be the control plane, then the connection requests from data planes are also written to this file with server name \"kong_cluster_listener\".  Set this value to `off` to disable logging Admin API requests. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for Admin API request access logs.\nIf hybrid mode is enabled and the current node is set\nto be the control plane, then the connection requests\nfrom data planes are also written to this file with\nserver name \"kong_cluster_listener\".\n\nSet this value to `off` to disable logging Admin API requests.\nIf this value is a relative path, it will be placed under the `prefix` location.\n"
   },
   "admin_error_log": {
     "defaultValue": "logs/error.log",
-    "description": "Path for Admin API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for Admin API request error logs.\nThe granularity of these logs is adjusted by the `log_level` property.\n"
   },
   "status_access_log": {
     "defaultValue": "off",
-    "description": "Path for Status API request access logs. The default value of `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for Status API request access logs.\nThe default value of `off` implies that logging for this API\nis disabled by default.\nIf this value is a relative path, it will be placed under the `prefix` location.\n"
   },
   "status_error_log": {
     "defaultValue": "logs/status_error.log",
-    "description": "Path for Status API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for Status API request error logs.\nThe granularity of these logs is adjusted by the `log_level` property.\n"
   },
   "debug_access_log": {
     "defaultValue": "off",
-    "description": "Path for Debug API request access logs. The default value `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for Debug API request access\nlogs. The default value `off`\nimplies that logging for this API\nis disabled by default.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n"
   },
   "debug_error_log": {
     "defaultValue": "logs/debug_error.log",
-    "description": "Path for Debug API request error logs. The granularity of these logs is adjusted using the `log_level` property."
+    "description": "Path for Debug API request error\nlogs. The granularity of these logs\nis adjusted using the `log_level`\nproperty.\n"
   },
   "vaults": {
     "defaultValue": "bundled",
-    "description": "Comma-separated list of vaults this node should load. By default, all the bundled vaults are enabled.  The specified name(s) will be substituted as such in the Lua namespace: `kong.vaults.{name}.*`."
+    "description": "Comma-separated list of vaults this node should load.\nBy default, all the bundled vaults are enabled.\n\nThe specified name(s) will be substituted as\nsuch in the Lua namespace:\n`kong.vaults.{name}.*`.\n"
   },
   "opentelemetry_tracing": {
     "defaultValue": "off",
-    "description": "Deprecated: use `tracing_instrumentations` instead."
+    "description": "Deprecated: use `tracing_instrumentations` instead.\n"
   },
   "tracing_instrumentations": {
     "defaultValue": "off",
-    "description": "Comma-separated list of tracing instrumentations this node should load. By default, no instrumentations are enabled.  Valid values for this setting are:  - `off`: do not enable instrumentations. - `request`: only enable request-level instrumentations. - `all`: enable all the following instrumentations. - `db_query`: trace database queries. - `dns_query`: trace DNS queries. - `router`: trace router execution, including router rebuilding. - `http_client`: trace OpenResty HTTP client requests. - `balancer`: trace balancer retries. - `plugin_rewrite`: trace plugin iterator execution with rewrite phase. - `plugin_access`: trace plugin iterator execution with access phase. - `plugin_header_filter`: trace plugin iterator execution with header_filter phase.  **Note:** In the current implementation, tracing instrumentations are not enabled in stream mode."
+    "description": "Comma-separated list of tracing instrumentations this node should load.\nBy default, no instrumentations are enabled.\n\nValid values for this setting are:\n\n- `off`: do not enable instrumentations.\n- `request`: only enable request-level instrumentations.\n- `all`: enable all the following instrumentations.\n- `db_query`: trace database queries.\n- `dns_query`: trace DNS queries.\n- `router`: trace router execution, including router rebuilding.\n- `http_client`: trace OpenResty HTTP client requests.\n- `balancer`: trace balancer retries.\n- `plugin_rewrite`: trace plugin iterator execution with rewrite phase.\n- `plugin_access`: trace plugin iterator execution with access phase.\n- `plugin_header_filter`: trace plugin iterator execution with header_filter phase.\n\n**Note:** In the current implementation, tracing instrumentations are not enabled in stream mode.\n"
   },
   "opentelemetry_tracing_sampling_rate": {
     "defaultValue": "1.0",
-    "description": "Deprecated: use `tracing_sampling_rate` instead."
+    "description": "Deprecated: use `tracing_sampling_rate` instead.\n"
   },
   "tracing_sampling_rate": {
     "defaultValue": "0.01",
-    "description": "Tracing instrumentation sampling rate. Tracer samples a fixed percentage of all spans following the sampling rate.  Example: `0.25`, this accounts for 25% of all traces."
+    "description": "Tracing instrumentation sampling rate.\nTracer samples a fixed percentage of all spans\nfollowing the sampling rate.\n\nExample: `0.25`, this accounts for 25% of all traces.\n"
   },
   "plugins": {
     "defaultValue": "bundled",
-    "description": "Comma-separated list of plugins this node should load. By default, only plugins bundled in official distributions are loaded via the `bundled` keyword.  Loading a plugin does not enable it by default, but only instructs Kong to load its source code and allows configuration via the various related Admin API endpoints.  The specified name(s) will be substituted as such in the Lua namespace: `kong.plugins.{name}.*`.  When the `off` keyword is specified as the only value, no plugins will be loaded.  `bundled` and plugin names can be mixed together, as the following examples suggest:  - `plugins = bundled,custom-auth,custom-log`   will include the bundled plugins plus two custom ones. - `plugins = custom-auth,custom-log` will   *only* include the `custom-auth` and `custom-log` plugins. - `plugins = off` will not include any plugins.  **Note:** Kong will not start if some plugins were previously configured (i.e. have rows in the database) and are not specified in this list. Before disabling a plugin, ensure all instances of it are removed before restarting Kong.  **Note:** Limiting the amount of available plugins can improve P99 latency when experiencing LRU churning in the database cache (i.e. when the configured `mem_cache_size`) is full."
+    "description": "Comma-separated list of plugins this node should load.\nBy default, only plugins bundled in official distributions\nare loaded via the `bundled` keyword.\n\nLoading a plugin does not enable it by default, but only\ninstructs Kong to load its source code and allows\nconfiguration via the various related Admin API endpoints.\n\nThe specified name(s) will be substituted as such in the\nLua namespace: `kong.plugins.{name}.*`.\n\nWhen the `off` keyword is specified as the only value,\nno plugins will be loaded.\n\n`bundled` and plugin names can be mixed together, as the\nfollowing examples suggest:\n\n- `plugins = bundled,custom-auth,custom-log`\n  will include the bundled plugins plus two custom ones.\n- `plugins = custom-auth,custom-log` will\n  *only* include the `custom-auth` and `custom-log` plugins.\n- `plugins = off` will not include any plugins.\n\n**Note:** Kong will not start if some plugins were previously\nconfigured (i.e. have rows in the database) and are not\nspecified in this list. Before disabling a plugin, ensure\nall instances of it are removed before restarting Kong.\n\n**Note:** Limiting the amount of available plugins can\nimprove P99 latency when experiencing LRU churning in the\ndatabase cache (i.e. when the configured `mem_cache_size`) is full.\n"
   },
   "dedicated_config_processing": {
     "defaultValue": "on",
-    "description": "Enables or disables a special worker process for configuration processing. This process increases memory usage a little bit while allowing to reduce latencies by moving some background tasks, such as CP/DP connection handling, to an additional worker process specific to handling these background tasks. Currently this has effect only on data planes."
+    "description": "Enables or disables a special worker\nprocess for configuration processing. This process\nincreases memory usage a little bit while\nallowing to reduce latencies by moving some\nbackground tasks, such as CP/DP connection\nhandling, to an additional worker process specific\nto handling these background tasks.\nCurrently this has effect only on data planes.\n"
   },
   "pluginserver_names": {
     "defaultValue": null,
-    "description": "Comma-separated list of names for pluginserver processes. The actual names are used for log messages and to relate the actual settings."
+    "description": "Comma-separated list of names for pluginserver\nprocesses. The actual names are used for\nlog messages and to relate the actual settings.\n"
   },
   "pluginserver_XXX_socket": {
     "defaultValue": "<prefix>/<XXX>.socket",
-    "description": "Path to the unix socket used by the <XXX> pluginserver."
+    "description": "Path to the unix socket\nused by the <XXX> pluginserver.\n"
   },
   "pluginserver_XXX_start_cmd": {
     "defaultValue": "/usr/local/bin/<XXX>",
-    "description": "Full command (including any needed arguments) to start the <XXX> pluginserver"
+    "description": "Full command (including\nany needed arguments) to\nstart the <XXX> pluginserver\n"
   },
   "pluginserver_XXX_query_cmd": {
     "defaultValue": "/usr/local/bin/query_<XXX>",
-    "description": "Full command to \"query\" the <XXX> pluginserver.  Should produce a JSON with the dump info of all plugins it manages"
+    "description": "Full command to \"query\" the\n<XXX> pluginserver.  Should\nproduce a JSON with the\ndump info of all plugins it\nmanages\n"
   },
   "port_maps": {
     "defaultValue": null,
-    "description": "With this configuration parameter, you can let Kong Gateway know the port from which the packets are forwarded to it. This is fairly common when running Kong in a containerized or virtualized environment. For example, `port_maps=80:8000, 443:8443` instructs Kong that the port 80 is mapped to 8000 (and the port 443 to 8443), where 8000 and 8443 are the ports that Kong is listening to.  This parameter helps Kong set a proper forwarded upstream HTTP request header or to get the proper forwarded port with the Kong PDK (in case other means determining it has failed). It changes routing by a destination port to route by a port from which packets are forwarded to Kong, and similarly it changes the default plugin log serializer to use the port according to this mapping instead of reporting the port Kong is listening to."
+    "description": "With this configuration parameter, you can\nlet Kong Gateway know the port from\nwhich the packets are forwarded to it. This\nis fairly common when running Kong in a\ncontainerized or virtualized environment.\nFor example, `port_maps=80:8000, 443:8443`\ninstructs Kong that the port 80 is mapped\nto 8000 (and the port 443 to 8443), where\n8000 and 8443 are the ports that Kong is\nlistening to.\n\nThis parameter helps Kong set a proper\nforwarded upstream HTTP request header or to\nget the proper forwarded port with the Kong PDK\n(in case other means determining it has\nfailed). It changes routing by a destination\nport to route by a port from which packets\nare forwarded to Kong, and similarly it\nchanges the default plugin log serializer to\nuse the port according to this mapping\ninstead of reporting the port Kong is\nlistening to.\n"
   },
   "anonymous_reports": {
     "defaultValue": "on",
-    "description": "Send anonymous usage data such as error stack traces to help improve Kong."
+    "description": "Send anonymous usage data such as error\nstack traces to help improve Kong.\n"
   },
   "proxy_server": {
     "defaultValue": null,
-    "description": "Proxy server defined as an encoded URL. Kong will only use this option if a component is explicitly configured to use a proxy."
+    "description": "Proxy server defined as an encoded URL. Kong will only\nuse this option if a component is explicitly configured\nto use a proxy.\n"
   },
   "proxy_server_ssl_verify": {
     "defaultValue": "off",
-    "description": "Toggles server certificate verification if `proxy_server` is in HTTPS. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+    "description": "Toggles server certificate verification if\n`proxy_server` is in HTTPS.\nSee the `lua_ssl_trusted_certificate`\nsetting to specify a certificate authority.\n"
   },
   "error_template_html": {
     "defaultValue": null,
-    "description": "Path to the custom html error template to override the default html kong error template.  The template may contain up to two `%s` placeholders. The first one will expand to the error message. The second one will expand to the request ID. Both placeholders are optional, but recommended. Adding more than two placeholders will result in a runtime error when trying to render the template: ``` <html>   <body>     <h1>My custom error template</h1>     <p>error: %s</p>     <p>request_id: %s</p>   </body> </html> ```"
+    "description": "Path to the custom html error template to\noverride the default html kong error\ntemplate.\n\nThe template may contain up to two `%s`\nplaceholders. The first one will expand to\nthe error message. The second one will\nexpand to the request ID. Both placeholders\nare optional, but recommended.\nAdding more than two placeholders will\nresult in a runtime error when trying to\nrender the template:\n```\n<html>\n  <body>\n    <h1>My custom error template</h1>\n    <p>error: %s</p>\n    <p>request_id: %s</p>\n  </body>\n</html>\n```\n"
   },
   "error_template_json": {
     "defaultValue": null,
-    "description": "Path to the custom json error template to override the default json kong error template.  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+    "description": "Path to the custom json error template to\noverride the default json kong error\ntemplate.\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n"
   },
   "error_template_xml": {
     "defaultValue": null,
-    "description": "Path to the custom xml error template to override the default xml kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+    "description": "Path to the custom xml error template to\noverride the default xml kong error template\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n"
   },
   "error_template_plain": {
     "defaultValue": null,
-    "description": "Path to the custom plain error template to override the default plain kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+    "description": "Path to the custom plain error template to\noverride the default plain kong error\ntemplate\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n"
   },
   "role": {
     "defaultValue": "traditional",
-    "description": "Use this setting to enable hybrid mode, This allows running some Kong nodes in a control plane role with a database and have them deliver configuration updates to other nodes running to DB-less running in a data plane role.  Valid values for this setting are:  - `traditional`: do not use hybrid mode. - `control_plane`: this node runs in a   control plane role. It can use a database   and will deliver configuration updates   to data plane nodes. - `data_plane`: this is a data plane node.   It runs DB-less and receives configuration   updates from a control plane node."
+    "description": "Use this setting to enable hybrid mode,\nThis allows running some Kong nodes in a\ncontrol plane role with a database and\nhave them deliver configuration updates\nto other nodes running to DB-less running in\na data plane role.\n\nValid values for this setting are:\n\n- `traditional`: do not use hybrid mode.\n- `control_plane`: this node runs in a\n  control plane role. It can use a database\n  and will deliver configuration updates\n  to data plane nodes.\n- `data_plane`: this is a data plane node.\n  It runs DB-less and receives configuration\n  updates from a control plane node.\n"
   },
   "cluster_mtls": {
     "defaultValue": "shared",
-    "description": "Sets the verification method between nodes of the cluster.  Valid values for this setting are:  - `shared`: use a shared certificate/key pair specified with   the `cluster_cert` and `cluster_cert_key` settings.   Note that CP and DP nodes must present the same certificate   to establish mTLS connections. - `pki`: use `cluster_ca_cert`, `cluster_server_name`, and   `cluster_cert` for verification. These are different   certificates for each DP node, but issued by a cluster-wide   common CA certificate: `cluster_ca_cert`. - `pki_check_cn`: similar to `pki` but additionally checks   for the common name of the data plane certificate specified   in `cluster_allowed_common_names`."
+    "description": "Sets the verification method between nodes of the cluster.\n\nValid values for this setting are:\n\n- `shared`: use a shared certificate/key pair specified with\n  the `cluster_cert` and `cluster_cert_key` settings.\n  Note that CP and DP nodes must present the same certificate\n  to establish mTLS connections.\n- `pki`: use `cluster_ca_cert`, `cluster_server_name`, and\n  `cluster_cert` for verification. These are different\n  certificates for each DP node, but issued by a cluster-wide\n  common CA certificate: `cluster_ca_cert`.\n- `pki_check_cn`: similar to `pki` but additionally checks\n  for the common name of the data plane certificate specified\n  in `cluster_allowed_common_names`.\n"
   },
   "cluster_cert": {
     "defaultValue": null,
-    "description": "Cluster certificate to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes. Under `pki` mode, it should be a different certificate for each DP node.  The certificate can be configured on this property with any of the following values: - absolute path to the certificate - certificate content - base64 encoded certificate content"
+    "description": "Cluster certificate to use when establishing secure communication\nbetween control and data plane nodes.\nYou can use the `kong hybrid` command to generate the certificate/key pair.\nUnder `shared` mode, it must be the same for all nodes.\nUnder `pki` mode, it should be a different certificate for each DP node.\n\nThe certificate can be configured on this property with any of the following values:\n- absolute path to the certificate\n- certificate content\n- base64 encoded certificate content\n"
   },
   "cluster_cert_key": {
     "defaultValue": null,
-    "description": "Cluster certificate key to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes.  Under `pki` mode it should be a different certificate for each DP node.  The certificate key can be configured on this property with either of the following values: - absolute path to the certificate key - certificate key content - base64 encoded certificate key content"
+    "description": "Cluster certificate key to\nuse when establishing secure communication\nbetween control and data plane nodes.\nYou can use the `kong hybrid` command to\ngenerate the certificate/key pair.\nUnder `shared` mode, it must be the same\nfor all nodes.  Under `pki` mode it\nshould be a different certificate for each\nDP node.\n\nThe certificate key can be configured on this\nproperty with either of the following values:\n- absolute path to the certificate key\n- certificate key content\n- base64 encoded certificate key content\n"
   },
   "cluster_ca_cert": {
     "defaultValue": null,
-    "description": "The trusted CA certificate file in PEM format used for: - Control plane to verify data plane's certificate - Data plane to verify control plane's certificate  Required on data plane if `cluster_mtls` is set to `pki`. If the control plane certificate is issued by a well-known CA, set `lua_ssl_trusted_certificate=system` on the data plane and leave this field empty.  This field is ignored if `cluster_mtls` is set to `shared`.  The certificate can be configured on this property with any of the following values: - absolute path to the certificate - certificate content - base64 encoded certificate content"
+    "description": "The trusted CA certificate file in PEM format used for:\n- Control plane to verify data plane's certificate\n- Data plane to verify control plane's certificate\n\nRequired on data plane if `cluster_mtls` is set to `pki`.\nIf the control plane certificate is issued by a well-known CA,\nset `lua_ssl_trusted_certificate=system` on the data plane and leave this field empty.\n\nThis field is ignored if `cluster_mtls` is set to `shared`.\n\nThe certificate can be configured on this property with any of the following values:\n- absolute path to the certificate\n- certificate content\n- base64 encoded certificate content\n"
   },
   "cluster_allowed_common_names": {
     "defaultValue": null,
-    "description": "The list of Common Names that are allowed to connect to control plane. Multiple entries may be supplied in a comma-separated string. When not set, only data plane with the same parent domain as the control plane cert is allowed to connect.  This field is ignored if `cluster_mtls` is not set to `pki_check_cn`."
+    "description": "The list of Common Names that are allowed to\nconnect to control plane. Multiple entries may\nbe supplied in a comma-separated string. When not\nset, only data plane with the same parent domain as the\ncontrol plane cert is allowed to connect.\n\nThis field is ignored if `cluster_mtls` is\nnot set to `pki_check_cn`.\n"
   },
   "cluster_server_name": {
     "defaultValue": null,
-    "description": "The server name used in the SNI of the TLS connection from a DP node to a CP node. Must match the Common Name (CN) or Subject Alternative Name (SAN) found in the CP certificate. If `cluster_mtls` is set to `shared`, this setting is ignored and `kong_clustering` is used."
+    "description": "The server name used in the SNI of the TLS\nconnection from a DP node to a CP node.\nMust match the Common Name (CN) or Subject\nAlternative Name (SAN) found in the CP\ncertificate.\nIf `cluster_mtls` is set to\n`shared`, this setting is ignored and\n`kong_clustering` is used.\n"
   },
   "cluster_control_plane": {
     "defaultValue": null,
-    "description": "To be used by data plane nodes only: address of the control plane node from which configuration updates will be fetched, in `host:port` format."
+    "description": "To be used by data plane nodes only:\naddress of the control plane node from which\nconfiguration updates will be fetched,\nin `host:port` format.\n"
   },
   "cluster_telemetry_endpoint": {
     "defaultValue": null,
-    "description": "To be used by data plane nodes only: telemetry address of the control plane node to which telemetry updates will be posted in `host:port` format."
+    "description": "To be used by data plane nodes only:\ntelemetry address of the control plane node\nto which telemetry updates will be posted\nin `host:port` format.\n"
   },
   "cluster_telemetry_server_name": {
     "defaultValue": null,
-    "description": "The SNI (Server Name Indication extension) to use for Vitals telemetry data."
+    "description": "The SNI (Server Name Indication extension)\nto use for Vitals telemetry data.\n"
   },
   "cluster_dp_labels": {
     "defaultValue": null,
-    "description": "Comma-separated list of labels for the data plane. Labels are key-value pairs that provide additional context information for each DP. Each label must be configured as a string in the format `key:value`.  Labels are only compatible with hybrid mode deployments with Kong Konnect (SaaS). This configuration doesn't work with self-hosted deployments.  Keys and values follow the AIP standards: https://kong-aip.netlify.app/aip/129/  Example: `deployment:mycloud,region:us-east-1`"
+    "description": "Comma-separated list of labels for the data plane.\nLabels are key-value pairs that provide additional\ncontext information for each DP.\nEach label must be configured as a string in the\nformat `key:value`.\n\nLabels are only compatible with hybrid mode\ndeployments with Kong Konnect (SaaS).\nThis configuration doesn't work with\nself-hosted deployments.\n\nKeys and values follow the AIP standards:\nhttps://kong-aip.netlify.app/aip/129/\n\nExample:\n`deployment:mycloud,region:us-east-1`\n"
   },
   "cluster_listen": {
     "defaultValue": "0.0.0.0:8005",
-    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster. This port is mTLS protected to ensure end-to-end security and integrity.  This setting has no effect if `role` is not set to `control_plane`.  Connections made to this endpoint are logged to the same location as Admin API access logs. See `admin_access_log` config description for more information."
+    "description": "Comma-separated list of addresses and ports on\nwhich the cluster control plane server should listen\nfor data plane connections.\nThe cluster communication port of the control plane\nmust be accessible by all the data planes\nwithin the same cluster. This port is mTLS protected\nto ensure end-to-end security and integrity.\n\nThis setting has no effect if `role` is not set to\n`control_plane`.\n\nConnections made to this endpoint are logged\nto the same location as Admin API access logs.\nSee `admin_access_log` config description for more\ninformation.\n"
   },
   "cluster_telemetry_listen": {
     "defaultValue": "0.0.0.0:8006",
-    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane telemetry connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster.  This setting has no effect if `role` is not set to `control_plane`."
+    "description": "Comma-separated list of addresses and ports on\nwhich the cluster control plane server should listen\nfor data plane telemetry connections.\nThe cluster communication port of the control plane\nmust be accessible by all the data planes\nwithin the same cluster.\n\nThis setting has no effect if `role` is not set to\n`control_plane`.\n"
   },
   "cluster_data_plane_purge_delay": {
     "defaultValue": "1209600",
-    "description": " How many seconds must pass from the time a DP node becomes offline to the time its entry gets removed from the database, as returned by the /clustering/data-planes Admin API endpoint.  This is to prevent the cluster data plane table from growing indefinitely. The default is set to 14 days. That is, if the CP hasn't heard from a DP for 14 days, its entry will be removed."
+    "description": "How many seconds must pass from the time a DP node\nbecomes offline to the time its entry gets removed\nfrom the database, as returned by the\n/clustering/data-planes Admin API endpoint.\n\nThis is to prevent the cluster data plane table from\ngrowing indefinitely. The default is set to\n14 days. That is, if the CP hasn't heard from a DP for\n14 days, its entry will be removed.\n"
   },
   "cluster_ocsp": {
     "defaultValue": "off",
-    "description": " Whether to check for revocation status of DP certificates using OCSP (Online Certificate Status Protocol). If enabled, the DP certificate should contain the \"Certificate Authority Information Access\" extension and the OCSP method with URI of which the OCSP responder can be reached from CP.  OCSP checks are only performed on CP nodes, it has no effect on DP nodes.  Valid values for this setting are:  - `on`: OCSP revocation check is enabled and DP   must pass the check in order to establish   connection with CP. - `off`: OCSP revocation check is disabled. - `optional`: OCSP revocation check will be attempted,   however, if the required extension is not   found inside DP-provided certificate   or communication with the OCSP responder   failed, then DP is still allowed through."
+    "description": "Whether to check for revocation status of DP\ncertificates using OCSP (Online Certificate Status Protocol).\nIf enabled, the DP certificate should contain the\n\"Certificate Authority Information Access\" extension\nand the OCSP method with URI of which the OCSP responder\ncan be reached from CP.\n\nOCSP checks are only performed on CP nodes, it has no\neffect on DP nodes.\n\nValid values for this setting are:\n\n- `on`: OCSP revocation check is enabled and DP\n  must pass the check in order to establish\n  connection with CP.\n- `off`: OCSP revocation check is disabled.\n- `optional`: OCSP revocation check will be attempted,\n  however, if the required extension is not\n  found inside DP-provided certificate\n  or communication with the OCSP responder\n  failed, then DP is still allowed through.\n"
   },
   "cluster_use_proxy": {
     "defaultValue": "off",
-    "description": " Whether to turn on HTTP CONNECT proxy support for hybrid mode connections. `proxy_server` will be used for hybrid mode connections if this option is turned on."
+    "description": "Whether to turn on HTTP CONNECT proxy support for\nhybrid mode connections. `proxy_server` will be used\nfor hybrid mode connections if this option is turned on.\n"
   },
   "cluster_max_payload": {
     "defaultValue": "16777216",
-    "description": " This sets the maximum compressed payload size allowed to be sent from CP to DP in hybrid mode. Default is 16MB - 16 * 1024 * 1024."
+    "description": "This sets the maximum compressed payload size allowed\nto be sent from CP to DP in hybrid mode.\nDefault is 16MB - 16 * 1024 * 1024.\n"
   },
   "proxy_listen": {
     "defaultValue": [
       "0.0.0.0:8000 reuseport backlog=16384",
       "0.0.0.0:8443 http2 ssl reuseport backlog=16384"
     ],
-    "description": " Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. The proxy server is the public entry point of Kong, which proxies traffic from your consumers to your backend services. This value accepts IPv4, IPv6, and hostnames.  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the `TCP_DEFER_ACCEPT` socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process,   allowing the kernel to better distribute incoming   connections between worker processes. - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small to prevent clients   seeing \"Connection refused\" errors when connecting to   a busy Kong instance.   **Note:** On Linux, this value is limited by the   setting of the `net.core.somaxconn` kernel parameter.   In order for the larger `backlog` set here to take   effect, it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` specifies whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections. - `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]`   configures the TCP keepalive behavior for the listening   socket. If this parameter is omitted, the operating   system’s settings will be in effect for the socket. If it   is set to the value `on`, the `SO_KEEPALIVE` option is turned   on for the socket. If it is set to the value `off`, the   `SO_KEEPALIVE` option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the `TCP_KEEPIDLE`,` TCP_KEEPINTVL`,   and `TCP_KEEPCNT` socket options.  This value can be set to `off`, thus disabling the HTTP/HTTPS proxy port for this node. If `stream_listen` is also set to `off`, this enables control plane mode for this node (in which all traffic proxying capabilities are disabled). This node can then be used only to configure a cluster of Kong nodes connected to the same datastore.  Example: `proxy_listen = 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`  See http://nginx.org/en/docs/http/ngx_http_core_module.html#listen for a description of the accepted formats for this and other `*_listen` values.  See https://www.nginx.com/resources/admin-guide/proxy-protocol/ for more details about the `proxy_protocol` parameter.  Not all `*_listen` values accept all formats specified in nginx's documentation."
+    "description": "Comma-separated list of addresses and ports on\nwhich the proxy server should listen for\nHTTP/HTTPS traffic.\nThe proxy server is the public entry point of Kong,\nwhich proxies traffic from your consumers to your\nbackend services. This value accepts IPv4, IPv6, and\nhostnames.\n\nSome suffixes can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's proxy server.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `deferred` instructs to use a deferred accept on\n  Linux (the `TCP_DEFER_ACCEPT` socket option).\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process,\n  allowing the kernel to better distribute incoming\n  connections between worker processes.\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small to prevent clients\n  seeing \"Connection refused\" errors when connecting to\n  a busy Kong instance.\n  **Note:** On Linux, this value is limited by the\n  setting of the `net.core.somaxconn` kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect, it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` specifies whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections.\n- `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]`\n  configures the TCP keepalive behavior for the listening\n  socket. If this parameter is omitted, the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value `on`, the `SO_KEEPALIVE` option is turned\n  on for the socket. If it is set to the value `off`, the\n  `SO_KEEPALIVE` option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the `TCP_KEEPIDLE`,` TCP_KEEPINTVL`,\n  and `TCP_KEEPCNT` socket options.\n\nThis value can be set to `off`, thus disabling\nthe HTTP/HTTPS proxy port for this node.\nIf `stream_listen` is also set to `off`, this enables\ncontrol plane mode for this node\n(in which all traffic proxying capabilities are\ndisabled). This node can then be used only to\nconfigure a cluster of Kong\nnodes connected to the same datastore.\n\nExample:\n`proxy_listen = 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`\n\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#listen\nfor a description of the accepted formats for this\nand other `*_listen` values.\n\nSee https://www.nginx.com/resources/admin-guide/proxy-protocol/\nfor more details about the `proxy_protocol`\nparameter.\n\nNot all `*_listen` values accept all formats\nspecified in nginx's documentation.\n"
   },
   "proxy_url": {
     "defaultValue": null,
-    "description": "Kong Proxy URL  The lookup, or balancer, address for your Kong Proxy nodes.  This value is commonly used in a microservices or service-mesh oriented architecture.  Accepted format (parts in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`  Examples:  - `<scheme>://<IP>:<PORT>` -> `proxy_url = http://127.0.0.1:8000` - `SSL <scheme>://<HOSTNAME>` -> `proxy_url = https://proxy.domain.tld` - `<scheme>://<HOSTNAME>/<PATH>` -> `proxy_url = http://dev-machine/dev-285`  By default, Kong Manager and Kong Portal will use the window request host and append the resolved listener port depending on the requested protocol."
+    "description": "Kong Proxy URL\n\nThe lookup, or balancer, address for your Kong Proxy nodes.\n\nThis value is commonly used in a microservices\nor service-mesh oriented architecture.\n\nAccepted format (parts in parentheses are optional):\n\n  `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`\n\nExamples:\n\n- `<scheme>://<IP>:<PORT>` -> `proxy_url = http://127.0.0.1:8000`\n- `SSL <scheme>://<HOSTNAME>` -> `proxy_url = https://proxy.domain.tld`\n- `<scheme>://<HOSTNAME>/<PATH>` -> `proxy_url = http://dev-machine/dev-285`\n\nBy default, Kong Manager and Kong Portal will use\nthe window request host and append the resolved\nlistener port depending on the requested protocol.\n"
   },
   "stream_listen": {
     "defaultValue": "off",
-    "description": " Comma-separated list of addresses and ports on which the stream mode should listen.  This value accepts IPv4, IPv6, and hostnames. Some suffixes can be specified for each pair: - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process,   allowing the kernel to better distribute incoming   connections between worker processes. - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small to prevent clients   seeing \"Connection refused\" errors when connecting to   a busy Kong instance.   **Note:** On Linux, this value is limited by the   setting of the `net.core.somaxconn` kernel parameter.   In order for the larger `backlog` set here to take   effect, it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` specifies whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the \"TCP keepalive\" behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value \"on\", the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value \"off\", the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the` TCP_KEEPIDLE`, `TCP_KEEPINTVL`,   and `TCP_KEEPCNT` socket options.  Examples:  ``` stream_listen = 127.0.0.1:7000 reuseport backlog=16384 stream_listen = 0.0.0.0:989 reuseport backlog=65536, 0.0.0.0:20 stream_listen = [::1]:1234 backlog=16384 ```  By default, this value is set to `off`, thus disabling the stream proxy port for this node."
+    "description": "Comma-separated list of addresses and ports on\nwhich the stream mode should listen.\n\nThis value accepts IPv4, IPv6, and hostnames.\nSome suffixes can be specified for each pair:\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process,\n  allowing the kernel to better distribute incoming\n  connections between worker processes.\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small to prevent clients\n  seeing \"Connection refused\" errors when connecting to\n  a busy Kong instance.\n  **Note:** On Linux, this value is limited by the\n  setting of the `net.core.somaxconn` kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect, it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` specifies whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections\n- so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]\n  configures the \"TCP keepalive\" behavior for the listening\n  socket. If this parameter is omitted then the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value \"on\", the SO_KEEPALIVE option is turned\n  on for the socket. If it is set to the value \"off\", the\n  SO_KEEPALIVE option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the` TCP_KEEPIDLE`, `TCP_KEEPINTVL`,\n  and `TCP_KEEPCNT` socket options.\n\nExamples:\n\n```\nstream_listen = 127.0.0.1:7000 reuseport backlog=16384\nstream_listen = 0.0.0.0:989 reuseport backlog=65536, 0.0.0.0:20\nstream_listen = [::1]:1234 backlog=16384\n```\n\nBy default, this value is set to `off`, thus\ndisabling the stream proxy port for this node.\n"
   },
   "admin_api_uri": {
     "defaultValue": null,
-    "description": "Deprecated: Use admin_gui_api_url instead"
+    "description": "Deprecated: Use admin_gui_api_url instead\n"
   },
   "admin_listen": {
     "defaultValue": [
       "127.0.0.1:8001 reuseport backlog=16384",
       "127.0.0.1:8444 http2 ssl reuseport backlog=16384"
     ],
-    "description": " Comma-separated list of addresses and ports on which the Admin interface should listen. The Admin interface is the API allowing you to configure and manage Kong. Access to this interface should be *restricted* to Kong administrators *only*. This value accepts IPv4, IPv6, and hostnames.  It is highly recommended to avoid exposing the Admin API to public interfaces, by using values such as `0.0.0.0:8001`  See https://docs.konghq.com/gateway/latest/production/running-kong/secure-admin-api/ for more information about how to secure your Admin API.  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the `TCP_DEFER_ACCEPT` socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process,   allowing the Kernel to better distribute incoming   connections between worker processes. - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small to prevent clients   seeing \"Connection refused\" errors when connecting to   a busy Kong instance.   **Note:** On Linux, this value is limited by the   setting of the `net.core.somaxconn` kernel parameter.   In order for the larger `backlog` set here to take   effect, it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` specifies whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections. - `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]`   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted, the operating   system’s settings will be in effect for the socket. If it   is set to the value `on`, the `SO_KEEPALIVE` option is turned   on for the socket. If it is set to the value `off`, the   `SO_KEEPALIVE` option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the `TCP_KEEPIDLE`, `TCP_KEEPINTVL`,   and `TCP_KEEPCNT` socket options.  This value can be set to `off`, thus disabling the Admin interface for this node, enabling a data plane mode (without configuration capabilities) pulling its configuration changes from the database.  Example: `admin_listen = 127.0.0.1:8444 http2 ssl`"
+    "description": "Comma-separated list of addresses and ports on\nwhich the Admin interface should listen.\nThe Admin interface is the API allowing you to\nconfigure and manage Kong.\nAccess to this interface should be *restricted*\nto Kong administrators *only*. This value accepts\nIPv4, IPv6, and hostnames.\n\nIt is highly recommended to avoid exposing the Admin API to public\ninterfaces, by using values such as `0.0.0.0:8001`\n\nSee https://docs.konghq.com/gateway/latest/production/running-kong/secure-admin-api/\nfor more information about how to secure your Admin API.\n\nSome suffixes can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's proxy server.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `deferred` instructs to use a deferred accept on\n  Linux (the `TCP_DEFER_ACCEPT` socket option).\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process,\n  allowing the Kernel to better distribute incoming\n  connections between worker processes.\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small to prevent clients\n  seeing \"Connection refused\" errors when connecting to\n  a busy Kong instance.\n  **Note:** On Linux, this value is limited by the\n  setting of the `net.core.somaxconn` kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect, it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` specifies whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections.\n- `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]`\n  configures the “TCP keepalive” behavior for the listening\n  socket. If this parameter is omitted, the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value `on`, the `SO_KEEPALIVE` option is turned\n  on for the socket. If it is set to the value `off`, the\n  `SO_KEEPALIVE` option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the `TCP_KEEPIDLE`, `TCP_KEEPINTVL`,\n  and `TCP_KEEPCNT` socket options.\n\nThis value can be set to `off`, thus disabling\nthe Admin interface for this node, enabling a\ndata plane mode (without configuration\ncapabilities) pulling its configuration changes\nfrom the database.\n\nExample: `admin_listen = 127.0.0.1:8444 http2 ssl`\n"
   },
   "status_listen": {
     "defaultValue": "127.0.0.1:8007 reuseport backlog=16384",
-    "description": " Comma-separated list of addresses and ports on which the Status API should listen. The Status API is a read-only endpoint allowing monitoring tools to retrieve metrics, healthiness, and other non-sensitive information of the current Kong node.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Status API server. - `proxy_protocol` will enable usage of the PROXY protocol.  This value can be set to `off`, disabling the Status API for this node.  Example: `status_listen = 0.0.0.0:8100 ssl http2`"
+    "description": "Comma-separated list of addresses and ports on\nwhich the Status API should listen.\nThe Status API is a read-only endpoint\nallowing monitoring tools to retrieve metrics,\nhealthiness, and other non-sensitive information\nof the current Kong node.\n\nThe following suffix can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's Status API server.\n- `proxy_protocol` will enable usage of the PROXY protocol.\n\nThis value can be set to `off`, disabling\nthe Status API for this node.\n\nExample: `status_listen = 0.0.0.0:8100 ssl http2`\n"
   },
   "debug_listen": {
     "defaultValue": "off",
-    "description": "Comma-separated list of addresses and ports on which the Debug API should listen.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Debug API server.  This value can be set to `off`, disabling the Debug API for this node.  Example: `debug_listen = 0.0.0.0:8200 ssl http2`"
+    "description": "Comma-separated list of addresses and ports on\nwhich the Debug API should listen.\n\nThe following suffix can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's Debug API server.\n\nThis value can be set to `off`, disabling\nthe Debug API for this node.\n\nExample: `debug_listen = 0.0.0.0:8200 ssl http2`\n"
   },
   "debug_listen_local": {
     "defaultValue": "on",
-    "description": "Expose `debug_listen` functionalities via a Unix domain socket under the Kong prefix.  This option allows local users to use `kong debug` command to invoke various debug functionalities without needing to enable `debug_listen` ahead of time."
+    "description": "Expose `debug_listen` functionalities via a\nUnix domain socket under the Kong prefix.\n\nThis option allows local users to use `kong debug` command\nto invoke various debug functionalities without needing to\nenable `debug_listen` ahead of time.\n"
   },
   "nginx_user": {
     "defaultValue": "kong kong",
-    "description": "Defines user and group credentials used by worker processes. If group is omitted, a group whose name equals that of user is used.  Example: `nginx_user = nginx www`  **Note**: If the `kong` user and the `kong` group are not available, the default user and group credentials will be `nobody nobody`."
+    "description": "Defines user and group credentials used by\nworker processes. If group is omitted, a\ngroup whose name equals that of user is\nused.\n\nExample: `nginx_user = nginx www`\n\n**Note**: If the `kong` user and the `kong`\ngroup are not available, the default user\nand group credentials will be\n`nobody nobody`.\n"
   },
   "nginx_worker_processes": {
     "defaultValue": "auto",
-    "description": "Determines the number of worker processes spawned by Nginx.  See http://nginx.org/en/docs/ngx_core_module.html#worker_processes for detailed usage of the equivalent Nginx directive and a description of accepted values."
+    "description": "Determines the number of worker processes\nspawned by Nginx.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_processes\nfor detailed usage of the equivalent Nginx\ndirective and a description of accepted\nvalues.\n"
   },
   "nginx_daemon": {
     "defaultValue": "on",
-    "description": "Determines whether Nginx will run as a daemon or as a foreground process. Mainly useful for development or when running Kong inside a Docker environment.  See http://nginx.org/en/docs/ngx_core_module.html#daemon."
+    "description": "Determines whether Nginx will run as a daemon\nor as a foreground process. Mainly useful\nfor development or when running Kong inside\na Docker environment.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#daemon.\n"
   },
   "mem_cache_size": {
     "defaultValue": "128m",
-    "description": "Size of each of the two shared memory caches for traditional mode database entities and runtime data, `kong_core_cache` and `kong_cache`.  The accepted units are `k` and `m`, with a minimum recommended value of a few MBs.  **Note**: As this option controls the size of two different cache zones, the total memory Kong uses to cache entities might be double this value. The created zones are shared by all worker processes and do not become larger when more workers are used."
+    "description": "Size of each of the two shared memory caches\nfor traditional mode database entities\nand runtime data, `kong_core_cache` and\n`kong_cache`.\n\nThe accepted units are `k` and `m`, with a minimum\nrecommended value of a few MBs.\n\n**Note**: As this option controls the size of two\ndifferent cache zones, the total memory Kong\nuses to cache entities might be double this value.\nThe created zones are shared by all worker\nprocesses and do not become larger when more\nworkers are used.\n"
   },
   "ssl_cipher_suite": {
     "defaultValue": "intermediate",
-    "description": "Defines the TLS ciphers served by Nginx. Accepted values are `modern`, `intermediate`, `old`, `fips` or `custom`. If you want to enable TLSv1.1, this value has to be `old`.  See https://wiki.mozilla.org/Security/Server_Side_TLS for detailed descriptions of each cipher suite. `fips` cipher suites are as described in https://wiki.openssl.org/index.php/FIPS_mode_and_TLS."
+    "description": "Defines the TLS ciphers served by Nginx.\nAccepted values are `modern`,\n`intermediate`, `old`, `fips` or `custom`.\nIf you want to enable TLSv1.1, this value has to be `old`.\n\nSee https://wiki.mozilla.org/Security/Server_Side_TLS\nfor detailed descriptions of each cipher\nsuite. `fips` cipher suites are as described in\nhttps://wiki.openssl.org/index.php/FIPS_mode_and_TLS.\n"
   },
   "ssl_ciphers": {
     "defaultValue": null,
-    "description": "Defines a custom list of TLS ciphers to be served by Nginx. This list must conform to the pattern defined by `openssl ciphers`. This value is ignored if `ssl_cipher_suite` is not `custom`. If you use DHE ciphers, you must also configure the `ssl_dhparam` parameter."
+    "description": "Defines a custom list of TLS ciphers to be\nserved by Nginx. This list must conform to\nthe pattern defined by `openssl ciphers`.\nThis value is ignored if `ssl_cipher_suite`\nis not `custom`.\nIf you use DHE ciphers, you must also\nconfigure the `ssl_dhparam` parameter.\n"
   },
   "ssl_protocols": {
     "defaultValue": "TLSv1.2 TLSv1.3",
-    "description": " Enables the specified protocols for client-side connections. The set of supported protocol versions also depends on the version of OpenSSL Kong was built with. This value is ignored if `ssl_cipher_suite` is not `custom`. If you want to enable TLSv1.1, you should set `ssl_cipher_suite` to `old`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols"
+    "description": "Enables the specified protocols for\nclient-side connections. The set of\nsupported protocol versions also depends\non the version of OpenSSL Kong was built\nwith. This value is ignored if\n`ssl_cipher_suite` is not `custom`.\nIf you want to enable TLSv1.1, you should\nset `ssl_cipher_suite` to `old`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols\n"
   },
   "ssl_prefer_server_ciphers": {
     "defaultValue": "on",
-    "description": "Specifies that server ciphers should be preferred over client ciphers when using the SSLv3 and TLS protocols. This value is ignored if `ssl_cipher_suite` is not `custom`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers"
+    "description": "Specifies that server ciphers should be\npreferred over client ciphers when using\nthe SSLv3 and TLS protocols. This value is\nignored if `ssl_cipher_suite` is not `custom`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers\n"
   },
   "ssl_dhparam": {
     "defaultValue": null,
-    "description": "Defines DH parameters for DHE ciphers from the predefined groups: `ffdhe2048`, `ffdhe3072`, `ffdhe4096`, `ffdhe6144`, `ffdhe8192`, from the absolute path to a parameters file, or directly from the parameters content.  This value is ignored if `ssl_cipher_suite` is `modern` or `intermediate`. The reason is that `modern` has no ciphers that need this, and `intermediate` uses `ffdhe2048`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam"
+    "description": "Defines DH parameters for DHE ciphers from the\npredefined groups: `ffdhe2048`, `ffdhe3072`,\n`ffdhe4096`, `ffdhe6144`, `ffdhe8192`,\nfrom the absolute path to a parameters file, or\ndirectly from the parameters content.\n\nThis value is ignored if `ssl_cipher_suite`\nis `modern` or `intermediate`. The reason is\nthat `modern` has no ciphers that need this,\nand `intermediate` uses `ffdhe2048`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam\n"
   },
   "ssl_session_tickets": {
     "defaultValue": "on",
-    "description": "Enables or disables session resumption through TLS session tickets. This has no impact when used with TLSv1.3.  Kong enables this by default for performance reasons, but it has security implications: https://github.com/mozilla/server-side-tls/issues/135  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets"
+    "description": "Enables or disables session resumption through\nTLS session tickets. This has no impact when\nused with TLSv1.3.\n\nKong enables this by default for performance\nreasons, but it has security implications:\nhttps://github.com/mozilla/server-side-tls/issues/135\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets\n"
   },
   "ssl_session_timeout": {
     "defaultValue": "1d",
-    "description": "Specifies a time during which a client may reuse the session parameters. See the rationale: https://github.com/mozilla/server-side-tls/issues/198  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout"
+    "description": "Specifies a time during which a client may\nreuse the session parameters. See the rationale:\nhttps://github.com/mozilla/server-side-tls/issues/198\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout\n"
   },
   "ssl_session_cache_size": {
     "defaultValue": "10m",
-    "description": "Sets the size of the caches that store session parameters.  See https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache"
+    "description": "Sets the size of the caches that store session parameters.\n\nSee https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache\n"
   },
   "ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `proxy_listen` values with TLS enabled.  If more than one certificate is specified, it can be used to provide alternate types of certificates (for example, ECC certificates) that will be served to clients that support them. Note that to properly serve using ECC certificates, it is recommended to also set `ssl_cipher_suite` to `modern` or `intermediate`.  Unless this option is explicitly set, Kong will auto-generate a pair of default certificates (RSA + ECC) the first time it starts up and use them for serving TLS requests.  Certificates can be configured on this property with any of the following values: - absolute path to the certificate - certificate content - base64 encoded certificate content"
+    "description": "Comma-separated list of certificates for `proxy_listen` values with TLS enabled.\n\nIf more than one certificate is specified, it can be used to provide\nalternate types of certificates (for example, ECC certificates) that will be served\nto clients that support them. Note that to properly serve using ECC certificates,\nit is recommended to also set `ssl_cipher_suite` to\n`modern` or `intermediate`.\n\nUnless this option is explicitly set, Kong will auto-generate\na pair of default certificates (RSA + ECC) the first time it starts up and use\nthem for serving TLS requests.\n\nCertificates can be configured on this property with any of the following\nvalues:\n- absolute path to the certificate\n- certificate content\n- base64 encoded certificate content\n"
   },
   "ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `proxy_listen` values with TLS enabled.  If more than one certificate was specified for `ssl_cert`, then this option should contain the corresponding key for all certificates provided in the same order.  Unless this option is explicitly set, Kong will auto-generate a pair of default private keys (RSA + ECC) the first time it starts up and use them for serving TLS requests.  Keys can be configured on this property with any of the following values: - absolute path to the certificate key - certificate key content - base64 encoded certificate key content"
+    "description": "Comma-separated list of keys for `proxy_listen` values with TLS enabled.\n\nIf more than one certificate was specified for `ssl_cert`, then this\noption should contain the corresponding key for all certificates\nprovided in the same order.\n\nUnless this option is explicitly set, Kong will auto-generate\na pair of default private keys (RSA + ECC) the first time it starts up and use\nthem for serving TLS requests.\n\nKeys can be configured on this property with any of the following\nvalues:\n- absolute path to the certificate key\n- certificate key content\n- base64 encoded certificate key content\n"
   },
   "client_ssl": {
     "defaultValue": "off",
-    "description": "Determines if Nginx should attempt to send client-side TLS certificates and perform Mutual TLS Authentication with upstream service when proxying requests."
+    "description": "Determines if Nginx should attempt to send client-side\nTLS certificates and perform Mutual TLS Authentication\nwith upstream service when proxying requests.\n"
   },
   "client_ssl_cert": {
     "defaultValue": null,
-    "description": "If `client_ssl` is enabled, the client certificate for the `proxy_ssl_certificate` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate can be configured on this property with any of the following values: - absolute path to the certificate - certificate content - base64 encoded certificate content"
+    "description": "If `client_ssl` is enabled, the client certificate\nfor the `proxy_ssl_certificate` directive.\n\nThis value can be overwritten dynamically with the `client_certificate`\nattribute of the `Service` object.\n\nThe certificate can be configured on this property with any of the following\nvalues:\n- absolute path to the certificate\n- certificate content\n- base64 encoded certificate content\n"
   },
   "client_ssl_cert_key": {
     "defaultValue": null,
-    "description": "If `client_ssl` is enabled, the client TLS key for the `proxy_ssl_certificate_key` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate key can be configured on this property with any of the following values: - absolute path to the certificate key - certificate key content - base64 encoded certificate key content"
+    "description": "If `client_ssl` is enabled, the client TLS key\nfor the `proxy_ssl_certificate_key` directive.\n\nThis value can be overwritten dynamically with the `client_certificate`\nattribute of the `Service` object.\n\nThe certificate key can be configured on this property with any of the following\nvalues:\n- absolute path to the certificate key\n- certificate key content\n- base64 encoded certificate key content\n"
   },
   "admin_ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `admin_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+    "description": "Comma-separated list of certificates for `admin_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n"
   },
   "admin_ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `admin_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+    "description": "Comma-separated list of keys for `admin_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n"
   },
   "status_ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `status_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+    "description": "Comma-separated list of certificates for `status_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n"
   },
   "status_ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `status_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+    "description": "Comma-separated list of keys for `status_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n"
   },
   "debug_ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `debug_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+    "description": "Comma-separated list of certificates for `debug_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n"
   },
   "debug_ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `debug_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+    "description": "Comma-separated list of keys for `debug_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n"
   },
   "headers": {
     "defaultValue": [
@@ -327,311 +327,311 @@
       "latency_tokens",
       "X-Kong-Request-Id"
     ],
-    "description": " Comma-separated list of headers Kong should inject in client responses.  Accepted values are: - `Server`: Injects `Server: kong/x.y.z`   on Kong-produced responses (e.g., Admin   API, rejected requests from auth plugin). - `Via`: Injects `Via: kong/x.y.z` for   successfully proxied requests. - `X-Kong-Proxy-Latency`: Time taken   (in milliseconds) by Kong to process   a request and run all plugins before   proxying the request upstream. - `X-Kong-Response-Latency`: Time taken   (in milliseconds) by Kong to produce   a response in case of, e.g., a plugin   short-circuiting the request, or in   case of an error. - `X-Kong-Upstream-Latency`: Time taken   (in milliseconds) by the upstream   service to send response headers. - `X-Kong-Admin-Latency`: Time taken   (in milliseconds) by Kong to process   an Admin API request. - `X-Kong-Upstream-Status`: The HTTP status   code returned by the upstream service.   This is particularly useful for clients to   distinguish upstream statuses if the   response is rewritten by a plugin. - `X-Kong-Request-Id`: Unique identifier of   the request. - `server_tokens`: Same as specifying both   `Server` and `Via`. - `latency_tokens`: Same as specifying   `X-Kong-Proxy-Latency`,   `X-Kong-Response-Latency`,   `X-Kong-Admin-Latency`, and   `X-Kong-Upstream-Latency`.  In addition to these, this value can be set to `off`, which prevents Kong from injecting any of the above headers. Note that this does not prevent plugins from injecting headers of their own.  Example: `headers = via, latency_tokens`"
+    "description": "Comma-separated list of headers Kong should\ninject in client responses.\n\nAccepted values are:\n- `Server`: Injects `Server: kong/x.y.z`\n  on Kong-produced responses (e.g., Admin\n  API, rejected requests from auth plugin).\n- `Via`: Injects `Via: kong/x.y.z` for\n  successfully proxied requests.\n- `X-Kong-Proxy-Latency`: Time taken\n  (in milliseconds) by Kong to process\n  a request and run all plugins before\n  proxying the request upstream.\n- `X-Kong-Response-Latency`: Time taken\n  (in milliseconds) by Kong to produce\n  a response in case of, e.g., a plugin\n  short-circuiting the request, or in\n  case of an error.\n- `X-Kong-Upstream-Latency`: Time taken\n  (in milliseconds) by the upstream\n  service to send response headers.\n- `X-Kong-Admin-Latency`: Time taken\n  (in milliseconds) by Kong to process\n  an Admin API request.\n- `X-Kong-Upstream-Status`: The HTTP status\n  code returned by the upstream service.\n  This is particularly useful for clients to\n  distinguish upstream statuses if the\n  response is rewritten by a plugin.\n- `X-Kong-Request-Id`: Unique identifier of\n  the request.\n- `server_tokens`: Same as specifying both\n  `Server` and `Via`.\n- `latency_tokens`: Same as specifying\n  `X-Kong-Proxy-Latency`,\n  `X-Kong-Response-Latency`,\n  `X-Kong-Admin-Latency`, and\n  `X-Kong-Upstream-Latency`.\n\nIn addition to these, this value can be set\nto `off`, which prevents Kong from injecting\nany of the above headers. Note that this\ndoes not prevent plugins from injecting\nheaders of their own.\n\nExample: `headers = via, latency_tokens`\n"
   },
   "headers_upstream": {
     "defaultValue": "X-Kong-Request-Id",
-    "description": " Comma-separated list of headers Kong should inject in requests to upstream.  At this time, the only accepted value is: - `X-Kong-Request-Id`: Unique identifier of   the request.  In addition, this value can be set to `off`, which prevents Kong from injecting the above header. Note that this does not prevent plugins from injecting headers of their own."
+    "description": "Comma-separated list of headers Kong should\ninject in requests to upstream.\n\nAt this time, the only accepted value is:\n- `X-Kong-Request-Id`: Unique identifier of\n  the request.\n\nIn addition, this value can be set\nto `off`, which prevents Kong from injecting\nthe above header. Note that this\ndoes not prevent plugins from injecting\nheaders of their own.\n"
   },
   "trusted_ips": {
     "defaultValue": null,
-    "description": "Defines trusted IP address blocks that are known to send correct `X-Forwarded-*` headers. Requests from trusted IPs make Kong forward their `X-Forwarded-*` headers upstream. Non-trusted requests make Kong insert its own `X-Forwarded-*` headers.  This property also sets the `set_real_ip_from` directive(s) in the Nginx configuration. It accepts the same type of values (CIDR blocks) but as a comma-separated list.  To trust *all* IPs, set this value to `0.0.0.0/0,::/0`.  If the special value `unix:` is specified, all UNIX-domain sockets will be trusted.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from for examples of accepted values."
+    "description": "Defines trusted IP address blocks that are\nknown to send correct `X-Forwarded-*`\nheaders.\nRequests from trusted IPs make Kong forward\ntheir `X-Forwarded-*` headers upstream.\nNon-trusted requests make Kong insert its\nown `X-Forwarded-*` headers.\n\nThis property also sets the\n`set_real_ip_from` directive(s) in the Nginx\nconfiguration. It accepts the same type of\nvalues (CIDR blocks) but as a\ncomma-separated list.\n\nTo trust *all* IPs, set this value to\n`0.0.0.0/0,::/0`.\n\nIf the special value `unix:` is specified,\nall UNIX-domain sockets will be trusted.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from\nfor examples of accepted values.\n"
   },
   "real_ip_header": {
     "defaultValue": "X-Real-IP",
-    "description": "Defines the request header field whose value will be used to replace the client address. This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  If this value receives `proxy_protocol`:  - at least one of the `proxy_listen` entries   must have the `proxy_protocol` flag   enabled. - the `proxy_protocol` parameter will be   appended to the `listen` directive of the   Nginx template.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header for a description of this directive."
+    "description": "Defines the request header field whose value\nwill be used to replace the client address.\nThis value sets the `ngx_http_realip_module`\ndirective of the same name in the Nginx\nconfiguration.\n\nIf this value receives `proxy_protocol`:\n\n- at least one of the `proxy_listen` entries\n  must have the `proxy_protocol` flag\n  enabled.\n- the `proxy_protocol` parameter will be\n  appended to the `listen` directive of the\n  Nginx template.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header\nfor a description of this directive.\n"
   },
   "real_ip_recursive": {
     "defaultValue": "off",
-    "description": "This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive for a description of this directive."
+    "description": "This value sets the `ngx_http_realip_module`\ndirective of the same name in the Nginx\nconfiguration.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive\nfor a description of this directive.\n"
   },
   "error_default_type": {
     "defaultValue": "text/plain",
-    "description": "Default MIME type to use when the request `Accept` header is missing and Nginx is returning an error for the request. Accepted values are `text/plain`, `text/html`, `application/json`, and `application/xml`."
+    "description": "Default MIME type to use when the request\n`Accept` header is missing and Nginx\nis returning an error for the request.\nAccepted values are `text/plain`,\n`text/html`, `application/json`, and\n`application/xml`.\n"
   },
   "upstream_keepalive_pool_size": {
     "defaultValue": "512",
-    "description": "Sets the default size of the upstream keepalive connection pools. Upstream keepalive connection pools are segmented by the `dst ip/dst port/SNI` attributes of a connection. A value of `0` will disable upstream keepalive connections by default, forcing each upstream request to open a new connection."
+    "description": "Sets the default size of the upstream\nkeepalive connection pools.\nUpstream keepalive connection pools\nare segmented by the `dst ip/dst\nport/SNI` attributes of a connection.\nA value of `0` will disable upstream\nkeepalive connections by default, forcing\neach upstream request to open a new\nconnection.\n"
   },
   "upstream_keepalive_max_requests": {
     "defaultValue": "10000",
-    "description": "Sets the default maximum number of requests that can be proxied upstream through one keepalive connection. After the maximum number of requests is reached, the connection will be closed. A value of `0` will disable this behavior, and a keepalive connection can be used to proxy an indefinite number of requests."
+    "description": "Sets the default maximum number of\nrequests that can be proxied upstream\nthrough one keepalive connection.\nAfter the maximum number of requests\nis reached, the connection will be\nclosed.\nA value of `0` will disable this\nbehavior, and a keepalive connection\ncan be used to proxy an indefinite\nnumber of requests.\n"
   },
   "upstream_keepalive_idle_timeout": {
     "defaultValue": "60",
-    "description": "Sets the default timeout (in seconds) for which an upstream keepalive connection should be kept open. When the timeout is reached while the connection has not been reused, it will be closed. A value of `0` will disable this behavior, and an idle keepalive connection may be kept open indefinitely."
+    "description": "Sets the default timeout (in seconds)\nfor which an upstream keepalive\nconnection should be kept open. When\nthe timeout is reached while the\nconnection has not been reused, it\nwill be closed.\nA value of `0` will disable this\nbehavior, and an idle keepalive\nconnection may be kept open\nindefinitely.\n"
   },
   "allow_debug_header": {
     "defaultValue": "off",
-    "description": "Enable the `Kong-Debug` header function. If it is `on`, Kong will add `Kong-Route-Id`, `Kong-Route-Name`, `Kong-Service-Id`, and `Kong-Service-Name` debug headers to the response when the client request header `Kong-Debug: 1` is present."
+    "description": "Enable the `Kong-Debug` header function.\nIf it is `on`, Kong will add\n`Kong-Route-Id`, `Kong-Route-Name`, `Kong-Service-Id`,\nand `Kong-Service-Name` debug headers to the response when\nthe client request header `Kong-Debug: 1` is present.\n"
   },
   "nginx_main_worker_rlimit_nofile": {
     "defaultValue": "auto",
-    "description": " Changes the limit on the maximum number of open files for worker processes.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile"
+    "description": "Changes the limit on the maximum number of open files\nfor worker processes.\n\nThe special and default value of `auto` sets this\nvalue to `ulimit -n` with the upper bound limited to\n16384 as a measure to protect against excess memory use,\nand the lower bound of 1024 as a good default.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile\n"
   },
   "nginx_events_worker_connections": {
     "defaultValue": "auto",
-    "description": " Sets the maximum number of simultaneous connections that can be opened by a worker process.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_connections"
+    "description": "Sets the maximum number of simultaneous\nconnections that can be opened by a worker process.\n\nThe special and default value of `auto` sets this\nvalue to `ulimit -n` with the upper bound limited to\n16384 as a measure to protect against excess memory use,\nand the lower bound of 1024 as a good default.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_connections\n"
   },
   "nginx_http_client_header_buffer_size": {
     "defaultValue": "1k",
-    "description": "Sets buffer size for reading the client request headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size"
+    "description": "Sets buffer size for reading the\nclient request headers.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size\n"
   },
   "nginx_http_large_client_header_buffers": {
     "defaultValue": "4 8k",
-    "description": "Sets the maximum number and size of buffers used for reading large client request headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers"
+    "description": "Sets the maximum number and\nsize of buffers used for\nreading large client\nrequest headers.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers\n"
   },
   "nginx_http_client_max_body_size": {
     "defaultValue": "0",
-    "description": "Defines the maximum request body size allowed by requests proxied by Kong, specified in the Content-Length request header. If a request exceeds this limit, Kong will respond with a 413 (Request Entity Too Large). Setting this value to 0 disables checking the request body size. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size"
+    "description": "Defines the maximum request body size\nallowed by requests proxied by Kong,\nspecified in the Content-Length request\nheader. If a request exceeds this\nlimit, Kong will respond with a 413\n(Request Entity Too Large). Setting\nthis value to 0 disables checking the\nrequest body size.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size\n"
   },
   "nginx_admin_client_max_body_size": {
     "defaultValue": "10m",
-    "description": "Defines the maximum request body size for Admin API."
+    "description": "Defines the maximum request body size for\nAdmin API.\n"
   },
   "nginx_http_charset": {
     "defaultValue": "UTF-8",
-    "description": "Adds the specified charset to the \"Content-Type\" response header field. If this charset is different from the charset specified in the `source_charset` directive, a conversion is performed.  The parameter `off` cancels the addition of charset to the \"Content-Type\" response header field. See http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset"
+    "description": "Adds the specified charset to the \"Content-Type\"\nresponse header field. If this charset is different\nfrom the charset specified in the `source_charset`\ndirective, a conversion is performed.\n\nThe parameter `off` cancels the addition of\ncharset to the \"Content-Type\" response header field.\nSee http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset\n"
   },
   "nginx_http_client_body_buffer_size": {
     "defaultValue": "8k",
-    "description": "Defines the buffer size for reading the request body. If the client request body is larger than this value, the body will be buffered to disk. Note that when the body is buffered to disk, Kong plugins that access or manipulate the request body may not work, so it is advisable to set this value as high as possible (e.g., set it as high as `client_max_body_size` to force request bodies to be kept in memory). Do note that high-concurrency environments will require significant memory allocations to process many concurrent large request bodies. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size"
+    "description": "Defines the buffer size for reading\nthe request body. If the client\nrequest body is larger than this\nvalue, the body will be buffered to\ndisk. Note that when the body is\nbuffered to disk, Kong plugins that\naccess or manipulate the request\nbody may not work, so it is\nadvisable to set this value as high\nas possible (e.g., set it as high\nas `client_max_body_size` to force\nrequest bodies to be kept in\nmemory). Do note that\nhigh-concurrency environments will\nrequire significant memory\nallocations to process many\nconcurrent large request bodies.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size\n"
   },
   "nginx_admin_client_body_buffer_size": {
     "defaultValue": "10m",
-    "description": "Defines the buffer size for reading the request body on Admin API."
+    "description": "Defines the buffer size for reading\nthe request body on Admin API.\n"
   },
   "nginx_http_lua_regex_match_limit": {
     "defaultValue": "100000",
-    "description": "Global `MATCH_LIMIT` for PCRE regex matching. The default of `100000` should ensure at worst any regex Kong executes could finish within roughly 2 seconds."
+    "description": "Global `MATCH_LIMIT` for PCRE\nregex matching. The default of `100000` should ensure\nat worst any regex Kong executes could finish within\nroughly 2 seconds.\n"
   },
   "nginx_http_lua_regex_cache_max_entries": {
     "defaultValue": "8192",
-    "description": "Specifies the maximum number of entries allowed in the worker process level PCRE JIT compiled regex cache. It is recommended to set it to at least (number of regex paths * 2) to avoid high CPU usages if you manually specified `router_flavor` to `traditional`. `expressions` and `traditional_compat` router do not make use of the PCRE library and their behavior is unaffected by this setting."
+    "description": "Specifies the maximum number of entries allowed\nin the worker process level PCRE JIT compiled regex cache.\nIt is recommended to set it to at least (number of regex paths * 2)\nto avoid high CPU usages if you manually specified `router_flavor` to\n`traditional`. `expressions` and `traditional_compat` router do\nnot make use of the PCRE library and their behavior\nis unaffected by this setting.\n"
   },
   "nginx_http_keepalive_requests": {
     "defaultValue": "10000",
-    "description": "Sets the maximum number of client requests that can be served through one keep-alive connection. After the maximum number of requests are made, the connection is closed. Closing connections periodically is necessary to free per-connection memory allocations. Therefore, using too high a maximum number of requests could result in excessive memory usage and is not recommended. See: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests"
+    "description": "Sets the maximum number of client requests that can be served through one\nkeep-alive connection. After the maximum number of requests are made,\nthe connection is closed.\nClosing connections periodically is necessary to free per-connection\nmemory allocations. Therefore, using too high a maximum number of requests\ncould result in excessive memory usage and is not recommended.\nSee: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests\n"
   },
   "database": {
     "defaultValue": "postgres",
-    "description": "Determines the database (or no database) for this node Accepted values are `postgres` and `off`."
+    "description": "Determines the database (or no database) for\nthis node\nAccepted values are `postgres` and `off`.\n"
   },
   "pg_host": {
     "defaultValue": "127.0.0.1",
-    "description": "Host of the Postgres server."
+    "description": "Host of the Postgres server.\n"
   },
   "pg_port": {
     "defaultValue": "5432",
-    "description": "Port of the Postgres server."
+    "description": "Port of the Postgres server.\n"
   },
   "pg_timeout": {
     "defaultValue": "5000",
-    "description": "Defines the timeout (in ms), for connecting, reading and writing."
+    "description": "Defines the timeout (in ms), for connecting,\nreading and writing.\n"
   },
   "pg_user": {
     "defaultValue": "kong",
-    "description": "Postgres user."
+    "description": "Postgres user.\n"
   },
   "pg_password": {
     "defaultValue": null,
-    "description": "Postgres user's password."
+    "description": "Postgres user's password.\n"
   },
   "pg_iam_auth": {
     "defaultValue": "off",
-    "description": "Determines whether the AWS IAM database Authentication will be used. When switch to `on`, the username defined in `pg_user` will be used as the database account, and the database connection will be forced to using TLS. `pg_password` will not be used when the switch is `on`. Note that the corresponding IAM policy must be correct, otherwise connecting will fail."
+    "description": "Determines whether the AWS IAM database\nAuthentication will be used. When switch to\n`on`, the username defined in `pg_user` will\nbe used as the database account, and the\ndatabase connection will be forced to using\nTLS. `pg_password` will not be used when\nthe switch is `on`. Note that the corresponding\nIAM policy must be correct, otherwise connecting\nwill fail.\n"
   },
   "pg_iam_auth_assume_role_arn": {
     "defaultValue": null,
-    "description": "The target AWS IAM role ARN that will be assumed when using AWS IAM database authentication. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+    "description": "The target AWS IAM role ARN that will be\nassumed when using AWS IAM database\nauthentication. Typically this is used\nfor operating between multiple roles\nor cross-accounts.\nIf you are not using assume role\nyou should not specify this value.\n"
   },
   "pg_iam_auth_role_session_name": {
     "defaultValue": "KongPostgres",
-    "description": "The role session name used for role assuming in AWS IAM Database Authentication. The default value is `KongPostgres`."
+    "description": "The role session name used for role\nassuming in AWS IAM Database\nAuthentication. The default value is\n`KongPostgres`.\n"
   },
   "pg_iam_auth_sts_endpoint_url": {
     "defaultValue": null,
-    "description": "The custom STS endpoint URL used for role assuming in AWS IAM Database Authentication.  Note that this value will override the default STS endpoint URL(which should be `https://sts.amazonaws.com`, or `https://sts.<region>.amazonaws.com` if you have `AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).  If you are not using private VPC endpoint for STS service, you should not specify this value."
+    "description": "The custom STS endpoint URL used for role assuming\nin AWS IAM Database Authentication.\n\nNote that this value will override the default\nSTS endpoint URL(which should be\n`https://sts.amazonaws.com`, or\n`https://sts.<region>.amazonaws.com` if you have\n`AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).\n\nIf you are not using private VPC endpoint for STS\nservice, you should not specify this value.\n"
   },
   "pg_database": {
     "defaultValue": "kong",
-    "description": "The database name to connect to."
+    "description": "The database name to connect to.\n"
   },
   "pg_schema": {
     "defaultValue": null,
-    "description": "The database schema to use. If unspecified, Kong will respect the `search_path` value of your PostgreSQL instance."
+    "description": "The database schema to use. If unspecified,\nKong will respect the `search_path` value of\nyour PostgreSQL instance.\n"
   },
   "pg_ssl": {
     "defaultValue": "off",
-    "description": "Toggles client-server TLS connections between Kong and PostgreSQL. Because PostgreSQL uses the same port for TLS and non-TLS, this is only a hint. If the server does not support TLS, the established connection will be a plain one."
+    "description": "Toggles client-server TLS connections\nbetween Kong and PostgreSQL.\nBecause PostgreSQL uses the same port for TLS\nand non-TLS, this is only a hint. If the\nserver does not support TLS, the established\nconnection will be a plain one.\n"
   },
   "pg_ssl_version": {
     "defaultValue": "tlsv1_2",
-    "description": "When using ssl between Kong and PostgreSQL, the version of tls to use. Accepted values are `tlsv1_1`, `tlsv1_2`, `tlsv1_3`, or 'any'. When `any` is set, the client negotiates the highest version with the server which can't be lower than `tlsv1_1`."
+    "description": "When using ssl between Kong and PostgreSQL,\nthe version of tls to use. Accepted values are\n`tlsv1_1`, `tlsv1_2`, `tlsv1_3`, or 'any'. When\n`any` is set, the client negotiates the highest\nversion with the server which can't be lower\nthan `tlsv1_1`.\n"
   },
   "pg_ssl_required": {
     "defaultValue": "off",
-    "description": "When `pg_ssl` is on this determines if TLS must be used between Kong and PostgreSQL. It aborts the connection if the server does not support SSL connections."
+    "description": "When `pg_ssl` is on this determines if\nTLS must be used between Kong and PostgreSQL.\nIt aborts the connection if the server does\nnot support SSL connections.\n"
   },
   "pg_ssl_verify": {
     "defaultValue": "off",
-    "description": "Toggles server certificate verification if `pg_ssl` is enabled. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+    "description": "Toggles server certificate verification if\n`pg_ssl` is enabled.\nSee the `lua_ssl_trusted_certificate`\nsetting to specify a certificate authority.\n"
   },
   "pg_ssl_cert": {
     "defaultValue": null,
-    "description": "The absolute path to the PEM encoded client TLS certificate for the PostgreSQL connection. Mutual TLS authentication against PostgreSQL is only enabled if this value is set."
+    "description": "The absolute path to the PEM encoded client\nTLS certificate for the PostgreSQL connection.\nMutual TLS authentication against\nPostgreSQL is only enabled if this value is set.\n"
   },
   "pg_ssl_cert_key": {
     "defaultValue": null,
-    "description": "If `pg_ssl_cert` is set, the absolute path to the PEM encoded client TLS private key for the PostgreSQL connection."
+    "description": "If `pg_ssl_cert` is set, the absolute path to\nthe PEM encoded client TLS private key for the\nPostgreSQL connection.\n"
   },
   "pg_max_concurrent_queries": {
     "defaultValue": "0",
-    "description": "Sets the maximum number of concurrent queries that can be executing at any given time. This limit is enforced per worker process; the total number of concurrent queries for this node will be will be: `pg_max_concurrent_queries * nginx_worker_processes`.  The default value of 0 removes this concurrency limitation."
+    "description": "Sets the maximum number of concurrent queries\nthat can be executing at any given time. This\nlimit is enforced per worker process; the\ntotal number of concurrent queries for this\nnode will be will be:\n`pg_max_concurrent_queries * nginx_worker_processes`.\n\nThe default value of 0 removes this\nconcurrency limitation.\n"
   },
   "pg_semaphore_timeout": {
     "defaultValue": "60000",
-    "description": "Defines the timeout (in ms) after which PostgreSQL query semaphore resource acquisition attempts will fail. Such failures will generally result in the associated proxy or Admin API request failing with an HTTP 500 status code. Detailed discussion of this behavior is available in the online documentation."
+    "description": "Defines the timeout (in ms) after which\nPostgreSQL query semaphore resource\nacquisition attempts will fail. Such\nfailures will generally result in the\nassociated proxy or Admin API request\nfailing with an HTTP 500 status code.\nDetailed discussion of this behavior is\navailable in the online documentation.\n"
   },
   "pg_keepalive_timeout": {
     "defaultValue": null,
-    "description": "Specify the maximal idle timeout (in ms) for the postgres connections in the pool. If this value is set to 0 then the timeout interval is unlimited.  If not specified this value will be same as `lua_socket_keepalive_timeout`"
+    "description": "Specify the maximal idle timeout (in ms)\nfor the postgres connections in the pool.\nIf this value is set to 0 then the timeout interval\nis unlimited.\n\nIf not specified this value will be same as\n`lua_socket_keepalive_timeout`\n"
   },
   "pg_pool_size": {
     "defaultValue": null,
-    "description": "Specifies the size limit (in terms of connection count) for the Postgres server. Note that this connection pool is intended per Nginx worker rather than per Kong instance.  If not specified, the default value is the same as `lua_socket_pool_size`"
+    "description": "Specifies the size limit (in terms of connection\ncount) for the Postgres server.\nNote that this connection pool is intended\nper Nginx worker rather than per Kong instance.\n\nIf not specified, the default value is the same as\n`lua_socket_pool_size`\n"
   },
   "pg_backlog": {
     "defaultValue": null,
-    "description": "If specified, this value will limit the total number of open connections to the Postgres server to `pg_pool_size`. If the connection pool is full, subsequent connect operations will be inserted in a queue with size equal to this option's value.  If the number of queued connect operations reaches `pg_backlog`, exceeding connections will fail.  If not specified, then number of open connections to the Postgres server is not limited."
+    "description": "If specified, this value will limit the total\nnumber of open connections to the Postgres\nserver to `pg_pool_size`. If the connection\npool is full, subsequent connect operations\nwill be inserted in a queue with size equal\nto this option's value.\n\nIf the number of queued connect operations\nreaches `pg_backlog`, exceeding connections will fail.\n\nIf not specified, then number of open connections\nto the Postgres server is not limited.\n"
   },
   "pg_ro_host": {
     "defaultValue": null,
-    "description": "Same as `pg_host`, but for the read-only connection. **Note:** Refer to the documentation section above for detailed usage."
+    "description": "Same as `pg_host`, but for the\nread-only connection.\n**Note:** Refer to the documentation\nsection above for detailed usage.\n"
   },
   "pg_ro_port": {
     "defaultValue": "<pg_port>",
-    "description": "Same as `pg_port`, but for the read-only connection."
+    "description": "Same as `pg_port`, but for the\nread-only connection.\n"
   },
   "pg_ro_timeout": {
     "defaultValue": "<pg_timeout>",
-    "description": "Same as `pg_timeout`, but for the read-only connection."
+    "description": "Same as `pg_timeout`, but for the\nread-only connection.\n"
   },
   "pg_ro_user": {
     "defaultValue": "<pg_user>",
-    "description": "Same as `pg_user`, but for the read-only connection."
+    "description": "Same as `pg_user`, but for the\nread-only connection.\n"
   },
   "pg_ro_password": {
     "defaultValue": "<pg_password>",
-    "description": "Same as `pg_password`, but for the read-only connection."
+    "description": "Same as `pg_password`, but for the\nread-only connection.\n"
   },
   "pg_ro_iam_auth": {
     "defaultValue": "<pg_iam_auth>",
-    "description": "Same as `pg_iam_auth`, but for the read-only connection."
+    "description": "Same as `pg_iam_auth`, but for the\nread-only connection.\n"
   },
   "pg_ro_iam_auth_assume_role_arn": {
     "defaultValue": null,
-    "description": "Same as `pg_iam_auth_assume_role_arn', but for the read-only connection."
+    "description": "Same as `pg_iam_auth_assume_role_arn',\nbut for the read-only connection.\n"
   },
   "pg_ro_iam_auth_role_session_name": {
     "defaultValue": "KongPostgres",
-    "description": "Same as `pg_iam_auth_role_session_name`, but for the read-only connection."
+    "description": "Same as `pg_iam_auth_role_session_name`,\nbut for the read-only connection.\n"
   },
   "pg_ro_iam_auth_sts_endpoint_url": {
     "defaultValue": null,
-    "description": "Same as `pg_iam_auth_sts_endpoint_url`, but for the read-only connection."
+    "description": "Same as `pg_iam_auth_sts_endpoint_url`,\nbut for the read-only connection.\n"
   },
   "pg_ro_database": {
     "defaultValue": "<pg_database>",
-    "description": "Same as `pg_database`, but for the read-only connection."
+    "description": "Same as `pg_database`, but for the\nread-only connection.\n"
   },
   "pg_ro_schema": {
     "defaultValue": "<pg_schema>",
-    "description": "Same as `pg_schema`, but for the read-only connection."
+    "description": "Same as `pg_schema`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl": {
     "defaultValue": "<pg_ssl>",
-    "description": "Same as `pg_ssl`, but for the read-only connection."
+    "description": "Same as `pg_ssl`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl_required": {
     "defaultValue": "<pg_ssl_required>",
-    "description": " Same as `pg_ssl_required`, but for the read-only connection."
+    "description": "Same as `pg_ssl_required`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl_verify": {
     "defaultValue": "<pg_ssl_verify>",
-    "description": " Same as `pg_ssl_verify`, but for the read-only connection."
+    "description": "Same as `pg_ssl_verify`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl_version": {
     "defaultValue": "<pg_ssl_version>",
-    "description": " Same as `pg_ssl_version`, but for the read-only connection."
+    "description": "Same as `pg_ssl_version`, but for the\nread-only connection.\n"
   },
   "pg_ro_max_concurrent_queries": {
     "defaultValue": "<pg_max_concurrent_queries>",
-    "description": " Same as `pg_max_concurrent_queries`, but for the read-only connection. Note: read-only concurrency is not shared with the main (read-write) connection."
+    "description": "Same as `pg_max_concurrent_queries`, but for\nthe read-only connection.\nNote: read-only concurrency is not shared\nwith the main (read-write) connection.\n"
   },
   "pg_ro_semaphore_timeout": {
     "defaultValue": "<pg_semaphore_timeout>",
-    "description": " Same as `pg_semaphore_timeout`, but for the read-only connection."
+    "description": "Same as `pg_semaphore_timeout`, but for the\nread-only connection.\n"
   },
   "pg_ro_keepalive_timeout": {
     "defaultValue": "<pg_keepalive_timeout>",
-    "description": " Same as `pg_keepalive_timeout`, but for the read-only connection."
+    "description": "Same as `pg_keepalive_timeout`, but for the\nread-only connection.\n"
   },
   "pg_ro_pool_size": {
     "defaultValue": "<pg_pool_size>",
-    "description": " Same as `pg_pool_size`, but for the read-only connection."
+    "description": "Same as `pg_pool_size`, but for the\nread-only connection.\n"
   },
   "pg_ro_backlog": {
     "defaultValue": "<pg_backlog>",
-    "description": " Same as `pg_backlog`, but for the read-only connection."
+    "description": "Same as `pg_backlog`, but for the\nread-only connection.\n"
   },
   "declarative_config": {
     "defaultValue": null,
-    "description": "The path to the declarative configuration file which holds the specification of all entities (routes, services, consumers, etc.) to be used when the `database` is set to `off`.  Entities are stored in Kong's LMDB cache, so you must ensure that enough headroom is allocated to it via the `lmdb_map_size` property.  If the hybrid mode `role` is set to `data_plane` and there's no configuration cache file, this configuration is used before connecting to the control plane node as a user-controlled fallback."
+    "description": "The path to the declarative configuration\nfile which holds the specification of all\nentities (routes, services, consumers, etc.)\nto be used when the `database` is set to\n`off`.\n\nEntities are stored in Kong's LMDB cache,\nso you must ensure that enough headroom is\nallocated to it via the `lmdb_map_size`\nproperty.\n\nIf the hybrid mode `role` is set to `data_plane`\nand there's no configuration cache file,\nthis configuration is used before connecting\nto the control plane node as a user-controlled\nfallback.\n"
   },
   "declarative_config_string": {
     "defaultValue": null,
-    "description": "The declarative configuration as a string"
+    "description": "The declarative configuration as a string\n"
   },
   "lmdb_environment_path": {
     "defaultValue": "dbless.lmdb",
-    "description": "Directory where the LMDB database files used by DB-less and hybrid mode to store Kong configurations reside.  This path is relative under the Kong `prefix`."
+    "description": "Directory where the LMDB database files used by\nDB-less and hybrid mode to store Kong\nconfigurations reside.\n\nThis path is relative under the Kong `prefix`.\n"
   },
   "lmdb_map_size": {
     "defaultValue": "2048m",
-    "description": "Maximum size of the LMDB memory map, used to store the DB-less and hybrid mode configurations. Default is 2048m.  This config defines the limit of LMDB file size; the actual file size growth will be on-demand and proportional to the actual config size.  Note this value can be set very large, say a couple of GBs, to accommodate future database growth and Multi-Version Concurrency Control (MVCC) headroom needs. The file size of the LMDB database file should stabilize after a few config reloads/hybrid mode syncs, and the actual memory used by the LMDB database will be smaller than the file size due to dynamic swapping of database pages by the OS."
+    "description": "Maximum size of the LMDB memory map, used to store the\nDB-less and hybrid mode configurations. Default is 2048m.\n\nThis config defines the limit of LMDB file size; the\nactual file size growth will be on-demand and\nproportional to the actual config size.\n\nNote this value can be set very large, say a couple of GBs,\nto accommodate future database growth and\nMulti-Version Concurrency Control (MVCC) headroom needs.\nThe file size of the LMDB database file should stabilize\nafter a few config reloads/hybrid mode syncs, and the actual\nmemory used by the LMDB database will be smaller than\nthe file size due to dynamic swapping of database pages by\nthe OS.\n"
   },
   "db_update_frequency": {
     "defaultValue": "5",
-    "description": "Frequency (in seconds) at which to check for updated entities with the datastore.  When a node creates, updates, or deletes an entity via the Admin API, other nodes need to wait for the next poll (configured by this value) to eventually purge the old cached entity and start using the new one."
+    "description": "Frequency (in seconds) at which to check for\nupdated entities with the datastore.\n\nWhen a node creates, updates, or deletes an\nentity via the Admin API, other nodes need\nto wait for the next poll (configured by\nthis value) to eventually purge the old\ncached entity and start using the new one.\n"
   },
   "db_update_propagation": {
     "defaultValue": "0",
-    "description": "Time (in seconds) taken for an entity in the datastore to be propagated to replica nodes of another datacenter.  When set, this property will increase the time taken by Kong to propagate the change of an entity.  Single-datacenter setups or PostgreSQL servers should suffer no such delays, and this value can be safely set to 0. Postgres setups with read replicas should set this value to the maximum expected replication lag between the writer and reader instances."
+    "description": "Time (in seconds) taken for an entity in the\ndatastore to be propagated to replica nodes\nof another datacenter.\n\nWhen set, this property will increase the\ntime taken by Kong to propagate the change\nof an entity.\n\nSingle-datacenter setups or PostgreSQL\nservers should suffer no such delays, and\nthis value can be safely set to 0.\nPostgres setups with read replicas should\nset this value to the maximum expected replication\nlag between the writer and reader instances.\n"
   },
   "db_cache_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of an entity from the datastore when cached by this node.  Database misses (no entity) are also cached according to this setting if you do not configure `db_cache_neg_ttl`.  If set to 0 (default), such cached entities or misses never expire."
+    "description": "Time-to-live (in seconds) of an entity from\nthe datastore when cached by this node.\n\nDatabase misses (no entity) are also cached\naccording to this setting if you do not\nconfigure `db_cache_neg_ttl`.\n\nIf set to 0 (default), such cached entities\nor misses never expire.\n"
   },
   "db_cache_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a datastore miss (no entity).  If not specified (default), `db_cache_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a datastore\nmiss (no entity).\n\nIf not specified (default), `db_cache_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "db_resurrect_ttl": {
     "defaultValue": "30",
-    "description": "Time (in seconds) for which stale entities from the datastore should be resurrected when they cannot be refreshed (e.g., the datastore is unreachable). When this TTL expires, a new attempt to refresh the stale entities will be made."
+    "description": "Time (in seconds) for which stale entities\nfrom the datastore should be resurrected\nwhen they cannot be refreshed (e.g., the\ndatastore is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nentities will be made.\n"
   },
   "db_cache_warmup_entities": {
     "defaultValue": "services",
-    "description": " Entities to be pre-loaded from the datastore into the in-memory cache at Kong start-up. This speeds up the first access of endpoints that use the given entities.  When the `services` entity is configured for warmup, the DNS entries for values in its `host` attribute are pre-resolved asynchronously as well.  Cache size set in `mem_cache_size` should be set to a value large enough to hold all instances of the specified entities. If the size is insufficient, Kong will log a warning."
+    "description": "Entities to be pre-loaded from the datastore\ninto the in-memory cache at Kong start-up.\nThis speeds up the first access of endpoints\nthat use the given entities.\n\nWhen the `services` entity is configured\nfor warmup, the DNS entries for values in\nits `host` attribute are pre-resolved\nasynchronously as well.\n\nCache size set in `mem_cache_size` should\nbe set to a value large enough to hold all\ninstances of the specified entities.\nIf the size is insufficient, Kong will log\na warning.\n"
   },
   "dns_resolver": {
     "defaultValue": null,
-    "description": "Comma-separated list of nameservers, each entry in `ip[:port]` format to be used by Kong. If not specified, the nameservers in the local `resolv.conf` file will be used. Port defaults to 53 if omitted. Accepts both IPv4 and IPv6 addresses."
+    "description": "Comma-separated list of nameservers, each\nentry in `ip[:port]` format to be used by\nKong. If not specified, the nameservers in\nthe local `resolv.conf` file will be used.\nPort defaults to 53 if omitted. Accepts\nboth IPv4 and IPv6 addresses.\n"
   },
   "dns_hostsfile": {
     "defaultValue": "/etc/hosts",
-    "description": "The hosts file to use. This file is read once and its content is static in memory. To read the file again after modifying it, Kong must be reloaded."
+    "description": "The hosts file to use. This file is read\nonce and its content is static in memory.\nTo read the file again after modifying it,\nKong must be reloaded.\n"
   },
   "dns_order": {
     "defaultValue": [
@@ -640,497 +640,497 @@
       "A",
       "CNAME"
     ],
-    "description": "The order in which to resolve different record types. The `LAST` type means the type of the last successful lookup (for the specified name). The format is a (case insensitive) comma-separated list."
+    "description": "The order in which to resolve different\nrecord types. The `LAST` type means the\ntype of the last successful lookup (for the\nspecified name). The format is a (case\ninsensitive) comma-separated list.\n"
   },
   "dns_valid_ttl": {
     "defaultValue": null,
-    "description": "By default, DNS records are cached using the TTL value of a response. If this property receives a value (in seconds), it will override the TTL for all records."
+    "description": "By default, DNS records are cached using\nthe TTL value of a response. If this\nproperty receives a value (in seconds), it\nwill override the TTL for all records.\n"
   },
   "dns_stale_ttl": {
     "defaultValue": "3600",
-    "description": "Defines, in seconds, how long a record will remain in cache past its TTL. This value will be used while the new DNS record is fetched in the background. Stale data will be used from expiry of a record until either the refresh query completes, or the `dns_stale_ttl` number of seconds have passed. This configuration enables Kong to be more resilient during resolver downtime."
+    "description": "Defines, in seconds, how long a record will\nremain in cache past its TTL. This value\nwill be used while the new DNS record is\nfetched in the background.\nStale data will be used from expiry of a\nrecord until either the refresh query\ncompletes, or the `dns_stale_ttl` number of\nseconds have passed.\nThis configuration enables Kong to be more\nresilient during resolver downtime.\n"
   },
   "dns_cache_size": {
     "defaultValue": "10000",
-    "description": "Defines the maximum allowed number of DNS records stored in memory cache. Least recently used DNS records are discarded from cache if it is full. Both errors and data are cached; therefore, a single name query can easily take up 10-15 slots."
+    "description": "Defines the maximum allowed number of\nDNS records stored in memory cache.\nLeast recently used DNS records are discarded\nfrom cache if it is full. Both errors and\ndata are cached; therefore, a single name query\ncan easily take up 10-15 slots.\n"
   },
   "dns_not_found_ttl": {
     "defaultValue": "30",
-    "description": "TTL in seconds for empty DNS responses and \"(3) name error\" responses."
+    "description": "TTL in seconds for empty DNS responses and\n\"(3) name error\" responses.\n"
   },
   "dns_error_ttl": {
     "defaultValue": "1",
-    "description": "TTL in seconds for error responses."
+    "description": "TTL in seconds for error responses.\n"
   },
   "dns_no_sync": {
     "defaultValue": "off",
-    "description": "If enabled, then upon a cache-miss every request will trigger its own DNS query. When disabled, multiple requests for the same name/type will be synchronized to a single query."
+    "description": "If enabled, then upon a cache-miss every\nrequest will trigger its own DNS query.\nWhen disabled, multiple requests for the\nsame name/type will be synchronized to a\nsingle query.\n"
   },
   "new_dns_client": {
     "defaultValue": "off",
-    "description": "Enable or disable the new DNS resolver"
+    "description": "Enable or disable the new DNS resolver\n"
   },
   "resolver_address": {
     "defaultValue": "<name servers parsed from resolv.conf>",
-    "description": " Comma-separated list of nameservers, each entry in `ip[:port]` format to be used by Kong. If not specified, the nameservers in the local `resolv.conf` file will be used. Port defaults to 53 if omitted. Accepts both IPv4 and IPv6 addresses.  Examples:  ``` resolver_address = 8.8.8.8 resolver_address = 8.8.8.8, [::1] resolver_address = 8.8.8.8:53, [::1]:53 ```"
+    "description": "Comma-separated list of nameservers, each\nentry in `ip[:port]` format to be used by\nKong. If not specified, the nameservers in\nthe local `resolv.conf` file will be used.\nPort defaults to 53 if omitted. Accepts\nboth IPv4 and IPv6 addresses.\n\nExamples:\n\n```\nresolver_address = 8.8.8.8\nresolver_address = 8.8.8.8, [::1]\nresolver_address = 8.8.8.8:53, [::1]:53\n```\n"
   },
   "resolver_hosts_file": {
     "defaultValue": "/etc/hosts",
-    "description": " The hosts file to use. This file is read once and its content is static in memory. To read the file again after modifying it, Kong must be reloaded."
+    "description": "The hosts file to use. This file is read\nonce and its content is static in memory.\nTo read the file again after modifying it,\nKong must be reloaded.\n"
   },
   "resolver_family": {
     "defaultValue": [
       "A",
       "SRV"
     ],
-    "description": "The supported query types.  For a domain name, Kong will only query either IP addresses (A or AAAA) or SRV records, but not both.  It will query SRV records only when the domain matches the \"_<proto>._<service>.<name>\" format, for example, \"_ldap._tcp.example.com\".  For IP addresses (A or AAAA) resolution, it first attempts IPv4 (A) and then queries IPv6 (AAAA)."
+    "description": "The supported query types.\n\nFor a domain name, Kong will only query\neither IP addresses (A or AAAA) or SRV\nrecords, but not both.\n\nIt will query SRV records only when the\ndomain matches the\n\"_<proto>._<service>.<name>\" format, for\nexample, \"_ldap._tcp.example.com\".\n\nFor IP addresses (A or AAAA) resolution, it\nfirst attempts IPv4 (A) and then queries\nIPv6 (AAAA).\n"
   },
   "resolver_valid_ttl": {
     "defaultValue": "<TTL from responses>",
-    "description": " By default, DNS records are cached using the TTL value of a response. This optional parameter (in seconds) allows overriding it."
+    "description": "By default, DNS records are cached using\nthe TTL value of a response. This optional\nparameter (in seconds) allows overriding it.\n"
   },
   "resolver_error_ttl": {
     "defaultValue": "1",
-    "description": "TTL in seconds for error responses and empty responses."
+    "description": "TTL in seconds for error responses and empty\nresponses.\n"
   },
   "resolver_stale_ttl": {
     "defaultValue": "3600",
-    "description": "Defines, in seconds, how long a record will remain in cache past its TTL. This value will be used while the new DNS record is fetched in the background.  Stale data will be used from expiry of a record until either the refresh query completes, or the `resolver_stale_ttl` number of seconds have passed.  This configuration enables Kong to be more resilient during the DNS server downtime."
+    "description": "Defines, in seconds, how long a record will\nremain in cache past its TTL. This value\nwill be used while the new DNS record is\nfetched in the background.\n\nStale data will be used from expiry of a\nrecord until either the refresh query\ncompletes, or the `resolver_stale_ttl` number\nof seconds have passed.\n\nThis configuration enables Kong to be more\nresilient during the DNS server downtime.\n"
   },
   "resolver_lru_cache_size": {
     "defaultValue": "10000",
-    "description": "The DNS client uses a two-layer cache system: L1 - worker-level LRU Lua VM cache L2 - across-workers shared memory cache  This value specifies the maximum allowed number of DNS responses stored in the L1 LRU lua VM cache.  A single name query can easily take up 1~10 slots, depending on attempted query types and extended domains from /etc/resolv.conf options `domain` or `search`."
+    "description": "The DNS client uses a two-layer cache system:\nL1 - worker-level LRU Lua VM cache\nL2 - across-workers shared memory cache\n\nThis value specifies the maximum allowed\nnumber of DNS responses stored in the L1 LRU\nlua VM cache.\n\nA single name query can easily take up 1~10\nslots, depending on attempted query types and\nextended domains from /etc/resolv.conf\noptions `domain` or `search`.\n"
   },
   "resolver_mem_cache_size": {
     "defaultValue": "5m",
-    "description": "This value specifies the size of the L2 shared memory cache for DNS responses, `kong_dns_cache`.  Accepted units are `k` and `m`, with a minimum recommended value of a few MBs.  5MB shared memory size could store ~20000 DNS responeses with single A record or ~10000 DNS responeses with 2~3 A records.  10MB shared memory size could store ~40000 DNS responeses with single A record or ~20000 DNS responeses with 2~3 A records."
+    "description": "This value specifies the size of the L2\nshared memory cache for DNS responses,\n`kong_dns_cache`.\n\nAccepted units are `k` and `m`, with a\nminimum recommended value of a few MBs.\n\n5MB shared memory size could store\n~20000 DNS responeses with single A record or\n~10000 DNS responeses with 2~3 A records.\n\n10MB shared memory size could store\n~40000 DNS responeses with single A record or\n~20000 DNS responeses with 2~3 A records.\n"
   },
   "vault_env_prefix": {
     "defaultValue": null,
-    "description": "Defines the environment variable vault's default prefix. For example if you have all your secrets stored in environment variables prefixed with `SECRETS_`, it can be configured here so that it isn't necessary to repeat them in Vault references."
+    "description": "Defines the environment variable vault's\ndefault prefix. For example if you have\nall your secrets stored in environment\nvariables prefixed with `SECRETS_`, it\ncan be configured here so that it isn't\nnecessary to repeat them in Vault\nreferences.\n"
   },
   "vault_aws_region": {
     "defaultValue": null,
-    "description": "The AWS region your vault is located in."
+    "description": "The AWS region your vault is located in.\n"
   },
   "vault_aws_endpoint_url": {
     "defaultValue": null,
-    "description": "The AWS SecretsManager service endpoint url. If not specified, the value used by vault will be the official AWS SecretsManager service url which is `https://secretsmanager.<region>.amazonaws.com` You can specify a complete URL(including the \"http/https\" scheme) to override the endpoint that vault will connect to."
+    "description": "The AWS SecretsManager service endpoint url.\nIf not specified, the value used by vault will\nbe the official AWS SecretsManager service url\nwhich is\n`https://secretsmanager.<region>.amazonaws.com`\nYou can specify a complete URL(including\nthe \"http/https\" scheme) to override the\nendpoint that vault will connect to.\n"
   },
   "vault_aws_assume_role_arn": {
     "defaultValue": null,
-    "description": "The target AWS IAM role ARN that will be assumed. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+    "description": "The target AWS IAM role ARN that will be\nassumed. Typically this is used for\noperating between multiple roles\nor cross-accounts.\nIf you are not using assume role\nyou should not specify this value.\n"
   },
   "vault_aws_role_session_name": {
     "defaultValue": "KongVault",
-    "description": "The role session name used for role assuming. The default value is `KongVault`."
+    "description": "The role session name used for role\nassuming. The default value is\n`KongVault`.\n"
   },
   "vault_aws_sts_endpoint_url": {
     "defaultValue": null,
-    "description": "The custom STS endpoint URL used for role assuming in AWS Vault.  Note that this value will override the default STS endpoint URL(which should be `https://sts.amazonaws.com`, or `https://sts.<region>.amazonaws.com` if you have `AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).  If you are not using private VPC endpoint for STS service, you should not specify this value."
+    "description": "The custom STS endpoint URL used for role assuming\nin AWS Vault.\n\nNote that this value will override the default\nSTS endpoint URL(which should be\n`https://sts.amazonaws.com`, or\n`https://sts.<region>.amazonaws.com` if you have\n`AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).\n\nIf you are not using private VPC endpoint for STS\nservice, you should not specify this value.\n"
   },
   "vault_aws_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the AWS vault when cached by this node.  AWS vault misses (no secret) are also cached according to this setting if you do not configure `vault_aws_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe AWS vault when cached by this node.\n\nAWS vault misses (no secret) are also cached\naccording to this setting if you do not\nconfigure `vault_aws_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_aws_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_aws_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a AWS vault\nmiss (no secret).\n\nIf not specified (default), `vault_aws_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_aws_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the AWS vault should be resurrected for when they cannot be refreshed (e.g., the AWS vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the AWS vault should be resurrected for\nwhen they cannot be refreshed (e.g., the\nAWS vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "vault_gcp_project_id": {
     "defaultValue": null,
-    "description": "The project ID from your Google API Console."
+    "description": "The project ID from your Google API Console.\n"
   },
   "vault_gcp_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the GCP vault when cached by this node.  GCP vault misses (no secret) are also cached according to this setting if you do not configure `vault_gcp_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe GCP vault when cached by this node.\n\nGCP vault misses (no secret) are also cached\naccording to this setting if you do not\nconfigure `vault_gcp_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_gcp_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_gcp_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a AWS vault\nmiss (no secret).\n\nIf not specified (default), `vault_gcp_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_gcp_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the GCP vault should be resurrected for when they cannot be refreshed (e.g., the GCP vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the GCP vault should be resurrected for\nwhen they cannot be refreshed (e.g., the\nGCP vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "vault_hcv_protocol": {
     "defaultValue": "http",
-    "description": "The protocol to connect with. Accepts one of `http` or `https`."
+    "description": "The protocol to connect with. Accepts one of\n`http` or `https`.\n"
   },
   "vault_hcv_host": {
     "defaultValue": "127.0.0.1",
-    "description": "The hostname of your HashiCorp vault."
+    "description": "The hostname of your HashiCorp vault.\n"
   },
   "vault_hcv_port": {
     "defaultValue": "8200",
-    "description": "The port number of your HashiCorp vault."
+    "description": "The port number of your HashiCorp vault.\n"
   },
   "vault_hcv_namespace": {
     "defaultValue": null,
-    "description": "Namespace for the HashiCorp Vault. Vault Enterprise requires a namespace to successfully connect to it."
+    "description": "Namespace for the HashiCorp Vault. Vault\nEnterprise requires a namespace to\nsuccessfully connect to it.\n"
   },
   "vault_hcv_mount": {
     "defaultValue": "secret",
-    "description": "The mount point."
+    "description": "The mount point.\n"
   },
   "vault_hcv_kv": {
     "defaultValue": "v1",
-    "description": "The secrets engine version. Accepts `v1` or `v2`."
+    "description": "The secrets engine version. Accepts `v1` or\n`v2`.\n"
   },
   "vault_hcv_token": {
     "defaultValue": null,
-    "description": "A token string."
+    "description": "A token string.\n"
   },
   "vault_hcv_auth_method": {
     "defaultValue": "token",
-    "description": "Defines the authentication mechanism when connecting to the Hashicorp Vault service. Accepted values are: `token`, `kubernetes` or `approle`."
+    "description": "Defines the authentication mechanism when\nconnecting to the Hashicorp Vault service.\nAccepted values are: `token`,\n`kubernetes` or `approle`.\n"
   },
   "vault_hcv_kube_role": {
     "defaultValue": null,
-    "description": "Defines the HashiCorp Vault role for the Kubernetes service account of the running pod. `vault_hcv_auth_method` must be set to `kubernetes` for this to activate."
+    "description": "Defines the HashiCorp Vault role for the\nKubernetes service account of the running\npod. `vault_hcv_auth_method` must be\nset to `kubernetes` for this to activate.\n"
   },
   "vault_hcv_kube_auth_path": {
     "defaultValue": "kubernetes",
-    "description": " Place where the Kubernetes auth method will be accessible: `/v1/auth/<vault_hcv_kube_auth_path>`"
+    "description": "Place where the Kubernetes auth method will be\naccessible: `/v1/auth/<vault_hcv_kube_auth_path>`\n"
   },
   "vault_hcv_kube_api_token_file": {
     "defaultValue": null,
-    "description": "Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+    "description": "Defines where the Kubernetes service account\ntoken should be read from the pod's\nfilesystem, if using a non-standard\ncontainer platform setup.\n"
   },
   "vault_hcv_approle_auth_path": {
     "defaultValue": "approle",
-    "description": " Place where the Approle auth method will be accessible: `/v1/auth/<vault_hcv_approle_auth_path>`"
+    "description": "Place where the Approle auth method will be\naccessible: `/v1/auth/<vault_hcv_approle_auth_path>`\n"
   },
   "vault_hcv_approle_role_id": {
     "defaultValue": null,
-    "description": "The Role ID of the Approle in HashiCorp Vault."
+    "description": "The Role ID of the Approle in HashiCorp Vault.\n"
   },
   "vault_hcv_approle_secret_id": {
     "defaultValue": null,
-    "description": "The Secret ID of the Approle in HashiCorp Vault."
+    "description": "The Secret ID of the Approle in HashiCorp Vault.\n"
   },
   "vault_hcv_approle_secret_id_file": {
     "defaultValue": null,
-    "description": "Defines where the Secret ID should be read from the pod's filesystem. This is usually used with HashiCorp Vault's response wrapping."
+    "description": "Defines where the Secret ID should be read from\nthe pod's filesystem. This is usually used with\nHashiCorp Vault's response wrapping.\n"
   },
   "vault_hcv_approle_response_wrapping": {
     "defaultValue": "false",
-    "description": "Defines whether the Secret ID read from configuration or file is actually a response-wrapping token instead of a real Secret ID."
+    "description": "Defines whether the Secret ID read from configuration\nor file is actually a response-wrapping token instead\nof a real Secret ID.\n"
   },
   "vault_hcv_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the HashiCorp vault when cached by this node.  HashiCorp vault misses (no secret) are also cached according to this setting if you do not configure `vault_hcv_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe HashiCorp vault when cached by this node.\n\nHashiCorp vault misses (no secret) are also\ncached according to this setting if you do not\nconfigure `vault_hcv_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_hcv_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a HashiCorp vault miss (no secret).  If not specified (default), `vault_hcv_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a HashiCorp vault\nmiss (no secret).\n\nIf not specified (default), `vault_hcv_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_hcv_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the HashiCorp vault should be resurrected for when they cannot be refreshed (e.g., the HashiCorp vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the HashiCorp vault should be resurrected\nfor when they cannot be refreshed (e.g., the\nHashiCorp vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "vault_azure_vault_uri": {
     "defaultValue": null,
-    "description": "The URI the vault is reachable from."
+    "description": "The URI the vault is reachable from.\n"
   },
   "vault_azure_client_id": {
     "defaultValue": null,
-    "description": "The client ID from your registered Application. Visit your Azure Dashboard and select *App Registrations* to check your client ID."
+    "description": "The client ID from your registered Application. Visit your Azure Dashboard and select *App Registrations* to check your client ID.\n"
   },
   "vault_azure_tenant_id": {
     "defaultValue": null,
-    "description": "The DirectoryId and TenantId both equate to the GUID representing the ActiveDirectory Tenant. Depending on context, either term may be used by Microsoft documentation and products, which can be confusing. In other words, the \"Tenant ID\" IS the \"Directory ID\""
+    "description": "The DirectoryId and TenantId both equate to the GUID representing the ActiveDirectory Tenant. Depending on context, either term may be used by Microsoft documentation and products, which can be confusing. In other words, the \"Tenant ID\" IS the \"Directory ID\"\n"
   },
   "vault_azure_type": {
     "defaultValue": "secrets",
-    "description": "Azure Key Vault enables Microsoft Azure applications and users to store and use several types of secret/key data: keys, secrets, and certificates. Kong currently only supports the `Secrets`"
+    "description": "Azure Key Vault enables Microsoft Azure applications and users to store and use several types of secret/key data: keys, secrets, and certificates. Kong currently only supports the `Secrets`\n"
   },
   "vault_azure_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the Azure Key Vault when cached by this node.  Key Vault misses (no secret) are also cached according to this setting if you do not configure `vault_azure_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe Azure Key Vault when cached by this node.\n\nKey Vault misses (no secret) are also\ncached according to this setting if you do not\nconfigure `vault_azure_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_azure_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a Azure Key Vault miss (no secret).  If not specified (default), `vault_azure_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a Azure Key Vault\nmiss (no secret).\n\nIf not specified (default), `vault_azure_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_azure_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the Azure Key Vault should be resurrected for when they cannot be refreshed (e.g., the the vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the Azure Key Vault should be resurrected\nfor when they cannot be refreshed (e.g., the\nthe vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "worker_consistency": {
     "defaultValue": "eventual",
-    "description": " Defines whether this node should rebuild its state synchronously or asynchronously (the balancers and the router are rebuilt on updates that affect them, e.g., updates to routes, services, or upstreams via the admin API or loading a declarative configuration file). (This option is deprecated and will be removed in future releases. The new default is `eventual`.)  Accepted values are:  - `strict`: the router will be rebuilt   synchronously, causing incoming requests to   be delayed until the rebuild is finished.   (This option is deprecated and will be removed    in future releases. The new default is `eventual`) - `eventual`: the router will be rebuilt   asynchronously via a recurring background   job running every second inside of each   worker.  Note that `strict` ensures that all workers of a given node will always proxy requests with an identical router, but increased long-tail latency can be observed if frequent routes and services updates are expected. Using `eventual` will help prevent long-tail latency issues in such cases, but may cause workers to route requests differently for a short period of time after routes and services updates."
+    "description": "Defines whether this node should rebuild its\nstate synchronously or asynchronously (the\nbalancers and the router are rebuilt on\nupdates that affect them, e.g., updates to\nroutes, services, or upstreams via the admin\nAPI or loading a declarative configuration\nfile). (This option is deprecated and will be\nremoved in future releases. The new default\nis `eventual`.)\n\nAccepted values are:\n\n- `strict`: the router will be rebuilt\n  synchronously, causing incoming requests to\n  be delayed until the rebuild is finished.\n  (This option is deprecated and will be removed\n   in future releases. The new default is `eventual`)\n- `eventual`: the router will be rebuilt\n  asynchronously via a recurring background\n  job running every second inside of each\n  worker.\n\nNote that `strict` ensures that all workers\nof a given node will always proxy requests\nwith an identical router, but increased\nlong-tail latency can be observed if\nfrequent routes and services updates are\nexpected.\nUsing `eventual` will help prevent long-tail\nlatency issues in such cases, but may\ncause workers to route requests differently\nfor a short period of time after routes and\nservices updates.\n"
   },
   "worker_state_update_frequency": {
     "defaultValue": "5",
-    "description": " Defines how often the worker state changes are checked with a background job. When a change is detected, a new router or balancer will be built, as needed. Raising this value will decrease the load on database servers and result in less jitter in proxy latency, but it might take more time to propagate changes to each individual worker."
+    "description": "Defines how often the worker state changes are\nchecked with a background job. When a change\nis detected, a new router or balancer will be\nbuilt, as needed. Raising this value will\ndecrease the load on database servers and\nresult in less jitter in proxy latency, but\nit might take more time to propagate changes\nto each individual worker.\n"
   },
   "router_flavor": {
     "defaultValue": "traditional_compatible",
-    "description": " Selects the router implementation to use when performing request routing. Incremental router rebuild is available when the flavor is set to either `expressions` or `traditional_compatible`, which could significantly shorten rebuild time for a large number of routes.  Accepted values are:  - `traditional_compatible`: the DSL-based expression   router engine will be used under the hood. However,   the router config interface will be the same   as `traditional`, and expressions are   automatically generated at router build time.   The `expression` field on the `route` object   is not visible. - `expressions`: the DSL-based expression router engine   will be used under the hood. The traditional router   config interface is still visible, and you can also write   router Expressions manually and provide them in the   `expression` field on the `route` object. - `traditional`: the pre-3.0 router engine will be   used. The config interface will be the same as   pre-3.0 Kong, and the `expression` field on the   `route` object is not visible.    Deprecation warning: In Kong 3.0, `traditional`   mode should be avoided and only be used if   `traditional_compatible` does not work as expected.   This flavor of the router will be removed in the next   major release of Kong."
+    "description": "Selects the router implementation to use when\nperforming request routing. Incremental router\nrebuild is available when the flavor is set\nto either `expressions` or\n`traditional_compatible`, which could\nsignificantly shorten rebuild time for a large\nnumber of routes.\n\nAccepted values are:\n\n- `traditional_compatible`: the DSL-based expression\n  router engine will be used under the hood. However,\n  the router config interface will be the same\n  as `traditional`, and expressions are\n  automatically generated at router build time.\n  The `expression` field on the `route` object\n  is not visible.\n- `expressions`: the DSL-based expression router engine\n  will be used under the hood. The traditional router\n  config interface is still visible, and you can also write\n  router Expressions manually and provide them in the\n  `expression` field on the `route` object.\n- `traditional`: the pre-3.0 router engine will be\n  used. The config interface will be the same as\n  pre-3.0 Kong, and the `expression` field on the\n  `route` object is not visible.\n\n  Deprecation warning: In Kong 3.0, `traditional`\n  mode should be avoided and only be used if\n  `traditional_compatible` does not work as expected.\n  This flavor of the router will be removed in the next\n  major release of Kong.\n"
   },
   "lua_max_req_headers": {
     "defaultValue": "100",
-    "description": "Maximum number of request headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request headers, and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many request headers."
+    "description": "Maximum number of request headers to parse by default.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request headers,\nand this setting does not have any effect. It is used\nto limit Kong and its plugins from reading too many\nrequest headers.\n"
   },
   "lua_max_resp_headers": {
     "defaultValue": "100",
-    "description": "Maximum number of response headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong returns all the response headers, and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many response headers."
+    "description": "Maximum number of response headers to parse by default.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong returns all the response headers,\nand this setting does not have any effect. It is used\nto limit Kong and its plugins from reading too many\nresponse headers.\n"
   },
   "lua_max_uri_args": {
     "defaultValue": "100",
-    "description": "Maximum number of request URI arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request query arguments, and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many query arguments."
+    "description": "Maximum number of request URI arguments to parse by\ndefault.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request query\narguments, and this setting does not have any effect.\nIt is used to limit Kong and its plugins from reading\ntoo many query arguments.\n"
   },
   "lua_max_post_args": {
     "defaultValue": "100",
-    "description": "Maximum number of request post arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request post arguments, and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many post arguments."
+    "description": "Maximum number of request post arguments to parse by\ndefault.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request post\narguments, and this setting does not have any effect.\nIt is used to limit Kong and its plugins from reading\ntoo many post arguments.\n"
   },
   "lua_ssl_trusted_certificate": {
     "defaultValue": "system",
-    "description": "Comma-separated list of certificate authorities for Lua cosockets in PEM format.  The special value `system` attempts to search for the \"usual default\" provided by each distro, according to an arbitrary heuristic. In the current implementation, the following pathnames will be tested in order, and the first one found will be used:  - `/etc/ssl/certs/ca-certificates.crt` (Debian/Ubuntu/Gentoo) - `/etc/pki/tls/certs/ca-bundle.crt` (Fedora/RHEL 6) - `/etc/ssl/ca-bundle.pem` (OpenSUSE) - `/etc/pki/tls/cacert.pem` (OpenELEC) - `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` (CentOS/RHEL 7) - `/etc/ssl/cert.pem` (OpenBSD, Alpine)  `system` can be used by itself or in conjunction with other CA file paths.  When `pg_ssl_verify` is enabled, these certificate authority files will be used for verifying Kong's database connections.  Certificates can be configured on this property with any of the following values: - `system` - absolute path to the certificate - certificate content - base64 encoded certificate content  See https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate"
+    "description": "Comma-separated list of certificate authorities\nfor Lua cosockets in PEM format.\n\nThe special value `system` attempts to search for the\n\"usual default\" provided by each distro, according\nto an arbitrary heuristic. In the current implementation,\nthe following pathnames will be tested in order,\nand the first one found will be used:\n\n- `/etc/ssl/certs/ca-certificates.crt` (Debian/Ubuntu/Gentoo)\n- `/etc/pki/tls/certs/ca-bundle.crt` (Fedora/RHEL 6)\n- `/etc/ssl/ca-bundle.pem` (OpenSUSE)\n- `/etc/pki/tls/cacert.pem` (OpenELEC)\n- `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` (CentOS/RHEL 7)\n- `/etc/ssl/cert.pem` (OpenBSD, Alpine)\n\n`system` can be used by itself or in conjunction with other\nCA file paths.\n\nWhen `pg_ssl_verify` is enabled, these\ncertificate authority files will be\nused for verifying Kong's database connections.\n\nCertificates can be configured on this property\nwith any of the following values:\n- `system`\n- absolute path to the certificate\n- certificate content\n- base64 encoded certificate content\n\nSee https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate\n"
   },
   "lua_ssl_verify_depth": {
     "defaultValue": "1",
-    "description": "Sets the verification depth in the server certificates chain used by Lua cosockets, set by `lua_ssl_trusted_certificate`. This includes the certificates configured for Kong's database connections. If the maximum depth is reached before reaching the end of the chain, verification will fail. This helps mitigate certificate based DoS attacks.  See https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth"
+    "description": "Sets the verification depth in the server\ncertificates chain used by Lua cosockets,\nset by `lua_ssl_trusted_certificate`.\nThis includes the certificates configured\nfor Kong's database connections.\nIf the maximum depth is reached before\nreaching the end of the chain, verification\nwill fail. This helps mitigate certificate\nbased DoS attacks.\n\nSee https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth\n"
   },
   "lua_ssl_protocols": {
     "defaultValue": "TLSv1.2 TLSv1.3",
-    "description": "Defines the TLS versions supported when handshaking with OpenResty's TCP cosocket APIs.  This affects connections made by Lua code, such as connections to the database Kong uses, or when sending logs using a logging plugin. It does *not* affect connections made to the upstream Service or from downstream clients."
+    "description": "Defines the TLS versions supported\nwhen handshaking with OpenResty's\nTCP cosocket APIs.\n\nThis affects connections made by Lua\ncode, such as connections to the\ndatabase Kong uses, or when sending logs\nusing a logging plugin. It does *not*\naffect connections made to the upstream\nService or from downstream clients.\n"
   },
   "lua_package_path": {
     "defaultValue": "./?.lua;./?/init.lua;",
-    "description": "Sets the Lua module search path (LUA_PATH). Useful when developing or using custom plugins not stored in the default search path.  See https://github.com/openresty/lua-nginx-module#lua_package_path"
+    "description": "Sets the Lua module search path\n(LUA_PATH). Useful when developing\nor using custom plugins not stored\nin the default search path.\n\nSee https://github.com/openresty/lua-nginx-module#lua_package_path\n"
   },
   "lua_package_cpath": {
     "defaultValue": null,
-    "description": "Sets the Lua C module search path (LUA_CPATH).  See https://github.com/openresty/lua-nginx-module#lua_package_cpath"
+    "description": "Sets the Lua C module search path\n(LUA_CPATH).\n\nSee https://github.com/openresty/lua-nginx-module#lua_package_cpath\n"
   },
   "lua_socket_pool_size": {
     "defaultValue": "256",
-    "description": "Specifies the size limit for every cosocket connection pool associated with every remote server.  See https://github.com/openresty/lua-nginx-module#lua_socket_pool_size"
+    "description": "Specifies the size limit for every cosocket\nconnection pool associated with every remote\nserver.\n\nSee https://github.com/openresty/lua-nginx-module#lua_socket_pool_size\n"
   },
   "enforce_rbac": {
     "defaultValue": "off",
-    "description": "Specifies whether Admin API RBAC is enforced. Accepts one of `entity`, `both`, `on`, or `off`.  - `on`: only endpoint-level authorization   is enforced. - `entity`: entity-level authorization   applies. - `both`: enables both endpoint and   entity-level authorization. - `off`: disables both endpoint and   entity-level authorization.  When enabled, Kong will deny requests to the Admin API when a nonexistent or invalid RBAC authorization token is passed, or the RBAC user with which the token is associated does not have permissions to access/modify the requested resource."
+    "description": "Specifies whether Admin API RBAC is enforced.\nAccepts one of `entity`, `both`, `on`, or\n`off`.\n\n- `on`: only endpoint-level authorization\n  is enforced.\n- `entity`: entity-level authorization\n  applies.\n- `both`: enables both endpoint and\n  entity-level authorization.\n- `off`: disables both endpoint and\n  entity-level authorization.\n\nWhen enabled, Kong will deny requests to the\nAdmin API when a nonexistent or invalid RBAC\nauthorization token is passed, or the RBAC\nuser with which the token is associated does\nnot have permissions to access/modify the\nrequested resource.\n"
   },
   "rbac_auth_header": {
     "defaultValue": "Kong-Admin-Token",
-    "description": "Defines the name of the HTTP request header from which the Admin API will attempt to authenticate the RBAC user."
+    "description": "Defines the name of the HTTP request\nheader from which the Admin API will\nattempt to authenticate the RBAC user.\n"
   },
   "event_hooks_enabled": {
     "defaultValue": "on",
-    "description": "When enabled, event hook entities represent a relationship between an event (source and event) and an action (handler). Similar to web hooks, event hooks can be used to communicate Kong Gateway service events. When a particular event happens on a service, the event hook calls a URL with information about that event. Event hook configurations differ depending on the handler. The events that are triggered send associated data.  See: https://docs.konghq.com/gateway/api/admin-ee/latest/#/Event-hooks/get-event-hooks"
+    "description": "When enabled, event hook entities represent a relationship\nbetween an event (source and event) and an action\n(handler). Similar to web hooks, event hooks can be used to\ncommunicate Kong Gateway service events. When a particular\nevent happens on a service, the event hook calls a URL with\ninformation about that event. Event hook configurations\ndiffer depending on the handler. The events that are\ntriggered send associated data.\n\nSee: https://docs.konghq.com/gateway/api/admin-ee/latest/#/Event-hooks/get-event-hooks\n"
   },
   "fips": {
     "defaultValue": "off",
-    "description": "Turn on FIPS mode; this mode is only available on a FIPS build."
+    "description": "Turn on FIPS mode; this mode is only available on a FIPS build.\n"
   },
   "admin_gui_listen": {
     "defaultValue": [
       "0.0.0.0:8002",
       "0.0.0.0:8445 ssl"
     ],
-    "description": " Kong Manager Listeners  Comma-separated list of addresses and ports on which Kong will expose Kong Manager. This web application lets you configure and manage Kong, and therefore should be kept secured.  Suffixes can be specified for each pair, similarly to the `admin_listen` directive."
+    "description": "Kong Manager Listeners\n\nComma-separated list of addresses and ports on which\nKong will expose Kong Manager. This web application\nlets you configure and manage Kong, and therefore\nshould be kept secured.\n\nSuffixes can be specified for each pair, similarly to\nthe `admin_listen` directive.\n"
   },
   "admin_gui_url": {
     "defaultValue": null,
-    "description": "Kong Manager URL  The lookup, or balancer, address for Kong Manager.  Accepted format (items in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>)`  Examples:  - `http://127.0.0.1:8003` - `https://kong-admin.test` - `http://dev-machine`  By default, Kong Manager will use the window request host and append the resolved listener port depending on the requested protocol."
+    "description": "Kong Manager URL\n\nThe lookup, or balancer, address for Kong Manager.\n\nAccepted format (items in parentheses are optional):\n\n  `<scheme>://<IP / HOSTNAME>(:<PORT>)`\n\nExamples:\n\n- `http://127.0.0.1:8003`\n- `https://kong-admin.test`\n- `http://dev-machine`\n\nBy default, Kong Manager will use the window request\nhost and append the resolved listener port depending\non the requested protocol.\n"
   },
   "admin_gui_path": {
     "defaultValue": "/",
-    "description": "Kong Manager base path  This configuration parameter allows the user to customize the path prefix where Kong Manager is served. When updating this parameter, it's recommended to update the path in `admin_gui_url` as well.  Accepted format:  - Path must start with a `/` - Path must not end with a `/` (except for the `/`) - Path can only contain letters, digits, hyphens (`-`), underscores (`_`), and slashes (`/`) - Path must not contain continuous slashes (e.g., `//` and `///`)  Examples:  - `/` - `/manager` - `/kong-manager` - `/kong/manager`"
+    "description": "Kong Manager base path\n\nThis configuration parameter allows the user to customize\nthe path prefix where Kong Manager is served. When updating\nthis parameter, it's recommended to update the path in `admin_gui_url`\nas well.\n\nAccepted format:\n\n- Path must start with a `/`\n- Path must not end with a `/` (except for the `/`)\n- Path can only contain letters, digits, hyphens (`-`),\nunderscores (`_`), and slashes (`/`)\n- Path must not contain continuous slashes (e.g., `//` and `///`)\n\nExamples:\n\n- `/`\n- `/manager`\n- `/kong-manager`\n- `/kong/manager`\n"
   },
   "admin_gui_api_url": {
     "defaultValue": null,
-    "description": "Hierarchical part of a URI which is composed optionally of a host, port, and path at which the Admin API accepts HTTP or HTTPS traffic. When this config is disabled, Kong Manager will use the window protocol + host and append the resolved admin_listen HTTP/HTTPS port."
+    "description": "Hierarchical part of a URI which is composed\noptionally of a host, port, and path at which the\nAdmin API accepts HTTP or HTTPS traffic. When\nthis config is disabled, Kong Manager will\nuse the window protocol + host and append the\nresolved admin_listen HTTP/HTTPS port.\n"
   },
   "admin_gui_ssl_protocols": {
     "defaultValue": "TLSv1.2 TLSv1.3",
-    "description": " Defines the TLS versions supported for Kong Manager"
+    "description": "Defines the TLS versions supported\nfor Kong Manager\n"
   },
   "admin_gui_ssl_cert": {
     "defaultValue": null,
-    "description": "The SSL certificate for `admin_gui_listen` values with SSL enabled.  values: - absolute path to the certificate - certificate content - base64 encoded certificate content"
+    "description": "The SSL certificate for `admin_gui_listen` values\nwith SSL enabled.\n\nvalues:\n- absolute path to the certificate\n- certificate content\n- base64 encoded certificate content\n"
   },
   "admin_gui_ssl_cert_key": {
     "defaultValue": null,
-    "description": "The SSL key for `admin_gui_listen` values with SSL enabled.  values: - absolute path to the certificate key - certificate key content - base64 encoded certificate key content"
+    "description": "The SSL key for `admin_gui_listen` values with SSL\nenabled.\n\nvalues:\n- absolute path to the certificate key\n- certificate key content\n- base64 encoded certificate key content\n"
   },
   "admin_gui_flags": {
     "defaultValue": "{}",
-    "description": " Alters the layout Admin GUI (JSON) to enable Kong Immunity in the Admin GUI."
+    "description": "Alters the layout Admin GUI (JSON)\nto enable Kong Immunity in the Admin GUI.\n"
   },
   "admin_gui_access_log": {
     "defaultValue": "logs/admin_gui_access.log",
-    "description": " Kong Manager Access Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables access logs for Kong Manager."
+    "description": "Kong Manager Access Logs\n\nHere you can set an absolute or relative path for Kong\nManager access logs. When the path is relative,\nlogs are placed in the `prefix` location.\n\nSetting this value to `off` disables access logs\nfor Kong Manager.\n"
   },
   "admin_gui_error_log": {
     "defaultValue": "logs/admin_gui_error.log",
-    "description": " Kong Manager Error Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables error logs for Kong Manager.  Granularity can be adjusted through the `log_level` directive."
+    "description": "Kong Manager Error Logs\n\nHere you can set an absolute or relative path for Kong\nManager access logs. When the path is relative,\nlogs are placed in the `prefix` location.\n\nSetting this value to `off` disables error logs for\nKong Manager.\n\nGranularity can be adjusted through the `log_level`\ndirective.\n"
   },
   "admin_gui_auth": {
     "defaultValue": null,
-    "description": "Kong Manager Authentication Plugin Name  Secures access to Kong Manager by specifying an authentication plugin to use.  Supported Plugins:  - `basic-auth`: Basic Authentication plugin - `ldap-auth-advanced`: LDAP Authentication plugin - `openid-connect`: OpenID Connect Authentication   plugin"
+    "description": "Kong Manager Authentication Plugin Name\n\nSecures access to Kong Manager by specifying an\nauthentication plugin to use.\n\nSupported Plugins:\n\n- `basic-auth`: Basic Authentication plugin\n- `ldap-auth-advanced`: LDAP Authentication plugin\n- `openid-connect`: OpenID Connect Authentication\n  plugin\n"
   },
   "admin_gui_auth_conf": {
     "defaultValue": null,
-    "description": "Kong Manager Authentication Plugin Config (JSON)  Specifies the configuration for the authentication plugin specified in `admin_gui_auth`.  For information about Plugin Configuration consult the associated plugin documentation.  Example for `basic-auth`:  `admin_gui_auth_conf = { \"hide_credentials\": true }`"
+    "description": "Kong Manager Authentication Plugin Config (JSON)\n\nSpecifies the configuration for the authentication\nplugin specified in `admin_gui_auth`.\n\nFor information about Plugin Configuration\nconsult the associated plugin documentation.\n\nExample for `basic-auth`:\n\n`admin_gui_auth_conf = { \"hide_credentials\": true }`\n"
   },
   "admin_gui_auth_password_complexity": {
     "defaultValue": null,
-    "description": "Kong Manager Authentication Password Complexity (JSON)  When `admin_gui_auth = basic-auth`, this property defines the rules required for Kong Manager passwords. Choose from preset rules or write your own.  Example using preset rules:  `admin_gui_auth_password_complexity = { \"kong-preset\": \"min_8\" }`  All values for kong-preset require the password to contain characters from at least three of the following categories:  1. Uppercase characters (A through Z)  2. Lowercase characters (a through z)  3. Base-10 digits (0 through 9)  4. Special characters (for example, &, $, #, %)  Supported preset rules: - `min_8`: minimum length of 8 - `min_12`: minimum length of 12 - `min_20`: minimum length of 20  To write your own rules, see https://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.  NOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.  Example:  `admin_gui_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`"
+    "description": "Kong Manager Authentication Password Complexity (JSON)\n\nWhen `admin_gui_auth = basic-auth`, this property defines\nthe rules required for Kong Manager passwords. Choose\nfrom preset rules or write your own.\n\nExample using preset rules:\n\n`admin_gui_auth_password_complexity = { \"kong-preset\": \"min_8\" }`\n\nAll values for kong-preset require the password to contain\ncharacters from at least three of the following categories:\n\n1. Uppercase characters (A through Z)\n\n2. Lowercase characters (a through z)\n\n3. Base-10 digits (0 through 9)\n\n4. Special characters (for example, &, $, #, %)\n\nSupported preset rules:\n- `min_8`: minimum length of 8\n- `min_12`: minimum length of 12\n- `min_20`: minimum length of 20\n\nTo write your own rules, see\nhttps://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.\n\nNOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.\n\nExample:\n\n`admin_gui_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`\n"
   },
   "admin_gui_session_conf": {
     "defaultValue": null,
-    "description": "Kong Manager Session Config (JSON)  Specifies the configuration for the Session plugin as used by Kong Manager.  For information about plugin configuration, consult the Kong Session plugin documentation.  Example: ``` admin_gui_session_conf = { \"cookie_name\": \"kookie\", \\                            \"secret\": \"changeme\" } ```"
+    "description": "Kong Manager Session Config (JSON)\n\nSpecifies the configuration for the Session plugin as\nused by Kong Manager.\n\nFor information about plugin configuration, consult\nthe Kong Session plugin documentation.\n\nExample:\n```\nadmin_gui_session_conf = { \"cookie_name\": \"kookie\", \\\n                           \"secret\": \"changeme\" }\n```\n"
   },
   "admin_gui_auth_header": {
     "defaultValue": "Kong-Admin-User",
-    "description": " Defines the name of the HTTP request header from which the Admin API will attempt to identify the Kong Admin user."
+    "description": "Defines the name of the HTTP request header from which\nthe Admin API will attempt to identify the Kong Admin\nuser.\n"
   },
   "admin_gui_auth_login_attempts": {
     "defaultValue": "0",
-    "description": " Number of times a user can attempt to login to Kong Manager. 0 means infinite attempts allowed."
+    "description": "Number of times a user can attempt to login to Kong\nManager. 0 means infinite attempts allowed.\n"
   },
   "admin_gui_auth_change_password_attempts": {
     "defaultValue": "0",
-    "description": " Number of times a user can attempt to change password. 0 means infinite attempts allowed."
+    "description": "Number of times a user can attempt to change password.\n0 means infinite attempts allowed.\n"
   },
   "admin_gui_auth_change_password_ttl": {
     "defaultValue": "86400",
-    "description": " Length, in seconds, of the TTL for changing password attempts records. Records in the database older than their TTL are automatically purged.  Example, 1 days: `1 * 24 * 60 * 60 = 86400.`"
+    "description": "Length, in seconds, of the TTL for changing password attempts\nrecords. Records in the database older than\ntheir TTL are automatically purged.\n\nExample, 1 days: `1 * 24 * 60 * 60 = 86400.`\n"
   },
   "admin_gui_header_txt": {
     "defaultValue": null,
-    "description": "Sets the text for the Kong Manager header banner. Header banner is not shown if this config is empty."
+    "description": "Sets the text for the Kong Manager header banner.\nHeader banner is not shown if this config is empty.\n"
   },
   "admin_gui_header_bg_color": {
     "defaultValue": null,
-    "description": "Sets the background color for the Kong Manager header banner. Accepts CSS color keyword, #-hexadecimal, or RGB format. Invalid values are ignored by Manager."
+    "description": "Sets the background color for the Kong Manager header banner.\nAccepts CSS color keyword, #-hexadecimal, or RGB\nformat. Invalid values are ignored by Manager.\n"
   },
   "admin_gui_header_txt_color": {
     "defaultValue": null,
-    "description": "Sets the text color for the Kong Manager header banner. Accepts CSS color keyword, #-hexadecimal, or RGB format. Invalid values are ignored by Kong Manager."
+    "description": "Sets the text color for the Kong Manager header banner.\nAccepts CSS color keyword, #-hexadecimal, or RGB\nformat. Invalid values are ignored by Kong Manager.\n"
   },
   "admin_gui_footer_txt": {
     "defaultValue": null,
-    "description": "Sets the text for the Kong Manager footer banner. Footer banner is not shown if this config is empty."
+    "description": "Sets the text for the Kong Manager footer banner. Footer banner\nis not shown if this config is empty.\n"
   },
   "admin_gui_footer_bg_color": {
     "defaultValue": null,
-    "description": "Sets the background color for the Kong Manager footer banner. Accepts CSS color keyword, #-hexadecimal, or RGB format. Invalid values are ignored by manager."
+    "description": "Sets the background color for the Kong Manager footer banner.\nAccepts CSS color keyword, #-hexadecimal, or RGB\nformat. Invalid values are ignored by manager.\n"
   },
   "admin_gui_footer_txt_color": {
     "defaultValue": null,
-    "description": "Sets the text color for the Kong Manager footer banner. Accepts CSS color keyword, #-hexadecimal, or RGB format. Invalid values are ignored by Kong Manager."
+    "description": "Sets the text color for the Kong Manager footer banner.\nAccepts CSS color keyword, #-hexadecimal, or RGB\nformat. Invalid values are ignored by Kong Manager.\n"
   },
   "admin_gui_login_banner_title": {
     "defaultValue": null,
-    "description": "Sets the title text for the Kong Manager login banner. Login banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+    "description": "Sets the title text for the Kong Manager login banner.\nLogin banner is not shown if both\n`admin_gui_login_banner_title` and\n`admin_gui_login_banner_body` are empty.\n"
   },
   "admin_gui_login_banner_body": {
     "defaultValue": null,
-    "description": "Sets the body text for the Kong Manager login banner. Login banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+    "description": "Sets the body text for the Kong Manager login banner.\nLogin banner is not shown if both\n`admin_gui_login_banner_title` and\n`admin_gui_login_banner_body` are empty.\n"
   },
   "konnect_mode": {
     "defaultValue": "off",
-    "description": "When enabled, the dataplane is connected to Konnect"
+    "description": "When enabled, the dataplane is connected to Konnect\n"
   },
   "analytics_flush_interval": {
     "defaultValue": "1",
-    "description": "Specify the maximum frequency, in seconds, at which local analytics and licensing data are flushed to the database or Konnect, depending on the installation mode. Kong also triggers a flush when the number of messages in the buffer is less than `analytics_buffer_size_limit`, regardless of whether the specified time interval has elapsed."
+    "description": "Specify the maximum frequency, in seconds,\nat which local analytics and licensing\ndata are flushed to the database or\nKonnect, depending on the installation mode.\nKong also triggers a flush when the number\nof messages in the buffer is less than\n`analytics_buffer_size_limit`, regardless\nof whether the specified time interval has\nelapsed.\n"
   },
   "analytics_buffer_size_limit": {
     "defaultValue": "100000",
-    "description": "Max number of messages can be buffered locally before dropping data in case there is no network connection to Konnect."
+    "description": "Max number of messages can be buffered locally\nbefore dropping data in case there is no\nnetwork connection to Konnect.\n"
   },
   "analytics_debug": {
     "defaultValue": "off",
-    "description": "Outputs analytics payload to Kong logs."
+    "description": "Outputs analytics payload to Kong logs.\n"
   },
   "admin_emails_from": {
     "defaultValue": "\"\"",
-    "description": "The email address for the `From` header for admin emails."
+    "description": "The email address for the `From` header\nfor admin emails.\n"
   },
   "admin_emails_reply_to": {
     "defaultValue": null,
-    "description": "Email address for the `Reply-To` header for admin emails."
+    "description": "Email address for the `Reply-To` header\nfor admin emails.\n"
   },
   "admin_invitation_expiry": {
     "defaultValue": "259200",
-    "description": "Expiration time for the admin invitation link (in seconds). 0 means no expiration.  Example, 72 hours: `72 * 60 * 60 = 259200`"
+    "description": "Expiration time for the admin invitation link\n(in seconds). 0 means no expiration.\n\nExample, 72 hours: `72 * 60 * 60 = 259200`\n"
   },
   "smtp_mock": {
     "defaultValue": "on",
-    "description": "This flag will mock the sending of emails. This can be used for testing before the SMTP client is fully configured."
+    "description": "This flag will mock the sending of emails. This can be\nused for testing before the SMTP client is fully\nconfigured.\n"
   },
   "smtp_host": {
     "defaultValue": "localhost",
-    "description": " The hostname of the SMTP server to connect to."
+    "description": "The hostname of the SMTP server to connect to.\n"
   },
   "smtp_port": {
     "defaultValue": "25",
-    "description": " The port number on the SMTP server to connect to."
+    "description": "The port number on the SMTP server to connect to.\n"
   },
   "smtp_starttls": {
     "defaultValue": "off",
-    "description": " When set to `on`, STARTTLS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 587."
+    "description": "When set to `on`, STARTTLS is used to encrypt\ncommunication with the SMTP server. This is normally\nused in conjunction with port 587.\n"
   },
   "smtp_username": {
     "defaultValue": null,
-    "description": "Username used for authentication with SMTP server"
+    "description": "Username used for authentication with SMTP server\n"
   },
   "smtp_password": {
     "defaultValue": null,
-    "description": "Password used for authentication with SMTP server"
+    "description": "Password used for authentication with SMTP server\n"
   },
   "smtp_ssl": {
     "defaultValue": "off",
-    "description": " When set to `on`, SMTPS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 465."
+    "description": "When set to `on`, SMTPS is used to encrypt\ncommunication with the SMTP server. This is normally\nused in conjunction with port 465.\n"
   },
   "smtp_auth_type": {
     "defaultValue": null,
-    "description": "The method used to authenticate with the SMTP server Valid options are `plain`, `login`, or `nil`"
+    "description": "The method used to authenticate with the SMTP server\nValid options are `plain`, `login`, or `nil`\n"
   },
   "smtp_domain": {
     "defaultValue": "localhost.localdomain",
-    "description": " The domain used in the `EHLO` connection and part of the `Message-ID` header"
+    "description": "The domain used in the `EHLO` connection and part of\nthe `Message-ID` header\n"
   },
   "smtp_timeout_connect": {
     "defaultValue": "60000",
-    "description": " The timeout (in milliseconds) for connecting to the SMTP server."
+    "description": "The timeout (in milliseconds) for connecting to the\nSMTP server.\n"
   },
   "smtp_timeout_send": {
     "defaultValue": "60000",
-    "description": " The timeout (in milliseconds) for sending data to the SMTP server."
+    "description": "The timeout (in milliseconds) for sending data to the\nSMTP server.\n"
   },
   "smtp_timeout_read": {
     "defaultValue": "60000",
-    "description": " The timeout (in milliseconds) for reading data from the SMTP server."
+    "description": "The timeout (in milliseconds) for reading data from\nthe SMTP server.\n"
   },
   "smtp_admin_emails": {
     "defaultValue": null,
-    "description": "Comma separated list of admin emails to receive notifications. Example `admin1@example.com, admin2@example.com`"
+    "description": "Comma separated list of admin emails to receive\nnotifications.\nExample `admin1@example.com, admin2@example.com`\n"
   },
   "audit_log": {
     "defaultValue": "off",
-    "description": "When enabled, Kong will log information about Admin API access and database row insertions, updates, and deletions."
+    "description": "When enabled, Kong will log information about\nAdmin API access and database row insertions,\nupdates, and deletions.\n"
   },
   "audit_log_ignore_methods": {
     "defaultValue": null,
-    "description": "Comma-separated list of HTTP methods that will not generate audit log entries. By default, all HTTP requests will be logged."
+    "description": "Comma-separated list of HTTP methods that\nwill not generate audit log entries. By\ndefault, all HTTP requests will be logged.\n"
   },
   "audit_log_ignore_paths": {
     "defaultValue": null,
-    "description": "Comma-separated list of request paths that will not generate audit log entries. By default, all HTTP requests will be logged."
+    "description": "Comma-separated list of request paths that\nwill not generate audit log entries. By\ndefault, all HTTP requests will be logged.\n"
   },
   "audit_log_ignore_tables": {
     "defaultValue": null,
-    "description": "Comma-separated list of database tables that will not generate audit log entries. By default, updates to all database tables will be logged (the term \"updates\" refers to the creation, update, or deletion of a row)."
+    "description": "Comma-separated list of database tables that\nwill not generate audit log entries. By\ndefault, updates to all database tables will\nbe logged (the term \"updates\" refers to the\ncreation, update, or deletion of a row).\n"
   },
   "audit_log_payload_exclude": {
     "defaultValue": [
@@ -1138,145 +1138,145 @@
       "secret",
       "password"
     ],
-    "description": " Comma-separated list of keys that will be filtered out of the payload. Keys that were filtered will be recorded in the audit log."
+    "description": "Comma-separated list of keys that will be\nfiltered out of the payload. Keys that were\nfiltered will be recorded in the audit log.\n"
   },
   "audit_log_record_ttl": {
     "defaultValue": "2592000",
-    "description": "Length, in seconds, of the TTL for audit log records. Records in the database older than their TTL are automatically purged.  Example, 30 days: `30 * 24 * 60 * 60 = 2592000`"
+    "description": "Length, in seconds, of the TTL for audit log\nrecords. Records in the database older than\ntheir TTL are automatically purged.\n\nExample, 30 days: `30 * 24 * 60 * 60 = 2592000`\n"
   },
   "audit_log_signing_key": {
     "defaultValue": null,
-    "description": "Defines the path to a private RSA signing key that can be used to insert a signature of audit records, adjacent to the record. The corresponding public key should be stored offline, and can be used to validate audit entries in the future. If this value is undefined, no signature will be generated."
+    "description": "Defines the path to a private RSA signing key\nthat can be used to insert a signature of\naudit records, adjacent to the record. The\ncorresponding public key should be stored\noffline, and can be used to validate audit\nentries in the future. If this value is\nundefined, no signature will be generated.\n"
   },
   "route_validation_strategy": {
     "defaultValue": "smart",
-    "description": "The strategy used to validate routes when creating or updating them. Different strategies are available to tune how to enforce splitting traffic of workspaces. - `smart` is the default option and uses the   algorithm described in   https://docs.konghq.com/gateway/latest/kong-enterprise/workspaces/. - `off` disables any check. - `path` enforces routes to comply with the pattern   described in config `enforce_route_path_pattern`. - `static` relies on the PostgreSQL database. Before creating a new route, it checks if the route is unique across all workspaces based on the following params: `paths`, `methods`, and `hosts`. If all fields of the new route overlap with an existing one, a 409 is returned with the route of the collision. The array order is not important for the overlap filter."
+    "description": "The strategy used to validate\nroutes when creating or updating them.\nDifferent strategies are available to tune\nhow to enforce splitting traffic of\nworkspaces.\n- `smart` is the default option and uses the\n  algorithm described in\n  https://docs.konghq.com/gateway/latest/kong-enterprise/workspaces/.\n- `off` disables any check.\n- `path` enforces routes to comply with the pattern\n  described in config `enforce_route_path_pattern`.\n- `static` relies on the PostgreSQL database.\nBefore creating a new route, it checks if the\nroute is unique across all workspaces based on\nthe following params: `paths`, `methods`, and\n`hosts`. If all fields of the new route overlap\nwith an existing one, a 409 is returned with the\nroute of the collision. The array order is not\nimportant for the overlap filter.\n"
   },
   "enforce_route_path_pattern": {
     "defaultValue": null,
-    "description": "Specifies the Lua pattern which will be enforced on the `paths` attribute of a route object. You can also add a placeholder for the workspace in the pattern, which will be rendered during runtime based on the workspace to which the `route` belongs. This setting is only relevant if `route_validation_strategy` is set to `path`.   Example For Pattern `/$(workspace)/v%d/.*` valid paths are:  1. `/group1/v1/` if route belongs to   workspace `group1`.  2. `/group2/v1/some_path` if route belongs to   workspace `group2`."
+    "description": "Specifies the Lua pattern which will\nbe enforced on the `paths` attribute of a\nroute object. You can also add a placeholder\nfor the workspace in the pattern, which\nwill be rendered during runtime based on the\nworkspace to which the `route` belongs.\nThis setting is only relevant if\n`route_validation_strategy` is set to `path`.\n\n\nExample\nFor Pattern `/$(workspace)/v%d/.*` valid paths\nare:\n\n1. `/group1/v1/` if route belongs to\n  workspace `group1`.\n\n2. `/group2/v1/some_path` if route belongs to\n  workspace `group2`.\n"
   },
   "keyring_enabled": {
     "defaultValue": "off",
-    "description": "When enabled, Kong will encrypt sensitive field values before writing them to the database, and subsequently decrypt them when retrieving data for the Admin API, Developer Portal, or proxy business logic. Symmetric encryption keys are managed based on the strategy defined below."
+    "description": "When enabled, Kong will encrypt sensitive\nfield values before writing them to the\ndatabase, and subsequently decrypt them when\nretrieving data for the Admin API, Developer\nPortal, or proxy business logic. Symmetric\nencryption keys are managed based on the\nstrategy defined below.\n"
   },
   "keyring_strategy": {
     "defaultValue": "cluster",
-    "description": "Defines the strategy implementation by which Kong nodes will manage symmetric encryption keys. Please see the Kong Enterprise documentation for a detailed description of each strategy. Acceptable values for this option are `cluster` and `vault`."
+    "description": "Defines the strategy implementation by which\nKong nodes will manage symmetric encryption\nkeys. Please see the Kong Enterprise\ndocumentation for a detailed description of\neach strategy. Acceptable values for this\noption are `cluster` and `vault`.\n"
   },
   "keyring_public_key": {
     "defaultValue": null,
-    "description": "Defines the public key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  Values: - absolute path to the public key - public key content - base64 encoded public key content"
+    "description": "Defines the public key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nValues:\n- absolute path to the public key\n- public key content\n- base64 encoded public key content\n"
   },
   "keyring_private_key": {
     "defaultValue": null,
-    "description": "Defines the private key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  Values: - absolute path to the private key - private key content - base64 encoded private key content"
+    "description": "Defines the private key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nValues:\n- absolute path to the private key\n- private key content\n- base64 encoded private key content\n"
   },
   "keyring_recovery_public_key": {
     "defaultValue": null,
-    "description": "Defines the public key to optionally encrypt all keyring materials and back them up in the database.  Values: - absolute path to the public key - public key content - base64 encoded public key content"
+    "description": "Defines the public key to optionally encrypt\nall keyring materials and back them up in the\ndatabase.\n\nValues:\n- absolute path to the public key\n- public key content\n- base64 encoded public key content\n"
   },
   "keyring_blob_path": {
     "defaultValue": null,
-    "description": "Defines the filesystem path at which Kong will back up the initial keyring material. This option is useful largely for development purposes."
+    "description": "Defines the filesystem path at which Kong\nwill back up the initial keyring material.\nThis option is useful largely for development\npurposes.\n"
   },
   "keyring_vault_host": {
     "defaultValue": null,
-    "description": "Defines the Vault host at which Kong will fetch the encryption material. This value should be defined in the format:  `<scheme>://<IP / HOSTNAME>:<PORT>`"
+    "description": "Defines the Vault host at which Kong will\nfetch the encryption material. This value\nshould be defined in the format:\n\n`<scheme>://<IP / HOSTNAME>:<PORT>`\n"
   },
   "keyring_vault_mount": {
     "defaultValue": null,
-    "description": "Defines the name of the Vault v2 KV secrets engine at which symmetric keys are found."
+    "description": "Defines the name of the Vault v2 KV secrets\nengine at which symmetric keys are found.\n"
   },
   "keyring_vault_path": {
     "defaultValue": null,
-    "description": "Defines the name of the Vault v2 KV path at which symmetric keys are found."
+    "description": "Defines the name of the Vault v2 KV path\nat which symmetric keys are found.\n"
   },
   "keyring_vault_auth_method": {
     "defaultValue": "token",
-    "description": " Defines the authentication mechanism when connecting to the Hashicorp Vault service.  Accepted values are: `token`, or `kubernetes`:  - `token`: Uses the static token defined in            the `keyring_vault_token`            configuration property.  - `kubernetes`: Uses the Kubernetes authentication                 mechanism, with the running pod's                 mapped service account, to assume                 the Hashicorp Vault role name that is                 defined in the `keyring_vault_kube_role`                 configuration property."
+    "description": "Defines the authentication mechanism when\nconnecting to the Hashicorp Vault service.\n\nAccepted values are: `token`, or `kubernetes`:\n\n- `token`: Uses the static token defined in\n           the `keyring_vault_token`\n           configuration property.\n\n- `kubernetes`: Uses the Kubernetes authentication\n                mechanism, with the running pod's\n                mapped service account, to assume\n                the Hashicorp Vault role name that is\n                defined in the `keyring_vault_kube_role`\n                configuration property.\n"
   },
   "keyring_vault_token": {
     "defaultValue": null,
-    "description": "Defines the token value used to communicate with the v2 KV Vault HTTP(S) API."
+    "description": "Defines the token value used to communicate\nwith the v2 KV Vault HTTP(S) API.\n"
   },
   "keyring_vault_kube_role": {
     "defaultValue": "default",
-    "description": " Defines the Hashicorp Vault role that will be assumed using the Kubernetes service account of the running pod.  `keyring_vault_auth_method` must be set to `kubernetes` for this to activate."
+    "description": "Defines the Hashicorp Vault role that will be\nassumed using the Kubernetes service account of\nthe running pod.\n\n`keyring_vault_auth_method` must be set to `kubernetes`\nfor this to activate.\n"
   },
   "keyring_vault_kube_api_token_file": {
     "defaultValue": "/run/secrets/kubernetes.io/serviceaccount/token",
-    "description": " Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+    "description": "Defines where the Kubernetes service account token\nshould be read from the pod's filesystem, if using\na non-standard container platform setup.\n"
   },
   "keyring_encrypt_license": {
     "defaultValue": "off",
-    "description": " Enables keyring encryption for license payloads stored in the database.  **Warning:** For Kong deployments that rely entirely on the database for license provisioning (i.e. not using `KONG_LICENSE_DATA` or `KONG_LICENSE_PATH`), enabling this option will delay license activation until after the node's keyring has been activated."
+    "description": "Enables keyring encryption for license payloads stored\nin the database.\n\n**Warning:** For Kong deployments that rely entirely on\nthe database for license provisioning (i.e. not using\n`KONG_LICENSE_DATA` or `KONG_LICENSE_PATH`), enabling\nthis option will delay license activation until after\nthe node's keyring has been activated.\n"
   },
   "untrusted_lua": {
     "defaultValue": "sandbox",
-    "description": " Controls loading of Lua functions from admin-supplied sources such as the Admin API. LuaJIT bytecode loading is always disabled.  **Warning:** LuaJIT is not designed as a secure runtime for running malicious code, therefore you should properly protect your Admin API endpoint even with sandboxing enabled. The sandbox only provides protection against trivial attackers or unintentional modification of the Kong global environment.  Accepted values are: `off`, `sandbox`, or `on`:  - `off`: Disallow loading of any arbitrary          Lua functions. The `off` option          disables any functionality that runs          arbitrary Lua code, including the          Serverless Functions plugins and any          transformation plugin that allows          custom Lua functions.  - `sandbox`: Allow loading of Lua functions,              but use a sandbox when executing              them. The sandboxed function has              restricted access to the global              environment and only has access              to standard Lua functions that              will generally not cause harm to              the Kong Gateway node.  - `on`: Functions have unrestricted         access to the global environment and         can load any Lua modules. This is         similar to the behavior in         Kong Gateway prior to 2.3.0.  The default `sandbox` environment does not allow importing other modules or libraries, or executing anything at the OS level (for example, file read/write). The global environment is also not accessible.  Examples of `untrusted_lua = sandbox` behavior:  - You can't access or change global values   such as `kong.configuration.pg_password` - You can run harmless Lua:   `local foo = 1 + 1`. However, OS level   functions are not allowed, like:   `os.execute(`rm -rf /*`)`.  For a full allowed/disallowed list, see: https://github.com/kikito/sandbox.lua/blob/master/sandbox.lua  To customize the sandbox environment, use the `untrusted_lua_sandbox_requires` and `untrusted_lua_sandbox_environment` parameters below."
+    "description": "Controls loading of Lua functions from admin-supplied\nsources such as the Admin API. LuaJIT bytecode\nloading is always disabled.\n\n**Warning:** LuaJIT is not designed as a secure\nruntime for running malicious code, therefore\nyou should properly protect your Admin API endpoint\neven with sandboxing enabled. The sandbox only\nprovides protection against trivial attackers or\nunintentional modification of the Kong global\nenvironment.\n\nAccepted values are: `off`, `sandbox`, or\n`on`:\n\n- `off`: Disallow loading of any arbitrary\n         Lua functions. The `off` option\n         disables any functionality that runs\n         arbitrary Lua code, including the\n         Serverless Functions plugins and any\n         transformation plugin that allows\n         custom Lua functions.\n\n- `sandbox`: Allow loading of Lua functions,\n             but use a sandbox when executing\n             them. The sandboxed function has\n             restricted access to the global\n             environment and only has access\n             to standard Lua functions that\n             will generally not cause harm to\n             the Kong Gateway node.\n\n- `on`: Functions have unrestricted\n        access to the global environment and\n        can load any Lua modules. This is\n        similar to the behavior in\n        Kong Gateway prior to 2.3.0.\n\nThe default `sandbox` environment does not\nallow importing other modules or libraries,\nor executing anything at the OS level (for\nexample, file read/write). The global\nenvironment is also not accessible.\n\nExamples of `untrusted_lua = sandbox`\nbehavior:\n\n- You can't access or change global values\n  such as `kong.configuration.pg_password`\n- You can run harmless Lua:\n  `local foo = 1 + 1`. However, OS level\n  functions are not allowed, like:\n  `os.execute(`rm -rf /*`)`.\n\nFor a full allowed/disallowed list, see:\nhttps://github.com/kikito/sandbox.lua/blob/master/sandbox.lua\n\nTo customize the sandbox environment, use\nthe `untrusted_lua_sandbox_requires` and\n`untrusted_lua_sandbox_environment`\nparameters below.\n"
   },
   "untrusted_lua_sandbox_requires": {
     "defaultValue": null,
-    "description": "Comma-separated list of modules allowed to be loaded with `require` inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  For example, say you have configured the Serverless pre-function plugin and it contains the following `requires`:  ``` local template = require \"resty.template\" local split = require \"kong.tools.string\".split ```  To run the plugin, add the modules to the allowed list: ``` untrusted_lua_sandbox_requires = resty.template, kong.tools.utils ```  **Warning:** Allowing certain modules may create opportunities to escape the sandbox. For example, allowing `os` or `luaposix` may be unsafe."
+    "description": "Comma-separated list of modules allowed to\nbe loaded with `require` inside the\nsandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\nFor example, say you have configured the\nServerless pre-function plugin and it\ncontains the following `requires`:\n\n```\nlocal template = require \"resty.template\"\nlocal split = require \"kong.tools.string\".split\n```\n\nTo run the plugin, add the modules to the\nallowed list:\n```\nuntrusted_lua_sandbox_requires = resty.template, kong.tools.utils\n```\n\n**Warning:** Allowing certain modules may\ncreate opportunities to escape the\nsandbox. For example, allowing `os` or\n`luaposix` may be unsafe.\n"
   },
   "untrusted_lua_sandbox_environment": {
     "defaultValue": null,
-    "description": "Comma-separated list of global Lua variables that should be made available inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  **Warning**: Certain variables, when made available, may create opportunities to escape the sandbox."
+    "description": "Comma-separated list of global Lua\nvariables that should be made available\ninside the sandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\n**Warning**: Certain variables, when made\navailable, may create opportunities to\nescape the sandbox.\n"
   },
   "openresty_path": {
     "defaultValue": null,
-    "description": "Path to the OpenResty installation that Kong will use. When this is empty (the default), Kong determines the OpenResty installation by searching for a system-installed OpenResty and falling back to searching $PATH for the nginx binary.  Setting this attribute disables the search behavior and explicitly instructs Kong which OpenResty installation to use."
+    "description": "Path to the OpenResty installation that Kong\nwill use. When this is empty (the default),\nKong determines the OpenResty installation\nby searching for a system-installed OpenResty\nand falling back to searching $PATH for the\nnginx binary.\n\nSetting this attribute disables the search\nbehavior and explicitly instructs Kong which\nOpenResty installation to use.\n"
   },
   "node_id": {
     "defaultValue": null,
-    "description": "Node ID for the Kong node. Every Kong node in a Kong cluster must have a unique and valid UUID. When empty, node ID is automatically generated."
+    "description": "Node ID for the Kong node. Every Kong node\nin a Kong cluster must have a unique and\nvalid UUID. When empty, node ID is\nautomatically generated.\n"
   },
   "cluster_fallback_config_import": {
     "defaultValue": "off",
-    "description": "Enable fallback configuration imports.  This should only be enabled for data planes."
+    "description": "Enable fallback configuration imports.\n\nThis should only be enabled for data planes.\n"
   },
   "cluster_fallback_config_storage": {
     "defaultValue": null,
-    "description": "Storage definition used by `cluster_fallback_config_import` and `cluster_fallback_config_export`.  Supported storage types: - S3-like storages - GCP storage service  To use S3 with a bucket named b and place all configs to with a key prefix named p, set it to: `s3://b/p` To use GCP for the same bucket and prefix, set it to: `gcs://b/p`  The credentials (and the endpoint URL for S3-like) for S3 are passed with environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where `AWS_CONFIG_STORAGE_ENDPOINT` is the endpoint that hosts S3-like storage.  The credentials for GCP are provided via the environment variable `GCP_SERVICE_ACCOUNT`."
+    "description": "Storage definition used by `cluster_fallback_config_import`\nand `cluster_fallback_config_export`.\n\nSupported storage types:\n- S3-like storages\n- GCP storage service\n\nTo use S3 with a bucket named b and place all configs\nto with a key prefix named p, set it to:\n`s3://b/p`\nTo use GCP for the same bucket and prefix, set it to:\n`gcs://b/p`\n\nThe credentials (and the endpoint URL for S3-like) for S3\nare passed with environment variables:\n`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,\nand `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where\n`AWS_CONFIG_STORAGE_ENDPOINT`\nis the endpoint that hosts S3-like storage.\n\nThe credentials for GCP are provided via the environment\nvariable `GCP_SERVICE_ACCOUNT`.\n"
   },
   "cluster_fallback_export_s3_config": {
     "defaultValue": null,
-    "description": "Fallback config export S3 configuration. This is used only when `cluster_fallback_config_storage` is an S3-like schema. If set, it will add the config table to the Kong exporter config S3 putObject request. The config table should be in JSON format and can be unserialized into a table. It should contain the necessary parameters as described in the documentation: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property. For example, if you want to set the ServerSideEncryption headers/KMS Key ID for the S3 putObject request, you can set the config table to: `{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"your-kms-key-id\"}`"
+    "description": "Fallback config export S3 configuration.\nThis is used only when `cluster_fallback_config_storage` is an S3-like schema.\nIf set, it will add the config table to the Kong exporter config S3 putObject request.\nThe config table should be in JSON format and can be unserialized into a table.\nIt should contain the necessary parameters as described in the documentation:\nhttps://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property.\nFor example, if you want to set the ServerSideEncryption headers/KMS Key ID\nfor the S3 putObject request, you can set the config table to:\n`{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"your-kms-key-id\"}`\n"
   },
   "cluster_fallback_config_export": {
     "defaultValue": "off",
-    "description": "Enable fallback configuration exports."
+    "description": "Enable fallback configuration exports.\n"
   },
   "cluster_fallback_config_export_delay": {
     "defaultValue": "60",
-    "description": "The fallback configuration export interval.  If the interval is set to 60 and configuration A is exported and there are new configurations B, C, and D in the next 60 seconds, it will wait until 60 seconds passed and export D, skipping B and C."
+    "description": "The fallback configuration export interval.\n\nIf the interval is set to 60 and configuration A is exported\nand there are new configurations B, C, and D in the next 60 seconds,\nit will wait until 60 seconds passed and export D, skipping B and C.\n"
   },
   "wasm": {
     "defaultValue": "off",
-    "description": "Enable/disable wasm support. This must be enabled in order to use wasm filters and filter chains."
+    "description": "Enable/disable wasm support. This must be enabled in\norder to use wasm filters and filter chains.\n"
   },
   "wasm_filters_path": {
     "defaultValue": null,
-    "description": "Path to the directory containing wasm filter modules.  At startup, Kong discovers available wasm filters by scanning this directory for files with the `.wasm` file extension.  The name of a wasm filter module is derived from the filename itself, with the .wasm extension removed. So, given the following tree:  ``` /path/to/wasm_filters ├── my_module.wasm ├── my_other_module.wasm └── not_a_wasm_module.txt ```  The resulting filter modules available for use in Kong will be:  - `my_module` - `my_other_module`  Notes:  - No recursion is performed. Only .wasm files at the   top level are registered. - This path _may_ be a symlink to a directory."
+    "description": "Path to the directory containing wasm filter modules.\n\nAt startup, Kong discovers available wasm filters by\nscanning this directory for files with the `.wasm`\nfile extension.\n\nThe name of a wasm filter module is derived from the\nfilename itself, with the .wasm extension removed. So,\ngiven the following tree:\n\n```\n/path/to/wasm_filters\n├── my_module.wasm\n├── my_other_module.wasm\n└── not_a_wasm_module.txt\n```\n\nThe resulting filter modules available for use in Kong\nwill be:\n\n- `my_module`\n- `my_other_module`\n\nNotes:\n\n- No recursion is performed. Only .wasm files at the\n  top level are registered.\n- This path _may_ be a symlink to a directory.\n"
   },
   "wasm_filters": {
     "defaultValue": [
       "bundled",
       "user"
     ],
-    "description": "Comma-separated list of Wasm filters to be made available for use in filter chains.  When the `off` keyword is specified as the only value, no filters will be available for use.  When the `bundled` keyword is specified, all filters bundled with Kong will be available.  When the `user` keyword is specified, all filters within the `wasm_filters_path` will be available.  **Examples:**  - `wasm_filters = bundled,user` enables _all_ bundled   and user-supplied filters - `wasm_filters = user` enables _only_ user-supplied   filters - `wasm_filters = filter-a,filter-b` enables _only_   filters named `filter-a` or `filter-b` (whether   bundled _or_ user-supplied)  If a conflict occurs where a bundled filter and a user-supplied filter share the same name, a warning will be logged, and the user-supplied filter will be used instead."
+    "description": "Comma-separated list of Wasm filters to be made\navailable for use in filter chains.\n\nWhen the `off` keyword is specified as the\nonly value, no filters will be available for use.\n\nWhen the `bundled` keyword is specified, all filters\nbundled with Kong will be available.\n\nWhen the `user` keyword is specified, all filters\nwithin the `wasm_filters_path` will be available.\n\n**Examples:**\n\n- `wasm_filters = bundled,user` enables _all_ bundled\n  and user-supplied filters\n- `wasm_filters = user` enables _only_ user-supplied\n  filters\n- `wasm_filters = filter-a,filter-b` enables _only_\n  filters named `filter-a` or `filter-b` (whether\n  bundled _or_ user-supplied)\n\nIf a conflict occurs where a bundled filter and a\nuser-supplied filter share the same name, a warning\nwill be logged, and the user-supplied filter will\nbe used instead.\n"
   },
   "test": {
     "defaultValue": "on",
-    "description": "test"
+    "description": "test\n"
   },
   "request_debug": {
     "defaultValue": "on",
-    "description": "When enabled, Kong will provide detailed timing information for its components to the client and the error log if the following headers are present in the proxy request: - `X-Kong-Request-Debug`:   If the value is set to `*`,   timing information will be collected and exported for the current request.   If this header is not present or contains an unknown value,   timing information will not be collected for the current request.   You can also specify a list of filters, separated by commas,   to filter the scope of the time information that is collected. The following filters are supported for `X-Kong-Request-Debug`: - `rewrite`: Collect timing information from the `rewrite` phase. - `access`: Collect timing information from the `access` phase. - `balancer`: Collect timing information from the `balancer` phase. - `response`: Collect timing information from the `response` phase. - `header_filter`: Collect timing information from the `header_filter` phase. - `body_filter`: Collect timing information from the `body_filter` phase. - `log`: Collect timing information from the `log` phase. - `upstream`: Collect timing information from the `upstream` phase.  - `X-Kong-Request-Debug-Log`:   If set to `true`, timing information will also be logged   in the Kong error log with a log level of `notice`.   Defaults to `false`.  - `X-Kong-Request-Debug-Token`:   Token for authenticating the client making the debug   request to prevent abuse. Debug requests originating from loopback   addresses do not require this header. "
+    "description": "When enabled, Kong will provide detailed timing information\nfor its components to the client and the error log\nif the following headers are present in the proxy request:\n- `X-Kong-Request-Debug`:\n  If the value is set to `*`,\n  timing information will be collected and exported for the current request.\n  If this header is not present or contains an unknown value,\n  timing information will not be collected for the current request.\n  You can also specify a list of filters, separated by commas,\n  to filter the scope of the time information that is collected.\nThe following filters are supported for `X-Kong-Request-Debug`:\n- `rewrite`: Collect timing information from the `rewrite` phase.\n- `access`: Collect timing information from the `access` phase.\n- `balancer`: Collect timing information from the `balancer` phase.\n- `response`: Collect timing information from the `response` phase.\n- `header_filter`: Collect timing information from the `header_filter` phase.\n- `body_filter`: Collect timing information from the `body_filter` phase.\n- `log`: Collect timing information from the `log` phase.\n- `upstream`: Collect timing information from the `upstream` phase.\n\n- `X-Kong-Request-Debug-Log`:\n  If set to `true`, timing information will also be logged\n  in the Kong error log with a log level of `notice`.\n  Defaults to `false`.\n\n- `X-Kong-Request-Debug-Token`:\n  Token for authenticating the client making the debug\n  request to prevent abuse. Debug requests originating from loopback\n  addresses do not require this header.\n\n"
   },
   "request_debug_token": {
     "defaultValue": "<random>",
-    "description": "The Request Debug Token is used in the `X-Kong-Request-Debug-Token` header to prevent abuse. If this value is not set (the default), a random token will be generated when Kong starts, restarts, or reloads. If a token is specified manually, then the provided token will be used.  You can locate the generated debug token in two locations: - Kong error log:   Debug token will be logged in the error log (notice level)   when Kong starts, restarts, or reloads.   The log line will have the: `[request-debug]` prefix to aid searching. - Filesystem:   Debug token will also be stored in a file located at   `{prefix}/.request_debug_token` and updated   when Kong starts, restarts, or reloads."
+    "description": "The Request Debug Token is used in the\n`X-Kong-Request-Debug-Token` header to prevent abuse.\nIf this value is not set (the default),\na random token will be generated\nwhen Kong starts, restarts, or reloads. If a token is\nspecified manually, then the provided token will be used.\n\nYou can locate the generated debug token in two locations:\n- Kong error log:\n  Debug token will be logged in the error log (notice level)\n  when Kong starts, restarts, or reloads.\n  The log line will have the: `[request-debug]` prefix to aid searching.\n- Filesystem:\n  Debug token will also be stored in a file located at\n  `{prefix}/.request_debug_token` and updated\n  when Kong starts, restarts, or reloads.\n"
   }
 }

--- a/app/_data/kong-conf/3.9.json
+++ b/app/_data/kong-conf/3.9.json
@@ -1,0 +1,1286 @@
+{
+  "prefix": {
+    "defaultValue": "/usr/local/kong/",
+    "description": "Working directory. Equivalent to Nginx's prefix path, containing temporary files and logs. Each Kong process must have a separate working directory."
+  },
+  "log_level": {
+    "defaultValue": "notice",
+    "description": "Log level of the Nginx server. Logs are found at `<prefix>/logs/error.log`."
+  },
+  "proxy_access_log": {
+    "defaultValue": "logs/access.log",
+    "description": "Path for proxy port request access logs. Set this value to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "proxy_error_log": {
+    "defaultValue": "logs/error.log",
+    "description": "Path for proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "proxy_stream_access_log": {
+    "defaultValue": "logs/access.log basic",
+    "description": "Path for TCP streams proxy port access logs. Set to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location. `basic` is defined as `'$remote_addr [$time_local] ' '$protocol $status $bytes_sent $bytes_received ' '$session_time'`"
+  },
+  "proxy_stream_error_log": {
+    "defaultValue": "logs/error.log",
+    "description": "Path for tcp streams proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "admin_access_log": {
+    "defaultValue": "logs/admin_access.log",
+    "description": "Path for Admin API request access logs. If hybrid mode is enabled and the current node is set to be the control plane, then the connection requests from data planes are also written to this file with server name \"kong_cluster_listener\".  Set this value to `off` to disable logging Admin API requests. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "admin_error_log": {
+    "defaultValue": "logs/error.log",
+    "description": "Path for Admin API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "status_access_log": {
+    "defaultValue": "off",
+    "description": "Path for Status API request access logs. The default value of `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "status_error_log": {
+    "defaultValue": "logs/status_error.log",
+    "description": "Path for Status API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+  },
+  "debug_access_log": {
+    "defaultValue": "off",
+    "description": "Path for Debug API request access logs. The default value `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+  },
+  "debug_error_log": {
+    "defaultValue": "logs/debug_error.log",
+    "description": "Path for Debug API request error logs. The granularity of these logs is adjusted using the `log_level` property."
+  },
+  "vaults": {
+    "defaultValue": "bundled",
+    "description": "Comma-separated list of vaults this node should load. By default, all the bundled vaults are enabled.  The specified name(s) will be substituted as such in the Lua namespace: `kong.vaults.{name}.*`."
+  },
+  "opentelemetry_tracing": {
+    "defaultValue": "off",
+    "description": "Deprecated: use `tracing_instrumentations` instead."
+  },
+  "tracing_instrumentations": {
+    "defaultValue": "off",
+    "description": "Comma-separated list of tracing instrumentations this node should load. By default, no instrumentations are enabled.  Valid values for this setting are:  - `off`: do not enable instrumentations. - `request`: only enable request-level instrumentations. - `all`: enable all the following instrumentations. - `db_query`: trace database queries. - `dns_query`: trace DNS queries. - `router`: trace router execution, including router rebuilding. - `http_client`: trace OpenResty HTTP client requests. - `balancer`: trace balancer retries. - `plugin_rewrite`: trace plugin iterator execution with rewrite phase. - `plugin_access`: trace plugin iterator execution with access phase. - `plugin_header_filter`: trace plugin iterator execution with header_filter phase.  **Note:** In the current implementation, tracing instrumentations are not enabled in stream mode."
+  },
+  "opentelemetry_tracing_sampling_rate": {
+    "defaultValue": "1.0",
+    "description": "Deprecated: use `tracing_sampling_rate` instead."
+  },
+  "tracing_sampling_rate": {
+    "defaultValue": "0.01",
+    "description": "Tracing instrumentation sampling rate. Tracer samples a fixed percentage of all spans following the sampling rate.  Example: `0.25`, this accounts for 25% of all traces."
+  },
+  "plugins": {
+    "defaultValue": "bundled",
+    "description": "Comma-separated list of plugins this node should load. By default, only plugins bundled in official distributions are loaded via the `bundled` keyword.  Loading a plugin does not enable it by default, but only instructs Kong to load its source code and allows configuration via the various related Admin API endpoints.  The specified name(s) will be substituted as such in the Lua namespace: `kong.plugins.{name}.*`.  When the `off` keyword is specified as the only value, no plugins will be loaded.  `bundled` and plugin names can be mixed together, as the following examples suggest:  - `plugins = bundled,custom-auth,custom-log`   will include the bundled plugins plus two custom ones. - `plugins = custom-auth,custom-log` will   *only* include the `custom-auth` and `custom-log` plugins. - `plugins = off` will not include any plugins.  **Note:** Kong will not start if some plugins were previously configured (i.e. have rows in the database) and are not specified in this list. Before disabling a plugin, ensure all instances of it are removed before restarting Kong.  **Note:** Limiting the amount of available plugins can improve P99 latency when experiencing LRU churning in the database cache (i.e. when the configured `mem_cache_size`) is full."
+  },
+  "dedicated_config_processing": {
+    "defaultValue": "on",
+    "description": "Enables or disables a special worker process for configuration processing. This process increases memory usage a little bit while allowing to reduce latencies by moving some background tasks, such as CP/DP connection handling, to an additional worker process specific to handling these background tasks. Currently this has effect only on data planes."
+  },
+  "pluginserver_names": {
+    "defaultValue": null,
+    "description": "Comma-separated list of names for pluginserver processes. The actual names are used for log messages and to relate the actual settings."
+  },
+  "pluginserver_XXX_socket": {
+    "defaultValue": "<prefix>/<XXX>.socket",
+    "description": "Path to the unix socket used by the <XXX> pluginserver."
+  },
+  "pluginserver_XXX_start_cmd": {
+    "defaultValue": "/usr/local/bin/<XXX>",
+    "description": "Full command (including any needed arguments) to start the <XXX> pluginserver."
+  },
+  "pluginserver_XXX_query_cmd": {
+    "defaultValue": "/usr/local/bin/query_<XXX>",
+    "description": "Full command to \"query\" the <XXX> pluginserver.  Should produce a JSON with the dump info of the plugin it manages."
+  },
+  "port_maps": {
+    "defaultValue": null,
+    "description": "With this configuration parameter, you can let Kong Gateway know the port from which the packets are forwarded to it. This is fairly common when running Kong in a containerized or virtualized environment. For example, `port_maps=80:8000, 443:8443` instructs Kong that the port 80 is mapped to 8000 (and the port 443 to 8443), where 8000 and 8443 are the ports that Kong is listening to.  This parameter helps Kong set a proper forwarded upstream HTTP request header or to get the proper forwarded port with the Kong PDK (in case other means determining it has failed). It changes routing by a destination port to route by a port from which packets are forwarded to Kong, and similarly it changes the default plugin log serializer to use the port according to this mapping instead of reporting the port Kong is listening to."
+  },
+  "anonymous_reports": {
+    "defaultValue": "on",
+    "description": "Send anonymous usage data such as error stack traces to help improve Kong."
+  },
+  "proxy_server": {
+    "defaultValue": null,
+    "description": "Proxy server defined as an encoded URL. Kong will only use this option if a component is explicitly configured to use a proxy."
+  },
+  "proxy_server_ssl_verify": {
+    "defaultValue": "off",
+    "description": "Toggles server certificate verification if `proxy_server` is in HTTPS. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+  },
+  "error_template_html": {
+    "defaultValue": null,
+    "description": "Path to the custom html error template to override the default html kong error template.  The template may contain up to two `%s` placeholders. The first one will expand to the error message. The second one will expand to the request ID. Both placeholders are optional, but recommended. Adding more than two placeholders will result in a runtime error when trying to render the template: ``` <html>   <body>     <h1>My custom error template</h1>     <p>error: %s</p>     <p>request_id: %s</p>   </body> </html> ```"
+  },
+  "error_template_json": {
+    "defaultValue": null,
+    "description": "Path to the custom json error template to override the default json kong error template.  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+  },
+  "error_template_xml": {
+    "defaultValue": null,
+    "description": "Path to the custom xml error template to override the default xml kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+  },
+  "error_template_plain": {
+    "defaultValue": null,
+    "description": "Path to the custom plain error template to override the default plain kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+  },
+  "role": {
+    "defaultValue": "traditional",
+    "description": "Use this setting to enable hybrid mode, This allows running some Kong nodes in a control plane role with a database and have them deliver configuration updates to other nodes running to DB-less running in a data plane role.  Valid values for this setting are:  - `traditional`: do not use hybrid mode. - `control_plane`: this node runs in a   control plane role. It can use a database   and will deliver configuration updates   to data plane nodes. - `data_plane`: this is a data plane node.   It runs DB-less and receives configuration   updates from a control plane node."
+  },
+  "cluster_mtls": {
+    "defaultValue": "shared",
+    "description": "Sets the verification method between nodes of the cluster.  Valid values for this setting are:  - `shared`: use a shared certificate/key pair specified with   the `cluster_cert` and `cluster_cert_key` settings.   Note that CP and DP nodes must present the same certificate   to establish mTLS connections. - `pki`: use `cluster_ca_cert`, `cluster_server_name`, and   `cluster_cert` for verification. These are different   certificates for each DP node, but issued by a cluster-wide   common CA certificate: `cluster_ca_cert`. - `pki_check_cn`: similar to `pki` but additionally checks   for the common name of the data plane certificate specified   in `cluster_allowed_common_names`."
+  },
+  "cluster_cert": {
+    "defaultValue": null,
+    "description": "Cluster certificate to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes. Under `pki` mode, it should be a different certificate for each DP node.  The certificate can be configured on this property with any of the following values: - absolute path to the certificate - certificate content - base64 encoded certificate content"
+  },
+  "cluster_cert_key": {
+    "defaultValue": null,
+    "description": "Cluster certificate key to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes.  Under `pki` mode it should be a different certificate for each DP node.  The certificate key can be configured on this property with either of the following values: - absolute path to the certificate key - certificate key content - base64 encoded certificate key content"
+  },
+  "cluster_ca_cert": {
+    "defaultValue": null,
+    "description": "The trusted CA certificate file in PEM format used for: - Control plane to verify data plane's certificate - Data plane to verify control plane's certificate  Required on data plane if `cluster_mtls` is set to `pki`. If the control plane certificate is issued by a well-known CA, set `lua_ssl_trusted_certificate=system` on the data plane and leave this field empty.  This field is ignored if `cluster_mtls` is set to `shared`.  The certificate can be configured on this property with any of the following values: - absolute path to the certificate - certificate content - base64 encoded certificate content"
+  },
+  "cluster_allowed_common_names": {
+    "defaultValue": null,
+    "description": "The list of Common Names that are allowed to connect to control plane. Multiple entries may be supplied in a comma-separated string. When not set, only data plane with the same parent domain as the control plane cert is allowed to connect.  This field is ignored if `cluster_mtls` is not set to `pki_check_cn`."
+  },
+  "cluster_server_name": {
+    "defaultValue": null,
+    "description": "The server name used in the SNI of the TLS connection from a DP node to a CP node. Must match the Common Name (CN) or Subject Alternative Name (SAN) found in the CP certificate. If `cluster_mtls` is set to `shared`, this setting is ignored and `kong_clustering` is used."
+  },
+  "cluster_control_plane": {
+    "defaultValue": null,
+    "description": "To be used by data plane nodes only: address of the control plane node from which configuration updates will be fetched, in `host:port` format."
+  },
+  "cluster_telemetry_endpoint": {
+    "defaultValue": null,
+    "description": "To be used by data plane nodes only: telemetry address of the control plane node to which telemetry updates will be posted in `host:port` format."
+  },
+  "cluster_telemetry_server_name": {
+    "defaultValue": null,
+    "description": "The SNI (Server Name Indication extension) to use for Vitals telemetry data."
+  },
+  "cluster_dp_labels": {
+    "defaultValue": null,
+    "description": "Comma-separated list of labels for the data plane. Labels are key-value pairs that provide additional context information for each DP. Each label must be configured as a string in the format `key:value`.  Labels are only compatible with hybrid mode deployments with Kong Konnect (SaaS). This configuration doesn't work with self-hosted deployments.  Keys and values follow the AIP standards: https://kong-aip.netlify.app/aip/129/  Example: `deployment:mycloud,region:us-east-1`"
+  },
+  "cluster_listen": {
+    "defaultValue": "0.0.0.0:8005",
+    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster. This port is mTLS protected to ensure end-to-end security and integrity.  This setting has no effect if `role` is not set to `control_plane`.  Connections made to this endpoint are logged to the same location as Admin API access logs. See `admin_access_log` config description for more information."
+  },
+  "cluster_telemetry_listen": {
+    "defaultValue": "0.0.0.0:8006",
+    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane telemetry connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster.  This setting has no effect if `role` is not set to `control_plane`."
+  },
+  "cluster_data_plane_purge_delay": {
+    "defaultValue": "1209600",
+    "description": " How many seconds must pass from the time a DP node becomes offline to the time its entry gets removed from the database, as returned by the /clustering/data-planes Admin API endpoint.  This is to prevent the cluster data plane table from growing indefinitely. The default is set to 14 days. That is, if the CP hasn't heard from a DP for 14 days, its entry will be removed."
+  },
+  "cluster_ocsp": {
+    "defaultValue": "off",
+    "description": " Whether to check for revocation status of DP certificates using OCSP (Online Certificate Status Protocol). If enabled, the DP certificate should contain the \"Certificate Authority Information Access\" extension and the OCSP method with URI of which the OCSP responder can be reached from CP.  OCSP checks are only performed on CP nodes, it has no effect on DP nodes.  Valid values for this setting are:  - `on`: OCSP revocation check is enabled and DP   must pass the check in order to establish   connection with CP. - `off`: OCSP revocation check is disabled. - `optional`: OCSP revocation check will be attempted,   however, if the required extension is not   found inside DP-provided certificate   or communication with the OCSP responder   failed, then DP is still allowed through."
+  },
+  "cluster_use_proxy": {
+    "defaultValue": "off",
+    "description": " Whether to turn on HTTP CONNECT proxy support for hybrid mode connections. `proxy_server` will be used for hybrid mode connections if this option is turned on."
+  },
+  "cluster_max_payload": {
+    "defaultValue": "16777216",
+    "description": " This sets the maximum compressed payload size allowed to be sent from CP to DP in hybrid mode. Default is 16MB - 16 * 1024 * 1024."
+  },
+  "proxy_listen": {
+    "defaultValue": [
+      "0.0.0.0:8000 reuseport backlog=16384",
+      "0.0.0.0:8443 http2 ssl reuseport backlog=16384"
+    ],
+    "description": " Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. The proxy server is the public entry point of Kong, which proxies traffic from your consumers to your backend services. This value accepts IPv4, IPv6, and hostnames.  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the `TCP_DEFER_ACCEPT` socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process,   allowing the kernel to better distribute incoming   connections between worker processes. - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small to prevent clients   seeing \"Connection refused\" errors when connecting to   a busy Kong instance.   **Note:** On Linux, this value is limited by the   setting of the `net.core.somaxconn` kernel parameter.   In order for the larger `backlog` set here to take   effect, it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` specifies whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections. - `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]`   configures the TCP keepalive behavior for the listening   socket. If this parameter is omitted, the operating   system’s settings will be in effect for the socket. If it   is set to the value `on`, the `SO_KEEPALIVE` option is turned   on for the socket. If it is set to the value `off`, the   `SO_KEEPALIVE` option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the `TCP_KEEPIDLE`,` TCP_KEEPINTVL`,   and `TCP_KEEPCNT` socket options.  This value can be set to `off`, thus disabling the HTTP/HTTPS proxy port for this node. If `stream_listen` is also set to `off`, this enables control plane mode for this node (in which all traffic proxying capabilities are disabled). This node can then be used only to configure a cluster of Kong nodes connected to the same datastore.  Example: `proxy_listen = 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`  See http://nginx.org/en/docs/http/ngx_http_core_module.html#listen for a description of the accepted formats for this and other `*_listen` values.  See https://www.nginx.com/resources/admin-guide/proxy-protocol/ for more details about the `proxy_protocol` parameter.  Not all `*_listen` values accept all formats specified in nginx's documentation."
+  },
+  "proxy_url": {
+    "defaultValue": null,
+    "description": "Kong Proxy URL  The lookup, or balancer, address for your Kong Proxy nodes.  This value is commonly used in a microservices or service-mesh oriented architecture.  Accepted format (parts in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`  Examples:  - `<scheme>://<IP>:<PORT>` -> `proxy_url = http://127.0.0.1:8000` - `SSL <scheme>://<HOSTNAME>` -> `proxy_url = https://proxy.domain.tld` - `<scheme>://<HOSTNAME>/<PATH>` -> `proxy_url = http://dev-machine/dev-285`  By default, Kong Manager and Kong Portal will use the window request host and append the resolved listener port depending on the requested protocol."
+  },
+  "stream_listen": {
+    "defaultValue": "off",
+    "description": " Comma-separated list of addresses and ports on which the stream mode should listen.  This value accepts IPv4, IPv6, and hostnames. Some suffixes can be specified for each pair: - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process,   allowing the kernel to better distribute incoming   connections between worker processes. - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small to prevent clients   seeing \"Connection refused\" errors when connecting to   a busy Kong instance.   **Note:** On Linux, this value is limited by the   setting of the `net.core.somaxconn` kernel parameter.   In order for the larger `backlog` set here to take   effect, it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` specifies whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the \"TCP keepalive\" behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value \"on\", the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value \"off\", the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the` TCP_KEEPIDLE`, `TCP_KEEPINTVL`,   and `TCP_KEEPCNT` socket options.  Examples:  ``` stream_listen = 127.0.0.1:7000 reuseport backlog=16384 stream_listen = 0.0.0.0:989 reuseport backlog=65536, 0.0.0.0:20 stream_listen = [::1]:1234 backlog=16384 ```  By default, this value is set to `off`, thus disabling the stream proxy port for this node."
+  },
+  "admin_api_uri": {
+    "defaultValue": null,
+    "description": "Deprecated: Use admin_gui_api_url instead"
+  },
+  "admin_listen": {
+    "defaultValue": [
+      "127.0.0.1:8001 reuseport backlog=16384",
+      "127.0.0.1:8444 http2 ssl reuseport backlog=16384"
+    ],
+    "description": " Comma-separated list of addresses and ports on which the Admin interface should listen. The Admin interface is the API allowing you to configure and manage Kong. Access to this interface should be *restricted* to Kong administrators *only*. This value accepts IPv4, IPv6, and hostnames.  It is highly recommended to avoid exposing the Admin API to public interfaces, by using values such as `0.0.0.0:8001`  See https://docs.konghq.com/gateway/latest/production/running-kong/secure-admin-api/ for more information about how to secure your Admin API.  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the `TCP_DEFER_ACCEPT` socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process,   allowing the Kernel to better distribute incoming   connections between worker processes. - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small to prevent clients   seeing \"Connection refused\" errors when connecting to   a busy Kong instance.   **Note:** On Linux, this value is limited by the   setting of the `net.core.somaxconn` kernel parameter.   In order for the larger `backlog` set here to take   effect, it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` specifies whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections. - `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]`   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted, the operating   system’s settings will be in effect for the socket. If it   is set to the value `on`, the `SO_KEEPALIVE` option is turned   on for the socket. If it is set to the value `off`, the   `SO_KEEPALIVE` option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the `TCP_KEEPIDLE`, `TCP_KEEPINTVL`,   and `TCP_KEEPCNT` socket options.  This value can be set to `off`, thus disabling the Admin interface for this node, enabling a data plane mode (without configuration capabilities) pulling its configuration changes from the database.  Example: `admin_listen = 127.0.0.1:8444 http2 ssl`"
+  },
+  "status_listen": {
+    "defaultValue": "127.0.0.1:8007 reuseport backlog=16384",
+    "description": " Comma-separated list of addresses and ports on which the Status API should listen. The Status API is a read-only endpoint allowing monitoring tools to retrieve metrics, healthiness, and other non-sensitive information of the current Kong node.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Status API server. - `proxy_protocol` will enable usage of the PROXY protocol.  This value can be set to `off`, disabling the Status API for this node.  Example: `status_listen = 0.0.0.0:8100 ssl http2`"
+  },
+  "debug_listen": {
+    "defaultValue": "off",
+    "description": "Comma-separated list of addresses and ports on which the Debug API should listen.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Debug API server.  This value can be set to `off`, disabling the Debug API for this node.  Example: `debug_listen = 0.0.0.0:8200 ssl http2`"
+  },
+  "debug_listen_local": {
+    "defaultValue": "on",
+    "description": "Expose `debug_listen` functionalities via a Unix domain socket under the Kong prefix.  This option allows local users to use `kong debug` command to invoke various debug functionalities without needing to enable `debug_listen` ahead of time."
+  },
+  "nginx_user": {
+    "defaultValue": "kong kong",
+    "description": "Defines user and group credentials used by worker processes. If group is omitted, a group whose name equals that of user is used.  Example: `nginx_user = nginx www`  **Note**: If the `kong` user and the `kong` group are not available, the default user and group credentials will be `nobody nobody`."
+  },
+  "nginx_worker_processes": {
+    "defaultValue": "auto",
+    "description": "Determines the number of worker processes spawned by Nginx.  See http://nginx.org/en/docs/ngx_core_module.html#worker_processes for detailed usage of the equivalent Nginx directive and a description of accepted values."
+  },
+  "nginx_daemon": {
+    "defaultValue": "on",
+    "description": "Determines whether Nginx will run as a daemon or as a foreground process. Mainly useful for development or when running Kong inside a Docker environment.  See http://nginx.org/en/docs/ngx_core_module.html#daemon."
+  },
+  "mem_cache_size": {
+    "defaultValue": "128m",
+    "description": "Size of each of the two shared memory caches for traditional mode database entities and runtime data, `kong_core_cache` and `kong_cache`.  The accepted units are `k` and `m`, with a minimum recommended value of a few MBs.  **Note**: As this option controls the size of two different cache zones, the total memory Kong uses to cache entities might be double this value. The created zones are shared by all worker processes and do not become larger when more workers are used."
+  },
+  "ssl_cipher_suite": {
+    "defaultValue": "intermediate",
+    "description": "Defines the TLS ciphers served by Nginx. Accepted values are `modern`, `intermediate`, `old`, `fips` or `custom`. If you want to enable TLSv1.1, this value has to be `old`.  See https://wiki.mozilla.org/Security/Server_Side_TLS for detailed descriptions of each cipher suite. `fips` cipher suites are as described in https://wiki.openssl.org/index.php/FIPS_mode_and_TLS."
+  },
+  "ssl_ciphers": {
+    "defaultValue": null,
+    "description": "Defines a custom list of TLS ciphers to be served by Nginx. This list must conform to the pattern defined by `openssl ciphers`. This value is ignored if `ssl_cipher_suite` is not `custom`. If you use DHE ciphers, you must also configure the `ssl_dhparam` parameter."
+  },
+  "ssl_protocols": {
+    "defaultValue": "TLSv1.2 TLSv1.3",
+    "description": " Enables the specified protocols for client-side connections. The set of supported protocol versions also depends on the version of OpenSSL Kong was built with. This value is ignored if `ssl_cipher_suite` is not `custom`. If you want to enable TLSv1.1, you should set `ssl_cipher_suite` to `old`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols"
+  },
+  "ssl_prefer_server_ciphers": {
+    "defaultValue": "on",
+    "description": "Specifies that server ciphers should be preferred over client ciphers when using the SSLv3 and TLS protocols. This value is ignored if `ssl_cipher_suite` is not `custom`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers"
+  },
+  "ssl_dhparam": {
+    "defaultValue": null,
+    "description": "Defines DH parameters for DHE ciphers from the predefined groups: `ffdhe2048`, `ffdhe3072`, `ffdhe4096`, `ffdhe6144`, `ffdhe8192`, from the absolute path to a parameters file, or directly from the parameters content.  This value is ignored if `ssl_cipher_suite` is `modern` or `intermediate`. The reason is that `modern` has no ciphers that need this, and `intermediate` uses `ffdhe2048`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam"
+  },
+  "ssl_session_tickets": {
+    "defaultValue": "on",
+    "description": "Enables or disables session resumption through TLS session tickets. This has no impact when used with TLSv1.3.  Kong enables this by default for performance reasons, but it has security implications: https://github.com/mozilla/server-side-tls/issues/135  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets"
+  },
+  "ssl_session_timeout": {
+    "defaultValue": "1d",
+    "description": "Specifies a time during which a client may reuse the session parameters. See the rationale: https://github.com/mozilla/server-side-tls/issues/198  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout"
+  },
+  "ssl_session_cache_size": {
+    "defaultValue": "10m",
+    "description": "Sets the size of the caches that store session parameters.  See https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache"
+  },
+  "ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `proxy_listen` values with TLS enabled.  If more than one certificate is specified, it can be used to provide alternate types of certificates (for example, ECC certificates) that will be served to clients that support them. Note that to properly serve using ECC certificates, it is recommended to also set `ssl_cipher_suite` to `modern` or `intermediate`.  Unless this option is explicitly set, Kong will auto-generate a pair of default certificates (RSA + ECC) the first time it starts up and use them for serving TLS requests.  Certificates can be configured on this property with any of the following values: - absolute path to the certificate - certificate content - base64 encoded certificate content"
+  },
+  "ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `proxy_listen` values with TLS enabled.  If more than one certificate was specified for `ssl_cert`, then this option should contain the corresponding key for all certificates provided in the same order.  Unless this option is explicitly set, Kong will auto-generate a pair of default private keys (RSA + ECC) the first time it starts up and use them for serving TLS requests.  Keys can be configured on this property with any of the following values: - absolute path to the certificate key - certificate key content - base64 encoded certificate key content"
+  },
+  "client_ssl": {
+    "defaultValue": "off",
+    "description": "Determines if Nginx should attempt to send client-side TLS certificates and perform Mutual TLS Authentication with upstream service when proxying requests."
+  },
+  "client_ssl_cert": {
+    "defaultValue": null,
+    "description": "If `client_ssl` is enabled, the client certificate for the `proxy_ssl_certificate` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate can be configured on this property with any of the following values: - absolute path to the certificate - certificate content - base64 encoded certificate content"
+  },
+  "client_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "If `client_ssl` is enabled, the client TLS key for the `proxy_ssl_certificate_key` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate key can be configured on this property with any of the following values: - absolute path to the certificate key - certificate key content - base64 encoded certificate key content"
+  },
+  "admin_ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `admin_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+  },
+  "admin_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `admin_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+  },
+  "status_ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `status_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+  },
+  "status_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `status_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+  },
+  "debug_ssl_cert": {
+    "defaultValue": null,
+    "description": "Comma-separated list of certificates for `debug_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+  },
+  "debug_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "Comma-separated list of keys for `debug_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+  },
+  "headers": {
+    "defaultValue": [
+      "server_tokens",
+      "latency_tokens",
+      "X-Kong-Request-Id"
+    ],
+    "description": " Comma-separated list of headers Kong should inject in client responses.  Accepted values are: - `Server`: Injects `Server: kong/x.y.z`   on Kong-produced responses (e.g., Admin   API, rejected requests from auth plugin). - `Via`: Injects `Via: kong/x.y.z` for   successfully proxied requests. - `X-Kong-Proxy-Latency`: Time taken   (in milliseconds) by Kong to process   a request and run all plugins before   proxying the request upstream. - `X-Kong-Response-Latency`: Time taken   (in milliseconds) by Kong to produce   a response in case of, e.g., a plugin   short-circuiting the request, or in   case of an error. - `X-Kong-Upstream-Latency`: Time taken   (in milliseconds) by the upstream   service to send response headers. - `X-Kong-Admin-Latency`: Time taken   (in milliseconds) by Kong to process   an Admin API request. - `X-Kong-Upstream-Status`: The HTTP status   code returned by the upstream service.   This is particularly useful for clients to   distinguish upstream statuses if the   response is rewritten by a plugin. - `X-Kong-Request-Id`: Unique identifier of   the request. - `server_tokens`: Same as specifying both   `Server` and `Via`. - `latency_tokens`: Same as specifying   `X-Kong-Proxy-Latency`,   `X-Kong-Response-Latency`,   `X-Kong-Admin-Latency`, and   `X-Kong-Upstream-Latency`.  In addition to these, this value can be set to `off`, which prevents Kong from injecting any of the above headers. Note that this does not prevent plugins from injecting headers of their own.  Example: `headers = via, latency_tokens`"
+  },
+  "headers_upstream": {
+    "defaultValue": "X-Kong-Request-Id",
+    "description": " Comma-separated list of headers Kong should inject in requests to upstream.  At this time, the only accepted value is: - `X-Kong-Request-Id`: Unique identifier of   the request.  In addition, this value can be set to `off`, which prevents Kong from injecting the above header. Note that this does not prevent plugins from injecting headers of their own."
+  },
+  "trusted_ips": {
+    "defaultValue": null,
+    "description": "Defines trusted IP address blocks that are known to send correct `X-Forwarded-*` headers. Requests from trusted IPs make Kong forward their `X-Forwarded-*` headers upstream. Non-trusted requests make Kong insert its own `X-Forwarded-*` headers.  This property also sets the `set_real_ip_from` directive(s) in the Nginx configuration. It accepts the same type of values (CIDR blocks) but as a comma-separated list.  To trust *all* IPs, set this value to `0.0.0.0/0,::/0`.  If the special value `unix:` is specified, all UNIX-domain sockets will be trusted.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from for examples of accepted values."
+  },
+  "real_ip_header": {
+    "defaultValue": "X-Real-IP",
+    "description": "Defines the request header field whose value will be used to replace the client address. This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  If this value receives `proxy_protocol`:  - at least one of the `proxy_listen` entries   must have the `proxy_protocol` flag   enabled. - the `proxy_protocol` parameter will be   appended to the `listen` directive of the   Nginx template.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header for a description of this directive."
+  },
+  "real_ip_recursive": {
+    "defaultValue": "off",
+    "description": "This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive for a description of this directive."
+  },
+  "error_default_type": {
+    "defaultValue": "text/plain",
+    "description": "Default MIME type to use when the request `Accept` header is missing and Nginx is returning an error for the request. Accepted values are `text/plain`, `text/html`, `application/json`, and `application/xml`."
+  },
+  "upstream_keepalive_pool_size": {
+    "defaultValue": "512",
+    "description": "Sets the default size of the upstream keepalive connection pools. Upstream keepalive connection pools are segmented by the `dst ip/dst port/SNI` attributes of a connection. A value of `0` will disable upstream keepalive connections by default, forcing each upstream request to open a new connection."
+  },
+  "upstream_keepalive_max_requests": {
+    "defaultValue": "10000",
+    "description": "Sets the default maximum number of requests that can be proxied upstream through one keepalive connection. After the maximum number of requests is reached, the connection will be closed. A value of `0` will disable this behavior, and a keepalive connection can be used to proxy an indefinite number of requests."
+  },
+  "upstream_keepalive_idle_timeout": {
+    "defaultValue": "60",
+    "description": "Sets the default timeout (in seconds) for which an upstream keepalive connection should be kept open. When the timeout is reached while the connection has not been reused, it will be closed. A value of `0` will disable this behavior, and an idle keepalive connection may be kept open indefinitely."
+  },
+  "allow_debug_header": {
+    "defaultValue": "off",
+    "description": "Enable the `Kong-Debug` header function. If it is `on`, Kong will add `Kong-Route-Id`, `Kong-Route-Name`, `Kong-Service-Id`, and `Kong-Service-Name` debug headers to the response when the client request header `Kong-Debug: 1` is present."
+  },
+  "nginx_main_worker_rlimit_nofile": {
+    "defaultValue": "auto",
+    "description": " Changes the limit on the maximum number of open files for worker processes.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile"
+  },
+  "nginx_events_worker_connections": {
+    "defaultValue": "auto",
+    "description": " Sets the maximum number of simultaneous connections that can be opened by a worker process.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_connections"
+  },
+  "nginx_http_client_header_buffer_size": {
+    "defaultValue": "1k",
+    "description": "Sets buffer size for reading the client request headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size"
+  },
+  "nginx_http_large_client_header_buffers": {
+    "defaultValue": "4 8k",
+    "description": "Sets the maximum number and size of buffers used for reading large client request headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers"
+  },
+  "nginx_http_client_max_body_size": {
+    "defaultValue": "0",
+    "description": "Defines the maximum request body size allowed by requests proxied by Kong, specified in the Content-Length request header. If a request exceeds this limit, Kong will respond with a 413 (Request Entity Too Large). Setting this value to 0 disables checking the request body size. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size"
+  },
+  "nginx_admin_client_max_body_size": {
+    "defaultValue": "10m",
+    "description": "Defines the maximum request body size for Admin API."
+  },
+  "nginx_http_charset": {
+    "defaultValue": "UTF-8",
+    "description": "Adds the specified charset to the \"Content-Type\" response header field. If this charset is different from the charset specified in the `source_charset` directive, a conversion is performed.  The parameter `off` cancels the addition of charset to the \"Content-Type\" response header field. See http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset"
+  },
+  "nginx_http_client_body_buffer_size": {
+    "defaultValue": "8k",
+    "description": "Defines the buffer size for reading the request body. If the client request body is larger than this value, the body will be buffered to disk. Note that when the body is buffered to disk, Kong plugins that access or manipulate the request body may not work, so it is advisable to set this value as high as possible (e.g., set it as high as `client_max_body_size` to force request bodies to be kept in memory). Do note that high-concurrency environments will require significant memory allocations to process many concurrent large request bodies. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size"
+  },
+  "nginx_admin_client_body_buffer_size": {
+    "defaultValue": "10m",
+    "description": "Defines the buffer size for reading the request body on Admin API."
+  },
+  "nginx_http_lua_regex_match_limit": {
+    "defaultValue": "100000",
+    "description": "Global `MATCH_LIMIT` for PCRE regex matching. The default of `100000` should ensure at worst any regex Kong executes could finish within roughly 2 seconds."
+  },
+  "nginx_http_lua_regex_cache_max_entries": {
+    "defaultValue": "8192",
+    "description": "Specifies the maximum number of entries allowed in the worker process level PCRE JIT compiled regex cache. It is recommended to set it to at least (number of regex paths * 2) to avoid high CPU usages if you manually specified `router_flavor` to `traditional`. `expressions` and `traditional_compat` router do not make use of the PCRE library and their behavior is unaffected by this setting."
+  },
+  "nginx_http_keepalive_requests": {
+    "defaultValue": "10000",
+    "description": "Sets the maximum number of client requests that can be served through one keep-alive connection. After the maximum number of requests are made, the connection is closed. Closing connections periodically is necessary to free per-connection memory allocations. Therefore, using too high a maximum number of requests could result in excessive memory usage and is not recommended. See: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests"
+  },
+  "database": {
+    "defaultValue": "postgres",
+    "description": "Determines the database (or no database) for this node Accepted values are `postgres` and `off`."
+  },
+  "pg_host": {
+    "defaultValue": "127.0.0.1",
+    "description": "Host of the Postgres server."
+  },
+  "pg_port": {
+    "defaultValue": "5432",
+    "description": "Port of the Postgres server."
+  },
+  "pg_timeout": {
+    "defaultValue": "5000",
+    "description": "Defines the timeout (in ms), for connecting, reading and writing."
+  },
+  "pg_user": {
+    "defaultValue": "kong",
+    "description": "Postgres user."
+  },
+  "pg_password": {
+    "defaultValue": null,
+    "description": "Postgres user's password."
+  },
+  "pg_iam_auth": {
+    "defaultValue": "off",
+    "description": "Determines whether the AWS IAM database Authentication will be used. When switch to `on`, the username defined in `pg_user` will be used as the database account, and the database connection will be forced to using TLS. `pg_password` will not be used when the switch is `on`. Note that the corresponding IAM policy must be correct, otherwise connecting will fail."
+  },
+  "pg_iam_auth_assume_role_arn": {
+    "defaultValue": null,
+    "description": "The target AWS IAM role ARN that will be assumed when using AWS IAM database authentication. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+  },
+  "pg_iam_auth_role_session_name": {
+    "defaultValue": "KongPostgres",
+    "description": "The role session name used for role assuming in AWS IAM Database Authentication. The default value is `KongPostgres`."
+  },
+  "pg_iam_auth_sts_endpoint_url": {
+    "defaultValue": null,
+    "description": "The custom STS endpoint URL used for role assuming in AWS IAM Database Authentication.  Note that this value will override the default STS endpoint URL(which should be `https://sts.amazonaws.com`, or `https://sts.<region>.amazonaws.com` if you have `AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).  If you are not using private VPC endpoint for STS service, you should not specify this value."
+  },
+  "pg_database": {
+    "defaultValue": "kong",
+    "description": "The database name to connect to."
+  },
+  "pg_schema": {
+    "defaultValue": null,
+    "description": "The database schema to use. If unspecified, Kong will respect the `search_path` value of your PostgreSQL instance."
+  },
+  "pg_ssl": {
+    "defaultValue": "off",
+    "description": "Toggles client-server TLS connections between Kong and PostgreSQL. Because PostgreSQL uses the same port for TLS and non-TLS, this is only a hint. If the server does not support TLS, the established connection will be a plain one."
+  },
+  "pg_ssl_version": {
+    "defaultValue": "tlsv1_2",
+    "description": "When using ssl between Kong and PostgreSQL, the version of tls to use. Accepted values are `tlsv1_1`, `tlsv1_2`, `tlsv1_3`, or 'any'. When `any` is set, the client negotiates the highest version with the server which can't be lower than `tlsv1_1`."
+  },
+  "pg_ssl_required": {
+    "defaultValue": "off",
+    "description": "When `pg_ssl` is on this determines if TLS must be used between Kong and PostgreSQL. It aborts the connection if the server does not support SSL connections."
+  },
+  "pg_ssl_verify": {
+    "defaultValue": "off",
+    "description": "Toggles server certificate verification if `pg_ssl` is enabled. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+  },
+  "pg_ssl_cert": {
+    "defaultValue": null,
+    "description": "The absolute path to the PEM encoded client TLS certificate for the PostgreSQL connection. Mutual TLS authentication against PostgreSQL is only enabled if this value is set."
+  },
+  "pg_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "If `pg_ssl_cert` is set, the absolute path to the PEM encoded client TLS private key for the PostgreSQL connection."
+  },
+  "pg_max_concurrent_queries": {
+    "defaultValue": "0",
+    "description": "Sets the maximum number of concurrent queries that can be executing at any given time. This limit is enforced per worker process; the total number of concurrent queries for this node will be will be: `pg_max_concurrent_queries * nginx_worker_processes`.  The default value of 0 removes this concurrency limitation."
+  },
+  "pg_semaphore_timeout": {
+    "defaultValue": "60000",
+    "description": "Defines the timeout (in ms) after which PostgreSQL query semaphore resource acquisition attempts will fail. Such failures will generally result in the associated proxy or Admin API request failing with an HTTP 500 status code. Detailed discussion of this behavior is available in the online documentation."
+  },
+  "pg_keepalive_timeout": {
+    "defaultValue": null,
+    "description": "Specify the maximal idle timeout (in ms) for the postgres connections in the pool. If this value is set to 0 then the timeout interval is unlimited.  If not specified this value will be same as `lua_socket_keepalive_timeout`"
+  },
+  "pg_pool_size": {
+    "defaultValue": null,
+    "description": "Specifies the size limit (in terms of connection count) for the Postgres server. Note that this connection pool is intended per Nginx worker rather than per Kong instance.  If not specified, the default value is the same as `lua_socket_pool_size`"
+  },
+  "pg_backlog": {
+    "defaultValue": null,
+    "description": "If specified, this value will limit the total number of open connections to the Postgres server to `pg_pool_size`. If the connection pool is full, subsequent connect operations will be inserted in a queue with size equal to this option's value.  If the number of queued connect operations reaches `pg_backlog`, exceeding connections will fail.  If not specified, then number of open connections to the Postgres server is not limited."
+  },
+  "pg_ro_host": {
+    "defaultValue": null,
+    "description": "Same as `pg_host`, but for the read-only connection. **Note:** Refer to the documentation section above for detailed usage."
+  },
+  "pg_ro_port": {
+    "defaultValue": "<pg_port>",
+    "description": "Same as `pg_port`, but for the read-only connection."
+  },
+  "pg_ro_timeout": {
+    "defaultValue": "<pg_timeout>",
+    "description": "Same as `pg_timeout`, but for the read-only connection."
+  },
+  "pg_ro_user": {
+    "defaultValue": "<pg_user>",
+    "description": "Same as `pg_user`, but for the read-only connection."
+  },
+  "pg_ro_password": {
+    "defaultValue": "<pg_password>",
+    "description": "Same as `pg_password`, but for the read-only connection."
+  },
+  "pg_ro_iam_auth": {
+    "defaultValue": "<pg_iam_auth>",
+    "description": "Same as `pg_iam_auth`, but for the read-only connection."
+  },
+  "pg_ro_iam_auth_assume_role_arn": {
+    "defaultValue": null,
+    "description": "Same as `pg_iam_auth_assume_role_arn', but for the read-only connection."
+  },
+  "pg_ro_iam_auth_role_session_name": {
+    "defaultValue": "KongPostgres",
+    "description": "Same as `pg_iam_auth_role_session_name`, but for the read-only connection."
+  },
+  "pg_ro_iam_auth_sts_endpoint_url": {
+    "defaultValue": null,
+    "description": "Same as `pg_iam_auth_sts_endpoint_url`, but for the read-only connection."
+  },
+  "pg_ro_database": {
+    "defaultValue": "<pg_database>",
+    "description": "Same as `pg_database`, but for the read-only connection."
+  },
+  "pg_ro_schema": {
+    "defaultValue": "<pg_schema>",
+    "description": "Same as `pg_schema`, but for the read-only connection."
+  },
+  "pg_ro_ssl": {
+    "defaultValue": "<pg_ssl>",
+    "description": "Same as `pg_ssl`, but for the read-only connection."
+  },
+  "pg_ro_ssl_required": {
+    "defaultValue": "<pg_ssl_required>",
+    "description": " Same as `pg_ssl_required`, but for the read-only connection."
+  },
+  "pg_ro_ssl_verify": {
+    "defaultValue": "<pg_ssl_verify>",
+    "description": " Same as `pg_ssl_verify`, but for the read-only connection."
+  },
+  "pg_ro_ssl_version": {
+    "defaultValue": "<pg_ssl_version>",
+    "description": " Same as `pg_ssl_version`, but for the read-only connection."
+  },
+  "pg_ro_max_concurrent_queries": {
+    "defaultValue": "<pg_max_concurrent_queries>",
+    "description": " Same as `pg_max_concurrent_queries`, but for the read-only connection. Note: read-only concurrency is not shared with the main (read-write) connection."
+  },
+  "pg_ro_semaphore_timeout": {
+    "defaultValue": "<pg_semaphore_timeout>",
+    "description": " Same as `pg_semaphore_timeout`, but for the read-only connection."
+  },
+  "pg_ro_keepalive_timeout": {
+    "defaultValue": "<pg_keepalive_timeout>",
+    "description": " Same as `pg_keepalive_timeout`, but for the read-only connection."
+  },
+  "pg_ro_pool_size": {
+    "defaultValue": "<pg_pool_size>",
+    "description": " Same as `pg_pool_size`, but for the read-only connection."
+  },
+  "pg_ro_backlog": {
+    "defaultValue": "<pg_backlog>",
+    "description": " Same as `pg_backlog`, but for the read-only connection."
+  },
+  "declarative_config": {
+    "defaultValue": null,
+    "description": "The path to the declarative configuration file which holds the specification of all entities (routes, services, consumers, etc.) to be used when the `database` is set to `off`.  Entities are stored in Kong's LMDB cache, so you must ensure that enough headroom is allocated to it via the `lmdb_map_size` property.  If the hybrid mode `role` is set to `data_plane` and there's no configuration cache file, this configuration is used before connecting to the control plane node as a user-controlled fallback."
+  },
+  "declarative_config_string": {
+    "defaultValue": null,
+    "description": "The declarative configuration as a string"
+  },
+  "lmdb_environment_path": {
+    "defaultValue": "dbless.lmdb",
+    "description": "Directory where the LMDB database files used by DB-less and hybrid mode to store Kong configurations reside.  This path is relative under the Kong `prefix`."
+  },
+  "lmdb_map_size": {
+    "defaultValue": "2048m",
+    "description": "Maximum size of the LMDB memory map, used to store the DB-less and hybrid mode configurations. Default is 2048m.  This config defines the limit of LMDB file size; the actual file size growth will be on-demand and proportional to the actual config size.  Note this value can be set very large, say a couple of GBs, to accommodate future database growth and Multi-Version Concurrency Control (MVCC) headroom needs. The file size of the LMDB database file should stabilize after a few config reloads/hybrid mode syncs, and the actual memory used by the LMDB database will be smaller than the file size due to dynamic swapping of database pages by the OS."
+  },
+  "db_update_frequency": {
+    "defaultValue": "5",
+    "description": "Frequency (in seconds) at which to check for updated entities with the datastore.  When a node creates, updates, or deletes an entity via the Admin API, other nodes need to wait for the next poll (configured by this value) to eventually purge the old cached entity and start using the new one."
+  },
+  "db_update_propagation": {
+    "defaultValue": "0",
+    "description": "Time (in seconds) taken for an entity in the datastore to be propagated to replica nodes of another datacenter.  When set, this property will increase the time taken by Kong to propagate the change of an entity.  Single-datacenter setups or PostgreSQL servers should suffer no such delays, and this value can be safely set to 0. Postgres setups with read replicas should set this value to the maximum expected replication lag between the writer and reader instances."
+  },
+  "db_cache_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of an entity from the datastore when cached by this node.  Database misses (no entity) are also cached according to this setting if you do not configure `db_cache_neg_ttl`.  If set to 0 (default), such cached entities or misses never expire."
+  },
+  "db_cache_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a datastore miss (no entity).  If not specified (default), `db_cache_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "db_resurrect_ttl": {
+    "defaultValue": "30",
+    "description": "Time (in seconds) for which stale entities from the datastore should be resurrected when they cannot be refreshed (e.g., the datastore is unreachable). When this TTL expires, a new attempt to refresh the stale entities will be made."
+  },
+  "db_cache_warmup_entities": {
+    "defaultValue": "services",
+    "description": " Entities to be pre-loaded from the datastore into the in-memory cache at Kong start-up. This speeds up the first access of endpoints that use the given entities.  When the `services` entity is configured for warmup, the DNS entries for values in its `host` attribute are pre-resolved asynchronously as well.  Cache size set in `mem_cache_size` should be set to a value large enough to hold all instances of the specified entities. If the size is insufficient, Kong will log a warning."
+  },
+  "dns_resolver": {
+    "defaultValue": null,
+    "description": "Comma-separated list of nameservers, each entry in `ip[:port]` format to be used by Kong. If not specified, the nameservers in the local `resolv.conf` file will be used. Port defaults to 53 if omitted. Accepts both IPv4 and IPv6 addresses."
+  },
+  "dns_hostsfile": {
+    "defaultValue": "/etc/hosts",
+    "description": "The hosts file to use. This file is read once and its content is static in memory. To read the file again after modifying it, Kong must be reloaded."
+  },
+  "dns_order": {
+    "defaultValue": [
+      "LAST",
+      "SRV",
+      "A",
+      "CNAME"
+    ],
+    "description": "The order in which to resolve different record types. The `LAST` type means the type of the last successful lookup (for the specified name). The format is a (case insensitive) comma-separated list."
+  },
+  "dns_valid_ttl": {
+    "defaultValue": null,
+    "description": "By default, DNS records are cached using the TTL value of a response. If this property receives a value (in seconds), it will override the TTL for all records."
+  },
+  "dns_stale_ttl": {
+    "defaultValue": "3600",
+    "description": "Defines, in seconds, how long a record will remain in cache past its TTL. This value will be used while the new DNS record is fetched in the background. Stale data will be used from expiry of a record until either the refresh query completes, or the `dns_stale_ttl` number of seconds have passed. This configuration enables Kong to be more resilient during resolver downtime."
+  },
+  "dns_cache_size": {
+    "defaultValue": "10000",
+    "description": "Defines the maximum allowed number of DNS records stored in memory cache. Least recently used DNS records are discarded from cache if it is full. Both errors and data are cached; therefore, a single name query can easily take up 10-15 slots."
+  },
+  "dns_not_found_ttl": {
+    "defaultValue": "30",
+    "description": "TTL in seconds for empty DNS responses and \"(3) name error\" responses."
+  },
+  "dns_error_ttl": {
+    "defaultValue": "1",
+    "description": "TTL in seconds for error responses."
+  },
+  "dns_no_sync": {
+    "defaultValue": "off",
+    "description": "If enabled, then upon a cache-miss every request will trigger its own DNS query. When disabled, multiple requests for the same name/type will be synchronized to a single query."
+  },
+  "new_dns_client": {
+    "defaultValue": "off",
+    "description": "Enable or disable the new DNS resolver"
+  },
+  "resolver_address": {
+    "defaultValue": "<name servers parsed from resolv.conf>",
+    "description": " Comma-separated list of nameservers, each entry in `ip[:port]` format to be used by Kong. If not specified, the nameservers in the local `resolv.conf` file will be used. Port defaults to 53 if omitted. Accepts both IPv4 and IPv6 addresses.  Examples:  ``` resolver_address = 8.8.8.8 resolver_address = 8.8.8.8, [::1] resolver_address = 8.8.8.8:53, [::1]:53 ```"
+  },
+  "resolver_hosts_file": {
+    "defaultValue": "/etc/hosts",
+    "description": " The hosts file to use. This file is read once and its content is static in memory. To read the file again after modifying it, Kong must be reloaded."
+  },
+  "resolver_family": {
+    "defaultValue": [
+      "A",
+      "SRV"
+    ],
+    "description": "The supported query types.  For a domain name, Kong will only query either IP addresses (A or AAAA) or SRV records, but not both.  It will query SRV records only when the domain matches the \"_<proto>._<service>.<name>\" format, for example, \"_ldap._tcp.example.com\".  For IP addresses (A or AAAA) resolution, it first attempts IPv4 (A) and then queries IPv6 (AAAA)."
+  },
+  "resolver_valid_ttl": {
+    "defaultValue": "<TTL from responses>",
+    "description": " By default, DNS records are cached using the TTL value of a response. This optional parameter (in seconds) allows overriding it."
+  },
+  "resolver_error_ttl": {
+    "defaultValue": "1",
+    "description": "TTL in seconds for error responses and empty responses."
+  },
+  "resolver_stale_ttl": {
+    "defaultValue": "3600",
+    "description": "Defines, in seconds, how long a record will remain in cache past its TTL. This value will be used while the new DNS record is fetched in the background.  Stale data will be used from expiry of a record until either the refresh query completes, or the `resolver_stale_ttl` number of seconds have passed.  This configuration enables Kong to be more resilient during the DNS server downtime."
+  },
+  "resolver_lru_cache_size": {
+    "defaultValue": "10000",
+    "description": "The DNS client uses a two-layer cache system: L1 - worker-level LRU Lua VM cache L2 - across-workers shared memory cache  This value specifies the maximum allowed number of DNS responses stored in the L1 LRU lua VM cache.  A single name query can easily take up 1~10 slots, depending on attempted query types and extended domains from /etc/resolv.conf options `domain` or `search`."
+  },
+  "resolver_mem_cache_size": {
+    "defaultValue": "5m",
+    "description": "This value specifies the size of the L2 shared memory cache for DNS responses, `kong_dns_cache`.  Accepted units are `k` and `m`, with a minimum recommended value of a few MBs.  5MB shared memory size could store ~20000 DNS responeses with single A record or ~10000 DNS responeses with 2~3 A records.  10MB shared memory size could store ~40000 DNS responeses with single A record or ~20000 DNS responeses with 2~3 A records."
+  },
+  "vault_env_prefix": {
+    "defaultValue": null,
+    "description": "Defines the environment variable vault's default prefix. For example if you have all your secrets stored in environment variables prefixed with `SECRETS_`, it can be configured here so that it isn't necessary to repeat them in Vault references."
+  },
+  "vault_aws_region": {
+    "defaultValue": null,
+    "description": "The AWS region your vault is located in."
+  },
+  "vault_aws_endpoint_url": {
+    "defaultValue": null,
+    "description": "The AWS SecretsManager service endpoint url. If not specified, the value used by vault will be the official AWS SecretsManager service url which is `https://secretsmanager.<region>.amazonaws.com` You can specify a complete URL(including the \"http/https\" scheme) to override the endpoint that vault will connect to."
+  },
+  "vault_aws_assume_role_arn": {
+    "defaultValue": null,
+    "description": "The target AWS IAM role ARN that will be assumed. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+  },
+  "vault_aws_role_session_name": {
+    "defaultValue": "KongVault",
+    "description": "The role session name used for role assuming. The default value is `KongVault`."
+  },
+  "vault_aws_sts_endpoint_url": {
+    "defaultValue": null,
+    "description": "The custom STS endpoint URL used for role assuming in AWS Vault.  Note that this value will override the default STS endpoint URL(which should be `https://sts.amazonaws.com`, or `https://sts.<region>.amazonaws.com` if you have `AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).  If you are not using private VPC endpoint for STS service, you should not specify this value."
+  },
+  "vault_aws_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the AWS vault when cached by this node.  AWS vault misses (no secret) are also cached according to this setting if you do not configure `vault_aws_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_aws_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_aws_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_aws_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the AWS vault should be resurrected for when they cannot be refreshed (e.g., the AWS vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "vault_gcp_project_id": {
+    "defaultValue": null,
+    "description": "The project ID from your Google API Console."
+  },
+  "vault_gcp_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the GCP vault when cached by this node.  GCP vault misses (no secret) are also cached according to this setting if you do not configure `vault_gcp_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_gcp_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_gcp_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_gcp_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the GCP vault should be resurrected for when they cannot be refreshed (e.g., the GCP vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "vault_hcv_protocol": {
+    "defaultValue": "http",
+    "description": "The protocol to connect with. Accepts one of `http` or `https`."
+  },
+  "vault_hcv_host": {
+    "defaultValue": "127.0.0.1",
+    "description": "The hostname of your HashiCorp vault."
+  },
+  "vault_hcv_port": {
+    "defaultValue": "8200",
+    "description": "The port number of your HashiCorp vault."
+  },
+  "vault_hcv_namespace": {
+    "defaultValue": null,
+    "description": "Namespace for the HashiCorp Vault. Vault Enterprise requires a namespace to successfully connect to it."
+  },
+  "vault_hcv_mount": {
+    "defaultValue": "secret",
+    "description": "The mount point."
+  },
+  "vault_hcv_kv": {
+    "defaultValue": "v1",
+    "description": "The secrets engine version. Accepts `v1` or `v2`."
+  },
+  "vault_hcv_token": {
+    "defaultValue": null,
+    "description": "A token string."
+  },
+  "vault_hcv_auth_method": {
+    "defaultValue": "token",
+    "description": "Defines the authentication mechanism when connecting to the Hashicorp Vault service. Accepted values are: `token`, `kubernetes` or `approle`."
+  },
+  "vault_hcv_kube_role": {
+    "defaultValue": null,
+    "description": "Defines the HashiCorp Vault role for the Kubernetes service account of the running pod. `vault_hcv_auth_method` must be set to `kubernetes` for this to activate."
+  },
+  "vault_hcv_kube_auth_path": {
+    "defaultValue": "kubernetes",
+    "description": " Place where the Kubernetes auth method will be accessible: `/v1/auth/<vault_hcv_kube_auth_path>`"
+  },
+  "vault_hcv_kube_api_token_file": {
+    "defaultValue": null,
+    "description": "Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+  },
+  "vault_hcv_approle_auth_path": {
+    "defaultValue": "approle",
+    "description": " Place where the Approle auth method will be accessible: `/v1/auth/<vault_hcv_approle_auth_path>`"
+  },
+  "vault_hcv_approle_role_id": {
+    "defaultValue": null,
+    "description": "The Role ID of the Approle in HashiCorp Vault."
+  },
+  "vault_hcv_approle_secret_id": {
+    "defaultValue": null,
+    "description": "The Secret ID of the Approle in HashiCorp Vault."
+  },
+  "vault_hcv_approle_secret_id_file": {
+    "defaultValue": null,
+    "description": "Defines where the Secret ID should be read from the pod's filesystem. This is usually used with HashiCorp Vault's response wrapping."
+  },
+  "vault_hcv_approle_response_wrapping": {
+    "defaultValue": "false",
+    "description": "Defines whether the Secret ID read from configuration or file is actually a response-wrapping token instead of a real Secret ID."
+  },
+  "vault_hcv_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the HashiCorp vault when cached by this node.  HashiCorp vault misses (no secret) are also cached according to this setting if you do not configure `vault_hcv_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_hcv_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a HashiCorp vault miss (no secret).  If not specified (default), `vault_hcv_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_hcv_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the HashiCorp vault should be resurrected for when they cannot be refreshed (e.g., the HashiCorp vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "vault_azure_vault_uri": {
+    "defaultValue": null,
+    "description": "The URI the vault is reachable from."
+  },
+  "vault_azure_client_id": {
+    "defaultValue": null,
+    "description": "The client ID from your registered Application. Visit your Azure Dashboard and select *App Registrations* to check your client ID."
+  },
+  "vault_azure_tenant_id": {
+    "defaultValue": null,
+    "description": "The DirectoryId and TenantId both equate to the GUID representing the ActiveDirectory Tenant. Depending on context, either term may be used by Microsoft documentation and products, which can be confusing. In other words, the \"Tenant ID\" IS the \"Directory ID\""
+  },
+  "vault_azure_type": {
+    "defaultValue": "secrets",
+    "description": "Azure Key Vault enables Microsoft Azure applications and users to store and use several types of secret/key data: keys, secrets, and certificates. Kong currently only supports the `Secrets`"
+  },
+  "vault_azure_ttl": {
+    "defaultValue": "0",
+    "description": "Time-to-live (in seconds) of a secret from the Azure Key Vault when cached by this node.  Key Vault misses (no secret) are also cached according to this setting if you do not configure `vault_azure_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+  },
+  "vault_azure_neg_ttl": {
+    "defaultValue": null,
+    "description": "Time-to-live (in seconds) of a Azure Key Vault miss (no secret).  If not specified (default), `vault_azure_ttl` value will be used instead.  If set to 0, misses will never expire."
+  },
+  "vault_azure_resurrect_ttl": {
+    "defaultValue": null,
+    "description": "Time (in seconds) for which stale secrets from the Azure Key Vault should be resurrected for when they cannot be refreshed (e.g., the the vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+  },
+  "worker_consistency": {
+    "defaultValue": "eventual",
+    "description": " Defines whether this node should rebuild its state synchronously or asynchronously (the balancers and the router are rebuilt on updates that affect them, e.g., updates to routes, services, or upstreams via the admin API or loading a declarative configuration file). (This option is deprecated and will be removed in future releases. The new default is `eventual`.)  Accepted values are:  - `strict`: the router will be rebuilt   synchronously, causing incoming requests to   be delayed until the rebuild is finished.   (This option is deprecated and will be removed    in future releases. The new default is `eventual`) - `eventual`: the router will be rebuilt   asynchronously via a recurring background   job running every second inside of each   worker.  Note that `strict` ensures that all workers of a given node will always proxy requests with an identical router, but increased long-tail latency can be observed if frequent routes and services updates are expected. Using `eventual` will help prevent long-tail latency issues in such cases, but may cause workers to route requests differently for a short period of time after routes and services updates."
+  },
+  "worker_state_update_frequency": {
+    "defaultValue": "5",
+    "description": " Defines how often the worker state changes are checked with a background job. When a change is detected, a new router or balancer will be built, as needed. Raising this value will decrease the load on database servers and result in less jitter in proxy latency, but it might take more time to propagate changes to each individual worker."
+  },
+  "router_flavor": {
+    "defaultValue": "traditional_compatible",
+    "description": " Selects the router implementation to use when performing request routing. Incremental router rebuild is available when the flavor is set to either `expressions` or `traditional_compatible`, which could significantly shorten rebuild time for a large number of routes.  Accepted values are:  - `traditional_compatible`: the DSL-based expression   router engine will be used under the hood. However,   the router config interface will be the same   as `traditional`, and expressions are   automatically generated at router build time.   The `expression` field on the `route` object   is not visible. - `expressions`: the DSL-based expression router engine   will be used under the hood. The traditional router   config interface is still visible, and you can also write   router Expressions manually and provide them in the   `expression` field on the `route` object. - `traditional`: the pre-3.0 router engine will be   used. The config interface will be the same as   pre-3.0 Kong, and the `expression` field on the   `route` object is not visible.    Deprecation warning: In Kong 3.0, `traditional`   mode should be avoided and only be used if   `traditional_compatible` does not work as expected.   This flavor of the router will be removed in the next   major release of Kong."
+  },
+  "lua_max_req_headers": {
+    "defaultValue": "100",
+    "description": "Maximum number of request headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request headers, and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many request headers."
+  },
+  "lua_max_resp_headers": {
+    "defaultValue": "100",
+    "description": "Maximum number of response headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong returns all the response headers, and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many response headers."
+  },
+  "lua_max_uri_args": {
+    "defaultValue": "100",
+    "description": "Maximum number of request URI arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request query arguments, and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many query arguments."
+  },
+  "lua_max_post_args": {
+    "defaultValue": "100",
+    "description": "Maximum number of request post arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request post arguments, and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many post arguments."
+  },
+  "lua_ssl_trusted_certificate": {
+    "defaultValue": "system",
+    "description": "Comma-separated list of certificate authorities for Lua cosockets in PEM format.  The special value `system` attempts to search for the \"usual default\" provided by each distro, according to an arbitrary heuristic. In the current implementation, the following pathnames will be tested in order, and the first one found will be used:  - `/etc/ssl/certs/ca-certificates.crt` (Debian/Ubuntu/Gentoo) - `/etc/pki/tls/certs/ca-bundle.crt` (Fedora/RHEL 6) - `/etc/ssl/ca-bundle.pem` (OpenSUSE) - `/etc/pki/tls/cacert.pem` (OpenELEC) - `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` (CentOS/RHEL 7) - `/etc/ssl/cert.pem` (OpenBSD, Alpine)  `system` can be used by itself or in conjunction with other CA file paths.  When `pg_ssl_verify` is enabled, these certificate authority files will be used for verifying Kong's database connections.  Certificates can be configured on this property with any of the following values: - `system` - absolute path to the certificate - certificate content - base64 encoded certificate content  See https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate"
+  },
+  "lua_ssl_verify_depth": {
+    "defaultValue": "1",
+    "description": "Sets the verification depth in the server certificates chain used by Lua cosockets, set by `lua_ssl_trusted_certificate`. This includes the certificates configured for Kong's database connections. If the maximum depth is reached before reaching the end of the chain, verification will fail. This helps mitigate certificate based DoS attacks.  See https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth"
+  },
+  "lua_ssl_protocols": {
+    "defaultValue": "TLSv1.2 TLSv1.3",
+    "description": "Defines the TLS versions supported when handshaking with OpenResty's TCP cosocket APIs.  This affects connections made by Lua code, such as connections to the database Kong uses, or when sending logs using a logging plugin. It does *not* affect connections made to the upstream Service or from downstream clients."
+  },
+  "lua_package_path": {
+    "defaultValue": "./?.lua;./?/init.lua;",
+    "description": "Sets the Lua module search path (LUA_PATH). Useful when developing or using custom plugins not stored in the default search path.  See https://github.com/openresty/lua-nginx-module#lua_package_path"
+  },
+  "lua_package_cpath": {
+    "defaultValue": null,
+    "description": "Sets the Lua C module search path (LUA_CPATH).  See https://github.com/openresty/lua-nginx-module#lua_package_cpath"
+  },
+  "lua_socket_pool_size": {
+    "defaultValue": "256",
+    "description": "Specifies the size limit for every cosocket connection pool associated with every remote server.  See https://github.com/openresty/lua-nginx-module#lua_socket_pool_size"
+  },
+  "enforce_rbac": {
+    "defaultValue": "off",
+    "description": "Specifies whether Admin API RBAC is enforced. Accepts one of `entity`, `both`, `on`, or `off`.  - `on`: only endpoint-level authorization   is enforced. - `entity`: entity-level authorization   applies. - `both`: enables both endpoint and   entity-level authorization. - `off`: disables both endpoint and   entity-level authorization.  When enabled, Kong will deny requests to the Admin API when a nonexistent or invalid RBAC authorization token is passed, or the RBAC user with which the token is associated does not have permissions to access/modify the requested resource."
+  },
+  "rbac_auth_header": {
+    "defaultValue": "Kong-Admin-Token",
+    "description": "Defines the name of the HTTP request header from which the Admin API will attempt to authenticate the RBAC user."
+  },
+  "event_hooks_enabled": {
+    "defaultValue": "on",
+    "description": "When enabled, event hook entities represent a relationship between an event (source and event) and an action (handler). Similar to web hooks, event hooks can be used to communicate Kong Gateway service events. When a particular event happens on a service, the event hook calls a URL with information about that event. Event hook configurations differ depending on the handler. The events that are triggered send associated data.  See: https://docs.konghq.com/gateway/api/admin-ee/latest/#/Event-hooks/get-event-hooks"
+  },
+  "fips": {
+    "defaultValue": "off",
+    "description": "Turn on FIPS mode; this mode is only available on a FIPS build."
+  },
+  "admin_gui_listen": {
+    "defaultValue": [
+      "0.0.0.0:8002",
+      "0.0.0.0:8445 ssl"
+    ],
+    "description": " Kong Manager Listeners  Comma-separated list of addresses and ports on which Kong will expose Kong Manager. This web application lets you configure and manage Kong, and therefore should be kept secured.  Suffixes can be specified for each pair, similarly to the `admin_listen` directive."
+  },
+  "admin_gui_url": {
+    "defaultValue": null,
+    "description": "Kong Manager URL  Comma-separated list of addresses (the lookup or balancer) for Kong Manager.  Accepted format (items in square brackets are optional):    `<scheme>://<IP / HOSTNAME>[:<PORT>][<PATH>][, <scheme>://<IP / HOSTNAME>[:<PORT>][<PATH>]]`  Examples:  - `http://127.0.0.1:8003` - `https://kong-admin.test` - `http://dev-machine` - `http://127.0.0.1:8003, https://exmple.com/manager`"
+  },
+  "admin_gui_path": {
+    "defaultValue": "/",
+    "description": "Kong Manager base path  This configuration parameter allows the user to customize the path prefix where Kong Manager is served. When updating this parameter, it's recommended to update the path in `admin_gui_url` as well.  Accepted format:  - Path must start with a `/` - Path must not end with a `/` (except for the `/`) - Path can only contain letters, digits, hyphens (`-`), underscores (`_`), and slashes (`/`) - Path must not contain continuous slashes (e.g., `//` and `///`)  Examples:  - `/` - `/manager` - `/kong-manager` - `/kong/manager`"
+  },
+  "admin_gui_api_url": {
+    "defaultValue": null,
+    "description": "Hierarchical part of a URI which is composed optionally of a host, port, and path at which the Admin API accepts HTTP or HTTPS traffic. When this config is disabled, Kong Manager will use the window protocol + host and append the resolved admin_listen HTTP/HTTPS port."
+  },
+  "admin_gui_ssl_protocols": {
+    "defaultValue": "TLSv1.2 TLSv1.3",
+    "description": " Defines the TLS versions supported for Kong Manager"
+  },
+  "admin_gui_ssl_cert": {
+    "defaultValue": null,
+    "description": "The SSL certificate for `admin_gui_listen` values with SSL enabled.  values: - absolute path to the certificate - certificate content - base64 encoded certificate content"
+  },
+  "admin_gui_ssl_cert_key": {
+    "defaultValue": null,
+    "description": "The SSL key for `admin_gui_listen` values with SSL enabled.  values: - absolute path to the certificate key - certificate key content - base64 encoded certificate key content"
+  },
+  "admin_gui_flags": {
+    "defaultValue": "{}",
+    "description": " Alters the layout Admin GUI (JSON) to enable Kong Immunity in the Admin GUI."
+  },
+  "admin_gui_access_log": {
+    "defaultValue": "logs/admin_gui_access.log",
+    "description": " Kong Manager Access Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables access logs for Kong Manager."
+  },
+  "admin_gui_error_log": {
+    "defaultValue": "logs/admin_gui_error.log",
+    "description": " Kong Manager Error Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables error logs for Kong Manager.  Granularity can be adjusted through the `log_level` directive."
+  },
+  "admin_gui_auth": {
+    "defaultValue": null,
+    "description": "Kong Manager Authentication Plugin Name  Secures access to Kong Manager by specifying an authentication plugin to use.  Supported Plugins:  - `basic-auth`: Basic Authentication plugin - `ldap-auth-advanced`: LDAP Authentication plugin - `openid-connect`: OpenID Connect Authentication   plugin"
+  },
+  "admin_gui_auth_conf": {
+    "defaultValue": null,
+    "description": "Kong Manager Authentication Plugin Config (JSON)  Specifies the configuration for the authentication plugin specified in `admin_gui_auth`.  For information about Plugin Configuration consult the associated plugin documentation.  Example for `basic-auth`:  `admin_gui_auth_conf = { \"hide_credentials\": true }`"
+  },
+  "admin_gui_auth_password_complexity": {
+    "defaultValue": null,
+    "description": "Kong Manager Authentication Password Complexity (JSON)  When `admin_gui_auth = basic-auth`, this property defines the rules required for Kong Manager passwords. Choose from preset rules or write your own.  Example using preset rules:  `admin_gui_auth_password_complexity = { \"kong-preset\": \"min_8\" }`  All values for kong-preset require the password to contain characters from at least three of the following categories:  1. Uppercase characters (A through Z)  2. Lowercase characters (a through z)  3. Base-10 digits (0 through 9)  4. Special characters (for example, &, $, #, %)  Supported preset rules: - `min_8`: minimum length of 8 - `min_12`: minimum length of 12 - `min_20`: minimum length of 20  To write your own rules, see https://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.  NOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.  Example:  `admin_gui_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`"
+  },
+  "admin_gui_session_conf": {
+    "defaultValue": null,
+    "description": "Kong Manager Session Config (JSON)  Specifies the configuration for the Session plugin as used by Kong Manager.  For information about plugin configuration, consult the Kong Session plugin documentation.  Example: ``` admin_gui_session_conf = { \"cookie_name\": \"kookie\", \\                            \"secret\": \"changeme\" } ```"
+  },
+  "admin_gui_auth_header": {
+    "defaultValue": "Kong-Admin-User",
+    "description": " Defines the name of the HTTP request header from which the Admin API will attempt to identify the Kong Admin user."
+  },
+  "admin_gui_auth_login_attempts": {
+    "defaultValue": "0",
+    "description": " Number of times a user can attempt to login to Kong Manager. 0 means infinite attempts allowed."
+  },
+  "admin_gui_auth_login_attempts_ttl": {
+    "defaultValue": "604800",
+    "description": " Length, in seconds, of the TTL for changing login attempts records. Records in the database older than their TTL are automatically purged.  This argument can be set to an integer between 0 and 100000000.  Example, 7 days: `7 * 24 * 60 * 60 = 604800.`"
+  },
+  "admin_gui_auth_change_password_attempts": {
+    "defaultValue": "0",
+    "description": " Number of times a user can attempt to change password. 0 means infinite attempts allowed."
+  },
+  "admin_gui_auth_change_password_ttl": {
+    "defaultValue": "86400",
+    "description": " Length, in seconds, of the TTL for changing password attempts records. Records in the database older than their TTL are automatically purged.  Example, 1 days: `1 * 24 * 60 * 60 = 86400.`"
+  },
+  "admin_gui_header_txt": {
+    "defaultValue": null,
+    "description": "Sets the text for the Kong Manager header banner. Header banner is not shown if this config is empty."
+  },
+  "admin_gui_header_bg_color": {
+    "defaultValue": null,
+    "description": "Sets the background color for the Kong Manager header banner. Accepts CSS color keyword, #-hexadecimal, or RGB format. Invalid values are ignored by Manager."
+  },
+  "admin_gui_header_txt_color": {
+    "defaultValue": null,
+    "description": "Sets the text color for the Kong Manager header banner. Accepts CSS color keyword, #-hexadecimal, or RGB format. Invalid values are ignored by Kong Manager."
+  },
+  "admin_gui_footer_txt": {
+    "defaultValue": null,
+    "description": "Sets the text for the Kong Manager footer banner. Footer banner is not shown if this config is empty."
+  },
+  "admin_gui_footer_bg_color": {
+    "defaultValue": null,
+    "description": "Sets the background color for the Kong Manager footer banner. Accepts CSS color keyword, #-hexadecimal, or RGB format. Invalid values are ignored by manager."
+  },
+  "admin_gui_footer_txt_color": {
+    "defaultValue": null,
+    "description": "Sets the text color for the Kong Manager footer banner. Accepts CSS color keyword, #-hexadecimal, or RGB format. Invalid values are ignored by Kong Manager."
+  },
+  "admin_gui_login_banner_title": {
+    "defaultValue": null,
+    "description": "Sets the title text for the Kong Manager login banner. Login banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+  },
+  "admin_gui_login_banner_body": {
+    "defaultValue": null,
+    "description": "Sets the body text for the Kong Manager login banner. Login banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+  },
+  "konnect_mode": {
+    "defaultValue": "off",
+    "description": "When enabled, the dataplane is connected to Konnect"
+  },
+  "analytics_flush_interval": {
+    "defaultValue": "1",
+    "description": "Specify the maximum frequency, in seconds, at which local analytics and licensing data are flushed to the database or Konnect, depending on the installation mode. Kong also triggers a flush when the number of messages in the buffer is less than `analytics_buffer_size_limit`, regardless of whether the specified time interval has elapsed."
+  },
+  "analytics_buffer_size_limit": {
+    "defaultValue": "100000",
+    "description": "Max number of messages can be buffered locally before dropping data in case there is no network connection to Konnect."
+  },
+  "analytics_debug": {
+    "defaultValue": "off",
+    "description": "Outputs analytics payload to Kong logs."
+  },
+  "admin_emails_from": {
+    "defaultValue": "\"\"",
+    "description": "The email address for the `From` header for admin emails."
+  },
+  "admin_emails_reply_to": {
+    "defaultValue": null,
+    "description": "Email address for the `Reply-To` header for admin emails."
+  },
+  "admin_invitation_expiry": {
+    "defaultValue": "259200",
+    "description": "Expiration time for the admin invitation link (in seconds). 0 means no expiration.  Example, 72 hours: `72 * 60 * 60 = 259200`"
+  },
+  "smtp_mock": {
+    "defaultValue": "on",
+    "description": "This flag will mock the sending of emails. This can be used for testing before the SMTP client is fully configured."
+  },
+  "smtp_host": {
+    "defaultValue": "localhost",
+    "description": " The hostname of the SMTP server to connect to."
+  },
+  "smtp_port": {
+    "defaultValue": "25",
+    "description": " The port number on the SMTP server to connect to."
+  },
+  "smtp_starttls": {
+    "defaultValue": "off",
+    "description": " When set to `on`, STARTTLS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 587."
+  },
+  "smtp_username": {
+    "defaultValue": null,
+    "description": "Username used for authentication with SMTP server"
+  },
+  "smtp_password": {
+    "defaultValue": null,
+    "description": "Password used for authentication with SMTP server"
+  },
+  "smtp_ssl": {
+    "defaultValue": "off",
+    "description": " When set to `on`, SMTPS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 465."
+  },
+  "smtp_auth_type": {
+    "defaultValue": null,
+    "description": "The method used to authenticate with the SMTP server Valid options are `plain`, `login`, or `nil`"
+  },
+  "smtp_domain": {
+    "defaultValue": "localhost.localdomain",
+    "description": " The domain used in the `EHLO` connection and part of the `Message-ID` header"
+  },
+  "smtp_timeout_connect": {
+    "defaultValue": "60000",
+    "description": " The timeout (in milliseconds) for connecting to the SMTP server."
+  },
+  "smtp_timeout_send": {
+    "defaultValue": "60000",
+    "description": " The timeout (in milliseconds) for sending data to the SMTP server."
+  },
+  "smtp_timeout_read": {
+    "defaultValue": "60000",
+    "description": " The timeout (in milliseconds) for reading data from the SMTP server."
+  },
+  "smtp_admin_emails": {
+    "defaultValue": null,
+    "description": "Comma separated list of admin emails to receive notifications. Example `admin1@example.com, admin2@example.com`"
+  },
+  "audit_log": {
+    "defaultValue": "off",
+    "description": "When enabled, Kong will log information about Admin API access and database row insertions, updates, and deletions."
+  },
+  "audit_log_ignore_methods": {
+    "defaultValue": null,
+    "description": "Comma-separated list of HTTP methods that will not generate audit log entries. By default, all HTTP requests will be logged."
+  },
+  "audit_log_ignore_paths": {
+    "defaultValue": null,
+    "description": "Comma-separated list of request paths that will not generate audit log entries. By default, all HTTP requests will be logged."
+  },
+  "audit_log_ignore_tables": {
+    "defaultValue": null,
+    "description": "Comma-separated list of database tables that will not generate audit log entries. By default, updates to all database tables will be logged (the term \"updates\" refers to the creation, update, or deletion of a row)."
+  },
+  "audit_log_payload_exclude": {
+    "defaultValue": [
+      "token",
+      "secret",
+      "password"
+    ],
+    "description": " Comma-separated list of keys that will be filtered out of the payload. Keys that were filtered will be recorded in the audit log."
+  },
+  "audit_log_record_ttl": {
+    "defaultValue": "2592000",
+    "description": "Length, in seconds, of the TTL for audit log records. Records in the database older than their TTL are automatically purged.  Example, 30 days: `30 * 24 * 60 * 60 = 2592000`"
+  },
+  "audit_log_signing_key": {
+    "defaultValue": null,
+    "description": "Defines the path to a private RSA signing key that can be used to insert a signature of audit records, adjacent to the record. The corresponding public key should be stored offline, and can be used to validate audit entries in the future. If this value is undefined, no signature will be generated."
+  },
+  "route_validation_strategy": {
+    "defaultValue": "smart",
+    "description": "The strategy used to validate routes when creating or updating them. Different strategies are available to tune how to enforce splitting traffic of workspaces. - `smart` is the default option and uses the   algorithm described in   https://docs.konghq.com/gateway/latest/kong-enterprise/workspaces/. - `off` disables any check. - `path` enforces routes to comply with the pattern   described in config `enforce_route_path_pattern`. - `static` relies on the PostgreSQL database. Before creating a new route, it checks if the route is unique across all workspaces based on the following params: `paths`, `methods`, and `hosts`. If all fields of the new route overlap with an existing one, a 409 is returned with the route of the collision. The array order is not important for the overlap filter."
+  },
+  "enforce_route_path_pattern": {
+    "defaultValue": null,
+    "description": "Specifies the Lua pattern which will be enforced on the `paths` attribute of a route object. You can also add a placeholder for the workspace in the pattern, which will be rendered during runtime based on the workspace to which the `route` belongs. This setting is only relevant if `route_validation_strategy` is set to `path`.   **Note:** The collision detection is only supported for plain text routes, do not rely on this feature to validate regex routes.  Example For Pattern `/$(workspace)/v%d/.*` valid paths are:  1. `/group1/v1/` if route belongs to   workspace `group1`.  2. `/group2/v1/some_path` if route belongs to   workspace `group2`."
+  },
+  "keyring_enabled": {
+    "defaultValue": "off",
+    "description": "When enabled, Kong will encrypt sensitive field values before writing them to the database, and subsequently decrypt them when retrieving data for the Admin API, Developer Portal, or proxy business logic. Symmetric encryption keys are managed based on the strategy defined below."
+  },
+  "keyring_strategy": {
+    "defaultValue": "cluster",
+    "description": "Defines the strategy implementation by which Kong nodes will manage symmetric encryption keys. Please see the Kong Enterprise documentation for a detailed description of each strategy. Acceptable values for this option are `cluster` and `vault`."
+  },
+  "keyring_public_key": {
+    "defaultValue": null,
+    "description": "Defines the public key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  Values: - absolute path to the public key - public key content - base64 encoded public key content"
+  },
+  "keyring_private_key": {
+    "defaultValue": null,
+    "description": "Defines the private key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  Values: - absolute path to the private key - private key content - base64 encoded private key content"
+  },
+  "keyring_recovery_public_key": {
+    "defaultValue": null,
+    "description": "Defines the public key to optionally encrypt all keyring materials and back them up in the database.  Values: - absolute path to the public key - public key content - base64 encoded public key content"
+  },
+  "keyring_blob_path": {
+    "defaultValue": null,
+    "description": "Defines the filesystem path at which Kong will back up the initial keyring material. This option is useful largely for development purposes."
+  },
+  "keyring_vault_host": {
+    "defaultValue": null,
+    "description": "Defines the Vault host at which Kong will fetch the encryption material. This value should be defined in the format:  `<scheme>://<IP / HOSTNAME>:<PORT>`"
+  },
+  "keyring_vault_mount": {
+    "defaultValue": null,
+    "description": "Defines the name of the Vault v2 KV secrets engine at which symmetric keys are found."
+  },
+  "keyring_vault_path": {
+    "defaultValue": null,
+    "description": "Defines the name of the Vault v2 KV path at which symmetric keys are found."
+  },
+  "keyring_vault_auth_method": {
+    "defaultValue": "token",
+    "description": " Defines the authentication mechanism when connecting to the Hashicorp Vault service.  Accepted values are: `token`, or `kubernetes`:  - `token`: Uses the static token defined in            the `keyring_vault_token`            configuration property.  - `kubernetes`: Uses the Kubernetes authentication                 mechanism, with the running pod's                 mapped service account, to assume                 the Hashicorp Vault role name that is                 defined in the `keyring_vault_kube_role`                 configuration property."
+  },
+  "keyring_vault_token": {
+    "defaultValue": null,
+    "description": "Defines the token value used to communicate with the v2 KV Vault HTTP(S) API."
+  },
+  "keyring_vault_kube_role": {
+    "defaultValue": "default",
+    "description": " Defines the Hashicorp Vault role that will be assumed using the Kubernetes service account of the running pod.  `keyring_vault_auth_method` must be set to `kubernetes` for this to activate."
+  },
+  "keyring_vault_kube_api_token_file": {
+    "defaultValue": "/run/secrets/kubernetes.io/serviceaccount/token",
+    "description": " Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+  },
+  "keyring_encrypt_license": {
+    "defaultValue": "off",
+    "description": " Enables keyring encryption for license payloads stored in the database.  **Warning:** For Kong deployments that rely entirely on the database for license provisioning (i.e. not using `KONG_LICENSE_DATA` or `KONG_LICENSE_PATH`), enabling this option will delay license activation until after the node's keyring has been activated."
+  },
+  "untrusted_lua": {
+    "defaultValue": "sandbox",
+    "description": " Controls loading of Lua functions from admin-supplied sources such as the Admin API. LuaJIT bytecode loading is always disabled.  **Warning:** LuaJIT is not designed as a secure runtime for running malicious code, therefore you should properly protect your Admin API endpoint even with sandboxing enabled. The sandbox only provides protection against trivial attackers or unintentional modification of the Kong global environment.  Accepted values are: `off`, `sandbox`, or `on`:  - `off`: Disallow loading of any arbitrary          Lua functions. The `off` option          disables any functionality that runs          arbitrary Lua code, including the          Serverless Functions plugins and any          transformation plugin that allows          custom Lua functions.  - `sandbox`: Allow loading of Lua functions,              but use a sandbox when executing              them. The sandboxed function has              restricted access to the global              environment and only has access              to standard Lua functions that              will generally not cause harm to              the Kong Gateway node.  - `on`: Functions have unrestricted         access to the global environment and         can load any Lua modules. This is         similar to the behavior in         Kong Gateway prior to 2.3.0.  The default `sandbox` environment does not allow importing other modules or libraries, or executing anything at the OS level (for example, file read/write). The global environment is also not accessible.  Examples of `untrusted_lua = sandbox` behavior:  - You can't access or change global values   such as `kong.configuration.pg_password` - You can run harmless Lua:   `local foo = 1 + 1`. However, OS level   functions are not allowed, like:   `os.execute(`rm -rf /*`)`.  For a full allowed/disallowed list, see: https://github.com/kikito/sandbox.lua/blob/master/sandbox.lua  To customize the sandbox environment, use the `untrusted_lua_sandbox_requires` and `untrusted_lua_sandbox_environment` parameters below."
+  },
+  "untrusted_lua_sandbox_requires": {
+    "defaultValue": null,
+    "description": "Comma-separated list of modules allowed to be loaded with `require` inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  For example, say you have configured the Serverless pre-function plugin and it contains the following `requires`:  ``` local template = require \"resty.template\" local split = require \"kong.tools.string\".split ```  To run the plugin, add the modules to the allowed list: ``` untrusted_lua_sandbox_requires = resty.template, kong.tools.utils ```  **Warning:** Allowing certain modules may create opportunities to escape the sandbox. For example, allowing `os` or `luaposix` may be unsafe."
+  },
+  "untrusted_lua_sandbox_environment": {
+    "defaultValue": null,
+    "description": "Comma-separated list of global Lua variables that should be made available inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  **Warning**: Certain variables, when made available, may create opportunities to escape the sandbox."
+  },
+  "openresty_path": {
+    "defaultValue": null,
+    "description": "Path to the OpenResty installation that Kong will use. When this is empty (the default), Kong determines the OpenResty installation by searching for a system-installed OpenResty and falling back to searching $PATH for the nginx binary.  Setting this attribute disables the search behavior and explicitly instructs Kong which OpenResty installation to use."
+  },
+  "node_id": {
+    "defaultValue": null,
+    "description": "Node ID for the Kong node. Every Kong node in a Kong cluster must have a unique and valid UUID. When empty, node ID is automatically generated."
+  },
+  "cluster_fallback_config_import": {
+    "defaultValue": "off",
+    "description": "Enable fallback configuration imports.  This should only be enabled for data planes."
+  },
+  "cluster_fallback_config_storage": {
+    "defaultValue": null,
+    "description": "Storage definition used by `cluster_fallback_config_import` and `cluster_fallback_config_export`.  Supported storage types: - S3-like storages - GCP storage service  To use S3 with a bucket named b and place all configs to with a key prefix named p, set it to: `s3://b/p` To use GCP for the same bucket and prefix, set it to: `gcs://b/p`  The credentials (and the endpoint URL for S3-like) for S3 are passed with environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where `AWS_CONFIG_STORAGE_ENDPOINT` is the endpoint that hosts S3-like storage.  The credentials for GCP are provided via the environment variable `GCP_SERVICE_ACCOUNT`."
+  },
+  "cluster_fallback_export_s3_config": {
+    "defaultValue": null,
+    "description": "Fallback config export S3 configuration. This is used only when `cluster_fallback_config_storage` is an S3-like schema. If set, it will add the config table to the Kong exporter config S3 putObject request. The config table should be in JSON format and can be unserialized into a table. It should contain the necessary parameters as described in the documentation: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property. For example, if you want to set the ServerSideEncryption headers/KMS Key ID for the S3 putObject request, you can set the config table to: `{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"your-kms-key-id\"}`"
+  },
+  "cluster_fallback_config_export": {
+    "defaultValue": "off",
+    "description": "Enable fallback configuration exports."
+  },
+  "cluster_fallback_config_export_delay": {
+    "defaultValue": "60",
+    "description": "The fallback configuration export interval.  If the interval is set to 60 and configuration A is exported and there are new configurations B, C, and D in the next 60 seconds, it will wait until 60 seconds passed and export D, skipping B and C."
+  },
+  "wasm": {
+    "defaultValue": "off",
+    "description": "Enable/disable wasm support. This must be enabled in order to use wasm filters and filter chains."
+  },
+  "wasm_filters_path": {
+    "defaultValue": null,
+    "description": "Path to the directory containing wasm filter modules.  At startup, Kong discovers available wasm filters by scanning this directory for files with the `.wasm` file extension.  The name of a wasm filter module is derived from the filename itself, with the .wasm extension removed. So, given the following tree:  ``` /path/to/wasm_filters ├── my_module.wasm ├── my_other_module.wasm └── not_a_wasm_module.txt ```  The resulting filter modules available for use in Kong will be:  - `my_module` - `my_other_module`  Notes:  - No recursion is performed. Only .wasm files at the   top level are registered. - This path _may_ be a symlink to a directory."
+  },
+  "wasm_filters": {
+    "defaultValue": [
+      "bundled",
+      "user"
+    ],
+    "description": "Comma-separated list of Wasm filters to be made available for use in filter chains.  When the `off` keyword is specified as the only value, no filters will be available for use.  When the `bundled` keyword is specified, all filters bundled with Kong will be available.  When the `user` keyword is specified, all filters within the `wasm_filters_path` will be available.  **Examples:**  - `wasm_filters = bundled,user` enables _all_ bundled   and user-supplied filters - `wasm_filters = user` enables _only_ user-supplied   filters - `wasm_filters = filter-a,filter-b` enables _only_   filters named `filter-a` or `filter-b` (whether   bundled _or_ user-supplied)  If a conflict occurs where a bundled filter and a user-supplied filter share the same name, a warning will be logged, and the user-supplied filter will be used instead."
+  },
+  "test": {
+    "defaultValue": "on",
+    "description": "test"
+  },
+  "request_debug": {
+    "defaultValue": "on",
+    "description": "When enabled, Kong will provide detailed timing information for its components to the client and the error log if the following headers are present in the proxy request: - `X-Kong-Request-Debug`:   If the value is set to `*`,   timing information will be collected and exported for the current request.   If this header is not present or contains an unknown value,   timing information will not be collected for the current request.   You can also specify a list of filters, separated by commas,   to filter the scope of the time information that is collected. The following filters are supported for `X-Kong-Request-Debug`: - `rewrite`: Collect timing information from the `rewrite` phase. - `access`: Collect timing information from the `access` phase. - `balancer`: Collect timing information from the `balancer` phase. - `response`: Collect timing information from the `response` phase. - `header_filter`: Collect timing information from the `header_filter` phase. - `body_filter`: Collect timing information from the `body_filter` phase. - `log`: Collect timing information from the `log` phase. - `upstream`: Collect timing information from the `upstream` phase.  - `X-Kong-Request-Debug-Log`:   If set to `true`, timing information will also be logged   in the Kong error log with a log level of `notice`.   Defaults to `false`.  - `X-Kong-Request-Debug-Token`:   Token for authenticating the client making the debug   request to prevent abuse.   ** Note: Debug requests originating from loopback   addresses do not require this header. Deploying Kong behind   other proxies may result in exposing the debug interface to   the public.** "
+  },
+  "request_debug_token": {
+    "defaultValue": "<random>",
+    "description": "The Request Debug Token is used in the `X-Kong-Request-Debug-Token` header to prevent abuse. If this value is not set (the default), a random token will be generated when Kong starts, restarts, or reloads. If a token is specified manually, then the provided token will be used.  You can locate the generated debug token in two locations: - Kong error log:   Debug token will be logged in the error log (notice level)   when Kong starts, restarts, or reloads.   The log line will have the: `[request-debug]` prefix to aid searching. - Filesystem:   Debug token will also be stored in a file located at   `{prefix}/.request_debug_token` and updated   when Kong starts, restarts, or reloads."
+  }
+}

--- a/app/_data/kong-conf/3.9.json
+++ b/app/_data/kong-conf/3.9.json
@@ -1,325 +1,325 @@
 {
   "prefix": {
     "defaultValue": "/usr/local/kong/",
-    "description": "Working directory. Equivalent to Nginx's prefix path, containing temporary files and logs. Each Kong process must have a separate working directory."
+    "description": "Working directory. Equivalent to Nginx's\nprefix path, containing temporary files\nand logs.\nEach Kong process must have a separate\nworking directory.\n"
   },
   "log_level": {
     "defaultValue": "notice",
-    "description": "Log level of the Nginx server. Logs are found at `<prefix>/logs/error.log`."
+    "description": "Log level of the Nginx server. Logs are\nfound at `<prefix>/logs/error.log`.\n"
   },
   "proxy_access_log": {
     "defaultValue": "logs/access.log",
-    "description": "Path for proxy port request access logs. Set this value to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for proxy port request access\nlogs. Set this value to `off` to\ndisable logging proxy requests.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n"
   },
   "proxy_error_log": {
     "defaultValue": "logs/error.log",
-    "description": "Path for proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for proxy port request error logs.\nThe granularity of these logs is adjusted by the `log_level` property.\n"
   },
   "proxy_stream_access_log": {
     "defaultValue": "logs/access.log basic",
-    "description": "Path for TCP streams proxy port access logs. Set to `off` to disable logging proxy requests. If this value is a relative path, it will be placed under the `prefix` location. `basic` is defined as `'$remote_addr [$time_local] ' '$protocol $status $bytes_sent $bytes_received ' '$session_time'`"
+    "description": "Path for TCP streams proxy port access logs.\nSet to `off` to disable logging proxy requests.\nIf this value is a relative path, it will be placed under the `prefix` location.\n`basic` is defined as `'$remote_addr [$time_local] '\n'$protocol $status $bytes_sent $bytes_received '\n'$session_time'`\n"
   },
   "proxy_stream_error_log": {
     "defaultValue": "logs/error.log",
-    "description": "Path for tcp streams proxy port request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for tcp streams proxy port request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n"
   },
   "admin_access_log": {
     "defaultValue": "logs/admin_access.log",
-    "description": "Path for Admin API request access logs. If hybrid mode is enabled and the current node is set to be the control plane, then the connection requests from data planes are also written to this file with server name \"kong_cluster_listener\".  Set this value to `off` to disable logging Admin API requests. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for Admin API request access logs.\nIf hybrid mode is enabled and the current node is set\nto be the control plane, then the connection requests\nfrom data planes are also written to this file with\nserver name \"kong_cluster_listener\".\n\nSet this value to `off` to disable logging Admin API requests.\nIf this value is a relative path, it will be placed under the `prefix` location.\n"
   },
   "admin_error_log": {
     "defaultValue": "logs/error.log",
-    "description": "Path for Admin API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for Admin API request error logs.\nThe granularity of these logs is adjusted by the `log_level` property.\n"
   },
   "status_access_log": {
     "defaultValue": "off",
-    "description": "Path for Status API request access logs. The default value of `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for Status API request access logs.\nThe default value of `off` implies that logging for this API\nis disabled by default.\nIf this value is a relative path, it will be placed under the `prefix` location.\n"
   },
   "status_error_log": {
     "defaultValue": "logs/status_error.log",
-    "description": "Path for Status API request error logs. The granularity of these logs is adjusted by the `log_level` property."
+    "description": "Path for Status API request error logs.\nThe granularity of these logs is adjusted by the `log_level` property.\n"
   },
   "debug_access_log": {
     "defaultValue": "off",
-    "description": "Path for Debug API request access logs. The default value `off` implies that logging for this API is disabled by default. If this value is a relative path, it will be placed under the `prefix` location."
+    "description": "Path for Debug API request access\nlogs. The default value `off`\nimplies that logging for this API\nis disabled by default.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n"
   },
   "debug_error_log": {
     "defaultValue": "logs/debug_error.log",
-    "description": "Path for Debug API request error logs. The granularity of these logs is adjusted using the `log_level` property."
+    "description": "Path for Debug API request error\nlogs. The granularity of these logs\nis adjusted using the `log_level`\nproperty.\n"
   },
   "vaults": {
     "defaultValue": "bundled",
-    "description": "Comma-separated list of vaults this node should load. By default, all the bundled vaults are enabled.  The specified name(s) will be substituted as such in the Lua namespace: `kong.vaults.{name}.*`."
+    "description": "Comma-separated list of vaults this node should load.\nBy default, all the bundled vaults are enabled.\n\nThe specified name(s) will be substituted as\nsuch in the Lua namespace:\n`kong.vaults.{name}.*`.\n"
   },
   "opentelemetry_tracing": {
     "defaultValue": "off",
-    "description": "Deprecated: use `tracing_instrumentations` instead."
+    "description": "Deprecated: use `tracing_instrumentations` instead.\n"
   },
   "tracing_instrumentations": {
     "defaultValue": "off",
-    "description": "Comma-separated list of tracing instrumentations this node should load. By default, no instrumentations are enabled.  Valid values for this setting are:  - `off`: do not enable instrumentations. - `request`: only enable request-level instrumentations. - `all`: enable all the following instrumentations. - `db_query`: trace database queries. - `dns_query`: trace DNS queries. - `router`: trace router execution, including router rebuilding. - `http_client`: trace OpenResty HTTP client requests. - `balancer`: trace balancer retries. - `plugin_rewrite`: trace plugin iterator execution with rewrite phase. - `plugin_access`: trace plugin iterator execution with access phase. - `plugin_header_filter`: trace plugin iterator execution with header_filter phase.  **Note:** In the current implementation, tracing instrumentations are not enabled in stream mode."
+    "description": "Comma-separated list of tracing instrumentations this node should load.\nBy default, no instrumentations are enabled.\n\nValid values for this setting are:\n\n- `off`: do not enable instrumentations.\n- `request`: only enable request-level instrumentations.\n- `all`: enable all the following instrumentations.\n- `db_query`: trace database queries.\n- `dns_query`: trace DNS queries.\n- `router`: trace router execution, including router rebuilding.\n- `http_client`: trace OpenResty HTTP client requests.\n- `balancer`: trace balancer retries.\n- `plugin_rewrite`: trace plugin iterator execution with rewrite phase.\n- `plugin_access`: trace plugin iterator execution with access phase.\n- `plugin_header_filter`: trace plugin iterator execution with header_filter phase.\n\n**Note:** In the current implementation, tracing instrumentations are not enabled in stream mode.\n"
   },
   "opentelemetry_tracing_sampling_rate": {
     "defaultValue": "1.0",
-    "description": "Deprecated: use `tracing_sampling_rate` instead."
+    "description": "Deprecated: use `tracing_sampling_rate` instead.\n"
   },
   "tracing_sampling_rate": {
     "defaultValue": "0.01",
-    "description": "Tracing instrumentation sampling rate. Tracer samples a fixed percentage of all spans following the sampling rate.  Example: `0.25`, this accounts for 25% of all traces."
+    "description": "Tracing instrumentation sampling rate.\nTracer samples a fixed percentage of all spans\nfollowing the sampling rate.\n\nExample: `0.25`, this accounts for 25% of all traces.\n"
   },
   "plugins": {
     "defaultValue": "bundled",
-    "description": "Comma-separated list of plugins this node should load. By default, only plugins bundled in official distributions are loaded via the `bundled` keyword.  Loading a plugin does not enable it by default, but only instructs Kong to load its source code and allows configuration via the various related Admin API endpoints.  The specified name(s) will be substituted as such in the Lua namespace: `kong.plugins.{name}.*`.  When the `off` keyword is specified as the only value, no plugins will be loaded.  `bundled` and plugin names can be mixed together, as the following examples suggest:  - `plugins = bundled,custom-auth,custom-log`   will include the bundled plugins plus two custom ones. - `plugins = custom-auth,custom-log` will   *only* include the `custom-auth` and `custom-log` plugins. - `plugins = off` will not include any plugins.  **Note:** Kong will not start if some plugins were previously configured (i.e. have rows in the database) and are not specified in this list. Before disabling a plugin, ensure all instances of it are removed before restarting Kong.  **Note:** Limiting the amount of available plugins can improve P99 latency when experiencing LRU churning in the database cache (i.e. when the configured `mem_cache_size`) is full."
+    "description": "Comma-separated list of plugins this node should load.\nBy default, only plugins bundled in official distributions\nare loaded via the `bundled` keyword.\n\nLoading a plugin does not enable it by default, but only\ninstructs Kong to load its source code and allows\nconfiguration via the various related Admin API endpoints.\n\nThe specified name(s) will be substituted as such in the\nLua namespace: `kong.plugins.{name}.*`.\n\nWhen the `off` keyword is specified as the only value,\nno plugins will be loaded.\n\n`bundled` and plugin names can be mixed together, as the\nfollowing examples suggest:\n\n- `plugins = bundled,custom-auth,custom-log`\n  will include the bundled plugins plus two custom ones.\n- `plugins = custom-auth,custom-log` will\n  *only* include the `custom-auth` and `custom-log` plugins.\n- `plugins = off` will not include any plugins.\n\n**Note:** Kong will not start if some plugins were previously\nconfigured (i.e. have rows in the database) and are not\nspecified in this list. Before disabling a plugin, ensure\nall instances of it are removed before restarting Kong.\n\n**Note:** Limiting the amount of available plugins can\nimprove P99 latency when experiencing LRU churning in the\ndatabase cache (i.e. when the configured `mem_cache_size`) is full.\n"
   },
   "dedicated_config_processing": {
     "defaultValue": "on",
-    "description": "Enables or disables a special worker process for configuration processing. This process increases memory usage a little bit while allowing to reduce latencies by moving some background tasks, such as CP/DP connection handling, to an additional worker process specific to handling these background tasks. Currently this has effect only on data planes."
+    "description": "Enables or disables a special worker\nprocess for configuration processing. This process\nincreases memory usage a little bit while\nallowing to reduce latencies by moving some\nbackground tasks, such as CP/DP connection\nhandling, to an additional worker process specific\nto handling these background tasks.\nCurrently this has effect only on data planes.\n"
   },
   "pluginserver_names": {
     "defaultValue": null,
-    "description": "Comma-separated list of names for pluginserver processes. The actual names are used for log messages and to relate the actual settings."
+    "description": "Comma-separated list of names for pluginserver\nprocesses. The actual names are used for\nlog messages and to relate the actual settings.\n"
   },
   "pluginserver_XXX_socket": {
     "defaultValue": "<prefix>/<XXX>.socket",
-    "description": "Path to the unix socket used by the <XXX> pluginserver."
+    "description": "Path to the unix socket\nused by the <XXX> pluginserver.\n"
   },
   "pluginserver_XXX_start_cmd": {
     "defaultValue": "/usr/local/bin/<XXX>",
-    "description": "Full command (including any needed arguments) to start the <XXX> pluginserver."
+    "description": "Full command (including\nany needed arguments) to\nstart the <XXX>\npluginserver.\n"
   },
   "pluginserver_XXX_query_cmd": {
     "defaultValue": "/usr/local/bin/query_<XXX>",
-    "description": "Full command to \"query\" the <XXX> pluginserver.  Should produce a JSON with the dump info of the plugin it manages."
+    "description": "Full command to \"query\" the\n<XXX> pluginserver.  Should\nproduce a JSON with the\ndump info of the plugin it\nmanages.\n"
   },
   "port_maps": {
     "defaultValue": null,
-    "description": "With this configuration parameter, you can let Kong Gateway know the port from which the packets are forwarded to it. This is fairly common when running Kong in a containerized or virtualized environment. For example, `port_maps=80:8000, 443:8443` instructs Kong that the port 80 is mapped to 8000 (and the port 443 to 8443), where 8000 and 8443 are the ports that Kong is listening to.  This parameter helps Kong set a proper forwarded upstream HTTP request header or to get the proper forwarded port with the Kong PDK (in case other means determining it has failed). It changes routing by a destination port to route by a port from which packets are forwarded to Kong, and similarly it changes the default plugin log serializer to use the port according to this mapping instead of reporting the port Kong is listening to."
+    "description": "With this configuration parameter, you can\nlet Kong Gateway know the port from\nwhich the packets are forwarded to it. This\nis fairly common when running Kong in a\ncontainerized or virtualized environment.\nFor example, `port_maps=80:8000, 443:8443`\ninstructs Kong that the port 80 is mapped\nto 8000 (and the port 443 to 8443), where\n8000 and 8443 are the ports that Kong is\nlistening to.\n\nThis parameter helps Kong set a proper\nforwarded upstream HTTP request header or to\nget the proper forwarded port with the Kong PDK\n(in case other means determining it has\nfailed). It changes routing by a destination\nport to route by a port from which packets\nare forwarded to Kong, and similarly it\nchanges the default plugin log serializer to\nuse the port according to this mapping\ninstead of reporting the port Kong is\nlistening to.\n"
   },
   "anonymous_reports": {
     "defaultValue": "on",
-    "description": "Send anonymous usage data such as error stack traces to help improve Kong."
+    "description": "Send anonymous usage data such as error\nstack traces to help improve Kong.\n"
   },
   "proxy_server": {
     "defaultValue": null,
-    "description": "Proxy server defined as an encoded URL. Kong will only use this option if a component is explicitly configured to use a proxy."
+    "description": "Proxy server defined as an encoded URL. Kong will only\nuse this option if a component is explicitly configured\nto use a proxy.\n"
   },
   "proxy_server_ssl_verify": {
     "defaultValue": "off",
-    "description": "Toggles server certificate verification if `proxy_server` is in HTTPS. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+    "description": "Toggles server certificate verification if\n`proxy_server` is in HTTPS.\nSee the `lua_ssl_trusted_certificate`\nsetting to specify a certificate authority.\n"
   },
   "error_template_html": {
     "defaultValue": null,
-    "description": "Path to the custom html error template to override the default html kong error template.  The template may contain up to two `%s` placeholders. The first one will expand to the error message. The second one will expand to the request ID. Both placeholders are optional, but recommended. Adding more than two placeholders will result in a runtime error when trying to render the template: ``` <html>   <body>     <h1>My custom error template</h1>     <p>error: %s</p>     <p>request_id: %s</p>   </body> </html> ```"
+    "description": "Path to the custom html error template to\noverride the default html kong error\ntemplate.\n\nThe template may contain up to two `%s`\nplaceholders. The first one will expand to\nthe error message. The second one will\nexpand to the request ID. Both placeholders\nare optional, but recommended.\nAdding more than two placeholders will\nresult in a runtime error when trying to\nrender the template:\n```\n<html>\n  <body>\n    <h1>My custom error template</h1>\n    <p>error: %s</p>\n    <p>request_id: %s</p>\n  </body>\n</html>\n```\n"
   },
   "error_template_json": {
     "defaultValue": null,
-    "description": "Path to the custom json error template to override the default json kong error template.  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+    "description": "Path to the custom json error template to\noverride the default json kong error\ntemplate.\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n"
   },
   "error_template_xml": {
     "defaultValue": null,
-    "description": "Path to the custom xml error template to override the default xml kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+    "description": "Path to the custom xml error template to\noverride the default xml kong error template\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n"
   },
   "error_template_plain": {
     "defaultValue": null,
-    "description": "Path to the custom plain error template to override the default plain kong error template  Similarly to `error_template_html`, the template may contain up to two `%s` placeholders for the error message and the request ID respectively."
+    "description": "Path to the custom plain error template to\noverride the default plain kong error\ntemplate\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n"
   },
   "role": {
     "defaultValue": "traditional",
-    "description": "Use this setting to enable hybrid mode, This allows running some Kong nodes in a control plane role with a database and have them deliver configuration updates to other nodes running to DB-less running in a data plane role.  Valid values for this setting are:  - `traditional`: do not use hybrid mode. - `control_plane`: this node runs in a   control plane role. It can use a database   and will deliver configuration updates   to data plane nodes. - `data_plane`: this is a data plane node.   It runs DB-less and receives configuration   updates from a control plane node."
+    "description": "Use this setting to enable hybrid mode,\nThis allows running some Kong nodes in a\ncontrol plane role with a database and\nhave them deliver configuration updates\nto other nodes running to DB-less running in\na data plane role.\n\nValid values for this setting are:\n\n- `traditional`: do not use hybrid mode.\n- `control_plane`: this node runs in a\n  control plane role. It can use a database\n  and will deliver configuration updates\n  to data plane nodes.\n- `data_plane`: this is a data plane node.\n  It runs DB-less and receives configuration\n  updates from a control plane node.\n"
   },
   "cluster_mtls": {
     "defaultValue": "shared",
-    "description": "Sets the verification method between nodes of the cluster.  Valid values for this setting are:  - `shared`: use a shared certificate/key pair specified with   the `cluster_cert` and `cluster_cert_key` settings.   Note that CP and DP nodes must present the same certificate   to establish mTLS connections. - `pki`: use `cluster_ca_cert`, `cluster_server_name`, and   `cluster_cert` for verification. These are different   certificates for each DP node, but issued by a cluster-wide   common CA certificate: `cluster_ca_cert`. - `pki_check_cn`: similar to `pki` but additionally checks   for the common name of the data plane certificate specified   in `cluster_allowed_common_names`."
+    "description": "Sets the verification method between nodes of the cluster.\n\nValid values for this setting are:\n\n- `shared`: use a shared certificate/key pair specified with\n  the `cluster_cert` and `cluster_cert_key` settings.\n  Note that CP and DP nodes must present the same certificate\n  to establish mTLS connections.\n- `pki`: use `cluster_ca_cert`, `cluster_server_name`, and\n  `cluster_cert` for verification. These are different\n  certificates for each DP node, but issued by a cluster-wide\n  common CA certificate: `cluster_ca_cert`.\n- `pki_check_cn`: similar to `pki` but additionally checks\n  for the common name of the data plane certificate specified\n  in `cluster_allowed_common_names`.\n"
   },
   "cluster_cert": {
     "defaultValue": null,
-    "description": "Cluster certificate to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes. Under `pki` mode, it should be a different certificate for each DP node.  The certificate can be configured on this property with any of the following values: - absolute path to the certificate - certificate content - base64 encoded certificate content"
+    "description": "Cluster certificate to use when establishing secure communication\nbetween control and data plane nodes.\nYou can use the `kong hybrid` command to generate the certificate/key pair.\nUnder `shared` mode, it must be the same for all nodes.\nUnder `pki` mode, it should be a different certificate for each DP node.\n\nThe certificate can be configured on this property with any of the following values:\n- absolute path to the certificate\n- certificate content\n- base64 encoded certificate content\n"
   },
   "cluster_cert_key": {
     "defaultValue": null,
-    "description": "Cluster certificate key to use when establishing secure communication between control and data plane nodes. You can use the `kong hybrid` command to generate the certificate/key pair. Under `shared` mode, it must be the same for all nodes.  Under `pki` mode it should be a different certificate for each DP node.  The certificate key can be configured on this property with either of the following values: - absolute path to the certificate key - certificate key content - base64 encoded certificate key content"
+    "description": "Cluster certificate key to\nuse when establishing secure communication\nbetween control and data plane nodes.\nYou can use the `kong hybrid` command to\ngenerate the certificate/key pair.\nUnder `shared` mode, it must be the same\nfor all nodes.  Under `pki` mode it\nshould be a different certificate for each\nDP node.\n\nThe certificate key can be configured on this\nproperty with either of the following values:\n- absolute path to the certificate key\n- certificate key content\n- base64 encoded certificate key content\n"
   },
   "cluster_ca_cert": {
     "defaultValue": null,
-    "description": "The trusted CA certificate file in PEM format used for: - Control plane to verify data plane's certificate - Data plane to verify control plane's certificate  Required on data plane if `cluster_mtls` is set to `pki`. If the control plane certificate is issued by a well-known CA, set `lua_ssl_trusted_certificate=system` on the data plane and leave this field empty.  This field is ignored if `cluster_mtls` is set to `shared`.  The certificate can be configured on this property with any of the following values: - absolute path to the certificate - certificate content - base64 encoded certificate content"
+    "description": "The trusted CA certificate file in PEM format used for:\n- Control plane to verify data plane's certificate\n- Data plane to verify control plane's certificate\n\nRequired on data plane if `cluster_mtls` is set to `pki`.\nIf the control plane certificate is issued by a well-known CA,\nset `lua_ssl_trusted_certificate=system` on the data plane and leave this field empty.\n\nThis field is ignored if `cluster_mtls` is set to `shared`.\n\nThe certificate can be configured on this property with any of the following values:\n- absolute path to the certificate\n- certificate content\n- base64 encoded certificate content\n"
   },
   "cluster_allowed_common_names": {
     "defaultValue": null,
-    "description": "The list of Common Names that are allowed to connect to control plane. Multiple entries may be supplied in a comma-separated string. When not set, only data plane with the same parent domain as the control plane cert is allowed to connect.  This field is ignored if `cluster_mtls` is not set to `pki_check_cn`."
+    "description": "The list of Common Names that are allowed to\nconnect to control plane. Multiple entries may\nbe supplied in a comma-separated string. When not\nset, only data plane with the same parent domain as the\ncontrol plane cert is allowed to connect.\n\nThis field is ignored if `cluster_mtls` is\nnot set to `pki_check_cn`.\n"
   },
   "cluster_server_name": {
     "defaultValue": null,
-    "description": "The server name used in the SNI of the TLS connection from a DP node to a CP node. Must match the Common Name (CN) or Subject Alternative Name (SAN) found in the CP certificate. If `cluster_mtls` is set to `shared`, this setting is ignored and `kong_clustering` is used."
+    "description": "The server name used in the SNI of the TLS\nconnection from a DP node to a CP node.\nMust match the Common Name (CN) or Subject\nAlternative Name (SAN) found in the CP\ncertificate.\nIf `cluster_mtls` is set to\n`shared`, this setting is ignored and\n`kong_clustering` is used.\n"
   },
   "cluster_control_plane": {
     "defaultValue": null,
-    "description": "To be used by data plane nodes only: address of the control plane node from which configuration updates will be fetched, in `host:port` format."
+    "description": "To be used by data plane nodes only:\naddress of the control plane node from which\nconfiguration updates will be fetched,\nin `host:port` format.\n"
   },
   "cluster_telemetry_endpoint": {
     "defaultValue": null,
-    "description": "To be used by data plane nodes only: telemetry address of the control plane node to which telemetry updates will be posted in `host:port` format."
+    "description": "To be used by data plane nodes only:\ntelemetry address of the control plane node\nto which telemetry updates will be posted\nin `host:port` format.\n"
   },
   "cluster_telemetry_server_name": {
     "defaultValue": null,
-    "description": "The SNI (Server Name Indication extension) to use for Vitals telemetry data."
+    "description": "The SNI (Server Name Indication extension)\nto use for Vitals telemetry data.\n"
   },
   "cluster_dp_labels": {
     "defaultValue": null,
-    "description": "Comma-separated list of labels for the data plane. Labels are key-value pairs that provide additional context information for each DP. Each label must be configured as a string in the format `key:value`.  Labels are only compatible with hybrid mode deployments with Kong Konnect (SaaS). This configuration doesn't work with self-hosted deployments.  Keys and values follow the AIP standards: https://kong-aip.netlify.app/aip/129/  Example: `deployment:mycloud,region:us-east-1`"
+    "description": "Comma-separated list of labels for the data plane.\nLabels are key-value pairs that provide additional\ncontext information for each DP.\nEach label must be configured as a string in the\nformat `key:value`.\n\nLabels are only compatible with hybrid mode\ndeployments with Kong Konnect (SaaS).\nThis configuration doesn't work with\nself-hosted deployments.\n\nKeys and values follow the AIP standards:\nhttps://kong-aip.netlify.app/aip/129/\n\nExample:\n`deployment:mycloud,region:us-east-1`\n"
   },
   "cluster_listen": {
     "defaultValue": "0.0.0.0:8005",
-    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster. This port is mTLS protected to ensure end-to-end security and integrity.  This setting has no effect if `role` is not set to `control_plane`.  Connections made to this endpoint are logged to the same location as Admin API access logs. See `admin_access_log` config description for more information."
+    "description": "Comma-separated list of addresses and ports on\nwhich the cluster control plane server should listen\nfor data plane connections.\nThe cluster communication port of the control plane\nmust be accessible by all the data planes\nwithin the same cluster. This port is mTLS protected\nto ensure end-to-end security and integrity.\n\nThis setting has no effect if `role` is not set to\n`control_plane`.\n\nConnections made to this endpoint are logged\nto the same location as Admin API access logs.\nSee `admin_access_log` config description for more\ninformation.\n"
   },
   "cluster_telemetry_listen": {
     "defaultValue": "0.0.0.0:8006",
-    "description": " Comma-separated list of addresses and ports on which the cluster control plane server should listen for data plane telemetry connections. The cluster communication port of the control plane must be accessible by all the data planes within the same cluster.  This setting has no effect if `role` is not set to `control_plane`."
+    "description": "Comma-separated list of addresses and ports on\nwhich the cluster control plane server should listen\nfor data plane telemetry connections.\nThe cluster communication port of the control plane\nmust be accessible by all the data planes\nwithin the same cluster.\n\nThis setting has no effect if `role` is not set to\n`control_plane`.\n"
   },
   "cluster_data_plane_purge_delay": {
     "defaultValue": "1209600",
-    "description": " How many seconds must pass from the time a DP node becomes offline to the time its entry gets removed from the database, as returned by the /clustering/data-planes Admin API endpoint.  This is to prevent the cluster data plane table from growing indefinitely. The default is set to 14 days. That is, if the CP hasn't heard from a DP for 14 days, its entry will be removed."
+    "description": "How many seconds must pass from the time a DP node\nbecomes offline to the time its entry gets removed\nfrom the database, as returned by the\n/clustering/data-planes Admin API endpoint.\n\nThis is to prevent the cluster data plane table from\ngrowing indefinitely. The default is set to\n14 days. That is, if the CP hasn't heard from a DP for\n14 days, its entry will be removed.\n"
   },
   "cluster_ocsp": {
     "defaultValue": "off",
-    "description": " Whether to check for revocation status of DP certificates using OCSP (Online Certificate Status Protocol). If enabled, the DP certificate should contain the \"Certificate Authority Information Access\" extension and the OCSP method with URI of which the OCSP responder can be reached from CP.  OCSP checks are only performed on CP nodes, it has no effect on DP nodes.  Valid values for this setting are:  - `on`: OCSP revocation check is enabled and DP   must pass the check in order to establish   connection with CP. - `off`: OCSP revocation check is disabled. - `optional`: OCSP revocation check will be attempted,   however, if the required extension is not   found inside DP-provided certificate   or communication with the OCSP responder   failed, then DP is still allowed through."
+    "description": "Whether to check for revocation status of DP\ncertificates using OCSP (Online Certificate Status Protocol).\nIf enabled, the DP certificate should contain the\n\"Certificate Authority Information Access\" extension\nand the OCSP method with URI of which the OCSP responder\ncan be reached from CP.\n\nOCSP checks are only performed on CP nodes, it has no\neffect on DP nodes.\n\nValid values for this setting are:\n\n- `on`: OCSP revocation check is enabled and DP\n  must pass the check in order to establish\n  connection with CP.\n- `off`: OCSP revocation check is disabled.\n- `optional`: OCSP revocation check will be attempted,\n  however, if the required extension is not\n  found inside DP-provided certificate\n  or communication with the OCSP responder\n  failed, then DP is still allowed through.\n"
   },
   "cluster_use_proxy": {
     "defaultValue": "off",
-    "description": " Whether to turn on HTTP CONNECT proxy support for hybrid mode connections. `proxy_server` will be used for hybrid mode connections if this option is turned on."
+    "description": "Whether to turn on HTTP CONNECT proxy support for\nhybrid mode connections. `proxy_server` will be used\nfor hybrid mode connections if this option is turned on.\n"
   },
   "cluster_max_payload": {
     "defaultValue": "16777216",
-    "description": " This sets the maximum compressed payload size allowed to be sent from CP to DP in hybrid mode. Default is 16MB - 16 * 1024 * 1024."
+    "description": "This sets the maximum compressed payload size allowed\nto be sent from CP to DP in hybrid mode.\nDefault is 16MB - 16 * 1024 * 1024.\n"
   },
   "proxy_listen": {
     "defaultValue": [
       "0.0.0.0:8000 reuseport backlog=16384",
       "0.0.0.0:8443 http2 ssl reuseport backlog=16384"
     ],
-    "description": " Comma-separated list of addresses and ports on which the proxy server should listen for HTTP/HTTPS traffic. The proxy server is the public entry point of Kong, which proxies traffic from your consumers to your backend services. This value accepts IPv4, IPv6, and hostnames.  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the `TCP_DEFER_ACCEPT` socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process,   allowing the kernel to better distribute incoming   connections between worker processes. - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small to prevent clients   seeing \"Connection refused\" errors when connecting to   a busy Kong instance.   **Note:** On Linux, this value is limited by the   setting of the `net.core.somaxconn` kernel parameter.   In order for the larger `backlog` set here to take   effect, it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` specifies whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections. - `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]`   configures the TCP keepalive behavior for the listening   socket. If this parameter is omitted, the operating   system’s settings will be in effect for the socket. If it   is set to the value `on`, the `SO_KEEPALIVE` option is turned   on for the socket. If it is set to the value `off`, the   `SO_KEEPALIVE` option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the `TCP_KEEPIDLE`,` TCP_KEEPINTVL`,   and `TCP_KEEPCNT` socket options.  This value can be set to `off`, thus disabling the HTTP/HTTPS proxy port for this node. If `stream_listen` is also set to `off`, this enables control plane mode for this node (in which all traffic proxying capabilities are disabled). This node can then be used only to configure a cluster of Kong nodes connected to the same datastore.  Example: `proxy_listen = 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`  See http://nginx.org/en/docs/http/ngx_http_core_module.html#listen for a description of the accepted formats for this and other `*_listen` values.  See https://www.nginx.com/resources/admin-guide/proxy-protocol/ for more details about the `proxy_protocol` parameter.  Not all `*_listen` values accept all formats specified in nginx's documentation."
+    "description": "Comma-separated list of addresses and ports on\nwhich the proxy server should listen for\nHTTP/HTTPS traffic.\nThe proxy server is the public entry point of Kong,\nwhich proxies traffic from your consumers to your\nbackend services. This value accepts IPv4, IPv6, and\nhostnames.\n\nSome suffixes can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's proxy server.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `deferred` instructs to use a deferred accept on\n  Linux (the `TCP_DEFER_ACCEPT` socket option).\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process,\n  allowing the kernel to better distribute incoming\n  connections between worker processes.\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small to prevent clients\n  seeing \"Connection refused\" errors when connecting to\n  a busy Kong instance.\n  **Note:** On Linux, this value is limited by the\n  setting of the `net.core.somaxconn` kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect, it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` specifies whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections.\n- `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]`\n  configures the TCP keepalive behavior for the listening\n  socket. If this parameter is omitted, the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value `on`, the `SO_KEEPALIVE` option is turned\n  on for the socket. If it is set to the value `off`, the\n  `SO_KEEPALIVE` option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the `TCP_KEEPIDLE`,` TCP_KEEPINTVL`,\n  and `TCP_KEEPCNT` socket options.\n\nThis value can be set to `off`, thus disabling\nthe HTTP/HTTPS proxy port for this node.\nIf `stream_listen` is also set to `off`, this enables\ncontrol plane mode for this node\n(in which all traffic proxying capabilities are\ndisabled). This node can then be used only to\nconfigure a cluster of Kong\nnodes connected to the same datastore.\n\nExample:\n`proxy_listen = 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`\n\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#listen\nfor a description of the accepted formats for this\nand other `*_listen` values.\n\nSee https://www.nginx.com/resources/admin-guide/proxy-protocol/\nfor more details about the `proxy_protocol`\nparameter.\n\nNot all `*_listen` values accept all formats\nspecified in nginx's documentation.\n"
   },
   "proxy_url": {
     "defaultValue": null,
-    "description": "Kong Proxy URL  The lookup, or balancer, address for your Kong Proxy nodes.  This value is commonly used in a microservices or service-mesh oriented architecture.  Accepted format (parts in parentheses are optional):    `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`  Examples:  - `<scheme>://<IP>:<PORT>` -> `proxy_url = http://127.0.0.1:8000` - `SSL <scheme>://<HOSTNAME>` -> `proxy_url = https://proxy.domain.tld` - `<scheme>://<HOSTNAME>/<PATH>` -> `proxy_url = http://dev-machine/dev-285`  By default, Kong Manager and Kong Portal will use the window request host and append the resolved listener port depending on the requested protocol."
+    "description": "Kong Proxy URL\n\nThe lookup, or balancer, address for your Kong Proxy nodes.\n\nThis value is commonly used in a microservices\nor service-mesh oriented architecture.\n\nAccepted format (parts in parentheses are optional):\n\n  `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`\n\nExamples:\n\n- `<scheme>://<IP>:<PORT>` -> `proxy_url = http://127.0.0.1:8000`\n- `SSL <scheme>://<HOSTNAME>` -> `proxy_url = https://proxy.domain.tld`\n- `<scheme>://<HOSTNAME>/<PATH>` -> `proxy_url = http://dev-machine/dev-285`\n\nBy default, Kong Manager and Kong Portal will use\nthe window request host and append the resolved\nlistener port depending on the requested protocol.\n"
   },
   "stream_listen": {
     "defaultValue": "off",
-    "description": " Comma-separated list of addresses and ports on which the stream mode should listen.  This value accepts IPv4, IPv6, and hostnames. Some suffixes can be specified for each pair: - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process,   allowing the kernel to better distribute incoming   connections between worker processes. - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small to prevent clients   seeing \"Connection refused\" errors when connecting to   a busy Kong instance.   **Note:** On Linux, this value is limited by the   setting of the `net.core.somaxconn` kernel parameter.   In order for the larger `backlog` set here to take   effect, it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` specifies whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections - so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]   configures the \"TCP keepalive\" behavior for the listening   socket. If this parameter is omitted then the operating   system’s settings will be in effect for the socket. If it   is set to the value \"on\", the SO_KEEPALIVE option is turned   on for the socket. If it is set to the value \"off\", the   SO_KEEPALIVE option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the` TCP_KEEPIDLE`, `TCP_KEEPINTVL`,   and `TCP_KEEPCNT` socket options.  Examples:  ``` stream_listen = 127.0.0.1:7000 reuseport backlog=16384 stream_listen = 0.0.0.0:989 reuseport backlog=65536, 0.0.0.0:20 stream_listen = [::1]:1234 backlog=16384 ```  By default, this value is set to `off`, thus disabling the stream proxy port for this node."
+    "description": "Comma-separated list of addresses and ports on\nwhich the stream mode should listen.\n\nThis value accepts IPv4, IPv6, and hostnames.\nSome suffixes can be specified for each pair:\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process,\n  allowing the kernel to better distribute incoming\n  connections between worker processes.\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small to prevent clients\n  seeing \"Connection refused\" errors when connecting to\n  a busy Kong instance.\n  **Note:** On Linux, this value is limited by the\n  setting of the `net.core.somaxconn` kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect, it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` specifies whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections\n- so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]\n  configures the \"TCP keepalive\" behavior for the listening\n  socket. If this parameter is omitted then the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value \"on\", the SO_KEEPALIVE option is turned\n  on for the socket. If it is set to the value \"off\", the\n  SO_KEEPALIVE option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the` TCP_KEEPIDLE`, `TCP_KEEPINTVL`,\n  and `TCP_KEEPCNT` socket options.\n\nExamples:\n\n```\nstream_listen = 127.0.0.1:7000 reuseport backlog=16384\nstream_listen = 0.0.0.0:989 reuseport backlog=65536, 0.0.0.0:20\nstream_listen = [::1]:1234 backlog=16384\n```\n\nBy default, this value is set to `off`, thus\ndisabling the stream proxy port for this node.\n"
   },
   "admin_api_uri": {
     "defaultValue": null,
-    "description": "Deprecated: Use admin_gui_api_url instead"
+    "description": "Deprecated: Use admin_gui_api_url instead\n"
   },
   "admin_listen": {
     "defaultValue": [
       "127.0.0.1:8001 reuseport backlog=16384",
       "127.0.0.1:8444 http2 ssl reuseport backlog=16384"
     ],
-    "description": " Comma-separated list of addresses and ports on which the Admin interface should listen. The Admin interface is the API allowing you to configure and manage Kong. Access to this interface should be *restricted* to Kong administrators *only*. This value accepts IPv4, IPv6, and hostnames.  It is highly recommended to avoid exposing the Admin API to public interfaces, by using values such as `0.0.0.0:8001`  See https://docs.konghq.com/gateway/latest/production/running-kong/secure-admin-api/ for more information about how to secure your Admin API.  Some suffixes can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's proxy server. - `proxy_protocol` will enable usage of the   PROXY protocol for a given address/port. - `deferred` instructs to use a deferred accept on   Linux (the `TCP_DEFER_ACCEPT` socket option). - `bind` instructs to make a separate bind() call   for a given address:port pair. - `reuseport` instructs to create an individual   listening socket for each worker process,   allowing the Kernel to better distribute incoming   connections between worker processes. - `backlog=N` sets the maximum length for the queue   of pending TCP connections. This number should   not be too small to prevent clients   seeing \"Connection refused\" errors when connecting to   a busy Kong instance.   **Note:** On Linux, this value is limited by the   setting of the `net.core.somaxconn` kernel parameter.   In order for the larger `backlog` set here to take   effect, it is necessary to raise   `net.core.somaxconn` at the same time to match or   exceed the `backlog` number set. - `ipv6only=on|off` specifies whether an IPv6 socket listening   on a wildcard address [::] will accept only IPv6   connections or both IPv6 and IPv4 connections. - `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]`   configures the “TCP keepalive” behavior for the listening   socket. If this parameter is omitted, the operating   system’s settings will be in effect for the socket. If it   is set to the value `on`, the `SO_KEEPALIVE` option is turned   on for the socket. If it is set to the value `off`, the   `SO_KEEPALIVE` option is turned off for the socket. Some   operating systems support setting of TCP keepalive parameters   on a per-socket basis using the `TCP_KEEPIDLE`, `TCP_KEEPINTVL`,   and `TCP_KEEPCNT` socket options.  This value can be set to `off`, thus disabling the Admin interface for this node, enabling a data plane mode (without configuration capabilities) pulling its configuration changes from the database.  Example: `admin_listen = 127.0.0.1:8444 http2 ssl`"
+    "description": "Comma-separated list of addresses and ports on\nwhich the Admin interface should listen.\nThe Admin interface is the API allowing you to\nconfigure and manage Kong.\nAccess to this interface should be *restricted*\nto Kong administrators *only*. This value accepts\nIPv4, IPv6, and hostnames.\n\nIt is highly recommended to avoid exposing the Admin API to public\ninterfaces, by using values such as `0.0.0.0:8001`\n\nSee https://docs.konghq.com/gateway/latest/production/running-kong/secure-admin-api/\nfor more information about how to secure your Admin API.\n\nSome suffixes can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's proxy server.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `deferred` instructs to use a deferred accept on\n  Linux (the `TCP_DEFER_ACCEPT` socket option).\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process,\n  allowing the Kernel to better distribute incoming\n  connections between worker processes.\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small to prevent clients\n  seeing \"Connection refused\" errors when connecting to\n  a busy Kong instance.\n  **Note:** On Linux, this value is limited by the\n  setting of the `net.core.somaxconn` kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect, it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` specifies whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections.\n- `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]`\n  configures the “TCP keepalive” behavior for the listening\n  socket. If this parameter is omitted, the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value `on`, the `SO_KEEPALIVE` option is turned\n  on for the socket. If it is set to the value `off`, the\n  `SO_KEEPALIVE` option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the `TCP_KEEPIDLE`, `TCP_KEEPINTVL`,\n  and `TCP_KEEPCNT` socket options.\n\nThis value can be set to `off`, thus disabling\nthe Admin interface for this node, enabling a\ndata plane mode (without configuration\ncapabilities) pulling its configuration changes\nfrom the database.\n\nExample: `admin_listen = 127.0.0.1:8444 http2 ssl`\n"
   },
   "status_listen": {
     "defaultValue": "127.0.0.1:8007 reuseport backlog=16384",
-    "description": " Comma-separated list of addresses and ports on which the Status API should listen. The Status API is a read-only endpoint allowing monitoring tools to retrieve metrics, healthiness, and other non-sensitive information of the current Kong node.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Status API server. - `proxy_protocol` will enable usage of the PROXY protocol.  This value can be set to `off`, disabling the Status API for this node.  Example: `status_listen = 0.0.0.0:8100 ssl http2`"
+    "description": "Comma-separated list of addresses and ports on\nwhich the Status API should listen.\nThe Status API is a read-only endpoint\nallowing monitoring tools to retrieve metrics,\nhealthiness, and other non-sensitive information\nof the current Kong node.\n\nThe following suffix can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's Status API server.\n- `proxy_protocol` will enable usage of the PROXY protocol.\n\nThis value can be set to `off`, disabling\nthe Status API for this node.\n\nExample: `status_listen = 0.0.0.0:8100 ssl http2`\n"
   },
   "debug_listen": {
     "defaultValue": "off",
-    "description": "Comma-separated list of addresses and ports on which the Debug API should listen.  The following suffix can be specified for each pair:  - `ssl` will require that all connections made   through a particular address/port be made with TLS   enabled. - `http2` will allow for clients to open HTTP/2   connections to Kong's Debug API server.  This value can be set to `off`, disabling the Debug API for this node.  Example: `debug_listen = 0.0.0.0:8200 ssl http2`"
+    "description": "Comma-separated list of addresses and ports on\nwhich the Debug API should listen.\n\nThe following suffix can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's Debug API server.\n\nThis value can be set to `off`, disabling\nthe Debug API for this node.\n\nExample: `debug_listen = 0.0.0.0:8200 ssl http2`\n"
   },
   "debug_listen_local": {
     "defaultValue": "on",
-    "description": "Expose `debug_listen` functionalities via a Unix domain socket under the Kong prefix.  This option allows local users to use `kong debug` command to invoke various debug functionalities without needing to enable `debug_listen` ahead of time."
+    "description": "Expose `debug_listen` functionalities via a\nUnix domain socket under the Kong prefix.\n\nThis option allows local users to use `kong debug` command\nto invoke various debug functionalities without needing to\nenable `debug_listen` ahead of time.\n"
   },
   "nginx_user": {
     "defaultValue": "kong kong",
-    "description": "Defines user and group credentials used by worker processes. If group is omitted, a group whose name equals that of user is used.  Example: `nginx_user = nginx www`  **Note**: If the `kong` user and the `kong` group are not available, the default user and group credentials will be `nobody nobody`."
+    "description": "Defines user and group credentials used by\nworker processes. If group is omitted, a\ngroup whose name equals that of user is\nused.\n\nExample: `nginx_user = nginx www`\n\n**Note**: If the `kong` user and the `kong`\ngroup are not available, the default user\nand group credentials will be\n`nobody nobody`.\n"
   },
   "nginx_worker_processes": {
     "defaultValue": "auto",
-    "description": "Determines the number of worker processes spawned by Nginx.  See http://nginx.org/en/docs/ngx_core_module.html#worker_processes for detailed usage of the equivalent Nginx directive and a description of accepted values."
+    "description": "Determines the number of worker processes\nspawned by Nginx.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_processes\nfor detailed usage of the equivalent Nginx\ndirective and a description of accepted\nvalues.\n"
   },
   "nginx_daemon": {
     "defaultValue": "on",
-    "description": "Determines whether Nginx will run as a daemon or as a foreground process. Mainly useful for development or when running Kong inside a Docker environment.  See http://nginx.org/en/docs/ngx_core_module.html#daemon."
+    "description": "Determines whether Nginx will run as a daemon\nor as a foreground process. Mainly useful\nfor development or when running Kong inside\na Docker environment.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#daemon.\n"
   },
   "mem_cache_size": {
     "defaultValue": "128m",
-    "description": "Size of each of the two shared memory caches for traditional mode database entities and runtime data, `kong_core_cache` and `kong_cache`.  The accepted units are `k` and `m`, with a minimum recommended value of a few MBs.  **Note**: As this option controls the size of two different cache zones, the total memory Kong uses to cache entities might be double this value. The created zones are shared by all worker processes and do not become larger when more workers are used."
+    "description": "Size of each of the two shared memory caches\nfor traditional mode database entities\nand runtime data, `kong_core_cache` and\n`kong_cache`.\n\nThe accepted units are `k` and `m`, with a minimum\nrecommended value of a few MBs.\n\n**Note**: As this option controls the size of two\ndifferent cache zones, the total memory Kong\nuses to cache entities might be double this value.\nThe created zones are shared by all worker\nprocesses and do not become larger when more\nworkers are used.\n"
   },
   "ssl_cipher_suite": {
     "defaultValue": "intermediate",
-    "description": "Defines the TLS ciphers served by Nginx. Accepted values are `modern`, `intermediate`, `old`, `fips` or `custom`. If you want to enable TLSv1.1, this value has to be `old`.  See https://wiki.mozilla.org/Security/Server_Side_TLS for detailed descriptions of each cipher suite. `fips` cipher suites are as described in https://wiki.openssl.org/index.php/FIPS_mode_and_TLS."
+    "description": "Defines the TLS ciphers served by Nginx.\nAccepted values are `modern`,\n`intermediate`, `old`, `fips` or `custom`.\nIf you want to enable TLSv1.1, this value has to be `old`.\n\nSee https://wiki.mozilla.org/Security/Server_Side_TLS\nfor detailed descriptions of each cipher\nsuite. `fips` cipher suites are as described in\nhttps://wiki.openssl.org/index.php/FIPS_mode_and_TLS.\n"
   },
   "ssl_ciphers": {
     "defaultValue": null,
-    "description": "Defines a custom list of TLS ciphers to be served by Nginx. This list must conform to the pattern defined by `openssl ciphers`. This value is ignored if `ssl_cipher_suite` is not `custom`. If you use DHE ciphers, you must also configure the `ssl_dhparam` parameter."
+    "description": "Defines a custom list of TLS ciphers to be\nserved by Nginx. This list must conform to\nthe pattern defined by `openssl ciphers`.\nThis value is ignored if `ssl_cipher_suite`\nis not `custom`.\nIf you use DHE ciphers, you must also\nconfigure the `ssl_dhparam` parameter.\n"
   },
   "ssl_protocols": {
     "defaultValue": "TLSv1.2 TLSv1.3",
-    "description": " Enables the specified protocols for client-side connections. The set of supported protocol versions also depends on the version of OpenSSL Kong was built with. This value is ignored if `ssl_cipher_suite` is not `custom`. If you want to enable TLSv1.1, you should set `ssl_cipher_suite` to `old`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols"
+    "description": "Enables the specified protocols for\nclient-side connections. The set of\nsupported protocol versions also depends\non the version of OpenSSL Kong was built\nwith. This value is ignored if\n`ssl_cipher_suite` is not `custom`.\nIf you want to enable TLSv1.1, you should\nset `ssl_cipher_suite` to `old`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols\n"
   },
   "ssl_prefer_server_ciphers": {
     "defaultValue": "on",
-    "description": "Specifies that server ciphers should be preferred over client ciphers when using the SSLv3 and TLS protocols. This value is ignored if `ssl_cipher_suite` is not `custom`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers"
+    "description": "Specifies that server ciphers should be\npreferred over client ciphers when using\nthe SSLv3 and TLS protocols. This value is\nignored if `ssl_cipher_suite` is not `custom`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers\n"
   },
   "ssl_dhparam": {
     "defaultValue": null,
-    "description": "Defines DH parameters for DHE ciphers from the predefined groups: `ffdhe2048`, `ffdhe3072`, `ffdhe4096`, `ffdhe6144`, `ffdhe8192`, from the absolute path to a parameters file, or directly from the parameters content.  This value is ignored if `ssl_cipher_suite` is `modern` or `intermediate`. The reason is that `modern` has no ciphers that need this, and `intermediate` uses `ffdhe2048`.  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam"
+    "description": "Defines DH parameters for DHE ciphers from the\npredefined groups: `ffdhe2048`, `ffdhe3072`,\n`ffdhe4096`, `ffdhe6144`, `ffdhe8192`,\nfrom the absolute path to a parameters file, or\ndirectly from the parameters content.\n\nThis value is ignored if `ssl_cipher_suite`\nis `modern` or `intermediate`. The reason is\nthat `modern` has no ciphers that need this,\nand `intermediate` uses `ffdhe2048`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam\n"
   },
   "ssl_session_tickets": {
     "defaultValue": "on",
-    "description": "Enables or disables session resumption through TLS session tickets. This has no impact when used with TLSv1.3.  Kong enables this by default for performance reasons, but it has security implications: https://github.com/mozilla/server-side-tls/issues/135  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets"
+    "description": "Enables or disables session resumption through\nTLS session tickets. This has no impact when\nused with TLSv1.3.\n\nKong enables this by default for performance\nreasons, but it has security implications:\nhttps://github.com/mozilla/server-side-tls/issues/135\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets\n"
   },
   "ssl_session_timeout": {
     "defaultValue": "1d",
-    "description": "Specifies a time during which a client may reuse the session parameters. See the rationale: https://github.com/mozilla/server-side-tls/issues/198  See http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout"
+    "description": "Specifies a time during which a client may\nreuse the session parameters. See the rationale:\nhttps://github.com/mozilla/server-side-tls/issues/198\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout\n"
   },
   "ssl_session_cache_size": {
     "defaultValue": "10m",
-    "description": "Sets the size of the caches that store session parameters.  See https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache"
+    "description": "Sets the size of the caches that store session parameters.\n\nSee https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache\n"
   },
   "ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `proxy_listen` values with TLS enabled.  If more than one certificate is specified, it can be used to provide alternate types of certificates (for example, ECC certificates) that will be served to clients that support them. Note that to properly serve using ECC certificates, it is recommended to also set `ssl_cipher_suite` to `modern` or `intermediate`.  Unless this option is explicitly set, Kong will auto-generate a pair of default certificates (RSA + ECC) the first time it starts up and use them for serving TLS requests.  Certificates can be configured on this property with any of the following values: - absolute path to the certificate - certificate content - base64 encoded certificate content"
+    "description": "Comma-separated list of certificates for `proxy_listen` values with TLS enabled.\n\nIf more than one certificate is specified, it can be used to provide\nalternate types of certificates (for example, ECC certificates) that will be served\nto clients that support them. Note that to properly serve using ECC certificates,\nit is recommended to also set `ssl_cipher_suite` to\n`modern` or `intermediate`.\n\nUnless this option is explicitly set, Kong will auto-generate\na pair of default certificates (RSA + ECC) the first time it starts up and use\nthem for serving TLS requests.\n\nCertificates can be configured on this property with any of the following\nvalues:\n- absolute path to the certificate\n- certificate content\n- base64 encoded certificate content\n"
   },
   "ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `proxy_listen` values with TLS enabled.  If more than one certificate was specified for `ssl_cert`, then this option should contain the corresponding key for all certificates provided in the same order.  Unless this option is explicitly set, Kong will auto-generate a pair of default private keys (RSA + ECC) the first time it starts up and use them for serving TLS requests.  Keys can be configured on this property with any of the following values: - absolute path to the certificate key - certificate key content - base64 encoded certificate key content"
+    "description": "Comma-separated list of keys for `proxy_listen` values with TLS enabled.\n\nIf more than one certificate was specified for `ssl_cert`, then this\noption should contain the corresponding key for all certificates\nprovided in the same order.\n\nUnless this option is explicitly set, Kong will auto-generate\na pair of default private keys (RSA + ECC) the first time it starts up and use\nthem for serving TLS requests.\n\nKeys can be configured on this property with any of the following\nvalues:\n- absolute path to the certificate key\n- certificate key content\n- base64 encoded certificate key content\n"
   },
   "client_ssl": {
     "defaultValue": "off",
-    "description": "Determines if Nginx should attempt to send client-side TLS certificates and perform Mutual TLS Authentication with upstream service when proxying requests."
+    "description": "Determines if Nginx should attempt to send client-side\nTLS certificates and perform Mutual TLS Authentication\nwith upstream service when proxying requests.\n"
   },
   "client_ssl_cert": {
     "defaultValue": null,
-    "description": "If `client_ssl` is enabled, the client certificate for the `proxy_ssl_certificate` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate can be configured on this property with any of the following values: - absolute path to the certificate - certificate content - base64 encoded certificate content"
+    "description": "If `client_ssl` is enabled, the client certificate\nfor the `proxy_ssl_certificate` directive.\n\nThis value can be overwritten dynamically with the `client_certificate`\nattribute of the `Service` object.\n\nThe certificate can be configured on this property with any of the following\nvalues:\n- absolute path to the certificate\n- certificate content\n- base64 encoded certificate content\n"
   },
   "client_ssl_cert_key": {
     "defaultValue": null,
-    "description": "If `client_ssl` is enabled, the client TLS key for the `proxy_ssl_certificate_key` directive.  This value can be overwritten dynamically with the `client_certificate` attribute of the `Service` object.  The certificate key can be configured on this property with any of the following values: - absolute path to the certificate key - certificate key content - base64 encoded certificate key content"
+    "description": "If `client_ssl` is enabled, the client TLS key\nfor the `proxy_ssl_certificate_key` directive.\n\nThis value can be overwritten dynamically with the `client_certificate`\nattribute of the `Service` object.\n\nThe certificate key can be configured on this property with any of the following\nvalues:\n- absolute path to the certificate key\n- certificate key content\n- base64 encoded certificate key content\n"
   },
   "admin_ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `admin_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+    "description": "Comma-separated list of certificates for `admin_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n"
   },
   "admin_ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `admin_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+    "description": "Comma-separated list of keys for `admin_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n"
   },
   "status_ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `status_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+    "description": "Comma-separated list of certificates for `status_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n"
   },
   "status_ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `status_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+    "description": "Comma-separated list of keys for `status_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n"
   },
   "debug_ssl_cert": {
     "defaultValue": null,
-    "description": "Comma-separated list of certificates for `debug_listen` values with TLS enabled.  See docs for `ssl_cert` for detailed usage."
+    "description": "Comma-separated list of certificates for `debug_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n"
   },
   "debug_ssl_cert_key": {
     "defaultValue": null,
-    "description": "Comma-separated list of keys for `debug_listen` values with TLS enabled.  See docs for `ssl_cert_key` for detailed usage."
+    "description": "Comma-separated list of keys for `debug_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n"
   },
   "headers": {
     "defaultValue": [
@@ -327,311 +327,311 @@
       "latency_tokens",
       "X-Kong-Request-Id"
     ],
-    "description": " Comma-separated list of headers Kong should inject in client responses.  Accepted values are: - `Server`: Injects `Server: kong/x.y.z`   on Kong-produced responses (e.g., Admin   API, rejected requests from auth plugin). - `Via`: Injects `Via: kong/x.y.z` for   successfully proxied requests. - `X-Kong-Proxy-Latency`: Time taken   (in milliseconds) by Kong to process   a request and run all plugins before   proxying the request upstream. - `X-Kong-Response-Latency`: Time taken   (in milliseconds) by Kong to produce   a response in case of, e.g., a plugin   short-circuiting the request, or in   case of an error. - `X-Kong-Upstream-Latency`: Time taken   (in milliseconds) by the upstream   service to send response headers. - `X-Kong-Admin-Latency`: Time taken   (in milliseconds) by Kong to process   an Admin API request. - `X-Kong-Upstream-Status`: The HTTP status   code returned by the upstream service.   This is particularly useful for clients to   distinguish upstream statuses if the   response is rewritten by a plugin. - `X-Kong-Request-Id`: Unique identifier of   the request. - `server_tokens`: Same as specifying both   `Server` and `Via`. - `latency_tokens`: Same as specifying   `X-Kong-Proxy-Latency`,   `X-Kong-Response-Latency`,   `X-Kong-Admin-Latency`, and   `X-Kong-Upstream-Latency`.  In addition to these, this value can be set to `off`, which prevents Kong from injecting any of the above headers. Note that this does not prevent plugins from injecting headers of their own.  Example: `headers = via, latency_tokens`"
+    "description": "Comma-separated list of headers Kong should\ninject in client responses.\n\nAccepted values are:\n- `Server`: Injects `Server: kong/x.y.z`\n  on Kong-produced responses (e.g., Admin\n  API, rejected requests from auth plugin).\n- `Via`: Injects `Via: kong/x.y.z` for\n  successfully proxied requests.\n- `X-Kong-Proxy-Latency`: Time taken\n  (in milliseconds) by Kong to process\n  a request and run all plugins before\n  proxying the request upstream.\n- `X-Kong-Response-Latency`: Time taken\n  (in milliseconds) by Kong to produce\n  a response in case of, e.g., a plugin\n  short-circuiting the request, or in\n  case of an error.\n- `X-Kong-Upstream-Latency`: Time taken\n  (in milliseconds) by the upstream\n  service to send response headers.\n- `X-Kong-Admin-Latency`: Time taken\n  (in milliseconds) by Kong to process\n  an Admin API request.\n- `X-Kong-Upstream-Status`: The HTTP status\n  code returned by the upstream service.\n  This is particularly useful for clients to\n  distinguish upstream statuses if the\n  response is rewritten by a plugin.\n- `X-Kong-Request-Id`: Unique identifier of\n  the request.\n- `server_tokens`: Same as specifying both\n  `Server` and `Via`.\n- `latency_tokens`: Same as specifying\n  `X-Kong-Proxy-Latency`,\n  `X-Kong-Response-Latency`,\n  `X-Kong-Admin-Latency`, and\n  `X-Kong-Upstream-Latency`.\n\nIn addition to these, this value can be set\nto `off`, which prevents Kong from injecting\nany of the above headers. Note that this\ndoes not prevent plugins from injecting\nheaders of their own.\n\nExample: `headers = via, latency_tokens`\n"
   },
   "headers_upstream": {
     "defaultValue": "X-Kong-Request-Id",
-    "description": " Comma-separated list of headers Kong should inject in requests to upstream.  At this time, the only accepted value is: - `X-Kong-Request-Id`: Unique identifier of   the request.  In addition, this value can be set to `off`, which prevents Kong from injecting the above header. Note that this does not prevent plugins from injecting headers of their own."
+    "description": "Comma-separated list of headers Kong should\ninject in requests to upstream.\n\nAt this time, the only accepted value is:\n- `X-Kong-Request-Id`: Unique identifier of\n  the request.\n\nIn addition, this value can be set\nto `off`, which prevents Kong from injecting\nthe above header. Note that this\ndoes not prevent plugins from injecting\nheaders of their own.\n"
   },
   "trusted_ips": {
     "defaultValue": null,
-    "description": "Defines trusted IP address blocks that are known to send correct `X-Forwarded-*` headers. Requests from trusted IPs make Kong forward their `X-Forwarded-*` headers upstream. Non-trusted requests make Kong insert its own `X-Forwarded-*` headers.  This property also sets the `set_real_ip_from` directive(s) in the Nginx configuration. It accepts the same type of values (CIDR blocks) but as a comma-separated list.  To trust *all* IPs, set this value to `0.0.0.0/0,::/0`.  If the special value `unix:` is specified, all UNIX-domain sockets will be trusted.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from for examples of accepted values."
+    "description": "Defines trusted IP address blocks that are\nknown to send correct `X-Forwarded-*`\nheaders.\nRequests from trusted IPs make Kong forward\ntheir `X-Forwarded-*` headers upstream.\nNon-trusted requests make Kong insert its\nown `X-Forwarded-*` headers.\n\nThis property also sets the\n`set_real_ip_from` directive(s) in the Nginx\nconfiguration. It accepts the same type of\nvalues (CIDR blocks) but as a\ncomma-separated list.\n\nTo trust *all* IPs, set this value to\n`0.0.0.0/0,::/0`.\n\nIf the special value `unix:` is specified,\nall UNIX-domain sockets will be trusted.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from\nfor examples of accepted values.\n"
   },
   "real_ip_header": {
     "defaultValue": "X-Real-IP",
-    "description": "Defines the request header field whose value will be used to replace the client address. This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  If this value receives `proxy_protocol`:  - at least one of the `proxy_listen` entries   must have the `proxy_protocol` flag   enabled. - the `proxy_protocol` parameter will be   appended to the `listen` directive of the   Nginx template.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header for a description of this directive."
+    "description": "Defines the request header field whose value\nwill be used to replace the client address.\nThis value sets the `ngx_http_realip_module`\ndirective of the same name in the Nginx\nconfiguration.\n\nIf this value receives `proxy_protocol`:\n\n- at least one of the `proxy_listen` entries\n  must have the `proxy_protocol` flag\n  enabled.\n- the `proxy_protocol` parameter will be\n  appended to the `listen` directive of the\n  Nginx template.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header\nfor a description of this directive.\n"
   },
   "real_ip_recursive": {
     "defaultValue": "off",
-    "description": "This value sets the `ngx_http_realip_module` directive of the same name in the Nginx configuration.  See http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive for a description of this directive."
+    "description": "This value sets the `ngx_http_realip_module`\ndirective of the same name in the Nginx\nconfiguration.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive\nfor a description of this directive.\n"
   },
   "error_default_type": {
     "defaultValue": "text/plain",
-    "description": "Default MIME type to use when the request `Accept` header is missing and Nginx is returning an error for the request. Accepted values are `text/plain`, `text/html`, `application/json`, and `application/xml`."
+    "description": "Default MIME type to use when the request\n`Accept` header is missing and Nginx\nis returning an error for the request.\nAccepted values are `text/plain`,\n`text/html`, `application/json`, and\n`application/xml`.\n"
   },
   "upstream_keepalive_pool_size": {
     "defaultValue": "512",
-    "description": "Sets the default size of the upstream keepalive connection pools. Upstream keepalive connection pools are segmented by the `dst ip/dst port/SNI` attributes of a connection. A value of `0` will disable upstream keepalive connections by default, forcing each upstream request to open a new connection."
+    "description": "Sets the default size of the upstream\nkeepalive connection pools.\nUpstream keepalive connection pools\nare segmented by the `dst ip/dst\nport/SNI` attributes of a connection.\nA value of `0` will disable upstream\nkeepalive connections by default, forcing\neach upstream request to open a new\nconnection.\n"
   },
   "upstream_keepalive_max_requests": {
     "defaultValue": "10000",
-    "description": "Sets the default maximum number of requests that can be proxied upstream through one keepalive connection. After the maximum number of requests is reached, the connection will be closed. A value of `0` will disable this behavior, and a keepalive connection can be used to proxy an indefinite number of requests."
+    "description": "Sets the default maximum number of\nrequests that can be proxied upstream\nthrough one keepalive connection.\nAfter the maximum number of requests\nis reached, the connection will be\nclosed.\nA value of `0` will disable this\nbehavior, and a keepalive connection\ncan be used to proxy an indefinite\nnumber of requests.\n"
   },
   "upstream_keepalive_idle_timeout": {
     "defaultValue": "60",
-    "description": "Sets the default timeout (in seconds) for which an upstream keepalive connection should be kept open. When the timeout is reached while the connection has not been reused, it will be closed. A value of `0` will disable this behavior, and an idle keepalive connection may be kept open indefinitely."
+    "description": "Sets the default timeout (in seconds)\nfor which an upstream keepalive\nconnection should be kept open. When\nthe timeout is reached while the\nconnection has not been reused, it\nwill be closed.\nA value of `0` will disable this\nbehavior, and an idle keepalive\nconnection may be kept open\nindefinitely.\n"
   },
   "allow_debug_header": {
     "defaultValue": "off",
-    "description": "Enable the `Kong-Debug` header function. If it is `on`, Kong will add `Kong-Route-Id`, `Kong-Route-Name`, `Kong-Service-Id`, and `Kong-Service-Name` debug headers to the response when the client request header `Kong-Debug: 1` is present."
+    "description": "Enable the `Kong-Debug` header function.\nIf it is `on`, Kong will add\n`Kong-Route-Id`, `Kong-Route-Name`, `Kong-Service-Id`,\nand `Kong-Service-Name` debug headers to the response when\nthe client request header `Kong-Debug: 1` is present.\n"
   },
   "nginx_main_worker_rlimit_nofile": {
     "defaultValue": "auto",
-    "description": " Changes the limit on the maximum number of open files for worker processes.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile"
+    "description": "Changes the limit on the maximum number of open files\nfor worker processes.\n\nThe special and default value of `auto` sets this\nvalue to `ulimit -n` with the upper bound limited to\n16384 as a measure to protect against excess memory use,\nand the lower bound of 1024 as a good default.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile\n"
   },
   "nginx_events_worker_connections": {
     "defaultValue": "auto",
-    "description": " Sets the maximum number of simultaneous connections that can be opened by a worker process.  The special and default value of `auto` sets this value to `ulimit -n` with the upper bound limited to 16384 as a measure to protect against excess memory use, and the lower bound of 1024 as a good default.  See http://nginx.org/en/docs/ngx_core_module.html#worker_connections"
+    "description": "Sets the maximum number of simultaneous\nconnections that can be opened by a worker process.\n\nThe special and default value of `auto` sets this\nvalue to `ulimit -n` with the upper bound limited to\n16384 as a measure to protect against excess memory use,\nand the lower bound of 1024 as a good default.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_connections\n"
   },
   "nginx_http_client_header_buffer_size": {
     "defaultValue": "1k",
-    "description": "Sets buffer size for reading the client request headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size"
+    "description": "Sets buffer size for reading the\nclient request headers.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size\n"
   },
   "nginx_http_large_client_header_buffers": {
     "defaultValue": "4 8k",
-    "description": "Sets the maximum number and size of buffers used for reading large client request headers. See http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers"
+    "description": "Sets the maximum number and\nsize of buffers used for\nreading large client\nrequest headers.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers\n"
   },
   "nginx_http_client_max_body_size": {
     "defaultValue": "0",
-    "description": "Defines the maximum request body size allowed by requests proxied by Kong, specified in the Content-Length request header. If a request exceeds this limit, Kong will respond with a 413 (Request Entity Too Large). Setting this value to 0 disables checking the request body size. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size"
+    "description": "Defines the maximum request body size\nallowed by requests proxied by Kong,\nspecified in the Content-Length request\nheader. If a request exceeds this\nlimit, Kong will respond with a 413\n(Request Entity Too Large). Setting\nthis value to 0 disables checking the\nrequest body size.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size\n"
   },
   "nginx_admin_client_max_body_size": {
     "defaultValue": "10m",
-    "description": "Defines the maximum request body size for Admin API."
+    "description": "Defines the maximum request body size for\nAdmin API.\n"
   },
   "nginx_http_charset": {
     "defaultValue": "UTF-8",
-    "description": "Adds the specified charset to the \"Content-Type\" response header field. If this charset is different from the charset specified in the `source_charset` directive, a conversion is performed.  The parameter `off` cancels the addition of charset to the \"Content-Type\" response header field. See http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset"
+    "description": "Adds the specified charset to the \"Content-Type\"\nresponse header field. If this charset is different\nfrom the charset specified in the `source_charset`\ndirective, a conversion is performed.\n\nThe parameter `off` cancels the addition of\ncharset to the \"Content-Type\" response header field.\nSee http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset\n"
   },
   "nginx_http_client_body_buffer_size": {
     "defaultValue": "8k",
-    "description": "Defines the buffer size for reading the request body. If the client request body is larger than this value, the body will be buffered to disk. Note that when the body is buffered to disk, Kong plugins that access or manipulate the request body may not work, so it is advisable to set this value as high as possible (e.g., set it as high as `client_max_body_size` to force request bodies to be kept in memory). Do note that high-concurrency environments will require significant memory allocations to process many concurrent large request bodies. See http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size"
+    "description": "Defines the buffer size for reading\nthe request body. If the client\nrequest body is larger than this\nvalue, the body will be buffered to\ndisk. Note that when the body is\nbuffered to disk, Kong plugins that\naccess or manipulate the request\nbody may not work, so it is\nadvisable to set this value as high\nas possible (e.g., set it as high\nas `client_max_body_size` to force\nrequest bodies to be kept in\nmemory). Do note that\nhigh-concurrency environments will\nrequire significant memory\nallocations to process many\nconcurrent large request bodies.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size\n"
   },
   "nginx_admin_client_body_buffer_size": {
     "defaultValue": "10m",
-    "description": "Defines the buffer size for reading the request body on Admin API."
+    "description": "Defines the buffer size for reading\nthe request body on Admin API.\n"
   },
   "nginx_http_lua_regex_match_limit": {
     "defaultValue": "100000",
-    "description": "Global `MATCH_LIMIT` for PCRE regex matching. The default of `100000` should ensure at worst any regex Kong executes could finish within roughly 2 seconds."
+    "description": "Global `MATCH_LIMIT` for PCRE\nregex matching. The default of `100000` should ensure\nat worst any regex Kong executes could finish within\nroughly 2 seconds.\n"
   },
   "nginx_http_lua_regex_cache_max_entries": {
     "defaultValue": "8192",
-    "description": "Specifies the maximum number of entries allowed in the worker process level PCRE JIT compiled regex cache. It is recommended to set it to at least (number of regex paths * 2) to avoid high CPU usages if you manually specified `router_flavor` to `traditional`. `expressions` and `traditional_compat` router do not make use of the PCRE library and their behavior is unaffected by this setting."
+    "description": "Specifies the maximum number of entries allowed\nin the worker process level PCRE JIT compiled regex cache.\nIt is recommended to set it to at least (number of regex paths * 2)\nto avoid high CPU usages if you manually specified `router_flavor` to\n`traditional`. `expressions` and `traditional_compat` router do\nnot make use of the PCRE library and their behavior\nis unaffected by this setting.\n"
   },
   "nginx_http_keepalive_requests": {
     "defaultValue": "10000",
-    "description": "Sets the maximum number of client requests that can be served through one keep-alive connection. After the maximum number of requests are made, the connection is closed. Closing connections periodically is necessary to free per-connection memory allocations. Therefore, using too high a maximum number of requests could result in excessive memory usage and is not recommended. See: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests"
+    "description": "Sets the maximum number of client requests that can be served through one\nkeep-alive connection. After the maximum number of requests are made,\nthe connection is closed.\nClosing connections periodically is necessary to free per-connection\nmemory allocations. Therefore, using too high a maximum number of requests\ncould result in excessive memory usage and is not recommended.\nSee: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests\n"
   },
   "database": {
     "defaultValue": "postgres",
-    "description": "Determines the database (or no database) for this node Accepted values are `postgres` and `off`."
+    "description": "Determines the database (or no database) for\nthis node\nAccepted values are `postgres` and `off`.\n"
   },
   "pg_host": {
     "defaultValue": "127.0.0.1",
-    "description": "Host of the Postgres server."
+    "description": "Host of the Postgres server.\n"
   },
   "pg_port": {
     "defaultValue": "5432",
-    "description": "Port of the Postgres server."
+    "description": "Port of the Postgres server.\n"
   },
   "pg_timeout": {
     "defaultValue": "5000",
-    "description": "Defines the timeout (in ms), for connecting, reading and writing."
+    "description": "Defines the timeout (in ms), for connecting,\nreading and writing.\n"
   },
   "pg_user": {
     "defaultValue": "kong",
-    "description": "Postgres user."
+    "description": "Postgres user.\n"
   },
   "pg_password": {
     "defaultValue": null,
-    "description": "Postgres user's password."
+    "description": "Postgres user's password.\n"
   },
   "pg_iam_auth": {
     "defaultValue": "off",
-    "description": "Determines whether the AWS IAM database Authentication will be used. When switch to `on`, the username defined in `pg_user` will be used as the database account, and the database connection will be forced to using TLS. `pg_password` will not be used when the switch is `on`. Note that the corresponding IAM policy must be correct, otherwise connecting will fail."
+    "description": "Determines whether the AWS IAM database\nAuthentication will be used. When switch to\n`on`, the username defined in `pg_user` will\nbe used as the database account, and the\ndatabase connection will be forced to using\nTLS. `pg_password` will not be used when\nthe switch is `on`. Note that the corresponding\nIAM policy must be correct, otherwise connecting\nwill fail.\n"
   },
   "pg_iam_auth_assume_role_arn": {
     "defaultValue": null,
-    "description": "The target AWS IAM role ARN that will be assumed when using AWS IAM database authentication. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+    "description": "The target AWS IAM role ARN that will be\nassumed when using AWS IAM database\nauthentication. Typically this is used\nfor operating between multiple roles\nor cross-accounts.\nIf you are not using assume role\nyou should not specify this value.\n"
   },
   "pg_iam_auth_role_session_name": {
     "defaultValue": "KongPostgres",
-    "description": "The role session name used for role assuming in AWS IAM Database Authentication. The default value is `KongPostgres`."
+    "description": "The role session name used for role\nassuming in AWS IAM Database\nAuthentication. The default value is\n`KongPostgres`.\n"
   },
   "pg_iam_auth_sts_endpoint_url": {
     "defaultValue": null,
-    "description": "The custom STS endpoint URL used for role assuming in AWS IAM Database Authentication.  Note that this value will override the default STS endpoint URL(which should be `https://sts.amazonaws.com`, or `https://sts.<region>.amazonaws.com` if you have `AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).  If you are not using private VPC endpoint for STS service, you should not specify this value."
+    "description": "The custom STS endpoint URL used for role assuming\nin AWS IAM Database Authentication.\n\nNote that this value will override the default\nSTS endpoint URL(which should be\n`https://sts.amazonaws.com`, or\n`https://sts.<region>.amazonaws.com` if you have\n`AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).\n\nIf you are not using private VPC endpoint for STS\nservice, you should not specify this value.\n"
   },
   "pg_database": {
     "defaultValue": "kong",
-    "description": "The database name to connect to."
+    "description": "The database name to connect to.\n"
   },
   "pg_schema": {
     "defaultValue": null,
-    "description": "The database schema to use. If unspecified, Kong will respect the `search_path` value of your PostgreSQL instance."
+    "description": "The database schema to use. If unspecified,\nKong will respect the `search_path` value of\nyour PostgreSQL instance.\n"
   },
   "pg_ssl": {
     "defaultValue": "off",
-    "description": "Toggles client-server TLS connections between Kong and PostgreSQL. Because PostgreSQL uses the same port for TLS and non-TLS, this is only a hint. If the server does not support TLS, the established connection will be a plain one."
+    "description": "Toggles client-server TLS connections\nbetween Kong and PostgreSQL.\nBecause PostgreSQL uses the same port for TLS\nand non-TLS, this is only a hint. If the\nserver does not support TLS, the established\nconnection will be a plain one.\n"
   },
   "pg_ssl_version": {
     "defaultValue": "tlsv1_2",
-    "description": "When using ssl between Kong and PostgreSQL, the version of tls to use. Accepted values are `tlsv1_1`, `tlsv1_2`, `tlsv1_3`, or 'any'. When `any` is set, the client negotiates the highest version with the server which can't be lower than `tlsv1_1`."
+    "description": "When using ssl between Kong and PostgreSQL,\nthe version of tls to use. Accepted values are\n`tlsv1_1`, `tlsv1_2`, `tlsv1_3`, or 'any'. When\n`any` is set, the client negotiates the highest\nversion with the server which can't be lower\nthan `tlsv1_1`.\n"
   },
   "pg_ssl_required": {
     "defaultValue": "off",
-    "description": "When `pg_ssl` is on this determines if TLS must be used between Kong and PostgreSQL. It aborts the connection if the server does not support SSL connections."
+    "description": "When `pg_ssl` is on this determines if\nTLS must be used between Kong and PostgreSQL.\nIt aborts the connection if the server does\nnot support SSL connections.\n"
   },
   "pg_ssl_verify": {
     "defaultValue": "off",
-    "description": "Toggles server certificate verification if `pg_ssl` is enabled. See the `lua_ssl_trusted_certificate` setting to specify a certificate authority."
+    "description": "Toggles server certificate verification if\n`pg_ssl` is enabled.\nSee the `lua_ssl_trusted_certificate`\nsetting to specify a certificate authority.\n"
   },
   "pg_ssl_cert": {
     "defaultValue": null,
-    "description": "The absolute path to the PEM encoded client TLS certificate for the PostgreSQL connection. Mutual TLS authentication against PostgreSQL is only enabled if this value is set."
+    "description": "The absolute path to the PEM encoded client\nTLS certificate for the PostgreSQL connection.\nMutual TLS authentication against\nPostgreSQL is only enabled if this value is set.\n"
   },
   "pg_ssl_cert_key": {
     "defaultValue": null,
-    "description": "If `pg_ssl_cert` is set, the absolute path to the PEM encoded client TLS private key for the PostgreSQL connection."
+    "description": "If `pg_ssl_cert` is set, the absolute path to\nthe PEM encoded client TLS private key for the\nPostgreSQL connection.\n"
   },
   "pg_max_concurrent_queries": {
     "defaultValue": "0",
-    "description": "Sets the maximum number of concurrent queries that can be executing at any given time. This limit is enforced per worker process; the total number of concurrent queries for this node will be will be: `pg_max_concurrent_queries * nginx_worker_processes`.  The default value of 0 removes this concurrency limitation."
+    "description": "Sets the maximum number of concurrent queries\nthat can be executing at any given time. This\nlimit is enforced per worker process; the\ntotal number of concurrent queries for this\nnode will be will be:\n`pg_max_concurrent_queries * nginx_worker_processes`.\n\nThe default value of 0 removes this\nconcurrency limitation.\n"
   },
   "pg_semaphore_timeout": {
     "defaultValue": "60000",
-    "description": "Defines the timeout (in ms) after which PostgreSQL query semaphore resource acquisition attempts will fail. Such failures will generally result in the associated proxy or Admin API request failing with an HTTP 500 status code. Detailed discussion of this behavior is available in the online documentation."
+    "description": "Defines the timeout (in ms) after which\nPostgreSQL query semaphore resource\nacquisition attempts will fail. Such\nfailures will generally result in the\nassociated proxy or Admin API request\nfailing with an HTTP 500 status code.\nDetailed discussion of this behavior is\navailable in the online documentation.\n"
   },
   "pg_keepalive_timeout": {
     "defaultValue": null,
-    "description": "Specify the maximal idle timeout (in ms) for the postgres connections in the pool. If this value is set to 0 then the timeout interval is unlimited.  If not specified this value will be same as `lua_socket_keepalive_timeout`"
+    "description": "Specify the maximal idle timeout (in ms)\nfor the postgres connections in the pool.\nIf this value is set to 0 then the timeout interval\nis unlimited.\n\nIf not specified this value will be same as\n`lua_socket_keepalive_timeout`\n"
   },
   "pg_pool_size": {
     "defaultValue": null,
-    "description": "Specifies the size limit (in terms of connection count) for the Postgres server. Note that this connection pool is intended per Nginx worker rather than per Kong instance.  If not specified, the default value is the same as `lua_socket_pool_size`"
+    "description": "Specifies the size limit (in terms of connection\ncount) for the Postgres server.\nNote that this connection pool is intended\nper Nginx worker rather than per Kong instance.\n\nIf not specified, the default value is the same as\n`lua_socket_pool_size`\n"
   },
   "pg_backlog": {
     "defaultValue": null,
-    "description": "If specified, this value will limit the total number of open connections to the Postgres server to `pg_pool_size`. If the connection pool is full, subsequent connect operations will be inserted in a queue with size equal to this option's value.  If the number of queued connect operations reaches `pg_backlog`, exceeding connections will fail.  If not specified, then number of open connections to the Postgres server is not limited."
+    "description": "If specified, this value will limit the total\nnumber of open connections to the Postgres\nserver to `pg_pool_size`. If the connection\npool is full, subsequent connect operations\nwill be inserted in a queue with size equal\nto this option's value.\n\nIf the number of queued connect operations\nreaches `pg_backlog`, exceeding connections will fail.\n\nIf not specified, then number of open connections\nto the Postgres server is not limited.\n"
   },
   "pg_ro_host": {
     "defaultValue": null,
-    "description": "Same as `pg_host`, but for the read-only connection. **Note:** Refer to the documentation section above for detailed usage."
+    "description": "Same as `pg_host`, but for the\nread-only connection.\n**Note:** Refer to the documentation\nsection above for detailed usage.\n"
   },
   "pg_ro_port": {
     "defaultValue": "<pg_port>",
-    "description": "Same as `pg_port`, but for the read-only connection."
+    "description": "Same as `pg_port`, but for the\nread-only connection.\n"
   },
   "pg_ro_timeout": {
     "defaultValue": "<pg_timeout>",
-    "description": "Same as `pg_timeout`, but for the read-only connection."
+    "description": "Same as `pg_timeout`, but for the\nread-only connection.\n"
   },
   "pg_ro_user": {
     "defaultValue": "<pg_user>",
-    "description": "Same as `pg_user`, but for the read-only connection."
+    "description": "Same as `pg_user`, but for the\nread-only connection.\n"
   },
   "pg_ro_password": {
     "defaultValue": "<pg_password>",
-    "description": "Same as `pg_password`, but for the read-only connection."
+    "description": "Same as `pg_password`, but for the\nread-only connection.\n"
   },
   "pg_ro_iam_auth": {
     "defaultValue": "<pg_iam_auth>",
-    "description": "Same as `pg_iam_auth`, but for the read-only connection."
+    "description": "Same as `pg_iam_auth`, but for the\nread-only connection.\n"
   },
   "pg_ro_iam_auth_assume_role_arn": {
     "defaultValue": null,
-    "description": "Same as `pg_iam_auth_assume_role_arn', but for the read-only connection."
+    "description": "Same as `pg_iam_auth_assume_role_arn',\nbut for the read-only connection.\n"
   },
   "pg_ro_iam_auth_role_session_name": {
     "defaultValue": "KongPostgres",
-    "description": "Same as `pg_iam_auth_role_session_name`, but for the read-only connection."
+    "description": "Same as `pg_iam_auth_role_session_name`,\nbut for the read-only connection.\n"
   },
   "pg_ro_iam_auth_sts_endpoint_url": {
     "defaultValue": null,
-    "description": "Same as `pg_iam_auth_sts_endpoint_url`, but for the read-only connection."
+    "description": "Same as `pg_iam_auth_sts_endpoint_url`,\nbut for the read-only connection.\n"
   },
   "pg_ro_database": {
     "defaultValue": "<pg_database>",
-    "description": "Same as `pg_database`, but for the read-only connection."
+    "description": "Same as `pg_database`, but for the\nread-only connection.\n"
   },
   "pg_ro_schema": {
     "defaultValue": "<pg_schema>",
-    "description": "Same as `pg_schema`, but for the read-only connection."
+    "description": "Same as `pg_schema`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl": {
     "defaultValue": "<pg_ssl>",
-    "description": "Same as `pg_ssl`, but for the read-only connection."
+    "description": "Same as `pg_ssl`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl_required": {
     "defaultValue": "<pg_ssl_required>",
-    "description": " Same as `pg_ssl_required`, but for the read-only connection."
+    "description": "Same as `pg_ssl_required`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl_verify": {
     "defaultValue": "<pg_ssl_verify>",
-    "description": " Same as `pg_ssl_verify`, but for the read-only connection."
+    "description": "Same as `pg_ssl_verify`, but for the\nread-only connection.\n"
   },
   "pg_ro_ssl_version": {
     "defaultValue": "<pg_ssl_version>",
-    "description": " Same as `pg_ssl_version`, but for the read-only connection."
+    "description": "Same as `pg_ssl_version`, but for the\nread-only connection.\n"
   },
   "pg_ro_max_concurrent_queries": {
     "defaultValue": "<pg_max_concurrent_queries>",
-    "description": " Same as `pg_max_concurrent_queries`, but for the read-only connection. Note: read-only concurrency is not shared with the main (read-write) connection."
+    "description": "Same as `pg_max_concurrent_queries`, but for\nthe read-only connection.\nNote: read-only concurrency is not shared\nwith the main (read-write) connection.\n"
   },
   "pg_ro_semaphore_timeout": {
     "defaultValue": "<pg_semaphore_timeout>",
-    "description": " Same as `pg_semaphore_timeout`, but for the read-only connection."
+    "description": "Same as `pg_semaphore_timeout`, but for the\nread-only connection.\n"
   },
   "pg_ro_keepalive_timeout": {
     "defaultValue": "<pg_keepalive_timeout>",
-    "description": " Same as `pg_keepalive_timeout`, but for the read-only connection."
+    "description": "Same as `pg_keepalive_timeout`, but for the\nread-only connection.\n"
   },
   "pg_ro_pool_size": {
     "defaultValue": "<pg_pool_size>",
-    "description": " Same as `pg_pool_size`, but for the read-only connection."
+    "description": "Same as `pg_pool_size`, but for the\nread-only connection.\n"
   },
   "pg_ro_backlog": {
     "defaultValue": "<pg_backlog>",
-    "description": " Same as `pg_backlog`, but for the read-only connection."
+    "description": "Same as `pg_backlog`, but for the\nread-only connection.\n"
   },
   "declarative_config": {
     "defaultValue": null,
-    "description": "The path to the declarative configuration file which holds the specification of all entities (routes, services, consumers, etc.) to be used when the `database` is set to `off`.  Entities are stored in Kong's LMDB cache, so you must ensure that enough headroom is allocated to it via the `lmdb_map_size` property.  If the hybrid mode `role` is set to `data_plane` and there's no configuration cache file, this configuration is used before connecting to the control plane node as a user-controlled fallback."
+    "description": "The path to the declarative configuration\nfile which holds the specification of all\nentities (routes, services, consumers, etc.)\nto be used when the `database` is set to\n`off`.\n\nEntities are stored in Kong's LMDB cache,\nso you must ensure that enough headroom is\nallocated to it via the `lmdb_map_size`\nproperty.\n\nIf the hybrid mode `role` is set to `data_plane`\nand there's no configuration cache file,\nthis configuration is used before connecting\nto the control plane node as a user-controlled\nfallback.\n"
   },
   "declarative_config_string": {
     "defaultValue": null,
-    "description": "The declarative configuration as a string"
+    "description": "The declarative configuration as a string\n"
   },
   "lmdb_environment_path": {
     "defaultValue": "dbless.lmdb",
-    "description": "Directory where the LMDB database files used by DB-less and hybrid mode to store Kong configurations reside.  This path is relative under the Kong `prefix`."
+    "description": "Directory where the LMDB database files used by\nDB-less and hybrid mode to store Kong\nconfigurations reside.\n\nThis path is relative under the Kong `prefix`.\n"
   },
   "lmdb_map_size": {
     "defaultValue": "2048m",
-    "description": "Maximum size of the LMDB memory map, used to store the DB-less and hybrid mode configurations. Default is 2048m.  This config defines the limit of LMDB file size; the actual file size growth will be on-demand and proportional to the actual config size.  Note this value can be set very large, say a couple of GBs, to accommodate future database growth and Multi-Version Concurrency Control (MVCC) headroom needs. The file size of the LMDB database file should stabilize after a few config reloads/hybrid mode syncs, and the actual memory used by the LMDB database will be smaller than the file size due to dynamic swapping of database pages by the OS."
+    "description": "Maximum size of the LMDB memory map, used to store the\nDB-less and hybrid mode configurations. Default is 2048m.\n\nThis config defines the limit of LMDB file size; the\nactual file size growth will be on-demand and\nproportional to the actual config size.\n\nNote this value can be set very large, say a couple of GBs,\nto accommodate future database growth and\nMulti-Version Concurrency Control (MVCC) headroom needs.\nThe file size of the LMDB database file should stabilize\nafter a few config reloads/hybrid mode syncs, and the actual\nmemory used by the LMDB database will be smaller than\nthe file size due to dynamic swapping of database pages by\nthe OS.\n"
   },
   "db_update_frequency": {
     "defaultValue": "5",
-    "description": "Frequency (in seconds) at which to check for updated entities with the datastore.  When a node creates, updates, or deletes an entity via the Admin API, other nodes need to wait for the next poll (configured by this value) to eventually purge the old cached entity and start using the new one."
+    "description": "Frequency (in seconds) at which to check for\nupdated entities with the datastore.\n\nWhen a node creates, updates, or deletes an\nentity via the Admin API, other nodes need\nto wait for the next poll (configured by\nthis value) to eventually purge the old\ncached entity and start using the new one.\n"
   },
   "db_update_propagation": {
     "defaultValue": "0",
-    "description": "Time (in seconds) taken for an entity in the datastore to be propagated to replica nodes of another datacenter.  When set, this property will increase the time taken by Kong to propagate the change of an entity.  Single-datacenter setups or PostgreSQL servers should suffer no such delays, and this value can be safely set to 0. Postgres setups with read replicas should set this value to the maximum expected replication lag between the writer and reader instances."
+    "description": "Time (in seconds) taken for an entity in the\ndatastore to be propagated to replica nodes\nof another datacenter.\n\nWhen set, this property will increase the\ntime taken by Kong to propagate the change\nof an entity.\n\nSingle-datacenter setups or PostgreSQL\nservers should suffer no such delays, and\nthis value can be safely set to 0.\nPostgres setups with read replicas should\nset this value to the maximum expected replication\nlag between the writer and reader instances.\n"
   },
   "db_cache_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of an entity from the datastore when cached by this node.  Database misses (no entity) are also cached according to this setting if you do not configure `db_cache_neg_ttl`.  If set to 0 (default), such cached entities or misses never expire."
+    "description": "Time-to-live (in seconds) of an entity from\nthe datastore when cached by this node.\n\nDatabase misses (no entity) are also cached\naccording to this setting if you do not\nconfigure `db_cache_neg_ttl`.\n\nIf set to 0 (default), such cached entities\nor misses never expire.\n"
   },
   "db_cache_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a datastore miss (no entity).  If not specified (default), `db_cache_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a datastore\nmiss (no entity).\n\nIf not specified (default), `db_cache_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "db_resurrect_ttl": {
     "defaultValue": "30",
-    "description": "Time (in seconds) for which stale entities from the datastore should be resurrected when they cannot be refreshed (e.g., the datastore is unreachable). When this TTL expires, a new attempt to refresh the stale entities will be made."
+    "description": "Time (in seconds) for which stale entities\nfrom the datastore should be resurrected\nwhen they cannot be refreshed (e.g., the\ndatastore is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nentities will be made.\n"
   },
   "db_cache_warmup_entities": {
     "defaultValue": "services",
-    "description": " Entities to be pre-loaded from the datastore into the in-memory cache at Kong start-up. This speeds up the first access of endpoints that use the given entities.  When the `services` entity is configured for warmup, the DNS entries for values in its `host` attribute are pre-resolved asynchronously as well.  Cache size set in `mem_cache_size` should be set to a value large enough to hold all instances of the specified entities. If the size is insufficient, Kong will log a warning."
+    "description": "Entities to be pre-loaded from the datastore\ninto the in-memory cache at Kong start-up.\nThis speeds up the first access of endpoints\nthat use the given entities.\n\nWhen the `services` entity is configured\nfor warmup, the DNS entries for values in\nits `host` attribute are pre-resolved\nasynchronously as well.\n\nCache size set in `mem_cache_size` should\nbe set to a value large enough to hold all\ninstances of the specified entities.\nIf the size is insufficient, Kong will log\na warning.\n"
   },
   "dns_resolver": {
     "defaultValue": null,
-    "description": "Comma-separated list of nameservers, each entry in `ip[:port]` format to be used by Kong. If not specified, the nameservers in the local `resolv.conf` file will be used. Port defaults to 53 if omitted. Accepts both IPv4 and IPv6 addresses."
+    "description": "Comma-separated list of nameservers, each\nentry in `ip[:port]` format to be used by\nKong. If not specified, the nameservers in\nthe local `resolv.conf` file will be used.\nPort defaults to 53 if omitted. Accepts\nboth IPv4 and IPv6 addresses.\n"
   },
   "dns_hostsfile": {
     "defaultValue": "/etc/hosts",
-    "description": "The hosts file to use. This file is read once and its content is static in memory. To read the file again after modifying it, Kong must be reloaded."
+    "description": "The hosts file to use. This file is read\nonce and its content is static in memory.\nTo read the file again after modifying it,\nKong must be reloaded.\n"
   },
   "dns_order": {
     "defaultValue": [
@@ -640,501 +640,501 @@
       "A",
       "CNAME"
     ],
-    "description": "The order in which to resolve different record types. The `LAST` type means the type of the last successful lookup (for the specified name). The format is a (case insensitive) comma-separated list."
+    "description": "The order in which to resolve different\nrecord types. The `LAST` type means the\ntype of the last successful lookup (for the\nspecified name). The format is a (case\ninsensitive) comma-separated list.\n"
   },
   "dns_valid_ttl": {
     "defaultValue": null,
-    "description": "By default, DNS records are cached using the TTL value of a response. If this property receives a value (in seconds), it will override the TTL for all records."
+    "description": "By default, DNS records are cached using\nthe TTL value of a response. If this\nproperty receives a value (in seconds), it\nwill override the TTL for all records.\n"
   },
   "dns_stale_ttl": {
     "defaultValue": "3600",
-    "description": "Defines, in seconds, how long a record will remain in cache past its TTL. This value will be used while the new DNS record is fetched in the background. Stale data will be used from expiry of a record until either the refresh query completes, or the `dns_stale_ttl` number of seconds have passed. This configuration enables Kong to be more resilient during resolver downtime."
+    "description": "Defines, in seconds, how long a record will\nremain in cache past its TTL. This value\nwill be used while the new DNS record is\nfetched in the background.\nStale data will be used from expiry of a\nrecord until either the refresh query\ncompletes, or the `dns_stale_ttl` number of\nseconds have passed.\nThis configuration enables Kong to be more\nresilient during resolver downtime.\n"
   },
   "dns_cache_size": {
     "defaultValue": "10000",
-    "description": "Defines the maximum allowed number of DNS records stored in memory cache. Least recently used DNS records are discarded from cache if it is full. Both errors and data are cached; therefore, a single name query can easily take up 10-15 slots."
+    "description": "Defines the maximum allowed number of\nDNS records stored in memory cache.\nLeast recently used DNS records are discarded\nfrom cache if it is full. Both errors and\ndata are cached; therefore, a single name query\ncan easily take up 10-15 slots.\n"
   },
   "dns_not_found_ttl": {
     "defaultValue": "30",
-    "description": "TTL in seconds for empty DNS responses and \"(3) name error\" responses."
+    "description": "TTL in seconds for empty DNS responses and\n\"(3) name error\" responses.\n"
   },
   "dns_error_ttl": {
     "defaultValue": "1",
-    "description": "TTL in seconds for error responses."
+    "description": "TTL in seconds for error responses.\n"
   },
   "dns_no_sync": {
     "defaultValue": "off",
-    "description": "If enabled, then upon a cache-miss every request will trigger its own DNS query. When disabled, multiple requests for the same name/type will be synchronized to a single query."
+    "description": "If enabled, then upon a cache-miss every\nrequest will trigger its own DNS query.\nWhen disabled, multiple requests for the\nsame name/type will be synchronized to a\nsingle query.\n"
   },
   "new_dns_client": {
     "defaultValue": "off",
-    "description": "Enable or disable the new DNS resolver"
+    "description": "Enable or disable the new DNS resolver\n"
   },
   "resolver_address": {
     "defaultValue": "<name servers parsed from resolv.conf>",
-    "description": " Comma-separated list of nameservers, each entry in `ip[:port]` format to be used by Kong. If not specified, the nameservers in the local `resolv.conf` file will be used. Port defaults to 53 if omitted. Accepts both IPv4 and IPv6 addresses.  Examples:  ``` resolver_address = 8.8.8.8 resolver_address = 8.8.8.8, [::1] resolver_address = 8.8.8.8:53, [::1]:53 ```"
+    "description": "Comma-separated list of nameservers, each\nentry in `ip[:port]` format to be used by\nKong. If not specified, the nameservers in\nthe local `resolv.conf` file will be used.\nPort defaults to 53 if omitted. Accepts\nboth IPv4 and IPv6 addresses.\n\nExamples:\n\n```\nresolver_address = 8.8.8.8\nresolver_address = 8.8.8.8, [::1]\nresolver_address = 8.8.8.8:53, [::1]:53\n```\n"
   },
   "resolver_hosts_file": {
     "defaultValue": "/etc/hosts",
-    "description": " The hosts file to use. This file is read once and its content is static in memory. To read the file again after modifying it, Kong must be reloaded."
+    "description": "The hosts file to use. This file is read\nonce and its content is static in memory.\nTo read the file again after modifying it,\nKong must be reloaded.\n"
   },
   "resolver_family": {
     "defaultValue": [
       "A",
       "SRV"
     ],
-    "description": "The supported query types.  For a domain name, Kong will only query either IP addresses (A or AAAA) or SRV records, but not both.  It will query SRV records only when the domain matches the \"_<proto>._<service>.<name>\" format, for example, \"_ldap._tcp.example.com\".  For IP addresses (A or AAAA) resolution, it first attempts IPv4 (A) and then queries IPv6 (AAAA)."
+    "description": "The supported query types.\n\nFor a domain name, Kong will only query\neither IP addresses (A or AAAA) or SRV\nrecords, but not both.\n\nIt will query SRV records only when the\ndomain matches the\n\"_<proto>._<service>.<name>\" format, for\nexample, \"_ldap._tcp.example.com\".\n\nFor IP addresses (A or AAAA) resolution, it\nfirst attempts IPv4 (A) and then queries\nIPv6 (AAAA).\n"
   },
   "resolver_valid_ttl": {
     "defaultValue": "<TTL from responses>",
-    "description": " By default, DNS records are cached using the TTL value of a response. This optional parameter (in seconds) allows overriding it."
+    "description": "By default, DNS records are cached using\nthe TTL value of a response. This optional\nparameter (in seconds) allows overriding it.\n"
   },
   "resolver_error_ttl": {
     "defaultValue": "1",
-    "description": "TTL in seconds for error responses and empty responses."
+    "description": "TTL in seconds for error responses and empty\nresponses.\n"
   },
   "resolver_stale_ttl": {
     "defaultValue": "3600",
-    "description": "Defines, in seconds, how long a record will remain in cache past its TTL. This value will be used while the new DNS record is fetched in the background.  Stale data will be used from expiry of a record until either the refresh query completes, or the `resolver_stale_ttl` number of seconds have passed.  This configuration enables Kong to be more resilient during the DNS server downtime."
+    "description": "Defines, in seconds, how long a record will\nremain in cache past its TTL. This value\nwill be used while the new DNS record is\nfetched in the background.\n\nStale data will be used from expiry of a\nrecord until either the refresh query\ncompletes, or the `resolver_stale_ttl` number\nof seconds have passed.\n\nThis configuration enables Kong to be more\nresilient during the DNS server downtime.\n"
   },
   "resolver_lru_cache_size": {
     "defaultValue": "10000",
-    "description": "The DNS client uses a two-layer cache system: L1 - worker-level LRU Lua VM cache L2 - across-workers shared memory cache  This value specifies the maximum allowed number of DNS responses stored in the L1 LRU lua VM cache.  A single name query can easily take up 1~10 slots, depending on attempted query types and extended domains from /etc/resolv.conf options `domain` or `search`."
+    "description": "The DNS client uses a two-layer cache system:\nL1 - worker-level LRU Lua VM cache\nL2 - across-workers shared memory cache\n\nThis value specifies the maximum allowed\nnumber of DNS responses stored in the L1 LRU\nlua VM cache.\n\nA single name query can easily take up 1~10\nslots, depending on attempted query types and\nextended domains from /etc/resolv.conf\noptions `domain` or `search`.\n"
   },
   "resolver_mem_cache_size": {
     "defaultValue": "5m",
-    "description": "This value specifies the size of the L2 shared memory cache for DNS responses, `kong_dns_cache`.  Accepted units are `k` and `m`, with a minimum recommended value of a few MBs.  5MB shared memory size could store ~20000 DNS responeses with single A record or ~10000 DNS responeses with 2~3 A records.  10MB shared memory size could store ~40000 DNS responeses with single A record or ~20000 DNS responeses with 2~3 A records."
+    "description": "This value specifies the size of the L2\nshared memory cache for DNS responses,\n`kong_dns_cache`.\n\nAccepted units are `k` and `m`, with a\nminimum recommended value of a few MBs.\n\n5MB shared memory size could store\n~20000 DNS responeses with single A record or\n~10000 DNS responeses with 2~3 A records.\n\n10MB shared memory size could store\n~40000 DNS responeses with single A record or\n~20000 DNS responeses with 2~3 A records.\n"
   },
   "vault_env_prefix": {
     "defaultValue": null,
-    "description": "Defines the environment variable vault's default prefix. For example if you have all your secrets stored in environment variables prefixed with `SECRETS_`, it can be configured here so that it isn't necessary to repeat them in Vault references."
+    "description": "Defines the environment variable vault's\ndefault prefix. For example if you have\nall your secrets stored in environment\nvariables prefixed with `SECRETS_`, it\ncan be configured here so that it isn't\nnecessary to repeat them in Vault\nreferences.\n"
   },
   "vault_aws_region": {
     "defaultValue": null,
-    "description": "The AWS region your vault is located in."
+    "description": "The AWS region your vault is located in.\n"
   },
   "vault_aws_endpoint_url": {
     "defaultValue": null,
-    "description": "The AWS SecretsManager service endpoint url. If not specified, the value used by vault will be the official AWS SecretsManager service url which is `https://secretsmanager.<region>.amazonaws.com` You can specify a complete URL(including the \"http/https\" scheme) to override the endpoint that vault will connect to."
+    "description": "The AWS SecretsManager service endpoint url.\nIf not specified, the value used by vault will\nbe the official AWS SecretsManager service url\nwhich is\n`https://secretsmanager.<region>.amazonaws.com`\nYou can specify a complete URL(including\nthe \"http/https\" scheme) to override the\nendpoint that vault will connect to.\n"
   },
   "vault_aws_assume_role_arn": {
     "defaultValue": null,
-    "description": "The target AWS IAM role ARN that will be assumed. Typically this is used for operating between multiple roles or cross-accounts. If you are not using assume role you should not specify this value."
+    "description": "The target AWS IAM role ARN that will be\nassumed. Typically this is used for\noperating between multiple roles\nor cross-accounts.\nIf you are not using assume role\nyou should not specify this value.\n"
   },
   "vault_aws_role_session_name": {
     "defaultValue": "KongVault",
-    "description": "The role session name used for role assuming. The default value is `KongVault`."
+    "description": "The role session name used for role\nassuming. The default value is\n`KongVault`.\n"
   },
   "vault_aws_sts_endpoint_url": {
     "defaultValue": null,
-    "description": "The custom STS endpoint URL used for role assuming in AWS Vault.  Note that this value will override the default STS endpoint URL(which should be `https://sts.amazonaws.com`, or `https://sts.<region>.amazonaws.com` if you have `AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).  If you are not using private VPC endpoint for STS service, you should not specify this value."
+    "description": "The custom STS endpoint URL used for role assuming\nin AWS Vault.\n\nNote that this value will override the default\nSTS endpoint URL(which should be\n`https://sts.amazonaws.com`, or\n`https://sts.<region>.amazonaws.com` if you have\n`AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).\n\nIf you are not using private VPC endpoint for STS\nservice, you should not specify this value.\n"
   },
   "vault_aws_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the AWS vault when cached by this node.  AWS vault misses (no secret) are also cached according to this setting if you do not configure `vault_aws_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe AWS vault when cached by this node.\n\nAWS vault misses (no secret) are also cached\naccording to this setting if you do not\nconfigure `vault_aws_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_aws_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_aws_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a AWS vault\nmiss (no secret).\n\nIf not specified (default), `vault_aws_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_aws_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the AWS vault should be resurrected for when they cannot be refreshed (e.g., the AWS vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the AWS vault should be resurrected for\nwhen they cannot be refreshed (e.g., the\nAWS vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "vault_gcp_project_id": {
     "defaultValue": null,
-    "description": "The project ID from your Google API Console."
+    "description": "The project ID from your Google API Console.\n"
   },
   "vault_gcp_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the GCP vault when cached by this node.  GCP vault misses (no secret) are also cached according to this setting if you do not configure `vault_gcp_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe GCP vault when cached by this node.\n\nGCP vault misses (no secret) are also cached\naccording to this setting if you do not\nconfigure `vault_gcp_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_gcp_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a AWS vault miss (no secret).  If not specified (default), `vault_gcp_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a AWS vault\nmiss (no secret).\n\nIf not specified (default), `vault_gcp_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_gcp_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the GCP vault should be resurrected for when they cannot be refreshed (e.g., the GCP vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the GCP vault should be resurrected for\nwhen they cannot be refreshed (e.g., the\nGCP vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "vault_hcv_protocol": {
     "defaultValue": "http",
-    "description": "The protocol to connect with. Accepts one of `http` or `https`."
+    "description": "The protocol to connect with. Accepts one of\n`http` or `https`.\n"
   },
   "vault_hcv_host": {
     "defaultValue": "127.0.0.1",
-    "description": "The hostname of your HashiCorp vault."
+    "description": "The hostname of your HashiCorp vault.\n"
   },
   "vault_hcv_port": {
     "defaultValue": "8200",
-    "description": "The port number of your HashiCorp vault."
+    "description": "The port number of your HashiCorp vault.\n"
   },
   "vault_hcv_namespace": {
     "defaultValue": null,
-    "description": "Namespace for the HashiCorp Vault. Vault Enterprise requires a namespace to successfully connect to it."
+    "description": "Namespace for the HashiCorp Vault. Vault\nEnterprise requires a namespace to\nsuccessfully connect to it.\n"
   },
   "vault_hcv_mount": {
     "defaultValue": "secret",
-    "description": "The mount point."
+    "description": "The mount point.\n"
   },
   "vault_hcv_kv": {
     "defaultValue": "v1",
-    "description": "The secrets engine version. Accepts `v1` or `v2`."
+    "description": "The secrets engine version. Accepts `v1` or\n`v2`.\n"
   },
   "vault_hcv_token": {
     "defaultValue": null,
-    "description": "A token string."
+    "description": "A token string.\n"
   },
   "vault_hcv_auth_method": {
     "defaultValue": "token",
-    "description": "Defines the authentication mechanism when connecting to the Hashicorp Vault service. Accepted values are: `token`, `kubernetes` or `approle`."
+    "description": "Defines the authentication mechanism when\nconnecting to the Hashicorp Vault service.\nAccepted values are: `token`,\n`kubernetes` or `approle`.\n"
   },
   "vault_hcv_kube_role": {
     "defaultValue": null,
-    "description": "Defines the HashiCorp Vault role for the Kubernetes service account of the running pod. `vault_hcv_auth_method` must be set to `kubernetes` for this to activate."
+    "description": "Defines the HashiCorp Vault role for the\nKubernetes service account of the running\npod. `vault_hcv_auth_method` must be\nset to `kubernetes` for this to activate.\n"
   },
   "vault_hcv_kube_auth_path": {
     "defaultValue": "kubernetes",
-    "description": " Place where the Kubernetes auth method will be accessible: `/v1/auth/<vault_hcv_kube_auth_path>`"
+    "description": "Place where the Kubernetes auth method will be\naccessible: `/v1/auth/<vault_hcv_kube_auth_path>`\n"
   },
   "vault_hcv_kube_api_token_file": {
     "defaultValue": null,
-    "description": "Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+    "description": "Defines where the Kubernetes service account\ntoken should be read from the pod's\nfilesystem, if using a non-standard\ncontainer platform setup.\n"
   },
   "vault_hcv_approle_auth_path": {
     "defaultValue": "approle",
-    "description": " Place where the Approle auth method will be accessible: `/v1/auth/<vault_hcv_approle_auth_path>`"
+    "description": "Place where the Approle auth method will be\naccessible: `/v1/auth/<vault_hcv_approle_auth_path>`\n"
   },
   "vault_hcv_approle_role_id": {
     "defaultValue": null,
-    "description": "The Role ID of the Approle in HashiCorp Vault."
+    "description": "The Role ID of the Approle in HashiCorp Vault.\n"
   },
   "vault_hcv_approle_secret_id": {
     "defaultValue": null,
-    "description": "The Secret ID of the Approle in HashiCorp Vault."
+    "description": "The Secret ID of the Approle in HashiCorp Vault.\n"
   },
   "vault_hcv_approle_secret_id_file": {
     "defaultValue": null,
-    "description": "Defines where the Secret ID should be read from the pod's filesystem. This is usually used with HashiCorp Vault's response wrapping."
+    "description": "Defines where the Secret ID should be read from\nthe pod's filesystem. This is usually used with\nHashiCorp Vault's response wrapping.\n"
   },
   "vault_hcv_approle_response_wrapping": {
     "defaultValue": "false",
-    "description": "Defines whether the Secret ID read from configuration or file is actually a response-wrapping token instead of a real Secret ID."
+    "description": "Defines whether the Secret ID read from configuration\nor file is actually a response-wrapping token instead\nof a real Secret ID.\n"
   },
   "vault_hcv_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the HashiCorp vault when cached by this node.  HashiCorp vault misses (no secret) are also cached according to this setting if you do not configure `vault_hcv_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe HashiCorp vault when cached by this node.\n\nHashiCorp vault misses (no secret) are also\ncached according to this setting if you do not\nconfigure `vault_hcv_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_hcv_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a HashiCorp vault miss (no secret).  If not specified (default), `vault_hcv_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a HashiCorp vault\nmiss (no secret).\n\nIf not specified (default), `vault_hcv_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_hcv_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the HashiCorp vault should be resurrected for when they cannot be refreshed (e.g., the HashiCorp vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the HashiCorp vault should be resurrected\nfor when they cannot be refreshed (e.g., the\nHashiCorp vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "vault_azure_vault_uri": {
     "defaultValue": null,
-    "description": "The URI the vault is reachable from."
+    "description": "The URI the vault is reachable from.\n"
   },
   "vault_azure_client_id": {
     "defaultValue": null,
-    "description": "The client ID from your registered Application. Visit your Azure Dashboard and select *App Registrations* to check your client ID."
+    "description": "The client ID from your registered Application. Visit your Azure Dashboard and select *App Registrations* to check your client ID.\n"
   },
   "vault_azure_tenant_id": {
     "defaultValue": null,
-    "description": "The DirectoryId and TenantId both equate to the GUID representing the ActiveDirectory Tenant. Depending on context, either term may be used by Microsoft documentation and products, which can be confusing. In other words, the \"Tenant ID\" IS the \"Directory ID\""
+    "description": "The DirectoryId and TenantId both equate to the GUID representing the ActiveDirectory Tenant. Depending on context, either term may be used by Microsoft documentation and products, which can be confusing. In other words, the \"Tenant ID\" IS the \"Directory ID\"\n"
   },
   "vault_azure_type": {
     "defaultValue": "secrets",
-    "description": "Azure Key Vault enables Microsoft Azure applications and users to store and use several types of secret/key data: keys, secrets, and certificates. Kong currently only supports the `Secrets`"
+    "description": "Azure Key Vault enables Microsoft Azure applications and users to store and use several types of secret/key data: keys, secrets, and certificates. Kong currently only supports the `Secrets`\n"
   },
   "vault_azure_ttl": {
     "defaultValue": "0",
-    "description": "Time-to-live (in seconds) of a secret from the Azure Key Vault when cached by this node.  Key Vault misses (no secret) are also cached according to this setting if you do not configure `vault_azure_neg_ttl`.  If set to 0 (default), such cached secrets or misses never expire."
+    "description": "Time-to-live (in seconds) of a secret from\nthe Azure Key Vault when cached by this node.\n\nKey Vault misses (no secret) are also\ncached according to this setting if you do not\nconfigure `vault_azure_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n"
   },
   "vault_azure_neg_ttl": {
     "defaultValue": null,
-    "description": "Time-to-live (in seconds) of a Azure Key Vault miss (no secret).  If not specified (default), `vault_azure_ttl` value will be used instead.  If set to 0, misses will never expire."
+    "description": "Time-to-live (in seconds) of a Azure Key Vault\nmiss (no secret).\n\nIf not specified (default), `vault_azure_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n"
   },
   "vault_azure_resurrect_ttl": {
     "defaultValue": null,
-    "description": "Time (in seconds) for which stale secrets from the Azure Key Vault should be resurrected for when they cannot be refreshed (e.g., the the vault is unreachable). When this TTL expires, a new attempt to refresh the stale secrets will be made."
+    "description": "Time (in seconds) for which stale secrets\nfrom the Azure Key Vault should be resurrected\nfor when they cannot be refreshed (e.g., the\nthe vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n"
   },
   "worker_consistency": {
     "defaultValue": "eventual",
-    "description": " Defines whether this node should rebuild its state synchronously or asynchronously (the balancers and the router are rebuilt on updates that affect them, e.g., updates to routes, services, or upstreams via the admin API or loading a declarative configuration file). (This option is deprecated and will be removed in future releases. The new default is `eventual`.)  Accepted values are:  - `strict`: the router will be rebuilt   synchronously, causing incoming requests to   be delayed until the rebuild is finished.   (This option is deprecated and will be removed    in future releases. The new default is `eventual`) - `eventual`: the router will be rebuilt   asynchronously via a recurring background   job running every second inside of each   worker.  Note that `strict` ensures that all workers of a given node will always proxy requests with an identical router, but increased long-tail latency can be observed if frequent routes and services updates are expected. Using `eventual` will help prevent long-tail latency issues in such cases, but may cause workers to route requests differently for a short period of time after routes and services updates."
+    "description": "Defines whether this node should rebuild its\nstate synchronously or asynchronously (the\nbalancers and the router are rebuilt on\nupdates that affect them, e.g., updates to\nroutes, services, or upstreams via the admin\nAPI or loading a declarative configuration\nfile). (This option is deprecated and will be\nremoved in future releases. The new default\nis `eventual`.)\n\nAccepted values are:\n\n- `strict`: the router will be rebuilt\n  synchronously, causing incoming requests to\n  be delayed until the rebuild is finished.\n  (This option is deprecated and will be removed\n   in future releases. The new default is `eventual`)\n- `eventual`: the router will be rebuilt\n  asynchronously via a recurring background\n  job running every second inside of each\n  worker.\n\nNote that `strict` ensures that all workers\nof a given node will always proxy requests\nwith an identical router, but increased\nlong-tail latency can be observed if\nfrequent routes and services updates are\nexpected.\nUsing `eventual` will help prevent long-tail\nlatency issues in such cases, but may\ncause workers to route requests differently\nfor a short period of time after routes and\nservices updates.\n"
   },
   "worker_state_update_frequency": {
     "defaultValue": "5",
-    "description": " Defines how often the worker state changes are checked with a background job. When a change is detected, a new router or balancer will be built, as needed. Raising this value will decrease the load on database servers and result in less jitter in proxy latency, but it might take more time to propagate changes to each individual worker."
+    "description": "Defines how often the worker state changes are\nchecked with a background job. When a change\nis detected, a new router or balancer will be\nbuilt, as needed. Raising this value will\ndecrease the load on database servers and\nresult in less jitter in proxy latency, but\nit might take more time to propagate changes\nto each individual worker.\n"
   },
   "router_flavor": {
     "defaultValue": "traditional_compatible",
-    "description": " Selects the router implementation to use when performing request routing. Incremental router rebuild is available when the flavor is set to either `expressions` or `traditional_compatible`, which could significantly shorten rebuild time for a large number of routes.  Accepted values are:  - `traditional_compatible`: the DSL-based expression   router engine will be used under the hood. However,   the router config interface will be the same   as `traditional`, and expressions are   automatically generated at router build time.   The `expression` field on the `route` object   is not visible. - `expressions`: the DSL-based expression router engine   will be used under the hood. The traditional router   config interface is still visible, and you can also write   router Expressions manually and provide them in the   `expression` field on the `route` object. - `traditional`: the pre-3.0 router engine will be   used. The config interface will be the same as   pre-3.0 Kong, and the `expression` field on the   `route` object is not visible.    Deprecation warning: In Kong 3.0, `traditional`   mode should be avoided and only be used if   `traditional_compatible` does not work as expected.   This flavor of the router will be removed in the next   major release of Kong."
+    "description": "Selects the router implementation to use when\nperforming request routing. Incremental router\nrebuild is available when the flavor is set\nto either `expressions` or\n`traditional_compatible`, which could\nsignificantly shorten rebuild time for a large\nnumber of routes.\n\nAccepted values are:\n\n- `traditional_compatible`: the DSL-based expression\n  router engine will be used under the hood. However,\n  the router config interface will be the same\n  as `traditional`, and expressions are\n  automatically generated at router build time.\n  The `expression` field on the `route` object\n  is not visible.\n- `expressions`: the DSL-based expression router engine\n  will be used under the hood. The traditional router\n  config interface is still visible, and you can also write\n  router Expressions manually and provide them in the\n  `expression` field on the `route` object.\n- `traditional`: the pre-3.0 router engine will be\n  used. The config interface will be the same as\n  pre-3.0 Kong, and the `expression` field on the\n  `route` object is not visible.\n\n  Deprecation warning: In Kong 3.0, `traditional`\n  mode should be avoided and only be used if\n  `traditional_compatible` does not work as expected.\n  This flavor of the router will be removed in the next\n  major release of Kong.\n"
   },
   "lua_max_req_headers": {
     "defaultValue": "100",
-    "description": "Maximum number of request headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request headers, and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many request headers."
+    "description": "Maximum number of request headers to parse by default.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request headers,\nand this setting does not have any effect. It is used\nto limit Kong and its plugins from reading too many\nrequest headers.\n"
   },
   "lua_max_resp_headers": {
     "defaultValue": "100",
-    "description": "Maximum number of response headers to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong returns all the response headers, and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many response headers."
+    "description": "Maximum number of response headers to parse by default.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong returns all the response headers,\nand this setting does not have any effect. It is used\nto limit Kong and its plugins from reading too many\nresponse headers.\n"
   },
   "lua_max_uri_args": {
     "defaultValue": "100",
-    "description": "Maximum number of request URI arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request query arguments, and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many query arguments."
+    "description": "Maximum number of request URI arguments to parse by\ndefault.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request query\narguments, and this setting does not have any effect.\nIt is used to limit Kong and its plugins from reading\ntoo many query arguments.\n"
   },
   "lua_max_post_args": {
     "defaultValue": "100",
-    "description": "Maximum number of request post arguments to parse by default.  This argument can be set to an integer between 1 and 1000.  When proxying, Kong sends all the request post arguments, and this setting does not have any effect. It is used to limit Kong and its plugins from reading too many post arguments."
+    "description": "Maximum number of request post arguments to parse by\ndefault.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request post\narguments, and this setting does not have any effect.\nIt is used to limit Kong and its plugins from reading\ntoo many post arguments.\n"
   },
   "lua_ssl_trusted_certificate": {
     "defaultValue": "system",
-    "description": "Comma-separated list of certificate authorities for Lua cosockets in PEM format.  The special value `system` attempts to search for the \"usual default\" provided by each distro, according to an arbitrary heuristic. In the current implementation, the following pathnames will be tested in order, and the first one found will be used:  - `/etc/ssl/certs/ca-certificates.crt` (Debian/Ubuntu/Gentoo) - `/etc/pki/tls/certs/ca-bundle.crt` (Fedora/RHEL 6) - `/etc/ssl/ca-bundle.pem` (OpenSUSE) - `/etc/pki/tls/cacert.pem` (OpenELEC) - `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` (CentOS/RHEL 7) - `/etc/ssl/cert.pem` (OpenBSD, Alpine)  `system` can be used by itself or in conjunction with other CA file paths.  When `pg_ssl_verify` is enabled, these certificate authority files will be used for verifying Kong's database connections.  Certificates can be configured on this property with any of the following values: - `system` - absolute path to the certificate - certificate content - base64 encoded certificate content  See https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate"
+    "description": "Comma-separated list of certificate authorities\nfor Lua cosockets in PEM format.\n\nThe special value `system` attempts to search for the\n\"usual default\" provided by each distro, according\nto an arbitrary heuristic. In the current implementation,\nthe following pathnames will be tested in order,\nand the first one found will be used:\n\n- `/etc/ssl/certs/ca-certificates.crt` (Debian/Ubuntu/Gentoo)\n- `/etc/pki/tls/certs/ca-bundle.crt` (Fedora/RHEL 6)\n- `/etc/ssl/ca-bundle.pem` (OpenSUSE)\n- `/etc/pki/tls/cacert.pem` (OpenELEC)\n- `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` (CentOS/RHEL 7)\n- `/etc/ssl/cert.pem` (OpenBSD, Alpine)\n\n`system` can be used by itself or in conjunction with other\nCA file paths.\n\nWhen `pg_ssl_verify` is enabled, these\ncertificate authority files will be\nused for verifying Kong's database connections.\n\nCertificates can be configured on this property\nwith any of the following values:\n- `system`\n- absolute path to the certificate\n- certificate content\n- base64 encoded certificate content\n\nSee https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate\n"
   },
   "lua_ssl_verify_depth": {
     "defaultValue": "1",
-    "description": "Sets the verification depth in the server certificates chain used by Lua cosockets, set by `lua_ssl_trusted_certificate`. This includes the certificates configured for Kong's database connections. If the maximum depth is reached before reaching the end of the chain, verification will fail. This helps mitigate certificate based DoS attacks.  See https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth"
+    "description": "Sets the verification depth in the server\ncertificates chain used by Lua cosockets,\nset by `lua_ssl_trusted_certificate`.\nThis includes the certificates configured\nfor Kong's database connections.\nIf the maximum depth is reached before\nreaching the end of the chain, verification\nwill fail. This helps mitigate certificate\nbased DoS attacks.\n\nSee https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth\n"
   },
   "lua_ssl_protocols": {
     "defaultValue": "TLSv1.2 TLSv1.3",
-    "description": "Defines the TLS versions supported when handshaking with OpenResty's TCP cosocket APIs.  This affects connections made by Lua code, such as connections to the database Kong uses, or when sending logs using a logging plugin. It does *not* affect connections made to the upstream Service or from downstream clients."
+    "description": "Defines the TLS versions supported\nwhen handshaking with OpenResty's\nTCP cosocket APIs.\n\nThis affects connections made by Lua\ncode, such as connections to the\ndatabase Kong uses, or when sending logs\nusing a logging plugin. It does *not*\naffect connections made to the upstream\nService or from downstream clients.\n"
   },
   "lua_package_path": {
     "defaultValue": "./?.lua;./?/init.lua;",
-    "description": "Sets the Lua module search path (LUA_PATH). Useful when developing or using custom plugins not stored in the default search path.  See https://github.com/openresty/lua-nginx-module#lua_package_path"
+    "description": "Sets the Lua module search path\n(LUA_PATH). Useful when developing\nor using custom plugins not stored\nin the default search path.\n\nSee https://github.com/openresty/lua-nginx-module#lua_package_path\n"
   },
   "lua_package_cpath": {
     "defaultValue": null,
-    "description": "Sets the Lua C module search path (LUA_CPATH).  See https://github.com/openresty/lua-nginx-module#lua_package_cpath"
+    "description": "Sets the Lua C module search path\n(LUA_CPATH).\n\nSee https://github.com/openresty/lua-nginx-module#lua_package_cpath\n"
   },
   "lua_socket_pool_size": {
     "defaultValue": "256",
-    "description": "Specifies the size limit for every cosocket connection pool associated with every remote server.  See https://github.com/openresty/lua-nginx-module#lua_socket_pool_size"
+    "description": "Specifies the size limit for every cosocket\nconnection pool associated with every remote\nserver.\n\nSee https://github.com/openresty/lua-nginx-module#lua_socket_pool_size\n"
   },
   "enforce_rbac": {
     "defaultValue": "off",
-    "description": "Specifies whether Admin API RBAC is enforced. Accepts one of `entity`, `both`, `on`, or `off`.  - `on`: only endpoint-level authorization   is enforced. - `entity`: entity-level authorization   applies. - `both`: enables both endpoint and   entity-level authorization. - `off`: disables both endpoint and   entity-level authorization.  When enabled, Kong will deny requests to the Admin API when a nonexistent or invalid RBAC authorization token is passed, or the RBAC user with which the token is associated does not have permissions to access/modify the requested resource."
+    "description": "Specifies whether Admin API RBAC is enforced.\nAccepts one of `entity`, `both`, `on`, or\n`off`.\n\n- `on`: only endpoint-level authorization\n  is enforced.\n- `entity`: entity-level authorization\n  applies.\n- `both`: enables both endpoint and\n  entity-level authorization.\n- `off`: disables both endpoint and\n  entity-level authorization.\n\nWhen enabled, Kong will deny requests to the\nAdmin API when a nonexistent or invalid RBAC\nauthorization token is passed, or the RBAC\nuser with which the token is associated does\nnot have permissions to access/modify the\nrequested resource.\n"
   },
   "rbac_auth_header": {
     "defaultValue": "Kong-Admin-Token",
-    "description": "Defines the name of the HTTP request header from which the Admin API will attempt to authenticate the RBAC user."
+    "description": "Defines the name of the HTTP request\nheader from which the Admin API will\nattempt to authenticate the RBAC user.\n"
   },
   "event_hooks_enabled": {
     "defaultValue": "on",
-    "description": "When enabled, event hook entities represent a relationship between an event (source and event) and an action (handler). Similar to web hooks, event hooks can be used to communicate Kong Gateway service events. When a particular event happens on a service, the event hook calls a URL with information about that event. Event hook configurations differ depending on the handler. The events that are triggered send associated data.  See: https://docs.konghq.com/gateway/api/admin-ee/latest/#/Event-hooks/get-event-hooks"
+    "description": "When enabled, event hook entities represent a relationship\nbetween an event (source and event) and an action\n(handler). Similar to web hooks, event hooks can be used to\ncommunicate Kong Gateway service events. When a particular\nevent happens on a service, the event hook calls a URL with\ninformation about that event. Event hook configurations\ndiffer depending on the handler. The events that are\ntriggered send associated data.\n\nSee: https://docs.konghq.com/gateway/api/admin-ee/latest/#/Event-hooks/get-event-hooks\n"
   },
   "fips": {
     "defaultValue": "off",
-    "description": "Turn on FIPS mode; this mode is only available on a FIPS build."
+    "description": "Turn on FIPS mode; this mode is only available on a FIPS build.\n"
   },
   "admin_gui_listen": {
     "defaultValue": [
       "0.0.0.0:8002",
       "0.0.0.0:8445 ssl"
     ],
-    "description": " Kong Manager Listeners  Comma-separated list of addresses and ports on which Kong will expose Kong Manager. This web application lets you configure and manage Kong, and therefore should be kept secured.  Suffixes can be specified for each pair, similarly to the `admin_listen` directive."
+    "description": "Kong Manager Listeners\n\nComma-separated list of addresses and ports on which\nKong will expose Kong Manager. This web application\nlets you configure and manage Kong, and therefore\nshould be kept secured.\n\nSuffixes can be specified for each pair, similarly to\nthe `admin_listen` directive.\n"
   },
   "admin_gui_url": {
     "defaultValue": null,
-    "description": "Kong Manager URL  Comma-separated list of addresses (the lookup or balancer) for Kong Manager.  Accepted format (items in square brackets are optional):    `<scheme>://<IP / HOSTNAME>[:<PORT>][<PATH>][, <scheme>://<IP / HOSTNAME>[:<PORT>][<PATH>]]`  Examples:  - `http://127.0.0.1:8003` - `https://kong-admin.test` - `http://dev-machine` - `http://127.0.0.1:8003, https://exmple.com/manager`"
+    "description": "Kong Manager URL\n\nComma-separated list of addresses (the lookup or balancer) for Kong Manager.\n\nAccepted format (items in square brackets are optional):\n\n  `<scheme>://<IP / HOSTNAME>[:<PORT>][<PATH>][, <scheme>://<IP / HOSTNAME>[:<PORT>][<PATH>]]`\n\nExamples:\n\n- `http://127.0.0.1:8003`\n- `https://kong-admin.test`\n- `http://dev-machine`\n- `http://127.0.0.1:8003, https://exmple.com/manager`\n"
   },
   "admin_gui_path": {
     "defaultValue": "/",
-    "description": "Kong Manager base path  This configuration parameter allows the user to customize the path prefix where Kong Manager is served. When updating this parameter, it's recommended to update the path in `admin_gui_url` as well.  Accepted format:  - Path must start with a `/` - Path must not end with a `/` (except for the `/`) - Path can only contain letters, digits, hyphens (`-`), underscores (`_`), and slashes (`/`) - Path must not contain continuous slashes (e.g., `//` and `///`)  Examples:  - `/` - `/manager` - `/kong-manager` - `/kong/manager`"
+    "description": "Kong Manager base path\n\nThis configuration parameter allows the user to customize\nthe path prefix where Kong Manager is served. When updating\nthis parameter, it's recommended to update the path in `admin_gui_url`\nas well.\n\nAccepted format:\n\n- Path must start with a `/`\n- Path must not end with a `/` (except for the `/`)\n- Path can only contain letters, digits, hyphens (`-`),\nunderscores (`_`), and slashes (`/`)\n- Path must not contain continuous slashes (e.g., `//` and `///`)\n\nExamples:\n\n- `/`\n- `/manager`\n- `/kong-manager`\n- `/kong/manager`\n"
   },
   "admin_gui_api_url": {
     "defaultValue": null,
-    "description": "Hierarchical part of a URI which is composed optionally of a host, port, and path at which the Admin API accepts HTTP or HTTPS traffic. When this config is disabled, Kong Manager will use the window protocol + host and append the resolved admin_listen HTTP/HTTPS port."
+    "description": "Hierarchical part of a URI which is composed\noptionally of a host, port, and path at which the\nAdmin API accepts HTTP or HTTPS traffic. When\nthis config is disabled, Kong Manager will\nuse the window protocol + host and append the\nresolved admin_listen HTTP/HTTPS port.\n"
   },
   "admin_gui_ssl_protocols": {
     "defaultValue": "TLSv1.2 TLSv1.3",
-    "description": " Defines the TLS versions supported for Kong Manager"
+    "description": "Defines the TLS versions supported\nfor Kong Manager\n"
   },
   "admin_gui_ssl_cert": {
     "defaultValue": null,
-    "description": "The SSL certificate for `admin_gui_listen` values with SSL enabled.  values: - absolute path to the certificate - certificate content - base64 encoded certificate content"
+    "description": "The SSL certificate for `admin_gui_listen` values\nwith SSL enabled.\n\nvalues:\n- absolute path to the certificate\n- certificate content\n- base64 encoded certificate content\n"
   },
   "admin_gui_ssl_cert_key": {
     "defaultValue": null,
-    "description": "The SSL key for `admin_gui_listen` values with SSL enabled.  values: - absolute path to the certificate key - certificate key content - base64 encoded certificate key content"
+    "description": "The SSL key for `admin_gui_listen` values with SSL\nenabled.\n\nvalues:\n- absolute path to the certificate key\n- certificate key content\n- base64 encoded certificate key content\n"
   },
   "admin_gui_flags": {
     "defaultValue": "{}",
-    "description": " Alters the layout Admin GUI (JSON) to enable Kong Immunity in the Admin GUI."
+    "description": "Alters the layout Admin GUI (JSON)\nto enable Kong Immunity in the Admin GUI.\n"
   },
   "admin_gui_access_log": {
     "defaultValue": "logs/admin_gui_access.log",
-    "description": " Kong Manager Access Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables access logs for Kong Manager."
+    "description": "Kong Manager Access Logs\n\nHere you can set an absolute or relative path for Kong\nManager access logs. When the path is relative,\nlogs are placed in the `prefix` location.\n\nSetting this value to `off` disables access logs\nfor Kong Manager.\n"
   },
   "admin_gui_error_log": {
     "defaultValue": "logs/admin_gui_error.log",
-    "description": " Kong Manager Error Logs  Here you can set an absolute or relative path for Kong Manager access logs. When the path is relative, logs are placed in the `prefix` location.  Setting this value to `off` disables error logs for Kong Manager.  Granularity can be adjusted through the `log_level` directive."
+    "description": "Kong Manager Error Logs\n\nHere you can set an absolute or relative path for Kong\nManager access logs. When the path is relative,\nlogs are placed in the `prefix` location.\n\nSetting this value to `off` disables error logs for\nKong Manager.\n\nGranularity can be adjusted through the `log_level`\ndirective.\n"
   },
   "admin_gui_auth": {
     "defaultValue": null,
-    "description": "Kong Manager Authentication Plugin Name  Secures access to Kong Manager by specifying an authentication plugin to use.  Supported Plugins:  - `basic-auth`: Basic Authentication plugin - `ldap-auth-advanced`: LDAP Authentication plugin - `openid-connect`: OpenID Connect Authentication   plugin"
+    "description": "Kong Manager Authentication Plugin Name\n\nSecures access to Kong Manager by specifying an\nauthentication plugin to use.\n\nSupported Plugins:\n\n- `basic-auth`: Basic Authentication plugin\n- `ldap-auth-advanced`: LDAP Authentication plugin\n- `openid-connect`: OpenID Connect Authentication\n  plugin\n"
   },
   "admin_gui_auth_conf": {
     "defaultValue": null,
-    "description": "Kong Manager Authentication Plugin Config (JSON)  Specifies the configuration for the authentication plugin specified in `admin_gui_auth`.  For information about Plugin Configuration consult the associated plugin documentation.  Example for `basic-auth`:  `admin_gui_auth_conf = { \"hide_credentials\": true }`"
+    "description": "Kong Manager Authentication Plugin Config (JSON)\n\nSpecifies the configuration for the authentication\nplugin specified in `admin_gui_auth`.\n\nFor information about Plugin Configuration\nconsult the associated plugin documentation.\n\nExample for `basic-auth`:\n\n`admin_gui_auth_conf = { \"hide_credentials\": true }`\n"
   },
   "admin_gui_auth_password_complexity": {
     "defaultValue": null,
-    "description": "Kong Manager Authentication Password Complexity (JSON)  When `admin_gui_auth = basic-auth`, this property defines the rules required for Kong Manager passwords. Choose from preset rules or write your own.  Example using preset rules:  `admin_gui_auth_password_complexity = { \"kong-preset\": \"min_8\" }`  All values for kong-preset require the password to contain characters from at least three of the following categories:  1. Uppercase characters (A through Z)  2. Lowercase characters (a through z)  3. Base-10 digits (0 through 9)  4. Special characters (for example, &, $, #, %)  Supported preset rules: - `min_8`: minimum length of 8 - `min_12`: minimum length of 12 - `min_20`: minimum length of 20  To write your own rules, see https://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.  NOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.  Example:  `admin_gui_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`"
+    "description": "Kong Manager Authentication Password Complexity (JSON)\n\nWhen `admin_gui_auth = basic-auth`, this property defines\nthe rules required for Kong Manager passwords. Choose\nfrom preset rules or write your own.\n\nExample using preset rules:\n\n`admin_gui_auth_password_complexity = { \"kong-preset\": \"min_8\" }`\n\nAll values for kong-preset require the password to contain\ncharacters from at least three of the following categories:\n\n1. Uppercase characters (A through Z)\n\n2. Lowercase characters (a through z)\n\n3. Base-10 digits (0 through 9)\n\n4. Special characters (for example, &, $, #, %)\n\nSupported preset rules:\n- `min_8`: minimum length of 8\n- `min_12`: minimum length of 12\n- `min_20`: minimum length of 20\n\nTo write your own rules, see\nhttps://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.\n\nNOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.\n\nExample:\n\n`admin_gui_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`\n"
   },
   "admin_gui_session_conf": {
     "defaultValue": null,
-    "description": "Kong Manager Session Config (JSON)  Specifies the configuration for the Session plugin as used by Kong Manager.  For information about plugin configuration, consult the Kong Session plugin documentation.  Example: ``` admin_gui_session_conf = { \"cookie_name\": \"kookie\", \\                            \"secret\": \"changeme\" } ```"
+    "description": "Kong Manager Session Config (JSON)\n\nSpecifies the configuration for the Session plugin as\nused by Kong Manager.\n\nFor information about plugin configuration, consult\nthe Kong Session plugin documentation.\n\nExample:\n```\nadmin_gui_session_conf = { \"cookie_name\": \"kookie\", \\\n                           \"secret\": \"changeme\" }\n```\n"
   },
   "admin_gui_auth_header": {
     "defaultValue": "Kong-Admin-User",
-    "description": " Defines the name of the HTTP request header from which the Admin API will attempt to identify the Kong Admin user."
+    "description": "Defines the name of the HTTP request header from which\nthe Admin API will attempt to identify the Kong Admin\nuser.\n"
   },
   "admin_gui_auth_login_attempts": {
     "defaultValue": "0",
-    "description": " Number of times a user can attempt to login to Kong Manager. 0 means infinite attempts allowed."
+    "description": "Number of times a user can attempt to login to Kong\nManager. 0 means infinite attempts allowed.\n"
   },
   "admin_gui_auth_login_attempts_ttl": {
     "defaultValue": "604800",
-    "description": " Length, in seconds, of the TTL for changing login attempts records. Records in the database older than their TTL are automatically purged.  This argument can be set to an integer between 0 and 100000000.  Example, 7 days: `7 * 24 * 60 * 60 = 604800.`"
+    "description": "Length, in seconds, of the TTL for changing login attempts\nrecords. Records in the database older than\ntheir TTL are automatically purged.\n\nThis argument can be set to an integer between 0 and 100000000.\n\nExample, 7 days: `7 * 24 * 60 * 60 = 604800.`\n"
   },
   "admin_gui_auth_change_password_attempts": {
     "defaultValue": "0",
-    "description": " Number of times a user can attempt to change password. 0 means infinite attempts allowed."
+    "description": "Number of times a user can attempt to change password.\n0 means infinite attempts allowed.\n"
   },
   "admin_gui_auth_change_password_ttl": {
     "defaultValue": "86400",
-    "description": " Length, in seconds, of the TTL for changing password attempts records. Records in the database older than their TTL are automatically purged.  Example, 1 days: `1 * 24 * 60 * 60 = 86400.`"
+    "description": "Length, in seconds, of the TTL for changing password attempts\nrecords. Records in the database older than\ntheir TTL are automatically purged.\n\nExample, 1 days: `1 * 24 * 60 * 60 = 86400.`\n"
   },
   "admin_gui_header_txt": {
     "defaultValue": null,
-    "description": "Sets the text for the Kong Manager header banner. Header banner is not shown if this config is empty."
+    "description": "Sets the text for the Kong Manager header banner.\nHeader banner is not shown if this config is empty.\n"
   },
   "admin_gui_header_bg_color": {
     "defaultValue": null,
-    "description": "Sets the background color for the Kong Manager header banner. Accepts CSS color keyword, #-hexadecimal, or RGB format. Invalid values are ignored by Manager."
+    "description": "Sets the background color for the Kong Manager header banner.\nAccepts CSS color keyword, #-hexadecimal, or RGB\nformat. Invalid values are ignored by Manager.\n"
   },
   "admin_gui_header_txt_color": {
     "defaultValue": null,
-    "description": "Sets the text color for the Kong Manager header banner. Accepts CSS color keyword, #-hexadecimal, or RGB format. Invalid values are ignored by Kong Manager."
+    "description": "Sets the text color for the Kong Manager header banner.\nAccepts CSS color keyword, #-hexadecimal, or RGB\nformat. Invalid values are ignored by Kong Manager.\n"
   },
   "admin_gui_footer_txt": {
     "defaultValue": null,
-    "description": "Sets the text for the Kong Manager footer banner. Footer banner is not shown if this config is empty."
+    "description": "Sets the text for the Kong Manager footer banner. Footer banner\nis not shown if this config is empty.\n"
   },
   "admin_gui_footer_bg_color": {
     "defaultValue": null,
-    "description": "Sets the background color for the Kong Manager footer banner. Accepts CSS color keyword, #-hexadecimal, or RGB format. Invalid values are ignored by manager."
+    "description": "Sets the background color for the Kong Manager footer banner.\nAccepts CSS color keyword, #-hexadecimal, or RGB\nformat. Invalid values are ignored by manager.\n"
   },
   "admin_gui_footer_txt_color": {
     "defaultValue": null,
-    "description": "Sets the text color for the Kong Manager footer banner. Accepts CSS color keyword, #-hexadecimal, or RGB format. Invalid values are ignored by Kong Manager."
+    "description": "Sets the text color for the Kong Manager footer banner.\nAccepts CSS color keyword, #-hexadecimal, or RGB\nformat. Invalid values are ignored by Kong Manager.\n"
   },
   "admin_gui_login_banner_title": {
     "defaultValue": null,
-    "description": "Sets the title text for the Kong Manager login banner. Login banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+    "description": "Sets the title text for the Kong Manager login banner.\nLogin banner is not shown if both\n`admin_gui_login_banner_title` and\n`admin_gui_login_banner_body` are empty.\n"
   },
   "admin_gui_login_banner_body": {
     "defaultValue": null,
-    "description": "Sets the body text for the Kong Manager login banner. Login banner is not shown if both `admin_gui_login_banner_title` and `admin_gui_login_banner_body` are empty."
+    "description": "Sets the body text for the Kong Manager login banner.\nLogin banner is not shown if both\n`admin_gui_login_banner_title` and\n`admin_gui_login_banner_body` are empty.\n"
   },
   "konnect_mode": {
     "defaultValue": "off",
-    "description": "When enabled, the dataplane is connected to Konnect"
+    "description": "When enabled, the dataplane is connected to Konnect\n"
   },
   "analytics_flush_interval": {
     "defaultValue": "1",
-    "description": "Specify the maximum frequency, in seconds, at which local analytics and licensing data are flushed to the database or Konnect, depending on the installation mode. Kong also triggers a flush when the number of messages in the buffer is less than `analytics_buffer_size_limit`, regardless of whether the specified time interval has elapsed."
+    "description": "Specify the maximum frequency, in seconds,\nat which local analytics and licensing\ndata are flushed to the database or\nKonnect, depending on the installation mode.\nKong also triggers a flush when the number\nof messages in the buffer is less than\n`analytics_buffer_size_limit`, regardless\nof whether the specified time interval has\nelapsed.\n"
   },
   "analytics_buffer_size_limit": {
     "defaultValue": "100000",
-    "description": "Max number of messages can be buffered locally before dropping data in case there is no network connection to Konnect."
+    "description": "Max number of messages can be buffered locally\nbefore dropping data in case there is no\nnetwork connection to Konnect.\n"
   },
   "analytics_debug": {
     "defaultValue": "off",
-    "description": "Outputs analytics payload to Kong logs."
+    "description": "Outputs analytics payload to Kong logs.\n"
   },
   "admin_emails_from": {
     "defaultValue": "\"\"",
-    "description": "The email address for the `From` header for admin emails."
+    "description": "The email address for the `From` header\nfor admin emails.\n"
   },
   "admin_emails_reply_to": {
     "defaultValue": null,
-    "description": "Email address for the `Reply-To` header for admin emails."
+    "description": "Email address for the `Reply-To` header\nfor admin emails.\n"
   },
   "admin_invitation_expiry": {
     "defaultValue": "259200",
-    "description": "Expiration time for the admin invitation link (in seconds). 0 means no expiration.  Example, 72 hours: `72 * 60 * 60 = 259200`"
+    "description": "Expiration time for the admin invitation link\n(in seconds). 0 means no expiration.\n\nExample, 72 hours: `72 * 60 * 60 = 259200`\n"
   },
   "smtp_mock": {
     "defaultValue": "on",
-    "description": "This flag will mock the sending of emails. This can be used for testing before the SMTP client is fully configured."
+    "description": "This flag will mock the sending of emails. This can be\nused for testing before the SMTP client is fully\nconfigured.\n"
   },
   "smtp_host": {
     "defaultValue": "localhost",
-    "description": " The hostname of the SMTP server to connect to."
+    "description": "The hostname of the SMTP server to connect to.\n"
   },
   "smtp_port": {
     "defaultValue": "25",
-    "description": " The port number on the SMTP server to connect to."
+    "description": "The port number on the SMTP server to connect to.\n"
   },
   "smtp_starttls": {
     "defaultValue": "off",
-    "description": " When set to `on`, STARTTLS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 587."
+    "description": "When set to `on`, STARTTLS is used to encrypt\ncommunication with the SMTP server. This is normally\nused in conjunction with port 587.\n"
   },
   "smtp_username": {
     "defaultValue": null,
-    "description": "Username used for authentication with SMTP server"
+    "description": "Username used for authentication with SMTP server\n"
   },
   "smtp_password": {
     "defaultValue": null,
-    "description": "Password used for authentication with SMTP server"
+    "description": "Password used for authentication with SMTP server\n"
   },
   "smtp_ssl": {
     "defaultValue": "off",
-    "description": " When set to `on`, SMTPS is used to encrypt communication with the SMTP server. This is normally used in conjunction with port 465."
+    "description": "When set to `on`, SMTPS is used to encrypt\ncommunication with the SMTP server. This is normally\nused in conjunction with port 465.\n"
   },
   "smtp_auth_type": {
     "defaultValue": null,
-    "description": "The method used to authenticate with the SMTP server Valid options are `plain`, `login`, or `nil`"
+    "description": "The method used to authenticate with the SMTP server\nValid options are `plain`, `login`, or `nil`\n"
   },
   "smtp_domain": {
     "defaultValue": "localhost.localdomain",
-    "description": " The domain used in the `EHLO` connection and part of the `Message-ID` header"
+    "description": "The domain used in the `EHLO` connection and part of\nthe `Message-ID` header\n"
   },
   "smtp_timeout_connect": {
     "defaultValue": "60000",
-    "description": " The timeout (in milliseconds) for connecting to the SMTP server."
+    "description": "The timeout (in milliseconds) for connecting to the\nSMTP server.\n"
   },
   "smtp_timeout_send": {
     "defaultValue": "60000",
-    "description": " The timeout (in milliseconds) for sending data to the SMTP server."
+    "description": "The timeout (in milliseconds) for sending data to the\nSMTP server.\n"
   },
   "smtp_timeout_read": {
     "defaultValue": "60000",
-    "description": " The timeout (in milliseconds) for reading data from the SMTP server."
+    "description": "The timeout (in milliseconds) for reading data from\nthe SMTP server.\n"
   },
   "smtp_admin_emails": {
     "defaultValue": null,
-    "description": "Comma separated list of admin emails to receive notifications. Example `admin1@example.com, admin2@example.com`"
+    "description": "Comma separated list of admin emails to receive\nnotifications.\nExample `admin1@example.com, admin2@example.com`\n"
   },
   "audit_log": {
     "defaultValue": "off",
-    "description": "When enabled, Kong will log information about Admin API access and database row insertions, updates, and deletions."
+    "description": "When enabled, Kong will log information about\nAdmin API access and database row insertions,\nupdates, and deletions.\n"
   },
   "audit_log_ignore_methods": {
     "defaultValue": null,
-    "description": "Comma-separated list of HTTP methods that will not generate audit log entries. By default, all HTTP requests will be logged."
+    "description": "Comma-separated list of HTTP methods that\nwill not generate audit log entries. By\ndefault, all HTTP requests will be logged.\n"
   },
   "audit_log_ignore_paths": {
     "defaultValue": null,
-    "description": "Comma-separated list of request paths that will not generate audit log entries. By default, all HTTP requests will be logged."
+    "description": "Comma-separated list of request paths that\nwill not generate audit log entries. By\ndefault, all HTTP requests will be logged.\n"
   },
   "audit_log_ignore_tables": {
     "defaultValue": null,
-    "description": "Comma-separated list of database tables that will not generate audit log entries. By default, updates to all database tables will be logged (the term \"updates\" refers to the creation, update, or deletion of a row)."
+    "description": "Comma-separated list of database tables that\nwill not generate audit log entries. By\ndefault, updates to all database tables will\nbe logged (the term \"updates\" refers to the\ncreation, update, or deletion of a row).\n"
   },
   "audit_log_payload_exclude": {
     "defaultValue": [
@@ -1142,145 +1142,145 @@
       "secret",
       "password"
     ],
-    "description": " Comma-separated list of keys that will be filtered out of the payload. Keys that were filtered will be recorded in the audit log."
+    "description": "Comma-separated list of keys that will be\nfiltered out of the payload. Keys that were\nfiltered will be recorded in the audit log.\n"
   },
   "audit_log_record_ttl": {
     "defaultValue": "2592000",
-    "description": "Length, in seconds, of the TTL for audit log records. Records in the database older than their TTL are automatically purged.  Example, 30 days: `30 * 24 * 60 * 60 = 2592000`"
+    "description": "Length, in seconds, of the TTL for audit log\nrecords. Records in the database older than\ntheir TTL are automatically purged.\n\nExample, 30 days: `30 * 24 * 60 * 60 = 2592000`\n"
   },
   "audit_log_signing_key": {
     "defaultValue": null,
-    "description": "Defines the path to a private RSA signing key that can be used to insert a signature of audit records, adjacent to the record. The corresponding public key should be stored offline, and can be used to validate audit entries in the future. If this value is undefined, no signature will be generated."
+    "description": "Defines the path to a private RSA signing key\nthat can be used to insert a signature of\naudit records, adjacent to the record. The\ncorresponding public key should be stored\noffline, and can be used to validate audit\nentries in the future. If this value is\nundefined, no signature will be generated.\n"
   },
   "route_validation_strategy": {
     "defaultValue": "smart",
-    "description": "The strategy used to validate routes when creating or updating them. Different strategies are available to tune how to enforce splitting traffic of workspaces. - `smart` is the default option and uses the   algorithm described in   https://docs.konghq.com/gateway/latest/kong-enterprise/workspaces/. - `off` disables any check. - `path` enforces routes to comply with the pattern   described in config `enforce_route_path_pattern`. - `static` relies on the PostgreSQL database. Before creating a new route, it checks if the route is unique across all workspaces based on the following params: `paths`, `methods`, and `hosts`. If all fields of the new route overlap with an existing one, a 409 is returned with the route of the collision. The array order is not important for the overlap filter."
+    "description": "The strategy used to validate\nroutes when creating or updating them.\nDifferent strategies are available to tune\nhow to enforce splitting traffic of\nworkspaces.\n- `smart` is the default option and uses the\n  algorithm described in\n  https://docs.konghq.com/gateway/latest/kong-enterprise/workspaces/.\n- `off` disables any check.\n- `path` enforces routes to comply with the pattern\n  described in config `enforce_route_path_pattern`.\n- `static` relies on the PostgreSQL database.\nBefore creating a new route, it checks if the\nroute is unique across all workspaces based on\nthe following params: `paths`, `methods`, and\n`hosts`. If all fields of the new route overlap\nwith an existing one, a 409 is returned with the\nroute of the collision. The array order is not\nimportant for the overlap filter.\n"
   },
   "enforce_route_path_pattern": {
     "defaultValue": null,
-    "description": "Specifies the Lua pattern which will be enforced on the `paths` attribute of a route object. You can also add a placeholder for the workspace in the pattern, which will be rendered during runtime based on the workspace to which the `route` belongs. This setting is only relevant if `route_validation_strategy` is set to `path`.   **Note:** The collision detection is only supported for plain text routes, do not rely on this feature to validate regex routes.  Example For Pattern `/$(workspace)/v%d/.*` valid paths are:  1. `/group1/v1/` if route belongs to   workspace `group1`.  2. `/group2/v1/some_path` if route belongs to   workspace `group2`."
+    "description": "Specifies the Lua pattern which will\nbe enforced on the `paths` attribute of a\nroute object. You can also add a placeholder\nfor the workspace in the pattern, which\nwill be rendered during runtime based on the\nworkspace to which the `route` belongs.\nThis setting is only relevant if\n`route_validation_strategy` is set to `path`.\n\n\n**Note:** The collision detection is only supported\nfor plain text routes, do not rely on this feature\nto validate regex routes.\n\nExample\nFor Pattern `/$(workspace)/v%d/.*` valid paths\nare:\n\n1. `/group1/v1/` if route belongs to\n  workspace `group1`.\n\n2. `/group2/v1/some_path` if route belongs to\n  workspace `group2`.\n"
   },
   "keyring_enabled": {
     "defaultValue": "off",
-    "description": "When enabled, Kong will encrypt sensitive field values before writing them to the database, and subsequently decrypt them when retrieving data for the Admin API, Developer Portal, or proxy business logic. Symmetric encryption keys are managed based on the strategy defined below."
+    "description": "When enabled, Kong will encrypt sensitive\nfield values before writing them to the\ndatabase, and subsequently decrypt them when\nretrieving data for the Admin API, Developer\nPortal, or proxy business logic. Symmetric\nencryption keys are managed based on the\nstrategy defined below.\n"
   },
   "keyring_strategy": {
     "defaultValue": "cluster",
-    "description": "Defines the strategy implementation by which Kong nodes will manage symmetric encryption keys. Please see the Kong Enterprise documentation for a detailed description of each strategy. Acceptable values for this option are `cluster` and `vault`."
+    "description": "Defines the strategy implementation by which\nKong nodes will manage symmetric encryption\nkeys. Please see the Kong Enterprise\ndocumentation for a detailed description of\neach strategy. Acceptable values for this\noption are `cluster` and `vault`.\n"
   },
   "keyring_public_key": {
     "defaultValue": null,
-    "description": "Defines the public key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  Values: - absolute path to the public key - public key content - base64 encoded public key content"
+    "description": "Defines the public key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nValues:\n- absolute path to the public key\n- public key content\n- base64 encoded public key content\n"
   },
   "keyring_private_key": {
     "defaultValue": null,
-    "description": "Defines the private key of an RSA keypair. This keypair is used for symmetric keyring import/export, e.g., for disaster recovery and optional bootstrapping.  Values: - absolute path to the private key - private key content - base64 encoded private key content"
+    "description": "Defines the private key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nValues:\n- absolute path to the private key\n- private key content\n- base64 encoded private key content\n"
   },
   "keyring_recovery_public_key": {
     "defaultValue": null,
-    "description": "Defines the public key to optionally encrypt all keyring materials and back them up in the database.  Values: - absolute path to the public key - public key content - base64 encoded public key content"
+    "description": "Defines the public key to optionally encrypt\nall keyring materials and back them up in the\ndatabase.\n\nValues:\n- absolute path to the public key\n- public key content\n- base64 encoded public key content\n"
   },
   "keyring_blob_path": {
     "defaultValue": null,
-    "description": "Defines the filesystem path at which Kong will back up the initial keyring material. This option is useful largely for development purposes."
+    "description": "Defines the filesystem path at which Kong\nwill back up the initial keyring material.\nThis option is useful largely for development\npurposes.\n"
   },
   "keyring_vault_host": {
     "defaultValue": null,
-    "description": "Defines the Vault host at which Kong will fetch the encryption material. This value should be defined in the format:  `<scheme>://<IP / HOSTNAME>:<PORT>`"
+    "description": "Defines the Vault host at which Kong will\nfetch the encryption material. This value\nshould be defined in the format:\n\n`<scheme>://<IP / HOSTNAME>:<PORT>`\n"
   },
   "keyring_vault_mount": {
     "defaultValue": null,
-    "description": "Defines the name of the Vault v2 KV secrets engine at which symmetric keys are found."
+    "description": "Defines the name of the Vault v2 KV secrets\nengine at which symmetric keys are found.\n"
   },
   "keyring_vault_path": {
     "defaultValue": null,
-    "description": "Defines the name of the Vault v2 KV path at which symmetric keys are found."
+    "description": "Defines the name of the Vault v2 KV path\nat which symmetric keys are found.\n"
   },
   "keyring_vault_auth_method": {
     "defaultValue": "token",
-    "description": " Defines the authentication mechanism when connecting to the Hashicorp Vault service.  Accepted values are: `token`, or `kubernetes`:  - `token`: Uses the static token defined in            the `keyring_vault_token`            configuration property.  - `kubernetes`: Uses the Kubernetes authentication                 mechanism, with the running pod's                 mapped service account, to assume                 the Hashicorp Vault role name that is                 defined in the `keyring_vault_kube_role`                 configuration property."
+    "description": "Defines the authentication mechanism when\nconnecting to the Hashicorp Vault service.\n\nAccepted values are: `token`, or `kubernetes`:\n\n- `token`: Uses the static token defined in\n           the `keyring_vault_token`\n           configuration property.\n\n- `kubernetes`: Uses the Kubernetes authentication\n                mechanism, with the running pod's\n                mapped service account, to assume\n                the Hashicorp Vault role name that is\n                defined in the `keyring_vault_kube_role`\n                configuration property.\n"
   },
   "keyring_vault_token": {
     "defaultValue": null,
-    "description": "Defines the token value used to communicate with the v2 KV Vault HTTP(S) API."
+    "description": "Defines the token value used to communicate\nwith the v2 KV Vault HTTP(S) API.\n"
   },
   "keyring_vault_kube_role": {
     "defaultValue": "default",
-    "description": " Defines the Hashicorp Vault role that will be assumed using the Kubernetes service account of the running pod.  `keyring_vault_auth_method` must be set to `kubernetes` for this to activate."
+    "description": "Defines the Hashicorp Vault role that will be\nassumed using the Kubernetes service account of\nthe running pod.\n\n`keyring_vault_auth_method` must be set to `kubernetes`\nfor this to activate.\n"
   },
   "keyring_vault_kube_api_token_file": {
     "defaultValue": "/run/secrets/kubernetes.io/serviceaccount/token",
-    "description": " Defines where the Kubernetes service account token should be read from the pod's filesystem, if using a non-standard container platform setup."
+    "description": "Defines where the Kubernetes service account token\nshould be read from the pod's filesystem, if using\na non-standard container platform setup.\n"
   },
   "keyring_encrypt_license": {
     "defaultValue": "off",
-    "description": " Enables keyring encryption for license payloads stored in the database.  **Warning:** For Kong deployments that rely entirely on the database for license provisioning (i.e. not using `KONG_LICENSE_DATA` or `KONG_LICENSE_PATH`), enabling this option will delay license activation until after the node's keyring has been activated."
+    "description": "Enables keyring encryption for license payloads stored\nin the database.\n\n**Warning:** For Kong deployments that rely entirely on\nthe database for license provisioning (i.e. not using\n`KONG_LICENSE_DATA` or `KONG_LICENSE_PATH`), enabling\nthis option will delay license activation until after\nthe node's keyring has been activated.\n"
   },
   "untrusted_lua": {
     "defaultValue": "sandbox",
-    "description": " Controls loading of Lua functions from admin-supplied sources such as the Admin API. LuaJIT bytecode loading is always disabled.  **Warning:** LuaJIT is not designed as a secure runtime for running malicious code, therefore you should properly protect your Admin API endpoint even with sandboxing enabled. The sandbox only provides protection against trivial attackers or unintentional modification of the Kong global environment.  Accepted values are: `off`, `sandbox`, or `on`:  - `off`: Disallow loading of any arbitrary          Lua functions. The `off` option          disables any functionality that runs          arbitrary Lua code, including the          Serverless Functions plugins and any          transformation plugin that allows          custom Lua functions.  - `sandbox`: Allow loading of Lua functions,              but use a sandbox when executing              them. The sandboxed function has              restricted access to the global              environment and only has access              to standard Lua functions that              will generally not cause harm to              the Kong Gateway node.  - `on`: Functions have unrestricted         access to the global environment and         can load any Lua modules. This is         similar to the behavior in         Kong Gateway prior to 2.3.0.  The default `sandbox` environment does not allow importing other modules or libraries, or executing anything at the OS level (for example, file read/write). The global environment is also not accessible.  Examples of `untrusted_lua = sandbox` behavior:  - You can't access or change global values   such as `kong.configuration.pg_password` - You can run harmless Lua:   `local foo = 1 + 1`. However, OS level   functions are not allowed, like:   `os.execute(`rm -rf /*`)`.  For a full allowed/disallowed list, see: https://github.com/kikito/sandbox.lua/blob/master/sandbox.lua  To customize the sandbox environment, use the `untrusted_lua_sandbox_requires` and `untrusted_lua_sandbox_environment` parameters below."
+    "description": "Controls loading of Lua functions from admin-supplied\nsources such as the Admin API. LuaJIT bytecode\nloading is always disabled.\n\n**Warning:** LuaJIT is not designed as a secure\nruntime for running malicious code, therefore\nyou should properly protect your Admin API endpoint\neven with sandboxing enabled. The sandbox only\nprovides protection against trivial attackers or\nunintentional modification of the Kong global\nenvironment.\n\nAccepted values are: `off`, `sandbox`, or\n`on`:\n\n- `off`: Disallow loading of any arbitrary\n         Lua functions. The `off` option\n         disables any functionality that runs\n         arbitrary Lua code, including the\n         Serverless Functions plugins and any\n         transformation plugin that allows\n         custom Lua functions.\n\n- `sandbox`: Allow loading of Lua functions,\n             but use a sandbox when executing\n             them. The sandboxed function has\n             restricted access to the global\n             environment and only has access\n             to Kong PDK, OpenResty, and\n             standard Lua functions that will\n             generally not cause harm to the\n             Kong Gateway node.\n\n- `on`: Functions have unrestricted\n        access to the global environment and\n        can load any Lua modules. This is\n        similar to the behavior in\n        Kong Gateway prior to 2.3.0.\n\nThe default `sandbox` environment does not\nallow importing other modules or libraries,\nor executing anything at the OS level (for\nexample, file read/write). The global\nenvironment is also not accessible.\n\nExamples of `untrusted_lua = sandbox`\nbehavior:\n\n- You can't access or change global values\n  such as `kong.configuration.pg_password`\n- You can run harmless Lua:\n  `local foo = 1 + 1`. However, OS level\n  functions are not allowed, like:\n  `os.execute(`rm -rf /*`)`.\n\nTo customize the sandbox environment, use\nthe `untrusted_lua_sandbox_requires` and\n`untrusted_lua_sandbox_environment`\nparameters below.\n"
   },
   "untrusted_lua_sandbox_requires": {
     "defaultValue": null,
-    "description": "Comma-separated list of modules allowed to be loaded with `require` inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  For example, say you have configured the Serverless pre-function plugin and it contains the following `requires`:  ``` local template = require \"resty.template\" local split = require \"kong.tools.string\".split ```  To run the plugin, add the modules to the allowed list: ``` untrusted_lua_sandbox_requires = resty.template, kong.tools.utils ```  **Warning:** Allowing certain modules may create opportunities to escape the sandbox. For example, allowing `os` or `luaposix` may be unsafe."
+    "description": "Comma-separated list of modules allowed to\nbe loaded with `require` inside the\nsandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\nFor example, say you have configured the\nServerless pre-function plugin and it\ncontains the following `requires`:\n\n```\nlocal template = require \"resty.template\"\nlocal split = require \"kong.tools.string\".split\n```\n\nTo run the plugin, add the modules to the\nallowed list:\n```\nuntrusted_lua_sandbox_requires = resty.template, kong.tools.utils\n```\n\n**Warning:** Allowing certain modules may\ncreate opportunities to escape the\nsandbox. For example, allowing `os` or\n`luaposix` may be unsafe.\n"
   },
   "untrusted_lua_sandbox_environment": {
     "defaultValue": null,
-    "description": "Comma-separated list of global Lua variables that should be made available inside the sandboxed environment. Ignored if `untrusted_lua` is not `sandbox`.  **Warning**: Certain variables, when made available, may create opportunities to escape the sandbox."
+    "description": "Comma-separated list of global Lua\nvariables that should be made available\ninside the sandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\n**Warning**: Certain variables, when made\navailable, may create opportunities to\nescape the sandbox.\n"
   },
   "openresty_path": {
     "defaultValue": null,
-    "description": "Path to the OpenResty installation that Kong will use. When this is empty (the default), Kong determines the OpenResty installation by searching for a system-installed OpenResty and falling back to searching $PATH for the nginx binary.  Setting this attribute disables the search behavior and explicitly instructs Kong which OpenResty installation to use."
+    "description": "Path to the OpenResty installation that Kong\nwill use. When this is empty (the default),\nKong determines the OpenResty installation\nby searching for a system-installed OpenResty\nand falling back to searching $PATH for the\nnginx binary.\n\nSetting this attribute disables the search\nbehavior and explicitly instructs Kong which\nOpenResty installation to use.\n"
   },
   "node_id": {
     "defaultValue": null,
-    "description": "Node ID for the Kong node. Every Kong node in a Kong cluster must have a unique and valid UUID. When empty, node ID is automatically generated."
+    "description": "Node ID for the Kong node. Every Kong node\nin a Kong cluster must have a unique and\nvalid UUID. When empty, node ID is\nautomatically generated.\n"
   },
   "cluster_fallback_config_import": {
     "defaultValue": "off",
-    "description": "Enable fallback configuration imports.  This should only be enabled for data planes."
+    "description": "Enable fallback configuration imports.\n\nThis should only be enabled for data planes.\n"
   },
   "cluster_fallback_config_storage": {
     "defaultValue": null,
-    "description": "Storage definition used by `cluster_fallback_config_import` and `cluster_fallback_config_export`.  Supported storage types: - S3-like storages - GCP storage service  To use S3 with a bucket named b and place all configs to with a key prefix named p, set it to: `s3://b/p` To use GCP for the same bucket and prefix, set it to: `gcs://b/p`  The credentials (and the endpoint URL for S3-like) for S3 are passed with environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where `AWS_CONFIG_STORAGE_ENDPOINT` is the endpoint that hosts S3-like storage.  The credentials for GCP are provided via the environment variable `GCP_SERVICE_ACCOUNT`."
+    "description": "Storage definition used by `cluster_fallback_config_import`\nand `cluster_fallback_config_export`.\n\nSupported storage types:\n- S3-like storages\n- GCP storage service\n\nTo use S3 with a bucket named b and place all configs\nto with a key prefix named p, set it to:\n`s3://b/p`\nTo use GCP for the same bucket and prefix, set it to:\n`gcs://b/p`\n\nThe credentials (and the endpoint URL for S3-like) for S3\nare passed with environment variables:\n`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,\nand `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where\n`AWS_CONFIG_STORAGE_ENDPOINT`\nis the endpoint that hosts S3-like storage.\n\nThe credentials for GCP are provided via the environment\nvariable `GCP_SERVICE_ACCOUNT`.\n"
   },
   "cluster_fallback_export_s3_config": {
     "defaultValue": null,
-    "description": "Fallback config export S3 configuration. This is used only when `cluster_fallback_config_storage` is an S3-like schema. If set, it will add the config table to the Kong exporter config S3 putObject request. The config table should be in JSON format and can be unserialized into a table. It should contain the necessary parameters as described in the documentation: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property. For example, if you want to set the ServerSideEncryption headers/KMS Key ID for the S3 putObject request, you can set the config table to: `{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"your-kms-key-id\"}`"
+    "description": "Fallback config export S3 configuration.\nThis is used only when `cluster_fallback_config_storage` is an S3-like schema.\nIf set, it will add the config table to the Kong exporter config S3 putObject request.\nThe config table should be in JSON format and can be unserialized into a table.\nIt should contain the necessary parameters as described in the documentation:\nhttps://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property.\nFor example, if you want to set the ServerSideEncryption headers/KMS Key ID\nfor the S3 putObject request, you can set the config table to:\n`{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"your-kms-key-id\"}`\n"
   },
   "cluster_fallback_config_export": {
     "defaultValue": "off",
-    "description": "Enable fallback configuration exports."
+    "description": "Enable fallback configuration exports.\n"
   },
   "cluster_fallback_config_export_delay": {
     "defaultValue": "60",
-    "description": "The fallback configuration export interval.  If the interval is set to 60 and configuration A is exported and there are new configurations B, C, and D in the next 60 seconds, it will wait until 60 seconds passed and export D, skipping B and C."
+    "description": "The fallback configuration export interval.\n\nIf the interval is set to 60 and configuration A is exported\nand there are new configurations B, C, and D in the next 60 seconds,\nit will wait until 60 seconds passed and export D, skipping B and C.\n"
   },
   "wasm": {
     "defaultValue": "off",
-    "description": "Enable/disable wasm support. This must be enabled in order to use wasm filters and filter chains."
+    "description": "Enable/disable wasm support. This must be enabled in\norder to use wasm filters and filter chains.\n"
   },
   "wasm_filters_path": {
     "defaultValue": null,
-    "description": "Path to the directory containing wasm filter modules.  At startup, Kong discovers available wasm filters by scanning this directory for files with the `.wasm` file extension.  The name of a wasm filter module is derived from the filename itself, with the .wasm extension removed. So, given the following tree:  ``` /path/to/wasm_filters ├── my_module.wasm ├── my_other_module.wasm └── not_a_wasm_module.txt ```  The resulting filter modules available for use in Kong will be:  - `my_module` - `my_other_module`  Notes:  - No recursion is performed. Only .wasm files at the   top level are registered. - This path _may_ be a symlink to a directory."
+    "description": "Path to the directory containing wasm filter modules.\n\nAt startup, Kong discovers available wasm filters by\nscanning this directory for files with the `.wasm`\nfile extension.\n\nThe name of a wasm filter module is derived from the\nfilename itself, with the .wasm extension removed. So,\ngiven the following tree:\n\n```\n/path/to/wasm_filters\n├── my_module.wasm\n├── my_other_module.wasm\n└── not_a_wasm_module.txt\n```\n\nThe resulting filter modules available for use in Kong\nwill be:\n\n- `my_module`\n- `my_other_module`\n\nNotes:\n\n- No recursion is performed. Only .wasm files at the\n  top level are registered.\n- This path _may_ be a symlink to a directory.\n"
   },
   "wasm_filters": {
     "defaultValue": [
       "bundled",
       "user"
     ],
-    "description": "Comma-separated list of Wasm filters to be made available for use in filter chains.  When the `off` keyword is specified as the only value, no filters will be available for use.  When the `bundled` keyword is specified, all filters bundled with Kong will be available.  When the `user` keyword is specified, all filters within the `wasm_filters_path` will be available.  **Examples:**  - `wasm_filters = bundled,user` enables _all_ bundled   and user-supplied filters - `wasm_filters = user` enables _only_ user-supplied   filters - `wasm_filters = filter-a,filter-b` enables _only_   filters named `filter-a` or `filter-b` (whether   bundled _or_ user-supplied)  If a conflict occurs where a bundled filter and a user-supplied filter share the same name, a warning will be logged, and the user-supplied filter will be used instead."
+    "description": "Comma-separated list of Wasm filters to be made\navailable for use in filter chains.\n\nWhen the `off` keyword is specified as the\nonly value, no filters will be available for use.\n\nWhen the `bundled` keyword is specified, all filters\nbundled with Kong will be available.\n\nWhen the `user` keyword is specified, all filters\nwithin the `wasm_filters_path` will be available.\n\n**Examples:**\n\n- `wasm_filters = bundled,user` enables _all_ bundled\n  and user-supplied filters\n- `wasm_filters = user` enables _only_ user-supplied\n  filters\n- `wasm_filters = filter-a,filter-b` enables _only_\n  filters named `filter-a` or `filter-b` (whether\n  bundled _or_ user-supplied)\n\nIf a conflict occurs where a bundled filter and a\nuser-supplied filter share the same name, a warning\nwill be logged, and the user-supplied filter will\nbe used instead.\n"
   },
   "test": {
     "defaultValue": "on",
-    "description": "test"
+    "description": "test\n"
   },
   "request_debug": {
     "defaultValue": "on",
-    "description": "When enabled, Kong will provide detailed timing information for its components to the client and the error log if the following headers are present in the proxy request: - `X-Kong-Request-Debug`:   If the value is set to `*`,   timing information will be collected and exported for the current request.   If this header is not present or contains an unknown value,   timing information will not be collected for the current request.   You can also specify a list of filters, separated by commas,   to filter the scope of the time information that is collected. The following filters are supported for `X-Kong-Request-Debug`: - `rewrite`: Collect timing information from the `rewrite` phase. - `access`: Collect timing information from the `access` phase. - `balancer`: Collect timing information from the `balancer` phase. - `response`: Collect timing information from the `response` phase. - `header_filter`: Collect timing information from the `header_filter` phase. - `body_filter`: Collect timing information from the `body_filter` phase. - `log`: Collect timing information from the `log` phase. - `upstream`: Collect timing information from the `upstream` phase.  - `X-Kong-Request-Debug-Log`:   If set to `true`, timing information will also be logged   in the Kong error log with a log level of `notice`.   Defaults to `false`.  - `X-Kong-Request-Debug-Token`:   Token for authenticating the client making the debug   request to prevent abuse.   ** Note: Debug requests originating from loopback   addresses do not require this header. Deploying Kong behind   other proxies may result in exposing the debug interface to   the public.** "
+    "description": "When enabled, Kong will provide detailed timing information\nfor its components to the client and the error log\nif the following headers are present in the proxy request:\n- `X-Kong-Request-Debug`:\n  If the value is set to `*`,\n  timing information will be collected and exported for the current request.\n  If this header is not present or contains an unknown value,\n  timing information will not be collected for the current request.\n  You can also specify a list of filters, separated by commas,\n  to filter the scope of the time information that is collected.\nThe following filters are supported for `X-Kong-Request-Debug`:\n- `rewrite`: Collect timing information from the `rewrite` phase.\n- `access`: Collect timing information from the `access` phase.\n- `balancer`: Collect timing information from the `balancer` phase.\n- `response`: Collect timing information from the `response` phase.\n- `header_filter`: Collect timing information from the `header_filter` phase.\n- `body_filter`: Collect timing information from the `body_filter` phase.\n- `log`: Collect timing information from the `log` phase.\n- `upstream`: Collect timing information from the `upstream` phase.\n\n- `X-Kong-Request-Debug-Log`:\n  If set to `true`, timing information will also be logged\n  in the Kong error log with a log level of `notice`.\n  Defaults to `false`.\n\n- `X-Kong-Request-Debug-Token`:\n  Token for authenticating the client making the debug\n  request to prevent abuse.\n  ** Note: Debug requests originating from loopback\n  addresses do not require this header. Deploying Kong behind\n  other proxies may result in exposing the debug interface to\n  the public.**\n\n"
   },
   "request_debug_token": {
     "defaultValue": "<random>",
-    "description": "The Request Debug Token is used in the `X-Kong-Request-Debug-Token` header to prevent abuse. If this value is not set (the default), a random token will be generated when Kong starts, restarts, or reloads. If a token is specified manually, then the provided token will be used.  You can locate the generated debug token in two locations: - Kong error log:   Debug token will be logged in the error log (notice level)   when Kong starts, restarts, or reloads.   The log line will have the: `[request-debug]` prefix to aid searching. - Filesystem:   Debug token will also be stored in a file located at   `{prefix}/.request_debug_token` and updated   when Kong starts, restarts, or reloads."
+    "description": "The Request Debug Token is used in the\n`X-Kong-Request-Debug-Token` header to prevent abuse.\nIf this value is not set (the default),\na random token will be generated\nwhen Kong starts, restarts, or reloads. If a token is\nspecified manually, then the provided token will be used.\n\nYou can locate the generated debug token in two locations:\n- Kong error log:\n  Debug token will be logged in the error log (notice level)\n  when Kong starts, restarts, or reloads.\n  The log line will have the: `[request-debug]` prefix to aid searching.\n- Filesystem:\n  Debug token will also be stored in a file located at\n  `{prefix}/.request_debug_token` and updated\n  when Kong starts, restarts, or reloads.\n"
   }
 }

--- a/app/_includes/components/kong_config_table.html
+++ b/app/_includes/components/kong_config_table.html
@@ -1,0 +1,23 @@
+<table class="table-auto">
+    <thead>
+        <tr>
+          <th class="font-semibold text-primary">Parameter</th>
+          <th class="font-semibold text-primary">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for field in config.fields %}
+        <tr>
+            <td>
+                <span class="block text-primary">
+                    <a href="/gateway/configuration/#{{field['name']}}"><code>{{ field['name'] | markdown }}</code></a>
+                </span>
+                <span class="text-secondary text-xs">env variable: <code>{{ field['name'] | upcase | liquify | markdown }}</code></span>
+            </td>
+            <td>
+                <span class="text-primary">{{ field['description'] | liquify | markdownify | markdown }}</span>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/app/_includes/components/kong_config_table.html
+++ b/app/_includes/components/kong_config_table.html
@@ -13,15 +13,17 @@
                     <code>{{ field.name | markdown }}</code>
                 </span>
                 {% if field.default_value != nil %}
+                {% assign default_value = field.default_value %}
                 {% if field.array? %}
-                    <span class="text-secondary text-xs">Default: <code>{{ field.default_value | join: ', ' | markdown }}</code></span>
-                {% else %}
-                    <span class="text-primary text-xs">Default: <code>{{ field.default_value | markdown }}</code></span>
+                    {% assign default_value = field.default_value | join: ', ' %}
                 {% endif %}
+                <span class="block mt-2">
+                    <span class="text-secondary text-xs">Default: <code>{{ default_value| markdown }}</code></span>
+                </span>
             {% endif %}
             </td>
             <td>
-                <span class="text-primary content">{{ field.description | markdownify }}</span>
+                <span class="content">{{ field.description | markdownify }}</span>
             </td>
         </tr>
         {% endfor %}

--- a/app/_includes/components/kong_config_table.html
+++ b/app/_includes/components/kong_config_table.html
@@ -2,6 +2,7 @@
     <thead>
         <tr>
           <th class="font-semibold text-primary">Parameter</th>
+          <th class="font-semibold text-primary">Default Value</th>
           <th class="font-semibold text-primary">Description</th>
         </tr>
     </thead>
@@ -10,12 +11,20 @@
         <tr>
             <td>
                 <span class="block text-primary">
-                    <a href="/gateway/configuration/#{{field['name']}}"><code>{{ field['name'] | markdown }}</code></a>
+                    <a href="/gateway/configuration/#{{field.name}}"><code>{{ field.name | markdown }}</code></a>
                 </span>
-                <span class="text-secondary text-xs">env variable: <code>{{ field['name'] | upcase | liquify | markdown }}</code></span>
             </td>
             <td>
-                <span class="text-primary">{{ field['description'] | liquify | markdownify | markdown }}</span>
+                {% if field.default_value != nil %}
+                    {% if field.array? %}
+                        <span class="text-primary"><code>{{ field.default_value | join: ', ' | markdown }}</code></span>
+                    {% else %}
+                        <span class="text-primary"><code>{{ field.default_value | markdown }}</code></span>
+                    {% endif %}
+                {% endif %}
+            </td>
+            <td>
+                <span class="text-primary">{{ field.description | liquify | markdownify | markdown }}</span>
             </td>
         </tr>
         {% endfor %}

--- a/app/_includes/components/kong_config_table.html
+++ b/app/_includes/components/kong_config_table.html
@@ -2,7 +2,6 @@
     <thead>
         <tr>
           <th class="font-semibold text-primary">Parameter</th>
-          <th class="font-semibold text-primary">Default Value</th>
           <th class="font-semibold text-primary">Description</th>
         </tr>
     </thead>
@@ -11,17 +10,15 @@
         <tr>
             <td>
                 <span class="block text-primary">
-                    <a href="/gateway/configuration/#{{field.name}}"><code>{{ field.name | markdown }}</code></a>
+                    <code>{{ field.name | markdown }}</code>
                 </span>
-            </td>
-            <td>
                 {% if field.default_value != nil %}
-                    {% if field.array? %}
-                        <span class="text-primary"><code>{{ field.default_value | join: ', ' | markdown }}</code></span>
-                    {% else %}
-                        <span class="text-primary"><code>{{ field.default_value | markdown }}</code></span>
-                    {% endif %}
+                {% if field.array? %}
+                    <span class="text-secondary text-xs">Default: <code>{{ field.default_value | join: ', ' | markdown }}</code></span>
+                {% else %}
+                    <span class="text-primary text-xs">Default: <code>{{ field.default_value | markdown }}</code></span>
                 {% endif %}
+            {% endif %}
             </td>
             <td>
                 <span class="text-primary content">{{ field.description | markdownify }}</span>

--- a/app/_includes/components/kong_config_table.html
+++ b/app/_includes/components/kong_config_table.html
@@ -24,7 +24,7 @@
                 {% endif %}
             </td>
             <td>
-                <span class="text-primary">{{ field.description | liquify | markdownify | markdown }}</span>
+                <span class="text-primary content">{{ field.description | markdownify }}</span>
             </td>
         </tr>
         {% endfor %}

--- a/app/_plugins/blocks/kong_config_table.rb
+++ b/app/_plugins/blocks/kong_config_table.rb
@@ -9,14 +9,14 @@ module Jekyll
       @name = markup.strip
     end
 
-    def render(context)
+    def render(context) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
       @context = context
       @site = context.registers[:site]
       @page = context.environments.first['page']
 
       contents = super
       config = YAML.load(contents)
-      drop = Drops::KongConfigTable.new(config['config'], release(@site, @page))
+      drop = Drops::KongConfigTable.new(config, release(@site, @page))
 
       context.stack do
         context['config'] = drop

--- a/app/_plugins/blocks/kong_config_table.rb
+++ b/app/_plugins/blocks/kong_config_table.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module Jekyll
+  class KongConfigTable < Liquid::Block # rubocop:disable Style/Documentation
+    def initialize(tag_name, markup, tokens)
+      super
+      @name = markup.strip
+    end
+
+    def render(context)
+      @context = context
+      @site = context.registers[:site]
+      @page = context.environments.first['page']
+
+      contents = super
+      config = YAML.load(contents)
+      drop = Drops::KongConfigTable.new(config['config'], release(@site, @page))
+
+      context.stack do
+        context['config'] = drop
+        Liquid::Template.parse(template).render(context)
+      end
+    rescue Psych::SyntaxError => e
+      message = <<~STRING
+        On `#{@page['path']}`, the following {% kong_config_table %} block contains a malformed yaml:
+        #{contents.strip.split("\n").each_with_index.map { |l, i| "#{i}: #{l}" }.join("\n")}
+        #{e.message}
+      STRING
+      raise ArgumentError, message
+    end
+
+    def release(site, page)
+      return latest_release(site) unless page['release']
+
+      release = releases(site).detect { |r| r['release'] == page['release'].number }
+
+      if release.key?('label')
+        latest_release(site)
+      else
+        release['release']
+      end
+    end
+
+    def latest_release(site)
+      @latest_release ||= releases(site).detect { |r| r['latest'] }['release']
+    end
+
+    def releases(site)
+      @releases ||= site.data.dig('products', 'gateway', 'releases')
+    end
+
+    def template
+      @template ||= File.read(File.expand_path('app/_includes/components/kong_config_table.html'))
+    end
+  end
+end
+
+Liquid::Template.register_tag('kong_config_table', Jekyll::KongConfigTable)

--- a/app/_plugins/drops/kong_config_table.rb
+++ b/app/_plugins/drops/kong_config_table.rb
@@ -18,7 +18,11 @@ module Jekyll
         end
 
         def default_value
-          @default_value ||= @field.fetch('default_value')
+          @default_value ||= @field.fetch('defaultValue')
+        end
+
+        def array?
+          default_value&.is_a?(Array)
         end
 
         def description

--- a/app/_plugins/drops/kong_config_table.rb
+++ b/app/_plugins/drops/kong_config_table.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+require_relative '../lib/site_accessor'
+
+module Jekyll
+  module Drops
+    class KongConfigTable < Liquid::Drop # rubocop:disable Style/Documentation
+      class KongConfigField < Liquid::Drop # rubocop:disable Style/Documentation
+        def initialize(config, field) # rubocop:disable Lint/MissingSuper
+          @config = config
+          @field = field || {}
+        end
+
+        def name
+          @name ||= @config.fetch('name')
+        end
+
+        def default_value
+          @default_value ||= @field.fetch('default_value')
+        end
+
+        def description
+          @description ||= @config['description'] || @field['description']
+        end
+      end
+
+      include Jekyll::SiteAccessor
+
+      def initialize(config, release_number) # rubocop:disable Lint/MissingSuper
+        @config = config
+        @release_number = release_number
+      end
+
+      def fields
+        @fields ||= @config.map { |c| KongConfigField.new(c, kong_conf[c['name']]) }
+      end
+
+      def kong_conf
+        @kong_conf ||= site.data.dig('kong-conf', @release_number.gsub('.', ''))
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/kong_config_table.rb
+++ b/app/_plugins/drops/kong_config_table.rb
@@ -18,7 +18,7 @@ module Jekyll
         end
 
         def default_value
-          @default_value ||= @field.fetch('defaultValue')
+          @default_value ||= @field['defaultValue']
         end
 
         def array?
@@ -35,14 +35,35 @@ module Jekyll
       def initialize(config, release_number) # rubocop:disable Lint/MissingSuper
         @config = config
         @release_number = release_number
+
+        validate_config!
       end
 
       def fields
-        @fields ||= @config.map { |c| KongConfigField.new(c, kong_conf[c['name']]) }
+        @fields ||= (params + directives).sort_by(&:name)
+      end
+
+      def params
+        @params ||= @config.fetch('config', []).map { |c| KongConfigField.new(c, kong_conf[c['name']]) }
+      end
+
+      def directives
+        @directives ||= @config.fetch('directives', []).map { |c| KongConfigField.new(c, kong_conf[c['name']]) }
       end
 
       def kong_conf
         @kong_conf ||= site.data.dig('kong-conf', @release_number.gsub('.', ''))
+      end
+
+      private
+
+      def validate_config!
+        @config.fetch('directives', []).each do |d|
+          unless d.key?('description')
+            raise ArgumentError,
+                  "Missing description for directive `#{d}` in kong_config_table"
+          end
+        end
       end
     end
   end

--- a/app/gateway/ssl-certificates.md
+++ b/app/gateway/ssl-certificates.md
@@ -65,20 +65,19 @@ You can directly upload certificates and keys to {{site.base_gateway}} through c
 
 All of the following parameters can also be set via [environment variables](/gateway/manage-kong-conf/).
 
-| Parameter | Type | Description |
-| ----------|------|-------------| 
-| [`ssl_cert`](/gateway/configuration/#ssl_cert) | Server cert |  Contains the contents or path to a certificate you want your proxy to present as a server certificate. |
-| [`ssl_cert_key`](/gateway/configuration/#ssl_cert_key) | Private key | Contains the contents or path to a private key for the certificate set via the `ssl_cert` parameter. |
-| [`admin_gui_ssl_cert`](/gateway/configuration/#admin_gui_ssl_cert) | Server cert | Contains the contents or path to a certificate you want your Kong Manager GUI to present as a server certificate. |
-| [`admin_gui_ssl_cert_key`](/gateway/configuration/#admin_gui_ssl_cert_key) | Private key  | Contains the contents or path to a private key for the certificate set via the `admin_gui_ssl_cert` parameter. |
-| [`admin_ssl_cert`](/gateway/configuration/#admin_ssl_cert) |  Server cert | Contains the contents or path to a certificate you want your Admin API to present as a server certificate. |
-| [`admin_ssl_cert_key`](/gateway/configuration/#admin_ssl_cert_key) | Private key  | Contains the contents or path to a private key for the certificate set via the `admin_ssl_cert` parameter. |
-| [`client_ssl_cert`](/gateway/configuration/#client_ssl_cert) | Client cert | Contains the contents or path to a certificate you want your Kong instance to serve as a client certificate to all upstreams. |
-| [`client_ssl_cert_key`](/gateway/configuration/#client_ssl_cert_key)  | Private key  | Contains the contents or path to a private key for the certificate set via the `client_ssl_cert` parameter. |
-| [`status_ssl_cert`](/gateway/configuration/#status_ssl_cert) | Server cert | Contains the contents or path to a certificate you want your Status Endpoint to serve as a server certificate. |
-| [`status_ssl_cert_key`](/gateway/configuration/#status_ssl_cert_key) | Private key  | Contains the contents or path to a private key for the certificate set via the `status_ssl_cert` parameter. |
-| [`lua_ssl_trusted_certificate`](/gateway/configuration/#lua_ssl_trusted_certificate) | CA cert | Contains the paths to CA root certificates used for verifying Lua cosocket connections. Any time that {{site.base_gateway}} uses Lua to create SSL connections, it'll use the CA root certs at this path to verify any certificates sent. |
-| [`nginx_proxy_proxy_ssl_trusted_certificate`](/gateway/configuration/#nginx_proxy_proxy_ssl_trusted_certificate)| CA cert | Contains the path to a PEM file that can hold multiple CA Root certificates for verifying all upstream server certificates. |
+{% kong_config_table %}
+config:
+  - name: ssl_cert
+  - name: ssl_cert_key
+  - name: admin_gui_ssl_cert
+  - name: admin_gui_ssl_cert_key
+  - name: admin_ssl_cert
+  - name: admin_ssl_cert_key
+  - name: client_ssl_cert
+  - name: client_ssl_cert_key
+  - name: status_ssl_cert
+  - name: status_ssl_cert_key
+  - name: lua_ssl_trusted_certificate
+{% endkong_config_table %}
 
 {{site.base_gateway}} also provides many customization settings for SSL connections. See the [Kong Configuration Reference](/gateway/configuration/) for all available options.
-

--- a/app/gateway/ssl-certificates.md
+++ b/app/gateway/ssl-certificates.md
@@ -65,6 +65,7 @@ You can directly upload certificates and keys to {{site.base_gateway}} through c
 
 All of the following parameters can also be set via [environment variables](/gateway/manage-kong-conf/).
 
+<!--vale off-->
 {% kong_config_table %}
 config:
   - name: ssl_cert
@@ -79,5 +80,6 @@ config:
   - name: status_ssl_cert_key
   - name: lua_ssl_trusted_certificate
 {% endkong_config_table %}
+<!--vale on-->
 
 {{site.base_gateway}} also provides many customization settings for SSL connections. See the [Kong Configuration Reference](/gateway/configuration/) for all available options.

--- a/app/gateway/ssl-certificates.md
+++ b/app/gateway/ssl-certificates.md
@@ -79,6 +79,10 @@ config:
   - name: status_ssl_cert
   - name: status_ssl_cert_key
   - name: lua_ssl_trusted_certificate
+directives:
+  - name: nginx_proxy_proxy_ssl_trusted_certificate
+    description: |
+      Path to a PEM file that can hold multiple CA Root certificates for verifying all upstream server certificates.
 {% endkong_config_table %}
 <!--vale on-->
 

--- a/tools/kong-conf-to-json/README.md
+++ b/tools/kong-conf-to-json/README.md
@@ -1,0 +1,21 @@
+# kong-conf-to-json
+
+Parse kong.conf and stores a json representation in `app/_data/kong-conf/<version>.json`.
+
+## How it works
+
+`kong-conf-to-json` requires `kong/kong-ee` to be available locally.
+From the root of your clone of the dev site repo:
+
+```bash
+cd kong-conf-to-json
+npm ci
+```
+
+## How to run it
+
+Transform a `kong.conf` file to `json` format by passing the relative path to the `kong.conf` file and its `version`, e.g.
+
+`node run --file=../../../kong.conf.default --version=3.9`
+
+will parse the file and write it to `app/_data/kong-conf/3.9.json`.

--- a/tools/kong-conf-to-json/package-lock.json
+++ b/tools/kong-conf-to-json/package-lock.json
@@ -1,0 +1,25 @@
+{
+    "name": "kong-conf-to-json",
+    "version": "1.0.0",
+    "lockfileVersion": 3,
+    "requires": true,
+    "packages": {
+        "": {
+            "name": "kong-conf-to-json",
+            "version": "1.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "minimist": "^1.2.8"
+            }
+        },
+        "node_modules/minimist": {
+            "version": "1.2.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+            "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
+        }
+    }
+}

--- a/tools/kong-conf-to-json/package.json
+++ b/tools/kong-conf-to-json/package.json
@@ -1,0 +1,12 @@
+{
+    "name": "kong-conf-to-json",
+    "version": "1.0.0",
+    "description": "",
+    "scripts": {},
+    "type": "module",
+    "keywords": [],
+    "license": "MIT",
+    "dependencies": {
+        "minimist": "^1.2.8"
+    }
+}

--- a/tools/kong-conf-to-json/run.js
+++ b/tools/kong-conf-to-json/run.js
@@ -45,7 +45,8 @@ function parseConfigFile(filePath) {
           config[currentParam].description += descriptionMatch[1]
             .trim()
             .slice(1)
-            .trimStart(); // Remove initial "#" and leading spaces
+            .trimStart() // Remove initial "#" and leading spaces
+            .concat("\n");
         }
         inDescription = true;
       } else {
@@ -53,7 +54,7 @@ function parseConfigFile(filePath) {
     } else {
       descriptionMatch = line.match(/^\s+\#(.*)/);
       if (descriptionMatch) {
-        config[currentParam].description += " " + line.trim().slice(2); // Remove initial "# "
+        config[currentParam].description += line.trim().slice(2).concat("\n"); // Remove initial "# "
       } else {
         inDescription = false;
       }

--- a/tools/kong-conf-to-json/run.js
+++ b/tools/kong-conf-to-json/run.js
@@ -1,0 +1,100 @@
+import fs from "fs";
+import minimist from "minimist";
+
+function parseConfigFile(filePath) {
+  const config = {};
+  const lines = fs.readFileSync(filePath, "utf-8").split("\n");
+
+  let currentParam = null;
+  let inDescription = false;
+
+  lines.forEach((line) => {
+    // Check if the line starts a new parameter definition
+    const paramMatch = line.match(/^\#(\w+)\s\=/);
+    if (paramMatch) {
+      currentParam = paramMatch[1]; // Remove the leading "#"
+      config[currentParam] = {
+        defaultValue: null,
+        description: "",
+      };
+      inDescription = false;
+    }
+
+    // Check if the line contains a default value assignment
+    const defaultValueMatch = line.match(/^\#\w+\s\=(\s[^#\n]*)(\#.*|$)/);
+    if (defaultValueMatch) {
+      const value = defaultValueMatch[1].trimStart();
+      if (value === "") {
+        config[currentParam].defaultValue = null;
+      } else {
+        if (value.split(",").length > 1) {
+          config[currentParam].defaultValue = value
+            .split(",")
+            .map((v) => v.trim());
+        } else {
+          config[currentParam].defaultValue = value.trimEnd();
+        }
+      }
+    }
+
+    let descriptionMatch;
+    if (!inDescription) {
+      if (paramMatch) {
+        descriptionMatch = line.match(/^\#\w+\s\=\s[^#\n]*(\#.*)/);
+        if (descriptionMatch) {
+          config[currentParam].description += descriptionMatch[1]
+            .trim()
+            .slice(1)
+            .trimStart(); // Remove initial "#" and leading spaces
+        }
+        inDescription = true;
+      } else {
+      }
+    } else {
+      descriptionMatch = line.match(/^\s+\#(.*)/);
+      if (descriptionMatch) {
+        config[currentParam].description += " " + line.trim().slice(2); // Remove initial "# "
+      } else {
+        inDescription = false;
+      }
+    }
+  });
+
+  return config;
+}
+
+(function main() {
+  const args = minimist(process.argv.slice(2));
+
+  try {
+    if (!args.file) {
+      console.error(
+        "Missing argument --file, relative path to the kong.conf file."
+      );
+      process.exit(1);
+    }
+
+    if (!args.version) {
+      console.error(
+        "Missing argument --version, version of the kong.conf file to parse."
+      );
+      process.exit(1);
+    }
+
+    const configFilePath = args.file;
+    const version = args.version;
+    const jsonConfig = parseConfigFile(configFilePath);
+    const destinationPath = `../../app/_data/kong-conf/${version}.json`;
+
+    fs.writeFileSync(
+      destinationPath,
+      JSON.stringify(jsonConfig, null, 2),
+      "utf8"
+    );
+    console.log(`kong.conf file in json format written to ${destinationPath}.`);
+    return 0;
+  } catch (error) {
+    console.log(error);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Description

Fixes [issue](https://github.com/Kong/developer.konghq.com/issues/283)
First draft.

I've added a tool that transforms the kong.conf file and stores a json representation of it (I generated it for 3.4 - 3.9).
We could also render another column with the default value if we want given that's already available.
Description is optional, it pulls the one in the field if none given.
I've rendered the env variable below the field.

It pulls the `kong..conf` json representation based on the page's version.
* if the page doesn't have a version, it uses latest
* if the page is unreleased, it uses latest

**Questions**
* Do we want to add a `set_env_variables: true` to render them or do we want to always render them? 
* I ignore fields that are present instead of making the build fail just because a field might have been added in a newer version of the file.

@cloudjumpercat @lena-larionova There isn't a `nginx_proxy_proxy_ssl_trusted_certificate` field in `kong.conf`, so I removed it from the table, but it is still being referenced [here](https://github.com/Kong/developer.konghq.com/blob/main/app/gateway/ssl-certificates.md?plain=1#L51).

Looks like it comes from this part of the [file](https://github.com/Kong/kong-ee/blob/master/kong.conf.default#L1128-L1151) (`NGINX injected directives`). Maybe we could add a directives key and list them under it?

## Preview Links


## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
