### PR TITLE
chore: Tools stub pages

### DIFF
--- a/app/_landing_pages/admin-api.yaml
+++ b/app/_landing_pages/admin-api.yaml
@@ -1,0 +1,18 @@
+metadata:
+  title: Kong Admin API
+  content_type: landing_page
+  description: This page is an introduction to the {{site.base_gateway}} Admin API.
+
+rows:
+  - header:
+      type: h1
+      text: "Kong Admin API"
+
+  - header:
+      type: h2
+      text: What is the Kong Admin API?
+    columns:
+    - blocks:
+        - type: text
+          config: |
+            @todo

--- a/app/_landing_pages/deck.yaml
+++ b/app/_landing_pages/deck.yaml
@@ -22,8 +22,8 @@ rows:
             This enables developers and operations teams to manage APIs from development through deployment, 
             ensuring consistency, reliability, and speed in API integrations.
 
-            decK is one of the many tools you can use to manage {{site.base_gateway}} and Konnect. To learn about other tools, 
-            review our [tools page](/references/).
+            decK is one of the many tools you can use to manage {{site.base_gateway}} and {{site.konnect_short_name}}. To learn about other tools, 
+            review our [tools page](/tools/).
 
   - header:
       type: h2
@@ -48,10 +48,10 @@ rows:
         - type: text
           config:
             decK is a tool that works with state files, which describe the configuration of {{site.base_gateway}}. These state files store {{site.base_gateway}}'s configuration in a clear, declarative format, allowing you to manage services, routes, plugins, consumers, and other entities that define how requests are processed and routed through the Gateway.
-            decK communicates with Kong Gateways via the [Admin API](/api/gateway/admin-ee/). 
+            decK communicates with {{site.base_gateway}} via the [Admin API](/api/gateway/admin-ee/). 
         - type: text
           config:
-            decK is one of several [tools](/references/) available for managing {{site.base_gateway}}.
+            decK is one of several [tools](/tools/) available for managing {{site.base_gateway}}.
 
       - header:
           type: h2
@@ -62,10 +62,10 @@ rows:
               blocks:
               - type: unordered_list
                 items:
-                    - "**[Terraform](https://docs.konghq.com/konnect/reference/terraform/)**: Manage infrastructure as code and automated deployments to streamline setup and configuration of Konnect and {{site.base_gateway}}"
-                    - "**[KIC](https://docs.konghq.com/kubernetes-ingress-controller/latest/)**: Manage ingress traffic and routing rules for your services"
+                    - "**[Terraform](/terraform/)**: Manage infrastructure as code and automated deployments to streamline setup and configuration of {{site.konnect_short_name}} and {{site.base_gateway}}"
+                    - "**[KIC](/kic/)**: Manage ingress traffic and routing rules for your services"
                     - "**[{{site.base_gateway}} Admin API](/api/gateway/admin-ee/)**: Manage on-prem {{site.base_gateway}} entities via an API"
-                    - "**[Control Plane Config API](/api/konnect/control-planes-config/)**: Manage {{site.base_gateway}} entities within Konnect control planes via an API"
+                    - "**[Control Plane Config API](/api/konnect/control-planes-config/)**: Manage {{site.base_gateway}} entities within {{site.konnect_short_name}} control planes via an API"
 
   - header:
       text: "What can decK do?"
@@ -133,10 +133,10 @@ rows:
                         - gateway
                         - validate
                 - text: |
-                    Sync Gateway configs to Konnect
+                    Sync Gateway configs to {{site.konnect_short_name}}
 
-                    _Tip: You can add Konnect flags to any deck command
-                    to target a Konnect control plane instead of a self-managed {{site.base_gateway}}._
+                    _Tip: You can add {{site.konnect_short_name}} flags to any deck command
+                    to target a {{site.konnect_short_name}} control plane instead of a self-managed {{site.base_gateway}}._
 
                   action:
                     type: command
@@ -195,16 +195,16 @@ rows:
     - blocks:
       - type: card
         config:
-          title: Entities Managed by decK
+          title: Entities managed by decK
           description: decK manages entity configuration for {{site.base_gateway}}, including all core proxy entities
           cta:
-            text: decK Entities &rarr;
-            url: https://docs.konghq.com/deck/latest/reference/entities/
+            text: decK entities &rarr;
+            url: /deck/managed-entities/
             align: end
     - blocks:
       - type: card
         config:
-          title: Best Practices
+          title: Best practices
           description: Learn about recommended approaches for using decK and avoid common pitfalls
           cta:
             text: Best practices &rarr;
@@ -216,7 +216,7 @@ rows:
           title: Changelog
           description: Running list of release notes for decK
           cta:
-            text: decK Changelog &rarr;
+            text: decK changelog &rarr;
             url: https://github.com/kong/deck/blob/main/CHANGELOG.md/
             align: end
 
