### PR TITLE
Vault entity fix: Add table with values that can be stored as secrets

### DIFF
--- a/.github/styles/base/Dictionary.txt
+++ b/.github/styles/base/Dictionary.txt
@@ -394,6 +394,7 @@ firstTimestamp
 flamegraph
 foogineer
 full_name
+gcp
 geo
 geos
 getter
@@ -416,6 +417,7 @@ hackathons
 hardcoded
 hardcoding
 hashicorp
+hcv
 header_filter
 headmatter
 healthcheck

--- a/app/_gateway_entities/vault.md
+++ b/app/_gateway_entities/vault.md
@@ -154,7 +154,7 @@ features:
     gcp: true
     aws: true
     azure: true
-  - title: Kong Gateway license<sup>2</sup>
+  - title: {{site.base_gateway}} license<sup>2</sup>
     url: /gateway/entities/license/
     konnect: false
     env: true

--- a/app/_gateway_entities/vault.md
+++ b/app/_gateway_entities/vault.md
@@ -47,13 +47,6 @@ declarative configuration files, logs, or the UI.
 
 For example, you could store a certificate and a key in a Vault, then reference them from a [Certificate entity](/gateway/entities/certificate/). This way, the certificate and key are not stored in the entity directly and are more secure.
 
-Some of the most common types of secrets used by {{site.base_gateway}} include:
-
-* Data store usernames and passwords, used with PostgreSQL and Redis
-* Private X.509 certificates
-* API keys
-* Sensitive configuration fields, generally used for authentication, hashing, signing, or encryption
-
 ## How do I add secrets to a Vault?
 
 You can add secrets to Vaults in one of the following ways:
@@ -63,7 +56,7 @@ You can add secrets to Vaults in one of the following ways:
 
 ## What can be stored as a secret?
 
-You can store and reference the following fields as secrets in a Vault:
+You can store and reference the following as secrets in a Vault:
 
 * All [`kong.conf` values](/gateway/manage-kong-conf/)<sup>1</sup>. For example:
   * Data store usernames and passwords, used with PostgreSQL and Redis

--- a/app/_gateway_entities/vault.md
+++ b/app/_gateway_entities/vault.md
@@ -116,6 +116,9 @@ features:
 
 When you want to use a secret stored in a Vault, you can reference the secret with a `vault` reference. You can use the `vault` reference in places such as `kong.conf`, declarative configuration files, logs, or in the UI.
 
+{:.info}
+> **Note:** You can't reference secrets stored in a [{{site.konnect_short_name}} Config Store](/how-to/configure-the-konnect-config-store/) Vault in `kong.conf` because {{site.konnect_short_name}} resolves the secret before connecting to {{site.base_gateway}}. 
+
 The Vault backend may store multiple related secrets inside an object, but the reference
 should always point to a key that resolves to a string value. For example, the following reference:
 

--- a/app/_gateway_entities/vault.md
+++ b/app/_gateway_entities/vault.md
@@ -61,13 +61,33 @@ You can add secrets to Vaults in one of the following ways:
 * {{site.konnect_short_name}} Config Store
 * Supported third-party backend vault
 
-## How do I configure access to a Vault?
+## What can be stored as a secret?
+
+You can store and reference the following fields as secrets in a Vault:
+
+* All [`kong.conf` values](/gateway/manage-kong-conf/)<sup>1</sup>. For example:
+  * Data store usernames and passwords, used with PostgreSQL and Redis
+  * Private X.509 certificates
+* Certificates and keys stored in the [Certificate {{site.base_gateway}} entity](/gateway/entities/certificate/)
+* [{{site.base_gateway}} license](/gateway/entities/license/)<sup>2</sup>
+* Referenceable plugin fields, such as third-party API keys (see table below for all values)
+
+{:.info}
+> **{{site.konnect_short_name}} Config Store limitations:**
+> * <sup>1</sup>: You can't reference secrets stored in a [{{site.konnect_short_name}} Config Store](/how-to/configure-the-konnect-config-store/) Vault in `kong.conf` because {{site.konnect_short_name}} resolves the secret after {{site.base_gateway}} connects to the control plane.
+> * <sup>2</sup>: In Konnect, the {{site.base_gateway}} license is managed and stored by {{site.konnect_short_name}}, and doesn't need to be stored manually in any Vault.
+
+### Referenceable plugin fields
+
+The following plugin fields can be stored and referenced as secrets:
+
+{% referenceable_fields %}
+
+## Supported Vault backends
 
 Each vault has its own required configuration. You can provide this configuration by creating a Vault entity, or by configuring specific environment variables before starting {{ site.base_gateway }}.
 
 For more information, choose a Vault below to see the specific configuration required.
