### PR TITLE
How to: HashiCorp Vault

### DIFF
--- a/app/_how-tos/configure-hashicorp-vault-as-a-vault-backend.md
+++ b/app/_how-tos/configure-hashicorp-vault-as-a-vault-backend.md
@@ -49,7 +49,7 @@ prereqs:
           vault server -dev -dev-root-token-id root -dev-tls
           ```
         1. In the output from the previous command, copy where it lists the `VAULT_ADDR` and `VAULT_CACERT` to export.
-        1. In a new termnial window, export your `VAULT_ADDR` and `VAULT_CACERT`, for example:
+        1. In a new terminal window, export your `VAULT_ADDR` and `VAULT_CACERT`, for example:
           ```
           export VAULT_ADDR='https://127.0.0.1:8200'
           export VAULT_CACERT='/var/folders/qr/zgztx0sj6n1dxy86sl36ntnw0000gn/T/vault-tls3037226588/vault-ca.pem'

--- a/app/_how-tos/configure-hashicorp-vault-as-a-vault-backend.md
+++ b/app/_how-tos/configure-hashicorp-vault-as-a-vault-backend.md
@@ -14,7 +14,6 @@ tier: enterprise
 
 works_on:
     - on-prem
-    - konnect
 
 min_version:
   gateway: '3.4'
