### PR TITLE
How-to: multiple plugin auth

### DIFF
--- a/app/_how-tos/allow-multiple-authentication.md
+++ b/app/_how-tos/allow-multiple-authentication.md
@@ -88,7 +88,7 @@ entities:
 
 We're going to assign a different authentication type to each Consumer later.
 
-## 3. Set up authentication
+## 2. Set up authentication
 
 Add the Key Auth and Basic Auth plugins to the `example-service` Gateway Service, and set the `anonymous` fallback to the Consumer we created earlier:
 
@@ -107,7 +107,7 @@ entities:
         anonymous: anonymous
 {% endentity_examples %}
 
-## 4. Test with anonymous Consumer
+## 3. Test with anonymous Consumer
 
 You now have authentication enabled on the Gateway Service, but the `anonymous` Consumer also allows requests from unauthenticated clients.
 
@@ -121,13 +121,15 @@ status_code: 200
 Check with nonsense credentials:
 
 {% validation request-check %}
-url: '/anything?apikey=nonsense'
+url: '/anything'
 status_code: 200
+headers:
+  - apikey:nonsense
 {% endvalidation %}
 
 In both cases, you should get a 200 response, as the `anonymous` Consumer is allowed.
 
-## 5. Configure credentials
+## 4. Configure credentials
 
 Configure different credentials for the two named users: basic auth for `Dana`, and key auth for `Mahan`:
 
@@ -144,7 +146,7 @@ entities:
 {% endentity_examples %}
 
 
-## 6. Add Request Termination to the anonymous Consumer
+## 5. Add Request Termination to the anonymous Consumer
 
 The anonymous Consumer gets no credentials, as we don't want unauthenticated users accessing our Gateway Service.
 Instead, you can configure the Request Termination plugin to handle anonymous Consumers and redirect their requests with a `401`:
@@ -160,15 +162,17 @@ entities:
             message: '"Error - Authentication required"'
 {% endentity_examples %}
 
-## 7. Validate authentication
+## 6. Validate authentication
 
 Let's check that authentication works.
 
 Try to access the Gateway Service via the `/anything` Route using a nonsense API key:
 
 {% validation request-check %}
-url: '/anything?apikey=nonsense'
+url: '/anything'
 status_code: 401
+headers:
+  - apikey:nonsense
 {% endvalidation %}
 
 The request should now fail with a `401` response and your configured error message, as this Consumer is considered anonymous.

--- a/app/_how-tos/allow-multiple-authentication.md
+++ b/app/_how-tos/allow-multiple-authentication.md
@@ -32,11 +32,8 @@ tags:
 tldr:
   q: How do I allow different clients to access an upstream service with different authentication types, and forbid access to any unauthenticated clients?
   a: |
-    You can use multiple authentication plugins with an anonymous Consumer to give clients multiple options for authentication. 
-    The anonymous Consumer acts as a fallback to catch all other unauthorized requests.
-
-    For example, you can configure Key Auth and Basic Auth, apply them to specific Consumers, and set `anonymous` in those plugins to catch access attempts from anyone else.
-    Then, apply the Request Termination plugin to requests made with the anonymous Consumer to terminate the requests and send back a specific message.
+    Configure multiple authentication plugins, like [Key Auth](/plugins/key-auth/) and [Basic Auth](/plugins/basic-auth/), and apply them to specific [Consumers](/gateway/entities/consumer/). Set `config.anonymous` in those plugins to the ID of the anonymous Consumer to catch access attempts from anyone else.
+    Then, apply the [Request Termination](/plugins/request-termination/) plugin to requests made with the anonymous Consumer to terminate the requests and send back a specific message.
 
 faqs:
   - q: What happens if I configure multiple authentication methods but don't use an anonymous Consumer?
@@ -51,7 +48,7 @@ faqs:
       If you want anonymous access to be forbidden, you **must** configure the Request Termination plugin on the anonymous Consumer.
   - q: Can I use the anonymous Consumer with OpenID Connect?
     a: |
