### PR TITLE
Chore: plugin page titles +description for search

### DIFF
--- a/app/deck/file/manipulation/plugins.md
+++ b/app/deck/file/manipulation/plugins.md
@@ -1,5 +1,5 @@
 ---
-title: Plugins
+title: Managing Plugins with decK
 short_title: deck file add-plugins
 description: Manage Plugin configurations in Kong declarative configuration file.
 

--- a/app/deck/file/manipulation/tags.md
+++ b/app/deck/file/manipulation/tags.md
@@ -1,5 +1,5 @@
 ---
-title: Tags
+title: Manage tags with decK
 short_title: deck file *-tags
 description: Manage tags in Kong declarative configuration file.
 
@@ -19,6 +19,8 @@ breadcrumbs:
   - /deck/file/manipulation/
 
 related_resources:
+  - text: Gateway tags
+    url: /gateway/tags/
   - text: All decK documentation
     url: /index/deck/
 ---

--- a/app/plugins.html
+++ b/app/plugins.html
@@ -1,21 +1,21 @@
 ---
-title: Plugins
+title: Kong Plugin Hub
 hub: true
 layout: default
 edit_and_issue_links: false
+description: Extend Kong Gateway and Kong Konnect with powerful plugins and easy integrations.
 ---
 
 <div class="flex flex-col gap-12 w-full">
   <div class="flex justify-between gap-[60px]">
       <div class="flex flex-col gap-6 py-24 self-center">
           <div class="flex flex-col gap-2">
-              <h1 class="font-extrabold text-[40px] leading-[60px]">Kong Plugins</h1>
-              <span class="leading-7">Extend Kong Gateway and Kong Konnect with powerful plugins and easy integrations.</span>
+              <h1 class="font-extrabold text-[40px] leading-[60px]">Kong Plugin Hub</h1>
+              <span class="leading-7">Extend Kong Gateway and Kong Konnect with powerful plugins and easy integrations</span>
           </div>
           <div class="flex gap-3 items-center lg:w-3/5">
               <a class="text-xs px-1 text-terciary leading-5" href="/gateway/entities/plugin/">Plugins Overview</a><span class="border-l border-primary/5 h-full"></span>
-              <a class="text-xs px-1 text-terciary leading-5" href="https://docs.konghq.com/hub/plugins/compatibility/">Compatibility</a><span class="border-l border-primary/5 h-full"></span>
-              <a class="text-xs px-1 text-terciary leading-5" href="https://docs.konghq.com/hub/plugins/license-tiers/">License Tiers</a>
+              <a class="text-xs px-1 text-terciary leading-5" href="/gateway/entities/plugin/#custom-plugins">Custom Plugin Development</a><span class="border-l border-primary/5 h-full"></span>
           </div>
       </div>
       <div class="hidden lg:flex pt-9 pr-9 ">


### PR DESCRIPTION
## Description

Minor edit for demo - need the plugin hub to show up in search better.

## Preview Links


## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
