### PR TITLE
Feat: install instructions

### DIFF
--- a/app/_how-tos/install-kgw-securely.md
+++ b/app/_how-tos/install-kgw-securely.md
@@ -42,7 +42,7 @@ tools:
 prereqs:
   inline:
     - title: Install {{site.base_gateway}}
-      include_content: prereqs/install/debian
+      include_content: prereqs/install/red-hat
 
 cleanup:
   inline:

--- a/app/_how-tos/install-kgw-securely.md
+++ b/app/_how-tos/install-kgw-securely.md
@@ -54,7 +54,7 @@ cleanup:
 ## 1. Create a Consumer
 
 [Consumers](/gateway/entities/consumer/) let you identify the client that's interacting with {{site.base_gateway}}.
-We're going to use key [authentication](/authentication/) in this tutorial, so the Consumer needs an API key to access any {{site.base_gateway}} Services.
+We're going to use key [authentication](/gateway/authentication/) in this tutorial, so the Consumer needs an API key to access any {{site.base_gateway}} Services.
 
 Add the following content to `kong.yaml` to create a Consumer:
 

--- a/app/_how-tos/install-kgw-securely.md
+++ b/app/_how-tos/install-kgw-securely.md
@@ -1,0 +1,109 @@
+---
+title: Install securely
+content_type: how_to
+related_resources:
+  - text: Rate Limiting
+    url: /rate-limiting/
+  - text: How to create rate limiting tiers with {{site.base_gateway}}
+    url:  /how-to/add-rate-limiting-tiers-with-kong-gateway/
+  - text: Rate Limiting plugin
+    url: /plugins/rate-limiting/
+  - text: Rate Limiting Advanced plugin
+    url: /plugins/rate-limiting-advanced/
+
+products:
+    - gateway
+
+works_on:
+    - on-prem
+
+min_version:
+  gateway: '3.4'
+
+plugins:
+  - rate-limiting
+  - key-auth
+
+entities: 
+  - service
+  - plugin
+  - consumer
+
+tags:
+    - rate-limiting
+
+tldr:
+    q: How do I rate limit a Consumer with {{site.base_gateway}}?
+    a: Enable an authentication plugin and create a <a href="/gateway/entities/consumer/">Consumer</a> with credentials, then enable the <a href="/plugins/rate-limiting/">Rate Limiting plugin</a> on the new Consumer.
+
+tools:
+    - deck
+
+prereqs:
+  inline:
+    - title: Install {{site.base_gateway}}
+      include_content: prereqs/install/debian
+
+cleanup:
+  inline:
+    - title: Destroy the {{site.base_gateway}} container
+      include_content: cleanup/products/gateway
+      icon_url: /assets/icons/gateway.svg
+---
+
+## 1. Create a Consumer
+
+[Consumers](/gateway/entities/consumer/) let you identify the client that's interacting with {{site.base_gateway}}.
+We're going to use key [authentication](/authentication/) in this tutorial, so the Consumer needs an API key to access any {{site.base_gateway}} Services.
+
+Add the following content to `kong.yaml` to create a Consumer:
+
+{% entity_examples %}
+entities:
+  consumers:
+    - username: jsmith
+      keyauth_credentials:
+        - key: example-key
+{% endentity_examples %}
+
+## 2. Enable authentication
+
+Authentication lets you identify a Consumer so that you can apply rate limiting.
+This example uses the [Key Authentication](/plugins/key-auth/) plugin, but you can use any authentication plugin that you prefer.
+
+Enable the plugin globally, which means it applies to all {{site.base_gateway}} Services and Routes:
+
+{% entity_examples %}
+entities:
+  plugins:
+    - name: key-auth
+      config:
+        key_names:
+          - apikey
+{% endentity_examples %}
+
+## 3. Enable rate limiting
+
+Enable the [Rate Limiting plugin](/plugins/rate-limiting/) for the Consumer. 
+In this example, the limit is 5 requests per minute and 1000 requests per hour.
+
+{% entity_examples %}
+entities:
+  plugins:
+    - name: rate-limiting
+      consumer: jsmith
+      config:
+        minute: 5
+        hour: 1000
+{% endentity_examples %}
+
+## 4. Validate
+
+You can run the following command to test the rate limiting as the Consumer:
+
+{% validation rate-limit-check %}
+iterations: 6
+url: '/anything'
+headers:
+  - 'apikey:example-key'
+{% endvalidation %}

