### PR TITLE
Security update process doc

### DIFF
--- a/app/_data/schemas/frontmatter/base.json
+++ b/app/_data/schemas/frontmatter/base.json
@@ -18,7 +18,7 @@
     },
     "content_type": {
       "type": "string",
-      "enum": ["landing_page", "how_to", "reference", "concept", "plugin", "plugin_example", "api"]
+      "enum": ["landing_page", "how_to", "reference", "concept", "plugin", "plugin_example", "api", "policy"]
     },
     "description": {
       "type": "string"

--- a/app/_data/schemas/frontmatter/policy.json
+++ b/app/_data/schemas/frontmatter/policy.json
@@ -1,0 +1,4 @@
+{
+    "$id": "schema:policy",
+    "allOf": [{ "$ref": "schema:base" }]
+  }

--- a/app/_includes/breadcrumbs.html
+++ b/app/_includes/breadcrumbs.html
@@ -1,3 +1,4 @@
+{% if page.breadcrumbs %}
 <div class="flex gap-1 justify-start text-xs items-center xl:basis-3/4">
   <a class="text-terciary" href="/">Home</a>
   <span>/</span>
@@ -6,3 +7,6 @@
     {% unless forloop.last %}<span>/</span>{% endunless %}
   {% endfor %}
 </div>
+{% else %}
+<div class="flex xl:basis-3/4"></div>
+{% endif %}

--- a/app/_includes/breadcrumbs_and_links.html
+++ b/app/_includes/breadcrumbs_and_links.html
@@ -1,11 +1,10 @@
 {% if page.breadcrumbs or page.edit_and_issue_links != false %}
 <div class="flex w-full justify-between pt-12 gap-16">
-    {% if page.breadcrumbs %}
-        {% include breadcrumbs.html %}
-    {% endif%}
+    {% include breadcrumbs.html %}
+
 
     {% if page.layout == 'plugins/example' or page.layout == 'landing_page' %}{% assign no_aside = true %}{% endif %}
-    <div class="flex gap-3 text-xs {% if page.breadcrumbs %} xl:basis-1/4 {% else %} w-full {% endif %}items-center {% if no_aside == true %}justify-end{% endif %}">
+    <div class="flex gap-3 text-xs xl:basis-1/4 items-center {% if no_aside == true %}justify-end{% endif %}">
         {% include edit_and_issue_links.html edit_link=page.edit_link %}
     </div>
   </div>

--- a/app/_includes/edit_and_issue_links.html
+++ b/app/_includes/edit_and_issue_links.html
@@ -1,7 +1,10 @@
+{% if include.edit_link %}
 <a class="text-brand flex gap-1 px-1 py-0.5 items-center text-xs" href="{{ include.edit_link }}">
     <div class="flex w-4 h-4 text-brand">{% include_svg '/assets/icons/social/github.svg' %}</div>
     Edit this Page
 </a>
+{% endif %}
+
 <a class="text-brand flex gap-1 px-1 py-0.5 items-center text-xs" href="{{ site.repos.developer }}/issues/">
     <div class="flex w-4 h-4 text-brand">{% include_svg '/assets/icons/warning.svg' %}</div>
     Report an Issue

--- a/app/_includes/get_help.html
+++ b/app/_includes/get_help.html
@@ -12,8 +12,10 @@
                 <span>Something wrong?</span>
                 <div class="flex gap-2">
                     <a class="text-brand" href="{{ site.repos.developer }}/issues/">Report an Issue</a>
-                    <span class="text-secondary">|</span>
-                    <a class="text-brand" href="{{ page.edit_link }}">Edit this Page</a>
+                    {% if page.edit_link %}
+                        <span class="text-secondary">|</span>
+                        <a class="text-brand" href="{{ page.edit_link }}">Edit this Page</a>
+                    {% endif %}
                 </div>
             </div>
         </div>

--- a/app/_landing_pages/gateway/security.yaml
+++ b/app/_landing_pages/gateway/security.yaml
@@ -1,0 +1,6 @@
+metadata:
+  title: Security in Kong Gateway
+  content_type: landing_page
+  description: todo
+  breadcrumbs:
+    - /gateway/

--- a/app/_plugins/generators/data/edit_link/base.rb
+++ b/app/_plugins/generators/data/edit_link/base.rb
@@ -3,7 +3,7 @@
 module Jekyll
   module Data
     module EditLink
-      class Base
+      class Base # rubocop:disable Style/Documentation
         def initialize(site:, page:)
           @site = site
           @page = page
@@ -16,7 +16,9 @@ module Jekyll
         private
 
         def edit_link
-          @edit_link ||= "#{repo_edit_url}/#{@page.relative_path}"
+          return if @page.data['content_type'] == 'policy'
+
+          "#{repo_edit_url}/#{@page.relative_path}"
         end
 
         def repo_edit_url

--- a/app/_plugins/generators/data/search_tags/base.rb
+++ b/app/_plugins/generators/data/search_tags/base.rb
@@ -11,7 +11,8 @@ module Jekyll
           'landing_page' => 'LandingPage',
           'plugin' => 'Plugin',
           'plugin_example' => 'PluginExample',
-          'reference' => 'Reference'
+          'reference' => 'Reference',
+          'policy' => 'Policy'
         }.freeze
 
         def self.make_for(site:, page:)

