### PR TITLE
Fix: Topologies display in plugin info boxes

### DIFF
--- a/app/_data/products/gateway.yml
+++ b/app/_data/products/gateway.yml
@@ -1,9 +1,14 @@
 name: Kong Gateway
 
 topologies:
-  - traditional
-  - hybrid
-  - db-less
+  on_prem:
+    - traditional
+    - hybrid
+    - db-less
+  konnect_deployments:
+    - hybrid
+    - cloud-gateways
+    - serverless
 
 tiers:
   enterprise:

--- a/app/_includes/info_box/sections/topologies.html
+++ b/app/_includes/info_box/sections/topologies.html
@@ -1,8 +1,19 @@
 <div class="flex flex-col gap-2  w-full">
-  <div class="text-primary font-medium">Supported Topologies</div>
+  <div class="text-primary font-medium">Supported Gateway Topologies</div>
   <div class="flex gap-1.5 flex-col md:flex-row">
-    {% for topology in include.topologies %}
+    {% for topology in include.topologies.on_prem %}
     <span {% unless forloop.last %}class="after:content-[',']"{% endunless %}>{{ topology }}</span>
     {% endfor %}
   </div>
 </div>
+
+{% if include.topologies.konnect_deployments %}
+<div class="flex flex-col gap-2  w-full">
+  <div class="text-primary font-medium">Supported Konnect Deployments</div>
+  <div class="flex gap-1.5 flex-col md:flex-row">
+    {% for deployment in include.topologies.konnect_deployments %}
+    <span {% unless forloop.last %}class="after:content-[',']"{% endunless %}>{{ deployment }}</span>
+    {% endfor %}
+  </div>
+</div>
+{% endif %}


### PR DESCRIPTION
## Description

Since I added a nested key in a previous update, the plugin info boxes now display broken lists of topologies:

![Screenshot 2025-02-03 at 9 37 46 PM](https://github.com/user-attachments/assets/a9739411-b0b3-47f9-9377-7a2d272c42d2)

This PR fixes that, it should now look like this:

![Screenshot 2025-02-03 at 9 36 02 PM](https://github.com/user-attachments/assets/99b4ee50-f4df-401c-86aa-da1df98fd8f4)

Any ideas for shorter labels appreciated.


## Preview Links


## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
