### PR TITLE
Fix: update the version in the specs for Kong Admin 3.9

### DIFF
--- a/api-specs/gateway/admin-ee/3.9/openapi.yaml
+++ b/api-specs/gateway/admin-ee/3.9/openapi.yaml
@@ -6236,7 +6236,7 @@ info:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
   title: Enterprise Kong Admin API
-  version: 3.8.0
+  version: 3.9.0
 openapi: 3.0.0
 paths:
   /:

--- a/api-specs/gateway/admin-oss/3.9/openapi.yaml
+++ b/api-specs/gateway/admin-oss/3.9/openapi.yaml
@@ -3622,7 +3622,7 @@ info:
     name: Apache 2.0
     url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
   title: Kong Admin API
-  version: 3.8.0
+  version: 3.9.0
 openapi: 3.0.0
 paths:
   /:


### PR DESCRIPTION
## Description

The 3.9 specs still list 3.8 as their version.

This is already fixed in Konnect Dev Portal, and there's a parallel PR open on docs.konghq.com.

Relates to https://github.com/Kong/docs.konghq.com/pull/8418.

## Preview Links


## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