--- a/app/_includes/prereqs/install/amazon-linux.md
+++ b/app/_includes/prereqs/install/amazon-linux.md
@@ -1,9 +1,9 @@
 {% navtabs %}
 {% navtab "Manually installation" %}
 1. Download {{site.base_gateway}}:
-```sh
-curl -Lo kong-enterprise-edition-3.9.0.1.rpm $(rpm --eval https://packages.konghq.com/public/gateway-39/rpm/amzn/%{amzn}/%{_arch}/kong-enterprise-edition-3.9.0.1.aws.%{_arch}.rpm)
-```
+    ```sh
+    curl -Lo kong-enterprise-edition-3.9.0.1.rpm $(rpm --eval https://packages.konghq.com/public/gateway-39/rpm/amzn/%{amzn}/%{_arch}/kong-enterprise-edition-3.9.0.1.aws.%{_arch}.rpm)
+    ```
 
 2. Install {{site.base_gateway}}:
     ```
@@ -12,16 +12,16 @@ curl -Lo kong-enterprise-edition-3.9.0.1.rpm $(rpm --eval https://packages.kongh
 {% endnavtab %}
 {% navtab "Package manager" %}
 1. Set up the package repository:
-```sh
- curl -1sLf "https://packages.konghq.com/public/gateway-39/config.rpm.txt?distro=amzn&codename=$(rpm --eval '%{amzn}')" | sudo tee /etc/yum.repos.d/kong-gateway-39.repo > /dev/null
-```
-```
- sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-39'
-```
+    ```sh
+    curl -1sLf "https://packages.konghq.com/public/gateway-39/config.rpm.txt?distro=amzn&codename=$(rpm --eval '%{amzn}')" | sudo tee /etc/yum.repos.d/kong-gateway-39.repo > /dev/null
+    ```
+    ```
+    sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-39'
+    ```
 
 2. Install {{site.base_gateway}}:
-```
-sudo yum install -y kong-enterprise-edition-3.9.0.1
-```
+    ```
+    sudo yum install -y kong-enterprise-edition-3.9.0.1
+    ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/_includes/prereqs/install/amazon-linux.md
+++ b/app/_includes/prereqs/install/amazon-linux.md
@@ -1,17 +1,17 @@
 {% navtabs %}
-{% navtab "Manual Installation" %}
-1. Download {{site.base_gateway}}
+{% navtab "Manually installation" %}
+1. Download {{site.base_gateway}}:
 ```sh
 curl -Lo kong-enterprise-edition-3.9.0.1.rpm $(rpm --eval https://packages.konghq.com/public/gateway-39/rpm/amzn/%{amzn}/%{_arch}/kong-enterprise-edition-3.9.0.1.aws.%{_arch}.rpm)
 ```
 
-2. Install {{site.base_gateway}}
+2. Install {{site.base_gateway}}:
     ```
     sudo yum install -y kong-enterprise-edition-3.9.0.1.rpm
     ```
 {% endnavtab %}
 {% navtab "Package manager" %}
-1. Set up the package repository
+1. Set up the package repository:
 ```sh
  curl -1sLf "https://packages.konghq.com/public/gateway-39/config.rpm.txt?distro=amzn&codename=$(rpm --eval '%{amzn}')" | sudo tee /etc/yum.repos.d/kong-gateway-39.repo > /dev/null
 ```
