### PR TITLE
Add {% control_plane_request %}

### DIFF
--- a/app/_data/control_plane_request.yml
+++ b/app/_data/control_plane_request.yml
@@ -1,0 +1,3 @@
+url_origin:
+  konnect: $KONNECT_CONTROL_PLANE_URL
+  on_prem: http://localhost:8001

--- a/app/_includes/control_plane_request.html
+++ b/app/_includes/control_plane_request.html
@@ -1,0 +1,11 @@
+{% if page.works_on contains 'konnect' %}
+<div data-deployment-topology="konnect" markdown="1" data-test-step="block">
+  {% include how-tos/validations/request-check/snippet.md url=config.konnect_url headers=config.headers body=config.body method=config.method %}
+</div>
+{% endif %}
+
+{% if page.works_on contains 'on-prem' %}
+<div data-deployment-topology="on-prem"  markdown="1" data-test-step="block">
+  {% include how-tos/validations/request-check/snippet.md url=config.on_prem_url headers=config.headers body=config.body method=config.method %}
+</div>
+{% endif %}

--- a/app/_plugins/drops/control_plane_request.rb
+++ b/app/_plugins/drops/control_plane_request.rb
@@ -8,11 +8,8 @@ module Jekyll
     class ControlPlaneRequest < Liquid::Drop # rubocop:disable Style/Documentation
       include Jekyll::SiteAccessor
 
-      attr_reader :name
-
       def initialize(yaml:) # rubocop:disable Lint/MissingSuper
         @yaml = yaml
-        @name = 'request-check'
 
         validate_yaml!
       end
@@ -40,21 +37,12 @@ module Jekyll
         ).to_s
       end
 
-      def data_validate_konnect
-        JSON.dump({ name: name, config: config.merge(url: konnect_url) })
-      end
-
-      def data_validate_on_prem
-        JSON.dump({ name: name, config: config.merge(url: on_prem_url) })
-      end
-
       def config
         @config ||= @yaml.except('url')
       end
 
       def template_file
-        # re-use request-check so that the data-attributes are rendered
-        @template_file ||= 'app/_includes/how-tos/validations/request-check/index.html'
+        @template_file ||= 'app/_includes/control_plane_request.html'
       end
 
       def method
@@ -69,8 +57,6 @@ module Jekyll
 
       def validate_yaml!
         raise ArgumentError, 'Missing `url` in {% control_plane_request %}.' unless @yaml.key?('url')
-
-        raise ArgumentError, 'Missing `status_code` in {% control_plane_request %}.' unless @yaml.key?('status_code')
       end
     end
   end

--- a/app/_plugins/drops/control_plane_request.rb
+++ b/app/_plugins/drops/control_plane_request.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require 'json'
+require_relative '../lib/site_accessor'
+
+module Jekyll
+  module Drops
+    class ControlPlaneRequest < Liquid::Drop # rubocop:disable Style/Documentation
+      include Jekyll::SiteAccessor
+
+      attr_reader :name
+
+      def initialize(yaml:) # rubocop:disable Lint/MissingSuper
+        @yaml = yaml
+        @name = 'request-check'
+
+        validate_yaml!
+      end
+
+      def [](key)
+        key = key.to_s
+        if respond_to?(key)
+          public_send(key)
+        elsif @yaml.key?(key)
+          @yaml[key]
+        elsif configuration.key?(key)
+          configuration[key]
+        end
+      end
+
+      def konnect_url
+        @konnect_url ||= File.join(
+          configuration.dig('url_origin', 'konnect'), @yaml['url']
+        ).to_s
+      end
+
+      def on_prem_url
+        @on_prem_url ||= URI.join(
+          configuration.dig('url_origin', 'on_prem'), @yaml['url']
+        ).to_s
+      end
+
+      def data_validate_konnect
+        JSON.dump({ name: name, config: config.merge(url: konnect_url) })
+      end
+
+      def data_validate_on_prem
+        JSON.dump({ name: name, config: config.merge(url: on_prem_url) })
+      end
+
+      def config
+        @config ||= @yaml.except('url')
+      end
+
+      def template_file
+        # re-use request-check so that the data-attributes are rendered
+        @template_file ||= 'app/_includes/how-tos/validations/request-check/index.html'
+      end
+
+      def method
+        @method ||= @yaml['method']
+      end
+
+      private
+
+      def configuration
+        @configuration ||= site.data['control_plane_request']
+      end
+
+      def validate_yaml!
+        raise ArgumentError, 'Missing `url` in {% control_plane_request %}.' unless @yaml.key?('url')
+
+        raise ArgumentError, 'Missing `status_code` in {% control_plane_request %}.' unless @yaml.key?('status_code')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Usage:
```
{% control_plane_request %}
url: /rbac/users
method: POST
headers:
    - 'Accept: application/json'
    - 'Content-Type: application/json'
    - 'Kong-Admin-Token: $KONG_ADMIN_TOKEN'
body:
    name: $ADMIN_NAME
    user_token: $USER_TOKEN

{% endcontrol_plane_request %}
```
Fixes #issue

## Preview Links


## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