@@ -228,52 +228,68 @@ rows:
       - blocks:
         - type: faqs
           config:
-            - q: I use Terraform to configure Kong, why should I care about decK?
+            - q: I use Terraform to configure {{site.base_gateway}}, why should I care about decK?
               a: |
                 If you are using Terraform and are happy with it, you should continue to use it. decK covers all the problems that Terraform solves and goes beyond it:
 
                 * With Terraform, you have to track and maintain Terraform files (*.tf) and the Terraform state (likely using a cloud storage solution). With decK, the entire configuration is stored in the YAML/JSON file(s) only. There is no separate state that needs to be tracked.
-                * decK can export and back up your existing Kong’s configuration, meaning, you can take an existing Kong installation, and have a backup, as well as a declarative configuration for it. With Terraform, you will have to import each and every entity in Kong into Terraform’s state.
+                * decK can export and back up your existing {{site.base_gateway}}'s configuration, meaning, you can take an existing {{site.base_gateway}} installation, and have a backup, as well as a declarative configuration for it. With Terraform, you will have to import each and every entity in {{site.base_gateway}} into Terraform’s state.
                 * decK can check if a configuration file is valid or not (validate sub-command).
-                * decK can quickly reset your Kong’s configuration when needed.
+                * decK can quickly reset your {{site.base_gateway}}'s configuration when needed.
                 * decK works out of the box with {{site.base_gateway}} features like Workspaces and RBAC.
             - q: Can I run multiple decK processes at the same time?
               a: |
-                The two processes will step on each other and might corrupt Kong’s configuration. You should ensure that there is only one instance of decK running at any point in time.
-            - q: Kong already has built-in declarative configuration, do I still need decK?
+                The two processes will step on each other and might corrupt {{site.base_gateway}}'s configuration. You should ensure that there is only one instance of decK running at any point in time.
+            - q: |
+               {{site.base_gateway}} already has built-in declarative configuration, do I still need decK?
               a: |
-                Kong has an official declarative configuration format.
+                {{site.base_gateway}} has an official declarative configuration format. {{site.base_gateway}} can generate such a file with the `kong config db_export` command, 
+                which exports most of {{site.base_gateway}}'s database into a file.
 
-                Kong can generate such a file with the kong config db_export command, which dumps almost the entire database of Kong into a file.
+                You can use a file in this format to configure {{site.base_gateway}} when it is running in a DB-less or in-memory mode. 
+                If you're using {{site.base_gateway}} in DB-less mode, you can't use decK for any sync, dump, or similar operations, as they require write access to the Admin API.
 
-                You can use a file in this format to configure Kong when it is running in a DB-less or in-memory mode. If you’re using Kong in DB-less mode, you can’t use decK for any sync, dump, or similar operations, as they require write access to the Admin API.
+                If you are using {{site.base_gateway}} alongside a database, you need decK because:
 
-                If you are using Kong alongside a database, you need decK because:
+                * {{site.base_gateway}}'s `kong config db_import` command isn't sufficient in the following situations:
+                  * The command is used to initialize a {{site.base_gateway}} database, 
+                  but we don't recommended using it if there are existing {{site.base_gateway}} nodes running, 
+                  as the cache in these nodes won't be invalidated when entities are changed or added. 
+                  In that case, you would need to manually restart all existing {{site.base_gateway}} nodes. 
+                  decK performs all the changes via Kong's Admin API, meaning the changes are always propagated to all nodes.
+                  * The command can only add and update entities in the database. 
+                    It won't remove the entities that are present in the database but aren't present in the configuration file.
+                  * The command needs direct access to {{site.base_gateway}}'s database, which may not be possible in your production networking environment.
+                * decK can easily perform detect drifts in configuration. 
+                For example, it can verify if the configuration stored inside {{site.base_gateway}}'s database and the configuration inside the config file is the same. 
+                This feature is designed for integrating decK with a CI system or a cronjob which periodically checks for drifts and alerts a team if needed.
+                * `deck gateway dump` outputs a more human-readable configuration file compared to {{site.base_gateway}}'s `db_import`.
+                
+                However, decK has the following limitations which may affect your use case:
 
