### PR TITLE
chore(deps): upgrade to spec-renderer v1.90.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@algolia/autocomplete-preset-algolia": "^1.18.1",
         "@kong/kongponents": "^9.14.24",
         "@kong/sdk-portal-js": "^2.15.2",
-        "@kong/spec-renderer": "^1.89.0",
+        "@kong/spec-renderer": "^1.90.1",
         "@tailwindcss/forms": "^0.5.10",
         "@vitejs/plugin-vue": "^5.1.2",
         "algoliasearch": "^5.20.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@algolia/autocomplete-preset-algolia": "^1.18.1",
     "@kong/kongponents": "^9.14.24",
     "@kong/sdk-portal-js": "^2.15.2",
-    "@kong/spec-renderer": "^1.89.0",
+    "@kong/spec-renderer": "^1.90.1",
     "@tailwindcss/forms": "^0.5.10",
     "@vitejs/plugin-vue": "^5.1.2",
     "algoliasearch": "^5.20.0",


### PR DESCRIPTION
## Description

[Diff](https://github.com/Kong/spec-renderer/compare/v1.89.0...v1.90.1)

Major changes:
- replace `h1` tags with `h2` tags ([info](https://github.com/Kong/spec-renderer/pull/544))
    ![image](https://github.com/user-attachments/assets/56871a9f-618a-42b8-8a5b-d47cef0df231)

- fixed server URL overflow on mobile ([info](https://github.com/Kong/spec-renderer/pull/541))
- sync selected auth scheme in try-it ([info](https://github.com/Kong/spec-renderer/pull/543))
    
https://github.com/user-attachments/assets/0463d0a4-f9b8-4168-8e72-716b6a2a196a