### PR TITLE
Add {% konnect_roles_table %}

### DIFF
--- a/app/_includes/components/konnect_roles_table.html
+++ b/app/_includes/components/konnect_roles_table.html
@@ -1,0 +1,23 @@
+<table class="table-auto">
+    <thead>
+        <tr>
+          <th class="font-semibold text-primary">Role</th>
+          <th class="font-semibold text-primary">Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for role_hash in config.roles %}
+        {% assign role = role_hash[1] %}
+        <tr>
+            <td>
+                <span class="block text-primary">
+                    <code>{{ role.properties.name.enum | first | markdown }}</code>
+                </span>
+            </td>
+            <td>
+                <span class="content">{{ role.properties.description.enum | first | markdownify }}</span>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>

--- a/app/_plugins/blocks/konnect_roles_table.rb
+++ b/app/_plugins/blocks/konnect_roles_table.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module Jekyll
+  class KonnectRolesTable < Liquid::Block # rubocop:disable Style/Documentation
+    def initialize(tag_name, markup, tokens)
+      super
+      @name = markup.strip
+    end
+
+    def render(context) # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+      @context = context
+      @site = context.registers[:site]
+      @page = context.environments.first['page']
+
+      contents = super
+      config = YAML.load(contents)
+      drop = Drops::KonnectRolesTable.new(config)
+
+      context.stack do
+        context['config'] = drop
+        Liquid::Template.parse(template).render(context)
+      end
+    rescue Psych::SyntaxError => e
+      message = <<~STRING
+        On `#{@page['path']}`, the following {% konnect_roles_table %} block contains a malformed yaml:
+        #{contents.strip.split("\n").each_with_index.map { |l, i| "#{i}: #{l}" }.join("\n")}
+        #{e.message}
+      STRING
+      raise ArgumentError, message
+    end
+
+    def template
+      @template ||= File.read(File.expand_path('app/_includes/components/konnect_roles_table.html'))
+    end
+  end
+end
+
+Liquid::Template.register_tag('konnect_roles_table', Jekyll::KonnectRolesTable)

--- a/app/_plugins/drops/konnect_roles_table.rb
+++ b/app/_plugins/drops/konnect_roles_table.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module Jekyll
+  module Drops
+    class KonnectRolesTable < Liquid::Drop # rubocop:disable Style/Documentation
+      def initialize(config) # rubocop:disable Lint/MissingSuper
+        @config = config
+
+        validate_config!
+      end
+
+      def roles
+        @roles ||= schema.dig('properties', 'roles', 'properties').sort
+      end
+
+      def schema
+        @schema ||= begin
+          key = @config.fetch('schema')
+          raise ArgumentError, "Couldn't find schema `#{key}`" unless schemas.key?(key)
+
+          schemas.fetch(key)
+        end
+      end
+
+      private
+
+      def validate_config!
+        raise ArgumentError, 'Missing  `schema` in konnect_roles_table' unless @config.key?('schema')
+      end
+
+      def schemas
+        @schemas ||= YAML
+                     .load(File.read(api_spec_file))
+                     .dig('components', 'responses', 'Roles', 'content', 'application/json', 'schema', 'properties')
+      end
+
+      def api_spec_file
+        # XXX: roles not defined in the spec
+        #   Networks
+        #   Service Catalog
+        #   Portals
+        #   Application Auth Strategies
+        #   DCR
+        # XXX: teams aren't defined in the spec
+        @api_spec_file ||= begin
+          folder = Dir.glob('api-specs/konnect/identity/*').max_by { |f| f[/\d+/].to_i }
+          File.join(folder, 'openapi.yaml')
+        end
+      end
+    end
+  end
+end

--- a/app/konnect/teams-and-roles.md
+++ b/app/konnect/teams-and-roles.md
@@ -24,30 +24,40 @@ Pull content from:
 
 ## API Products
 
+<!-- vale off -->
 {% konnect_roles_table %}
 schema: api_products
 {% endkonnect_roles_table %}
+<!-- vale on -->
 
 ## Control Planes
 
+<!-- vale off -->
 {% konnect_roles_table %}
 schema: control_planes
 {% endkonnect_roles_table %}
+<!-- vale on -->
 
 ## Audit Logs
 
+<!-- vale off -->
 {% konnect_roles_table %}
 schema: audit_logs
 {% endkonnect_roles_table %}
+<!-- vale on -->
 
 ## Identity
 
+<!-- vale off -->
 {% konnect_roles_table %}
 schema: identity
 {% endkonnect_roles_table %}
+<!-- vale on -->
 
 ## Mesh control planes
 
+<!-- vale off -->
 {% konnect_roles_table %}
 schema: mesh_control_planes
 {% endkonnect_roles_table %}
+<!-- vale on -->

--- a/app/konnect/teams-and-roles.md
+++ b/app/konnect/teams-and-roles.md
@@ -20,3 +20,34 @@ Pull content from:
 * https://docs.konghq.com/konnect/org-management/teams-and-roles/manage/
 * https://docs.konghq.com/konnect/org-management/teams-and-roles/teams-reference/
 * https://docs.konghq.com/konnect/org-management/teams-and-roles/roles-reference/
+
+
+## API Products
+
+{% konnect_roles_table %}
+schema: api_products
+{% endkonnect_roles_table %}
+
+## Control Planes
+
+{% konnect_roles_table %}
+schema: control_planes
+{% endkonnect_roles_table %}
+
+## Audit Logs
+
+{% konnect_roles_table %}
+schema: audit_logs
+{% endkonnect_roles_table %}
+
+## Identity
+
+{% konnect_roles_table %}
+schema: identity
+{% endkonnect_roles_table %}
+
+## Mesh control planes
+
+{% konnect_roles_table %}
+schema: mesh_control_planes
+{% endkonnect_roles_table %}


### PR DESCRIPTION
## Description

Add {% konnect_roles_table %} block.

Renders a table with the roles + description of the provided schema

Usage:
Pass the name of the schema as defined in
`api-specs/konnect/identity/vX/openapi.yaml`

The name of the schemas can be found under:
`components.responses.Roles.content.application/json.schema.properties`

```
{% konnect_roles_table %}
schema: audit_logs
{% endkonnect_roles_table %}
```

TODO:
* The following  roles are not defined in the spec
      - Networks
      -   Service Catalog
      -   Portals
      -   Application Auth Strategies
      -   DCR
* Teams aren't defined in the spec

Related https://github.com/Kong/developer.konghq.com/issues/372


## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
