### PR TITLE
Add basic {% entity_params_table %}

### DIFF
--- a/app/_includes/components/entity_params_table.html
+++ b/app/_includes/components/entity_params_table.html
@@ -1,0 +1,31 @@
+<table class="table-auto">
+    <thead>
+        <tr>
+          <th class="font-semibold text-primary">Parameter</th>
+          <th class="font-semibold text-primary">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for field in config.fields %}
+        <tr>
+            <td>
+                <span class="block text-primary">
+                    <code>{{ field.name | markdown }}</code>
+                </span>
+                {% if field.default_value != nil %}
+                {% assign default_value = field.default_value %}
+                {% if field.array? %}
+                    {% assign default_value = field.default_value | join: ', ' %}
+                {% endif %}
+                <span class="block mt-2">
+                    <span class="text-secondary text-xs">Default: <code>{{ default_value| markdown }}</code></span>
+                </span>
+            {% endif %}
+            </td>
+            <td>
+                <span class="content">{{ field.description | markdownify }}</span>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/app/_plugins/blocks/entity_params_table.rb
+++ b/app/_plugins/blocks/entity_params_table.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module Jekyll
+  class EntityParamsTable < Liquid::Block # rubocop:disable Style/Documentation
+    def initialize(tag_name, markup, tokens)
+      super
+      @name = markup.strip
+    end
+
+    def render(context) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+      @context = context
+      @site = context.registers[:site]
+      @page = context.environments.first['page']
+
+      contents = super
+      config = YAML.load(contents)
+      drop = Drops::EntityParamsTable.new(config, release(@site, @page))
+
+      context.stack do
+        context['config'] = drop
+        Liquid::Template.parse(template).render(context)
+      end
+    rescue Psych::SyntaxError => e
+      message = <<~STRING
+        On `#{@page['path']}`, the following {% entity_params_table %} block contains a malformed yaml:
+        #{contents.strip.split("\n").each_with_index.map { |l, i| "#{i}: #{l}" }.join("\n")}
+        #{e.message}
+      STRING
+      raise ArgumentError, message
+    end
+
+    def release(site, page)
+      return latest_release(site) unless page['release']
+
+      release = releases(site).detect { |r| r['release'] == page['release'].number }
+
+      if release.key?('label')
+        latest_release(site)
+      else
+        release['release']
+      end
+    end
+
+    def latest_release(site)
+      @latest_release ||= releases(site).detect { |r| r['latest'] }['release']
+    end
+
+    def releases(site)
+      @releases ||= site.data.dig('products', 'gateway', 'releases')
+    end
+
+    def template
+      @template ||= File.read(File.expand_path('app/_includes/components/entity_params_table.html'))
+    end
+  end
+end
+
+Liquid::Template.register_tag('entity_params_table', Jekyll::EntityParamsTable)

--- a/app/_plugins/drops/entity_params_table.rb
+++ b/app/_plugins/drops/entity_params_table.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+require_relative '../lib/site_accessor'
+
+module Jekyll
+  module Drops
+    class EntityParamsTable < Liquid::Drop # rubocop:disable Style/Documentation
+      class EntityParamsField < Liquid::Drop # rubocop:disable Style/Documentation
+        def initialize(config, field) # rubocop:disable Lint/MissingSuper
+          @config = config
+          @field = field || {}
+        end
+
+        def name
+          @name ||= @config.fetch('name')
+        end
+
+        def default_value
+          @default_value ||= @field['default']
+        end
+
+        def array?
+          @field['type'] == 'array'
+        end
+
+        def description
+          @description ||= @config['description'] || @field['description']
+        end
+      end
+
+      include Jekyll::SiteAccessor
+
+      def initialize(config, release_number) # rubocop:disable Lint/MissingSuper
+        @config = config
+        @release_number = release_number
+      end
+
+      def fields
+        @fields ||= params.sort_by(&:name)
+      end
+
+      def params
+        @params ||= @config.fetch('config', []).map do |f|
+          keys = f.fetch('name').split('.').map { |k| "properties.#{k}" }.join('.')
+          EntityParamsField.new(f, schema.dig(*keys.split('.')))
+        end
+      end
+
+      private
+
+      def schema
+        @schema ||= YAML.load(File.read(schema_file)).dig('components', 'schemas', @config.fetch('entity'))
+      end
+
+      def schema_file
+        @schema_file ||= begin
+          path = File.join('api-specs', 'gateway', 'admin-ee', @release_number, 'openapi.yaml')
+          raise ArgumentError, "Schema file not found: #{path}." unless File.exist?(path)
+
+          path
+        end
+      end
+    end
+  end
+end