--- a/app/_plugins/generators/data/search_tags/policy.rb
+++ b/app/_plugins/generators/data/search_tags/policy.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Jekyll
+  module Data
+    module SearchTags
+      class Policy < Base
+      end
+    end
+  end
+end

--- a/app/_plugins/hooks/split_into_sections.rb
+++ b/app/_plugins/hooks/split_into_sections.rb
@@ -7,7 +7,7 @@ Jekyll::Hooks.register :documents, :post_convert do |doc, _payload|
 end
 
 Jekyll::Hooks.register :pages, :post_convert do |page, _payload|
-  next unless %w[concept reference plugin].include?(page.data['content_type'])
+  next unless %w[concept reference plugin policy].include?(page.data['content_type'])
 
   SectionWrapper::Base.make_for(page).process
 end

--- a/app/gateway/security-update-process.md
+++ b/app/gateway/security-update-process.md
@@ -1,0 +1,34 @@
+---
+title: Kong Security Update Process
+
+description: Learn how Kong handles vulnerabilities or potential vulnerabilities in Kong or third-party code, and how to report any security issues.
+
+content_type: concept
+layout: concept
+
+breadcrumbs:
+  - /gateway/
+  - /gateway/security/
+
+related_resources:
+  - text: Security in Kong Gateway
+    url: /gateway/security/
+  - text: Common Vulnerability Scoring System
+    url: https://www.first.org/cvss/
+---
+
+## Reporting a vulnerability
+
+If you have found a vulnerability or a potential vulnerability in {{site.base_gateway}} or any Kong software, or know of a publicly disclosed security vulnerability, please let us know immediately by emailing [security@konghq.com](mailto:security@konghq.com). We’ll send a confirmation email to acknowledge your report, and we’ll send an additional email when we’ve identified the issue positively or negatively.
+
+Once a report is received, we will investigate the vulnerability and assign it a [CVSS](https://www.first.org/cvss/) score, which will determine the timeline for the development of an appropriate fix.
+
+While the fix development is underway, we ask that you do not share or publicize an unresolved vulnerability with third parties. If you responsibly submitted a vulnerability report, we will do our best to acknowledge your report in a timely fashion and notify you of the estimated timeline for a fix.
+
+## Fix development process
+
+If a discovered vulnerability with a CVSS score above 4.0 (medium severity or higher) affects the latest major release of the {{site.base_gateway}} or other Kong software, then we will work to develop a fix in the most timely fashion. The work and communication around the fix will happen in private channels, and a delivery estimate will be given to the vulnerability reporter. Once the fix is developed and verified, a new patch version will be released by Kong for each supported {{site.ee_product_name}} release and for the current release of the open source {{site.base_gateway}}. We will disclose the vulnerability as appropriate.
+
+Discovered vulnerabilities with a CVSS score below 4.0 (low severity) will follow the same fix development and release process but with a less urgent timeline.
+
+Vulnerabilities affecting upstream projects (for example, NGINX, OpenResty, OpenSSL) will receive fixes as per the upstream project’s disclosure timeline.

--- a/app/gateway/security-update-process.md
+++ b/app/gateway/security-update-process.md
@@ -11,7 +11,7 @@ breadcrumbs:
   - /gateway/security/
 
 related_resources:
-  - text: Security in Kong Gateway
+  - text: Security in {{site.base_gateway}}
     url: /gateway/security/
   - text: Common Vulnerability Scoring System
     url: https://www.first.org/cvss/

--- a/app/vulnerabilities.md
+++ b/app/vulnerabilities.md
@@ -4,11 +4,9 @@ title: Kong Security Update Process
 description: Learn how Kong handles vulnerabilities or potential vulnerabilities in Kong or third-party code, and how to report any security issues.
 
 content_type: concept
-layout: concept
+layout: reference
 
-breadcrumbs:
-  - /gateway/
-  - /gateway/security/
+no_version: true
 
 related_resources:
   - text: Security in {{site.base_gateway}}
@@ -31,4 +29,4 @@ If a discovered vulnerability with a CVSS score above 4.0 (medium severity or hi
 
 Discovered vulnerabilities with a CVSS score below 4.0 (low severity) will follow the same fix development and release process but with a less urgent timeline.
 
-Vulnerabilities affecting upstream projects (for example, NGINX, OpenResty, OpenSSL) will receive fixes as per the upstream project’s disclosure timeline.
+Vulnerabilities affecting upstream projects (for example, NGINX, OpenResty, OpenSSL, and others) will receive fixes as per the upstream project’s disclosure timeline.

--- a/app/vulnerabilities.md
+++ b/app/vulnerabilities.md
@@ -3,7 +3,7 @@ title: Kong Security Update Process
 
 description: Learn how Kong handles vulnerabilities or potential vulnerabilities in Kong or third-party code, and how to report any security issues.
 
-content_type: concept
+content_type: policy
 layout: reference
 
 no_version: true

--- a/tools/track-docs-changes/config/sources.yml
+++ b/tools/track-docs-changes/config/sources.yml
@@ -224,3 +224,6 @@ app/gateway/routing/expressions-router-examples.md:
 app/gateway/networking/dns-config-reference.md:
   - app/_src/gateway/production/networking/dns-considerations.md
 
+# concepts
+app/gateway/security-update-process.md:
+  - app/_src/gateway/production/security-update-process.md


### PR DESCRIPTION
## Description

Fixes #274 

Questions + ideas + notes:
* This doc is coming from Kong Gateway but the text keeps referring to "Kong Gateway and other Kong products". Can we rephrase this and make it a blanket statement without specifically mentioning Kong Gateway, or do we need to consult with someone in eng to make that decision?
  * Leave as-is
* We should mark external links in some way, both in text and in info boxes. The "CVSS" link in this doc is external but there's no way to tell without clicking it.
  * Created issue: [External link icons](https://github.com/Kong/developer.konghq.com/issues/342)
* Does this info belong on the dev site? I think yes, because it's no longer just a docs site. On the docs site, I might've said no.
  * Yes, it belongs here

@cloudjumpercat - this would be a good doc to link from the security landing page.


## Preview Links
https://deploy-preview-319--kongdeveloper.netlify.app/vulnerabilities/

## Checklist 

- [x] Every page is page one.
- [ N/A ] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
