### PR TITLE
Remove overflow-auto from plugin examples

### DIFF
--- a/app/_includes/components/plugin_config_example.html
+++ b/app/_includes/components/plugin_config_example.html
@@ -34,7 +34,7 @@
      {% assign target = entity_example.target.key %}
 
      {% assign formatted_examples = entity_example.formatted_examples %}
-      <div tabindex="0" class="entity-example-target-panel hidden overflow-auto content" aria-labelledby="select-target-{{ entity_example.id }}" data-target="{{ target }}">
+      <div tabindex="0" class="entity-example-target-panel hidden content" aria-labelledby="select-target-{{ entity_example.id }}" data-target="{{ target }}">
         {% if target == 'global' %}
           {% capture global_context %}{% include components/plugin_config_example/global.md %}{% endcapture %}
           {{ global_context | markdownify }}
@@ -42,7 +42,7 @@
 
         {% for formatted_example in formatted_examples %}
           {% assign format = formatted_example.format %}
-          <div tabindex="0" class="entity-example-format-panel hidden overflow-auto content" aria-labelledby="select-format-{{ entity_example.id }}" data-format="{{ format }}">
+          <div tabindex="0" class="entity-example-format-panel hidden content" aria-labelledby="select-format-{{ entity_example.id }}" data-format="{{ format }}">
             {% capture markdown_template %}{% include {{ formatted_example.template_file }} presenter=formatted_example.presenter render_context=true %}{% endcapture %}
             {{ markdown_template | markdownify }}
           </div>


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
