### PR TITLE
Fix: QA for vaults docs

### DIFF
--- a/app/_gateway_entities/vault.md
+++ b/app/_gateway_entities/vault.md
@@ -38,6 +38,12 @@ api_specs:
 schema:
     api: gateway/admin-ee
     path: /schemas/Vault
+
+next_steps:
+  - text: Set up a {{site.konnect_short_name}} Config Store
+    url: /how-to/configure-the-konnect-config-store/
+  - text: Set up HashiCorp Vault as a vault backend
+    url: /how-to/configure-hashicorp-vault-as-a-vault-backend/
 ---
 
 ## What is a Vault?
@@ -118,7 +124,7 @@ features:
     oss: false
     enterprise: true
     supports_konnect: true
-  - title: Hashicorp Vault
+  - title: HashiCorp Vault
     url: /how-to/configure-hashicorp-vault-as-a-vault-backend/
     oss: false
     enterprise: true

--- a/app/_how-tos/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity.md
+++ b/app/_how-tos/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity.md
@@ -76,6 +76,10 @@ cleanup:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg 
+
+next_steps:
+  - text: Review the Vaults entity
+    url: /gateway/entities/vault/
 ---
 
 ## 1. Configure the Vault entity

--- a/app/_how-tos/configure-azure-key-vaults-as-a-vault-backend-with-vault-entity.md
+++ b/app/_how-tos/configure-azure-key-vaults-as-a-vault-backend-with-vault-entity.md
@@ -81,6 +81,10 @@ cleanup:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg 
+
+next_steps:
+  - text: Review the Vaults entity
+    url: /gateway/entities/vault/
 ---
 
 ## 1. Configure the Vault entity

--- a/app/_how-tos/configure-google-cloud-secret-as-a-vault-backend.md
+++ b/app/_how-tos/configure-google-cloud-secret-as-a-vault-backend.md
@@ -80,6 +80,10 @@ cleanup:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg
+
+next_steps:
+  - text: Review the Vaults entity
+    url: /gateway/entities/vault/
 ---
 
 ## 1. Configure Secret Manager as a vault with the Vault entity

--- a/app/_how-tos/configure-hashicorp-vault-as-a-vault-backend.md
+++ b/app/_how-tos/configure-hashicorp-vault-as-a-vault-backend.md
@@ -76,6 +76,10 @@ cleanup:
     - title: Clean up Konnect environment
       include_content: cleanup/platform/konnect
       icon_url: /assets/icons/gateway.svg
+
+next_steps:
+  - text: Review the Vaults entity
+    url: /gateway/entities/vault/
 ---
 
 ## 1. Create a secret in HashiCorp Vault

--- a/app/_how-tos/configure-the-konnect-config-store.md
+++ b/app/_how-tos/configure-the-konnect-config-store.md
@@ -36,21 +36,6 @@ faqs:
   - q: Can I reference {{site.konnect_short_name}} Config Store Vault secrets in `kong.conf`?
     a: No. You can't reference secrets stored in a {{site.konnect_short_name}} Config Store Vault in `kong.conf` because {{site.konnect_short_name}} resolves the secret after {{site.base_gateway}} connects to the control plane. For more information about the fields you can reference as secrets, see [What can be stored as a secret?](/gateway/entities/vault/#what-can-be-stored-as-a-secret).
 