--- a/app/gateway/traffic-control/health-checks-circuit-breakers.md
+++ b/app/gateway/traffic-control/health-checks-circuit-breakers.md
@@ -151,23 +151,38 @@ don't apply to Upstreams assigned to services with the protocol attribute set to
 To enable active health checks, you need to configure the parameters
 under `healthchecks.active` in the [Upstream object configuration](/gateway/entities/upstream/#schema).
 
-| Parameter | Description |
-|-----------|-------------|
-| `healthchecks.active.type` | Specify whether to perform `http` or `https` probes, or set this field to `tcp` to test the connection to a given host and port. |
-| `healthchecks.active.healthy.interval` | Interval between active health checks for healthy Targets (in seconds). Set this to a positive value to enable active healthchecks for healthy Targets. |
-| `healthchecks.active.unhealthy.interval` | Interval between active health checks for unhealthy Targets (in seconds). Set this to a positive value to enable active healthchecks for unhealthy Targets. |
-| `healthchecks.active.http_path` | The path that should be used when issuing the HTTP GET request to the Target. The default value is `"/"`. |
-| `healthchecks.active.timeout` | The connection timeout limit for the HTTP GET request of the probe. The default value is 1 second. |
-| `healthchecks.active.concurrency` | Number of Targets to check concurrently in active health checks. |
-| `healthchecks.active.https_verify_certificate` | (*Only used for HTTPS*) Whether to check the validity of the SSL certificate of the remote host when performing active health checks using HTTPS. <br><br> Failed TLS verifications will increment the `TCP failures` counter. `HTTP failures` refer only to HTTP status codes, whether probes are done through HTTP or HTTPS. |
-| `healthchecks.active.https_sni` | (*Only used for HTTPS*) The hostname to use as an SNI (Server Name Identification) when performing active health checks using HTTPS. This is particularly useful when Targets are configured using IPs, so that the Target host's certificate can be verified with the proper SNI. |
-| `healthchecks.active.healthy.successes` | Number of successes in active probes (as defined by `healthchecks.active.healthy.http_statuses`) to consider a Target healthy. |
-| `healthchecks.active.unhealthy.tcp_failures` | Number of TCP failures or TLS verification failures in active probes to consider a Target unhealthy. |
-| `healthchecks.active.unhealthy.timeouts` | Number of timeouts in active probes to consider a Target unhealthy. |
-| `healthchecks.active.unhealthy.http_failures` | Number of HTTP failures in active probes (as defined by `healthchecks.active.unhealthy.http_statuses`) to consider a Target unhealthy. |
-| `healthchecks.active.healthy.http_statuses` | An array of HTTP statuses to consider a success, indicating healthiness, when returned by a probe in active health checks. |
-| `healthchecks.active.unhealthy.http_statuses` | An array of HTTP statuses to consider a failure, indicating unhealthiness, when returned by a probe in active health checks. |
-
+{% entity_params_table %}
+entity: Upstream
+config:
+  - name: healthchecks.active.type
+    description: Specify whether to perform `http` or `https` probes, or set this field to `tcp` to test the connection to a given host and port.
+  - name: healthchecks.active.healthy.interval
+    description: Interval between active health checks for healthy Targets (in seconds). Set this to a positive value to enable active healthchecks for healthy Targets.
+  - name: healthchecks.active.unhealthy.interval
+    description: Interval between active health checks for unhealthy Targets (in seconds). Set this to a positive value to enable active healthchecks for unhealthy Targets.
+  - name: healthchecks.active.http_path
+    description: The path that should be used when issuing the HTTP GET request to the Target. The default value is `"/"`.
+  - name: healthchecks.active.timeout
+    description: The connection timeout limit for the HTTP GET request of the probe. The default value is 1 second.
+  - name: healthchecks.active.concurrency
+    description: Number of Targets to check concurrently in active health checks.
+  - name: healthchecks.active.https_verify_certificate
+    description: (*Only used for HTTPS*) Whether to check the validity of the SSL certificate of the remote host when performing active health checks using HTTPS. <br><br> Failed TLS verifications will increment the `TCP failures` counter. `HTTP failures` refer only to HTTP status codes, whether probes are done through HTTP or HTTPS.
+  - name: healthchecks.active.https_sni
+    description: (*Only used for HTTPS*) The hostname to use as an SNI (Server Name Identification) when performing active health checks using HTTPS. This is particularly useful when Targets are configured using IPs, so that the Target host's certificate can be verified with the proper SNI.
+  - name: healthchecks.active.healthy.successes
+    description: Number of successes in active probes (as defined by `healthchecks.active.healthy.http_statuses`) to consider a Target healthy.
+  - name: healthchecks.active.unhealthy.tcp_failures
+    description: Number of TCP failures or TLS verification failures in active probes to consider a Target unhealthy.
+  - name: healthchecks.active.unhealthy.timeouts
+    description: Number of timeouts in active probes to consider a Target unhealthy.
+  - name: healthchecks.active.unhealthy.http_failures
+    description: Number of HTTP failures in active probes (as defined by `healthchecks.active.unhealthy.http_statuses`) to consider a Target unhealthy.
+  - name: healthchecks.active.healthy.http_statuses
+    description: An array of HTTP statuses to consider a success, indicating healthiness, when returned by a probe in active health checks.
+  - name: healthchecks.active.unhealthy.http_statuses
+    description: An array of HTTP statuses to consider a failure, indicating unhealthiness, when returned by a probe in active health checks.
+{% endentity_params_table %}
 
 ### Disable active health checks
 
@@ -187,14 +202,22 @@ The ring balancer starts skipping this Target and doesn't route any more traffic
 Passive health checks don't have a probe, as they work by interpreting the ongoing traffic that flows from a Target. 
 To enable passive checks, you only need to configure the Upstream's counter thresholds, which you can find under `healthchecks.passive` in the [Upstream object configuration](/gateway/entities/upstream/#schema):
 
-| Parameter | Description |
-|-----------|-------------|
-| `healthchecks.passive.healthy.successes` | Number of successes in proxied traffic (as defined by `healthchecks.passive.healthy.http_statuses`) to consider a Target healthy, as observed by passive health checks. This needs to be positive when passive checks are enabled so that healthy traffic resets the unhealthy counters. |
-| `healthchecks.passive.unhealthy.tcp_failures` | Number of TCP failures in proxied traffic to consider a Target unhealthy, as observed by passive health checks. |
-| `healthchecks.passive.unhealthy.timeouts` | Number of timeouts in proxied traffic to consider a Target unhealthy, as observed by passive health checks. |
-| `healthchecks.passive.unhealthy.http_failures` | Number of HTTP failures in proxied traffic (as defined by `healthchecks.passive.unhealthy.http_statuses`) to consider a Target unhealthy, as observed by passive health checks. |
-| `healthchecks.passive.healthy.http_statuses` | An array of HTTP statuses which represent healthiness when produced by proxied traffic, as observed by passive health checks. |
-| `healthchecks.passive.unhealthy.http_statuses` | An array of HTTP statuses which represent unhealthiness when produced by proxied traffic, as observed by passive health checks. |
+{% entity_params_table %}
+entity: Upstream
+config:
+  - name: healthchecks.passive.healthy.successes
+    description: Number of successes in proxied traffic (as defined by `healthchecks.passive.healthy.http_statuses`) to consider a Target healthy, as observed by passive health checks. This needs to be positive when passive checks are enabled so that healthy traffic resets the unhealthy counters.
+  - name: healthchecks.passive.unhealthy.tcp_failures
+    description: Number of TCP failures in proxied traffic to consider a Target unhealthy, as observed by passive health checks.
+  - name: healthchecks.passive.unhealthy.timeouts
+    description: Number of timeouts in proxied traffic to consider a Target unhealthy, as observed by passive health checks.
+  - name: healthchecks.passive.unhealthy.http_failures
+    description: Number of HTTP failures in proxied traffic (as defined by `healthchecks.passive.unhealthy.http_statuses`) to consider a Target unhealthy, as observed by passive health checks.
+  - name: healthchecks.passive.healthy.http_statuses
+    description: An array of HTTP statuses which represent healthiness when produced by proxied traffic, as observed by passive health checks.
+  - name: healthchecks.passive.unhealthy.http_statuses
+    description: An array of HTTP statuses which represent unhealthiness when produced by proxied traffic, as observed by passive health checks.
+{% endentity_params_table %}
 
 ### Re-enable a Target disabled by a passive health check
 


### PR DESCRIPTION
## Description

 Block that renders a table with entity params and their description, it pulls the information from gateway/admin-ee API spec (the local file we have in the api-specs folder).

Usage:
```
{% entity_params_table %}
entity: Upstream # This should match the name of the entity in the Schema defined in the api spec
config:
  - name: healthchecks.passive.healthy.successes
    description: Number of successes in proxied traffic (as defined by `healthchecks.passive.healthy.http_statuses`) to consider a Target healthy, as observed by passive health checks. This needs to be positive when passive checks are enabled so that healthy traffic resets the unhealthy counters.
  - name: healthchecks.passive.unhealthy.tcp_failures
    description: Number of TCP failures in proxied traffic to consider a Target unhealthy, as observed by passive health checks.
  - name: healthchecks.passive.unhealthy.timeouts
    description: Number of timeouts in proxied traffic to consider a Target unhealthy, as observed by passive health checks.
  - name: healthchecks.passive.unhealthy.http_failures
    description: Number of HTTP failures in proxied traffic (as defined by `healthchecks.passive.unhealthy.http_statuses`) to consider a Target unhealthy, as observed by passive health checks.
  - name: healthchecks.passive.healthy.http_statuses 
    description: An array of HTTP statuses which represent healthiness when produced by proxied traffic, as observed by passive health checks.
  - name: healthchecks.passive.unhealthy.http_statuses 
    description: An array of HTTP statuses which represent unhealthiness when produced by proxied traffic, as observed by passive health checks.
 {% endentity_params_table %}
```
It pulls the description from the field and falls back to the one provided.

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
