### PR TITLE
Konnect ports/hostnames

### DIFF
--- a/app/_includes/sections/data-plane-node-ports.md
+++ b/app/_includes/sections/data-plane-node-ports.md
@@ -1,6 +1,6 @@
 In general, the proxy ports are the *only* ports that should be made available to your clients. Upstream services are accessible via the proxy interface and ports, so make sure that these values only grant the access level you require. 
 
-Your proxy will need have rules added for any HTTP/HTTPS and TCP/TLS stream listeners that you configure. For example, if you want {{site.base_gateway}} to manage traffic on port `4242`, your firewall must allow traffic on that port.
+Your proxy will need rules added for any HTTP/HTTPS and TCP/TLS stream listeners that you configure. For example, if you want {{site.base_gateway}} to manage traffic on port `4242`, your firewall must allow traffic on that port.
 
 The following are the default proxy ports:
 

--- a/app/_includes/sections/data-plane-node-ports.md
+++ b/app/_includes/sections/data-plane-node-ports.md
@@ -1,0 +1,12 @@
+In general, the proxy ports are the *only* ports that should be made available to your clients. Upstream services are accessible via the proxy interface and ports, so make sure that these values only grant the access level you require. 
+
+Your proxy will need have rules added for any HTTP/HTTPS and TCP/TLS stream listeners that you configure. For example, if you want {{site.base_gateway}} to manage traffic on port `4242`, your firewall must allow traffic on that port.
+
+The following are the default proxy ports:
+
+| Port | Protocol | `kong.conf` setting | Description | 
+|---------|---------|------------|------------|
+| `8000` | HTTP     | [`proxy_listen`](/gateway/configuration/#proxy_listen) | Takes incoming HTTP traffic from [Consumers](/gateway/entities/consumer/), and forwards it to upstream services. | 
+| `8443` | HTTPS    | [`proxy_listen`](/gateway/configuration/#proxy_listen) | Takes incoming HTTPS traffic from [Consumers](/gateway/entities/consumer/), and forwards it to upstream services. |
+
+You can also proxy TCP/TLS streams, which is disabled by default. If you want to proxy this traffic, see [`stream_listen` in the Kong configuration reference](/gateway/configuration/) for more information about stream proxy listen options and how to enable it.

--- a/app/_includes/sections/data-plane-node-ports.md
+++ b/app/_includes/sections/data-plane-node-ports.md
@@ -1,6 +1,6 @@
-In general, the proxy ports are the *only* ports that should be made available to your clients. Upstream services are accessible via the proxy interface and ports, so make sure that these values only grant the access level you require. 
+The proxy ports are the *only* ports that should be made available to your clients. Upstream services are accessible via the proxy interface and ports, so make sure that these values only grant the access level you require. 
 
-Your proxy will need rules added for any HTTP/HTTPS and TCP/TLS stream listeners that you configure. For example, if you want {{site.base_gateway}} to manage traffic on port `4242`, your firewall must allow traffic on that port.
+Your proxy will need rules added for any HTTP/HTTPS and TCP/TLS stream listeners that you configure. For example, if you want {{site.base_gateway}} to manage traffic on port `4242`, your firewall must configure the Route to allow traffic on that port.
 
 The following are the default proxy ports:
 

--- a/app/gateway/cp-dp-communication.md
+++ b/app/gateway/cp-dp-communication.md
@@ -28,6 +28,7 @@ related_resources:
 
 Contains info from:
 * https://docs.konghq.com/konnect/gateway-manager/data-plane-nodes/secure-communications/
+* https://docs.konghq.com/konnect/network-resiliency/ (FAQ?)
 
 ## Use a forward proxy to secure communication across a firewall
 

--- a/app/gateway/network-ports-firewall.md
+++ b/app/gateway/network-ports-firewall.md
@@ -24,18 +24,7 @@ related_resources:
 
 ## Proxy ports
 
-In general, the proxy ports are the *only* ports that should be made available to your clients. Upstream services are accessible via the proxy interface and ports, so make sure that these values only grant the access level you require. 
-
-Your proxy will need have rules added for any HTTP/HTTPS and TCP/TLS stream listeners that you configure. For example, if you want {{site.base_gateway}} to manage traffic on port `4242`, your firewall must allow traffic on that port.
-
-The following are the default proxy ports:
-
-| Port | Protocol | `kong.conf` setting | Description | 
-|---------|---------|------------|------------|
-| `8000` | HTTP     | [`proxy_listen`](/gateway/configuration/#proxy_listen) | Takes incoming HTTP traffic from [Consumers](/gateway/entities/consumer/), and forwards it to upstream services. | 
-| `8443` | HTTPS    | [`proxy_listen`](/gateway/configuration/#proxy_listen) | Takes incoming HTTPS traffic from [Consumers](/gateway/entities/consumer/), and forwards it to upstream services. |
-
-You can also proxy TCP/TLS streams, which is disabled by default. If you want to proxy this traffic, see [`stream_listen` in the Kong configuration reference](/gateway/configuration/) for more information about stream proxy listen options and how to enable it.
+{% include_cached /sections/data-plane-node-ports.md %}
 
 ## Admin API ports
 

--- a/app/konnect/mesh-manager.md
+++ b/app/konnect/mesh-manager.md
@@ -1,0 +1,23 @@
+---
+title: "Service meshes in {{site.konnect_short_name}} with Mesh Manager"
+description: 'placeholder'
+content_type: reference
+layout: reference
+products:
+    - gateway
+works_on:
+    - konnect
+tools:
+    - admin-api
+    - konnect-api
+    - deck
+    - kic
+    - terraform
+related_resources:
+  - text: placeholder
+    url: /
+---
+
+@todo
+
+pull content from https://docs.konghq.com/konnect/mesh-manager/

--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -1,10 +1,12 @@
 ---
-title: "{{site.konnect_short_name}} ports and network requirments"
+title: "{{site.konnect_short_name}} ports and network requirements"
 description: 'See which ports and hostnames {{site.konnect_short_name}} uses.'
 content_type: reference
 layout: reference
 products:
     - gateway
+works_on:
+  - konnect
 tools:
     - admin-api
     - konnect-api
@@ -50,7 +52,7 @@ want to use port `3001` for the proxy, map `3001:8000`.
 Data plane nodes initiate the connection to the {{site.konnect_short_name}} control plane.
 They require access through firewalls to communicate with the control plane. To let a data plane node request and receive configuration, and send telemetry data, add the applicable hostnames in this section to the firewall allowlist.
 
-{{site.kic_product_name}} also uses these hostnames to initiate the connection to the {{site.konnect_short_name}} [Control Planes Configuration API](/konnect/api/control-plane-configuration/latest/) to:
+{{site.kic_product_name}} also uses these hostnames to initiate the connection to the {{site.konnect_short_name}} [Control Planes Configuration API](/api/konnect/control-planes-config/) to:
 
 * Synchronize the configuration of the {{site.base_gateway}} instances with {{site.konnect_short_name}}
 * Register data plane nodes

--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -1,0 +1,85 @@
+---
+title: "{{site.konnect_short_name}} ports and network requirments"
+description: 'See which ports and hostnames {{site.konnect_short_name}} uses.'
+content_type: reference
+layout: reference
+products:
+    - gateway
+tools:
+    - admin-api
+    - konnect-api
+    - deck
+    - kic
+    - terraform
+related_resources:
+  - text: "{{site.base_gateway}} ports"
+    url: /gateway/network-ports-firewall/
+  - text: Networking in {{site.base_gateway}}
+    url: /gateway/network/
+---
+
+{{site.konnect_short_name}} control planes and data plane nodes rely on specific ports and hostnames for secure communication and configuration. The following sections outline the required ports for cluster communication, audit logging, and the hostnames for connecting to regional control plane and telemetry endpoints.
+
+## Control plane ports
+
+The {{site.konnect_saas}} control plane uses the following ports:
+
+| Port      | Protocol  | Description |
+|:----------|:----------|:------------|
+| `443`    | TCP <br>HTTPS | Cluster communication port for configuration and telemetry data. The {{site.konnect_saas}} control plane uses this port to listen for connections and communicate with data plane nodes. <br> The cluster communication port must be accessible to data plane nodes within the same cluster. This port is protected by mTLS to ensure end-to-end security and integrity. |
+| `8071`   | TCP <br> UDP | Port used for audit logging. |
+
+{{site.base_gateway}}'s hosted control plane expects traffic on these ports, so they can't be customized. 
+
+{:.info}
+> **Note**: If you can't make outbound connections using port `443`, you can use an existing proxy in your network to make the connection. See [Use a forward proxy to secure communication across a firewall](/gateway/cp-dp-communication/#use-a-forward-proxy-to-secure-communication-across-a-firewall) for details. 
+
+## Data plane node ports
+
+{{site.base_gateway}} uses data plane node ports to proxy communication.
+
+{% include_cached /sections/data-plane-node-ports.md %}
+
+For Kubernetes or Docker deployments, map ports as needed. For example, if you
+want to use port `3001` for the proxy, map `3001:8000`.
+
+## {{site.konnect_short_name}} and {{site.kic_product_name}} hostnames
+
+Data plane nodes initiate the connection to the {{site.konnect_short_name}} control plane.
+They require access through firewalls to communicate with the control plane.
+
+Hostnames are region-specific. You must allowlist the hostnames to let a data plane node request and receive configuration, and send telemetry data. 
+
+{{site.kic_product_name}} also uses these hostnames to initiate the connection to the {{site.konnect_short_name}} [Control Planes Configuration API](/konnect/api/control-plane-configuration/latest/) to:
+
+* Synchronize the configuration of the {{site.base_gateway}} instances with {{site.konnect_short_name}}
+* Register data plane nodes
+* Fetch license information
+
+Data plane nodes initiate the connection to {{site.konnect_short_name}} APIs to report Analytics data.
+
+Add the following hostnames to the firewall allowlist (depending on the [geographic regions](/konnect/geo) you use).
+
+The following [geographic regions](/konnect/geos) and their hostname region identifiers are supported:
+* AU: `au`
+* EU: `eu`
+* IN: `in`
+* ME: `me`
+* US: `us`
+
+Depending on the regions your organization uses, you'll need to allowlist the hostnames and include the region-specific identifier in the hostname in place of `{region}`:
+
+| Hostname      | Supported regions | Description |
+|----------|----------|----------|
+| `cloud.konghq.com`    | All | The {{site.konnect_short_name}} platform. |
+| `global.api.konghq.com` | All | The {{site.konnect_short_name}} API for platform authentication, identity, permissions, teams, and organizational entitlements and settings. |
+| `{region}.api.konghq.com` | All | The {{site.konnect_short_name}} API for the geo. Necessary if you are using decK in your workflow, decK uses this API to access and apply configurations. |
+| `PORTAL_ID.{region}.portal.konghq.com` | All | The URL for the Dev Portal in the geo. |
+| `CONTROL_PLANE_ID.{region}.cp0.konghq.com` | AU, IN, ME, US | Handles configuration for a control plane in the geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.eu.cp0.konghq.com` | EU | Handles configuration for a control plane in the EU geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_ID.{region}.tp0.konghq.com` | All | Gathers telemetry data for a control plane in the geo. This hostname is unique to each organization and control plane. |
+
+
+## Mesh Manager hostnames
+
+If you plan to use [Mesh Manager](/konnect/mesh-manager/) to manage your Kong service mesh, you must add the `{geo}.mesh.sync.konghq.com:443` hostname to your firewall allowlist. The geo can be `au`, `eu`, `us`, or `global`.

--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -30,7 +30,7 @@ The {{site.konnect_short_name}} control plane uses the following ports:
 
 | Port      | Protocol  | Description |
 |:----------|:----------|:------------|
-| `443`    | TCP <br>HTTPS | Cluster communication port for configuration and telemetry data. The {{site.konnect_saas}} control plane uses this port to listen for connections and communicate with data plane nodes. <br> The cluster communication port must be accessible to data plane nodes within the same cluster. This port is protected by mTLS to ensure end-to-end security and integrity. |
+| `443`    | TCP <br>HTTPS | Cluster communication port for configuration and telemetry data. The {{site.konnect_saas}} control plane uses this port to listen for connections and to communicate with data plane nodes. <br> The cluster communication port must be accessible to data plane nodes within the same cluster. This port is protected by mTLS to ensure end-to-end security and integrity. |
 | `8071`   | TCP <br> UDP | Port used for audit logging. |
 
 {{site.base_gateway}}'s hosted control plane expects traffic on these ports, so they can't be customized. 
@@ -40,25 +40,12 @@ The {{site.konnect_short_name}} control plane uses the following ports:
 
 ## Data plane node ports
 
-{{site.base_gateway}} uses data plane node ports to proxy communication.
 
 {% include_cached /sections/data-plane-node-ports.md %}
 
-For Kubernetes or Docker deployments, map ports as needed. For example, if you
-want to use port `3001` for the proxy, map `3001:8000`.
 
 ## Hostnames
 
-Data plane nodes initiate the connection to the {{site.konnect_short_name}} control plane.
-They require access through firewalls to communicate with the control plane. To let a data plane node request and receive configuration, and send telemetry data, add the applicable hostnames in this section to the firewall allowlist.
-
-{{site.kic_product_name}} also uses these hostnames to initiate the connection to the {{site.konnect_short_name}} [Control Planes Configuration API](/api/konnect/control-planes-config/) to:
-
-* Synchronize the configuration of the {{site.base_gateway}} instances with {{site.konnect_short_name}}
-* Register data plane nodes
-* Fetch license information
-
-Data plane nodes initiate the connection to {{site.konnect_short_name}} APIs to report Analytics data.
 
 The following [geographic regions](/konnect/geos/) and their hostname region identifiers are supported:
 * AU (Australia): `au`
@@ -80,4 +67,4 @@ Depending on the regions your organization uses, you'll need to allowlist the ho
 
 ## Mesh Manager hostnames
 
-If you plan to use [Mesh Manager](/konnect/mesh-manager/) to manage your Kong service mesh, you must add the `{geo}.mesh.sync.konghq.com:443` hostname to your firewall allowlist. The geo can be `au`, `eu`, `us`, or `global`.
+If you use [Mesh Manager](/konnect/mesh-manager/) to manage your Kong service mesh, you must add the `{geo}.mesh.sync.konghq.com:443` hostname to your firewall allowlist. The geo can be `au`, `eu`, `us`, or `global`.

--- a/app/konnect/network.md
+++ b/app/konnect/network.md
@@ -16,13 +16,15 @@ related_resources:
     url: /gateway/network-ports-firewall/
   - text: Networking in {{site.base_gateway}}
     url: /gateway/network/
+  - text: " {{site.base_gateway}} control plane and data plane communication"
+    url: /gateway/cp-dp-communication/
 ---
 
-{{site.konnect_short_name}} control planes and data plane nodes rely on specific ports and hostnames for secure communication and configuration. The following sections outline the required ports for cluster communication, audit logging, and the hostnames for connecting to regional control plane and telemetry endpoints.
+{{site.konnect_short_name}} control planes and data plane nodes rely on specific ports and hostnames for secure communication and configuration. The following tables detail the required ports for cluster communication, audit logging, and the hostnames for connecting to regional control plane and telemetry endpoints.
 
 ## Control plane ports
 
-The {{site.konnect_saas}} control plane uses the following ports:
+The {{site.konnect_short_name}} control plane uses the following ports:
 
 | Port      | Protocol  | Description |
 |:----------|:----------|:------------|
@@ -43,12 +45,10 @@ The {{site.konnect_saas}} control plane uses the following ports:
 For Kubernetes or Docker deployments, map ports as needed. For example, if you
 want to use port `3001` for the proxy, map `3001:8000`.
 
-## {{site.konnect_short_name}} and {{site.kic_product_name}} hostnames
+## Hostnames
 
 Data plane nodes initiate the connection to the {{site.konnect_short_name}} control plane.
-They require access through firewalls to communicate with the control plane.
-
-Hostnames are region-specific. You must allowlist the hostnames to let a data plane node request and receive configuration, and send telemetry data. 
+They require access through firewalls to communicate with the control plane. To let a data plane node request and receive configuration, and send telemetry data, add the applicable hostnames in this section to the firewall allowlist.
 
 {{site.kic_product_name}} also uses these hostnames to initiate the connection to the {{site.konnect_short_name}} [Control Planes Configuration API](/konnect/api/control-plane-configuration/latest/) to:
 
@@ -58,27 +58,23 @@ Hostnames are region-specific. You must allowlist the hostnames to let a data pl
 
 Data plane nodes initiate the connection to {{site.konnect_short_name}} APIs to report Analytics data.
 
-Add the following hostnames to the firewall allowlist (depending on the [geographic regions](/konnect/geo) you use).
-
-The following [geographic regions](/konnect/geos) and their hostname region identifiers are supported:
-* AU: `au`
-* EU: `eu`
-* IN: `in`
-* ME: `me`
-* US: `us`
+The following [geographic regions](/konnect/geos/) and their hostname region identifiers are supported:
+* AU (Australia): `au`
+* EU (Europe): `eu`
+* ME (Middle East): `me`
+* IN (India): `in`
+* US (United States): `us`
 
 Depending on the regions your organization uses, you'll need to allowlist the hostnames and include the region-specific identifier in the hostname in place of `{region}`:
 
-| Hostname      | Supported regions | Description |
-|----------|----------|----------|
-| `cloud.konghq.com`    | All | The {{site.konnect_short_name}} platform. |
-| `global.api.konghq.com` | All | The {{site.konnect_short_name}} API for platform authentication, identity, permissions, teams, and organizational entitlements and settings. |
-| `{region}.api.konghq.com` | All | The {{site.konnect_short_name}} API for the geo. Necessary if you are using decK in your workflow, decK uses this API to access and apply configurations. |
-| `PORTAL_ID.{region}.portal.konghq.com` | All | The URL for the Dev Portal in the geo. |
-| `CONTROL_PLANE_ID.{region}.cp0.konghq.com` | AU, IN, ME, US | Handles configuration for a control plane in the geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
-| `CONTROL_PLANE_DNS_PREFIX.eu.cp0.konghq.com` | EU | Handles configuration for a control plane in the EU geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
-| `CONTROL_PLANE_ID.{region}.tp0.konghq.com` | All | Gathers telemetry data for a control plane in the geo. This hostname is unique to each organization and control plane. |
-
+| Hostname      | Description |
+|----------|----------|
+| `cloud.konghq.com`    | The {{site.konnect_short_name}} platform. |
+| `global.api.konghq.com` | The {{site.konnect_short_name}} API for platform authentication, identity, permissions, teams, and organizational entitlements and settings. |
+| `{region}.api.konghq.com` | The {{site.konnect_short_name}} API for the geo. Necessary if you are using decK in your workflow, decK uses this API to access and apply configurations. |
+| `PORTAL_ID.{region}.portal.konghq.com` | The URL for the Dev Portal in the geo. |
+| `CONTROL_PLANE_DNS_PREFIX.{region}.cp0.konghq.com` | Handles configuration for a control plane in the geo. Data plane nodes connect to this host to receive configuration updates. This hostname is unique to each organization and control plane. |
+| `CONTROL_PLANE_DNS_PREFIX.{region}.tp0.konghq.com` | Gathers telemetry data for a control plane in the geo. This hostname is unique to each organization and control plane. |
 
 ## Mesh Manager hostnames
 

--- a/tools/track-docs-changes/config/sources.yml
+++ b/tools/track-docs-changes/config/sources.yml
@@ -302,6 +302,8 @@ app/gateway/network-ports-firewall.md:
   - app/_src/gateway/production/networking/firewall.md
 app/gateway/cp-dp-communication.md:
   - app/_src/gateway/production/networking/cp-dp-proxy.md
+app/konnect/network.md:
+  - app/konnect/network.md
 
 # traffic control
 app/gateway/traffic-control/proxy.md:


### PR DESCRIPTION
## Description

Fixes #497 

Source doc: https://docs.konghq.com/konnect/network/

Stub page GH issue: https://github.com/Kong/developer.konghq.com/issues/532

## Preview Links
https://deploy-preview-531--kongdeveloper.netlify.app/konnect/network/

## Notes for reviewers

- The cluster and telemetry hostnames are different from the source doc. This is because the source is wrong, I verified it here: https://kongstrong.slack.com/archives/C04RXLGNB6K/p1740607033227059 I'll be opening a PR to the docs repo that fixes this.


## Checklist 

- [x] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. *N/A: reference doc*
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