-prereqs:
-  inline:
-    - title: Environment variables
-      content: |
-        To use the copy, paste, and run the instructions in this how-to, you must export these additional environmental variables:
-
-        ```sh
-        export KONNECT_CONTROL_PLANE_URL=https://{region}.api.konghq.com
-        export CONTROL_PLANE_ID=your-control-plane-uuid
-        ```
-
-        * `{region}`: Replace with the [{{site.konnect_short_name}} region](/konnect/geos/) you're using.
-        * `CONTROL_PLANE_ID`: You can find your control plane UUID by navigating to the control plane in the {{site.konnect_short_name}} UI or by sending a `GET` request to the [`/control-planes` endpoint](/api/konnect/control-planes/v2/#/operations/list-control-planes).
-      icon_url: /assets/icons/file.svg
-
 tools:
   - konnect-api
  
@@ -62,6 +47,10 @@ cleanup:
 
 min_version:
     gateway: '3.4'
+
+next_steps:
+  - text: Review the Vaults entity
+    url: /gateway/entities/vault/
 ---
 
 ## 1. Configure a {{site.konnect_short_name}} Config Store

--- a/app/_how-tos/store-a-mistral-api-key-as-a-secret-in-konnect-config-store.md
+++ b/app/_how-tos/store-a-mistral-api-key-as-a-secret-in-konnect-config-store.md
@@ -67,6 +67,10 @@ cleanup:
 
 min_version:
     gateway: '3.4'
+
+next_steps:
+  - text: Review the Vaults entity
+    url: /gateway/entities/vault/
 ---
 
 

--- a/app/_how-tos/store-keyring-in-hashicorp-vault.md
+++ b/app/_how-tos/store-keyring-in-hashicorp-vault.md
@@ -68,6 +68,10 @@ cleanup:
 
 min_version:
     gateway: '3.4'
+
+next_steps:
+  - text: Review the Vaults entity
+    url: /gateway/entities/vault/
 ---
 
 ## 1. Create a key in the HashiCorp vault

--- a/app/_includes/prereqs/products/konnect.md
+++ b/app/_includes/prereqs/products/konnect.md
@@ -6,19 +6,32 @@ This is a Konnect tutorial.
 If you don't have a Konnect account, you can get started quickly with our [onboarding wizard](https://konghq.com/products/kong-konnect/register?utm_medium=referral&utm_source=docs).
 
 1. The following Konnect items are required to complete this tutorial:
-
+{% if page.tools contains 'deck' %}
     * Personal access token (PAT): Create a new personal access token by opening the [Konnect PAT page](https://cloud.konghq.com/global/account/tokens) and selecting **Generate Token**.
     * Control Plane Name: You can use an existing Control Plane or [create a new one](https://cloud.konghq.com/gateway-manager/create-control-plane) to use for this tutorial.
     * Konnect Proxy URL: By default, a self-hosted Data Plane uses `http://localhost:8000`. You can set up Data Plane nodes for your Control Plane from the [Gateway Manager](https://cloud.konghq.com/gateway-manager/) in Konnect.
+{% else %}
+    * Personal access token (PAT): Create a new personal access token by opening the [Konnect PAT page](https://cloud.konghq.com/global/account/tokens) and selecting **Generate Token**.
+    * Control Plane ID: You can use an existing Control Plane or [create a new one](https://cloud.konghq.com/gateway-manager/create-control-plane) to use for this tutorial. You can find your control plane UUID by navigating to the control plane in the Konnect UI or by sending a `GET` request to the [`/control-planes` endpoint](/api/konnect/control-planes/v2/#/operations/list-control-planes).
+    * Control Plane URL: `https://{region}.api.konghq.com`. Replace `{region}` with your organization's region (for example, `eu` or `us`).
+    * Konnect Proxy URL: By default, a self-hosted Data Plane uses `http://localhost:8000`. You can set up Data Plane nodes for your Control Plane from the [Gateway Manager](https://cloud.konghq.com/gateway-manager/) in Konnect.
+{% endif %}
+2. Set the personal access token, the Control Plane name, the Control Plane URL, and the Konnect proxy URL as environment variables:
 
-2. Set the personal access token, the Control Plane Name and the Konnect proxy URL as environment variables:
-
+{% if page.tools contains 'deck' %}
     ```sh
     export DECK_KONNECT_TOKEN=your-token
     export DECK_KONNECT_CONTROL_PLANE_NAME=your-control-plane-name
     export KONNECT_PROXY_URL=konnect-proxy-url
     ```
-
+{% else %}
+    ```sh
+    export KONNECT_TOKEN=your-token
+    export KONNECT_CONTROL_PLANE_ID=your-control-plane-uuid
+    export KONNECT_CONTROL_PLANE_URL=https://{region}.api.konghq.com
+    export KONNECT_PROXY_URL=konnect-proxy-url
+    ```
+{% endif %}
 {% endcapture %}
 
 

--- a/app/_layouts/how-to.html
+++ b/app/_layouts/how-to.html
@@ -4,7 +4,7 @@ layout: with_aside
 {% include how-tos/tldr.html %}
 
 <div class="flex flex-col gap-8 accordion" data-all-expanded="true">
-{% include sections/prerequisites.html tier=page.tier %}
+{% include sections/prerequisites.html tier=page.tier tools=page.tools %}
 
 {{ content }}
 


### PR DESCRIPTION
## Description

Fixes #461 

* Next steps on all the vault backend docs
* Adjust the Konnect prereq when there is no decK involved - previously it was still using decK env variables even when decK wasn't available. This also removed the need for a second prereq that sets more environment variables

## Preview Links

[prereqs for Konnect API without decK](https://deploy-preview-473--kongdeveloper.netlify.app/how-to/configure-the-konnect-config-store/); also see next steps at the bottom
[page that has the decK env variables/instructions](https://deploy-preview-473--kongdeveloper.netlify.app/how-to/configure-hashicorp-vault-as-a-vault-backend/
)
## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