@@ -46,14 +45,10 @@ prereqs:
         1. [Install HashiCorp Vault](https://developer.hashicorp.com/vault/tutorials/get-started/install-binary#install-vault).
         1. In a terminal, start your Vault dev server with `root` as your token, and enable TLS.
           ```
-          vault server -dev -dev-root-token-id root -dev-tls
+          vault server -dev -dev-root-token-id root
           ```
         1. In the output from the previous command, copy where it lists the `VAULT_ADDR` and `VAULT_CACERT` to export.
-        1. In a new terminal window, export your `VAULT_ADDR` and `VAULT_CACERT`, for example:
-          ```
-          export VAULT_ADDR='https://127.0.0.1:8200'
-          export VAULT_CACERT='/var/folders/qr/zgztx0sj6n1dxy86sl36ntnw0000gn/T/vault-tls3037226588/vault-ca.pem'
-          ```
+        1. In a new terminal window, export your `VAULT_ADDR` and `VAULT_CACERT` as environment variables.
         1. Verify that your Vault is running correctly:
           ```
           vault status
@@ -62,59 +57,7 @@ prereqs:
           ```
           vault login root
           ```
-        1. [Create the `admin-policy.hcl` policy file](https://developer.hashicorp.com/vault/tutorials/policies/policies#write-a-policy). This contains the [permissions you need to create and use secrets](https://developer.hashicorp.com/vault/tutorials/secrets-management/versioned-kv#policy-requirements):
-          ```
-          tee admin-policy.hcl <<EOF
-          # Read system health check
-          path "sys/health"
-          {
-            capabilities = ["read", "sudo"]
-          }
-          # Create and manage ACL policies broadly across Vault
-          # List existing policies
-          path "sys/policies/acl"
-          {
-            capabilities = ["list"]
-          }
-          # Create and manage ACL policies
-          path "sys/policies/acl/*"
-          {
-            capabilities = ["create", "read", "update", "delete", "list", "sudo"]
-          }
-          # Enable and manage authentication methods broadly across Vault
-          # Manage auth methods broadly across Vault
-          path "auth/*"
-          {
-            capabilities = ["create", "read", "update", "delete", "list", "sudo"]
-          }
-          # Create, update, and delete auth methods
-          path "sys/auth/*"
-          {
-            capabilities = ["create", "update", "delete", "sudo"]
-          }
-          # List auth methods
-          path "sys/auth"
-          {
-            capabilities = ["read"]
-          }
-          # Enable and manage the key/value secrets engine at `secret/` path
-          # List, create, update, and delete key/value secrets
-          path "secret/*"
-          {
-            capabilities = ["create", "read", "update", "delete", "list", "sudo"]
-          }
-          # Manage secrets engines
-          path "sys/mounts/*"
-          {
-            capabilities = ["create", "read", "update", "delete", "list", "sudo"]
-          }
-          # List existing secrets engines.
-          path "sys/mounts"
-          {
-            capabilities = ["read"]
-          }
-          EOF
-          ```
+        1. [Create the `admin-policy.hcl` policy file](https://developer.hashicorp.com/vault/tutorials/policies/policies#write-a-policy). This contains the [permissions you need to create and use secrets](https://developer.hashicorp.com/vault/tutorials/secrets-management/versioned-kv#policy-requirements).
         1. Upload the policy you just created:
           ```
           vault policy write admin admin-policy.hcl
@@ -132,9 +75,9 @@ prereqs:
 
 cleanup:
   inline:
-    - title: Clean up Konnect environment
-      include_content: cleanup/platform/konnect
-      icon_url: /assets/icons/gateway.svg
+    - title: Clean up HashiCorp Vault
+      include_content: cleanup/third-party/hashicorp
+      icon_url: /assets/icons/hashicorp.svg
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg

--- a/app/_how-tos/configure-hashicorp-vault-as-a-vault-backend.md
+++ b/app/_how-tos/configure-hashicorp-vault-as-a-vault-backend.md
@@ -43,12 +43,12 @@ prereqs:
         > **Important:** This tutorial uses the literal `root` string as your token, which should only be used in testing and development environments.
 
         1. [Install HashiCorp Vault](https://developer.hashicorp.com/vault/tutorials/get-started/install-binary#install-vault).
-        1. In a terminal, start your Vault dev server with `root` as your token, and enable TLS.
+        1. In a terminal, start your Vault dev server with `root` as your token.
           ```
           vault server -dev -dev-root-token-id root
           ```
-        1. In the output from the previous command, copy where it lists the `VAULT_ADDR` and `VAULT_CACERT` to export.
-        1. In a new terminal window, export your `VAULT_ADDR` and `VAULT_CACERT` as environment variables.
+        1. In the output from the previous command, copy the `VAULT_ADDR` to export.
+        1. In a new terminal window, export your `VAULT_ADDR` as an environment variable.
         1. Verify that your Vault is running correctly:
           ```
           vault status

--- a/app/_how-tos/configure-hashicorp-vault-as-a-vault-backend.md
+++ b/app/_how-tos/configure-hashicorp-vault-as-a-vault-backend.md
@@ -19,8 +19,6 @@ works_on:
 min_version:
   gateway: '3.4'
 
-plugins:
-
 entities: 
   - vault
 
@@ -29,12 +27,108 @@ tags:
     - secrets-management
 
 tldr:
-    q: How do I 
-    a: placeholder
+    q: How can I access HashiCorp Vaults secrets in {{site.base_gateway}}? 
+    a: |
+      [Install and run HashiCorp Vault](https://developer.hashicorp.com/vault/tutorials/get-started/install-binary#install-vault) in dev mode or self-managed. [Write a secret to the Vault](https://developer.hashicorp.com/vault/tutorials/secrets-management/versioned-kv?variants=vault-deploy%3Aselfhosted#write-secrets) like `vault kv put secret/customer/acme name="ACME Inc."`. Save your HashiCorp Vault token, host, port, protocol, and KV secrets engine version and use them to configure a {{site.base_gateway}} [Vault entity](/gateway/entities/vault/). Use `{vault://hashicorp-vault/customer/acme/name}` to reference the secret in any referenceable field.
 
 tools:
     - deck
 
+prereqs:
+  inline: 
+    - title: HashiCorp Vault
+      content: |
+        This how-to requires you to have a dev mode or self-managed HashiCorp Vault. The following instructions will guide you through configuring a HashiCorp Vault in dev mode with the resources you need to integrate it with {{site.base_gateway}}.
+
+        {:.warning}
+        > **Important:** This tutorial uses the literal `root` string as your token, which should only be used in testing and development environments.
+
+        1. [Install HashiCorp Vault](https://developer.hashicorp.com/vault/tutorials/get-started/install-binary#install-vault).
+        1. In a terminal, start your Vault dev server with `root` as your token, and enable TLS.
+          ```
+          vault server -dev -dev-root-token-id root -dev-tls
+          ```
+        1. In the output from the previous command, copy where it lists the `VAULT_ADDR` and `VAULT_CACERT` to export.
+        1. In a new termnial window, export your `VAULT_ADDR` and `VAULT_CACERT`, for example:
+          ```
+          export VAULT_ADDR='https://127.0.0.1:8200'
+          export VAULT_CACERT='/var/folders/qr/zgztx0sj6n1dxy86sl36ntnw0000gn/T/vault-tls3037226588/vault-ca.pem'
+          ```
+        1. Verify that your Vault is running correctly:
+          ```
+          vault status
+          ```
+        1. Authenticate with Vault:
+          ```
+          vault login root
+          ```
+        1. [Create the `admin-policy.hcl` policy file](https://developer.hashicorp.com/vault/tutorials/policies/policies#write-a-policy). This contains the [permissions you need to create and use secrets](https://developer.hashicorp.com/vault/tutorials/secrets-management/versioned-kv#policy-requirements):
+          ```
+          tee admin-policy.hcl <<EOF
+          # Read system health check
+          path "sys/health"
+          {
+            capabilities = ["read", "sudo"]
+          }
+          # Create and manage ACL policies broadly across Vault
+          # List existing policies
+          path "sys/policies/acl"
+          {
+            capabilities = ["list"]
+          }
+          # Create and manage ACL policies
+          path "sys/policies/acl/*"
+          {
+            capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+          }
+          # Enable and manage authentication methods broadly across Vault
+          # Manage auth methods broadly across Vault
+          path "auth/*"
+          {
+            capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+          }
+          # Create, update, and delete auth methods
+          path "sys/auth/*"
+          {
+            capabilities = ["create", "update", "delete", "sudo"]
+          }
+          # List auth methods
+          path "sys/auth"
+          {
+            capabilities = ["read"]
+          }
+          # Enable and manage the key/value secrets engine at `secret/` path
+          # List, create, update, and delete key/value secrets
+          path "secret/*"
+          {
+            capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+          }
+          # Manage secrets engines
+          path "sys/mounts/*"
+          {
+            capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+          }
+          # List existing secrets engines.
+          path "sys/mounts"
+          {
+            capabilities = ["read"]
+          }
+          EOF
+          ```
+        1. Upload the policy you just created:
+          ```
+          vault policy write admin admin-policy.hcl
+          ```
+        1. [Verify that you are using the `v2` secrets engine](https://developer.hashicorp.com/vault/tutorials/secrets-management/versioned-kv?variants=vault-deploy%3Aselfhosted#check-the-kv-secrets-engine-version):
+          ```
+          vault read sys/mounts/secret
+          ```
+          The `options` key should have the `map[version:2]` value.
+        1. [Write the secret](https://developer.hashicorp.com/vault/tutorials/secrets-management/versioned-kv?variants=vault-deploy%3Aselfhosted#write-secrets):
+          ```
+          vault kv put secret/customer/acme name="ACME Inc."
+          ```
+      icon_url: /assets/icons/hashicorp.svg
 
 cleanup:
   inline:
@@ -46,6 +140,33 @@ cleanup:
       icon_url: /assets/icons/gateway.svg
 ---
 
-@todo
+## 1. Create a Vault entity for HashiCorp Vault 
 
-Use content from https://docs.konghq.com/gateway/latest/kong-enterprise/secrets-management/backends/hashicorp-vault/ 
+In this tutorial, we're using `host.docker.internal` as our host instead of the `localhost` that HashiCorp Vault is using because {{site.base_gateway}} is running in a container that has a different `localhost` to you.
+
+Using decK, create a Vault entity in the `kong.yaml` file with the required parameters for HashiCorp Vault:
+
+{% entity_example %}
+type: vault
+data:
+  name: hcv
+  prefix: hashicorp-vault
+  description: Storing secrets in HashiCorp Vault
+  config:
+    host: host.docker.internal
+    kv: v2
+    mount: secret
+    port: 8200
+    protocol: http
+    token: 'root'
+{% endentity_example %}
+
+## 2. Validate
+
+To validate that the secret was stored correctly in HashiCorp Vault, you can call a secret from your vault using the `kong vault get` command within the Data Plane container. If the Docker container is named `kong-quickstart-gateway`, you can use the following command:
+
+```sh
+docker exec kong-quickstart-gateway kong vault get {vault://hashicorp-vault/customer/acme/name}
+```
+
+If the vault was configured correctly, this command should return the value of the secret. You can use `{vault://hashicorp-vault/customer/acme/name}` to reference the secret in any referenceable field.

--- a/app/_includes/cleanup/third-party/hashicorp.md
+++ b/app/_includes/cleanup/third-party/hashicorp.md
@@ -5,5 +5,5 @@ pkill vault
 
 Unset environment variables:
 ```
-unset VAULT_ADDR VAULT_CACERT
+unset VAULT_ADDR
 ```

--- a/app/_includes/cleanup/third-party/hashicorp.md
+++ b/app/_includes/cleanup/third-party/hashicorp.md
@@ -1,0 +1,9 @@
+[Stop the HashiCorp Vault dev server process](https://developer.hashicorp.com/vault/tutorials/get-started/setup#clean-up) by running the following:
+```
+pkill vault
+```
+
+Unset environment variables:
+```
+unset VAULT_ADDR VAULT_CACERT
+```

--- a/tools/track-docs-changes/config/sources.yml
+++ b/tools/track-docs-changes/config/sources.yml
@@ -144,6 +144,8 @@ app/_how-tos/enable-rbac-with-admin-api.md:
   - app/konnect/dev-portal/access-and-approval/manage-teams.md
 app/_how-tos/store-secrets-in-konnect-config-store.md:
   - app/konnect/gateway-manager/configuration/config-store.md
+app/_how-tos/configure-hashicorp-vault-as-a-vault-backend.md:
+  - app/_src/gateway/kong-enterprise/secrets-management/backends/hashicorp-vault.md
 
 # plugins
 app/_kong_plugins/ai-rate-limiting-advanced/index.md:


### PR DESCRIPTION
## Description

Questions for reviewers:

- **HashiCorp Vault prereq instructions:**
  - Are all the commands too much? Should we rely more on specific verbiage and HashiCorp docs links? Ex. "[Create the `admin-policy.hcl` policy file](https://developer.hashicorp.com/vault/tutorials/policies/policies#write-a-policy). This contains the [permissions you need to create and use secrets](https://developer.hashicorp.com/vault/tutorials/secrets-management/versioned-kv#policy-requirements)" and no commands? I thought by adding more commands, this could help users and the automated tests. However, then we're testing if Hashicorp works...
- **Explanation of config parameters:** 
  - Do you wish there was more of an explanation about the config parameters (like host, port, protocol, mount, etc.) and where those values come from? Ex. "We configured the token as `root` when we started the HCV, so we'll use `root` as the token in our Vault entity config." Or is it clear enough where you could configure the Vault entity with different HCV values easily?
- **Validation is Kong Gateway-only:** 
  - HCV entity is supported in Konnect, and I believe everything will work, except the validation step. I can't think of one, but is there a different validation we can do for Konnect to verify that it works? I wouldn't like it if we couldn't publish this for Konnect just because of the validation step.

Fixes #231 

## Preview Links

https://deploy-preview-344--kongdeveloper.netlify.app/how-to/configure-hashicorp-vault-as-a-vault-backend/

## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. **Note:** I tried testing Konnect, I think the validation step would just need to be different for this to work?
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
