### PR TITLE
Feat: How to configure AWS Secrets for DB

### DIFF
--- a/.github/styles/frontmatter/Keys.txt
+++ b/.github/styles/frontmatter/Keys.txt
@@ -16,3 +16,4 @@ works_on
 konnect_product_id
 no_version
 search_aliases
+skip_product

--- a/app/_how-tos/store-the-gateway-database-credentials-with-aws-secrets-manager.md
+++ b/app/_how-tos/store-the-gateway-database-credentials-with-aws-secrets-manager.md
@@ -3,7 +3,9 @@ title: Store the {{site.base_gateway}} database credentials with AWS Secrets Man
 content_type: how_to
 related_resources:
   - text: Secrets management
-    url: /gateway/secrets-management
+    url: /gateway/secrets-management/
+ - text: Configure AWS Secrets Manager as a vault backend using the Vault entity
+   url: /how-to/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity/
 
 products:
   - gateway
@@ -89,7 +91,7 @@ The username and password specified in this command are the PostgreSQL master cr
 Define the username and password to use to connect {{site.base_gateway}} to the database and store them in environment variables.
 ```sh
 export KONG_PG_USER=kong
-export KONG_PG_PASSWORD=KongFTW
+export KONG_PG_PASSWORD=KongPassword
 ```
 
 ## 4. Create a database user
@@ -106,7 +108,7 @@ docker exec -it kong-database psql -U admin -c "CREATE DATABASE kong OWNER ${KON
 ```
 
 ## 6. Create a secret in AWS Secrets Manager
-Use AWS CLI to create a new secret named `kong-gateway-database` containing the username and password you defined:
+Use the AWS CLI to create a new secret named `kong-gateway-database` containing the username and password you defined:
 ```sh
 aws secretsmanager create-secret --name kong-gateway-database \
  --description "Kong GW Database credentials" \

--- a/app/_how-tos/store-the-gateway-database-credentials-with-aws-secrets-manager.md
+++ b/app/_how-tos/store-the-gateway-database-credentials-with-aws-secrets-manager.md
@@ -25,7 +25,7 @@ tldr:
     a: |
       Create a secret in AWS Secrets Manager with your PostgreSQL credentials, and start {{site.base_gateway}} with the required environment variables:
         - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, and `AWS_REGION` to connect to AWS
-        - `KONG_PG_USER` and ``, where the values are references to your AWS secret
+        - `KONG_PG_USER` and `KONG_PG_PASSWORD`, where the values are references to your AWS secret
       
 prereqs:
   skip_product: true

--- a/app/_how-tos/store-the-gateway-database-credentials-with-aws-secrets-manager.md
+++ b/app/_how-tos/store-the-gateway-database-credentials-with-aws-secrets-manager.md
@@ -28,6 +28,7 @@ tldr:
         - `KONG_PG_USER` and ``, where the values are references to your AWS secret
       
 prereqs:
+  skip_product: true
   inline:
     - title: AWS configuration
       content: |

--- a/app/_how-tos/store-the-gateway-database-credentials-with-aws-secrets-manager.md
+++ b/app/_how-tos/store-the-gateway-database-credentials-with-aws-secrets-manager.md
@@ -112,7 +112,7 @@ docker exec -it kong-database psql -U admin -c "CREATE DATABASE kong OWNER ${KON
 Use AWS CLI to create a new secret named `kong-gateway-database` containing the username and password you defined:
 ```sh
 aws secretsmanager create-secret --name kong-gateway-database \
- --description "Kong GW Database credentials"
+ --description "Kong GW Database credentials" \
  --secret-string '{"pg_user":"'${KONG_PG_USER}'","pg_password":"'${KONG_PG_PASSWORD}'"}'
 ```
 

--- a/app/_how-tos/store-the-gateway-database-credentials-with-aws-secrets-manager.md
+++ b/app/_how-tos/store-the-gateway-database-credentials-with-aws-secrets-manager.md
@@ -41,11 +41,13 @@ prereqs:
           - `secretsmanager:GetSecretValue`
         - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) installed
         
-        You will also need the following authentication information to connect your AWS Secrets Manager with {{site.base_gateway}}:
+        You'll also need the following authentication information to connect your AWS Secrets Manager with {{site.base_gateway}}:
         - Your access key ID
         - Your secret access key
         - Your session token
         - Your AWS region, `us-east-1` in this example
