### PR TITLE
Migrate cors changelog

### DIFF
--- a/app/_kong_plugins/cors/changelog.md
+++ b/app/_kong_plugins/cors/changelog.md
@@ -4,3 +4,12 @@ no_version: true
 ---
 
 ## Changelog
+
+### {{site.base_gateway}} 3.8.x
+* Fixed an issue where the `Access-Control-Allow-Origin` header was not sent when `conf.origins` had multiple entries but included `*`.
+   [#13334](https://github.com/Kong/kong/issues/13334)
+
+### {{site.base_gateway}} 3.5.x
+
+* Added support for the `Access-Control-Request-Private-Network` header in 
+  cross-origin pre-flight requests. [#11523](https://github.com/kong/kong/pull/11523)

--- a/app/_kong_plugins/cors/index.md
+++ b/app/_kong_plugins/cors/index.md
@@ -42,9 +42,7 @@ categories:
 
 The CORS plugin lets you add Cross-Origin Resource Sharing (CORS) to a Service or a Route. This allows you to automate the configuration of CORS rules, ensuring that your upstreams only accept and share resources with approved sources.
 
-
 {% include sections/cors-and-kong-gateway.md %}
-
 
 ## CORS limitations
 
@@ -55,5 +53,3 @@ limitation of the [CORS specification](https://developer.mozilla.org/en-US/docs/
 Because of this limitation, this plugin only works for routes that have been
 configured with a `paths` setting. The CORS plugin does not work for routes that
 are being resolved using a custom DNS (the `hosts` property).
-
-


### PR DESCRIPTION
## Description

Fixes #421 

The plugin was already migrated previously, so this really only moves the changelog.

## Preview Links


## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
