### PR TITLE
feat: use kong spec-renderer v1.88.0 package [KHCP-15445]

### DIFF
--- a/app/_assets/entrypoints/api_spec.js
+++ b/app/_assets/entrypoints/api_spec.js
@@ -1,6 +1,6 @@
 import { createApp } from "vue";
 import APISpec from "~/javascripts/apps/APISpec.vue";
-import "@kong/spec-renderer-dev/dist/style.css";
+import "@kong/spec-renderer/dist/style.css";
 
 if (document.getElementById("api-spec") !== null) {
   const app = createApp(APISpec);

--- a/app/_assets/entrypoints/entity_schema.js
+++ b/app/_assets/entrypoints/entity_schema.js
@@ -1,6 +1,6 @@
 import { createApp } from 'vue';
 import EntitySchema from '~/javascripts/apps/EntitySchema.vue';
-import '@kong/spec-renderer-dev/dist/style.css'
+import '@kong/spec-renderer/dist/style.css'
 
 if (document.getElementById('entity-schema-app') !== null) {
   const app = createApp(EntitySchema);

--- a/app/_assets/entrypoints/plugin_schema.js
+++ b/app/_assets/entrypoints/plugin_schema.js
@@ -1,6 +1,6 @@
 import { createApp } from "vue";
 import PluginSchema from "~/javascripts/apps/PluginSchema.vue";
-import "@kong/spec-renderer-dev/dist/style.css";
+import "@kong/spec-renderer/dist/style.css";
 
 if (document.getElementById("schema") !== null) {
   const app = createApp(PluginSchema);

--- a/app/_assets/javascripts/apps/APISpec.vue
+++ b/app/_assets/javascripts/apps/APISpec.vue
@@ -65,7 +65,7 @@
 
 <script setup>
 import { onBeforeMount, ref, watch } from 'vue';
-import { SpecDocument, SpecRendererToc, parseSpecDocument,  parsedDocument, tableOfContents } from '@kong/spec-renderer-dev';
+import { SpecDocument, SpecRendererToc, parseSpecDocument,  parsedDocument, tableOfContents } from '@kong/spec-renderer';
 import ApiService from '../services/api.js';
 import { KSkeleton, KSelect, KSlideout } from '@kong/kongponents';
 import { MenuIcon } from '@kong/icons'

--- a/app/_assets/javascripts/apps/EntitySchema.vue
+++ b/app/_assets/javascripts/apps/EntitySchema.vue
@@ -15,7 +15,7 @@
 <script setup>
 import { ref, onMounted, watch, computed } from 'vue'
 
-import { SchemaRenderer, parseSpecDocument, parsedDocument } from '@kong/spec-renderer-dev'
+import { SchemaRenderer, parseSpecDocument, parsedDocument } from '@kong/spec-renderer'
 import ApiService from '../services/api.js'
 
 const { path, product, version } = window.entitySchema;

--- a/app/_assets/javascripts/apps/PluginSchema.vue
+++ b/app/_assets/javascripts/apps/PluginSchema.vue
@@ -11,7 +11,7 @@
   </template>
 
 <script setup>
-import { SchemaRenderer } from '@kong/spec-renderer-dev'
+import { SchemaRenderer } from '@kong/spec-renderer'
 
 const schema = window.schema;
 </script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@algolia/autocomplete-preset-algolia": "^1.18.1",
         "@kong/kongponents": "^9.14.24",
         "@kong/sdk-portal-js": "^2.15.2",
-        "@kong/spec-renderer-dev": "^1.87.3",
+        "@kong/spec-renderer": "^1.88.0",
         "@vitejs/plugin-vue": "^5.1.2",
         "algoliasearch": "^5.20.0",
         "axios": "^1.7.4",
@@ -1061,10 +1061,10 @@
         "proxy-from-env": "^1.1.0"
       }
     },
-    "node_modules/@kong/spec-renderer-dev": {
-      "version": "1.87.13",
-      "resolved": "https://registry.npmjs.org/@kong/spec-renderer-dev/-/spec-renderer-dev-1.87.13.tgz",
-      "integrity": "sha512-T3FS6XsimOZt1FDW5rZDjjB6gcIZLIi/kuEbYGjsXRKbycKU2F1Y9a4AxrEjw62SF6oM+TOva/qsRfKvX9+VLg==",
+    "node_modules/@kong/spec-renderer": {
+      "version": "1.88.0",
+      "resolved": "https://registry.npmjs.org/@kong/spec-renderer/-/spec-renderer-1.88.0.tgz",
+      "integrity": "sha512-VxEEQoZm5cgMrJlWB85Cp9AuNZzJ+SprAgpbC95s98Ks7sclWMxpF278wuMroxQoycNvkubHjZg2F4gZRYDIpQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.7.3",
@@ -1073,7 +1073,6 @@
         "@floating-ui/vue": "^1.1.6",
         "@kong/icons": "^1.21.2",
         "@scalar/openapi-parser": "^0.10.4",
-        "@seriousme/openapi-schema-validator": "^2.3.1",
         "@stoplight/http-spec": "^7.1.0",
         "@stoplight/json": "^3.21.7",
         "@stoplight/types": "^14.1.1",
@@ -1082,10 +1081,8 @@
         "allof-merge": "^0.6.6",
         "flatted": "^3.3.3",
         "httpsnippet": "^3.0.9",
-        "json-schema": "^0.4.0",
         "lodash-es": "^4.17.21",
         "markdown-it": "^14.1.0",
-        "openapi3-ts": "4.4.0",
         "sanitize-html": "^2.14.0",
         "shiki": "^2.3.2"
       },
@@ -1182,40 +1179,6 @@
       }
     },
     "node_modules/@scalar/openapi-parser/node_modules/ajv-formats": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