@@ -19,7 +19,7 @@ curl -Lo kong-enterprise-edition-3.9.0.1.rpm $(rpm --eval https://packages.kongh
  sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-39'
 ```
 
-2. Install {{site.base_gateway}}
+2. Install {{site.base_gateway}}:
 ```
 sudo yum install -y kong-enterprise-edition-3.9.0.1
 ```

--- a/app/_includes/prereqs/install/amazon-linux.md
+++ b/app/_includes/prereqs/install/amazon-linux.md
@@ -1,0 +1,27 @@
+{% navtabs %}
+{% navtab "Manual Installation" %}
+1. Download {{site.base_gateway}}
+```sh
+curl -Lo kong-enterprise-edition-3.9.0.1.rpm $(rpm --eval https://packages.konghq.com/public/gateway-39/rpm/amzn/%{amzn}/%{_arch}/kong-enterprise-edition-3.9.0.1.aws.%{_arch}.rpm)
+```
+
+2. Install {{site.base_gateway}}
+    ```
+    sudo yum install -y kong-enterprise-edition-3.9.0.1.rpm
+    ```
+{% endnavtab %}
+{% navtab "Package manager" %}
+1. Set up the package repository
+```sh
+ curl -1sLf "https://packages.konghq.com/public/gateway-39/config.rpm.txt?distro=amzn&codename=$(rpm --eval '%{amzn}')" | sudo tee /etc/yum.repos.d/kong-gateway-39.repo > /dev/null
+```
+```
+ sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-39'
+```
+
+2. Install {{site.base_gateway}}
+```
+sudo yum install -y kong-enterprise-edition-3.9.0.1
+```
+{% endnavtab %}
+{% endnavtabs %}

--- a/app/_includes/prereqs/install/debian.md
+++ b/app/_includes/prereqs/install/debian.md
@@ -1,30 +1,30 @@
 {% navtabs %}
-{% navtab "Manual Installation" %}
-1. Download {{site.base_gateway}}
+{% navtab "Manual installation" %}
+1. Download {{site.base_gateway}}:
 ```sh
 curl -Lo kong-enterprise-edition-3.9.0.1.deb "https://packages.konghq.com/public/gateway-39/deb/debian/pool/bullseye/main/k/ko/kong-enterprise-edition_3.9.0.1/kong-enterprise-edition_3.9.0.1_$(dpkg --print-architecture).deb"
 ```
 
-2. Install {{site.base_gateway}}
+2. Install {{site.base_gateway}}:
     ```
     sudo apt install -y ./kong-enterprise-edition-3.9.0.1.deb
     ```
 {% endnavtab %}
 {% navtab "Package manager" %}
-1. Set up the package repository
+1. Set up the package repository:
 ```sh
 curl -1sLf "https://packages.konghq.com/public/gateway-39/gpg.B9DCD032B1696A89.key" |  gpg --dearmor | sudo tee /usr/share/keyrings/kong-gateway-39-archive-keyring.gpg > /dev/null
 ```
 ```
 curl -1sLf "https://packages.konghq.com/public/gateway-39/config.deb.txt?distro=debian&codename=$(lsb_release -sc)" | sudo tee /etc/apt/sources.list.d/kong-gateway-39.list > /dev/null
 ```
-2. Update the package manager
+2. Update the package manager:
 
     ```sh
     sudo apt update
     ```
 
-3. Install {{site.base_gateway}}
+3. Install {{site.base_gateway}}:
 ```
 sudo apt install -y kong-enterprise-edition=3.9.0.1
 ```

--- a/app/_includes/prereqs/install/debian.md
+++ b/app/_includes/prereqs/install/debian.md
@@ -1,0 +1,32 @@
+{% navtabs %}
+{% navtab "Manual Installation" %}
+1. Download {{site.base_gateway}}
+```sh
+curl -Lo kong-enterprise-edition-3.9.0.1.deb "https://packages.konghq.com/public/gateway-39/deb/debian/pool/bullseye/main/k/ko/kong-enterprise-edition_3.9.0.1/kong-enterprise-edition_3.9.0.1_$(dpkg --print-architecture).deb"
+```
+
+2. Install {{site.base_gateway}}
+    ```
+    sudo apt install -y ./kong-enterprise-edition-3.9.0.1.deb
+    ```
+{% endnavtab %}
+{% navtab "Package manager" %}
+1. Set up the package repository
+```sh
+curl -1sLf "https://packages.konghq.com/public/gateway-39/gpg.B9DCD032B1696A89.key" |  gpg --dearmor | sudo tee /usr/share/keyrings/kong-gateway-39-archive-keyring.gpg > /dev/null
+```
+```
+curl -1sLf "https://packages.konghq.com/public/gateway-39/config.deb.txt?distro=debian&codename=$(lsb_release -sc)" | sudo tee /etc/apt/sources.list.d/kong-gateway-39.list > /dev/null
+```
+2. Update the package manager
+
+    ```sh
+    sudo apt update
+    ```
+
+3. Install {{site.base_gateway}}
+```
+sudo apt install -y kong-enterprise-edition=3.9.0.1
+```
+{% endnavtab %}
+{% endnavtabs %}

--- a/app/_includes/prereqs/install/red-hat.md
+++ b/app/_includes/prereqs/install/red-hat.md
@@ -1,9 +1,9 @@
 {% navtabs %}
 {% navtab "Manual Installation" %}
 1. Download {{site.base_gateway}}:
-```sh
-curl -Lo kong-enterprise-edition-3.9.0.1.rpm $(rpm --eval https://packages.konghq.com/public/gateway-39/rpm/el/%{rhel}/%{_arch}/kong-enterprise-edition-3.9.0.1.el%{rhel}.%{_arch}.rpm)
-```
+    ```sh
+    curl -Lo kong-enterprise-edition-3.9.0.1.rpm $(rpm --eval https://packages.konghq.com/public/gateway-39/rpm/el/%{rhel}/%{_arch}/kong-enterprise-edition-3.9.0.1.el%{rhel}.%{_arch}.rpm)
+    ```
 
 2. Install {{site.base_gateway}}:
     ```
@@ -12,16 +12,16 @@ curl -Lo kong-enterprise-edition-3.9.0.1.rpm $(rpm --eval https://packages.kongh
 {% endnavtab %}
 {% navtab "Package manager" %}
 1. Set up the package repository:
-```sh
- curl -1sLf "https://packages.konghq.com/public/gateway-39/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-39.repo
-```
-```
- sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-39'
-```
+    ```sh
+    curl -1sLf "https://packages.konghq.com/public/gateway-39/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-39.repo
+    ```
+    ```
+    sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-39'
+    ```
 
 2. Install {{site.base_gateway}}:
-```
-sudo yum install -y kong-enterprise-edition-3.9.0.1
-```
+    ```
+    sudo yum install -y kong-enterprise-edition-3.9.0.1
+    ```
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/_includes/prereqs/install/red-hat.md
+++ b/app/_includes/prereqs/install/red-hat.md
@@ -1,17 +1,17 @@
 {% navtabs %}
 {% navtab "Manual Installation" %}
-1. Download {{site.base_gateway}}
+1. Download {{site.base_gateway}}:
 ```sh
 curl -Lo kong-enterprise-edition-3.9.0.1.rpm $(rpm --eval https://packages.konghq.com/public/gateway-39/rpm/el/%{rhel}/%{_arch}/kong-enterprise-edition-3.9.0.1.el%{rhel}.%{_arch}.rpm)
 ```
 
-2. Install {{site.base_gateway}}
+2. Install {{site.base_gateway}}:
     ```
     sudo yum install -y kong-enterprise-edition-3.9.0.1.rpm
     ```
 {% endnavtab %}
 {% navtab "Package manager" %}
-1. Set up the package repository
+1. Set up the package repository:
 ```sh
  curl -1sLf "https://packages.konghq.com/public/gateway-39/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-39.repo
 ```
@@ -19,7 +19,7 @@ curl -Lo kong-enterprise-edition-3.9.0.1.rpm $(rpm --eval https://packages.kongh
  sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-39'
 ```
 
-2. Install {{site.base_gateway}}
+2. Install {{site.base_gateway}}:
 ```
 sudo yum install -y kong-enterprise-edition-3.9.0.1
 ```

--- a/app/_includes/prereqs/install/red-hat.md
+++ b/app/_includes/prereqs/install/red-hat.md
@@ -1,0 +1,27 @@
+{% navtabs %}
+{% navtab "Manual Installation" %}
+1. Download {{site.base_gateway}}
+```sh
+curl -Lo kong-enterprise-edition-3.9.0.1.rpm $(rpm --eval https://packages.konghq.com/public/gateway-39/rpm/el/%{rhel}/%{_arch}/kong-enterprise-edition-3.9.0.1.el%{rhel}.%{_arch}.rpm)
+```
+
+2. Install {{site.base_gateway}}
+    ```
+    sudo yum install -y kong-enterprise-edition-3.9.0.1.rpm
+    ```
+{% endnavtab %}
+{% navtab "Package manager" %}
+1. Set up the package repository
+```sh
+ curl -1sLf "https://packages.konghq.com/public/gateway-39/config.rpm.txt?distro=el&codename=$(rpm --eval '%{rhel}')" | sudo tee /etc/yum.repos.d/kong-gateway-39.repo
+```
+```
+ sudo yum -q makecache -y --disablerepo='*' --enablerepo='kong-gateway-39'
+```
+
+2. Install {{site.base_gateway}}
+```
+sudo yum install -y kong-enterprise-edition-3.9.0.1
+```
+{% endnavtab %}
+{% endnavtabs %}

--- a/app/_includes/prereqs/install/ubuntu.md
+++ b/app/_includes/prereqs/install/ubuntu.md
@@ -1,30 +1,30 @@
 {% navtabs %}
-{% navtab "Manual Installation" %}
-1. Download {{site.base_gateway}}
+{% navtab "Manual installation" %}
+1. Download {{site.base_gateway}}:
 ```sh
 curl -Lo kong-enterprise-edition-3.9.0.1.deb "https://packages.konghq.com/public/gateway-39/deb/ubuntu/pool/noble/main/k/ko/kong-enterprise-edition_3.9.0.1/kong-enterprise-edition_3.9.0.1_$(dpkg --print-architecture).deb"
 ```
 
-2. Install {{site.base_gateway}}
+2. Install {{site.base_gateway}}:
     ```
     sudo apt install -y ./kong-enterprise-edition-3.9.0.1.deb
     ```
 {% endnavtab %}
 {% navtab "Package manager" %}
-1. Set up the package repository
+1. Set up the package repository:
 ```sh
 curl -1sLf "https://packages.konghq.com/public/gateway-39/gpg.B9DCD032B1696A89.key" |  gpg --dearmor | sudo tee /usr/share/keyrings/kong-gateway-39-archive-keyring.gpg > /dev/null
 ```
 ```
 curl -1sLf "https://packages.konghq.com/public/gateway-39/config.deb.txt?distro=debian&codename=$(lsb_release -sc)" | sudo tee /etc/apt/sources.list.d/kong-gateway-39.list > /dev/null
 ```
-2. Update the package manager
+2. Update the package manager:
 
     ```sh
     sudo apt update
     ```
 
-3. Install {{site.base_gateway}}
+3. Install {{site.base_gateway}}:
 ```
 sudo apt install -y kong-enterprise-edition=3.9.0.1
 ```

--- a/app/_includes/prereqs/install/ubuntu.md
+++ b/app/_includes/prereqs/install/ubuntu.md
@@ -1,0 +1,32 @@
+{% navtabs %}
+{% navtab "Manual Installation" %}
+1. Download {{site.base_gateway}}
+```sh
+curl -Lo kong-enterprise-edition-3.9.0.1.deb "https://packages.konghq.com/public/gateway-39/deb/ubuntu/pool/noble/main/k/ko/kong-enterprise-edition_3.9.0.1/kong-enterprise-edition_3.9.0.1_$(dpkg --print-architecture).deb"
+```
+
+2. Install {{site.base_gateway}}
+    ```
+    sudo apt install -y ./kong-enterprise-edition-3.9.0.1.deb
+    ```
+{% endnavtab %}
+{% navtab "Package manager" %}
+1. Set up the package repository
+```sh
+curl -1sLf "https://packages.konghq.com/public/gateway-39/gpg.B9DCD032B1696A89.key" |  gpg --dearmor | sudo tee /usr/share/keyrings/kong-gateway-39-archive-keyring.gpg > /dev/null
+```
+```
+curl -1sLf "https://packages.konghq.com/public/gateway-39/config.deb.txt?distro=debian&codename=$(lsb_release -sc)" | sudo tee /etc/apt/sources.list.d/kong-gateway-39.list > /dev/null
+```
+2. Update the package manager
+
+    ```sh
+    sudo apt update
+    ```
+
+3. Install {{site.base_gateway}}
+```
+sudo apt install -y kong-enterprise-edition=3.9.0.1
+```
+{% endnavtab %}
+{% endnavtabs %}

--- a/app/_landing_pages/install.yaml
+++ b/app/_landing_pages/install.yaml
@@ -1,0 +1,10 @@
+metadata:
+  title: Installation options
+  content_type: landing_page
+  description: Installation options 
+
+rows:
+  - header:
+      type: h1
+      text: "@todo"
+


### PR DESCRIPTION
## Description
Install instructions as a series of includes. So we can build landing pages and prererqs for install docs. Everything except RedHat was tested. 

Ticket for platform to support current docs.konghq.com URL rendering thing:
https://github.com/Kong/developer.konghq.com/issues/386


Fixes https://github.com/Kong/developer.konghq.com/issues/388

## Preview Links

No preview links available since it is all just includes. 
## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