-                * Kong’s kong config db_import command is used to initialize a Kong database, but it is not recommended to use it if there are existing Kong nodes that are running, as the cache in these nodes will not be invalidated when entities are changed/added. You will need to manually restart all existing Kong nodes. decK performs all the changes via Kong’s Admin API, meaning the changes are always propagated to all nodes.
-                * Kong’s kong config db_import can only add and update entities in the database. It will not remove the entities that are present in the database but are not present in the configuration file.
-                * Kong’s kong config db_import command needs direct access to Kong’s database, which might or might not be possible in your production networking environment.
-                * decK can easily perform detect drifts in configuration. For example, it can verify if the configuration stored inside Kong’s database and that inside the config file is the same. This feature is designed in decK to integrate decK with a CI system or a cronjob which periodically checks for drifts and alerts a team if needed.
-                * deck dump or deck gateway dump outputs a more human-readable configuration file compared to Kong’s db_import.
-                However, decK has the following limitations which might or might not affect your use case:
-
-                If you have a very large installation, it can take some time for decK to sync up the configuration to Kong. This can be mitigated by adopting distributed configuration for your Kong installation and tweaking the --parallelism value. Kong’s db_import will usually be faster by orders of magnitude.
-                decK cannot export and re-import fields that are hashed in the database. This means fields like password of basic-auth credential cannot be correctly re-imported by decK. This happens because Kong’s Admin API call to sync the configuration will re-hash the already hashed password.
-            - q: I’m a {{site.base_gateway}} user, can I use decK?
+                * If you have a very large installation, it can take some time for decK to sync up the configuration to {{site.base_gateway}}. 
+                This can be mitigated by adopting distributed configuration for your {{site.base_gateway}} installation and tweaking the `--parallelism` value. 
+                {{site.base_gateway}}`s `db_import` will usually be faster by orders of magnitude.
+                * decK can't export and re-import fields that are hashed in the database. 
+                This means that fields like the password of the `basic-auth` credential can't be correctly re-imported by decK. This 
+                happens because {{site.base_gateway}}'s Admin API call to sync the configuration will rehash the already hashed password.
+            - q: I'm a {{site.base_gateway}} user, can I use decK?
               a: |
-                decK is designed to be compatible with open-source and enterprise versions of Kong.
-            - q: I'm a Konnect user, can I use decK?
+                decK is designed to be compatible with open-source and enterprise versions of {{site.base_gateway}}.
+            - q: I'm a {{site.konnect_short_name}} user, can I use decK?
               a: |
-                Yes, decK is compatible with Konnect. We recommend upgrading to decK 1.12 to take advantage of the new --konnect CLI flags.
-            - q: I use Cassandra as a data store for Kong, can I use decK?
+                Yes, decK is compatible with {{site.konnect_short_name}}. 
+                
+                {{site.konnect_short_name}} requires decK v1.40.0 or above. Versions below this will see inconsistent `deck gateway diff` and `sync` results.
+            - q: I use Cassandra as a data store for {{site.base_gateway}}, can I use decK?
               a: |
-                As of {{site.base_gateway}} 3.4, you can’t use Cassandra as a data store, as it is longer supported by Kong.
-                You can use decK with earlier versions of Kong backed by Cassandra. However, if you observe errors during a sync process, you will have to tweak decK’s settings and make a few adjustments.
+                As of {{site.base_gateway}} 3.4, you can't use Cassandra as a data store, as it is longer supported by {{site.base_gateway}}.
+                You can use decK with earlier versions of {{site.base_gateway}} backed by Cassandra. However, if you observe errors during a sync process, you will have to tweak decK's settings and make a few adjustments.
 
                 decK heavily parallelizes its operations, which can induce a lot of load onto your Cassandra cluster. You should consider:
 
                 * decK is read-intensive for most parts, meaning it will perform read-intensive queries on your Cassandra cluster, so make sure you tune your Cassandra cluster accordingly.
-                * decK talks to the same Kong node that talks to the same Cassandra node in your cluster.
+                * decK talks to the same {{site.base_gateway}} node that talks to the same Cassandra node in your cluster.
                 Use the `--parallelism 1` flag to ensure that there is only request being processed at a time. This will slow down sync process and should be used as a last resort.
             - q: Is there a JSON Schema for decK?
               a:  |
@@ -300,7 +316,7 @@ rows:
                 * `GET, POST, PATCH, PUT, DELETE /{entityType}` or `GET, POST, PATCH, PUT, DELETE /{workspace}/{entityType}`: Perform read and write operations on entities.
 
                   If you are running {{site.ee_product_name}}, then decK interacts with entities inside workspaces.
-                  See the [Entities managed by decK](https://docs.konghq.com/deck/latest/reference/entities/) reference for the full list.
+                  See the [Entities managed by decK](/deck/managed-entities/) reference for the full list.
 
                   Note that decK also performs operations on entities enabled by plugins, such as `/basic-auths`, `/jwts`, and so on.
                 * `GET /`: Get the {{site.base_gateway}} version.

--- a/app/_landing_pages/kic.yaml
+++ b/app/_landing_pages/kic.yaml
@@ -1,0 +1,18 @@
+metadata:
+  title: "{{site.kic_product_name}}"
+  content_type: landing_page
+  description: This page is an introduction to the {{site.kic_product_name}}.
+
+rows:
+  - header:
+      type: h1
+      text: "{{site.kic_product_name}} (KIC)"
+
+  - header:
+      type: h2
+      text: What is the {{site.kic_product_name}}?
+    columns:
+    - blocks:
+        - type: text
+          config: |
+            @todo

--- a/app/_landing_pages/konnect-api.yaml
+++ b/app/_landing_pages/konnect-api.yaml
@@ -1,0 +1,18 @@
+metadata:
+  title: "{{site.konnect_short_name}} APIs"
+  content_type: landing_page
+  description: This page is an introduction to the {{site.konnect_short_name}} APIs.
+
+rows:
+  - header:
+      type: h1
+      text: "{{site.konnect_short_name}} APIs"
+
+  - header:
+      type: h2
+      text: What are the {{site.konnect_short_name}} APIs?
+    columns:
+    - blocks:
+        - type: text
+          config: |
+            @todo

--- a/app/_landing_pages/terraform.yaml
+++ b/app/_landing_pages/terraform.yaml
@@ -1,0 +1,18 @@
+metadata:
+  title: Terraform providers for Kong
+  content_type: landing_page
+  description: This page is an introduction to the Terraform providers for {{site.base_gateway}} and {{site.konnect_short_name}}.
+
+rows:
+  - header:
+      type: h1
+      text: "Terraform providers for Kong"
+
+  - header:
+      type: h2
+      text: What is Terraform?
+    columns:
+    - blocks:
+        - type: text
+          config: |
+            @todo

--- a/app/_landing_pages/tools.yaml
+++ b/app/_landing_pages/tools.yaml
@@ -1,0 +1,66 @@
+metadata:
+  title: "Tools for managing {{site.konnect_short_name}} and {{site.base_gateway}}"
+  content_type: landing_page
+  description: An introduction to the common tools for managing {{site.base_gateway}} and {{site.konnect_short_name}}.
+
+rows:
+  - header:
+      type: h1
+      text: "Tools for managing {{site.konnect_short_name}} and {{site.base_gateway}}"
+
+  - header:
+      type: h2
+      text: Tools
+    columns:
+      - blocks:
+        - type: card
+          config:
+            title: decK
+            description: |
+              decK is a command line tool that facilitates API Lifecycle Automation (APIOps) by offering a comprehensive toolkit of 
+              commands designed to orchestrate and automate the entire process of API delivery.
+            cta:
+              text: 
+              url: /deck/
+              align: end
+      - blocks:
+        - type: card
+          config:
+            title: "{{site.konnect_short_name}} APIs"
+            description: |
+              Use the {{site.konnect_short_name}} APIs to manage your ecosystem, including {{site.base_gateway}} configuration management, Analytics, Dev Portal, and more.
+            cta:
+              text: 
+              url: /konnect-api/
+              align: end
+      - blocks:
+        - type: card
+          config:
+            title: Kong Admin API
+            description: |
+              {{site.base_gateway}} comes with an internal RESTful API for administration purposes. 
+              This API comes in two options: open-source and Enterprise.
+            cta:
+              text: 
+              url: /admin-api/
+              align: end
+      - blocks:
+        - type: card
+          config:
+            title: "{{site.kic_product_name}}"
+            description: |
+              {{site.kic_product_name}} allows you to run {{site.base_gateway}} as a Kubernetes Ingress to handle inbound requests for a Kubernetes cluster.
+            cta:
+              text: 
+              url: /konnect-api/
+              align: end
+      - blocks:
+        - type: card
+          config:
+            title: "Terraform providers for Kong"
+            description: |
+              Kong offers two Terraform providers: one for managing {{site.base_gateway}} in {{site.konnect_short_name}}, and one for managing {{site.base_gateway}} on-prem.
+            cta:
+              text: 
+              url: /konnect-api/
+              align: end

--- a/app/_landing_pages/tools.yaml
+++ b/app/_landing_pages/tools.yaml
@@ -52,7 +52,7 @@ rows:
               {{site.kic_product_name}} allows you to run {{site.base_gateway}} as a Kubernetes Ingress to handle inbound requests for a Kubernetes cluster.
             cta:
               text: 
-              url: /konnect-api/
+              url: /kic/
               align: end
       - blocks:
         - type: card
@@ -62,5 +62,5 @@ rows:
               Kong offers two Terraform providers: one for managing {{site.base_gateway}} in {{site.konnect_short_name}}, and one for managing {{site.base_gateway}} on-prem.
             cta:
               text: 
-              url: /konnect-api/
+              url: /terraform/
               align: end


### PR DESCRIPTION
## Description

Tools stub pages to stop link checker from failing.

## Preview Links

https://deploy-preview-355--kongdeveloper.netlify.app/tools/


## Checklist 

- [x] Every page is page one.
- [ N/A ] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [ N/A ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ N/A ] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