-      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependencies": {
-        "ajv": "^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "ajv": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@seriousme/openapi-schema-validator": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@seriousme/openapi-schema-validator/-/openapi-schema-validator-2.3.1.tgz",
-      "integrity": "sha512-szUXBZJUhq+Yw+vUro2QeltSIoZvMDQi3MLqJhIKcRcRYyFt9B6dyjMD1RVf3nFvNAHkWqa48NJA46ti2P8smA==",
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^8.17.1",
-        "ajv-draft-04": "^1.0.0",
-        "ajv-formats": "^3.0.1",
-        "js-yaml": "^4.1.0",
-        "minimist": "^1.2.8"
-      },
-      "bin": {
-        "bundle-api": "bin/bundle-api-cli.js",
-        "validate-api": "bin/validate-api-cli.js"
-      }
-    },
-    "node_modules/@seriousme/openapi-schema-validator/node_modules/ajv-formats": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
@@ -4319,12 +4282,6 @@
       "dependencies": {
         "bluebird": "*"
       }
-    },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -20804,15 +20761,6 @@
         "emoji-regex-xs": "^1.0.0",
         "regex": "^6.0.1",
         "regex-recursion": "^6.0.2"
-      }
-    },
-    "node_modules/openapi3-ts": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/openapi3-ts/-/openapi3-ts-4.4.0.tgz",
-      "integrity": "sha512-9asTNB9IkKEzWMcHmVZE7Ts3kC9G7AFHfs8i7caD8HbI76gEjdkId4z/AkP83xdZsH7PLAnnbl47qZkXuxpArw==",
-      "license": "MIT",
-      "dependencies": {
-        "yaml": "^2.5.0"
       }
     },
     "node_modules/package-json-from-dist": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@algolia/autocomplete-preset-algolia": "^1.18.1",
     "@kong/kongponents": "^9.14.24",
     "@kong/sdk-portal-js": "^2.15.2",
-    "@kong/spec-renderer-dev": "^1.87.3",
+    "@kong/spec-renderer": "^1.88.0",
     "@vitejs/plugin-vue": "^5.1.2",
     "algoliasearch": "^5.20.0",
     "axios": "^1.7.4",


### PR DESCRIPTION
# Summary

Replace usage of `@kong/spec-renderer-dev` package with `@kong/spec-renderer` (we dropped the dev from the package name in [v1.88.0](https://github.com/Kong/spec-renderer/releases/tag/v1.88.0))