-      If you are using the OpenID Connect plugin for handling Consumer authentication, you must set both [`config.anonymous`](/plugins/openid-connect/reference/#config-anonymous) and [`config.consumer_claim`](/plugins/openid-connect/reference/#config-consumer_claim) in the plugin's configuration, as setting `config.anonymous` alone won't map that Consumer.
+      If you are using the [OpenID Connect](/plugins/openid-connect/) plugin for handling Consumer authentication, you must set both [`config.anonymous`](/plugins/openid-connect/reference/#config-anonymous) and [`config.consumer_claim`](/plugins/openid-connect/reference/#config-consumer_claim) in the plugin's configuration, as setting `config.anonymous` alone won't map that Consumer.
   
 tools:
   - deck
@@ -111,14 +108,14 @@ entities:
 
 You now have authentication enabled on the Gateway Service, but the `anonymous` Consumer also allows requests from unauthenticated clients.
 
-Check without credentials:
+The following validation works because the unauthenticated request falls back to the anonymous Consumer, which allows it through:
 
 {% validation request-check %}
 url: '/anything'
 status_code: 200
 {% endvalidation %}
 
-Check with nonsense credentials:
+The following validation with fake credentials also works because an incorrect API key is treated as anonymous:
 
 {% validation request-check %}
 url: '/anything'
@@ -131,7 +128,7 @@ In both cases, you should get a 200 response, as the `anonymous` Consumer is all
 
 ## 4. Configure credentials
 
-Configure different credentials for the two named users: basic auth for `Dana`, and key auth for `Mahan`:
+Now, let's configure Consumers with different auth credentials and prevent unauthenticated access. Configure different credentials for the two named users: basic auth for `Dana`, and key auth for `Mahan`:
 
 {% entity_examples %}
 entities:

--- a/app/_how-tos/allow-multiple-authentication.md
+++ b/app/_how-tos/allow-multiple-authentication.md
@@ -72,8 +72,10 @@ cleanup:
 
 ## 1. Create Consumers
 
-Create three Consumers, including an `anonymous` Consumer.
-The `anonymous` Consumer doesn't correspond to any real user, and will only serve as a fallback:
+You can use multiple authentication plugins with an anonymous Consumer to give clients multiple options for authentication. 
+The anonymous Consumer doesn't correspond to any real user, and acts as a fallback to catch all other unauthorized requests.
+
+Create three Consumers, including the `anonymous` Consumer:
 
 {% entity_examples %}
 entities:

--- a/app/_how-tos/allow-multiple-authentication.md
+++ b/app/_how-tos/allow-multiple-authentication.md
@@ -73,20 +73,7 @@ cleanup:
       icon_url: /assets/icons/gateway.svg
 ---
 
-## 1. Create an ID
-
-Create a UUID:
-
-```
-uuidgen
-```
-
-Export the ID to an environment variable:
-```sh
-export DECK_ANONYMOUS_CONSUMER=434772ef-af0c-4227-a33b-76e33b9fd7df
-```
-
-## 2. Create Consumers
+## 1. Create Consumers
 
 Create three Consumers, including an `anonymous` Consumer.
 The `anonymous` Consumer doesn't correspond to any real user, and will only serve as a fallback:
@@ -95,12 +82,8 @@ The `anonymous` Consumer doesn't correspond to any real user, and will only serv
 entities:
   consumers:
     - username: anonymous
-      id: ${anonymous_consumer}
     - username: Dana
     - username: Mahan
-variables:
-  anonymous_consumer:
-    value: $ANONYMOUS_CONSUMER
 {% endentity_examples %}
 
 We're going to assign a different authentication type to each Consumer later.
@@ -116,15 +99,12 @@ entities:
       service: example-service
       config:
         hide_credentials: true
-        anonymous: ${anonymous_consumer}
+        anonymous: anonymous
     - name: basic-auth
       service: example-service
       config:
         hide_credentials: true
-        anonymous: ${anonymous_consumer}
-variables:
-  anonymous_consumer:
-    value: $ANONYMOUS_CONSUMER
+        anonymous: anonymous
 {% endentity_examples %}
 
 ## 4. Test with anonymous Consumer

--- a/app/_how-tos/allow-multiple-authentication.md
+++ b/app/_how-tos/allow-multiple-authentication.md
@@ -39,16 +39,16 @@ faqs:
   - q: What happens if I configure multiple authentication methods but don't use an anonymous Consumer?
     a: |
       If `config.anonymous` isn't set, then all configured authentication plugins will attempt to authenticate every request. 
-      For example, if you have Key Auth and Basic Auth configured on a Gateway Service, then every request will have to contain **both** types of authentication. 
-      In this case, the last plugin executed will be the one setting the credentials passed to the upstream service. 
+      For example, if you have Key Auth and Basic Auth configured on a Gateway Service, then every request has to contain **both** types of authentication. 
+      In this case, the last plugin executed is the one setting the credentials passed to the upstream service. 
 
   - q: What if I configure an anonymous Consumer but don't add request termination?
     a: |
-      When multiple authentication plugins are enabled on Gateway Service and `config.anonymous` is set without any request termination, unauthorized requests will be allowed through. 
+      When multiple authentication plugins are enabled on a Gateway Service and `config.anonymous` is set without any request termination, unauthorized requests will be allowed through. 
       If you want anonymous access to be forbidden, you **must** configure the Request Termination plugin on the anonymous Consumer.
   - q: Can I use the anonymous Consumer with OpenID Connect?
     a: |
-      If you are using the [OpenID Connect](/plugins/openid-connect/) plugin for handling Consumer authentication, you must set both [`config.anonymous`](/plugins/openid-connect/reference/#config-anonymous) and [`config.consumer_claim`](/plugins/openid-connect/reference/#config-consumer_claim) in the plugin's configuration, as setting `config.anonymous` alone won't map that Consumer.
+      If you are using the [OpenID Connect](/plugins/openid-connect/) plugin for handling Consumer authentication, you must set both [`config.anonymous`](/plugins/openid-connect/reference/#config-anonymous) and [`config.consumer_claim`](/plugins/openid-connect/reference/#config-consumer_claim) in the plugin's configuration, as setting `config.anonymous` alone doesn't map that Consumer.
   
 tools:
   - deck

--- a/app/_how-tos/allow-multiple-authentication.md
+++ b/app/_how-tos/allow-multiple-authentication.md
@@ -95,9 +95,12 @@ The `anonymous` Consumer doesn't correspond to any real user, and will only serv
 entities:
   consumers:
     - username: anonymous
-      id: {% raw %}${{ env "DECK_ANONYMOUS_CONSUMER" }}{% endraw %}
+      id: ${anonymous_consumer}
     - username: Dana
     - username: Mahan
+variables:
+  anonymous_consumer:
+    value: $ANONYMOUS_CONSUMER
 {% endentity_examples %}
 
 We're going to assign a different authentication type to each Consumer later.
@@ -113,12 +116,15 @@ entities:
       service: example-service
       config:
         hide_credentials: true
-        anonymous: {% raw %}${{ env "DECK_ANONYMOUS_CONSUMER" }}{% endraw %}
+        anonymous: ${anonymous_consumer}
     - name: basic-auth
       service: example-service
       config:
         hide_credentials: true
-        anonymous: {% raw %}${{ env "DECK_ANONYMOUS_CONSUMER" }}{% endraw %}
+        anonymous: ${anonymous_consumer}
+variables:
+  anonymous_consumer:
+    value: $ANONYMOUS_CONSUMER
 {% endentity_examples %}
 
 ## 4. Test with anonymous Consumer

--- a/app/_how-tos/allow-multiple-authentication.md
+++ b/app/_how-tos/allow-multiple-authentication.md
@@ -171,7 +171,7 @@ entities:
         - name: request-termination
           config:
             status_code: 401
-            message: '"Error Authentication required"'
+            message: '"Error - Authentication required"'
 {% endentity_examples %}
 
 ## 7. Validate authentication

--- a/app/_includes/how-tos/validations/request-check/index.html
+++ b/app/_includes/how-tos/validations/request-check/index.html
@@ -1,11 +1,11 @@
 {% if page.works_on contains 'konnect' %}
 <div data-deployment-topology="konnect" markdown="1" data-test-step="{{ config.data_validate_konnect | escape }}">
-  {% include how-tos/validations/request-check/snippet.md url=config.konnect_url headers=config.headers body=config.body method=config.method %}
+  {% include how-tos/validations/request-check/snippet.md url=config.konnect_url headers=config.headers body=config.body method=config.method user=config.user %}
 </div>
 {% endif %}
 
 {% if page.works_on contains 'on-prem' %}
 <div data-deployment-topology="on-prem"  markdown="1" data-test-step="{{ config.data_validate_on_prem | escape }}">
-  {% include how-tos/validations/request-check/snippet.md url=config.on_prem_url headers=config.headers body=config.body method=config.method %}
+  {% include how-tos/validations/request-check/snippet.md url=config.on_prem_url headers=config.headers body=config.body method=config.method user=config.user %}
 </div>
 {% endif %}

--- a/app/_includes/how-tos/validations/request-check/snippet.md
+++ b/app/_includes/how-tos/validations/request-check/snippet.md
@@ -1,7 +1,8 @@
 {% if include.method %}
 ```bash
 curl -i -X {{include.method}} {{include.url}} {% if include.headers %}\{%- endif -%}{% for header in include.headers %}
-     -H "{{header}}" {%- unless forloop.last -%}\{% endunless %}{%- endfor %}{% if include.body %}\
+     -H "{{header}}" {%- unless forloop.last -%}\{% endunless %}{%- endfor %}{% if include.user %}\
+     --user {{include.user}}{%- endif -%}{% if include.body %}\
      --data-raw '
 {{ include.body | json_prettify | escape_env_variables | indent: 4 }}
     '{% endif %}
@@ -9,6 +10,7 @@ curl -i -X {{include.method}} {{include.url}} {% if include.headers %}\{%- endif
 {% else %}
 ```bash
 curl -i {{include.url}} {% if include.headers %}\{%- endif -%}{% for header in include.headers %}
-     -H "{{header}}" {%- unless forloop.last -%}\{% endunless %}{%- endfor %}
+     -H "{{header}}" {%- unless forloop.last -%}\{% endunless %}{%- endfor %}{% if include.user %}\
+     --user {{include.user}}{%- endif -%}
 ```
 {% endif %}

--- a/app/_includes/how-tos/validations/request-check/snippet.md
+++ b/app/_includes/how-tos/validations/request-check/snippet.md
@@ -2,7 +2,7 @@
 ```bash
 curl -i -X {{include.method}} {{include.url}} {% if include.headers %}\{%- endif -%}{% for header in include.headers %}
      -H "{{header}}" {%- unless forloop.last -%}\{% endunless %}{%- endfor %}{% if include.user %}\
-     --user {{include.user}}{%- endif -%}{% if include.body %}\
+     -u {{include.user}}{%- endif %}{% if include.body %}\
      --data-raw '
 {{ include.body | json_prettify | escape_env_variables | indent: 4 }}
     '{% endif %}
@@ -11,6 +11,6 @@ curl -i -X {{include.method}} {{include.url}} {% if include.headers %}\{%- endif
 ```bash
 curl -i {{include.url}} {% if include.headers %}\{%- endif -%}{% for header in include.headers %}
      -H "{{header}}" {%- unless forloop.last -%}\{% endunless %}{%- endfor %}{% if include.user %}\
-     --user {{include.user}}{%- endif -%}
+     -u {{include.user}}{%- endif %}
 ```
 {% endif %}

--- a/app/_includes/how-tos/validations/request-check/snippet.md
+++ b/app/_includes/how-tos/validations/request-check/snippet.md
@@ -1,6 +1,6 @@
 {% if include.method %}
 ```bash
-curl -i -X {{include.method}} {{include.url}} {% if include.headers %}\{%- endif -%}{% for header in include.headers %}
+curl -i -X {{include.method}} {{include.url }} {% if include.headers %}\{%- endif -%}{% for header in include.headers %}
      -H "{{header}}" {%- unless forloop.last -%}\{% endunless %}{%- endfor %}{% if include.user %}\
      -u {{include.user}}{%- endif %}{% if include.body %}\
      --data-raw '
@@ -9,7 +9,7 @@ curl -i -X {{include.method}} {{include.url}} {% if include.headers %}\{%- endif
 ```
 {% else %}
 ```bash
-curl -i {{include.url}} {% if include.headers %}\{%- endif -%}{% for header in include.headers %}
+curl -i {{include.url }} {% if include.headers %}\{%- endif -%}{% for header in include.headers %}
      -H "{{header}}" {%- unless forloop.last -%}\{% endunless %}{%- endfor %}{% if include.user %}\
      -u {{include.user}}{%- endif %}
 ```

--- a/tools/track-docs-changes/config/sources.yml
+++ b/tools/track-docs-changes/config/sources.yml
@@ -165,7 +165,8 @@ app/_how-tos/throttle-apis-with-services-and-consumers.md:
 app/_how-tos/test-certificate-generation-locally-with-ngrok-and-acme.md:
   - app/_hub/kong-inc/acme/how-to/_index.md
   - app/_hub/kong-inc/acme/how-to/_local-testing-development.md
-
+app/_how-tos/allow-multiple-authentication.md:
+  - app/_src/gateway/kong-plugins/authentication/allowing-multiple-authentication-methods.md
 
 # plugins
 app/_kong_plugins/ai-rate-limiting-advanced/index.md:


### PR DESCRIPTION
## Description

Fixes #401 

I couldn't figure out how to add the `--user` argument for the request check without breaking the output. What am I missing @fabianrbz ?

Also, the [original guide](https://docs.konghq.com/gateway/latest/kong-plugins/authentication/allowing-multiple-authentication-methods/#:~:text=%2D%2Ddata%20%27%7B%22name%22%3A%20%22request%2Dtermination%22%2C%20%22config%22%3A%20%7B%20%22status_code%22%3A%20401%2C%20%22content_type%22%3A%20%22application/json%3B%20charset%3Dutf%2D8%22%2C%20%22body%22%3A%20%22%7B%5C%22error%5C%22%3A%20%5C%22Authentication%20required%5C%22%7D%22%7D%20%7D%27) sets the error message for the Request Termination plugin in the JSON body, but I never got that to work right, so I went with setting it via `config.message` instead.

## Preview Links

https://deploy-preview-472--kongdeveloper.netlify.app/how-to/allow-multiple-authentication/

## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
