### PR TITLE
chore(spec-renderer): bump to v1.89.0 [KHCP-15281]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@algolia/autocomplete-preset-algolia": "^1.18.1",
         "@kong/kongponents": "^9.14.24",
         "@kong/sdk-portal-js": "^2.15.2",
-        "@kong/spec-renderer": "^1.88.1-pr.540.c51d379.0",
+        "@kong/spec-renderer": "^1.89.0",
         "@vitejs/plugin-vue": "^5.1.2",
         "algoliasearch": "^5.20.0",
         "axios": "^1.7.4",
@@ -1062,9 +1062,9 @@
       }
     },
     "node_modules/@kong/spec-renderer": {
-      "version": "1.88.1-pr.540.c51d379.0",
-      "resolved": "https://registry.npmjs.org/@kong/spec-renderer/-/spec-renderer-1.88.1-pr.540.c51d379.0.tgz",
-      "integrity": "sha512-qPTZqPoxLaJVjT3OXt5mYoO4k08O1y7O6geFPSKYNntTb/y+v8hi+xHCtzxWHORBJkXlsKFOP5BjpOKbuxoPng==",
+      "version": "1.89.0",
+      "resolved": "https://registry.npmjs.org/@kong/spec-renderer/-/spec-renderer-1.89.0.tgz",
+      "integrity": "sha512-ZapvUbwyZ9CWnEWhkg/AQRJxjD33+33twEXcVB+TyZkoGbrnG4JWoak28xet4PlAVdPRgN9FtlIcf0laaeLbOg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.7.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@algolia/autocomplete-preset-algolia": "^1.18.1",
         "@kong/kongponents": "^9.14.24",
         "@kong/sdk-portal-js": "^2.15.2",
-        "@kong/spec-renderer": "^1.88.0",
+        "@kong/spec-renderer": "^1.88.1-pr.540.c51d379.0",
         "@vitejs/plugin-vue": "^5.1.2",
         "algoliasearch": "^5.20.0",
         "axios": "^1.7.4",
@@ -1062,9 +1062,9 @@
       }
     },
     "node_modules/@kong/spec-renderer": {
-      "version": "1.88.0",
-      "resolved": "https://registry.npmjs.org/@kong/spec-renderer/-/spec-renderer-1.88.0.tgz",
-      "integrity": "sha512-VxEEQoZm5cgMrJlWB85Cp9AuNZzJ+SprAgpbC95s98Ks7sclWMxpF278wuMroxQoycNvkubHjZg2F4gZRYDIpQ==",
+      "version": "1.88.1-pr.540.c51d379.0",
+      "resolved": "https://registry.npmjs.org/@kong/spec-renderer/-/spec-renderer-1.88.1-pr.540.c51d379.0.tgz",
+      "integrity": "sha512-qPTZqPoxLaJVjT3OXt5mYoO4k08O1y7O6geFPSKYNntTb/y+v8hi+xHCtzxWHORBJkXlsKFOP5BjpOKbuxoPng==",
       "license": "Apache-2.0",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^11.7.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@algolia/autocomplete-preset-algolia": "^1.18.1",
     "@kong/kongponents": "^9.14.24",
     "@kong/sdk-portal-js": "^2.15.2",
-    "@kong/spec-renderer": "^1.88.0",
+    "@kong/spec-renderer": "^1.88.1-pr.540.c51d379.0",
     "@vitejs/plugin-vue": "^5.1.2",
     "algoliasearch": "^5.20.0",
     "axios": "^1.7.4",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@algolia/autocomplete-preset-algolia": "^1.18.1",
     "@kong/kongponents": "^9.14.24",
     "@kong/sdk-portal-js": "^2.15.2",
-    "@kong/spec-renderer": "^1.88.1-pr.540.c51d379.0",
+    "@kong/spec-renderer": "^1.89.0",
     "@vitejs/plugin-vue": "^5.1.2",
     "algoliasearch": "^5.20.0",
     "axios": "^1.7.4",


### PR DESCRIPTION
## Description

As part of [v1.89.0](https://github.com/Kong/spec-renderer/releases/tag/v1.89.0) of spec-renderer we've enabled scrolling into view the nested fields that are linked via permalinks.

https://konghq.atlassian.net/browse/KHCP-15281

## Preview

https://github.com/user-attachments/assets/e1b37143-76d4-4f78-9c32-1cdc97dc681e