-
-## Supported backends
 
 {% feature_table %}
 item_title: Backend
@@ -111,74 +131,6 @@ features:
     enterprise: true
     supports_konnect: true
 {% endfeature_table %}
-
-## What can be stored as a secret?
-
-You can store and reference the following fields as secrets in a Vault:
-
-{% feature_table %}
-item_title: Field type
-columns:
-  - title: {{site.konnect_short_name}} Config Store
-    key: konnect
-  - title: Env variable vault
-    key: env
-  - title: HashiCorp Vault
-    key: hcv
-  - title: Google Cloud
-    key: gcp
-  - title: AWS
-    key: aws
-  - title: Azure
-    key: azure
-
-features:
-  - title: |
-      All `kong.conf` values<sup>1</sup>
-
-      For example:
-      * Data store usernames and passwords, used with PostgreSQL and Redis
-      * Private X.509 certificates
-    url: /gateway/manage-kong-conf/
-    konnect: false
-    env: true
-    hcv: true
-    gcp: true
-    aws: true
-    azure: true
-  - title: Certificates and keys stored in the Certificate Gateway entity
-    url: /gateway/entities/certificate/
-    konnect: true
-    env: true
-    hcv: true
-    gcp: true
-    aws: true
-    azure: true
-  - title: {{site.base_gateway}} license<sup>2</sup>
-    url: /gateway/entities/license/
-    konnect: false
-    env: true
-    hcv: true
-    gcp: true
-    aws: true
-    azure: true
-  - title: Referenceable plugin fields, such as third-party API keys (see table below for all values)
-    konnect: true
-    env: true
-    hcv: true
-    gcp: true
-    aws: true
-    azure: true
-{% endfeature_table %}
-
-{:.info}
-> **Notes:**
-> * <sup>1</sup>: You can't reference secrets stored in a [{{site.konnect_short_name}} Config Store](/how-to/configure-the-konnect-config-store/) Vault in `kong.conf` because {{site.konnect_short_name}} resolves the secret after {{site.base_gateway}} connects to the control plane.
-> * <sup>2</sup>: In Konnect, the {{site.base_gateway}} license is managed and stored by {{site.konnect_short_name}}, and doesn't need to be stored manually in any Vault.
-
-The following plugin fields can be stored and referenced as secrets:
-
-{% referenceable_fields %}
 
 ## How do I reference secrets stored in a Vault?
 

--- a/app/_gateway_entities/vault.md
+++ b/app/_gateway_entities/vault.md
@@ -112,12 +112,77 @@ features:
     supports_konnect: true
 {% endfeature_table %}
 
