### PR TITLE
Simplify Konnect decK steps

### DIFF
--- a/app/_includes/components/entity_examples.html
+++ b/app/_includes/components/entity_examples.html
@@ -2,16 +2,5 @@
 echo '
 _format_version: "3.0"
 {{ entity_examples.data }}
-' | deck gateway apply - \
-  --konnect-token $KONNECT_TOKEN \
-  --konnect-control-plane-name $KONNECT_CP_NAME
-```
-{: data-file="kong.yaml" data-deployment-topology="konnect" data-test-step="block" }
-
-```yaml
-echo '
-_format_version: "3.0"
-{{ entity_examples.data }}
 ' | deck gateway apply -
 ```
-{: data-file="kong.yaml" data-deployment-topology="on-prem" data-test-step="block" }

--- a/app/_includes/how-tos/steps/apply_config.md
+++ b/app/_includes/how-tos/steps/apply_config.md
@@ -7,14 +7,6 @@ First, compare the decK file or files to the state of the {{site.base_gateway}}:
 ```bash
 deck gateway diff deck_files
 ```
-{: data-deployment-topology="on-prem" data-test-step="block" }
-
-```bash
-deck gateway diff deck_files \
-  --konnect-token ${{konnect_token}} \
-  --konnect-control-plane-name $KONNECT_CP_NAME
-```
-{: data-deployment-topology="konnect" data-test-step="block" }
 
 The output shows you which entities will change if you sync the state files.
 
@@ -23,10 +15,3 @@ If everything looks right, synchronize them to update your Gateway configuration
 ```bash
 deck gateway sync deck_files
 ```
-{: data-deployment-topology="on-prem"  data-test-step="block" }
-```bash
-deck gateway sync deck_files \
-  --konnect-token ${{konnect_token}} \
-  --konnect-control-plane-name $KONNECT_CP_NAME
-```
-{: data-deployment-topology="konnect" data-test-step="block" }

--- a/app/_includes/how-tos/steps/ping-gateway.md
+++ b/app/_includes/how-tos/steps/ping-gateway.md
@@ -5,13 +5,6 @@ We'll be using decK for this tutorial, so let's check that {{site.base_gateway}}
 ```sh
 deck gateway ping
 ```
-{: data-deployment-topology="on-prem" }
-```bash
-deck gateway ping \
-  --konnect-token ${{konnect_token}} \
-  --konnect-control-plane-name $KONNECT_CP_NAME
-```
-{: data-deployment-topology="konnect" }
 
 If everything is running, then you should get the following response:
 

--- a/app/_includes/prereqs/entities.md
+++ b/app/_includes/prereqs/entities.md
@@ -11,19 +11,8 @@ For this tutorial, you'll need {{site.base_gateway}} entities, like Gateway Serv
 ```yaml
 echo '
 {{ include.data }}
-' | deck gateway apply - \
-  --konnect-token $KONNECT_TOKEN \
-  --konnect-control-plane-name $KONNECT_CP_NAME
-```
-{: data-file="prereqs.yaml" data-deployment-topology="konnect" data-test-prereqs="block"}
-
-```yaml
-echo '
-{{ include.data }}
 ' | deck gateway apply -
 ```
-{: data-file="prereqs.yaml" data-deployment-topology="on-prem" data-test-prereqs="block"}
-
 {% endcapture %}
 {{ entities | indent: 3 }}
 

--- a/app/_includes/prereqs/products/konnect.md
+++ b/app/_includes/prereqs/products/konnect.md
@@ -14,8 +14,8 @@ If you don't have a Konnect account, you can get started quickly with our [onboa
 2. Set the personal access token, the Control Plane Name and the Konnect proxy URL as environment variables:
 
     ```sh
-    export KONNECT_TOKEN=your-token
-    export KONNECT_CP_NAME=your-control-plane-name
+    export DECK_KONNECT_TOKEN=your-token
+    export DECK_KONNECT_CONTROL_PLANE_NAME=your-control-plane-name
     export KONNECT_PROXY_URL=konnect-proxy-url
     ```
 


### PR DESCRIPTION
## Description

The `--konnect-X` flags can be replaced with `DECK_KONNECT_X` environment vars. This allows us to keep `deck` commands consistent across Konnect and on-prem

## Preview Links

/how-to/add-rate-limiting-for-a-consumer-with-kong-gateway/
