### PR TITLE
Add link to index in related_resources

### DIFF
--- a/app/_plugins/generators/data/add_index_to_related_resources.rb
+++ b/app/_plugins/generators/data/add_index_to_related_resources.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Data
+    class AddIndexToRelatedResources # rubocop:disable Style/Documentation
+      attr_reader :site, :page
+
+      def initialize(site:, page:)
+        @site = site
+        @page = page
+      end
+
+      def process
+        return if @page.data['content_type'] == 'landing_page'
+        return if product.nil? && tool.nil?
+        return unless documentation_index
+
+        if @page.data.key?('related_resources')
+          @page.data['related_resources'].unshift(index_related_resource)
+        else
+          @page.data['related_resources'] = [index_related_resource]
+        end
+      end
+
+      def index_related_resource
+        { 'text' => documentation_index.data['title'], 'url' => documentation_index.url }
+      end
+
+      private
+
+      def documentation_index
+        if product
+          key = product == 'api-ops' ? tool : product
+          @site.data.dig('indices', key)
+        else
+          @site.data.dig('indices', tool)
+        end
+      end
+
+      def product
+        @product ||= @page.data.fetch('products', []).first
+      end
+
+      def tool
+        @tool ||= @page.data.fetch('tools', []).first
+      end
+    end
+  end
+end

--- a/app/_plugins/generators/indices.rb
+++ b/app/_plugins/generators/indices.rb
@@ -5,10 +5,15 @@ module Jekyll
     priority :low
 
     def generate(site)
+      site.data['indices'] = {}
       Dir.glob(File.join(site.source, '_indices/**/*.yaml')).each do |file|
         @seen = {}
         @sections = {}
-        site.pages << build_page(site, file)
+        page = build_page(site, file)
+
+        site.pages << page
+        slug = File.basename(file, File.extname(file))
+        site.data['indices'][slug] = page
       end
     end
 

--- a/app/_plugins/generators/page_data.rb
+++ b/app/_plugins/generators/page_data.rb
@@ -17,10 +17,11 @@ module Jekyll
         Data::Seo.new(site:, page:).process
         Data::SearchTags::Base.make_for(site:, page:).process
         Data::MinVersion.new(site:, page:).process
+        Data::AddIndexToRelatedResources.new(site:, page:).process
       end
     end
 
-    def process_docs(site)
+    def process_docs(site) # rubocop:disable Metrics/AbcSize
       site.documents.each do |page|
         Data::EditLink::Base.new(site:, page:).process
         Data::Prerequisites.new(site:, page:).process
@@ -29,6 +30,7 @@ module Jekyll
         Data::Seo.new(site:, page:).process
         Data::SearchTags::Base.make_for(site:, page:).process
         Data::MinVersion.new(site:, page:).process
+        Data::AddIndexToRelatedResources.new(site:, page:).process
       end
     end
   end


### PR DESCRIPTION
## Description

Leaving this here for now.
I didn't add it to landing_pages because we might want to do something specific there.
It's based on product or tool.

Note: we need to remove existing links

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