+## What can be stored as a secret?
+
+You can store and reference the following fields as secrets in a Vault:
+
+{% feature_table %}
+item_title: Field type
+columns:
+  - title: {{site.konnect_short_name}} Config Store
+    key: konnect
+  - title: Env variable vault
+    key: env
+  - title: HashiCorp Vault
+    key: hcv
+  - title: Google Cloud
+    key: gcp
+  - title: AWS
+    key: aws
+  - title: Azure
+    key: azure
+
+features:
+  - title: |
+      All `kong.conf` values<sup>1</sup>
+
+      For example:
+      * Data store usernames and passwords, used with PostgreSQL and Redis
+      * Private X.509 certificates
+    url: /gateway/manage-kong-conf/
+    konnect: false
+    env: true
+    hcv: true
+    gcp: true
+    aws: true
+    azure: true
+  - title: Certificates and keys stored in the Certificate Gateway entity
+    url: /gateway/entities/certificate/
+    konnect: true
+    env: true
+    hcv: true
+    gcp: true
+    aws: true
+    azure: true
+  - title: Kong Gateway license<sup>2</sup>
+    url: /gateway/entities/license/
+    konnect: false
+    env: true
+    hcv: true
+    gcp: true
+    aws: true
+    azure: true
+  - title: Referenceable plugin fields, such as third-party API keys (see table below for all values)
+    konnect: true
+    env: true
+    hcv: true
+    gcp: true
+    aws: true
+    azure: true
+{% endfeature_table %}
+
+{:.info}
+> **Notes:**
+> * <sup>1</sup>: You can't reference secrets stored in a [{{site.konnect_short_name}} Config Store](/how-to/configure-the-konnect-config-store/) Vault in `kong.conf` because {{site.konnect_short_name}} resolves the secret after {{site.base_gateway}} connects to the control plane.
+> * <sup>2</sup>: In Konnect, the {{site.base_gateway}} license is managed and stored by {{site.konnect_short_name}}, and doesn't need to be stored manually in any Vault.
+
+The following plugin fields can be stored and referenced as secrets:
+
+{% referenceable_fields %}
+
 ## How do I reference secrets stored in a Vault?
 
 When you want to use a secret stored in a Vault, you can reference the secret with a `vault` reference. You can use the `vault` reference in places such as `kong.conf`, declarative configuration files, logs, or in the UI.
-
-{:.info}
-> **Note:** You can't reference secrets stored in a [{{site.konnect_short_name}} Config Store](/how-to/configure-the-konnect-config-store/) Vault in `kong.conf` because {{site.konnect_short_name}} resolves the secret before connecting to {{site.base_gateway}}. 
 
 The Vault backend may store multiple related secrets inside an object, but the reference
 should always point to a key that resolves to a string value. For example, the following reference:

--- a/app/_how-tos/configure-the-konnect-config-store.md
+++ b/app/_how-tos/configure-the-konnect-config-store.md
@@ -32,6 +32,10 @@ tldr:
       3. Store your secret as a key/value pair using the `/secrets` endpoint. 
       4. Reference the secret using the Vault prefix and key (for example: `{vault://mysecretvault/secret-key}`).
 
+faqs:
+  - q: Can I reference {{site.konnect_short_name}} Config Store Vault secrets in `kong.conf`?
+    a: No. You can't reference secrets stored in a {{site.konnect_short_name}} Config Store Vault in `kong.conf` because {{site.konnect_short_name}} resolves the secret before connecting to {{site.base_gateway}}.
+
 prereqs:
   inline:
     - title: Environment variables

--- a/app/_how-tos/configure-the-konnect-config-store.md
+++ b/app/_how-tos/configure-the-konnect-config-store.md
@@ -34,7 +34,7 @@ tldr:
 
 faqs:
   - q: Can I reference {{site.konnect_short_name}} Config Store Vault secrets in `kong.conf`?
-    a: No. You can't reference secrets stored in a {{site.konnect_short_name}} Config Store Vault in `kong.conf` because {{site.konnect_short_name}} resolves the secret before connecting to {{site.base_gateway}}.
+    a: No. You can't reference secrets stored in a {{site.konnect_short_name}} Config Store Vault in `kong.conf` because {{site.konnect_short_name}} resolves the secret after {{site.base_gateway}} connects to the control plane. For more information about the fields you can reference as secrets, see [What can be stored as a secret?](/gateway/entities/vault/#what-can-be-stored-as-a-secret).
 
 prereqs:
   inline:


### PR DESCRIPTION
## Description

Fixes an issue we talked about on Friday about Config Store not working with kong.conf

## Preview Links
https://deploy-preview-385--kongdeveloper.netlify.app/how-to/configure-the-konnect-config-store/#faq
https://deploy-preview-385--kongdeveloper.netlify.app/gateway/entities/vault/#what-can-be-stored-as-a-secret

## Checklist 

- [x] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. N/A: Technical info confirmed by Michael
- [x] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes] (https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes) N/A: there was no existing docs source for this info
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
