### PR TITLE
Fix: Service catalog broken variable and tile format

### DIFF
--- a/app/_landing_pages/service-catalog/integrations.yaml
+++ b/app/_landing_pages/service-catalog/integrations.yaml
@@ -18,7 +18,7 @@ rows:
               blocks:
                 - type: text
                   text: |
-                    **Integrations** are applications—either {{site.konnect_short_name}}-internal or external—that extend the functionality of the {{site.service_catalog_name}}.
+                    **Integrations** are applications—either {{site.konnect_short_name}}-internal or external—that extend the functionality of the Service Catalog.
 
                     When enabled, an integration allows you to:
                     - **Discover new resources** from connected systems
@@ -56,6 +56,10 @@ rows:
               cta:
                 text: Learn more
                 url: /service-catalog/integrations/traceable/
+     
+      
+
+  - columns:
       - blocks:
           - type: card
             config:
@@ -65,9 +69,6 @@ rows:
               cta:
                 text: Learn more
                 url: /service-catalog/integrations/gitlab
-      
-
-  - columns:
       - blocks:
           - type: card
             config:


### PR DESCRIPTION
## Description

Fixing these two issues:

Non-existent variable:
<img width="834" alt="Screenshot 2025-03-06 at 4 15 47 PM" src="https://github.com/user-attachments/assets/540fd9c7-73ab-4353-abdd-fd41e3254f74" />

Tiles look awkward in a 4/2 split; we can adjust it to 4 at a future date where there are more tiles:
<img width="1448" alt="Screenshot 2025-03-06 at 4 15 42 PM" src="https://github.com/user-attachments/assets/94672bfa-4a68-4c3b-a64b-1b42932acaf6" />

## Preview Links


## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
