### PR TITLE
Dynamic plugin ordering

### DIFF
--- a/app/_gateway_entities/plugin.md
+++ b/app/_gateway_entities/plugin.md
@@ -133,8 +133,77 @@ This can be [adjusted dynamically](#dynamic-plugin-ordering) using the plugin's 
 You can override the [priority](#plugin-priority) for any {{site.base_gateway}} plugin using each plugin’s `ordering` configuration parameter. 
 This determines plugin ordering during the `access` phase, and lets you create dynamic dependencies between plugins.
 
-<!-- @todo: migrate https://docs.konghq.com/gateway/latest/kong-enterprise/plugin-ordering/ -->
+You can choose to run a particular plugin `before` or `after` a specified plugin or list of plugins.
 
+The configuration looks like this:
+
+```yaml
+pluginA:
+  ordering:
+    before|after:
+      access:
+        - pluginB
+        - pluginC
+```
+
+#### Example with before token
+
+For example, let’s say you want to limit the amount of requests against your Gateway Service and Route **before** Kong requests authentication.
+The following example uses the Rate Limiting Advanced plugin with the Key Auth plugin as the authentication method:
+
+{% entity_example %}
+type: plugin
+data:
+  name: rate-limiting
+  config:
+    minute:
+    - 5
+    policy: local
+    limit_by: ip
+  ordering:
+    before:
+      - key-auth
+formats:
+  - deck
+{% endentity_example %}
+
+#### Example with after token
+
+For example, you may want to first transform a request with the Request Transformer plugin, then request authentication.
+You can change the order of the authentication plugin (Basic Auth, in this example) so that it always runs **after** transformation:
+
+{% entity_example %}
+type: plugin
+data:
+  name: basic-auth
+  ordering:
+    after:
+      - request-transformer
+formats:
+  - deck
+{% endentity_example %}
+
+
+#### Known limitations of dynamic plugin ordering
+
+If using dynamic ordering, manually test all configurations, and handle this feature with care. 
+There are a number of considerations that can affect your environment:
+
+* **Consumer scoping**: If you have [Consumer-scoped plugins](#scoping-plugins) anywhere in your Workspace or Control Plane, you can't use dynamic plugin ordering.
+
+  Consumer mapping and dynamic plugin ordering both run in the `access` phase, but the order of the  plugins must be determined after Consumer mapping has happened.
+  {{site.base_gateway}} can't reliably change the order of the plugins in relation to mapped Consumers.
+
+* **Cascading deletes**: There is no support to detect if a plugin has a dependency to a deleted plugin, so handle your configuration with care.
+
+* **Performance**: Dynamic plugin ordering requires sorting plugins during a request, which adds latency to the request. 
+In some cases, this might be compensated for when you run rate limiting before an expensive authentication plugin.
+    
+  Re-ordering _any_ plugin in Workspace or Control Plan has performance implications to all other plugins within the same environment. 
+  If possible, consider offloading plugin ordering to a separate environment.
+
+* **Validation**: Validating dynamic plugin ordering is a non-trivial task and would require insight into the user's business logic. 
+{{site.base_gateway}} tries to catch basic mistakes but it can't detect all potentially dangerous configurations.
 
 ## Plugin queuing
 

--- a/tools/track-docs-changes/config/sources.yml
+++ b/tools/track-docs-changes/config/sources.yml
@@ -40,6 +40,8 @@ app/_gateway_entities/consumer.md:
 app/_gateway_entities/plugin.md:
   - app/hub/plugins/overview/index.md
   - app/hub/plugins/compatibility/index.md
+  - app/_src/gateway/kong-enterprise/plugin-ordering/index.md
+  - app/_src/gateway/kong-enterprise/plugin-ordering/get-started.md
 app/_gateway_entities/route.md:
   - app/_src/gateway/key-concepts/routes.md
   - app/_src/gateway/how-kong-works/routing-traffic.md


### PR DESCRIPTION
## Description

Fixes #554 

I massively cut down the original two pages, https://docs.konghq.com/gateway/3.9.x/kong-enterprise/plugin-ordering/ and https://docs.konghq.com/gateway/3.9.x/kong-enterprise/plugin-ordering/get-started/. 
There were a lot of words saying very little.

@fabianrbz : I noticed that the plugin entity_example tag doesn't pick up `ordering`. I couldn't quite figure out how to add that to the example generator - can you take a look?

Example:
```
{% entity_example %}
type: plugin
data:
  name: rate-limiting
  config:
    minute:
    - 5
    policy: local
    limit_by: ip
  ordering:
    before:
      - key-auth
formats:
  - deck
{% endentity_example %}
```
In the output, the `ordering` section is missing:
```
  ordering:
    before:
      - key-auth
```

<img width="1023" alt="Screenshot 2025-03-05 at 4 04 00 PM" src="https://github.com/user-attachments/assets/432d4093-5d58-4723-a875-b3196218af48" />


  

## Preview Links


## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