+
+        For this example, you can get [temporary credentials](https://docs.aws.amazon.com/singlesignon/latest/userguide/howtogetcredentials.html) from the AWS portal.
 
         Create environment variables to store these credentials:
         ```sh
@@ -115,7 +117,8 @@ aws secretsmanager create-secret --name kong-gateway-database \
  --secret-string '{"pg_user":"'${KONG_PG_USER}'","pg_password":"'${KONG_PG_PASSWORD}'"}'
 ```
 
-## 7. Run the Kong migrations
+## 7. Initialize the database
+Use the `kong migrations bootstrap` command to initialize the database:
 ```sh
 docker run --rm \
  --network=kong-net \
@@ -144,3 +147,11 @@ docker run -d --name kong-gateway \
  -e KONG_LICENSE_DATA \
  kong/kong-gateway:latest
 ```
+This command returns the ID of the {{site.base_gateway}} container.
+
+## 9. Validate
+To verify that everything worked as expected, you can check its status with this command:
+```sh
+docker container ls
+```
+If the `kong-gateway` container is running, that means it successfully connected to the database using the credentials in the vault.

--- a/app/_how-tos/store-the-gateway-database-credentials-with-aws-secrets-manager.md
+++ b/app/_how-tos/store-the-gateway-database-credentials-with-aws-secrets-manager.md
@@ -44,18 +44,15 @@ prereqs:
         - Your secret access key
         - Your session token
         - Your AWS region, `us-east-1` in this example
-      icon_url: /assets/icons/aws.svg
 
-    - title: Environment variables
-      content: |
-          Set the environment variables needed to authenticate to AWS:
-          ```sh
-          export AWS_ACCESS_KEY_ID=your-aws-access-key-id
-          export AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key
-          export AWS_SESSION_TOKEN=your-aws-session-token
-          export AWS_REGION="us-east-1"
-          ```
-      icon_url: /assets/icons/file.svg
+        Create environment variables to store these credentials:
+        ```sh
+        export AWS_ACCESS_KEY_ID=your-aws-access-key-id
+        export AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key
+        export AWS_SESSION_TOKEN=your-aws-session-token
+        export AWS_REGION="us-east-1"
+        ```
+      icon_url: /assets/icons/aws.svg
 
 cleanup:
   inline:

--- a/app/_how-tos/store-the-gateway-database-credentials-with-aws-secrets-manager.md
+++ b/app/_how-tos/store-the-gateway-database-credentials-with-aws-secrets-manager.md
@@ -1,0 +1,146 @@
+---
+title: Store the {{site.base_gateway}} database credentials with AWS Secrets Manager
+content_type: how_to
+related_resources:
+  - text: Secrets management
+    url: /gateway/secrets-management
+
+products:
+  - gateway
+
+tier: enterprise
+
+works_on:
+  - on-prem
+
+min_version:
+  gateway: '3.4'
+
+tags:
+  - security
+  - secrets-management
+
+tldr:
+    q: How can I connect {{site.base_gateway}} to the database using credentials stored in AWS Secrets Manager?
+    a: |
+      Create a secret in AWS Secrets Manager with your PostgreSQL credentials, and start {{site.base_gateway}} with the required environment variables:
+        - `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, and `AWS_REGION` to connect to AWS
+        - `KONG_PG_USER` and ``, where the values are references to your AWS secret
+      
+prereqs:
+  inline:
+    - title: AWS configuration
+      content: |
+        This tutorial requires: 
+        - An AWS subscription with access to [AWS Secrets Manager](https://docs.aws.amazon.com/secretsmanager/latest/userguide/intro.html) and the following permissions:
+          - `secretsmanager:CreateSecret`
+          - `secretsmanager:PutSecretValue`
+          - `secretsmanager:GetSecretValue`
+        - [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html) installed
+        
+        You will also need the following authentication information to connect your AWS Secrets Manager with {{site.base_gateway}}:
+        - Your access key ID
+        - Your secret access key
+        - Your session token
+        - Your AWS region, `us-east-1` in this example
+      icon_url: /assets/icons/aws.svg
+
+    - title: Environment variables
+      content: |
+          Set the environment variables needed to authenticate to AWS:
+          ```sh
+          export AWS_ACCESS_KEY_ID=your-aws-access-key-id
+          export AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key
+          export AWS_SESSION_TOKEN=your-aws-session-token
+          export AWS_REGION="us-east-1"
+          ```
+      icon_url: /assets/icons/file.svg
+
+cleanup:
+  inline:
+    - title: Clean up AWS resources
+      include_content: cleanup/third-party/aws
+      icon_url: /assets/icons/aws.svg
+    - title: Clean up Konnect environment
+      include_content: cleanup/platform/konnect
+      icon_url: /assets/icons/gateway.svg
+    - title: Destroy the {{site.base_gateway}} container
+      include_content: cleanup/products/gateway
+      icon_url: /assets/icons/gateway.svg 
+---
+
+## 1. Create a Docker network
+```sh
+docker network create kong-net
+```
+The Docker network will be used for communication between {{site.base_gateway}} and the database.
+
+## 2. Run the database
+Create the `kong-database` container for the PostgreSQL database: 
+```sh
+docker run -d --name kong-database \
+ --network=kong-net \
+ -p 5432:5432 \
+ -e "POSTGRES_USER=admin" \
+ -e "POSTGRES_PASSWORD=password" \
+ postgres:9.6
+```
+The username and password specified in this command are the PostgreSQL master credentials.
+
+## 3. Create environment variables
+Define the username and password to use to connect {{site.base_gateway}} to the database and store them in environment variables.
+```sh
+export KONG_PG_USER=kong
+export KONG_PG_PASSWORD=KongFTW
+```
+
+## 4. Create a database user
+Create a user in the PostgreSQL container, using the credentials defined in the previous step:
+```sh
+docker exec -it kong-database psql -U admin -c \
+ "CREATE USER ${KONG_PG_USER} WITH PASSWORD '${KONG_PG_PASSWORD}'"
+```
+
+## 5. Create a database
+Create a database named `kong`, with the user you created as the owner:
+```sh
+docker exec -it kong-database psql -U admin -c "CREATE DATABASE kong OWNER ${KONG_PG_USER};"
+```
+
+## 6. Create a secret in AWS Secrets Manager
+Use AWS CLI to create a new secret named `kong-gateway-database` containing the username and password you defined:
+```sh
+aws secretsmanager create-secret --name kong-gateway-database \
+ --description "Kong GW Database credentials"
+ --secret-string '{"pg_user":"'${KONG_PG_USER}'","pg_password":"'${KONG_PG_PASSWORD}'"}'
+```
+
+## 7. Run the Kong migrations
+```sh
+docker run --rm \
+ --network=kong-net \
+ -e "KONG_DATABASE=postgres" \
+ -e "KONG_PG_HOST=kong-database" \
+ -e KONG_PG_USER \
+ -e KONG_PG_PASSWORD \
+ kong/kong-gateway:latest kong migrations bootstrap
+```
+{:.note}
+> Note: `kong migrations` does not support secrets managements, so this step passes the database credentials with environment variables.
+
+## 8. Start {{site.base_gateway}}
+Create the {{site.base_gateway}} container with your AWS credentials and the vault references in the environment:
+```sh
+docker run -d --name kong-gateway \
+ --network=kong-net \
+ -e "KONG_DATABASE=postgres" \
+ -e "KONG_PG_HOST=kong-database" \
+ -e AWS_ACCESS_KEY_ID \
+ -e AWS_SECRET_ACCESS_KEY \
+ -e AWS_REGION \
+ -e AWS_SESSION_TOKEN \
+ -e "KONG_PG_USER={vault://aws/kong-gateway-database/pg_user}" \
+ -e "KONG_PG_PASSWORD={vault://aws/kong-gateway-database/pg_password}" \
+ -e KONG_LICENSE_DATA \
+ kong/kong-gateway:latest
+```

--- a/app/_how-tos/store-the-gateway-database-credentials-with-aws-secrets-manager.md
+++ b/app/_how-tos/store-the-gateway-database-credentials-with-aws-secrets-manager.md
@@ -4,8 +4,8 @@ content_type: how_to
 related_resources:
   - text: Secrets management
     url: /gateway/secrets-management/
- - text: Configure AWS Secrets Manager as a vault backend using the Vault entity
-   url: /how-to/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity/
+  - text: Configure AWS Secrets Manager as a vault backend using the Vault entity
+    url: /how-to/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity/
 
 products:
   - gateway

--- a/app/_includes/components/prereqs.html
+++ b/app/_includes/components/prereqs.html
@@ -1,31 +1,35 @@
 <div class="flex flex-col accordion prerequisites" data-default="0" data-multiple="false" data-test-id="prereqs">
-  {% if page.products %}
-    {% assign inline_before = prereqs.inline | where: "position", "before" %}
-    {% for prereq in inline_before %}
-    <div class="flex flex-col gap-1.5 border-b border-primary/5 accordion-item last:border-b-0">
-  {% include prereqs/inline.md prereq=prereq %}
-    </div>
-    {% endfor %}
+    {% unless prereqs.skip_product == true %}
+  
+    {% if page.products %}
+      {% assign inline_before = prereqs.inline | where: "position", "before" %}
+      {% for prereq in inline_before %}
+      <div class="flex flex-col gap-1.5 border-b border-primary/5 accordion-item last:border-b-0">
+    {% include prereqs/inline.md prereq=prereq %}
+      </div>
+      {% endfor %}
 
-    {% if page.products contains 'gateway' %}
-      {% if page.works_on contains 'konnect' %}
-      <div class="flex flex-col gap-1.5 border-b border-primary/5 accordion-item  last:border-b-0" data-deployment-topology="konnect" data-test-setup="konnect">
-        {% include prereqs/products/konnect.md tier=include.tier %}
-      </div>
+      {% if page.products contains 'gateway' %}
+        {% if page.works_on contains 'konnect' %}
+        <div class="flex flex-col gap-1.5 border-b border-primary/5 accordion-item  last:border-b-0" data-deployment-topology="konnect" data-test-setup="konnect">
+          {% include prereqs/products/konnect.md tier=include.tier %}
+        </div>
+        {% endif %}
+        <div class="flex flex-col gap-1.5 border-b border-primary/5 accordion-item  last:border-b-0" data-deployment-topology="on-prem" data-test-setup='{ "gateway": "{{page.min_version.gateway}}" }'>
+          {% assign variables=prereqs['gateway'] %}
+          {% include prereqs/products/gateway.md tier=include.tier rbac=page.rbac env_variables=variables %}
+        </div>
       {% endif %}
-      <div class="flex flex-col gap-1.5 border-b border-primary/5 accordion-item  last:border-b-0" data-deployment-topology="on-prem" data-test-setup='{ "gateway": "{{page.min_version.gateway}}" }'>
-        {% assign variables=prereqs['gateway'] %}
-        {% include prereqs/products/gateway.md tier=include.tier rbac=page.rbac env_variables=variables %}
-      </div>
+
+      {% for product in prereqs.products %}
+          <div class="flex flex-col gap-1.5 border-b border-primary/5 accordion-item  last:border-b-0">
+  {% assign product_include = 'prereqs/products/' | append: product | append: '.md' %}
+  {% include {{ product_include }} tier=include.tier %}
+          </div>
+      {% endfor %}
     {% endif %}
 
-    {% for product in prereqs.products %}
-        <div class="flex flex-col gap-1.5 border-b border-primary/5 accordion-item  last:border-b-0">
-{% assign product_include = 'prereqs/products/' | append: product | append: '.md' %}
-{% include {{ product_include }} tier=include.tier %}
-        </div>
-    {% endfor %}
-  {% endif %}
+  {% endunless %}
 
   {% for tool in prereqs.tools %}
   {% assign tool_include = 'prereqs/tools/' | append: tool | append: '.md' %}

--- a/tools/track-docs-changes/config/sources.yml
+++ b/tools/track-docs-changes/config/sources.yml
@@ -143,6 +143,8 @@ app/_how-tos/enable-rbac-with-admin-api.md:
   - app/konnect/dev-portal/access-and-approval/manage-teams.md
 app/_how-tos/store-secrets-in-konnect-config-store.md:
   - app/konnect/gateway-manager/configuration/config-store.md
+app/_how-tos/store-the-gateway-database-credentials-with-aws-secrets-manager.md:
+  - app/_src/gateway/kong-enterprise/secrets-management/how-to/aws-secrets-manager.md
 
 # plugins
 app/_kong_plugins/ai-rate-limiting-advanced/index.md:


### PR DESCRIPTION
## Description

Fixes #269 

## Note to reviewers

If you want to avoid creating a secret in AWS, I left the `kong-gateway-database` secret I used for testing. If you want to create one, make sure to change the name of the secret in the commands.
You can get temporary credentials by signing in to AWS and clicking Access keys on the AWS access portal.

## Preview Links

https://deploy-preview-348--kongdeveloper.netlify.app/how-to/store-the-gateway-database-credentials-with-aws-secrets-manager/

## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
