### PR TITLE
chore: Bump latest gateway version to 3.10

### DIFF
--- a/api-specs/gateway/admin-ee/3.10/openapi.yaml
+++ b/api-specs/gateway/admin-ee/3.10/openapi.yaml
@@ -1,0 +1,16733 @@
+components:
+  parameters:
+    pagination-offset:
+      description: Offset from which to return the next set of resources. Use the value of the 'offset' field from the response of a list operation as input here to paginate through all the resources
+      in: query
+      name: offset
+      schema:
+        type: string
+    pagination-size:
+      description: Number of resources to be returned.
+      in: query
+      name: size
+      schema:
+        default: 100
+        maximum: 1000
+        minimum: 1
+        type: integer
+    pagination-tags-filter:
+      description: A list of tags to filter the list of resources on. Multiple tags can be concatenated using `,` to mean AND or using `/` to mean OR.
+      example: 'tag1,tag2'
+      in: query
+      name: tags
+      schema:
+        type: string
+        nullable: false
+    certificate_name_or_id:
+      name: certificate_name_or_id
+      in: path
+      required: true
+      schema:
+        type: string
+        enum:
+          - a3ad71a8-6685-4b03-a101-980a953544f6
+          - name
+        example: name
+      description: The unique identifier or the `name` attribute of the Certificate whose SNIs are to be retrieved. When using this endpoint, only SNIs associated to the specified Certificate will be listed.
+    sni_name_or_id:
+      name: sni_name_or_id
+      in: path
+      required: true
+      schema:
+        type: string
+        example: my-sni
+      description: The unique identifier or the name of the SNI to retrieve.
+    tag:
+      name: tags
+      in: path
+      required: true
+      schema:
+        type: string
+        example: example
+      description: Tags are strings associated to entities in Kong.
+    log_level:
+      name: log_level
+      in: path
+      required: true
+      schema:
+        type: string
+        enum:
+          - info
+          - notice
+          - warn
+          - error
+          - crit
+        example: warn
+      description: Log levels are set in Kong's configuration. Log levels increase in order of their severity
+    target_id_or_target:
+      name: target_id_or_target
+      in: path
+      required: true
+      schema:
+        type: string
+        example: 'example.com:8000'
+      description: The host/port combination element of the target to set as unhealthy, or the `id` of an existing target entry.
+    vault_id_or_prefix:
+      name: vault_id_or_prefix
+      in: path
+      required: true
+      schema:
+        type: string
+        example: env
+      description: The unique identifier or the prefix of the Vault to retrieve.
+    plugin_id:
+      name: plugin_id
+      in: path
+      required: true
+      schema:
+        type: string
+        example: response-ratelimiting
+      description: The unique identifier of the plugin to create or update.
+    upstream_id_or_name:
+      name: upstream_id_or_name
+      in: path
+      required: true
+      schema:
+        type: string
+        example: 7fca84d6-7d37-4a74-a7b0-93e576089a41
+      description: The unique identifier or the name of the Upstream associated to the Certificate to be retrieved.
+    key-set_id_or_name:
+      name: key-set_id_or_name
+      in: path
+      required: true
+      schema:
+        type: string
+        example: 46CA83EE-671C-11ED-BFAB-2FE47512C77A
+      description: The unique identifier or the `name` attribute of the Key Set that should be associated to the newly-created Key.
+    route_id_or_name:
+      name: route_id_or_name
+      in: path
+      required: true
+      schema:
+        type: string
+        example: my-route
+      description: The unique identifier or the name of the route to retrieve.
+    key_id_or_name:
+      name: key_id_or_name
+      in: path
+      required: true
+      schema:
+        type: string
+        example: 24D0DBDA-671C-11ED-BA0B-EF1DCCD3725
+      description: The unique identifier or the name of the Key to retrieve.
+    ca_certificate_id:
+      name: ca_certificate_id
+      description: ID of the related certificate
+      in: path
+      required: true
+      schema:
+        type: string
+        example: 7fca84d6-7d37-4a74-a7b0-93e576089a41"
+    certificate_id:
+      name: certificate_id
+      in: path
+      required: true
+      schema:
+        type: string
+        example: 7fca84d6-7d37-4a74-a7b0-93e576089a41"
+      description: The unique identifier of the Certificate to retrieve.
+    service_id_or_name:
+      name: service_id_or_name
+      description: ID **or** name of the service to lookup
+      example: test-service
+      in: path
+      required: true
+      schema:
+        type: string
+    group_name_or_id:
+      name: group_name_or_id
+      in: path
+      required: true
+      schema:
+        anyOf:
+          - type: string
+            example: my_group
+          - type: string
+            example: 84a73fb8-50fc-44a7-a4d5-aa17728ee83f
+        type: string
+        example: my_group
+      description: The name or UUID of the consumer group.
+    group_name:
+      name: group_name
+      in: path
+      required: true
+      schema:
+        type: string
+        example: My-Group
+      description: A unique name for the consumer group you want to create.
+    consumer_name_or_id:
+      name: consumer_name_or_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The name or UUID of the consumer to remove.
+    consumer_group_name_or_id:
+      name: consumer_group_name_or_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The name or UUID of the consumer group to remove.
+    consumer_username_or_id:
+      name: consumer_username_or_id
+      in: path
+      required: true
+      schema:
+        type: string
+        example: my-username
+      description: The unique identifier or the username of the Consumer to retrieve.
+    license-id:
+      name: license-id
+      in: path
+      required: true
+      schema:
+        type: string
+        example: 30b4edb7-0847-4f65-af90-efbed8b0161f
+      description: The license's unique ID.
+    workspace_id_or_name:
+      name: workspace_id_or_name
+      in: path
+      required: true
+      schema:
+        type: string
+        example: 2747d1e5-8246-4f65-a939-b392f1ee17f8
+      description: ID or name of the workspace to look up.
+    workspace:
+      name: workspace
+      in: path
+      required: true
+      schema:
+        type: string
+        example: team-a
+      description: Name or ID of workspace
+    Gatewayapi_Consumer_username_or_id:
+      name: consumer_username_or_id
+      in: path
+      required: true
+      schema:
+        type: string
+        example: my-username
+      description: The unique identifier or the username of the Consumer to retrieve.
+    Gatewayapi_Pagination-tags-filter:
+      description: A list of tags to filter the list of resources on. Multiple tags can be concatenated using `,` to mean AND or using `/` to mean OR.
+      example: 'tag1,tag2'
+      in: query
+      name: tags
+      schema:
+        type: string
+        nullable: false
+    filter_chain_id:
+      name: filter_chain_id
+      in: path
+      required: true
+      schema:
+        type: string
+      description: The unique identifier of the filter chain to retrieve.
+    beforeAuditLogFilter:
+      name: before_audit_log_filter
+      in: query
+      required: false
+      schema:
+        $ref: '#/components/schemas/RequestTimestampFilterSchema'
+      description: |
+        Before filter could be used to request audit log data that was recorded before certain time (exclusive).
+        It can either be a timestamp as Unix Epoch or a string following RFC3339 Schema (without fractions of a second) - ex: '2024-04-25T15:03:24Z'
+    afterAuditLogFilter:
+      name: after_audit_log_filter
+      in: query
+      required: false
+      schema:
+        $ref: '#/components/schemas/RequestTimestampFilterSchema'
+      description: |
+        After filter could be used to request audit log data that was recorded after certain time (inclusive).
+        It can either be a timestamp as Unix Epoch or a string following RFC3339 Schema (without fractions of a second) - ex: '2024-04-25T15:03:24Z'
+    PartialId:
+      name: PartialId
+      in: path
+      required: true
+      description: ID of the Partial
+      schema:
+        type: string
+        example: 2747d1e5-8246-4f65-a939-b392f1ee17f8
+  schemas:
+    Admin:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier for the admin.
+        created_at:
+          type: integer
+          format: timestamp
+          description: Timestamp when the admin was created.
+        updated_at:
+          type: integer
+          format: timestamp
+          description: Timestamp when the admin was last updated.
+        username:
+          type: string
+          description: The admin's username.
+          uniqueItems: true
+        username_lower:
+          type: string
+          description: The admin's username in lowercase.
+        custom_id:
+          type: string
+          description: The Admin’s custom ID.
+          uniqueItems: true
+        email:
+          type: string
+          format: email
+          description: The admin's email address.
+          uniqueItems: true
+        status:
+          type: string
+          description: The status of the admin.
+          enum:
+            - active
+            - inactive
+        rbac_token_enabled:
+          type: boolean
+          description: Allows the Admin to use and reset their RBAC token; true by default.
+          default: true
+        consumer:
+          type: string
+          description: The ID of the associated consumer.
+          format: uuid
+        rbac_user:
+          type: string
+          description: The ID of the associated RBAC user.
+          format: uuid
+      required:
+        - username
+        - status
+        - rbac_token_enabled
+        - consumer
+        - rbac_user
+    Group:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier for the group.
+        created_at:
+          type: integer
+          format: timestamp
+          description: Timestamp when the group was created.
+        updated_at:
+          type: integer
+          format: timestamp
+          description: Timestamp when the group was last updated.
+        name:
+          type: string
+          description: The name of the group.
+          uniqueItems: true
+        comment:
+          type: string
+          description: Any comments associated with the specific group.
+      required:
+        - name
+    UnauthorizedError:
+      type: object
+      properties:
+        status:
+          type: integer
+        message:
+          type: string
+      required:
+        - status
+        - message
+    CA-Certificate:
+      description: A CA certificate object represents a trusted CA. These objects are used by Kong to verify the validity of a client or server certificate.
+      example:
+        cert: |-
+          -----BEGIN CERTIFICATE-----
+          certificate-content
+          -----END CERTIFICATE-----
+        id: b2f34145-0343-41a4-9602-4c69dec2f260
+      type: object
+      properties:
+        cert:
+          description: PEM-encoded public certificate of the CA.
+          type: string
+        cert_digest:
+          description: SHA256 hex digest of the public certificate. This field is read-only and it cannot be set by the caller, the value is automatically computed.
+          type: string
+        created_at:
+          description: Unix epoch when the resource was created.
+          type: integer
+        id:
+          type: string
+        tags:
+          description: An optional set of strings associated with the Certificate for grouping and filtering.
+          type: array
+          items:
+            type: string
+            example: tag
+    Certificate:
+      description: A certificate object represents a public certificate, and can be optionally paired with the corresponding private key. These objects are used by Kong to handle SSL/TLS termination for encrypted requests, or for use as a trusted CA store when validating peer certificate of client/service. Certificates are optionally associated with SNI objects to tie a cert/key pair to one or more hostnames. If intermediate certificates are required in addition to the main certificate, they should be concatenated together into one string according to the following order, main certificate on the top, followed by any intermediates.
+      example:
+        cert: |-
+          -----BEGIN CERTIFICATE-----
+          certificate-content
+          -----END CERTIFICATE-----
+        id: b2f34145-0343-41a4-9602-4c69dec2f269
+        key: |-
+          -----BEGIN PRIVATE KEY-----
+          private-key-content
+          -----END PRIVATE KEY-----
+      properties:
+        cert:
+          description: PEM-encoded public certificate chain of the SSL key pair. This field is _referenceable_, which means it can be securely stored as a [secret](/gateway/latest/plan-and-deploy/security/secrets-management/getting-started) in a vault. References must follow a [specific format](/gateway/latest/plan-and-deploy/security/secrets-management/reference-format).
+          type: string
+        cert_alt:
+          description: PEM-encoded public certificate chain of the alternate SSL key pair. This should only be set if you have both RSA and ECDSA types of certificate available and would like Kong to prefer serving using ECDSA certs when client advertises support for it. This field is _referenceable_, which means it can be securely stored as a [secret](/gateway/latest/plan-and-deploy/security/secrets-management/getting-started) in a vault. References must follow a [specific format](/gateway/latest/plan-and-deploy/security/secrets-management/reference-format).
+          type: string
+        created_at:
+          description: Unix epoch when the resource was created.
+          type: integer
+        id:
+          type: string
+        key:
+          description: PEM-encoded private key of the SSL key pair. This field is _referenceable_, which means it can be securely stored as a [secret](/gateway/latest/plan-and-deploy/security/secrets-management/getting-started) in a vault. References must follow a [specific format](/gateway/latest/plan-and-deploy/security/secrets-management/reference-format).
+          type: string
+        key_alt:
+          description: PEM-encoded private key of the alternate SSL key pair. This should only be set if you have both RSA and ECDSA types of certificate available and would like Kong to prefer serving using ECDSA certs when client advertises support for it. This field is _referenceable_, which means it can be securely stored as a [secret](/gateway/latest/plan-and-deploy/security/secrets-management/getting-started) in a vault. References must follow a [specific format](/gateway/latest/plan-and-deploy/security/secrets-management/reference-format).
+          type: string
+        tags:
+          description: An optional set of strings associated with the Certificate for grouping and filtering.
+          items:
+            type: string
+          type: array
+        updated_at:
+          description: Unix epoch when the resource was last updated.
+          type: integer
+        snis:
+          description: >
+            A list of SNIs associated with the certificate.
+          type: array
+          items:
+            type: string
+            format: hostname
+      type: object
+    Consumer:
+      description: The Consumer object represents a consumer - or a user - of a Service. You can either rely on Kong as the primary datastore, or you can map the consumer list with your database to keep consistency between Kong and your existing primary datastore.
+      example:
+        custom_id: '4200'
+        id: 8a388226-20e8-4027-a486-25e4f7db5d21
+        tags:
+          - silver-tier
+        username: bob-the-builder
+      properties:
+        created_at:
+          description: Unix epoch when the resource was created.
+          type: integer
+        custom_id:
+          description: Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request.
+          type: string
+        id:
+          type: string
+        tags:
+          description: An optional set of strings associated with the Consumer for grouping and filtering.
+          items:
+            type: string
+          type: array
+        updated_at:
+          description: Unix epoch when the resource was last updated.
+          type: integer
+        username:
+          description: The unique username of the Consumer. You must send either this field or `custom_id` with the request.
+          type: string
+      type: object
+      x-examples:
+        Consumer Object:
+          custom_id: '4200'
+          id: 8a388226-80e8-4027-a486-25e4f7db5d21
+          tags:
+            - silver-tier
+          username: bob-the-builder
+    ConsumerGroup:
+      description: Consumer groups enable the organization and categorization of consumers (users or applications) within an API ecosystem. By grouping consumers together, you eliminate the need to manage them individually, providing a scalable, efficient approach to managing configurations.
+      type: object
+      properties:
+        created_at:
+          description: Unix epoch when the resource was created.
+          type: integer
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier for the Consumer Group.
+          nullable: true
+        name:
+          type: string
+          description: The name of the Consumer Group.
+        tags:
+          description: An optional set of strings associated with the Consumer Group for grouping and filtering.
+          items:
+            type: string
+          type: array
+        updated_at:
+          description: Unix epoch when the resource was last updated.
+          type: integer
+      additionalProperties: false
+      required:
+        - name
+    Key:
+      description: A Key object holds a representation of asymmetric keys in various formats. When Kong or a Kong plugin requires a specific public or private key to perform certain operations, it can use this entity.
+      example:
+        id: d958f66b-8e99-44d2-b0b4-edd5bbf24658
+        jwk: '{"alg":"RSA",  "kid": "42",  ...}'
+        kid: '42'
+        x5t: 'a3f1c6b8d9e5...'
+        name: a-key
+        pem:
+          private_key: '-----BEGIN'
+          public_key: '-----BEGIN'
+        set:
+          id: b86b331c-dcd0-4b3e-97ce-47c5a9543031
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Unique identifier for the key.
+        set:
+          type: object
+          description: The ID of the key-set with which to associate the key.
+          properties:
+            id:
+              type: string
+              format: uuid
+        name:
+          type: string
+          description: The name to associate with the given keys.
+        kid:
+          type: string
+          description: A unique identifier for a key.
+        x5t:
+          type: string
+          description: X.509 certificate SHA-1 thumbprint.
+        jwk:
+          type: string
+          description: A JSON Web Key represented as a string.
+        pem:
+          type: object
+          description: PEM representation of the key.
+          properties:
+            private_key:
+              type: string
+            public_key:
+              type: string
+        tags:
+          type: array
+          items:
+            type: string
+        created_at:
+          type: integer
+          format: int64
+          description: Timestamp (seconds) of when the key was created.
+        updated_at:
+          type: integer
+          format: int64
+          description: Timestamp (seconds) of when the key was last updated.
+    Key-set:
+      example:
+        id: b58c7d9d-e54f-444c-b24d-cdfc4159f61e
+        name: example-key-set
+        tags:
+          - idp-keys
+      properties:
+        created_at:
+          description: Unix epoch when the resource was created.
+          type: integer
+        id:
+          type: string
+        name:
+          type: string
+        tags:
+          items:
+            type: string
+          type: array
+        updated_at:
+          description: Unix epoch when the resource was last updated.
+          type: integer
+      type: object
+      title: Key-set
+    Plugin:
+      description: A Plugin entity represents a plugin configuration that will be executed during the HTTP request/response lifecycle. It is how you can add functionalities to Services that run behind Kong, like Authentication or Rate Limiting for example. You can find more information about how to install and what values each plugin takes by visiting the [Kong Hub](https://docs.konghq.com/hub/). When adding a Plugin Configuration to a Service, every request made by a client to that Service will run said Plugin. If a Plugin needs to be tuned to different values for some specific Consumers, you can do so by creating a separate plugin instance that specifies both the Service and the Consumer, through the `service` and `consumer` fields.
+      example:
+        config:
+          anonymous: null
+          hide_credentials: false
+          key_in_body: false
+          key_in_header: true
+          key_in_query: true
+          key_names:
+            - apikey
+          run_on_preflight: true
+        enabled: true
+        id: 3fd1eea1-885a-4011-b986-289943ff8177
+        name: key-auth
+        protocols:
+          - grpc
+          - grpcs
+          - http
+          - https
+      properties:
+        config:
+          description: The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/).
+          type: object
+        consumer:
+          additionalProperties: false
+          description: If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
+          properties:
+            id:
+              type: string
+          type: object
+        consumer_group:
+          additionalProperties: false
+          description: If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
+          properties:
+            id:
+              type: string
+          type: object
+        created_at:
+          description: Unix epoch when the resource was created.
+          type: integer
+        enabled:
+          default: true
+          description: Whether the plugin is applied.
+          type: boolean
+        id:
+          type: string
+        name:
+          description: "The name of the plugin that's going to be added. The plugin must be installed in every Kong instance separately."
+          type: string
+        ordering:
+          type: object
+        protocols:
+          default:
+            - grpc
+            - grpcs
+            - http
+            - https
+          description: A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `tcp` and `tls`.
+          items:
+            type: string
+          type: array
+        route:
+          additionalProperties: false
+          description: If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
+          properties:
+            id:
+              type: string
+          type: object
+        service:
+          additionalProperties: false
+          description: If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
+          properties:
+            id:
+              type: string
+          type: object
+        tags:
+          description: An optional set of strings associated with the plugin for grouping and filtering.
+          items:
+            type: string
+          type: array
+        updated_at:
+          description: Unix epoch when the resource was last updated.
+          type: integer
+        partials:
+          description: List of partials linked to that plugin
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+                example: ce44eef5-41ed-47f6-baab-f725cecf98c7
+                format: uuid
+              name:
+                type: string
+                example: my-partial-1
+              path:
+                type: string
+                description: The path at which the Partial configuration will be applied.
+                example: config.redis
+      type: object
+    Route:
+      description: Route entities define rules to match client requests. Each Route is associated with a Service, and a Service may have multiple Routes associated to it. Every request matching a given Route will be proxied to its associated Service. The combination of Routes and Services (and the separation of concerns between them) offers a powerful routing mechanism with which it is possible to define fine-grained entry-points in Kong leading to different upstream services of your infrastructure. You need at least one matching rule that applies to the protocol being matched by the Route.
+      example:
+        hosts:
+          - foo.example.com
+          - foo.example.us
+        id: 56c4566c-14cc-4132-9011-4139fcbbe50a
+        name: example-route
+        paths:
+          - /v1
+          - /v2
+        service:
+          id: bd380f99-659d-415e-b0e7-72ea05df3218
+      properties:
+        created_at:
+          description: Unix epoch when the resource was created.
+          type: integer
+        destinations:
+          description: A list of IP destinations of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+          items:
+            properties:
+              default: {}
+            type: object
+          type: array
+        headers:
+          description: One or more lists of values indexed by header name that will cause this Route to match if present in the request. The `Host` header cannot be used with this `attribute:` hosts should be specified using the `hosts` attribute. When `headers` contains only one value and that value starts with the special prefix `~*`, the value is interpreted as a regular expression.
+          type: object
+        hosts:
+          description: A list of domain names that match this Route. Note that the hosts value is case sensitive.
+          items:
+            type: string
+          type: array
+        https_redirect_status_code:
+          default: 426
+          description: The status code Kong responds with when all properties of a Route match except the protocol i.e. if the protocol of the request is `HTTP` instead of `HTTPS`. `Location` header is injected by Kong if the field is set to 301, 302, 307 or 308. This config applies only if the Route is configured to only accept the `https` protocol.
+          type: integer
+        id:
+          type: string
+        methods:
+          description: A list of HTTP methods that match this Route.
+          items:
+            type: string
+          type: array
+        name:
+          description: The name of the Route. Route names must be unique, and they are case sensitive. For example, there can be two different Routes named "test" and "Test".
+          type: string
+        path_handling:
+          default: v0
+          description: Controls how the Service path, Route path and requested path are combined when sending a request to the upstream. See above for a detailed description of each behavior.
+          type: string
+        paths:
+          description: A list of paths that match this Route.
+          items:
+            type: string
+          type: array
+        preserve_host:
+          default: false
+          description: "When matching a route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. If set to `false`, the upstream `Host` header will be that of the service's `host`."
+          type: boolean
+        protocols:
+          default:
+            - http
+            - https
+          description: An array of the protocols this Route should allow. See the [Route Object](#route-object) section for a list of accepted protocols. When set to only `"https"`, HTTP requests are answered with an upgrade error. When set to only `"http"`, HTTPS requests are answered with an error.
+          items:
+            type: string
+          type: array
+        regex_priority:
+          default: 0
+          description: A number used to choose which route resolves a given request when several routes match it using regexes simultaneously. When two routes match the path and have the same `regex_priority`, the older one (lowest `created_at`) is used. Note that the priority for non-regex routes is different (longer non-regex routes are matched before shorter ones).
+          type: integer
+        request_buffering:
+          default: true
+          description: Whether to enable request body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that receive data with chunked transfer encoding.
+          type: boolean
+        response_buffering:
+          default: true
+          description: Whether to enable response body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that send data with chunked transfer encoding.
+          type: boolean
+        service:
+          additionalProperties: false
+          description: The Service this route is associated to. This is where the route proxies traffic to.
+          properties:
+            id:
+              type: string
+          type: object
+        expression:
+          description: The route expression used for advanced routing scenarios. This field is used to evaluate route matches based on complex criteria beyond the standard routing fields.
+          type: string
+        priority:
+          description: A number used to specify the matching order for expression routes. The higher the `priority`, the sooner a route will be evaluated. This field is ignored unless `expression` field is set. The value must be between 0 and 2^46 - 1.
+          type: integer
+          default: 0
+        snis:
+          description: A list of SNIs that match this route when using stream routing.
+          items:
+            type: string
+          type: array
+        sources:
+          description: A list of IP sources of incoming connections that match this route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+          items:
+            properties:
+              default: {}
+            type: object
+          type: array
+        strip_path:
+          default: true
+          description: When matching a route via one of the `paths`, strip the matching prefix from the upstream request URL.
+          type: boolean
+        tags:
+          description: An optional set of strings associated with the route for grouping and filtering.
+          items:
+            type: string
+          type: array
+        updated_at:
+          description: Unix epoch when the resource was last updated.
+          type: integer
+      type: object
+    SNI:
+      description: An SNI object represents a many-to-one mapping of hostnames to a certificate. That is, a certificate object can have many hostnames associated with it; when Kong receives an SSL request, it uses the SNI field in the Client Hello to lookup the certificate object based on the SNI associated with the certificate.
+      example:
+        certificate:
+          id: bd380f99-659d-415e-b0e7-72ea05df3218
+        id: 36c4566c-14cc-4132-9011-4139fcbbe50a
+        name: some.example.org
+      properties:
+        certificate:
+          additionalProperties: false
+          description: The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object.
+          properties:
+            id:
+              type: string
+          type: object
+        created_at:
+          description: Unix epoch when the resource was created.
+          type: integer
+        id:
+          type: string
+        name:
+          description: The SNI name to associate with the given certificate.
+          type: string
+        tags:
+          description: An optional set of strings associated with the SNIs for grouping and filtering.
+          items:
+            type: string
+          type: array
+        updated_at:
+          description: Unix epoch when the resource was last updated.
+          type: integer
+      type: object
+    Service:
+      description: Service entities, as the name implies, are abstractions of each of your own upstream services. Examples of Services would be a data transformation microservice, a billing API, etc. The main attribute of a Service is its URL (where Kong should proxy traffic to), which can be set as a single string or by specifying its `protocol`, `host`, `port` and `path` individually. Services are associated to routes (a Service can have many routes associated with it). Routes are entry-points in Kong and define rules to match client requests. Once a route is matched, Kong proxies the request to its associated Service. See the [Proxy Reference][proxy-reference] for a detailed explanation of how Kong proxies traffic.
+      example:
+        host: example.internal
+        id: 49fd316e-c457-481c-9fc7-8079153e4f3c
+        name: example-service
+        path: /
+        port: 80
+        protocol: http
+      properties:
+        ca_certificates:
+          description: Array of `CA Certificate` object UUIDs that are used to build the trust store while verifying upstream servers TLS certificate. If set to `null` when Nginx default is respected. If default CA list in Nginx are not specified and TLS verification is enabled, then handshake with upstream server will always fail (because no CA are trusted).
+          items:
+            type: string
+          type: array
+        client_certificate:
+          additionalProperties: false
+          description: Certificate to be used as client certificate while TLS handshaking to the upstream server.
+          properties:
+            id:
+              type: string
+          type: object
+        connect_timeout:
+          default: 60000
+          description: The timeout in milliseconds for establishing a connection to the upstream server.
+          type: integer
+        created_at:
+          description: Unix epoch when the resource was created.
+          type: integer
+        enabled:
+          default: true
+          description: Whether the Service is active. If set to `false`, the proxy behavior will be as if any routes attached to it do not exist (404).
+          type: boolean
+        host:
+          description: The host of the upstream server. Note that the host value is case sensitive.
+          type: string
+        id:
+          type: string
+        name:
+          description: The Service name.
+          type: string
+        path:
+          description: The path to be used in requests to the upstream server.
+          type: string
+        port:
+          default: 80
+          description: The upstream server port.
+          type: integer
+        protocol:
+          default: http
+          description: The protocol used to communicate with the upstream.
+          type: string
+        read_timeout:
+          default: 60000
+          description: The timeout in milliseconds between two successive read operations for transmitting a request to the upstream server.
+          type: integer
+        retries:
+          default: 5
+          description: The number of retries to execute upon failure to proxy.
+          type: integer
+        tags:
+          description: An optional set of strings associated with the Service for grouping and filtering.
+          items:
+            type: string
+          type: array
+        tls_verify:
+          description: Whether to enable verification of upstream server TLS certificate. If set to `null`, then the Nginx default is respected.
+          type: boolean
+        tls_verify_depth:
+          description: Maximum depth of chain while verifying Upstream server's TLS certificate. If set to `null`, then the Nginx default is respected.
+          type: integer
+        updated_at:
+          description: Unix epoch when the resource was last updated.
+          type: integer
+        url:
+          description: Helper field to set `protocol`, `host`, `port` and `path` using a URL. This field is write-only and is not returned in responses.
+          type: string
+        write_timeout:
+          default: 60000
+          description: The timeout in milliseconds between two successive write operations for transmitting a request to the upstream server.
+          type: integer
+      type: object
+      title: Service
+    Target:
+      description: A target is an ip address/hostname with a port that identifies an instance of a backend service. Every upstream can have many targets, and the targets can be dynamically added, modified, or deleted. Changes take effect on the fly. To disable a target, post a new one with `weight=0`; alternatively, use the `DELETE` convenience method to accomplish the same. The current target object definition is the one with the latest `created_at`.
+      example:
+        id: 089292a7-ba3d-4d88-acf0-97b4b2e2621a
+        target: 203.0.113.42
+        upstream:
+          id: 5f1d7e76-2fed-4806-a6af-869984f025cb
+        weight: 100
+      properties:
+        created_at:
+          description: Unix epoch when the resource was created.
+          type: number
+        id:
+          type: string
+        tags:
+          description: An optional set of strings associated with the Target for grouping and filtering.
+          items:
+            type: string
+          type: array
+        target:
+          description: The target address (ip or hostname) and port. If the hostname resolves to an SRV record, the `port` value will be overridden by the value from the DNS record.
+          type: string
+        updated_at:
+          description: Unix epoch when the resource was last updated.
+          type: number
+        upstream:
+          additionalProperties: false
+          properties:
+            id:
+              type: string
+          type: object
+        weight:
+          default: 100
+          description: The weight this target gets within the upstream loadbalancer (`0`-`65535`). If the hostname resolves to an SRV record, the `weight` value will be overridden by the value from the DNS record.
+          type: integer
+      type: object
+    Upstream:
+      description: The upstream object represents a virtual hostname and can be used to loadbalance incoming requests over multiple services (targets). So for example an upstream named `service.v1.xyz` for a Service object whose `host` is `service.v1.xyz`. Requests for this Service would be proxied to the targets defined within the upstream. An upstream also includes a [health checker][healthchecks], which is able to enable and disable targets based on their ability or inability to serve requests. The configuration for the health checker is stored in the upstream object, and applies to all of its targets.
+      example:
+        algorithm: round-robin
+        hash_fallback: none
+        hash_on: none
+        hash_on_cookie_path: /
+        healthchecks:
+          active:
+            concurrency: 10
+            healthy:
+              http_statuses:
+                - 200
+                - 302
+              interval: 0
+              successes: 0
+            http_path: /
+            https_verify_certificate: true
+            timeout: 1
+            type: http
+            unhealthy:
+              http_failures: 0
+              http_statuses:
+                - 429
+                - 404
+                - 500
+                - 501
+                - 502
+                - 503
+                - 504
+                - 505
+              interval: 0
+              tcp_failures: 0
+              timeouts: 0
+          passive:
+            healthy:
+              http_statuses:
+                - 200
+                - 201
+                - 202
+                - 203
+                - 204
+                - 205
+                - 206
+                - 207
+                - 208
+                - 226
+                - 300
+                - 301
+                - 302
+                - 303
+                - 304
+                - 305
+                - 306
+                - 307
+                - 308
+              successes: 0
+            type: http
+            unhealthy:
+              http_failures: 0
+              http_statuses:
+                - 429
+                - 500
+                - 503
+              tcp_failures: 0
+              timeouts: 0
+          threshold: 0
+        id: 6eed5e9c-5398-4026-9a4c-d48f18a2431e
+        name: api.example.internal
+        slots: 10000
+      properties:
+        algorithm:
+          description: Which load balancing algorithm to use.
+          type: string
+          default: round-robin
+          enum:
+            - consistent-hashing
+            - least-connections
+            - round-robin
+            - latency
+          nullable: true
+        client_certificate:
+          additionalProperties: false
+          description: If set, the certificate to be used as client certificate while TLS handshaking to the upstream server.
+          properties:
+            id:
+              type: string
+          type: object
+        created_at:
+          description: Unix epoch when the resource was created.
+          type: integer
+        hash_fallback:
+          default: none
+          description: What to use as hashing input if the primary `hash_on` does not return a hash (eg. header is missing, or no Consumer identified). Not available if `hash_on` is set to `cookie`.
+          type: string
+        hash_fallback_header:
+          description: The header name to take the value from as hash input. Only required when `hash_fallback` is set to `header`.
+          type: string
+        hash_fallback_query_arg:
+          description: The name of the query string argument to take the value from as hash input. Only required when `hash_fallback` is set to `query_arg`.
+          type: string
+        hash_fallback_uri_capture:
+          description: The name of the route URI capture to take the value from as hash input. Only required when `hash_fallback` is set to `uri_capture`.
+          type: string
+        hash_on:
+          default: none
+          description: What to use as hashing input. Using `none` results in a weighted-round-robin scheme with no hashing.
+          type: string
+        hash_on_cookie:
+          description: The cookie name to take the value from as hash input. Only required when `hash_on` or `hash_fallback` is set to `cookie`. If the specified cookie is not in the request, Kong will generate a value and set the cookie in the response.
+          type: string
+        hash_on_cookie_path:
+          default: /
+          description: The cookie path to set in the response headers. Only required when `hash_on` or `hash_fallback` is set to `cookie`.
+          type: string
+        hash_on_header:
+          description: The header name to take the value from as hash input. Only required when `hash_on` is set to `header`.
+          type: string
+        hash_on_query_arg:
+          description: The name of the query string argument to take the value from as hash input. Only required when `hash_on` is set to `query_arg`.
+          type: string
+        hash_on_uri_capture:
+          description: The name of the route URI capture to take the value from as hash input. Only required when `hash_on` is set to `uri_capture`.
+          type: string
+        healthchecks:
+          properties:
+            active:
+              properties:
+                concurrency:
+                  default: 10
+                  type: integer
+                headers:
+                  type: object
+                healthy:
+                  properties:
+                    http_statuses:
+                      default:
+                        - 200
+                        - 302
+                      items:
+                        type: integer
+                      type: array
+                    interval:
+                      default: 0
+                      type: number
+                    successes:
+                      default: 0
+                      type: integer
+                  type: object
+                http_path:
+                  default: /
+                  type: string
+                https_sni:
+                  type: string
+                https_verify_certificate:
+                  default: true
+                  type: boolean
+                timeout:
+                  default: 1
+                  type: number
+                type:
+                  default: http
+                  type: string
+                unhealthy:
+                  properties:
+                    http_failures:
+                      default: 0
+                      type: integer
+                    http_statuses:
+                      default:
+                        - 429
+                        - 404
+                        - 500
+                        - 501
+                        - 502
+                        - 503
+                        - 504
+                        - 505
+                      items:
+                        type: integer
+                      type: array
+                    interval:
+                      default: 0
+                      type: number
+                    tcp_failures:
+                      default: 0
+                      type: integer
+                    timeouts:
+                      default: 0
+                      type: integer
+                  type: object
+              type: object
+            passive:
+              properties:
+                healthy:
+                  properties:
+                    http_statuses:
+                      default:
+                        - 200
+                        - 201
+                        - 202
+                        - 203
+                        - 204
+                        - 205
+                        - 206
+                        - 207
+                        - 208
+                        - 226
+                        - 300
+                        - 301
+                        - 302
+                        - 303
+                        - 304
+                        - 305
+                        - 306
+                        - 307
+                        - 308
+                      items:
+                        type: integer
+                      type: array
+                    successes:
+                      default: 0
+                      type: integer
+                  type: object
+                type:
+                  default: http
+                  type: string
+                unhealthy:
+                  properties:
+                    http_failures:
+                      default: 0
+                      type: integer
+                    http_statuses:
+                      default:
+                        - 429
+                        - 500
+                        - 503
+                      items:
+                        type: integer
+                      type: array
+                    tcp_failures:
+                      default: 0
+                      type: integer
+                    timeouts:
+                      default: 0
+                      type: integer
+                  type: object
+              type: object
+            threshold:
+              default: 0
+              type: number
+          type: object
+        host_header:
+          description: The hostname to be used as `Host` header when proxying requests through Kong.
+          type: string
+        id:
+          type: string
+        name:
+          description: This is a hostname, which must be equal to the `host` of a Service.
+          type: string
+        slots:
+          default: 10000
+          description: The number of slots in the load balancer algorithm. If `algorithm` is set to `round-robin`, this setting determines the maximum number of slots. If `algorithm` is set to `consistent-hashing`, this setting determines the actual number of slots in the algorithm. Accepts an integer in the range `10`-`65536`.
+          type: integer
+        tags:
+          description: An optional set of strings associated with the Upstream for grouping and filtering.
+          items:
+            type: string
+          type: array
+        updated_at:
+          description: Unix epoch when the resource was last updated.
+          type: integer
+        use_srv_name:
+          default: false
+          description: If set, the balancer will use SRV hostname(if DNS Answer has SRV record) as the proxy upstream `Host`.
+          type: boolean
+      type: object
+    Vault:
+      description: Vault entities are used to configure different Vault connectors. Examples of Vaults are Environment Variables, HashiCorp Vault and AWS Secrets Manager. Configuring a Vault allows referencing the secrets with other entities. For example a certificate entity can store a reference to a certificate and key, stored in a vault, instead of storing the certificate and key within the entity. This allows a proper separation of secrets and configuration and prevents secret sprawl.
+      type: object
+      properties:
+        config:
+          description: The configuration properties for the Vault which can be found on the vaults' documentation page.
+          type: object
+          additionalProperties: true
+        created_at:
+          description: Unix epoch when the resource was created.
+          type: integer
+          readOnly: true
+        description:
+          description: The description of the Vault entity.
+          type: string
+          nullable: true
+        id:
+          type: string
+          nullable: true
+        name:
+          description: 'The name of the Vault that''s going to be added. Currently, the Vault implementation must be installed in every Kong instance.'
+          type: string
+        prefix:
+          description: The unique prefix (or identifier) for this Vault configuration. The prefix is used to load the right Vault configuration and implementation when referencing secrets with the other entities.
+          type: string
+        tags:
+          description: An optional set of strings associated with the Vault for grouping and filtering.
+          type: array
+          items:
+            type: string
+        updated_at:
+          description: Unix epoch when the resource was last updated.
+          type: integer
+          readOnly: true
+      example:
+        config:
+          prefix: ENV_PREFIX
+        description: environment variable based vault
+        id: 2747d1e5-8246-4f65-a939-b392f1ee17f8
+        name: env
+        prefix: env
+        tags:
+          - foo
+          - bar
+      additionalProperties: false
+      required:
+        - name
+        - prefix
+        - config
+    Workspace:
+      type: object
+      properties:
+        comment:
+          type: string
+        config:
+          type: object
+          properties:
+            meta:
+              type: object
+            portal:
+              default: false
+              type: boolean
+              description: Portal enabled
+            portal_access_request_email:
+              type: boolean
+            portal_application_request_email:
+              type: boolean
+            portal_application_status_email:
+              type: boolean
+            portal_approved_email:
+              type: boolean
+            portal_auth:
+              type: string
+            portal_auth_conf:
+              type: string
+            portal_auto_approve:
+              type: boolean
+            portal_cors_origins:
+              type: array
+              items:
+                type: string
+            portal_developer_meta_fields:
+              default: '[{"label":"Full Name","title":"full_name","validator":{"required":true,"type":"string"}}]'
+              type: string
+            portal_emails_from:
+              type: string
+            portal_emails_reply_to:
+              type: string
+            portal_invite_email:
+              type: boolean
+            portal_is_legacy:
+              type: boolean
+            portal_reset_email:
+              type: boolean
+            portal_reset_success_email:
+              type: boolean
+            portal_session_conf:
+              type: string
+            portal_smtp_admin_emails:
+              type: array
+              items:
+                type: string
+            portal_token_exp:
+              type: integer
+        created_at:
+          description: Unix epoch when the resource was created.
+          type: integer
+        id:
+          type: string
+          description: The unique UUID for this resource.
+        meta:
+          type: object
+          properties:
+            color:
+              type: string
+            thumbnail:
+              type: string
+        name:
+          type: string
+      x-examples:
+        Example 1:
+          comment: string
+          config:
+            meta: {}
+            portal: false
+            portal_access_request_email: true
+            portal_application_request_email: true
+            portal_application_status_email: true
+            portal_approved_email: true
+            portal_auth: string
+            portal_auth_conf: string
+            portal_auto_approve: true
+            portal_cors_origins:
+              - string
+            portal_developer_meta_fields: >-
+              [{"label":"Full Name","title":"full_name","validator":{"required":true,"type":"string"}}]
+            portal_emails_from: string
+            portal_emails_reply_to: string
+            portal_invite_email: true
+            portal_is_legacy: true
+            portal_reset_email: true
+            portal_reset_success_email: true
+            portal_session_conf: string
+            portal_smtp_admin_emails:
+              - string
+            portal_token_exp: 0
+          created_at: 0
+          id: string
+          meta:
+            color: string
+            thumbnail: string
+          name: string
+      description: Workspaces provide a way to segment Kong entities.
+    pagination-offset-response:
+      description: Offset is used to paginate through the API. Provide this value to the next list operation to fetch the next page
+      type: string
+    Filter-chains:
+      type: object
+      x-examples:
+        Example 1:
+          id: ce44eef5-41ed-47f6-baab-f725cecf98c7
+          name: my-chain
+          created_at: 1422386534
+          updated_at: 1422386534
+          enabled: true
+          route: null
+          service: 20487393-41ed-47f6-93a8-3407cade2002
+          filters:
+            - name: go-rate-limiting
+              enabled: true
+              config: '{ "minute": 30 }'
+            - name: rust-response-transformer
+              enabled: true
+              config: '{ "remove_header": "X-Example" }'
+          tags:
+            - my-tag
+      description: A filter chain is the database entity representing one or more WebAssembly filters executed for each request to a particular service or route, each one with its configuration.
+      title: Filter-chains
+      properties:
+        id:
+          type: string
+          description: The unique identifier or the name attribute of the route that should be associated to the newly created filter chain.
+          example: ce44eef5-41ed-47f6-baab-f725cecf98c7
+          format: uuid
+        name:
+          type: string
+          description: |
+            The name of the filter chain.
+          example: my-chain
+        created_at:
+          type: integer
+          example: 1422386534
+        updated_at:
+          type: integer
+          example: 1422386534
+        enabled:
+          type: boolean
+          description: |
+            Whether the filter chain is applied. Default: true.
+          default: true
+        route:
+          description: The route to which this chain is applied. A filter chain must be applied to either a single route or a single service. Default `null`. In form-encoded format, the notation is `route.id=<route id>` or `route.name=<route name>`. In JSON format, use `"route":{"id":"<route id>"}` or `"route":{"name":"<route name>"}`.
+          nullable: true
+        service:
+          type: string
+          description: The service to which this chain is applied. A filter chain must be applied to either a single route or a single service. Default `null`. In form-encoded format, the notation is `service.id=<service id>` or `service.name=<service name>`. In JSON format, use `"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
+          example: 20487393-41ed-47f6-93a8-3407cade2002
+        filters:
+          type: array
+          description: An array of filter definitions. Each filter is an object containing a mandatory name, an optional config, and a boolean enabled setting.
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                description: |
+                  The name of the filter
+                example: go-rate-limiting
+              enabled:
+                type: boolean
+                description: Enable the filter
+              config:
+                type: string
+                description: configuration filter headers
+                example: '{ \"minute\": 30 }'
+        tags:
+          type: array
+          items:
+            type: string
+    RequestTimestampFilterSchema:
+      oneOf:
+        - type: string
+          pattern: '^(\d+|\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)$'
+        - type: integer
+    Partial:
+      type: object
+      required: 
+        - type
+      properties:
+        id:
+          type: string
+          example: ce44eef5-41ed-47f6-baab-f725cecf98c7
+          format: uuid
+        name:
+          type: string
+          example: my-partial-1
+        type:
+          type: string
+          enum: [redis-ce, redis-ee]
+        config:
+          type: object
+        created_at:
+          description: Unix epoch when the resource was created.
+          type: number
+        updated_at:
+          description: Unix epoch when the resource was updated.
+          type: number
+        tags:
+          type: array
+          description: |
+            The name to associate with the given Key Set.
+          items:
+            type: string
+    PluginLink:
+      type: object
+      properties:
+        id:
+          type: string
+          example: ce44eef5-41ed-47f6-baab-f725cecf98c7
+          format: uuid
+        name:
+          type: string
+  responses:
+    HTTP401Error:
+      content:
+        application/json:
+          examples:
+            DuplicateApiKey:
+              summary: Duplicate API key found
+              value:
+                message: Duplicate API key found
+                status: 401
+            InvalidAuthCred:
+              summary: Invalid authentication credentials
+              value:
+                message: Unauthorized
+                status: 401
+            NoAPIKey:
+              summary: No API key found
+              value:
+                message: No API key found in request
+                status: 401
+          schema:
+            $ref: '#/components/schemas/UnauthorizedError'
+      description: Unauthorized
+    tags-response:
+      description: Tags response body
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                data:
+                  - entity_name: services
+                    entity_id: acf60b10-125c-4c1a-bffe-6ed55daefba4
+                    tag: s1
+                offset: c47139f3-d780-483d-8a97-17e9adc5a7ab
+                next: /tags?offset=c47139f3-d780-483d-8a97-17e9adc5a7ab
+            properties:
+              data:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    entity_name:
+                      type: string
+                      example: services
+                      description: The name of the entity that corresponds to a tag
+                    entity_id:
+                      type: string
+                      example: c87440e1-0496-420b-b06f-dac59544bb6c
+                      description: The unique ID for the entity that is attached to the tag
+                    tag:
+                      type: string
+                      example: example
+                      description: The tag
+              offset:
+                type: string
+                example: 1fb491c4-f4a7-4bca-aeba-7f3bcee4d2f9
+                description: Pagination information
+              next:
+                type: string
+                example: /tags/example?offset=1fb491c4-f4a7-4bca-aeba-7f3bcee4d2f9
+                description: Pagination information
+          examples:
+            Tags response:
+              value:
+                data:
+                  - entity_name: services
+                    entity_id: c87440e1-0496-420b-b06f-dac59544bb6c
+                    tag: example
+                offset: 1fb491c4-f4a7-4bca-aeba-7f3bcee4d2f9
+                next: /tags/example?offset=1fb491c4-f4a7-4bca-aeba-7f3bcee4d2f9
+    key-set-response:
+      description: Key set object response body
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                id: b58c7d9d-e54f-444c-b24d-cdfc4159f61e
+                name: example-key-set
+                created_at: 1422386534
+                updated_at: 1422386534
+                tags:
+                  - idp-keys
+                next: 'http://localhost:8001/key-sets?offset=6378122c-a0a1-438d-a5c6-efabae9fb969'
+            properties:
+              id:
+                type: string
+                example: 4D0DBDA-671C-11ED-BA0B-EF1DCCD3725F
+              name:
+                type: string
+                description: |
+                  The name to associate with the given Key Set.
+                example: my-key_set
+              created_at:
+                type: integer
+                description: Unix epoch when the resource was last created.
+                example: 1422386534
+              updated_at:
+                type: integer
+                description: |
+                  Unix epoch when the resource was last updated.
+                example: 1422386534
+              tags:
+                type: array
+                description: |
+                  The name to associate with the given Key Set
+                items:
+                  type: string
+              next:
+                type: string
+                description: |
+                  Offset is used to paginate through the API. Provide this value to the next list operation to fetch the next page
+                example: 'http://localhost:8001/key-sets?offset=6378122c-a0a1-438d-a5c6-efabae9fb969'
+          examples:
+            example:
+              value:
+                id: 4D0DBDA-671C-11ED-BA0B-EF1DCCD3725F
+                name: my-key_set
+                created_at: 1422386534
+                updated_at: 1422386534
+                tags:
+                  - string
+                next: 'http://localhost:8001/key-sets?offset=6378122c-a0a1-438d-a5c6-efabae9fb969'
+    plugin-response:
+      description: A plugin  entity represents a plugin configuration that will be executed during the HTTP request/response lifecycle.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+              name:
+                type: string
+                description: The name of the plugin thats going to be added. Currently, the plugin must be installed in every Kong instance separately.
+                example: rate-limiting
+              created_at:
+                type: integer
+                description: Unix epoch when the resource was created.
+              route:
+                type: string
+                description: If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used. Default, `null`.With form-encoded, the notation is `route.id=<route id>` or `route.name=<route name>`. With JSON, use `route:{"id":"<route id>"}` or `"route":{"name":"<route name>"}`.
+                nullable: true
+              service:
+                type: string
+                description: If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified service.
+                nullable: true
+              consumer:
+                type: string
+                description: If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.)
+                nullable: true
+              instance_name:
+                type: string
+                description: |
+                  An optional custom name to identify an instance of the plugin, for example `basic-auth_example-service`.
+                  
+                  The instance name shows up in Kong Manager, so it's useful when running the same 
+                  plugin in multiple contexts, for example, on multiple services. You can also use it to access a specific plugin instance
+                  via the Kong Admin API.
+
+                  An instance name must be unique within a workspace for Kong Gateway Enterprise.
+                example: rate-limiting-foo
+              config:
+                type: object
+                description: The configuration properties for the plugin
+                properties:
+                  hour:
+                    type: integer
+                    example: 500
+                  minute:
+                    type: integer
+                    example: 500
+              protocols:
+                type: array
+                description: A list of the request protocols that will trigger this plugin.
+                items:
+                  type: string
+                  enum:
+                    - http
+                    - grpc
+                    - grpcs
+                    - tls
+                    - tcp
+                  default: http
+              enabled:
+                type: boolean
+                description: |
+                  Whether the plugin is applied. Default: `true`.
+                default: true
+              tags:
+                type: array
+                description: |
+                  An optional set of strings associated with the plugin for grouping and filtering.
+                items:
+                  type: string
+              ordering:
+                type: object
+                description: |
+                  Describes a dependency to another plugin to determine plugin ordering during the access phase.
+                  - `before`: The plugin will be executed before a specified plugin or list of plugins.
+                  - `after`: The plugin will be executed after a specified plugin or list of plugins.
+                properties:
+                  before:
+                    type: array
+                    items:
+                      type: string
+          x-examples:
+            Example 1:
+              id: ce44eef5-41ed-47f6-baab-f725cecf98c7
+              name: rate-limiting
+              created_at: 1422386534
+              route: null
+              service: null
+              consumer: null
+              instance_name: rate-limiting-foo
+              config:
+                hour: 500
+                minute: 20
+              protocols:
+                - http
+                - https
+              enabled: true
+              tags:
+                - user-level
+                - low-priority
+              ordering:
+                before:
+                  - plugin-name
+          examples:
+            Plugin response:
+              value:
+                data:
+                  - id: 02621eee-8309-4bf6-b36b-a82017a5393e
+                    name: rate-limiting
+                    created_at: 1422386534
+                    route: null
+                    service: null
+                    consumer: null
+                    config:
+                      hour: 500
+                      minute: 20
+                    protocols:
+                      - http
+                      - https
+                    enabled: true
+                    tags:
+                      - user-level
+                      - low-priority
+                    ordering:
+                      before:
+                        - plugin-name
+                  - id: 66c7b5c4-4aaf-4119-af1e-ee3ad75d0af4
+                    name: rate-limiting
+                    created_at: 1422386534
+                    route: null
+                    service: null
+                    consumer: null
+                    config:
+                      hour: 500
+                      minute: 20
+                    protocols:
+                      - tcp
+                      - tls
+                    enabled: true
+                    tags:
+                      - admin
+                      - high-priority
+                      - critical
+                    ordering:
+                      after:
+                        - plugin-name
+                next: 'http://localhost:8001/plugins?offset=6378122c-a0a1-438d-a5c6-efabae9fb969'
+    sni-response:
+      description: SNI response object
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                data:
+                  - id: 147f5ef0-1ed6-4711-b77f-489262f8bff7
+                    name: my-sni
+                    created_at: 1422386534
+                    tags:
+                      - user-level
+                      - low-priority
+                    certificate:
+                      id: a3ad71a8-6685-4b03-a101-980a953544f6
+                  - id: b87eb55d-69a1-41d2-8653-8d706eecefc0
+                    name: my-sni
+                    created_at: 1422386534
+                    tags:
+                      - admin
+                      - high-priority
+                      - critical
+                    certificate:
+                      id: 4e8d95d4-40f2-4818-adcb-30e00c349618
+                next: 'http://localhost:8001/snis?offset=6378122c-a0a1-438d-a5c6-efabae9fb969'
+            properties:
+              data:
+                type: array
+                description: Array of SNIs
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      example: 147f5ef0-1ed6-4711-b77f-489262f8bff7
+                      description: The unique identifier or the name attribute of the Certificate whose SNIs are to be retrieved. When using this endpoint, only SNIs associated to the specified Certificate will be listed.
+                    name:
+                      type: string
+                      description: |
+                        The SNI name to associate with the given certificate.
+                      example: my-sni
+                    created_at:
+                      type: integer
+                      example: 1422386534
+                      description: |
+                        Unix epoch when the resource was created.
+                    tags:
+                      type: array
+                      description: |
+                        An optional set of strings associated with the SNIs for grouping and filtering.
+                      items:
+                        type: string
+                    certificate:
+                      type: object
+                      description: |
+                        The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object.
+                      properties:
+                        id:
+                          type: string
+                          example: 2e013e8-7623-4494-a347-6d29108ff68b
+                          description: The unique identifier or the name attribute of the Certificate whose SNIs
+              next:
+                type: string
+                example: 'http://localhost:8001/snis?offset=6378122c-a0a1-438d-a5c6-efabae9fb969'
+                description: Offset is used to paginate through the API. Provide this value to the next list operation to fetch the next page
+    consumer-response-data:
+      description: The consumer object response body
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                data:
+                  - id: a4407883-c166-43fd-80ca-3ca035b0cdb7
+                    created_at: 1422386534
+                    username: my-username
+                    custom_id: my-custom-id
+                    tags:
+                      - user-level
+                      - low-priority
+                  - id: 01c23299-839c-49a5-a6d5-8864c09184af
+                    created_at: 1422386534
+                    username: my-username
+                    custom_id: my-custom-id
+                    tags:
+                      - admin
+                      - high-priority
+                      - critical
+                next: 'http://localhost:8001/consumers?offset=6378122c-a0a1-438d-a5c6-efabae9fb969'
+            properties:
+              data:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                      description: The unique identifier or the name attribute of the consumer.
+                      example: a4407883-c166-43fd-80ca-3ca035b0cdb7
+                    created_at:
+                      type: integer
+                      description: Unix epoch when the resource was created.
+                      example: 1422386534
+                    username:
+                      type: string
+                      description: The unique username of the consumer. You must send either this field or` custom_i`d with the request.
+                      example: my-username
+                    custom_id:
+                      type: string
+                      description: Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request.
+                      example: my-custom-id
+                    tags:
+                      type: array
+                      description: |
+                        An optional set of strings associated with the Consumer for grouping and filtering.
+                      items:
+                        type: string
+                        example: admin
+              next:
+                type: string
+                description: Pagination information
+                example: 'http://localhost:8001/consumers?offset=6378122c-a0a1-438d-a5c6-efabae9fb969'
+    consumer_group_response:
+      description: The consumer group response body
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                description: The data array contains consumer group objects
+                items:
+                  type: object
+                  properties:
+                    created_at:
+                      type: integer
+                      description: Unix epoch when the resource was created.
+                      example: 1719859003
+                    id:
+                      type: string
+                      description: The UUID of the consumer group
+                      example: 0d8f5353-8dd2-4013-859a-21510b970a64
+                    name:
+                      type: string
+                      description: The name of the consumer group
+                      example: group2
+                    tags:
+                      type: array
+                      description: An optional set of strings associated with the consumer group for grouping and filtering.
+                      items:
+                        type: string
+                        example: example_tag
+                    updated_at:
+                      type: integer
+                      description: Unix epoch when the resource was last updated.
+                      example: 1719859003
+              next:
+                type: string
+                description: Link to the next page of results, if applicable
+                example: null
+            x-examples:
+              Example 1:
+                data:
+                  - created_at: 1719859003
+                    id: 0d8f5353-8dd2-4013-859a-21510b970a64
+                    name: group2
+                    tags: []
+                    updated_at: 1719859003
+                  - created_at: 1719858982
+                    id: 7012a570-e372-4280-92db-7fbbe4af80bb
+                    name: group1
+                    tags: []
+                    updated_at: 1719858982
+                  - created_at: 1719859346
+                    id: 9faf2f1b-2110-4690-8b64-c70dc14aa51a
+                    name: group3
+                    tags: null
+                    updated_at: 1719859346
+                next: null
+              Consumer group example:
+                data:
+                  - created_at: 1719859003
+                    id: 0d8f5353-8dd2-4013-859a-21510b970a64
+                    name: group2
+                    tags: []
+                    updated_at: 1719859003
+                next: null
+    add_consumer_to_group_response:
+      description: The object returns information about the consumer and the group
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                consumer:
+                  created_at: 1638918560
+                  custom_id: null
+                  id: 288f2bfc-04e2-4ec3-b6f3-40408dff5417
+                  tags: null
+                  type: 0
+                  username: BarryAllen
+                  username_lower: barryallen
+                consumer_groups:
+                  - created_at: 1638918476
+                    id: e2c3f16e-22c7-4ef4-b6e4-ab25c522b339
+                    name: JL
+                    tags: null
+            properties:
+              consumer:
+                type: object
+                properties:
+                  created_at:
+                    type: integer
+                    description: Unix epoch when the resource was created.
+                    example: 1638918560
+                  custom_id:
+                    type: string
+                    description: Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request.
+                    nullable: true
+                  id:
+                    type: string
+                    description: The UUID for the consumer
+                  tags:
+                    type: object
+                    description: An optional set of strings associated with consumer group for grouping and filtering.
+                    nullable: true
+                  type:
+                    type: integer
+                    default: 0
+                    example: 0
+                  username:
+                    type: string
+                    description: The unique username of the Consumer. You must send either this field or `custom_id` with the request.
+                  username_lower:
+                    type: string
+                    description: A lowercase representation of the username
+              consumer_groups:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    created_at:
+                      type: integer
+                      description: Unix epoch when the resource was created.
+                    id:
+                      type: string
+                      description: The UUID for the consumer group
+                    name:
+                      type: string
+                      description: The name of the consumer group
+                    tags:
+                      type: object
+                      description: An optional set of strings associated with consumer group for grouping and filtering.
+                      nullable: true
+          examples:
+            Example:
+              value:
+                consumer:
+                  created_at: 0
+                  custom_id: null
+                  id: string
+                  tags: null
+                  type: 0
+                  username: string
+                  username_lower: string
+                consumer_groups:
+                  - created_at: 0
+                    id: string
+                    name: string
+                    tags:
+                      red: null
+    consumer_response:
+      description: A consumer response object
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                description: The data array contains consumer objects
+                items:
+                  type: object
+                  properties:
+                    created_at:
+                      type: integer
+                      description: Unix epoch when the resource was created.
+                      example: 1719859293
+                    custom_id:
+                      type: string
+                      description: Custom ID of the consumer
+                      example: consumer_id3
+                    id:
+                      type: string
+                      example: 1cf590ba-4b23-46fa-9e8d-4296213e2ac6
+                      description: The consumer ID
+                    tags:
+                      type: array
+                      description: Tags associated with the consumer
+                      items:
+                        type: string
+                        example: test
+                    type:
+                      type: integer
+                      default: 0
+                      example: 0
+                    updated_at:
+                      type: integer
+                      description: Unix epoch when the resource was last updated.
+                      example: 1719859293
+                    username:
+                      type: string
+                      example: consumer3
+                      description: The username of the consumer
+                    username_lower:
+                      type: string
+                      example: consumer3
+                      description: Lowercase representation of the consumer username.
+              next:
+                type: string
+                description: Link to the next page of results, if applicable
+                example: null
+            x-examples:
+              Example 1:
+                data:
+                  - created_at: 1719859293
+                    custom_id: consumer_id3
+                    id: 1cf590ba-4b23-46fa-9e8d-4296213e2ac6
+                    tags: null
+                    type: 0
+                    updated_at: 1719859293
+                    username: consumer3
+                    username_lower: consumer3
+                  - created_at: 1719858943
+                    custom_id: consumer_id
+                    id: 73b74f15-5185-4b16-a2fc-3c2fd834ba6c
+                    tags: null
+                    type: 0
+                    updated_at: 1719858943
+                    username: consumer
+                    username_lower: consumer
+                  - created_at: 1719858965
+                    custom_id: consumer_id2
+                    id: f9383372-7bf4-4275-8bbc-4f89d7a38a23
+                    tags: null
+                    type: 0
+                    updated_at: 1719858965
+                    username: consumer2
+                    username_lower: consumer2
+                next: null
+              One consumer:
+                data:
+                  - created_at: 1719859293
+                    custom_id: consumer_id3
+                    id: 1cf590ba-4b23-46fa-9e8d-4296213e2ac6
+                    tags: null
+                    type: 0
+                    updated_at: 1719859293
+                    username: consumer3
+                    username_lower: consumer3
+                next: null
+              Multiple consumers:
+                data:
+                  - created_at: 1719859293
+                    custom_id: consumer_id3
+                    id: 1cf590ba-4b23-46fa-9e8d-4296213e2ac6
+                    tags: null
+                    type: 0
+                    updated_at: 1719859293
+                    username: consumer3
+                    username_lower: consumer3
+                  - created_at: 1719858943
+                    custom_id: consumer_id
+                    id: 73b74f15-5185-4b16-a2fc-3c2fd834ba6c
+                    tags: null
+                    type: 0
+                    updated_at: 1719858943
+                    username: consumer
+                    username_lower: consumer
+                  - created_at: 1719858965
+                    custom_id: consumer_id2
+                    id: f9383372-7bf4-4275-8bbc-4f89d7a38a23
+                    tags: null
+                    type: 0
+                    updated_at: 1719858965
+                    username: consumer2
+                    username_lower: consumer2
+                next: null
+    license-response:
+      description: The license response object.
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                created_at: 1500508800
+                id: 30b4edb7-0847-4f65-af90-efbed8b0161f
+                payload: '{"license":{"payload":{"admin_seats":"1","customer":"Example Company, Inc","dataplanes":"1","license_creation_date":"2017-07-20","license_expiration_date":"2017-07-21","license_key":"00141000017ODj3AAG_a1V41000004wT0OEAU","product_subscription":"Konnect Enterprise","support_plan":"None"},"signature":"24cc21223633044c15c300be19cacc26ccc5aca0dd9a12df8a7324a1970fe304bc07b8dcd7fb08d7b92e04169313377ae3b550ead653b951bc44cd2eb59f6beb","version":"1"}}'
+                updated_at: 1500508800
+            properties:
+              created_at:
+                type: integer
+                example: 1500508800
+              id:
+                type: string
+                example: 30b4edb7-0847-4f65-af90-efbed8b0161f
+                description: The UUID of the license
+              payload:
+                type: string
+                example: '{\"license\":{\"payload\":{\"admin_seats\":\"1\",\"customer\":\"Example Company, Inc\",\"dataplanes\":\"1\",\"license_creation_date\":\"2017-07-20\",\"license_expiration_date\":\"2017-07-21\",\"license_key\":\"00141000017ODj3AAG_a1V41000004wT0OEAU\",\"product_subscription\":\"Konnect Enterprise\",\"support_plan\":\"None\"},\"signature\":\"24cc21223633044c15c300be19cacc26ccc5aca0dd9a12df8a7324a1970fe304bc07b8dcd7fb08d7b92e04169313377ae3b550ead653b951bc44cd2eb59f6beb\",\"version\":\"1\"}}'
+                description: |
+                  The Kong Gateway license in JSON format.
+              updated_at:
+                type: integer
+                example: 1500508800
+          examples:
+            Active license:
+              value:
+                created_at: 1500508800
+                id: 30b4edb7-0847-4f65-af90-efbed8b0161f
+                payload: '{\"license\":{\"payload\":{\"admin_seats\":\"1\",\"customer\":\"Example Company, Inc\",\"dataplanes\":\"1\",\"license_creation_date\":\"2017-07-20\",\"license_expiration_date\":\"2017-07-21\",\"license_key\":\"00141000017ODj3AAG_a1V41000004wT0OEAU\",\"product_subscription\":\"Konnect Enterprise\",\"support_plan\":\"None\"},\"signature\":\"24cc21223633044c15c300be19cacc26ccc5aca0dd9a12df8a7324a1970fe304bc07b8dcd7fb08d7b92e04169313377ae3b550ead653b951bc44cd2eb59f6beb\",\"version\":\"1\"}}'
+                updated_at: 1500508800
+            No license:
+              value:
+                data: []
+                next: null
+    report-response:
+      description: Fields available in the report
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                checksum: 38b06b3c3c69299740e1f2d48a1a197d17864b99
+                consumers_count: 0
+                counters:
+                  total_requests: 10
+                  buckets: 
+                    - bucket: 2025-01
+                      request_count: 10
+                db_version: postgres 13.18
+                deployment_info:
+                  type: hybrid
+                kong_version: 3.9.0.0
+                license:
+                  license_expiration_date: "2025-02-20"
+                  license_key: ASDASDASDASDASDASDASDASDASD_ASDASDA
+                plugins_count:
+                  tiers:
+                    custom: 0
+                    enterprise:
+                      rate-limiting-advanced: 1
+                    free:
+                      basic-auth: 1
+                  unique_route_kafkas: 0
+                  unique_route_lambdas: 0
+                rbac_users: 0
+                routes_count: 0
+                services_count: 0
+                system_info:
+                  cores: 4
+                  hostname: 13b867agsa008
+                  uname: Linux x86_64
+                timestamp: a1737692223
+                workspaces_count: 1
+            properties:
+              checksum:
+                type: string
+                description: The checksum of the current report.
+                example: 38b06b3c3c69299740e1f2d48a1a197d17864b99
+              counters:
+                type: object
+                description: |
+                  Counts the number of requests made in a given month.
+                properties:
+                  total_requests:
+                    type: number
+                    description: The total number of requests made in all buckets.
+                    example: 10
+                  buckets:
+                    type: array
+                    description: A list of year-month buckets and the number of requests made in each one.
+                    items:
+                      properties:
+                        bucket: 
+                          type: string
+                          description: Year and month when the requests were processed. If the value in bucket is UNKNOWN, then the requests were processed before Kong Gateway 2.7.0.1.
+                          example: 2025-01
+                        request_count: 
+                          type: integer
+                          description: Number of requests processed in the given month and year.
+                          example: 10
+              db_version:
+                type: string
+                description: |
+                  The type and version of the data store Kong Gateway is using.
+                example: postgres 13.18
+              deployment_info:
+                type: object
+                description: Displays information about the deployment running Kong Gateway.
+                properties:
+                  type:
+                    type: string
+                    description: Type of the deployment mode.
+                    example: traditional
+                  connected_dp_count:
+                    type: number
+                    description: Number of data planes across the cluster. If the deployment is not hybrid mode, the field is not displayed.
+              kong_version:
+                type: string
+                description: |
+                  The version of the Kong Gateway instance.
+                example: 3.9.0.0
+              license:
+                type: object
+                description: Information about the license.
+                properties:
+                  license_expiration_date:
+                    type: string
+                    description: The date current license expires. If no license is present, the field displays as 2017-7-20.
+                    example: "2025-02-20"
+                  license_key:
+                    type: string
+                    description: |
+                      An encrypted identifier for the current license key. If no license is present, the field displays as UNLICENSED.
+                    example: ASDASDASDASDASDASDASDASDASD_ASDASDA
+              rbac_users:
+                type: integer
+                description: |
+                  The number of users registered with through RBAC.
+                example: 0
+              consumers_count:
+                type: integer
+                description: The number of configured consumers in the Kong Gateway instance.
+                example: 0
+              plugins_count:
+                type: object
+                description: Counts the number of plugins in use.
+                properties:
+                  unique_route_lambdas:
+                    type: number
+                    description: |
+                      Number of AWS Lambda plugins in use. Only counts in case of the plugin is defined on a service-less route level and have a unique function name.
+                    example: 0
+                  unique_route_kafkas:
+                    type: number
+                    description: Number of unique broker IPs listed in broker array across Kafka Upstream plugins defined on a service-less route level.
+                    example: 0
+                  tiers:
+                    type: object
+                    description: The number of configured plugins in each subscription tier.
+                    properties:
+                      custom:
+                        type: object
+                        description: A list of all configured custom plugins and the number of instances of each.
+                      enterprise:
+                        type: object
+                        description:  A list of all configured Enterprise plugins and the number of instances of each.
+                        example:
+                          rate-limiting-advanced: 1
+                      free:
+                        type: object
+                        description: A list of all configured free plugins and the number of instances of each.
+                        example:
+                          basic-auth: 1
+              routes_count:
+                type: integer
+                description: The number of configured routes in the Kong Gateway instance.
+                example: 0
+              services_count:
+                type: integer
+                description: |
+                  The number of configured services in the Kong Gateway instance.
+                example: 0
+              system_info:
+                type: object
+                description: |
+                  Displays information about the system running Kong Gateway.
+                properties:
+                  cores:
+                    type: integer
+                    description: Number of CPU cores on the node
+                    example: 11
+                  hostname:
+                    type: string
+                    description: Encrypted system hostname
+                    example: 13b867agsa008
+                  uname:
+                    type: string
+                    description: Operating system
+                    example: Linux x86_64
+              timestamp:
+                type: string
+                description: The timestamp of the current response.
+                example: 1737692223
+              workspaces_count:
+                type: integer
+                description: |
+                  The number of workspaces configured in the Kong Gateway instance.
+                example: 1
+    key-ring-response:
+      description: The contents of the keyring.
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                ids:
+                  - LaW1urRQ
+                active: LaW1urRQ
+            description: The keyring object contains an array of keyring ids.
+            properties:
+              ids:
+                type: array
+                description: The list of the active key IDs
+                items:
+                  type: string
+                  example: LaW1urRQ
+              active:
+                type: string
+                example: LaW1urRQ
+                description: The ID of the active key.
+          examples:
+            example:
+              value:
+                ids:
+                  - LaW1urRQ
+                active: LaW1urRQ
+    keyring-generate-response:
+      description: Keyring response object
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              key:
+                type: string
+              id:
+                type: string
+            x-examples:
+              Example 1:
+                key: t6NWgbj3g9cbNVC3/D6oZ2Md1Br5gWtRrqb1T2FZy44=
+                id: 8zgITLQh
+    workspace-response:
+      description: The workspace response object.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Workspace'
+    workspace_create_response:
+      description: The response object for creating a new workspace.
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                total: 1
+                data:
+                  - created_at: 1529627841000
+                    id: a43fc3f9-98e4-43b0-b703-c3b1004980d5
+                    name: default
+            properties:
+              total:
+                type: integer
+                description: The amount of workspaces.
+              data:
+                type: array
+                description: The array of workspaces
+                items:
+                  type: object
+                  properties:
+                    created_at:
+                      type: integer
+                      example: 1529627841000
+                      description: The time and date of workspace creation.
+                    id:
+                      type: string
+                      example: a43fc3f9-98e4-43b0-b703-c3b1004980d5
+                      description: The unique ID of the workspace
+                    name:
+                      type: string
+                      description: The name assigned in the request body.
+                      example: default
+    get-endpoints:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  type: string
+            x-examples:
+              Example 1:
+                data:
+                  - /
+                  - /acls
+                  - '/acls/{acls}'
+                  - '/acls/{acls}/consumer'
+                  - /acme
+                  - /acme/certificates
+                  - '/acme/certificates/{certificates}'
+                  - /acme_storage
+                  - '/acme_storage/{acme_storage}'
+                  - /admins
+                  - /admins/password_resets
+                  - /admins/register
+                  - /admins/self/password
+                  - /admins/self/token
+                  - '/admins/{admins}'
+                  - '/admins/{admins}/consumer'
+                  - '/admins/{admins}/rbac_user'
+                  - '/admins/{admin}/roles'
+                  - '/admins/{admin}/workspaces'
+                  - /applications
+                  - '/applications/{applications}'
+                  - '/applications/{applications}/application_instances'
+                  - '/applications/{applications}/application_instances/{application_instances}'
+                  - '/applications/{applications}/consumer'
+                  - '/applications/{applications}/credentials/{plugin}'
+                  - '/applications/{applications}/credentials/{plugin}/{credential_id}'
+                  - '/applications/{applications}/developer'
+                  - /auth
+                  - /basic-auths
+                  - '/basic-auths/{basicauth_credentials}'
+                  - '/basic-auths/{basicauth_credentials}/consumer'
+                  - /ca_certificates
+                  - '/ca_certificates/{ca_certificates}'
+                  - '/ca_certificates/{ca_certificates}/mtls_auth_credentials'
+                  - '/ca_certificates/{ca_certificates}/mtls_auth_credentials/{mtls_auth_credentials}'
+                  - /cache
+                  - '/cache/{key}'
+                  - /certificates
+                  - '/certificates/{certificates}'
+                  - '/certificates/{certificates}/services'
+                  - '/certificates/{certificates}/services/{services}'
+                  - '/certificates/{certificates}/snis'
+                  - '/certificates/{certificates}/snis/{snis}'
+                  - '/certificates/{certificates}/upstreams'
+                  - '/certificates/{certificates}/upstreams/{upstreams}'
+                  - /clustering/data-planes
+                  - /clustering/status
+                  - /config
+                  - /consumer_groups
+                  - '/consumer_groups/{consumer_groups}'
+                  - '/consumer_groups/{consumer_groups}/consumers'
+                  - '/consumer_groups/{consumer_groups}/consumers/{consumers}'
+                  - '/consumer_groups/{consumer_groups}/overrides/plugins/rate-limiting-advanced'
+                  - '/consumer_groups/{consumer_groups}/plugins'
+                  - '/consumer_groups/{consumer_groups}/plugins/{plugins}'
+                  - /consumers
+                  - '/consumers/{consumers}'
+                  - '/consumers/{consumers}/acls'
+                  - '/consumers/{consumers}/acls/{acls}'
+                  - '/consumers/{consumers}/admins'
+                  - '/consumers/{consumers}/admins/{admins}'
+                  - '/consumers/{consumers}/applications'
+                  - '/consumers/{consumers}/applications/{applications}'
+                  - '/consumers/{consumers}/basic-auth'
+                  - '/consumers/{consumers}/basic-auth/{basicauth_credentials}'
+                  - '/consumers/{consumers}/consumer_groups'
+                  - '/consumers/{consumers}/consumer_groups/{consumer_groups}'
+                  - '/consumers/{consumers}/developers'
+                  - '/consumers/{consumers}/developers/{developers}'
+                  - '/consumers/{consumers}/hmac-auth'
+                  - '/consumers/{consumers}/hmac-auth/{hmacauth_credentials}'
+                  - '/consumers/{consumers}/jwt'
+                  - '/consumers/{consumers}/jwt/{jwt_secrets}'
+                  - '/consumers/{consumers}/key-auth'
+                  - '/consumers/{consumers}/key-auth/{keyauth_credentials}'
+                  - '/consumers/{consumers}/key-auth-enc'
+                  - '/consumers/{consumers}/key-auth-enc/{keyauth_enc_credentials}'
+                  - '/consumers/{consumers}/login_attempts'
+                  - '/consumers/{consumers}/login_attempts/{login_attempts}'
+                  - '/consumers/{consumers}/mtls-auth'
+                  - '/consumers/{consumers}/mtls-auth/{mtls_auth_credentials}'
+                  - '/consumers/{consumers}/mtls_auth_credentials'
+                  - '/consumers/{consumers}/mtls_auth_credentials/{mtls_auth_credentials}'
+                  - '/consumers/{consumers}/oauth2'
+                  - '/consumers/{consumers}/oauth2/{oauth2_credentials}'
+                  - '/consumers/{consumers}/plugins'
+                  - '/consumers/{consumers}/plugins/{plugins}'
+                  - '/debug/cluster/log-level/{log_level}'
+                  - /debug/node/log-level
+                  - '/debug/node/log-level/{log_level}'
+                  - /debug/profiling/cpu
+                  - /debug/profiling/gc-snapshot
+                  - /debug/profiling/memory
+                  - /degraphql_routes
+                  - '/degraphql_routes/{degraphql_routes}'
+                  - '/degraphql_routes/{degraphql_routes}/service'
+                  - /developers
+                  - /developers/export
+                  - /developers/invite
+                  - /developers/roles
+                  - '/developers/roles/{rbac_roles}'
+                  - '/developers/{developers}'
+                  - '/developers/{developers}/applications'
+                  - '/developers/{developers}/applications/{applications}'
+                  - '/developers/{developers}/applications/{applications}/application_instances'
+                  - '/developers/{developers}/applications/{applications}/application_instances/{application_instances}'
+                  - '/developers/{developers}/applications/{applications}/credentials/{plugin}'
+                  - '/developers/{developers}/applications/{applications}/credentials/{plugin}/{credential_id}'
+                  - '/developers/{developers}/consumer'
+                  - '/developers/{developers}/credentials/{plugin}'
+                  - '/developers/{developers}/credentials/{plugin}/{credential_id}'
+                  - '/developers/{developers}/rbac_user'
+                  - '/developers/{email_or_id}/plugins/'
+                  - '/developers/{email_or_id}/plugins/{id}'
+                  - /document_objects
+                  - '/document_objects/{document_objects}'
+                  - '/document_objects/{document_objects}/service'
+                  - /endpoints
+                  - /entities/migrate
+                  - /event-hooks
+                  - /event-hooks/sources
+                  - '/event-hooks/sources/{source}'
+                  - '/event-hooks/sources/{source}/{event}'
+                  - '/event-hooks/{event_hooks}'
+                  - '/event-hooks/{event_hooks}/ping'
+                  - '/event-hooks/{event_hooks}/test'
+                  - /files
+                  - /files/*
+                  - /files/partials/*
+                  - '/files/{files}'
+                  - /filter-chains
+                  - '/filter-chains/{filter_chains}'
+                  - '/filter-chains/{filter_chains}/route'
+                  - '/filter-chains/{filter_chains}/service'
+                  - /graphql-proxy-cache-advanced
+                  - '/graphql-proxy-cache-advanced/{cache_key}'
+                  - '/graphql-proxy-cache-advanced/{plugin_id}/caches/{cache_key}'
+                  - /graphql-rate-limiting-advanced/costs
+                  - '/graphql-rate-limiting-advanced/costs/{graphql_ratelimiting_advanced_cost_decoration}'
+                  - /graphql_ratelimiting_advanced_cost_decoration
+                  - '/graphql_ratelimiting_advanced_cost_decoration/{graphql_ratelimiting_advanced_cost_decoration}'
+                  - '/graphql_ratelimiting_advanced_cost_decoration/{graphql_ratelimiting_advanced_cost_decoration}/service'
+                  - /groups
+                  - '/groups/{groups}'
+                  - '/groups/{groups}/roles'
+                  - /hmac-auths
+                  - '/hmac-auths/{hmacauth_credentials}'
+                  - '/hmac-auths/{hmacauth_credentials}/consumer'
+                  - /jwt-signer/jwks
+                  - '/jwt-signer/jwks/{jwt_signer_jwks}'
+                  - '/jwt-signer/jwks/{jwt_signer_jwks}/rotate'
+                  - /jwts
+                  - '/jwts/{jwt_secrets}'
+                  - '/jwts/{jwt_secrets}/consumer'
+                  - /key-auths
+                  - '/key-auths/{keyauth_credentials}'
+                  - '/key-auths/{keyauth_credentials}/consumer'
+                  - /key-auths-enc
+                  - '/key-auths-enc/{keyauth_enc_credentials}'
+                  - '/key-auths-enc/{keyauth_enc_credentials}/consumer'
+                  - /key-sets
+                  - '/key-sets/{key_sets}'
+                  - '/key-sets/{key_sets}/keys'
+                  - '/key-sets/{key_sets}/keys/{keys}'
+                  - /keyring
+                  - /keyring/activate
+                  - /keyring/active
+                  - /keyring/export
+                  - /keyring/generate
+                  - /keyring/import
+                  - /keyring/import/raw
+                  - /keyring/recover
+                  - /keyring/remove
+                  - /keyring/vault/sync
+                  - /keys
+                  - '/keys/{keys}'
+                  - '/keys/{keys}/set'
+                  - /konnect_applications
+                  - '/konnect_applications/{konnect_applications}'
+                  - /license/report
+                  - /licenses
+                  - '/licenses/{licenses}'
+                  - /login_attempts
+                  - '/login_attempts/{login_attempts}'
+                  - '/login_attempts/{login_attempts}/consumer'
+                  - /metrics
+                  - /mtls-auths
+                  - '/mtls-auths/{mtls_auth_credentials}/consumer'
+                  - /mtls_auth_credentials
+                  - '/mtls_auth_credentials/{mtls_auth_credentials}'
+                  - '/mtls_auth_credentials/{mtls_auth_credentials}/ca_certificate'
+                  - '/mtls_auth_credentials/{mtls_auth_credentials}/consumer'
+                  - /oauth2
+                  - '/oauth2/{oauth2_credentials}'
+                  - '/oauth2/{oauth2_credentials}/consumer'
+                  - '/oauth2/{oauth2_credentials}/oauth2_tokens'
+                  - '/oauth2/{oauth2_credentials}/oauth2_tokens/{oauth2_tokens}'
+                  - /oauth2_tokens
+                  - '/oauth2_tokens/{oauth2_tokens}'
+                  - '/oauth2_tokens/{oauth2_tokens}/credential'
+                  - '/oauth2_tokens/{oauth2_tokens}/service'
+                  - /openid-connect/issuers
+                  - '/openid-connect/issuers/{oic_issuers}'
+                  - /openid-connect/jwks
+                  - /plugins
+                  - /plugins/enabled
+                  - '/plugins/schema/{name}'
+                  - '/plugins/{plugins}'
+                  - '/plugins/{plugins}/consumer'
+                  - '/plugins/{plugins}/consumer_group'
+                  - '/plugins/{plugins}/route'
+                  - '/plugins/{plugins}/service'
+                  - /proxy-cache
+                  - '/proxy-cache/{cache_key}'
+                  - '/proxy-cache/{plugin_id}/caches/{cache_key}'
+                  - /proxy-cache-advanced
+                  - '/proxy-cache-advanced/{cache_key}'
+                  - '/proxy-cache-advanced/{plugin_id}/caches/{cache_key}'
+                  - /rbac/roles
+                  - '/rbac/roles/{rbac_roles}'
+                  - '/rbac/roles/{rbac_roles}/endpoints'
+                  - '/rbac/roles/{rbac_roles}/endpoints/permissions'
+                  - '/rbac/roles/{rbac_roles}/endpoints/{workspace}/*'
+                  - '/rbac/roles/{rbac_roles}/entities'
+                  - '/rbac/roles/{rbac_roles}/entities/permissions'
+                  - '/rbac/roles/{rbac_roles}/entities/{entity_id}'
+                  - '/rbac/roles/{rbac_roles}/permissions'
+                  - /rbac/users
+                  - '/rbac/users/{rbac_users}'
+                  - '/rbac/users/{rbac_users}/admins'
+                  - '/rbac/users/{rbac_users}/admins/{admins}'
+                  - '/rbac/users/{rbac_users}/developers'
+                  - '/rbac/users/{rbac_users}/developers/{developers}'
+                  - '/rbac/users/{rbac_users}/permissions'
+                  - '/rbac/users/{rbac_users}/roles'
+                  - /routes
+                  - '/routes/{routes}'
+                  - '/routes/{routes}/filter-chains'
+                  - '/routes/{routes}/filter-chains/{filter_chains}'
+                  - '/routes/{routes}/filters/all'
+                  - '/routes/{routes}/filters/disabled'
+                  - '/routes/{routes}/filters/enabled'
+                  - '/routes/{routes}/plugins'
+                  - '/routes/{routes}/plugins/{plugins}'
+                  - '/routes/{routes}/service'
+                  - /schemas/plugins/validate
+                  - '/schemas/plugins/{name}'
+                  - '/schemas/{db_entity_name}/validate'
+                  - '/schemas/{name}'
+                  - /services
+                  - '/services/{services}'
+                  - '/services/{services}/application_instances'
+                  - '/services/{services}/application_instances/{application_instances}'
+                  - '/services/{services}/applications'
+                  - '/services/{services}/client_certificate'
+                  - '/services/{services}/degraphql/routes'
+                  - '/services/{services}/degraphql/routes/{degraphql_routes}'
+                  - '/services/{services}/degraphql_routes'
+                  - '/services/{services}/degraphql_routes/{degraphql_routes}'
+                  - '/services/{services}/document_objects'
+                  - '/services/{services}/document_objects/{document_objects}'
+                  - '/services/{services}/filter-chains'
+                  - '/services/{services}/filter-chains/{filter_chains}'
+                  - '/services/{services}/graphql-rate-limiting-advanced/costs'
+                  - '/services/{services}/graphql_ratelimiting_advanced_cost_decoration'
+                  - '/services/{services}/graphql_ratelimiting_advanced_cost_decoration/{graphql_ratelimiting_advanced_cost_decoration}'
+                  - '/services/{services}/oauth2_tokens'
+                  - '/services/{services}/oauth2_tokens/{oauth2_tokens}'
+                  - '/services/{services}/plugins'
+                  - '/services/{services}/plugins/{plugins}'
+                  - '/services/{services}/routes'
+                  - '/services/{services}/routes/{routes}'
+                  - /sessions
+                  - '/sessions/{sessions}'
+                  - /snis
+                  - '/snis/{snis}'
+                  - '/snis/{snis}/certificate'
+                  - /status
+                  - /tags
+                  - '/tags/{tags}'
+                  - /targets
+                  - '/targets/{targets}'
+                  - '/targets/{targets}/upstream'
+                  - /timers
+                  - /upstreams
+                  - '/upstreams/{upstreams}'
+                  - '/upstreams/{upstreams}/client_certificate'
+                  - '/upstreams/{upstreams}/health'
+                  - '/upstreams/{upstreams}/targets'
+                  - '/upstreams/{upstreams}/targets/all'
+                  - '/upstreams/{upstreams}/targets/{targets}'
+                  - '/upstreams/{upstreams}/targets/{targets}/healthy'
+                  - '/upstreams/{upstreams}/targets/{targets}/unhealthy'
+                  - '/upstreams/{upstreams}/targets/{targets}/{address}/healthy'
+                  - '/upstreams/{upstreams}/targets/{targets}/{address}/unhealthy'
+                  - /userinfo
+                  - /vault-auth
+                  - '/vault-auth/{vault_auth_vaults}'
+                  - '/vault-auth/{vault}/credentials'
+                  - '/vault-auth/{vault}/credentials/token/{access_token}'
+                  - '/vault-auth/{vault}/credentials/{consumer}'
+                  - /vaults
+                  - '/vaults/{vaults}'
+                  - /vitals/
+                  - /vitals/cluster
+                  - /vitals/cluster/status_codes
+                  - '/vitals/consumers/{consumer_id}/cluster'
+                  - /vitals/nodes/
+                  - '/vitals/nodes/{node_id}'
+                  - '/vitals/reports/{entity_type}'
+                  - /vitals/status_code_classes
+                  - /vitals/status_codes/by_consumer
+                  - /vitals/status_codes/by_consumer_and_route
+                  - /vitals/status_codes/by_route
+                  - /vitals/status_codes/by_service
+                  - /workspaces
+                  - '/workspaces/{workspaces}'
+                  - '/workspaces/{workspaces}/meta'
+                  - '/{workspace_name}/kong'
+                  - workspace_/acls
+                  - 'workspace_/acls/{acls}'
+                  - 'workspace_/acls/{acls}/consumer'
+                  - workspace_/acme
+                  - workspace_/acme/certificates
+                  - 'workspace_/acme/certificates/{certificates}'
+                  - workspace_/acme_storage
+                  - 'workspace_/acme_storage/{acme_storage}'
+                  - workspace_/admins
+                  - workspace_/admins/password_resets
+                  - workspace_/admins/register
+                  - workspace_/admins/self/password
+                  - workspace_/admins/self/token
+                  - 'workspace_/admins/{admins}'
+                  - 'workspace_/admins/{admins}/consumer'
+                  - 'workspace_/admins/{admins}/rbac_user'
+                  - 'workspace_/admins/{admin}/roles'
+                  - 'workspace_/admins/{admin}/workspaces'
+                  - workspace_/applications
+                  - 'workspace_/applications/{applications}'
+                  - 'workspace_/applications/{applications}/application_instances'
+                  - 'workspace_/applications/{applications}/application_instances/{application_instances}'
+                  - 'workspace_/applications/{applications}/consumer'
+                  - 'workspace_/applications/{applications}/credentials/{plugin}'
+                  - 'workspace_/applications/{applications}/credentials/{plugin}/{credential_id}'
+                  - 'workspace_/applications/{applications}/developer'
+                  - workspace_/auth
+                  - workspace_/basic-auths
+                  - 'workspace_/basic-auths/{basicauth_credentials}'
+                  - 'workspace_/basic-auths/{basicauth_credentials}/consumer'
+                  - workspace_/ca_certificates
+                  - 'workspace_/ca_certificates/{ca_certificates}'
+                  - 'workspace_/ca_certificates/{ca_certificates}/mtls_auth_credentials'
+                  - 'workspace_/ca_certificates/{ca_certificates}/mtls_auth_credentials/{mtls_auth_credentials}'
+                  - workspace_/cache
+                  - 'workspace_/cache/{key}'
+                  - workspace_/certificates
+                  - 'workspace_/certificates/{certificates}'
+                  - 'workspace_/certificates/{certificates}/services'
+                  - 'workspace_/certificates/{certificates}/services/{services}'
+                  - 'workspace_/certificates/{certificates}/snis'
+                  - 'workspace_/certificates/{certificates}/snis/{snis}'
+                  - 'workspace_/certificates/{certificates}/upstreams'
+                  - 'workspace_/certificates/{certificates}/upstreams/{upstreams}'
+                  - workspace_/clustering/data-planes
+                  - workspace_/clustering/status
+                  - workspace_/config
+                  - workspace_/consumer_groups
+                  - 'workspace_/consumer_groups/{consumer_groups}'
+                  - 'workspace_/consumer_groups/{consumer_groups}/consumers'
+                  - 'workspace_/consumer_groups/{consumer_groups}/consumers/{consumers}'
+                  - 'workspace_/consumer_groups/{consumer_groups}/overrides/plugins/rate-limiting-advanced'
+                  - 'workspace_/consumer_groups/{consumer_groups}/plugins'
+                  - 'workspace_/consumer_groups/{consumer_groups}/plugins/{plugins}'
+                  - workspace_/consumers
+                  - 'workspace_/consumers/{consumers}'
+                  - 'workspace_/consumers/{consumers}/acls'
+                  - 'workspace_/consumers/{consumers}/acls/{acls}'
+                  - 'workspace_/consumers/{consumers}/admins'
+                  - 'workspace_/consumers/{consumers}/admins/{admins}'
+                  - 'workspace_/consumers/{consumers}/applications'
+                  - 'workspace_/consumers/{consumers}/applications/{applications}'
+                  - 'workspace_/consumers/{consumers}/basic-auth'
+                  - 'workspace_/consumers/{consumers}/basic-auth/{basicauth_credentials}'
+                  - 'workspace_/consumers/{consumers}/consumer_groups'
+                  - 'workspace_/consumers/{consumers}/consumer_groups/{consumer_groups}'
+                  - 'workspace_/consumers/{consumers}/developers'
+                  - 'workspace_/consumers/{consumers}/developers/{developers}'
+                  - 'workspace_/consumers/{consumers}/hmac-auth'
+                  - 'workspace_/consumers/{consumers}/hmac-auth/{hmacauth_credentials}'
+                  - 'workspace_/consumers/{consumers}/jwt'
+                  - 'workspace_/consumers/{consumers}/jwt/{jwt_secrets}'
+                  - 'workspace_/consumers/{consumers}/key-auth'
+                  - 'workspace_/consumers/{consumers}/key-auth/{keyauth_credentials}'
+                  - 'workspace_/consumers/{consumers}/key-auth-enc'
+                  - 'workspace_/consumers/{consumers}/key-auth-enc/{keyauth_enc_credentials}'
+                  - 'workspace_/consumers/{consumers}/login_attempts'
+                  - 'workspace_/consumers/{consumers}/login_attempts/{login_attempts}'
+                  - 'workspace_/consumers/{consumers}/mtls-auth'
+                  - 'workspace_/consumers/{consumers}/mtls-auth/{mtls_auth_credentials}'
+                  - 'workspace_/consumers/{consumers}/mtls_auth_credentials'
+                  - 'workspace_/consumers/{consumers}/mtls_auth_credentials/{mtls_auth_credentials}'
+                  - 'workspace_/consumers/{consumers}/oauth2'
+                  - 'workspace_/consumers/{consumers}/oauth2/{oauth2_credentials}'
+                  - 'workspace_/consumers/{consumers}/plugins'
+                  - 'workspace_/consumers/{consumers}/plugins/{plugins}'
+                  - 'workspace_/debug/cluster/log-level/{log_level}'
+                  - workspace_/debug/node/log-level
+                  - 'workspace_/debug/node/log-level/{log_level}'
+                  - workspace_/debug/profiling/cpu
+                  - workspace_/debug/profiling/gc-snapshot
+                  - workspace_/debug/profiling/memory
+                  - workspace_/degraphql_routes
+                  - 'workspace_/degraphql_routes/{degraphql_routes}'
+                  - 'workspace_/degraphql_routes/{degraphql_routes}/service'
+                  - workspace_/developers
+                  - workspace_/developers/export
+                  - workspace_/developers/invite
+                  - workspace_/developers/roles
+                  - 'workspace_/developers/roles/{rbac_roles}'
+                  - 'workspace_/developers/{developers}'
+                  - 'workspace_/developers/{developers}/applications'
+                  - 'workspace_/developers/{developers}/applications/{applications}'
+                  - 'workspace_/developers/{developers}/applications/{applications}/application_instances'
+                  - 'workspace_/developers/{developers}/applications/{applications}/application_instances/{application_instances}'
+                  - 'workspace_/developers/{developers}/applications/{applications}/credentials/{plugin}'
+                  - 'workspace_/developers/{developers}/applications/{applications}/credentials/{plugin}/{credential_id}'
+                  - 'workspace_/developers/{developers}/consumer'
+                  - 'workspace_/developers/{developers}/credentials/{plugin}'
+                  - 'workspace_/developers/{developers}/credentials/{plugin}/{credential_id}'
+                  - 'workspace_/developers/{developers}/rbac_user'
+                  - 'workspace_/developers/{email_or_id}/plugins/'
+                  - 'workspace_/developers/{email_or_id}/plugins/{id}'
+                  - workspace_/document_objects
+                  - 'workspace_/document_objects/{document_objects}'
+                  - 'workspace_/document_objects/{document_objects}/service'
+                  - workspace_/endpoints
+                  - workspace_/entities/migrate
+                  - workspace_/event-hooks
+                  - workspace_/event-hooks/sources
+                  - 'workspace_/event-hooks/sources/{source}'
+                  - 'workspace_/event-hooks/sources/{source}/{event}'
+                  - 'workspace_/event-hooks/{event_hooks}'
+                  - 'workspace_/event-hooks/{event_hooks}/ping'
+                  - 'workspace_/event-hooks/{event_hooks}/test'
+                  - workspace_/files
+                  - workspace_/files/*
+                  - workspace_/files/partials/*
+                  - 'workspace_/files/{files}'
+                  - workspace_/filter-chains
+                  - 'workspace_/filter-chains/{filter_chains}'
+                  - 'workspace_/filter-chains/{filter_chains}/route'
+                  - 'workspace_/filter-chains/{filter_chains}/service'
+                  - workspace_/graphql-proxy-cache-advanced
+                  - 'workspace_/graphql-proxy-cache-advanced/{cache_key}'
+                  - 'workspace_/graphql-proxy-cache-advanced/{plugin_id}/caches/{cache_key}'
+                  - workspace_/graphql-rate-limiting-advanced/costs
+                  - 'workspace_/graphql-rate-limiting-advanced/costs/{graphql_ratelimiting_advanced_cost_decoration}'
+                  - workspace_/graphql_ratelimiting_advanced_cost_decoration
+                  - 'workspace_/graphql_ratelimiting_advanced_cost_decoration/{graphql_ratelimiting_advanced_cost_decoration}'
+                  - 'workspace_/graphql_ratelimiting_advanced_cost_decoration/{graphql_ratelimiting_advanced_cost_decoration}/service'
+                  - workspace_/groups
+                  - 'workspace_/groups/{groups}'
+                  - 'workspace_/groups/{groups}/roles'
+                  - workspace_/hmac-auths
+                  - 'workspace_/hmac-auths/{hmacauth_credentials}'
+                  - 'workspace_/hmac-auths/{hmacauth_credentials}/consumer'
+                  - workspace_/jwt-signer/jwks
+                  - 'workspace_/jwt-signer/jwks/{jwt_signer_jwks}'
+                  - 'workspace_/jwt-signer/jwks/{jwt_signer_jwks}/rotate'
+                  - workspace_/jwts
+                  - 'workspace_/jwts/{jwt_secrets}'
+                  - 'workspace_/jwts/{jwt_secrets}/consumer'
+                  - workspace_/key-auths
+                  - 'workspace_/key-auths/{keyauth_credentials}'
+                  - 'workspace_/key-auths/{keyauth_credentials}/consumer'
+                  - workspace_/key-auths-enc
+                  - 'workspace_/key-auths-enc/{keyauth_enc_credentials}'
+                  - 'workspace_/key-auths-enc/{keyauth_enc_credentials}/consumer'
+                  - workspace_/key-sets
+                  - 'workspace_/key-sets/{key_sets}'
+                  - 'workspace_/key-sets/{key_sets}/keys'
+                  - 'workspace_/key-sets/{key_sets}/keys/{keys}'
+                  - workspace_/keyring
+                  - workspace_/keyring/activate
+                  - workspace_/keyring/active
+                  - workspace_/keyring/export
+                  - workspace_/keyring/generate
+                  - workspace_/keyring/import
+                  - workspace_/keyring/import/raw
+                  - workspace_/keyring/recover
+                  - workspace_/keyring/remove
+                  - workspace_/keyring/vault/sync
+                  - workspace_/keys
+                  - 'workspace_/keys/{keys}'
+                  - 'workspace_/keys/{keys}/set'
+                  - workspace_/konnect_applications
+                  - 'workspace_/konnect_applications/{konnect_applications}'
+                  - workspace_/license/report
+                  - workspace_/licenses
+                  - 'workspace_/licenses/{licenses}'
+                  - workspace_/login_attempts
+                  - 'workspace_/login_attempts/{login_attempts}'
+                  - 'workspace_/login_attempts/{login_attempts}/consumer'
+                  - workspace_/metrics
+                  - workspace_/mtls-auths
+                  - 'workspace_/mtls-auths/{mtls_auth_credentials}/consumer'
+                  - workspace_/mtls_auth_credentials
+                  - 'workspace_/mtls_auth_credentials/{mtls_auth_credentials}'
+                  - 'workspace_/mtls_auth_credentials/{mtls_auth_credentials}/ca_certificate'
+                  - 'workspace_/mtls_auth_credentials/{mtls_auth_credentials}/consumer'
+                  - workspace_/oauth2
+                  - 'workspace_/oauth2/{oauth2_credentials}'
+                  - 'workspace_/oauth2/{oauth2_credentials}/consumer'
+                  - 'workspace_/oauth2/{oauth2_credentials}/oauth2_tokens'
+                  - 'workspace_/oauth2/{oauth2_credentials}/oauth2_tokens/{oauth2_tokens}'
+                  - workspace_/oauth2_tokens
+                  - 'workspace_/oauth2_tokens/{oauth2_tokens}'
+                  - 'workspace_/oauth2_tokens/{oauth2_tokens}/credential'
+                  - 'workspace_/oauth2_tokens/{oauth2_tokens}/service'
+                  - workspace_/openid-connect/issuers
+                  - 'workspace_/openid-connect/issuers/{oic_issuers}'
+                  - workspace_/openid-connect/jwks
+                  - workspace_/plugins
+                  - workspace_/plugins/enabled
+                  - 'workspace_/plugins/schema/{name}'
+                  - 'workspace_/plugins/{plugins}'
+                  - 'workspace_/plugins/{plugins}/consumer'
+                  - 'workspace_/plugins/{plugins}/consumer_group'
+                  - 'workspace_/plugins/{plugins}/route'
+                  - 'workspace_/plugins/{plugins}/service'
+                  - workspace_/proxy-cache
+                  - 'workspace_/proxy-cache/{cache_key}'
+                  - 'workspace_/proxy-cache/{plugin_id}/caches/{cache_key}'
+                  - workspace_/proxy-cache-advanced
+                  - 'workspace_/proxy-cache-advanced/{cache_key}'
+                  - 'workspace_/proxy-cache-advanced/{plugin_id}/caches/{cache_key}'
+                  - workspace_/rbac/roles
+                  - 'workspace_/rbac/roles/{rbac_roles}'
+                  - 'workspace_/rbac/roles/{rbac_roles}/endpoints'
+                  - 'workspace_/rbac/roles/{rbac_roles}/endpoints/permissions'
+                  - 'workspace_/rbac/roles/{rbac_roles}/endpoints/{workspace}/*'
+                  - 'workspace_/rbac/roles/{rbac_roles}/entities'
+                  - 'workspace_/rbac/roles/{rbac_roles}/entities/permissions'
+                  - 'workspace_/rbac/roles/{rbac_roles}/entities/{entity_id}'
+                  - 'workspace_/rbac/roles/{rbac_roles}/permissions'
+                  - workspace_/rbac/users
+                  - 'workspace_/rbac/users/{rbac_users}'
+                  - 'workspace_/rbac/users/{rbac_users}/admins'
+                  - 'workspace_/rbac/users/{rbac_users}/admins/{admins}'
+                  - 'workspace_/rbac/users/{rbac_users}/developers'
+                  - 'workspace_/rbac/users/{rbac_users}/developers/{developers}'
+                  - 'workspace_/rbac/users/{rbac_users}/permissions'
+                  - 'workspace_/rbac/users/{rbac_users}/roles'
+                  - workspace_/routes
+                  - 'workspace_/routes/{routes}'
+                  - 'workspace_/routes/{routes}/filter-chains'
+                  - 'workspace_/routes/{routes}/filter-chains/{filter_chains}'
+                  - 'workspace_/routes/{routes}/filters/all'
+                  - 'workspace_/routes/{routes}/filters/disabled'
+                  - 'workspace_/routes/{routes}/filters/enabled'
+                  - 'workspace_/routes/{routes}/plugins'
+                  - 'workspace_/routes/{routes}/plugins/{plugins}'
+                  - 'workspace_/routes/{routes}/service'
+                  - workspace_/schemas/plugins/validate
+                  - 'workspace_/schemas/plugins/{name}'
+                  - 'workspace_/schemas/{db_entity_name}/validate'
+                  - 'workspace_/schemas/{name}'
+                  - workspace_/services
+                  - 'workspace_/services/{services}'
+                  - 'workspace_/services/{services}/application_instances'
+                  - 'workspace_/services/{services}/application_instances/{application_instances}'
+                  - 'workspace_/services/{services}/applications'
+                  - 'workspace_/services/{services}/client_certificate'
+                  - 'workspace_/services/{services}/degraphql/routes'
+                  - 'workspace_/services/{services}/degraphql/routes/{degraphql_routes}'
+                  - 'workspace_/services/{services}/degraphql_routes'
+                  - 'workspace_/services/{services}/degraphql_routes/{degraphql_routes}'
+                  - 'workspace_/services/{services}/document_objects'
+                  - 'workspace_/services/{services}/document_objects/{document_objects}'
+                  - 'workspace_/services/{services}/filter-chains'
+                  - 'workspace_/services/{services}/filter-chains/{filter_chains}'
+                  - 'workspace_/services/{services}/graphql-rate-limiting-advanced/costs'
+                  - 'workspace_/services/{services}/graphql_ratelimiting_advanced_cost_decoration'
+                  - 'workspace_/services/{services}/graphql_ratelimiting_advanced_cost_decoration/{graphql_ratelimiting_advanced_cost_decoration}'
+                  - 'workspace_/services/{services}/oauth2_tokens'
+                  - 'workspace_/services/{services}/oauth2_tokens/{oauth2_tokens}'
+                  - 'workspace_/services/{services}/plugins'
+                  - 'workspace_/services/{services}/plugins/{plugins}'
+                  - 'workspace_/services/{services}/routes'
+                  - 'workspace_/services/{services}/routes/{routes}'
+                  - workspace_/sessions
+                  - 'workspace_/sessions/{sessions}'
+                  - workspace_/snis
+                  - 'workspace_/snis/{snis}'
+                  - 'workspace_/snis/{snis}/certificate'
+                  - workspace_/status
+                  - workspace_/tags
+                  - 'workspace_/tags/{tags}'
+                  - workspace_/targets
+                  - 'workspace_/targets/{targets}'
+                  - 'workspace_/targets/{targets}/upstream'
+                  - workspace_/timers
+                  - workspace_/upstreams
+                  - 'workspace_/upstreams/{upstreams}'
+                  - 'workspace_/upstreams/{upstreams}/client_certificate'
+                  - 'workspace_/upstreams/{upstreams}/health'
+                  - 'workspace_/upstreams/{upstreams}/targets'
+                  - 'workspace_/upstreams/{upstreams}/targets/all'
+                  - 'workspace_/upstreams/{upstreams}/targets/{targets}'
+                  - 'workspace_/upstreams/{upstreams}/targets/{targets}/healthy'
+                  - 'workspace_/upstreams/{upstreams}/targets/{targets}/unhealthy'
+                  - 'workspace_/upstreams/{upstreams}/targets/{targets}/{address}/healthy'
+                  - 'workspace_/upstreams/{upstreams}/targets/{targets}/{address}/unhealthy'
+                  - workspace_/userinfo
+                  - workspace_/vault-auth
+                  - 'workspace_/vault-auth/{vault_auth_vaults}'
+                  - 'workspace_/vault-auth/{vault}/credentials'
+                  - 'workspace_/vault-auth/{vault}/credentials/token/{access_token}'
+                  - 'workspace_/vault-auth/{vault}/credentials/{consumer}'
+                  - workspace_/vaults
+                  - 'workspace_/vaults/{vaults}'
+                  - workspace_/vitals/
+                  - workspace_/vitals/cluster
+                  - workspace_/vitals/cluster/status_codes
+                  - 'workspace_/vitals/consumers/{consumer_id}/cluster'
+                  - workspace_/vitals/nodes/
+                  - 'workspace_/vitals/nodes/{node_id}'
+                  - 'workspace_/vitals/reports/{entity_type}'
+                  - workspace_/vitals/status_code_classes
+                  - workspace_/vitals/status_codes/by_consumer
+                  - workspace_/vitals/status_codes/by_consumer_and_route
+                  - workspace_/vitals/status_codes/by_route
+                  - workspace_/vitals/status_codes/by_service
+                  - workspace_/workspaces
+                  - 'workspace_/workspaces/{workspaces}'
+                  - 'workspace_/workspaces/{workspaces}/meta'
+          examples:
+            Get all endpoints:
+              value:
+                data:
+                  - /
+                  - /acls
+                  - '/acls/{acls}'
+                  - '/acls/{acls}/consumer'
+                  - /acme
+                  - /acme/certificates
+                  - '/acme/certificates/{certificates}'
+                  - /acme_storage
+                  - '/acme_storage/{acme_storage}'
+                  - /admins
+                  - /admins/password_resets
+                  - /admins/register
+                  - /admins/self/password
+                  - /admins/self/token
+                  - '/admins/{admins}'
+                  - '/admins/{admins}/consumer'
+                  - '/admins/{admins}/rbac_user'
+                  - '/admins/{admin}/roles'
+                  - '/admins/{admin}/workspaces'
+                  - /applications
+                  - '/applications/{applications}'
+                  - '/applications/{applications}/application_instances'
+                  - '/applications/{applications}/application_instances/{application_instances}'
+                  - '/applications/{applications}/consumer'
+                  - '/applications/{applications}/credentials/{plugin}'
+                  - '/applications/{applications}/credentials/{plugin}/{credential_id}'
+                  - '/applications/{applications}/developer'
+                  - /auth
+                  - /basic-auths
+                  - '/basic-auths/{basicauth_credentials}'
+                  - '/basic-auths/{basicauth_credentials}/consumer'
+                  - /ca_certificates
+                  - '/ca_certificates/{ca_certificates}'
+                  - '/ca_certificates/{ca_certificates}/mtls_auth_credentials'
+                  - '/ca_certificates/{ca_certificates}/mtls_auth_credentials/{mtls_auth_credentials}'
+                  - /cache
+                  - '/cache/{key}'
+                  - /certificates
+                  - '/certificates/{certificates}'
+                  - '/certificates/{certificates}/services'
+                  - '/certificates/{certificates}/services/{services}'
+                  - '/certificates/{certificates}/snis'
+                  - '/certificates/{certificates}/snis/{snis}'
+                  - '/certificates/{certificates}/upstreams'
+                  - '/certificates/{certificates}/upstreams/{upstreams}'
+                  - /clustering/data-planes
+                  - /clustering/status
+                  - /config
+                  - /consumer_groups
+                  - '/consumer_groups/{consumer_groups}'
+                  - '/consumer_groups/{consumer_groups}/consumers'
+                  - '/consumer_groups/{consumer_groups}/consumers/{consumers}'
+                  - '/consumer_groups/{consumer_groups}/overrides/plugins/rate-limiting-advanced'
+                  - '/consumer_groups/{consumer_groups}/plugins'
+                  - '/consumer_groups/{consumer_groups}/plugins/{plugins}'
+                  - /consumers
+                  - '/consumers/{consumers}'
+                  - '/consumers/{consumers}/acls'
+                  - '/consumers/{consumers}/acls/{acls}'
+                  - '/consumers/{consumers}/admins'
+                  - '/consumers/{consumers}/admins/{admins}'
+                  - '/consumers/{consumers}/applications'
+                  - '/consumers/{consumers}/applications/{applications}'
+                  - '/consumers/{consumers}/basic-auth'
+                  - '/consumers/{consumers}/basic-auth/{basicauth_credentials}'
+                  - '/consumers/{consumers}/consumer_groups'
+                  - '/consumers/{consumers}/consumer_groups/{consumer_groups}'
+                  - '/consumers/{consumers}/developers'
+                  - '/consumers/{consumers}/developers/{developers}'
+                  - '/consumers/{consumers}/hmac-auth'
+                  - '/consumers/{consumers}/hmac-auth/{hmacauth_credentials}'
+                  - '/consumers/{consumers}/jwt'
+                  - '/consumers/{consumers}/jwt/{jwt_secrets}'
+                  - '/consumers/{consumers}/key-auth'
+                  - '/consumers/{consumers}/key-auth/{keyauth_credentials}'
+                  - '/consumers/{consumers}/key-auth-enc'
+                  - '/consumers/{consumers}/key-auth-enc/{keyauth_enc_credentials}'
+                  - '/consumers/{consumers}/login_attempts'
+                  - '/consumers/{consumers}/login_attempts/{login_attempts}'
+                  - '/consumers/{consumers}/mtls-auth'
+                  - '/consumers/{consumers}/mtls-auth/{mtls_auth_credentials}'
+                  - '/consumers/{consumers}/mtls_auth_credentials'
+                  - '/consumers/{consumers}/mtls_auth_credentials/{mtls_auth_credentials}'
+                  - '/consumers/{consumers}/oauth2'
+                  - '/consumers/{consumers}/oauth2/{oauth2_credentials}'
+                  - '/consumers/{consumers}/plugins'
+                  - '/consumers/{consumers}/plugins/{plugins}'
+                  - '/debug/cluster/log-level/{log_level}'
+                  - /debug/node/log-level
+                  - '/debug/node/log-level/{log_level}'
+                  - /debug/profiling/cpu
+                  - /debug/profiling/gc-snapshot
+                  - /debug/profiling/memory
+                  - /degraphql_routes
+                  - '/degraphql_routes/{degraphql_routes}'
+                  - '/degraphql_routes/{degraphql_routes}/service'
+                  - /developers
+                  - /developers/export
+                  - /developers/invite
+                  - /developers/roles
+                  - '/developers/roles/{rbac_roles}'
+                  - '/developers/{developers}'
+                  - '/developers/{developers}/applications'
+                  - '/developers/{developers}/applications/{applications}'
+                  - '/developers/{developers}/applications/{applications}/application_instances'
+                  - '/developers/{developers}/applications/{applications}/application_instances/{application_instances}'
+                  - '/developers/{developers}/applications/{applications}/credentials/{plugin}'
+                  - '/developers/{developers}/applications/{applications}/credentials/{plugin}/{credential_id}'
+                  - '/developers/{developers}/consumer'
+                  - '/developers/{developers}/credentials/{plugin}'
+                  - '/developers/{developers}/credentials/{plugin}/{credential_id}'
+                  - '/developers/{developers}/rbac_user'
+                  - '/developers/{email_or_id}/plugins/'
+                  - '/developers/{email_or_id}/plugins/{id}'
+                  - /document_objects
+                  - '/document_objects/{document_objects}'
+                  - '/document_objects/{document_objects}/service'
+                  - /endpoints
+                  - /entities/migrate
+                  - /event-hooks
+                  - /event-hooks/sources
+                  - '/event-hooks/sources/{source}'
+                  - '/event-hooks/sources/{source}/{event}'
+                  - '/event-hooks/{event_hooks}'
+                  - '/event-hooks/{event_hooks}/ping'
+                  - '/event-hooks/{event_hooks}/test'
+                  - /files
+                  - /files/*
+                  - /files/partials/*
+                  - '/files/{files}'
+                  - /filter-chains
+                  - '/filter-chains/{filter_chains}'
+                  - '/filter-chains/{filter_chains}/route'
+                  - '/filter-chains/{filter_chains}/service'
+                  - /graphql-proxy-cache-advanced
+                  - '/graphql-proxy-cache-advanced/{cache_key}'
+                  - '/graphql-proxy-cache-advanced/{plugin_id}/caches/{cache_key}'
+                  - /graphql-rate-limiting-advanced/costs
+                  - '/graphql-rate-limiting-advanced/costs/{graphql_ratelimiting_advanced_cost_decoration}'
+                  - /graphql_ratelimiting_advanced_cost_decoration
+                  - '/graphql_ratelimiting_advanced_cost_decoration/{graphql_ratelimiting_advanced_cost_decoration}'
+                  - '/graphql_ratelimiting_advanced_cost_decoration/{graphql_ratelimiting_advanced_cost_decoration}/service'
+                  - /groups
+                  - '/groups/{groups}'
+                  - '/groups/{groups}/roles'
+                  - /hmac-auths
+                  - '/hmac-auths/{hmacauth_credentials}'
+                  - '/hmac-auths/{hmacauth_credentials}/consumer'
+                  - /jwt-signer/jwks
+                  - '/jwt-signer/jwks/{jwt_signer_jwks}'
+                  - '/jwt-signer/jwks/{jwt_signer_jwks}/rotate'
+                  - /jwts
+                  - '/jwts/{jwt_secrets}'
+                  - '/jwts/{jwt_secrets}/consumer'
+                  - /key-auths
+                  - '/key-auths/{keyauth_credentials}'
+                  - '/key-auths/{keyauth_credentials}/consumer'
+                  - /key-auths-enc
+                  - '/key-auths-enc/{keyauth_enc_credentials}'
+                  - '/key-auths-enc/{keyauth_enc_credentials}/consumer'
+                  - /key-sets
+                  - '/key-sets/{key_sets}'
+                  - '/key-sets/{key_sets}/keys'
+                  - '/key-sets/{key_sets}/keys/{keys}'
+                  - /keyring
+                  - /keyring/activate
+                  - /keyring/active
+                  - /keyring/export
+                  - /keyring/generate
+                  - /keyring/import
+                  - /keyring/import/raw
+                  - /keyring/recover
+                  - /keyring/remove
+                  - /keyring/vault/sync
+                  - /keys
+                  - '/keys/{keys}'
+                  - '/keys/{keys}/set'
+                  - /konnect_applications
+                  - '/konnect_applications/{konnect_applications}'
+                  - /license/report
+                  - /licenses
+                  - '/licenses/{licenses}'
+                  - /login_attempts
+                  - '/login_attempts/{login_attempts}'
+                  - '/login_attempts/{login_attempts}/consumer'
+                  - /metrics
+                  - /mtls-auths
+                  - '/mtls-auths/{mtls_auth_credentials}/consumer'
+                  - /mtls_auth_credentials
+                  - '/mtls_auth_credentials/{mtls_auth_credentials}'
+                  - '/mtls_auth_credentials/{mtls_auth_credentials}/ca_certificate'
+                  - '/mtls_auth_credentials/{mtls_auth_credentials}/consumer'
+                  - /oauth2
+                  - '/oauth2/{oauth2_credentials}'
+                  - '/oauth2/{oauth2_credentials}/consumer'
+                  - '/oauth2/{oauth2_credentials}/oauth2_tokens'
+                  - '/oauth2/{oauth2_credentials}/oauth2_tokens/{oauth2_tokens}'
+                  - /oauth2_tokens
+                  - '/oauth2_tokens/{oauth2_tokens}'
+                  - '/oauth2_tokens/{oauth2_tokens}/credential'
+                  - '/oauth2_tokens/{oauth2_tokens}/service'
+                  - /openid-connect/issuers
+                  - '/openid-connect/issuers/{oic_issuers}'
+                  - /openid-connect/jwks
+                  - /plugins
+                  - /plugins/enabled
+                  - '/plugins/schema/{name}'
+                  - '/plugins/{plugins}'
+                  - '/plugins/{plugins}/consumer'
+                  - '/plugins/{plugins}/consumer_group'
+                  - '/plugins/{plugins}/route'
+                  - '/plugins/{plugins}/service'
+                  - /proxy-cache
+                  - '/proxy-cache/{cache_key}'
+                  - '/proxy-cache/{plugin_id}/caches/{cache_key}'
+                  - /proxy-cache-advanced
+                  - '/proxy-cache-advanced/{cache_key}'
+                  - '/proxy-cache-advanced/{plugin_id}/caches/{cache_key}'
+                  - /rbac/roles
+                  - '/rbac/roles/{rbac_roles}'
+                  - '/rbac/roles/{rbac_roles}/endpoints'
+                  - '/rbac/roles/{rbac_roles}/endpoints/permissions'
+                  - '/rbac/roles/{rbac_roles}/endpoints/{workspace}/*'
+                  - '/rbac/roles/{rbac_roles}/entities'
+                  - '/rbac/roles/{rbac_roles}/entities/permissions'
+                  - '/rbac/roles/{rbac_roles}/entities/{entity_id}'
+                  - '/rbac/roles/{rbac_roles}/permissions'
+                  - /rbac/users
+                  - '/rbac/users/{rbac_users}'
+                  - '/rbac/users/{rbac_users}/admins'
+                  - '/rbac/users/{rbac_users}/admins/{admins}'
+                  - '/rbac/users/{rbac_users}/developers'
+                  - '/rbac/users/{rbac_users}/developers/{developers}'
+                  - '/rbac/users/{rbac_users}/permissions'
+                  - '/rbac/users/{rbac_users}/roles'
+                  - /routes
+                  - '/routes/{routes}'
+                  - '/routes/{routes}/filter-chains'
+                  - '/routes/{routes}/filter-chains/{filter_chains}'
+                  - '/routes/{routes}/filters/all'
+                  - '/routes/{routes}/filters/disabled'
+                  - '/routes/{routes}/filters/enabled'
+                  - '/routes/{routes}/plugins'
+                  - '/routes/{routes}/plugins/{plugins}'
+                  - '/routes/{routes}/service'
+                  - /schemas/plugins/validate
+                  - '/schemas/plugins/{name}'
+                  - '/schemas/{db_entity_name}/validate'
+                  - '/schemas/{name}'
+                  - /services
+                  - '/services/{services}'
+                  - '/services/{services}/application_instances'
+                  - '/services/{services}/application_instances/{application_instances}'
+                  - '/services/{services}/applications'
+                  - '/services/{services}/client_certificate'
+                  - '/services/{services}/degraphql/routes'
+                  - '/services/{services}/degraphql/routes/{degraphql_routes}'
+                  - '/services/{services}/degraphql_routes'
+                  - '/services/{services}/degraphql_routes/{degraphql_routes}'
+                  - '/services/{services}/document_objects'
+                  - '/services/{services}/document_objects/{document_objects}'
+                  - '/services/{services}/filter-chains'
+                  - '/services/{services}/filter-chains/{filter_chains}'
+                  - '/services/{services}/graphql-rate-limiting-advanced/costs'
+                  - '/services/{services}/graphql_ratelimiting_advanced_cost_decoration'
+                  - '/services/{services}/graphql_ratelimiting_advanced_cost_decoration/{graphql_ratelimiting_advanced_cost_decoration}'
+                  - '/services/{services}/oauth2_tokens'
+                  - '/services/{services}/oauth2_tokens/{oauth2_tokens}'
+                  - '/services/{services}/plugins'
+                  - '/services/{services}/plugins/{plugins}'
+                  - '/services/{services}/routes'
+                  - '/services/{services}/routes/{routes}'
+                  - /sessions
+                  - '/sessions/{sessions}'
+                  - /snis
+                  - '/snis/{snis}'
+                  - '/snis/{snis}/certificate'
+                  - /status
+                  - /tags
+                  - '/tags/{tags}'
+                  - /targets
+                  - '/targets/{targets}'
+                  - '/targets/{targets}/upstream'
+                  - /timers
+                  - /upstreams
+                  - '/upstreams/{upstreams}'
+                  - '/upstreams/{upstreams}/client_certificate'
+                  - '/upstreams/{upstreams}/health'
+                  - '/upstreams/{upstreams}/targets'
+                  - '/upstreams/{upstreams}/targets/all'
+                  - '/upstreams/{upstreams}/targets/{targets}'
+                  - '/upstreams/{upstreams}/targets/{targets}/healthy'
+                  - '/upstreams/{upstreams}/targets/{targets}/unhealthy'
+                  - '/upstreams/{upstreams}/targets/{targets}/{address}/healthy'
+                  - '/upstreams/{upstreams}/targets/{targets}/{address}/unhealthy'
+                  - /userinfo
+                  - /vault-auth
+                  - '/vault-auth/{vault_auth_vaults}'
+                  - '/vault-auth/{vault}/credentials'
+                  - '/vault-auth/{vault}/credentials/token/{access_token}'
+                  - '/vault-auth/{vault}/credentials/{consumer}'
+                  - /vaults
+                  - '/vaults/{vaults}'
+                  - /vitals/
+                  - /vitals/cluster
+                  - /vitals/cluster/status_codes
+                  - '/vitals/consumers/{consumer_id}/cluster'
+                  - /vitals/nodes/
+                  - '/vitals/nodes/{node_id}'
+                  - '/vitals/reports/{entity_type}'
+                  - /vitals/status_code_classes
+                  - /vitals/status_codes/by_consumer
+                  - /vitals/status_codes/by_consumer_and_route
+                  - /vitals/status_codes/by_route
+                  - /vitals/status_codes/by_service
+                  - /workspaces
+                  - '/workspaces/{workspaces}'
+                  - '/workspaces/{workspaces}/meta'
+                  - '/{workspace_name}/kong'
+                  - workspace_/acls
+                  - 'workspace_/acls/{acls}'
+                  - 'workspace_/acls/{acls}/consumer'
+                  - workspace_/acme
+                  - workspace_/acme/certificates
+                  - 'workspace_/acme/certificates/{certificates}'
+                  - workspace_/acme_storage
+                  - 'workspace_/acme_storage/{acme_storage}'
+                  - workspace_/admins
+                  - workspace_/admins/password_resets
+                  - workspace_/admins/register
+                  - workspace_/admins/self/password
+                  - workspace_/admins/self/token
+                  - 'workspace_/admins/{admins}'
+                  - 'workspace_/admins/{admins}/consumer'
+                  - 'workspace_/admins/{admins}/rbac_user'
+                  - 'workspace_/admins/{admin}/roles'
+                  - 'workspace_/admins/{admin}/workspaces'
+                  - workspace_/applications
+                  - 'workspace_/applications/{applications}'
+                  - 'workspace_/applications/{applications}/application_instances'
+                  - 'workspace_/applications/{applications}/application_instances/{application_instances}'
+                  - 'workspace_/applications/{applications}/consumer'
+                  - 'workspace_/applications/{applications}/credentials/{plugin}'
+                  - 'workspace_/applications/{applications}/credentials/{plugin}/{credential_id}'
+                  - 'workspace_/applications/{applications}/developer'
+                  - workspace_/auth
+                  - workspace_/basic-auths
+                  - 'workspace_/basic-auths/{basicauth_credentials}'
+                  - 'workspace_/basic-auths/{basicauth_credentials}/consumer'
+                  - workspace_/ca_certificates
+                  - 'workspace_/ca_certificates/{ca_certificates}'
+                  - 'workspace_/ca_certificates/{ca_certificates}/mtls_auth_credentials'
+                  - 'workspace_/ca_certificates/{ca_certificates}/mtls_auth_credentials/{mtls_auth_credentials}'
+                  - workspace_/cache
+                  - 'workspace_/cache/{key}'
+                  - workspace_/certificates
+                  - 'workspace_/certificates/{certificates}'
+                  - 'workspace_/certificates/{certificates}/services'
+                  - 'workspace_/certificates/{certificates}/services/{services}'
+                  - 'workspace_/certificates/{certificates}/snis'
+                  - 'workspace_/certificates/{certificates}/snis/{snis}'
+                  - 'workspace_/certificates/{certificates}/upstreams'
+                  - 'workspace_/certificates/{certificates}/upstreams/{upstreams}'
+                  - workspace_/clustering/data-planes
+                  - workspace_/clustering/status
+                  - workspace_/config
+                  - workspace_/consumer_groups
+                  - 'workspace_/consumer_groups/{consumer_groups}'
+                  - 'workspace_/consumer_groups/{consumer_groups}/consumers'
+                  - 'workspace_/consumer_groups/{consumer_groups}/consumers/{consumers}'
+                  - 'workspace_/consumer_groups/{consumer_groups}/overrides/plugins/rate-limiting-advanced'
+                  - 'workspace_/consumer_groups/{consumer_groups}/plugins'
+                  - 'workspace_/consumer_groups/{consumer_groups}/plugins/{plugins}'
+                  - workspace_/consumers
+                  - 'workspace_/consumers/{consumers}'
+                  - 'workspace_/consumers/{consumers}/acls'
+                  - 'workspace_/consumers/{consumers}/acls/{acls}'
+                  - 'workspace_/consumers/{consumers}/admins'
+                  - 'workspace_/consumers/{consumers}/admins/{admins}'
+                  - 'workspace_/consumers/{consumers}/applications'
+                  - 'workspace_/consumers/{consumers}/applications/{applications}'
+                  - 'workspace_/consumers/{consumers}/basic-auth'
+                  - 'workspace_/consumers/{consumers}/basic-auth/{basicauth_credentials}'
+                  - 'workspace_/consumers/{consumers}/consumer_groups'
+                  - 'workspace_/consumers/{consumers}/consumer_groups/{consumer_groups}'
+                  - 'workspace_/consumers/{consumers}/developers'
+                  - 'workspace_/consumers/{consumers}/developers/{developers}'
+                  - 'workspace_/consumers/{consumers}/hmac-auth'
+                  - 'workspace_/consumers/{consumers}/hmac-auth/{hmacauth_credentials}'
+                  - 'workspace_/consumers/{consumers}/jwt'
+                  - 'workspace_/consumers/{consumers}/jwt/{jwt_secrets}'
+                  - 'workspace_/consumers/{consumers}/key-auth'
+                  - 'workspace_/consumers/{consumers}/key-auth/{keyauth_credentials}'
+                  - 'workspace_/consumers/{consumers}/key-auth-enc'
+                  - 'workspace_/consumers/{consumers}/key-auth-enc/{keyauth_enc_credentials}'
+                  - 'workspace_/consumers/{consumers}/login_attempts'
+                  - 'workspace_/consumers/{consumers}/login_attempts/{login_attempts}'
+                  - 'workspace_/consumers/{consumers}/mtls-auth'
+                  - 'workspace_/consumers/{consumers}/mtls-auth/{mtls_auth_credentials}'
+                  - 'workspace_/consumers/{consumers}/mtls_auth_credentials'
+                  - 'workspace_/consumers/{consumers}/mtls_auth_credentials/{mtls_auth_credentials}'
+                  - 'workspace_/consumers/{consumers}/oauth2'
+                  - 'workspace_/consumers/{consumers}/oauth2/{oauth2_credentials}'
+                  - 'workspace_/consumers/{consumers}/plugins'
+                  - 'workspace_/consumers/{consumers}/plugins/{plugins}'
+                  - 'workspace_/debug/cluster/log-level/{log_level}'
+                  - workspace_/debug/node/log-level
+                  - 'workspace_/debug/node/log-level/{log_level}'
+                  - workspace_/debug/profiling/cpu
+                  - workspace_/debug/profiling/gc-snapshot
+                  - workspace_/debug/profiling/memory
+                  - workspace_/degraphql_routes
+                  - 'workspace_/degraphql_routes/{degraphql_routes}'
+                  - 'workspace_/degraphql_routes/{degraphql_routes}/service'
+                  - workspace_/developers
+                  - workspace_/developers/export
+                  - workspace_/developers/invite
+                  - workspace_/developers/roles
+                  - 'workspace_/developers/roles/{rbac_roles}'
+                  - 'workspace_/developers/{developers}'
+                  - 'workspace_/developers/{developers}/applications'
+                  - 'workspace_/developers/{developers}/applications/{applications}'
+                  - 'workspace_/developers/{developers}/applications/{applications}/application_instances'
+                  - 'workspace_/developers/{developers}/applications/{applications}/application_instances/{application_instances}'
+                  - 'workspace_/developers/{developers}/applications/{applications}/credentials/{plugin}'
+                  - 'workspace_/developers/{developers}/applications/{applications}/credentials/{plugin}/{credential_id}'
+                  - 'workspace_/developers/{developers}/consumer'
+                  - 'workspace_/developers/{developers}/credentials/{plugin}'
+                  - 'workspace_/developers/{developers}/credentials/{plugin}/{credential_id}'
+                  - 'workspace_/developers/{developers}/rbac_user'
+                  - 'workspace_/developers/{email_or_id}/plugins/'
+                  - 'workspace_/developers/{email_or_id}/plugins/{id}'
+                  - workspace_/document_objects
+                  - 'workspace_/document_objects/{document_objects}'
+                  - 'workspace_/document_objects/{document_objects}/service'
+                  - workspace_/endpoints
+                  - workspace_/entities/migrate
+                  - workspace_/event-hooks
+                  - workspace_/event-hooks/sources
+                  - 'workspace_/event-hooks/sources/{source}'
+                  - 'workspace_/event-hooks/sources/{source}/{event}'
+                  - 'workspace_/event-hooks/{event_hooks}'
+                  - 'workspace_/event-hooks/{event_hooks}/ping'
+                  - 'workspace_/event-hooks/{event_hooks}/test'
+                  - workspace_/files
+                  - workspace_/files/*
+                  - workspace_/files/partials/*
+                  - 'workspace_/files/{files}'
+                  - workspace_/filter-chains
+                  - 'workspace_/filter-chains/{filter_chains}'
+                  - 'workspace_/filter-chains/{filter_chains}/route'
+                  - 'workspace_/filter-chains/{filter_chains}/service'
+                  - workspace_/graphql-proxy-cache-advanced
+                  - 'workspace_/graphql-proxy-cache-advanced/{cache_key}'
+                  - 'workspace_/graphql-proxy-cache-advanced/{plugin_id}/caches/{cache_key}'
+                  - workspace_/graphql-rate-limiting-advanced/costs
+                  - 'workspace_/graphql-rate-limiting-advanced/costs/{graphql_ratelimiting_advanced_cost_decoration}'
+                  - workspace_/graphql_ratelimiting_advanced_cost_decoration
+                  - 'workspace_/graphql_ratelimiting_advanced_cost_decoration/{graphql_ratelimiting_advanced_cost_decoration}'
+                  - 'workspace_/graphql_ratelimiting_advanced_cost_decoration/{graphql_ratelimiting_advanced_cost_decoration}/service'
+                  - workspace_/groups
+                  - 'workspace_/groups/{groups}'
+                  - 'workspace_/groups/{groups}/roles'
+                  - workspace_/hmac-auths
+                  - 'workspace_/hmac-auths/{hmacauth_credentials}'
+                  - 'workspace_/hmac-auths/{hmacauth_credentials}/consumer'
+                  - workspace_/jwt-signer/jwks
+                  - 'workspace_/jwt-signer/jwks/{jwt_signer_jwks}'
+                  - 'workspace_/jwt-signer/jwks/{jwt_signer_jwks}/rotate'
+                  - workspace_/jwts
+                  - 'workspace_/jwts/{jwt_secrets}'
+                  - 'workspace_/jwts/{jwt_secrets}/consumer'
+                  - workspace_/key-auths
+                  - 'workspace_/key-auths/{keyauth_credentials}'
+                  - 'workspace_/key-auths/{keyauth_credentials}/consumer'
+                  - workspace_/key-auths-enc
+                  - 'workspace_/key-auths-enc/{keyauth_enc_credentials}'
+                  - 'workspace_/key-auths-enc/{keyauth_enc_credentials}/consumer'
+                  - workspace_/key-sets
+                  - 'workspace_/key-sets/{key_sets}'
+                  - 'workspace_/key-sets/{key_sets}/keys'
+                  - 'workspace_/key-sets/{key_sets}/keys/{keys}'
+                  - workspace_/keyring
+                  - workspace_/keyring/activate
+                  - workspace_/keyring/active
+                  - workspace_/keyring/export
+                  - workspace_/keyring/generate
+                  - workspace_/keyring/import
+                  - workspace_/keyring/import/raw
+                  - workspace_/keyring/recover
+                  - workspace_/keyring/remove
+                  - workspace_/keyring/vault/sync
+                  - workspace_/keys
+                  - 'workspace_/keys/{keys}'
+                  - 'workspace_/keys/{keys}/set'
+                  - workspace_/konnect_applications
+                  - 'workspace_/konnect_applications/{konnect_applications}'
+                  - workspace_/license/report
+                  - workspace_/licenses
+                  - 'workspace_/licenses/{licenses}'
+                  - workspace_/login_attempts
+                  - 'workspace_/login_attempts/{login_attempts}'
+                  - 'workspace_/login_attempts/{login_attempts}/consumer'
+                  - workspace_/metrics
+                  - workspace_/mtls-auths
+                  - 'workspace_/mtls-auths/{mtls_auth_credentials}/consumer'
+                  - workspace_/mtls_auth_credentials
+                  - 'workspace_/mtls_auth_credentials/{mtls_auth_credentials}'
+                  - 'workspace_/mtls_auth_credentials/{mtls_auth_credentials}/ca_certificate'
+                  - 'workspace_/mtls_auth_credentials/{mtls_auth_credentials}/consumer'
+                  - workspace_/oauth2
+                  - 'workspace_/oauth2/{oauth2_credentials}'
+                  - 'workspace_/oauth2/{oauth2_credentials}/consumer'
+                  - 'workspace_/oauth2/{oauth2_credentials}/oauth2_tokens'
+                  - 'workspace_/oauth2/{oauth2_credentials}/oauth2_tokens/{oauth2_tokens}'
+                  - workspace_/oauth2_tokens
+                  - 'workspace_/oauth2_tokens/{oauth2_tokens}'
+                  - 'workspace_/oauth2_tokens/{oauth2_tokens}/credential'
+                  - 'workspace_/oauth2_tokens/{oauth2_tokens}/service'
+                  - workspace_/openid-connect/issuers
+                  - 'workspace_/openid-connect/issuers/{oic_issuers}'
+                  - workspace_/openid-connect/jwks
+                  - workspace_/plugins
+                  - workspace_/plugins/enabled
+                  - 'workspace_/plugins/schema/{name}'
+                  - 'workspace_/plugins/{plugins}'
+                  - 'workspace_/plugins/{plugins}/consumer'
+                  - 'workspace_/plugins/{plugins}/consumer_group'
+                  - 'workspace_/plugins/{plugins}/route'
+                  - 'workspace_/plugins/{plugins}/service'
+                  - workspace_/proxy-cache
+                  - 'workspace_/proxy-cache/{cache_key}'
+                  - 'workspace_/proxy-cache/{plugin_id}/caches/{cache_key}'
+                  - workspace_/proxy-cache-advanced
+                  - 'workspace_/proxy-cache-advanced/{cache_key}'
+                  - 'workspace_/proxy-cache-advanced/{plugin_id}/caches/{cache_key}'
+                  - workspace_/rbac/roles
+                  - 'workspace_/rbac/roles/{rbac_roles}'
+                  - 'workspace_/rbac/roles/{rbac_roles}/endpoints'
+                  - 'workspace_/rbac/roles/{rbac_roles}/endpoints/permissions'
+                  - 'workspace_/rbac/roles/{rbac_roles}/endpoints/{workspace}/*'
+                  - 'workspace_/rbac/roles/{rbac_roles}/entities'
+                  - 'workspace_/rbac/roles/{rbac_roles}/entities/permissions'
+                  - 'workspace_/rbac/roles/{rbac_roles}/entities/{entity_id}'
+                  - 'workspace_/rbac/roles/{rbac_roles}/permissions'
+                  - workspace_/rbac/users
+                  - 'workspace_/rbac/users/{rbac_users}'
+                  - 'workspace_/rbac/users/{rbac_users}/admins'
+                  - 'workspace_/rbac/users/{rbac_users}/admins/{admins}'
+                  - 'workspace_/rbac/users/{rbac_users}/developers'
+                  - 'workspace_/rbac/users/{rbac_users}/developers/{developers}'
+                  - 'workspace_/rbac/users/{rbac_users}/permissions'
+                  - 'workspace_/rbac/users/{rbac_users}/roles'
+                  - workspace_/routes
+                  - 'workspace_/routes/{routes}'
+                  - 'workspace_/routes/{routes}/filter-chains'
+                  - 'workspace_/routes/{routes}/filter-chains/{filter_chains}'
+                  - 'workspace_/routes/{routes}/filters/all'
+                  - 'workspace_/routes/{routes}/filters/disabled'
+                  - 'workspace_/routes/{routes}/filters/enabled'
+                  - 'workspace_/routes/{routes}/plugins'
+                  - 'workspace_/routes/{routes}/plugins/{plugins}'
+                  - 'workspace_/routes/{routes}/service'
+                  - workspace_/schemas/plugins/validate
+                  - 'workspace_/schemas/plugins/{name}'
+                  - 'workspace_/schemas/{db_entity_name}/validate'
+                  - 'workspace_/schemas/{name}'
+                  - workspace_/services
+                  - 'workspace_/services/{services}'
+                  - 'workspace_/services/{services}/application_instances'
+                  - 'workspace_/services/{services}/application_instances/{application_instances}'
+                  - 'workspace_/services/{services}/applications'
+                  - 'workspace_/services/{services}/client_certificate'
+                  - 'workspace_/services/{services}/degraphql/routes'
+                  - 'workspace_/services/{services}/degraphql/routes/{degraphql_routes}'
+                  - 'workspace_/services/{services}/degraphql_routes'
+                  - 'workspace_/services/{services}/degraphql_routes/{degraphql_routes}'
+                  - 'workspace_/services/{services}/document_objects'
+                  - 'workspace_/services/{services}/document_objects/{document_objects}'
+                  - 'workspace_/services/{services}/filter-chains'
+                  - 'workspace_/services/{services}/filter-chains/{filter_chains}'
+                  - 'workspace_/services/{services}/graphql-rate-limiting-advanced/costs'
+                  - 'workspace_/services/{services}/graphql_ratelimiting_advanced_cost_decoration'
+                  - 'workspace_/services/{services}/graphql_ratelimiting_advanced_cost_decoration/{graphql_ratelimiting_advanced_cost_decoration}'
+                  - 'workspace_/services/{services}/oauth2_tokens'
+                  - 'workspace_/services/{services}/oauth2_tokens/{oauth2_tokens}'
+                  - 'workspace_/services/{services}/plugins'
+                  - 'workspace_/services/{services}/plugins/{plugins}'
+                  - 'workspace_/services/{services}/routes'
+                  - 'workspace_/services/{services}/routes/{routes}'
+                  - workspace_/sessions
+                  - 'workspace_/sessions/{sessions}'
+                  - workspace_/snis
+                  - 'workspace_/snis/{snis}'
+                  - 'workspace_/snis/{snis}/certificate'
+                  - workspace_/status
+                  - workspace_/tags
+                  - 'workspace_/tags/{tags}'
+                  - workspace_/targets
+                  - 'workspace_/targets/{targets}'
+                  - 'workspace_/targets/{targets}/upstream'
+                  - workspace_/timers
+                  - workspace_/upstreams
+                  - 'workspace_/upstreams/{upstreams}'
+                  - 'workspace_/upstreams/{upstreams}/client_certificate'
+                  - 'workspace_/upstreams/{upstreams}/health'
+                  - 'workspace_/upstreams/{upstreams}/targets'
+                  - 'workspace_/upstreams/{upstreams}/targets/all'
+                  - 'workspace_/upstreams/{upstreams}/targets/{targets}'
+                  - 'workspace_/upstreams/{upstreams}/targets/{targets}/healthy'
+                  - 'workspace_/upstreams/{upstreams}/targets/{targets}/unhealthy'
+                  - 'workspace_/upstreams/{upstreams}/targets/{targets}/{address}/healthy'
+                  - 'workspace_/upstreams/{upstreams}/targets/{targets}/{address}/unhealthy'
+                  - workspace_/userinfo
+                  - workspace_/vault-auth
+                  - 'workspace_/vault-auth/{vault_auth_vaults}'
+                  - 'workspace_/vault-auth/{vault}/credentials'
+                  - 'workspace_/vault-auth/{vault}/credentials/token/{access_token}'
+                  - 'workspace_/vault-auth/{vault}/credentials/{consumer}'
+                  - workspace_/vaults
+                  - 'workspace_/vaults/{vaults}'
+                  - workspace_/vitals/
+                  - workspace_/vitals/cluster
+                  - workspace_/vitals/cluster/status_codes
+                  - 'workspace_/vitals/consumers/{consumer_id}/cluster'
+                  - workspace_/vitals/nodes/
+                  - 'workspace_/vitals/nodes/{node_id}'
+                  - 'workspace_/vitals/reports/{entity_type}'
+                  - workspace_/vitals/status_code_classes
+                  - workspace_/vitals/status_codes/by_consumer
+                  - workspace_/vitals/status_codes/by_consumer_and_route
+                  - workspace_/vitals/status_codes/by_route
+                  - workspace_/vitals/status_codes/by_service
+                  - workspace_/workspaces
+                  - 'workspace_/workspaces/{workspaces}'
+                  - 'workspace_/workspaces/{workspaces}/meta'
+    admins-response:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                data:
+                  - created_at: 1556638385
+                    id: 665b4070-541f-48bf-82c1-53030babaa81
+                    updated_at: 1556638385
+                    status: 4
+                    username: test-admin
+                    email: test@test.com
+                    rbac_token_enabled: true
+                  - created_at: 1556563122
+                    id: a93ff120-9e6c-4198-b47e-f779104c7eac
+                    updated_at: 1556563122
+                    status: 0
+                    username: kong_admin
+                    rbac_token_enabled: false
+                next: null
+            properties:
+              data:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    created_at:
+                      type: integer
+                    id:
+                      type: string
+                    updated_at:
+                      type: integer
+                    status:
+                      type: integer
+                      description: The status field indicates the state of the invitation.
+                    username:
+                      type: string
+                    email:
+                      type: string
+                    rbac_token_enabled:
+                      type: boolean
+              next:
+                nullable: true
+    groups-response:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                data:
+                  - created_at: 1717123483
+                    id: 4844ded2-06d1-44f5-974a-03982696f889
+                    updated_at: 1717123483
+                    name: group1
+                    comment: comment1
+                  - created_at: 1717123637
+                    id: 65b3d436-3c5b-4b0e-a2a5-ee188d526ad8
+                    updated_at: 1717123637
+                    name: group2
+                    comment: comment2
+                next: null
+            properties:
+              data:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    created_at:
+                      type: integer
+                    id:
+                      type: string
+                    updated_at:
+                      type: integer
+                    name:
+                      type: string
+                    comment:
+                      type: string
+              next:
+                nullable: true
+    rbac-user-response:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    comment:
+                      type: string
+                    created_at:
+                      type: integer
+                    enabled:
+                      type: boolean
+                    id:
+                      type: string
+                    name:
+                      type: string
+                    user_token:
+                      type: string
+                    user_token_ident:
+                      type: string
+              next:
+                type: string
+            x-examples:
+              Example 1:
+                data:
+                  - comment: null
+                    created_at: 1557512629
+                    enabled: true
+                    id: f035f120-a95e-4327-b2ae-8fa264601d75
+                    name: doc_lord
+                    user_token: $2b$09$TIMneYcTosdG9WbzRsqcweAS2zote8g6I8HqXAtbFHR1pds2ymsh6
+                    user_token_ident: 88ea3
+                  - comment: null
+                    created_at: 1557522650
+                    enabled: true
+                    id: fa6881b2-f49f-4007-9475-577cd21d34f4
+                    name: doc_knight
+                    user_token: $2b$09$Za30VKAAAmyoB9zF2PNEF.9hgKcN2BdKkptPMCubPK/Ps08lzZjYG
+                    user_token_ident: 4d870
+                next: null
+          examples:
+            Returned user:
+              value:
+                data:
+                  - comment: null
+                    created_at: 1557512629
+                    enabled: true
+                    id: f035f120-a95e-4327-b2ae-8fa264601d75
+                    name: doc_lord
+                    user_token: $2b$09$TIMneYcTosdG9WbzRsqcweAS2zote8g6I8HqXAtbFHR1pds2ymsh6
+                    user_token_ident: 88ea3
+                  - comment: null
+                    created_at: 1557522650
+                    enabled: true
+                    id: fa6881b2-f49f-4007-9475-577cd21d34f4
+                    name: doc_knight
+                    user_token: $2b$09$Za30VKAAAmyoB9zF2PNEF.9hgKcN2BdKkptPMCubPK/Ps08lzZjYG
+                    user_token_ident: 4d870
+                next: null
+    audit-objects-response:
+      description: Example response generated for checking the `/status` endpoint without RBAC enabled.
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                data:
+                  - client_ip: 127.0.0.1
+                    method: GET
+                    path: /status
+                    payload: null
+                    rbac_user_id: null
+                    rbac_user_name: null
+                    removed_from_payload: null
+                    request_id: OjOcUBvt6q6XJlX3dd6BSpy1uUkTyctC
+                    request_source: null
+                    request_timestamp: 1676424547
+                    signature: null
+                    status: 200
+                    ttl: 2591997
+                    workspace: 1065b6d6-219f-4002-b3e9-334fc3eff46c
+                total: 1
+            properties:
+              data:
+                type: array
+                description: The client IP address
+                items:
+                  type: object
+                  properties:
+                    client_ip:
+                      type: string
+                      description: The client IP address
+                    method:
+                      type: string
+                      description: The HTTP method
+                    path:
+                      type: string
+                      description: The path of the endpoint
+                    payload:
+                      nullable: true
+                    rbac_user_id:
+                      nullable: true
+                    rbac_user_name:
+                      nullable: true
+                    removed_from_payload:
+                      nullable: true
+                    request_id:
+                      type: string
+                    request_source:
+                      nullable: true
+                    request_timestamp:
+                      type: integer
+                    signature:
+                      nullable: true
+                    status:
+                      type: integer
+                    ttl:
+                      type: integer
+                    workspace:
+                      type: string
+              total:
+                type: integer
+    database-audit-log-response:
+      description: Example response for a consumer creation log entry
+      content:
+        application/json:
+          schema:
+            properties:
+              id:
+                type: string
+    event-hooks-response:
+      description: Example event hooks response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    config:
+                      type: object
+                      properties:
+                        body:
+                          type: string
+                        body_format:
+                          type: boolean
+                        headers:
+                          type: object
+                          properties:
+                            content-type:
+                              type: string
+                        headers_format:
+                          type: boolean
+                        method:
+                          type: string
+                        payload:
+                          type: object
+                          properties:
+                            text:
+                              type: string
+                        payload_format:
+                          type: boolean
+                        secret:
+                          type: string
+                        ssl_verify:
+                          type: boolean
+                        url:
+                          type: string
+                        functions:
+                          type: array
+                          items:
+                            type: string
+                    created_at:
+                      type: integer
+                    event:
+                      type: string
+                    handler:
+                      type: string
+                    id:
+                      type: string
+                    on_change:
+                      type: string
+                    snooze:
+                      type: integer
+                    source:
+                      type: string
+              next:
+                type: string
+            x-examples:
+              Example 1:
+                data:
+                  - config:
+                      body: null
+                      body_format: true
+                      headers:
+                        content-type: application/json
+                      headers_format: false
+                      method: POST
+                      payload:
+                        text: payload_text
+                      payload_format: true
+                      secret: null
+                      ssl_verify: false
+                      url: 'https://hooks.slack.com/services/foo/bar/baz'
+                    created_at: 1627588552
+                    event: admins
+                    handler: webhook-custom
+                    id: 937df175-3db2-4e6d-8aa1-d95c94a76089
+                    on_change: null
+                    snooze: null
+                    source: crud
+                  - config:
+                      headers: {}
+                      secret: null
+                      ssl_verify: false
+                      url: 'https://webhook.site/a1b2c3-d4e5-g6h7-i8j9-k1l2m3n4o5p6'
+                    created_at: 1627581575
+                    event: consumers
+                    handler: webhook
+                    id: c57340ab-9fed-40fd-bb7e-1cef8d37c2df
+                    on_change: null
+                    snooze: null
+                    source: crud
+                  - config:
+                      functions:
+                        - |
+                          return function (data, event, source, pid)
+                            local user = data.entity.username
+                            error("Event hook on consumer " .. user .. "")
+                          end
+                    created_at: 1627595513
+                    event: consumers
+                    handler: lambda
+                    id: c9fdd58d-5416-4d3a-9467-51e5cfe4ca0e
+                    on_change: null
+                    snooze: null
+                    source: crud
+                next: null
+          examples:
+            Example event hooks response:
+              value:
+                data:
+                  - config:
+                      body: "null"
+                      body_format: true
+                      headers:
+                        content-type: string
+                      headers_format: true
+                      method: string
+                      payload:
+                        text: string
+                      payload_format: true
+                      secret: "null"
+                      ssl_verify: true
+                      url: string
+                      functions:
+                        - string
+                    created_at: 0
+                    event: string
+                    handler: string
+                    id: string
+                    on_change: "string"
+                    snooze: 0
+                    source: string
+                next: "null"
+    event-hooks-request:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: object
+                properties:
+                  event:
+                    description: A string describing the Kong entity the event hook listens to for events.
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      description:
+                        type: string
+                  handler:
+                    description: |
+                      A string describing one of four handler options: webhook, webhook-custom, log, or lambda.
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      description:
+                        type: string
+                  source:
+                    type: object
+                    description: A string describing the action that triggers the event hook.
+                    properties:
+                      type:
+                        type: string
+                      description:
+                        type: string
+                  snooze:
+                    type: object
+                    description: An optional integer describing the time in seconds to delay an event trigger to avoid spamming an integration.
+                    properties:
+                      type:
+                        type: string
+                      description:
+                        type: string
+                  on_change:
+                    type: object
+                    description: An optional boolean indicating whether to trigger an event when key parts of a payload have changed.
+                    properties:
+                      type:
+                        type: string
+                      description:
+                        type: string
+                  config.url:
+                    type: object
+                    description: The URL the JSON POST request is made to with the event data as the payload.
+                    properties:
+                      type:
+                        type: string
+                      description:
+                        type: string
+                  config.method:
+                    type: object
+                    description: The HTTP method used to create the custom webhook.
+                    properties:
+                      type:
+                        type: string
+                      description:
+                        type: string
+                  config.payload:
+                    type: object
+                    description: An object that includes key/value pairs that describe the configurable payload body. Supports templating. The full list of available template parameters can be found in the `/sources` API output, under the `fields` JSON object.
+                    properties:
+                      type:
+                        type: string
+                      description:
+                        type: string
+                  config.payload_format:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        description: A optional boolean (defaults to true) indicating whether to format the `config.payload` with resty templating. When set to false, the payload is sent as a raw object.
+                      description:
+                        type: string
+                  config.body:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      description:
+                        type: string
+                  config.body_format:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      description:
+                        type: string
+                  config.headers:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      description:
+                        type: string
+                  config.headers_format:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      description:
+                        type: string
+                  config.secret:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      description:
+                        type: string
+                  config.ssl_verify:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      description:
+                        type: string
+            x-examples:
+              Example 1:
+                data:
+                  event:
+                    type: string
+                    description: A string describing the Kong entity the event hook listens to for events. (optional)
+                  handler:
+                    type: string
+                    description: |
+                     A string describing one of four handler options: webhook, webhook-custom, log, or lambda. (required)
+                  source:
+                    type: string
+                    description: A string describing the action that triggers the event 'https://hooks.slack.com/services/foo/bar/baz'
+                    requried: true
+                  snooze:
+                    type: integer
+                    description: An optional integer describing the time in seconds to delay an event trigger to avoid spamming an integration.
+                  on_change:
+                    type: boolean
+                    description: An optional boolean indicating whether to trigger an event when key parts of a payload have changed.
+                  config.url:
+                    type: string
+                    description: The URL the JSON POST request is made to with the event data as the payloads.
+                    required: true
+                  config.method:
+                    type: string
+                    description: The HTTP method used to create the custom webhook.
+                    required: true
+                  config.payload:
+                    type: object
+                    description: An object that includes key/value pairs that describe the configurable payload body. Supports templating.
+                  config.payload_format:
+                    type: boolean
+                    description: An optional boolean indicating whether to format the config.payload with resty templating. When set to false, the payload is sent as a raw object.
+                    default: true
+                  config.body:
+                    type: string
+                    description: An optional string sent in the remote request.
+                  config.body_format:
+                    type: boolean
+                    description: An optional boolean indicating whether to format `config.body` with resty templating. When set to false, the body is sent as a raw object. 
+                    default: true
+                  config.headers:
+                    type: object
+                    description: An object defining additional HTTP headers to send in the webhook request.
+                  config.headers_format:
+                    type: boolean
+                    description: An optional boolean indicating whether to format `config.headers` with resty templating. When set to true, the `config.headers` value is treated as a template.
+                    default: false
+                  config.secret:
+                    type: string
+                    description: An optional string used to sign the remote webhook for remote verification. When set, Kong signs the body of the event hook with HMAC-SHA1 and includes it in a header, `x-kong-signature`, sent to the remote endpoint. (optional)
+                  config.ssl_verify:
+                    type: boolean
+                    description: A boolean indicating whether to verify the SSL certificate of the remote HTTPS server where the event hook will be sent.
+                    default: false
+    ping-event-hook:
+      description: Example response
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              source:
+                type: string
+              event_hooks:
+                type: object
+                properties:
+                  source:
+                    type: string
+                  id:
+                    type: string
+                  on_change:
+                    type: string
+                  event:
+                    type: string
+                  handler:
+                    type: string
+                  created_at:
+                    type: integer
+                  config:
+                    type: object
+                    properties:
+                      headers:
+                        type: object
+                        properties:
+                          content-type:
+                            type: string
+                      ssl_verify:
+                        type: boolean
+                      url:
+                        type: string
+                      secret:
+                        type: string
+                  snooze:
+                    type: string
+              event:
+                type: string
+            x-examples:
+              Example 1:
+                source: 'kong:event_hooks'
+                event_hooks:
+                  source: crud
+                  id: c57340ab-9fed-40fd-bb7e-1cef8d37c2df
+                  on_change: null
+                  event: consumers
+                  handler: webhook
+                  created_at: 1627581575
+                  config:
+                    headers:
+                      content-type: application/json
+                    ssl_verify: false
+                    url: 'https://webhook.site/a1b2c3-d4e5-g6h7-i8j9-k1l2m3n4o5p6'
+                    secret: null
+                  snooze: null
+                event: ping
+          examples:
+            Pinged event hook:
+              value:
+                source: 'kong:event_hooks'
+                event_hooks:
+                  source: crud
+                  id: c57340ab-9fed-40fd-bb7e-1cef8d37c2df
+                  on_change: "string"
+                  event: consumers
+                  handler: webhook
+                  created_at: 1627581575
+                  config:
+                    headers:
+                      content-type: application/json
+                    ssl_verify: false
+                    url: 'https://webhook.site/a1b2c3-d4e5-g6h7-i8j9-k1l2m3n4o5p6'
+                    secret: "secret"
+                  snooze: "null"
+                event: ping
+  requestBodies:
+    vault-request:
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                prefix: env
+                name: env
+                description: This vault is used to retrieve Redis database access credentials.
+                config:
+                  prefix: SSL_
+                tags:
+                  - database-credentials
+                  - data-plane
+            properties:
+              prefix:
+                type: string
+                description: |
+                  The unique prefix (or identifier) for this vault configuration. Use this prefix to load the right vault configuration and implementation when referencing secrets with the other entities.
+                example: env
+              name:
+                type: string
+                description: |
+                  The name of the vault that's being added. The vault implementation must be installed in every Kong instance.
+                example: env
+              description:
+                type: string
+                description: |
+                  The description of the vault object.
+                example: This vault is used to retrieve Redis database access credentials.
+              config:
+                type: object
+                description: |
+                  The configuration properties for the vault, which can be found on the vaults' documentation page.
+                properties:
+                  prefix:
+                    type: string
+                    example: SSL_
+              tags:
+                type: array
+                description: |
+                  An optional set of strings associated with the vault, used for grouping and filtering.
+                items:
+                  type: string
+          examples:
+            Example 1:
+              value:
+                prefix: env
+                name: env
+                description: This vault is used to retrieve Redis database access credentials.
+                config:
+                  prefix: SSL_
+                tags:
+                  - database-credentials
+                  - data-plane
+      description: The request object for creating a new vault object.
+    target-request:
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                upstream:
+                  id: bdab0e47-4e37-4f0b-8fd0-87d95cc4addc
+                target: 'example.com:8000'
+                weight: 100
+                tags:
+                  - user-level
+                  - low-priority
+            properties:
+              upstream:
+                type: object
+                description: |
+                  The unique identifier or the name of the upstream for which to update the target.
+                properties:
+                  id:
+                    type: string
+                    example: 173a6cee-90d1-40a7-89cf-0329eca780a6
+                    description: The unique identifier or the name of the upstream for which to update the target.
+              weight:
+                default: 100
+                description: The weight this target gets within the upstream load balancer (`0`-`65535`). If the hostname resolves to an SRV record, the `weight` value will be overridden by the value from the DNS record.
+                type: integer
+                minimum: 0
+                maximum: 65535
+              tags:
+                type: array
+                description: An optional set of strings associated with the target for grouping and filtering.
+                items:
+                  type: string
+          examples:
+            Example:
+              value:
+                upstream:
+                  id: 173a6cee-90d1-40a7-89cf-0329eca780a6
+                weight: 100
+                tags:
+                  - string
+      description: The request body for creating a new target entity.
+    upstream-request:
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                id: 58c8ccbb-eafb-4566-991f-2ed4f678fa70
+                created_at: 1422386534
+                name: my-upstream
+                algorithm: round-robin
+                hash_on: none
+                hash_fallback: none
+                hash_on_cookie_path: /
+                slots: 10000
+                healthchecks:
+                  passive:
+                    type: http
+                    healthy:
+                      http_statuses:
+                        - 200
+                        - 201
+                        - 202
+                        - 203
+                        - 204
+                        - 205
+                        - 206
+                        - 207
+                        - 208
+                        - 226
+                        - 300
+                        - 301
+                        - 302
+                        - 303
+                        - 304
+                        - 305
+                        - 306
+                        - 307
+                        - 308
+                      successes: 0
+                    unhealthy:
+                      http_statuses:
+                        - 429
+                        - 500
+                        - 503
+                      timeouts: 0
+                      http_failures: 0
+                      tcp_failures: 0
+                  active:
+                    https_verify_certificate: true
+                    healthy:
+                      http_statuses:
+                        - 200
+                        - 302
+                      successes: 0
+                      interval: 0
+                    unhealthy:
+                      http_failures: 0
+                      http_statuses:
+                        - 429
+                        - 404
+                        - 500
+                        - 501
+                        - 502
+                        - 503
+                        - 504
+                        - 505
+                      timeouts: 0
+                      tcp_failures: 0
+                      interval: 0
+                    type: http
+                    concurrency: 10
+                    headers:
+                      - x-my-header:
+                          - foo
+                          - bar
+                        x-another-header:
+                          - bla
+                    timeout: 1
+                    http_path: /
+                    https_sni: example.com
+                  threshold: 0
+                tags:
+                  - user-level
+                  - low-priority
+                host_header: example.com
+                client_certificate:
+                  id: ea29aaa3-3b2d-488c-b90c-56df8e0dd8c6
+                use_srv_name: false
+            properties:
+              name:
+                type: string
+                description: This is a hostname, which must be equal to the `host` of a service.
+                example: my-upstream
+              algorithm:
+                type: string
+                description: |
+                  Which load balancing algorithm to use.
+                enum:
+                  - consistent-hashing
+                  - least-connections
+                  - round-robin
+                  - latency
+                default: round-robin
+                example: round-robin
+              hash_on:
+                type: string
+                description: What to use as hashing input. Using none results in a weighted-round-robin scheme with no hashing
+                default: none
+                enum:
+                  - none
+                  - consumer
+                  - ip
+                  - cookie
+                  - uri_capture
+                  - path
+                  - query_arg
+              hash_fallback:
+                type: string
+                description: What to use as hashing input if the primary hash_on does not return a hash (eg. header is missing, or no Consumer identified). Not available if hash_on is set to cookie.
+                default: none
+                enum:
+                  - none
+                  - consumer
+                  - ip
+                  - cookie
+                  - uri_capture
+                  - path
+                  - query_arg
+                example: none
+              hash_on_header:
+                type: string
+                description: The header name to take the value from as hash input. Only required when `hash_on` is set to header.
+                example: none
+              hash_fallback_header:
+                type: string
+                description: The header name to take the value from as hash input. Only required when hash_fallback is set to header.
+                default: none
+                example: none
+              hash_on_cookie:
+                type: string
+                description: The cookie name to take the value from as hash input. Only required when `hash_on` or `hash_fallback` is set to `cookie`. If the specified cookie is not in the request, Kong will generate a value and set the cookie in the response.
+                example: none
+              hash_on_cookie_path:
+                type: string
+                description: The cookie path to set in the response headers. Only required when `hash_on` or `hash_fallback` is set to `cookie`.
+                default: /
+                example: /
+              hash_on_query_arg:
+                type: string
+                description: The name of the query string argument to take the value from as hash input. Only required when `hash_on` is set to `query_arg`.
+                example: hash_value
+              hash_fallback_query_arg:
+                type: string
+                description: The name of the query string argument to take the value from as hash input. Only required when `hash_fallback` is set to `query_arg`.
+                example: hash_value
+              hash_on_uri_capture:
+                type: string
+                description: The name of the route URI capture to take the value from as hash input. Only required when `hash_on` is set to `uri_capture`.
+                example: hash_value
+              hash_fallback_uri_capture:
+                type: string
+                description: The name of the route URI capture to take the value from as hash input. Only required when `hash_fallback` is set to `uri_capture`.
+                example: hash_value
+              slots:
+                type: integer
+                description: The number of slots in the load balancer algorithm. If the algorithm is set to `round-robin`, this setting determines the maximum number of slots. If the algorithm is set to `consistent-hashing`, this setting determines the actual number of slots in the algorithm. Accepts an integer in the range 10-65536.
+                minimum: 10
+                maximum: 65536
+                default: 10000
+                example: 5000
+              healthchecks:
+                type: object
+                properties:
+                  passive:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                        description: Whether to perform passive health checks interpreting HTTP/HTTPS statuses, or just check for TCP connection success. In passive checks, http and https options are equivalent. Accepted values are `tcp`, `http`, `https`, `grpc`, `grpcs`.
+                        default: http
+                        enum:
+                          - tcp
+                          - http
+                          - https
+                          - grpc
+                          - grpcs
+                        example: tcp
+                      healthy:
+                        type: object
+                        properties:
+                          http_statuses:
+                            type: array
+                            description: An array of HTTP statuses which represent healthiness when produced by proxied traffic, as observed by passive health checks.  With form-encoded, the notation is `http_statuses[]=200&http_statuses[]=201`. With JSON, use an array.
+                            default:
+                              - 200
+                              - 201
+                              - 202
+                              - 203
+                              - 204
+                              - 205
+                              - 206
+                              - 207
+                              - 208
+                              - 226
+                              - 300
+                              - 301
+                              - 302
+                              - 303
+                              - 304
+                              - 305
+                              - 306
+                              - 307
+                              - 308
+                            example:
+                              - 200
+                              - 201
+                              - 202
+                            items:
+                              type: integer
+                              enum:
+                                - 200
+                                - 201
+                                - 202
+                                - 203
+                                - 204
+                                - 205
+                                - 206
+                                - 207
+                                - 208
+                                - 226
+                                - 300
+                                - 301
+                                - 302
+                                - 303
+                                - 304
+                                - 305
+                                - 306
+                                - 307
+                                - 308
+                          successes:
+                            type: integer
+                            description: Number of successes in proxied traffic (as defined by `healthchecks.passive.healthy.http_statuses`) to consider a target healthy, as observed by passive health checks.
+                            default: 0
+                            example: 2
+                      unhealthy:
+                        type: object
+                        properties:
+                          http_statuses:
+                            type: array
+                            description: An array of HTTP statuses which represent unhealthiness when produced by proxied traffic, as observed by passive health checks. With form-encoded, the notation is `http_statuses[]=429&http_statuses[]=500`. With JSON, use an array.
+                            default:
+                              - 429
+                              - 500
+                              - 503
+                            example:
+                              - 500
+                              - 503
+                            items:
+                              type: integer
+                              enum:
+                                - 429
+                                - 500
+                                - 503
+                          timeouts:
+                            type: integer
+                            description: Number of timeouts in proxied traffic to consider a target unhealthy, as observed by passive health checks.
+                            default: 0
+                            example: 1
+                          http_failures:
+                            type: integer
+                            description: Number of HTTP failures in proxied traffic (as defined by `healthchecks.passive.unhealthy.http_statuses`) to consider a target unhealthy, as observed by passive health checks.
+                            default: 0
+                            example: 3
+                          tcp_failures:
+                            type: integer
+                            description: Number of TCP connection failures to consider a target unhealthy, as observed by passive health checks.
+                            default: 0
+                            example: 1
+                  active:
+                    type: object
+                    properties:
+                      https_verify_certificate:
+                        type: boolean
+                      healthy:
+                        type: object
+                        properties:
+                          http_statuses:
+                            type: array
+                            description: An array of HTTP statuses to consider a success, indicating healthiness, when returned by a probe in active health checks. With form-encoded, the notation is `http_statuses[]=200&http_statuses[]=302`. With JSON, use an array.
+                            default:
+                              - 200
+                              - 302
+                            example:
+                              - 200
+                              - 201
+                            items:
+                              type: integer
+                          successes:
+                            type: integer
+                            description: Number of successes in active probes (as defined by `healthchecks.active.healthy.http_statuses`) to consider a target healthy.
+                            default: 0
+                            example: 3
+                          interval:
+                            type: integer
+                            description: Interval between active health checks for healthy targets (in seconds). A value of zero indicates that active probes for healthy targets should not be performed.
+                            default: 0
+                            example: 30
+                      unhealthy:
+                        type: object
+                        properties:
+                          http_failures:
+                            type: integer
+                            description: Number of HTTP failures in active probes (as defined by `healthchecks.active.unhealthy.http_statuses`) to consider a target unhealthy.
+                            default: 0
+                            example: 2
+                          http_statuses:
+                            type: array
+                            description: An array of HTTP statuses to consider a failure, indicating unhealthiness, when returned by a probe in active health checks. With form-encoded, the notation is `http_statuses[]=429&http_statuses[]=404`. With JSON, use an array.
+                            default:
+                              - 429
+                              - 404
+                              - 500
+                              - 501
+                              - 502
+                              - 503
+                              - 504
+                              - 505
+                            example:
+                              - 400
+                              - 404
+                            items:
+                              type: integer
+                          timeouts:
+                            type: integer
+                            description: Number of timeouts in active probes to consider a target unhealthy.
+                            default: 0
+                            example: 2
+                          tcp_failures:
+                            type: integer
+                            description: Number of TCP failures in active probes to consider a target unhealthy.
+                            default: 0
+                            example: 1
+                          interval:
+                            type: integer
+                            description: Interval between active health checks for unhealthy targets (in seconds). A value of zero indicates that active probes for unhealthy targets should not be performed.
+                            default: 0
+                            example: 10
+                      type:
+                        type: string
+                        description: Whether to perform active health checks using HTTP or HTTPS, or just attempt a TCP connection.
+                        enum:
+                          - tcp
+                          - http
+                          - https
+                          - grpc
+                          - grpcs
+                        default: http
+                        example: https
+                      concurrency:
+                        type: integer
+                        description: Number of targets to check concurrently in active health checks.
+                        default: 10
+                        example: 5
+                      headers:
+                        type: object
+                        description: One or more lists of values indexed by header name to use in GET HTTP request to run as a probe on active health checks. Values must be pre-formatted.
+                        example:
+                          x-my-header:
+                            - foo
+                            - bar
+                          x-another-header:
+                            - bla
+                      timeout:
+                        type: integer
+                        description: Socket timeout for active health checks (in seconds).
+                        default: 1
+                        example: 5
+                      http_path:
+                        type: string
+                        description: Path to use in GET HTTP request to run as a probe on active health checks.
+                        default: /
+                      https_sni:
+                        type: string
+                        description: The hostname to use as an SNI (Server Name Identification) when performing active health checks using HTTPS. This is particularly useful when Targets are configured using IPs, so that the target host's certificate can be verified with the proper SNI.
+                  threshold:
+                    type: integer
+                    description: The minimum percentage of the upstream's targets' weight that must be available for the whole upstream to be considered healthy.
+                    minimum: 0
+                    maximum: 100
+                    default: 0
+              tags:
+                type: array
+                description: An optional set of strings associated with the Upstream for grouping and filtering.
+                example:
+                  - user-level
+                  - low-priority
+                items:
+                  type: string
+              host_header:
+                type: string
+                description: The hostname to be used as Host header when proxying requests through Kong.
+              client_certificate:
+                type: object
+                description: If set, the certificate to be used as client certificate while TLS handshaking to the upstream server.
+                properties:
+                  id:
+                    type: string
+                    example: ea29aaa3-3b2d-488c-b90c-56df8e0dd8c6
+              use_srv_name:
+                type: boolean
+                description: If set, the balancer will use SRV hostname(if DNS Answer has SRV record) as the proxy upstream Host.
+                example: false
+            required:
+              - name
+          examples:
+            Upstream:
+              value:
+                name: my-upstream
+                algorithm: round-robin
+                hash_on: none
+                hash_fallback: none
+                hash_on_cookie_path: /
+                slots: 10000
+                healthchecks:
+                  passive:
+                    type: http
+                    healthy:
+                      http_statuses:
+                        - 200
+                        - 201
+                        - 202
+                        - 203
+                        - 204
+                        - 205
+                        - 206
+                        - 207
+                        - 208
+                        - 226
+                        - 300
+                        - 301
+                        - 302
+                        - 303
+                        - 304
+                        - 305
+                        - 306
+                        - 307
+                        - 308
+                      successes: 0
+                    unhealthy:
+                      http_statuses:
+                        - 429
+                        - 500
+                        - 503
+                      timeouts: 0
+                      http_failures: 0
+                      tcp_failures: 0
+                  active:
+                    https_verify_certificate: true
+                    healthy:
+                      http_statuses:
+                        - 200
+                        - 302
+                      successes: 0
+                      interval: 0
+                    unhealthy:
+                      http_failures: 0
+                      http_statuses:
+                        - 429
+                        - 404
+                        - 500
+                        - 501
+                        - 502
+                        - 503
+                        - 504
+                        - 505
+                      timeouts: 0
+                      tcp_failures: 0
+                      interval: 0
+                    type: http
+                    concurrency: 10
+                    headers:
+                      type: object
+                      properties:
+                        x-my-header:
+                          type: array
+                          items:
+                            type: string
+                          description: The value(s) of the x-my-header header.
+                        x-another-header:
+                          type: array
+                          items:
+                            type: string
+                          description: The value(s) of the x-another-header header.
+                    timeout: 1
+                    http_path: /
+                    https_sni: example.com
+                  threshold: 0
+                tags:
+                  - user-level
+                  - low-priority
+                host_header: example.com
+                client_certificate:
+                  id: ea29aaa3-3b2d-488c-b90c-56df8e0dd8c6
+                use_srv_name: false
+            Example request:
+              value:
+                name: my-upstream
+                tags:
+                  - user-level
+                  - low-priority
+                algorithm: round-robin
+      description: The request object for creating a new upstream.
+    service-request:
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                id: 9748f662-7711-4a90-8186-dc02f10eb0f5
+                created_at: 1422386534
+                updated_at: 1422386534
+                name: my-service
+                retries: 5
+                protocol: http
+                host: example.com
+                port: 80
+                path: /some_api
+                connect_timeout: 60000
+                write_timeout: 60000
+                read_timeout: 60000
+                tags:
+                  - user-level
+                  - low-priority
+                client_certificate:
+                  id: 4e3ad2e4-0bc4-4638-8e34-c84a417ba39b
+                tls_verify: true
+                tls_verify_depth: null
+                ca_certificates:
+                  - 4e3ad2e4-0bc4-4638-8e34-c84a417ba39b
+                  - 51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515
+                enabled: true
+            properties:
+              name:
+                type: string
+                description: |
+                  The service name.
+                example: my-service
+              retries:
+                type: integer
+                description: |
+                  The number of retries to execute upon failure to proxy. Default:`5`.
+                default: 5
+                example: 5
+              protocol:
+                type: string
+                description: |-
+                  The protocol used to communicate with the upstream. Accepted values are: "`grpc`", "`grpcs`", "`http`", "`https`", "`tcp`", "`tls`", "`tls_passthrough`", "`udp`", "`ws`"
+                  , "`wss`"
+                  . Default: "`http`".
+                default: http
+                enum:
+                  - grpc
+                  - grpcs
+                  - http
+                  - https
+                  - tcp
+                  - 'tls '
+                  - tls_passthrough
+                  - udp
+                  - ws
+                  - wss
+                example: http
+              host:
+                type: string
+                description: |
+                  The host of the upstream server. Note that the host value is case sensitive.
+                example: example.com
+              port:
+                type: integer
+                description: |
+                  The upstream server port. Default: `80`.
+                default: 80
+                example: 80
+              path:
+                type: string
+                description: |
+                  The path to be used in requests to the upstream server.
+                example: /some_api
+              connect_timeout:
+                type: integer
+                description: The timeout in milliseconds for establishing a connection to the upstream server. Default `60000`.
+                default: 6000
+                example: 6000
+              write_timeout:
+                type: integer
+                description: |
+                  The timeout in milliseconds between two successive write operations for transmitting a request to the upstream server. Default: `60000`.
+                default: 6000
+                example: 6000
+              read_timeout:
+                type: integer
+                description: |
+                  The timeout in milliseconds between two successive read operations for transmitting a request to the upstream server. Default: `60000`.
+                default: 6000
+                example: 6000
+              tags:
+                type: array
+                description: |
+                  An optional set of strings associated with the service for grouping and filtering.
+                items:
+                  type: string
+                  example: user-level
+              client_certificate:
+                type: object
+                description: Certificate to be used as client certificate while TLS handshaking to the upstream server. With form-encoded, the notation is `client_certificate.id=<client_certificate id>`. With JSON, use `"client_certificate":{"id":"<client_certificate id>"}`.
+                properties:
+                  id:
+                    type: string
+                    example: 4e3ad2e4-0bc4-4638-8e34-c84a417ba39b
+              tls_verify:
+                type: boolean
+                description: |
+                  Whether to enable verification of upstream server TLS certificate. If set to null, then the Nginx default is respected.
+                default: true
+              tls_verify_depth:
+                type: string
+                description: |
+                  Maximum depth of chain while verifying Upstream server's TLS certificate. If set to null, then the Nginx default is respected. Default: null.
+                example: respected
+                default: null
+                nullable: true
+              ca_certificates:
+                type: array
+                description: Array of CA Certificate object UUIDs that are used to build the trust store while verifying upstream servers TLS certificate. If set to null when Nginx default is respected. With form-encoded, the notation is `ca_certificates[]=4e3ad2e4-0bc4-4638-8e34-c84a417ba39b&ca_certificates[]=51e77dc2-8f3e-4afa-9d0e-0e3bbbcfd515`. With JSON, use an array.
+                items:
+                  type: string
+                  example: 4e3ad2e4-0bc4-4638-8e34-c84a417ba39b
+              enabled:
+                type: boolean
+                default: true
+                description: Whether the service is active. If set to `false`, the proxy behavior will be as if any routes attached to it do not exist (404).
+            required:
+              - protocol
+              - host
+              - port
+              - enabled
+          examples:
+            Example:
+              value:
+                name: my-service
+                retries: 5
+                protocol: http
+                host: example.com
+                port: 80
+                path: /some_api
+                connect_timeout: 6000
+                write_timeout: 6000
+                read_timeout: 6000
+                tags:
+                  - user-level
+                client_certificate:
+                  id: 4e3ad2e4-0bc4-4638-8e34-c84a417ba39b
+                tls_verify: true
+                tls_verify_depth: null
+                ca_certificates:
+                  - 4e3ad2e4-0bc4-4638-8e34-c84a417ba39b
+                enabled: true
+      description: The request body for creating a new service entity.
+    route-request:
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                name: my-route
+                protocols:
+                  - http
+                  - https
+                methods:
+                  - GET
+                  - POST
+                hosts:
+                  - example.com
+                  - foo.test
+                paths:
+                  - /foo
+                  - /bar
+                headers:
+                  x-my-header:
+                    - foo
+                    - bar
+                  x-another-header:
+                    - bla
+                https_redirect_status_code: 426
+                regex_priority: 0
+                strip_path: true
+                path_handling: v0
+                preserve_host: false
+                request_buffering: true
+                response_buffering: true
+                snis:
+                  - foo.test
+                  - example.com
+                sources:
+                  - ip: 10.1.0.0/16
+                    port: 1234
+                  - ip: 10.2.2.2
+                  - port: 9123
+                destinations:
+                  - ip: 10.1.0.0/16
+                    port: 1234
+                  - ip: 10.2.2.2
+                  - port: 9123
+                tags:
+                  - user-level
+                  - low-priority
+                service:
+                  id: af8330d3-dbdc-48bd-b1be-55b98608834b
+            properties:
+              name:
+                type: string
+                description: |
+                  The name of the route. Route names must be unique, and they are case sensitive. For example, there can be two different routes named "test" and "Test".
+              protocols:
+                type: array
+                description: An array of the protocols this route should allow
+                items:
+                  type: string
+                  default: https
+                  example: tcp
+              methods:
+                type: array
+                description: |
+                  A list of HTTP methods that match this route.
+                items:
+                  type: string
+                  example: GET
+              hosts:
+                type: array
+                description: A list of domain names that match this route. Note that the hosts value is case sensitive. With form-encoded, the notation is `hosts[]=example.com&hosts[]=foo.test`. With JSON, use an Array.
+                items:
+                  type: string
+              paths:
+                type: array
+                description: A list of paths that match this route. With form-encoded, the notation is `paths[]=/foo&paths[]=/bar`. With JSON, use an array. The path can be a regular expression, or a plain text pattern.
+                items:
+                  type: string
+              headers:
+                type: object
+                description: One or more lists of values indexed by header name that will cause this route to match if present in the request. The Host header cannot be used with this attribute hosts should be specified using the `hosts` attribute. When headers contains only one value and that value starts with the special prefix` ~*`, the value is interpreted as a regular expression.
+                properties:
+                  x-my-header:
+                    type: array
+                    items:
+                      type: string
+                  x-another-header:
+                    type: array
+                    items:
+                      type: string
+              https_redirect_status_code:
+                type: integer
+                description: |-
+                  The status code Kong responds with when all properties of a route match except the protocol i.e. if the protocol of the request is `HTTP` instead of `HTTPS`
+                  Location header is injected by Kong if the field is set to `301`, `302`, `307` or `308`. Note: This config applies only if the route is configured to only accept the https protocol. Accepted values are: `426`, `301`, `302`, `307`, `308`. Default: `426`.
+                default: 426
+                enum:
+                  - 426
+                  - 301
+                  - 302
+                  - 307
+                  - 308
+                example: 426
+              regex_priority:
+                type: integer
+                description: A number used to choose which route resolves a given request when several routes match it using regexes simultaneously. When two routes match the path and have the same regex_priority, the older one (lowest `created_at`) is used. Note that the priority for non-regex routes is different (longer non-regex routes are matched before shorter ones).
+                default: 0
+                example: 0
+              strip_path:
+                type: boolean
+                description: When matching a route via one of the paths, strip the matching prefix from the upstream request URL.
+                default: true
+              path_handling:
+                type: string
+                description: Controls how the service path, route path and requested path are combined when sending a request to the upstream. Accepted values are "`v0`", "`v1`".
+                enum:
+                  - v1
+                  - v0
+                example: v0
+              preserve_host:
+                type: boolean
+                description: When matching a route via one of the `hosts` domain names, use the request `host` header in the upstream request headers. If set to `false`, the upstream Host header will be that of the service's host.
+                default: true
+              request_buffering:
+                type: boolean
+                default: true
+                description: |
+                  Whether to enable request body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that receive data with chunked transfer encoding. Default: true.
+              response_buffering:
+                type: boolean
+                default: true
+                description: |
+                  Whether to enable response body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that send data with chunked transfer encoding. Default: `true`.
+              snis:
+                type: array
+                description: |
+                  A list of SNIs that match this route when using stream routing.
+                items:
+                  type: string
+              sources:
+                type: array
+                description: |
+                  A list of IP sources of incoming connections that match this route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+                items:
+                  type: object
+                  properties:
+                    ip:
+                      type: string
+                      example: 10.1.0.0/16
+                    port:
+                      type: integer
+                      example: 1234
+              destinations:
+                type: array
+                description: |
+                  A list of IP destinations of incoming connections that match this route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
+                items:
+                  type: object
+                  properties:
+                    ip:
+                      type: string
+                      example: 0.1.0.0/16
+                    port:
+                      type: integer
+              tags:
+                type: array
+                description: |
+                  An optional set of strings associated with the route for grouping and filtering.
+                items:
+                  type: string
+              service:
+                type: object
+                description: The service this route is associated to. This is where the route proxies traffic to. With form-encoded, the notation is service.id=<service id> or service.name=<service name>. With JSON, use `"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
+                nullable: true
+                properties:
+                  id:
+                    type: string
+                    example: af8330d3-dbdc-48bd-b1be-55b98608834b
+            required:
+              - protocols
+              - https_redirect_status_code
+              - preserve_host
+              - request_buffering
+              - response_buffering
+          examples:
+            Create a route:
+              value:
+                name: my-route
+                protocols:
+                  - http
+                  - https
+                methods:
+                  - GET
+                  - POST
+                hosts:
+                  - example.com
+                  - foo.test
+                paths:
+                  - /foo
+                  - /bar
+                headers:
+                  x-my-header:
+                    - foo
+                    - bar
+                  x-another-header:
+                    - bla
+                https_redirect_status_code: 426
+                regex_priority: 0
+                strip_path: true
+                path_handling: v0
+                preserve_host: false
+                request_buffering: true
+                response_buffering: true
+                tags:
+                  - user-level
+                  - low-priority
+                service:
+                  id: af8330d3-dbdc-48bd-b1be-55b98608834b
+      description: Route request body
+    keys-request:
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                set:
+                  id: 46CA83EE-671C-11ED-BFAB-2FE47512C77A
+                name: my-key
+                kid: '42'
+                jwk: '{"alg":"RSA",  "kid": "42",  ...}'
+                pem:
+                  private_key: '-----BEGIN'
+                  public_key: '-----BEGIN'
+                tags:
+                  - application-a
+                  - public-key-xyz
+            properties:
+              set:
+                type: object
+                description: The id (an UUID) of the key-set with which to associate the key .With form-encoded, the notation is `set.id=<set id>` or `set.name=<set name>`. With JSON, use `"set":{"id":"<set id>"}` or `"set":{"name":"<set name>"}.`
+                properties:
+                  id:
+                    type: string
+                    description: 46CA83EE-671C-11ED-BFAB-2FE47512C77A
+              name:
+                type: string
+                example: my-key
+                description: |
+                  The name to associate with the given keys.
+              kid:
+                type: string
+                description: |
+                  A unique identifier for a key.
+                example: '42'
+              jwk:
+                type: string
+                description: A JSON Web Key represented as a string.
+                example: '{\"alg\":\"RSA\",  \"kid\": \"42\",  ...}'
+              pem:
+                type: object
+                description: |
+                  A keypair in PEM format.
+                properties:
+                  private_key:
+                    type: string
+                    example: 'private_key": "-----BEGIN'
+                  public_key:
+                    type: string
+                    example: 'public_key": "-----BEGIN'
+              tags:
+                type: array
+                description: |
+                  An optional set of strings associated with the Key for grouping and filtering.
+                items:
+                  type: string
+            required:
+              - kid
+      description: The request body for creating a new key entity.
+    key-set-request:
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                name: my-key_set
+                tags:
+                  - google-keys
+                  - mozilla-keys
+            properties:
+              name:
+                type: string
+                description: |
+                  The name to associate with the given Key Set.
+                example: my-key_set
+              tags:
+                type: array
+                description: |
+                  An optional set of strings associated with the Key for grouping and filtering.
+                items:
+                  type: string
+      description: The request body for creating a new Key Set entity.
+    plugin-request:
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                name: rate-limiting
+                route: null
+                service: null
+                consumer: null
+                instance_name: rate-limiting-foo
+                config:
+                  hour: 500
+                  minute: 20
+                protocols:
+                  - http
+                  - https
+                enabled: true
+                tags:
+                  - user-level
+                  - low-priority
+                ordering:
+                  before:
+                    - plugin-name
+                partials:
+                  - id: ce44eef5-41ed-47f6-baab-f725cecf98c7
+            properties:
+              name:
+                type: string
+                description: The name of the plugin that's being added. The plugin must be installed in every Kong instance separately.
+                example: rate-limiting
+              route:
+                type: string
+                description: If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used. Default `null`.With form-encoded, the notation is `route.id=<route id> or route.name=<route name>`. With JSON, use `"route":{"id":"<route id>"}` or `"route":{"name":"<route name>"}`.
+                nullable: true
+              service:
+                type: string
+                description: If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified service.
+                nullable: true
+              consumer:
+                type: string
+                description: If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.)
+                nullable: true
+              instance_name:
+                type: string
+                description: |
+                  An optional custom name to identify an instance of the plugin, for example `basic-auth_example-service`.
+                  
+                  The instance name shows up in Kong Manager, so it's useful when running the same 
+                  plugin in multiple contexts, for example, on multiple services. You can also use it to access a specific plugin instance
+                  via the Kong Admin API.
+
+                  An instance name must be unique within a workspace for Kong Gateway Enterprise.
+                example: rate-limiting-foo
+              config:
+                type: object
+                description: The configuration properties for the plugin
+                properties:
+                  hour:
+                    type: integer
+                    example: 500
+                  minute:
+                    type: integer
+                    example: 500
+              protocols:
+                type: array
+                description: A list of the request protocols that will trigger this plugin.
+                items:
+                  type: string
+                  enum:
+                    - http
+                    - grpc
+                    - grpcs
+                    - tls
+                    - tcp
+                  default: http
+              enabled:
+                type: boolean
+                description: |
+                  Whether the plugin is applied. Default: `true`.
+                default: true
+              tags:
+                type: array
+                description: |
+                  An optional set of strings associated with the plugin for grouping and filtering.
+                items:
+                  type: string
+              ordering:
+                type: object
+                description: |
+                  Describes a dependency to another plugin to determine plugin ordering during the access phase.
+                  - `before`: The plugin will be executed before a specified plugin or list of plugins.
+                  - `after`: The plugin will be executed after a specified plugin or list of plugins.
+                properties:
+                  before:
+                    type: array
+                    items:
+                      type: string
+              partials:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: string
+                description: If provided, the Plugin will be linked to given Partial
+                nullable: true
+          examples:
+            request example:
+              value:
+                name: rate-limiting
+                route: string
+                service: string
+                consumer: string
+                instance_name: rate-limiting-foo
+                config:
+                  hour: 500
+                  minute: 500
+                protocols:
+                  - http
+                enabled: true
+                tags:
+                  - string
+                ordering:
+                  before:
+                    - string
+      description: Plugin request body
+    consumer-request:
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                id: ec1a1f6f-2aa4-4e58-93ff-b56368f19b27
+                created_at: 1422386534
+                username: my-username
+                custom_id: my-custom-id
+                tags:
+                  - user-level
+                  - low-priority
+            properties:
+              username:
+                type: string
+                description: |
+                  The unique username of the Consumer. You must send either this field or custom_id with the request.
+              custom_id:
+                type: string
+                description: |
+                  Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or username with the request.
+              tags:
+                type: array
+                description: |
+                  An optional set of strings associated with the Consumer for grouping and filtering.
+                items:
+                  type: string
+            required:
+              - username
+              - custom_id
+      description: Consumer request body
+    create-sni:
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                name: my-sni
+                tags:
+                  - user-level
+                  - low-priority
+                certificate:
+                  id: a2e013e8-7623-4494-a347-6d29108ff68b
+            properties:
+              name:
+                type: string
+                description: The SNI name to associate with the given certificate.
+                example: my-sni
+              tags:
+                type: array
+                description: |
+                  An optional set of strings associated with the SNIs for grouping and filtering.
+                items:
+                  type: string
+                  example: '["user-level", "low-priority"]'
+              certificate:
+                type: object
+                description: The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object. With form-encoded, the notation is `certificate.id=<certificate id>`. With JSON, use `"certificate":{"id":"<certificate id>"}`.
+                properties:
+                  id:
+                    type: string
+                    example: 91020192-062d-416f-a275-9addeeaffaf2
+                    description: 91020192-062d-416f-a275-9addeeaffaf2
+            required:
+              - name
+              - certificate
+      description: A JSON object containing the details of the new SNI, including the name, certificate, and tags.
+    cert-request:
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example:
+                id: 7fca84d6-7d37-4a74-a7b0-93e576089a41
+                created_at: 1422386534
+                cert: '-----BEGIN CERTIFICATE-----...'
+                key: '-----BEGIN RSA PRIVATE KEY-----...'
+                cert_alt: '-----BEGIN CERTIFICATE-----...'
+                key_alt: '-----BEGIN EC PRIVATE KEY-----...'
+                snis:
+                  - foo.test
+                  - example.com
+                tags:
+                  - user-level
+                  - low-priority
+            properties:
+              cert:
+                type: string
+                description: PEM-encoded public certificate chain of the SSL key pair.
+                example: '-----BEGIN CERTIFICATE-----...'
+              key:
+                type: string
+                example: '-----BEGIN RSA PRIVATE KEY-----...'
+                description: PEM-encoded private key of the SSL key pair.
+              cert_alt:
+                type: string
+                description: PEM-encoded public certificate chain of the alternate SSL key pair.
+              key_alt:
+                type: string
+                description: PEM-encoded private key of the alternate SSL key pair.
+                example: '"-----BEGIN EC PRIVATE KEY-----..."'
+              snis:
+                type: array
+                description: An array of zero or more hostnames to associate with this certificate as SNIs.
+                items:
+                  type: string
+              tags:
+                type: array
+                description: |
+                  An optional set of strings associated with the Certificate for grouping and filtering.
+                items:
+                  type: string
+              passphrase:
+                type: string
+                description: To load an encrypted private key into Kong, specify the passphrase using this attributKong will decrypt the private key and store it in its database. e. Enterprise Only
+                example: example
+            required:
+              - cert
+              - key
+      description: The certificate request body
+    CA-cert-request:
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                cert: '-----BEGIN CERTIFICATE-----...'
+                cert_digest: c641e28d77e93544f2fa87b2cf3f3d51...
+                tags:
+                  - user-level
+                  - low-priority
+            properties:
+              cert:
+                type: string
+                description: |
+                  PEM-encoded public certificate of the CA.
+                example: '"-----BEGIN CERTIFICATE-----..."'
+              cert_digest:
+                type: string
+                example: c641e28d77e93544f2fa87b2cf3f3d51...
+                description: |
+                  SHA256 hex digest of the public certificate.
+              tags:
+                type: array
+                description: An optional set of strings associated with the Certificate for grouping and filtering.
+                items:
+                  type: string
+            required:
+              - cert
+      description: This request body represents a new Certificate Authority (CA) certificate and includes the properties required to create a new certificate.
+    consumer_group_request:
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                created_at: 1557522650
+                id: fa6881b2-f49f-4007-9475-577cd21d34f4
+                name: JL
+                tags:
+                  - tag1
+                  - tag2
+            properties:
+              name:
+                type: string
+                description: A unique name for the consumer group you want to create.
+                example: my_group
+              tags:
+                type: array
+                description: An optional set of strings associated with the consumer group for grouping and filtering.
+                items:
+                  type: string
+            required:
+              - name
+          examples:
+            example consumer group request body:
+              value:
+                name: my_group
+                tags:
+                  - string
+      description: The consumer groups request body for creating new consumer groups.
+    license-request:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              payload:
+                type: string
+                description: |
+                  The Kong Gateway license in JSON format.
+                example: '{\"license\":{\"payload\":{\"admin_seats\":\"1\",\"customer\":\"Example Company, Inc\",\"dataplanes\":\"1\",\"license_creation_date\":\"2017-07-20\",\"license_expiration_date\":\"2017-07-20\",\"license_key\":\"00141000017ODj3AAG_a1V41000004wT0OEAU\",\"product_subscription\":\"Konnect Enterprise\",\"support_plan\":\"None\"},\"signature\":\"6985968131533a967fcc721244a979948b1066967f1e9cd65dbd8eeabe060fc32d894a2945f5e4a03c1cd2198c74e058ac63d28b045c2f1fcec95877bd790e1b\",\"version\":\"1\"}}'
+      description: The request body for uploading a license.
+    workspace-request:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+                description: |
+                  The workspace name.
+                example: my-workspace
+      description: |
+        The workspace object describes the workspace entity, which has an ID and a name.
+    rbac-request:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+              
+                description: |
+                  The RBAC user name.
+              user_token:
+                type: string
+               
+                description: The authentication token to be presented to the Admin API. The value will be hashed and cannot be fetched in plaintext.
+              enabled:
+                type: string
+               
+                description: |
+                  A flag to enable or disable the user. By default, users are enabled.
+              comment:
+                type: string
+               
+                description: |
+                  A string describing the RBAC user object.
+    filter-chains-request:
+      content:
+        application/json:
+          schema:
+            type: object
+            x-examples:
+              Example 1:
+                id: ce44eef5-41ed-47f6-baab-f725cecf98c7
+                name: my-chain
+                created_at: 1422386534
+                updated_at: 1422386534
+                enabled: true
+                route: null
+                service: 20487393-41ed-47f6-93a8-3407cade2002
+                filters:
+                  - name: go-rate-limiting
+                    enabled: true
+                    config: '{ "minute": 30 }'
+                  - name: rust-response-transformer
+                    enabled: true
+                    config: '{ "remove_header": "X-Example" }'
+                tags:
+                  - my-tag
+            properties:
+              ' name':
+                type: string
+                
+                description: |
+                  The name of the filter chain.
+                example: my-chain
+              enabled:
+                type: string
+                
+                description: |
+                  Whether the filter chain is applied. Default: true.
+              route:
+                type: string
+                
+                description: |
+                  The route to which this chain is applied. 
+                  A filter chain must be applied to either a single route or a single service. 
+                  Default: `null`. 
+                  
+                  In form-encoded format, the notation is `route.id=<route id>` or `route.name=<route name>`. 
+                  In JSON format, use `"route":{"id":"<route id>"}` or `"route":{"name":"<route name>"}`.
+              service:
+                type: string
+               
+                description: |
+                  The service to which this chain is applied. 
+                  A filter chain must be applied to either a single route or a single service. Default: `null`. 
+                  
+                  In form-encoded format, the notation is `service.id=<service id>` or `service.name=<service name>`. 
+                  In JSON format, use `"service":{"id":"<service id>"}` or `"service":{"name":"<service name>"}`.
+                example: 20487393-41ed-47f6-93a8-3407cade2002
+              filters:
+                type: string
+                
+                description: An array of filter definitions. Each filter is an object containing a mandatory name, an optional config, and a boolean enabled setting.
+              tags:
+                type: string
+                
+                description: |
+                  An optional set of strings associated with the filter chain for grouping and filtering.
+          examples:
+            Example 1:
+              value:
+                ' name': my-chain
+                enabled: string
+                route: string
+                service: 20487393-41ed-47f6-93a8-3407cade2002
+                filters: string
+                tags: string
+      description: A filter chain is the database entity representing one or more WebAssembly filters executed for each request to a particular service or route, each one with its configuration.
+    add-webhook:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              event:
+                type: string
+               
+                description: |
+                  A string describing the Kong entity the event hook listens to for events.
+                example: consumers
+              handler:
+                type: string
+               
+                description: |
+                  A string describing one of four handler options: webhook, webhook-custom, log, or lambda.
+                example: webhook
+              source:
+                type: string
+                
+                description: |
+                  A string describing the action that triggers the event hook.
+                example: crud
+              snooze:
+                type: integer
+                
+                description: |
+                  An optional integer describing the time in seconds to delay an event trigger to avoid spamming an integration.
+                example: 0
+                default: 0
+              on_change:
+                type: boolean
+                
+                description: |
+                  An optional boolean indicating whether to trigger an event when key parts of a payload have changed.
+              config.url:
+                type: string
+                
+                description: |
+                  The URL the JSON POST request is made to with the event data as the payload.
+                example: 'https://webhook.site/a1b2c3-d4e5-g6h7-i8j9-k1l2m3n4o5p6'
+              config.headers:
+                type: object
+              
+                description: |
+                  An object defining additional HTTP headers to send in the webhook request. For example `{"X-Custom-Header": "My Value"}`.
+                properties:
+                  headers:
+                    type: string
+                   
+                    description: |
+                      Optional configuration header
+              config.secret:
+                type: string
+               
+                description: |
+                  An optional string used to sign the remote webhook for remote verification. When set, Kong signs the body of the event hook with HMAC-SHA1 and includes it in a header, `x-kong-signature`, sent to the remote endpoint.
+              config.ssl_verify:
+                type: string
+               
+                description: |
+                  A boolean indicating whether to verify the SSL certificate of the remote HTTPS server where the event hook will be sent. The default is false.
+            required:
+              - handler
+              - source
+              - config.url
+          examples:
+            Example 2:
+              value:
+                event: consumers
+                handler: webhook
+                source: crud
+                snooze: 0
+                on_change: true
+                config.url: 'https://webhook.site/a1b2c3-d4e5-g6h7-i8j9-k1l2m3n4o5p6'
+                config.headers:
+                  headers: string
+                config.secret: string
+                config.ssl_verify: string
+      description: Request body for adding a webhook
+    add-custom-webhook:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              event:
+                type: string
+               
+                description: |
+                  A string describing the Kong entity the event hook listens to for events.
+                example: admins
+              handler:
+                type: string
+               
+                description: |
+                  A string describing one of four handler options: webhook, webhook-custom, log, or lambda.
+                example: webhook-custom
+              source:
+                type: string
+              
+                description: |
+                  A string describing one of four handler options: webhook, webhook-custom, log, or lambda.
+                example: crud
+              snooze:
+                type: integer
+                
+                description: |
+                  An optional integer describing the time in seconds to delay an event trigger to avoid spamming an integration.
+                default: 1
+              on_change:
+                type: boolean
+                
+                description: |
+                  An optional boolean indicating whether to trigger an event when key parts of a payload have changed.
+                default: true
+              config.url:
+                type: string
+                
+                description: |
+                  The URL the JSON POST request is made to with the event data as the payload.
+                example: 'https://hooks.slack.com/services/foo/bar/baz'
+              config.method:
+                type: string
+                
+                description: |
+                  The HTTP method used to create the custom webhook.
+                example: GET
+              config.payload:
+                type: object
+                
+                description: |
+                  An object that includes key/value pairs that describe the configurable payload body. Supports templating. The full list of available template parameters can be found in the /sources API output, under the fields JSON object.
+                properties:
+                  text:
+                    type: string
+                   
+                    description: Configuration payload
+              config.payload_format:
+                type: boolean
+                
+                description: |
+                  A optional boolean (defaults to true) indicating whether to format `config.payload` with resty templating. When set to false, the payload is sent as a raw object.
+              config.body:
+                type: string
+                
+                description: |
+                  An optional string sent in the remote request.
+              config.body_format:
+                type: boolean
+                
+                description: |
+                  An optional boolean (defaults to true) indicating whether to format `config.body` with resty templating. When set to false, the body is sent as a raw object. To see all the available parameters defined for a specific source, check the source fields displayed by the `/event-hooks/source` endpoint.
+              config.headers:
+                type: object
+               
+                description: |
+                  An object defining additional HTTP headers to send in the webhook request. For example `{"Content-type": "application/json", "X-Custom-Header": "My Value"}`.
+              config.headers_format:
+                type: string
+                
+                description: |
+                  An optional boolean (defaults to false) indicating whether to format `config.headers` with resty templating. When set to true, the `config.headers` value is treated as a template. To see all the available parameters defined for a specific source, check the source fields displayed by the `/event-hooks/sources` endpoint.
+              config.secret:
+                type: string
+                
+                description: |
+                  An optional string used to sign the remote webhook for remote verification. When set, Kong signs the body of the event hook with HMAC-SHA1 and includes it in a header, `x-kong-signature`, to the remote endpoint.
+              config.ssl_verify:
+                type: boolean
+                
+            required:
+              - handler
+              - source
+              - config.url
+              - config.method
+      description: Request body for adding a custom webhook
+    add-log:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              event:
+                type: string
+                
+                description: |
+                  A string describing the Kong entity the event hook listens to for events.
+                example: routes
+              handler:
+                type: string
+                
+                description: |
+                  A string describing one of four handler options: webhook, webhook-custom, log, or lambda.
+                example: log
+              source:
+                type: string
+               
+                description: |
+                  A string describing the action that triggers the event hook.
+                example: crud
+              snooze:
+                type: integer
+               
+                description: |
+                  An optional integer describing the time in seconds to delay an event trigger to avoid spamming an integration.
+              on_change:
+                type: boolean
+               
+                description: |
+                  An optional boolean indicating whether to trigger an event when key parts of a payload have changed.
+            required:
+              - handler
+              - source
+          examples:
+            Example log request:
+              value:
+                event: routes
+                handler: log
+                source: crud
+                snooze: 0
+                on_change: true
+      description: Add a log event hook request body
+    lambda-event-hook:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              event:
+                type: string
+                
+                description: |
+                  A string describing the Kong entity the event hook listens to for events.
+                example: consumers
+              handler:
+                type: string
+                
+                description: |
+                  A string describing one of four handler options: webhook, webhook-custom, log, or lambda.
+                example: lambda
+              source:
+                type: string
+                
+                description: |
+                  A string describing the action that triggers the event hook.
+                example: crud
+              snooze:
+                type: boolean
+                
+                description: |
+                  An optional integer describing the time in seconds to delay an event trigger to avoid spamming an integration.
+              on_change:
+                type: boolean
+                
+                description: |
+                  An optional boolean indicating whether to trigger an event when key parts of a payload have changed.
+              config.functions:
+                type: array
+               
+                description: |
+                  An array of Lua code functions to execute on the event hook.
+                items:
+                 
+                  type: string
+                  example: '"functions": [             "return function (data, event, source, pid)\n  local user = data.entity.username\n  error(\"Event hook on consumer \" .. user .. \"\")\nend\n"         ]'
+            required:
+              - handler
+              - source
+              - config.functions
+          examples:
+            lambda-event-hook:
+              value:
+                event: consumers
+                handler: lambda
+                source: crud
+                snooze: true
+                on_change: true
+                config.functions:
+                  - '"functions": [             "return function (data, event, source, pid)\n  local user = data.entity.username\n  error(\"Event hook on consumer \" .. user .. \"\")\nend\n"         ]'
+      description: Request body for adding a lambda event hook
+  securitySchemes:
+    kongAdminToken:
+      type: apiKey
+      in: header
+      name: Kong-Admin-Token
+      description: |
+        When RBAC is enabled, an admin token is required to use the Kong Admin API. 
+        This token is passed in a `Kong-Admin-Token` header by default. 
+        To configure the header name, adjust `rbac_auth_header` in `kong.conf`.
+        <br><br>
+        Each admin has their own token.
+        The admin associated with the token must have relevant permissions for the object they're interacting with.
+        Generate tokens using the `/admins` API.
+        <br><br>
+        If RBAC isn't enabled, this token isn't required.
+
+externalDocs:
+  description: Kong Gateway Enterprise Admin API
+  url: 'https://docs.konghq.com'
+info:
+  contact:
+    email: docs@konghq.com
+    name: Kong Inc
+    url: 'https://konghq.com'
+  description: |-
+    OpenAPI 3.0 spec for Kong Gateway's Enterprise Admin API.
+
+    You can learn more about Kong Gateway at [docs.konghq.com](https://docs.konghq.com)
+    .Give Kong a star at [Kong/kong](https://github.com/kong/kong) repository.
+  license:
+    name: Apache 2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+  title: Enterprise Kong Admin API
+  version: 3.10.0.0
+openapi: 3.0.0
+paths:
+  /:
+    get:
+      summary: Get Kong's instance information
+      tags:
+        - Information
+      operationId: geInfo
+      description: |
+        Returns detailed information about the Kong gateway instance, including the full Kong configuration, available and unavailable plugins, version, edition (enterprise or community), a tagline, the unique node identifier, and other metadata.
+      responses:
+        '200':
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  version:
+                    type: string
+                    description: The version number of the Kong instance.
+                    example: "2.3.3"
+                  edition:
+                    type: string
+                    description: Indicates whether the Kong instance is the Community or Enterprise edition.
+                    example: "enterprise"
+                  tagline:
+                    type: string
+                    description: A tagline or slogan for the Kong instance.
+                    example: "Welcome to Kong"
+                  node_id:
+                    type: string
+                    description: A unique identifier for the node, in UUID format.
+                    format: uuid
+                    example: "a74d7c4f-ef83-4bbe-a5e7-3f5409f4a0b9"
+                  hostname:
+                    type: string
+                    description: The hostname of the Kong node.
+                    example: "kong-node.example.com"
+                  timers:
+                    type: object
+                    description: Information about running and pending timers.
+                    properties:
+                      running:
+                        type: integer
+                        description: The number of running timers.
+                        example: 5
+                      pending:
+                        type: integer
+                        description: The number of pending timers.
+                        example: 2
+                  plugins:
+                    type: object
+                    description: Information about plugins.
+                    properties:
+                      available_on_server:
+                        type: object
+                        additionalProperties:
+                          type: object
+                          properties:
+                            version:
+                              type: string
+                              description: The version of the plugin.
+                            priority:
+                              type: integer
+                              description: The priority of the plugin.
+                      enabled_in_cluster:
+                        type: array
+                        items:
+                          type: string
+                        description: A list of distinct plugin names enabled in the cluster.
+                        example: ["jwt", "acl"]
+                  lua_version:
+                    type: string
+                    description: The version of Lua used by the Kong instance.
+                    example: "LuaJIT 2.1.0-beta3"
+                  configuration:
+                    type: object
+                    description: A sanitized version of the Kong configuration, excluding sensitive values.
+                    additionalProperties: true
+                  pids:
+                    type: object
+                    description: Process IDs for the master process and worker processes.
+                    properties:
+                      master:
+                        type: integer
+                        description: The PID of the master process.
+                        example: 4321
+                      workers:
+                        type: array
+                        items:
+                          type: integer
+                        description: An array of worker process PIDs.
+                        example: [1234, 5678]
+              examples:
+                fullExample:
+                  summary: Example response
+                  value: 
+                    configuration:
+                      _debug_pg_ttl_cleanup_interval: 300
+                      admin_acc_logs: "/usr/local/kong/logs/admin_access.log"
+                      admin_access_log: "/dev/stdout"
+                      admin_approved_email: "true"
+                      admin_emails_from: "\"\""
+                      admin_error_log: "/dev/stderr"
+                      admin_gui_access_log: "logs/admin_gui_access.log"
+                      admin_gui_auth_header: "******"
+                      admin_gui_auth_login_attempts: 0
+                      admin_gui_error_log: "logs/admin_gui_error.log"
+                      admin_gui_flags: "{}"
+                      admin_gui_listen:
+                        - "0.0.0.0:8002"
+                        - "0.0.0.0:8445 ssl"
+                      admin_gui_origin: "http://localhost:8002"
+                    edition: "enterprise"
+                    hostname: "8a487998603b"
+                    lua_version: "LuaJIT 2.1.0-20231117"
+                    node_id: "1f257156-5e44-46e2-a618-767f5c7529e3"
+                    pids:
+                      master: 1
+                      workers:
+                        - 2382
+                        - 2383
+                    plugins:
+                      available_on_server:
+                        acl: true
+                        acme: true
+                      disabled_on_server:
+                        application-registration: true
+                      enabled_in_cluster: []
+                    tagline: "Welcome to kong"
+                    timers:
+                      pending: 1
+                      running: 1128
+                    version: "3.6.0.0"
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '405':
+          description: Method Not Allowed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UnauthorizedError'
+          headers:
+            Server:
+              description: Kong's server tokens.
+              schema:
+                type: string
+                example: "kong/2.3.3"
+  /ca_certificates:
+    get:
+      description: Retrieve a list of all available Certificate Authority (CA) certificates, including the certificate ID, creation date, and other details. You can use query parameters to filter the results by size or tags, for example `/ca-certificates?size=50&tags=enterprise`.
+      operationId: list-ca_certificate
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CA-Certificate'
+          description: A successful response listing CA Certificates
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all CA Certificates
+      tags:
+        - CA Certificates
+    post:
+      description: Create a new Certificate Authority (CA) certificate. The request body must include the `cert` property, the certificate data in PEM format; it can also include `cert_digest`, a digest of the certificate in hex format for verifying the certificates integrity, and `tags`, an optional list of tags to categorize the certificate.
+      operationId: create-ca_certificate
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CA-Certificate'
+          description: Successfully created CA Certificate
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  Example 1:
+                    fields:
+                      cert: 'invalid certificate: x509.new: asn1/a_d2i_fp.c:197:error:0D06B08E:asn1 encoding routines:asn1_d2i_read_bio:not enough data'
+                    message: 'schema violation (cert: invalid certificate: x509.new: asn1/a_d2i_fp.c:197:error:0D06B08E:asn1 encoding routines:asn1_d2i_read_bio:not enough data)'
+                    name: schema violation
+                    code: 2
+                properties:
+                  fields:
+                    type: object
+                    properties:
+                      cert:
+                        type: string
+                        description: Error information about the certificate.
+                        example: 'invalid certificate: x509.new:'
+                  message:
+                    type: string
+                    description: More information about the error
+                    example: 'schema violation (cert: invalid certificate: x509.new:'
+                  name:
+                    type: string
+                    description: The name of the error.
+                    example: schema violation
+                  code:
+                    type: integer
+                    description: An error code.
+                    example: 2
+              examples:
+                invalid certificate:
+                  value:
+                    fields:
+                      cert: 'invalid certificate: x509.new:'
+                    message: 'schema violation (cert: invalid certificate: x509.new:'
+                    name: schema violation
+                    code: 2
+          description: 400 Bad Request
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new CA Certificate
+      tags:
+        - CA Certificates
+      requestBody:
+        $ref: '#/components/requestBodies/CA-cert-request'
+  '/ca_certificates/{ca_certificate_id}':
+    delete:
+      description: Delete the specified Certificate Authority (CA) certificate using the provided ca_certificate_id.
+      operationId: delete-ca_certificate
+      responses:
+        '204':
+          description: Successfully deleted CA Certificate or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a CA Certificate
+      tags:
+        - CA Certificates
+    get:
+      description: Retrieve details about the specified Certificate Authority (CA) certificate using the provided path parameter `ca_certificate_id`.
+      operationId: get-ca_certificate
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CA-Certificate'
+          description: Successfully fetched CA Certificate
+        '404':
+          description: Resource does not exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Fetch a CA Certificate
+      tags:
+        - CA Certificates
+    patch:
+      description: Update a CA Certificate
+      operationId: update-ca_certificate
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CA-Certificate'
+          description: Successfully updated CA Certificate
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid CA Certificate
+        '404':
+          description: Resource does not exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Update a CA Certificate
+      tags:
+        - CA Certificates
+      requestBody:
+        $ref: '#/components/requestBodies/CA-cert-request'
+    put:
+      description: Update the specified Certificate Authority (CA) certificate using the provided `ca_certificate_id`. Use this endpoint to modify an existing CA certificate in the system. The request body should include the fields of the CA certificate that need to be updated.
+      operationId: upsert-ca_certificate
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CA-Certificate'
+          description: Successfully upserted CA Certificate
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid CA Certificate
+        '404':
+          description: Not Found
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a CA Certificate
+      tags:
+        - CA Certificates
+      requestBody:
+        $ref: '#/components/requestBodies/CA-cert-request'
+    parameters:
+      - $ref: '#/components/parameters/ca_certificate_id'
+  /certificates:
+    get:
+      description: Retrieve a list of all available CA Certificate Authority (CA) certificates. You can use query parameters to filter the results by size or tags, for example `/certificates?size=50&tags=enterprise`.
+      operationId: list-certificate
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Certificate'
+              examples:
+                Certificate:
+                  value:
+                    cert: |-
+                      -----BEGIN CERTIFICATE-----
+                      certificate-content
+                      -----END CERTIFICATE-----
+                    id: b2f34145-0343-41a4-9602-4c69dec2f269
+                    key: |-
+                      -----BEGIN PRIVATE KEY-----
+                      private-key-content
+                      -----END PRIVATE KEY-----
+          description: A successful response listing Certificates
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all Certificates
+      tags:
+        - Certificates
+    post:
+      description: Create a new certificate with the provided details. Use this endpoint to add a new certificate to the system. The request body must include the certificate data and other details required for creating a new certificate.
+      operationId: create-certificate
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Certificate'
+        description: Description of the new Certificate for creation
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Certificate'
+          description: Successfully created Certificate
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  Example 1:
+                    fields:
+                      key: 'invalid key: pkey.new:load_key: pem/pem_lib.c:949:error:09091064:PEM routines:PEM_read_bio_ex:bad base64 decode'
+                      cert: 'invalid certificate: x509.new: asn1/tasn_dec.c:309:error:0D07803A:asn1 encoding routines:asn1_item_embed_d2i:nested asn1 error'
+                    message: '2 schema violations (cert: invalid certificate: x509.new: asn1/tasn_dec.c:309:error:0D07803A:asn1 encoding routines:asn1_item_embed_d2i:nested asn1 error; key: invalid key: pkey.new:load_key: pem/pem_lib.c:949:error:09091064:PEM routines:PEM_read_bio_ex:bad base64 decode)'
+                    name: schema violation
+                    code: 2
+                properties:
+                  fields:
+                    type: object
+                    properties:
+                      key:
+                        type: string
+                        description: Information about the key.
+                        example: 'invalid key: pkey.new:load_key: '
+                      cert:
+                        type: string
+                        description: Information about the certificate.
+                        example: 'invalid certificate: x509.new: '
+                  message:
+                    type: string
+                    description: error message
+                    example: '2 schema violations (cert: invalid certificate: x509.new: asn1/tasn_dec.c:309:error:0D07803A:asn1'
+                  name:
+                    type: string
+                    description: The name of the error message.
+                    example: schema violation
+                  code:
+                    type: integer
+                    description: An error code.
+                    example: 2
+              examples:
+                Example 1:
+                  value:
+                    fields:
+                      key: string
+                      cert: string
+                    message: string
+                    name: string
+                    code: 0
+          description: Invalid Certificate
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new Certificate
+      tags:
+        - Certificates
+  '/certificates/{certificate_id}':
+    delete:
+      description: Delete a Certificate
+      operationId: delete-certificate
+      responses:
+        '204':
+          description: Successfully deleted Certificate or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a Certificate
+      tags:
+        - Certificates
+    get:
+      description: Get a Certificate using ID.
+      operationId: get-certificate
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Certificate'
+          description: Successfully fetched Certificate
+        '404':
+          description: Resource does not exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Fetch a Certificate
+      tags:
+        - Certificates
+    patch:
+      description: |
+        Update a Certificate
+
+        Inserts (or replaces) the certificate under the requested `certificate_id`with the definition specified in the request body. When the `name` or `id` attribute has the structure of a UUID, the certificate being inserted/replaced will be identified by its `id`. Otherwise it will be identified by the `name`.
+
+        When creating a new Certificate without specifying `id` (neither in the path or the request body), then it will be auto-generated.
+      operationId: update-certificate
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Certificate'
+          description: Successfully updated Certificate
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Certificate
+        '404':
+          description: Resource does not exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Update a Certificate
+      tags:
+        - Certificates
+      requestBody:
+        $ref: '#/components/requestBodies/cert-request'
+    put:
+      description: |
+        Update details about the specified certificate using the provided path parameter `certificate_id`.
+
+        Inserts (or replaces) the certificate under the requested `certificate_id`with the definition specified in the request body. When the `name` or `id` attribute has the structure of a UUID, the certificate being inserted/replaced will be identified by its `id`. Otherwise it will be identified by the `name`.
+
+        When creating a new Certificate without specifying `id` (neither in the path or the request body), then it will be auto-generated.
+      operationId: upsert-certificate
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Certificate'
+          description: Successfully upserted Certificate
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Certificate
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a Certificate
+      tags:
+        - Certificates
+      requestBody:
+        $ref: '#/components/requestBodies/cert-request'
+    parameters:
+      - $ref: '#/components/parameters/certificate_id'
+  '/certificates/{certificate_name_or_id}/snis':
+    get:
+      description: Retrieve a paginated list of all SNIs associated with a certificate. Use this endpoint to retrieve a list of SNIs that are linked to a specific certificate. You can use the optional query parameters to filter the results based on specific criteria. The response will include the list of SNIs and pagination information. See the response schema for details on the expected format of the response body.
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/SNI'
+                    type: array
+                  offset:
+                    $ref: '#/components/schemas/pagination-offset-response'
+          description: A successful response listing SNIs
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all SNIs associated with a Certificate
+      tags:
+        - SNIs
+      operationId: list-sni-with-certificate
+    post:
+      description: Create a new SNI and associate it with a certificate in the system. Use this endpoint to add a new SNI to the system and link it to a specific certificate.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SNI'
+          description: Successfully created SNI
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid SNI
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new SNI associated with a Certificate
+      tags:
+        - SNIs
+      operationId: create-sni-with-certificate
+      requestBody:
+        $ref: '#/components/requestBodies/create-sni'
+    parameters:
+      - name: certificate_name_or_id
+        in: path
+        required: true
+        schema:
+          type: string
+          enum:
+            - a3ad71a8-6685-4b03-a101-980a953544f6
+            - name
+          example: name
+        description: The unique identifier or the `name` attribute of the Certificate whose SNIs are to be retrieved. When using this endpoint, only SNIs associated to the specified Certificate will be listed.
+  '/certificates/{certificate_id}/snis/{sni_name_or_id}':
+    delete:
+      description: |
+        Delete a an SNI associated with a Certificate using ID or name.
+      responses:
+        '204':
+          description: Successfully deleted SNI or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a an SNI associated with a Certificate
+      tags:
+        - SNIs
+      operationId: delete-sni-with-cert
+    get:
+      description: Get an SNI associated with a Certificate using ID or name.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SNI'
+          description: Successfully fetched SNI
+        '404':
+          description: Resource does not exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Fetch an SNI associated with a Certificate
+      tags:
+        - SNIs
+      operationId: fetch-sni-with-cert
+    patch:
+      description: Update an existing SNI associated with a certificate in the system using the SNI ID or name. The request body should include the fields of the SNI that need to be updated, such as the name, description, or other properties. If the request body contains valid data, the endpoint will update the SNI and return a success response.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SNI'
+          description: Successfully updated SNI
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid SNI
+        '404':
+          description: Resource does not exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Update a an SNI associated with a Certificate
+      tags:
+        - SNIs
+      operationId: update-sni-with-cert
+      requestBody:
+        $ref: '#/components/requestBodies/create-sni'
+    put:
+      description: |
+        Create or Update an SNI associated with a Certificate using ID or name.
+
+        Inserts (or replaces) the SNI under the requested resource with the definition specified in the body. The SNI will be identified via the name or id attribute.
+
+        When the name or id attribute has the structure of a UUID, the SNI being inserted/replaced will be identified by its id. Otherwise it will be identified by its name.
+
+        When creating a new SNI without specifying id (neither in the URL nor in the body), then it will be auto-generated.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SNI'
+          description: Successfully upserted SNI
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid SNI
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert an SNI associated with a Certificate
+      tags:
+        - SNIs
+      operationId: upsert-sni-with-cert
+      requestBody:
+        $ref: '#/components/requestBodies/create-sni'
+    parameters:
+      - $ref: '#/components/parameters/certificate_id'
+      - $ref: '#/components/parameters/sni_name_or_id'
+  /consumers:
+    get:
+      description: Retrieve a list of all consumers.You can use query parameters to filter the results by size or tags, for example `/consumers?size=50&tags=enterprise`.
+      operationId: list-consumer
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_response'
+      summary: List all Consumers
+      tags:
+        - Consumers
+    post:
+      description: Create a new Consumer
+      operationId: create-consumer
+      responses:
+        '201':
+          $ref: '#/components/responses/consumer_response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Consumer
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  Example 1:
+                    fields:
+                      username: stri22ng
+                    message: UNIQUE violation detected on `{username="stri22ng"}`
+                    name: unique constraint violation
+                    code: 5
+                properties:
+                  fields:
+                    type: object
+                    description: An array of fields that may have caused the error.
+                    properties:
+                      username:
+                        type: string
+                        description: The username that triggerd the conflict.
+                        example: stri22ng
+                  message:
+                    type: string
+                    description: Detail about the conflict.
+                    example: UNIQUE violation detected on `{username=\"stri22ng\"}`
+                  name:
+                    type: string
+                    description: THe name of the violation.
+                    example: unique constraint violation
+                  code:
+                    type: integer
+                    description: Error code for debugging purposes.
+                    example: 5
+              examples:
+                Constraint violation:
+                  value:
+                    fields:
+                      username: stri22ng
+                    message: UNIQUE violation detected on `{username="stri22ng"}`
+                    name: unique constraint violation
+                    code: 5
+      summary: Create a new Consumer
+      tags:
+        - Consumers
+      requestBody:
+        $ref: '#/components/requestBodies/consumer-request'
+  '/consumers/{consumer_username_or_id}':
+    delete:
+      description: Delete a Consumer
+      operationId: delete-consumer
+      responses:
+        '204':
+          description: Successfully deleted Consumer or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a Consumer
+      tags:
+        - Consumers
+    get:
+      description: |
+        Retrieve the details of a specific consumer in the system using either the consumer ID or the consumer username. If the consumer with the specified ID or username cannot be found, the endpoint will return a 404.
+      operationId: get-consumer
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_response'
+        '404':
+          description: Resource does not exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Fetch a consumer
+      tags:
+        - Consumers
+    patch:
+      description: |
+        Update the details of a specific consumer in the system using either the consumer ID or the consumer username.If the consumer with the specified ID or username cannot be found, the endpoint will return a 404.
+      operationId: update-consumer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Consumer'
+          description: Successfully updated Consumer
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Consumer
+        '404':
+          description: Resource does not exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Update a Consumer
+      tags:
+        - Consumers
+      requestBody:
+        $ref: '#/components/requestBodies/consumer-request'
+    put:
+      description: |-
+        Create or Update Consumer using ID or username. The consumer will be identified via the username or id attribute.If the consumer with the specified ID or username cannot be found, the endpoint will return a 404.
+
+        When the username or id attribute has the structure of a UUID, the Consumer being inserted/replaced will be identified by its id. Otherwise it will be identified by its username.
+
+        When creating a new Consumer without specifying id (neither in the URL nor in the body), then it will be auto-generated.
+
+        Notice that specifying a username in the URL and a different one in the request body is not allowed.
+      operationId: upsert-consumer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Consumer'
+          description: Successfully upserted Consumer
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Consumer
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a Consumer
+      tags:
+        - Consumers
+      requestBody:
+        $ref: '#/components/requestBodies/consumer-request'
+    parameters:
+      - $ref: '#/components/parameters/consumer_username_or_id'
+  '/consumers/{consumer_username_or_id}/plugins':
+    get:
+      description: Retrieve a list of all plugins associated with a consumer.
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/Plugin'
+                    type: array
+                  offset:
+                    $ref: '#/components/schemas/pagination-offset-response'
+          description: A successful response listing plugins
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all plugins associated with a consumer
+      tags:
+        - Plugins
+      operationId: list-plugins-with-consumer
+    post:
+      description: Create a new plugin associated with a Consumer
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Plugin'
+          description: Successfully created plugin
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new plugin associated with a consumer
+      tags:
+        - Plugins
+      operationId: create-plugin-for-consumer
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+    parameters:
+      - $ref: '#/components/parameters/consumer_username_or_id'
+  '/consumers/{consumer_name_or_id}/plugins/{plugin_id}':
+    delete:
+      description: Delete a plugin associated with a aconsumer using ID.
+      responses:
+        '204':
+          description: Successfully deleted plugin or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a plugin associated with a consumer
+      tags:
+        - Plugins
+      operationId: delete-plugin-for-consumer
+    get:
+      description: Get a plugin associated with a Consumer using ID.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  Example 1:
+                    message: Not found
+                properties:
+                  message:
+                    type: string
+                    example: Not Found
+                    description: 404 Not Found
+              examples:
+                Not Found:
+                  value:
+                    message: Not Found
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Fetch a plugin associated with a Consumer
+      tags:
+        - Plugins
+      operationId: fetch-plugin-with-consumer
+    patch:
+      description: Update a plugin associated with a consumer using the consumer username or ID.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a plugin associated with a consumer
+      tags:
+        - Plugins
+      operationId: update-plugin-with-consumer
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+    put:
+      description: Create or Update a plugin associated with a Consumer using ID.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a plugin associated with a Consumer
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+      operationId: upsert-plugin-for-customer
+    parameters:
+      - $ref: '#/components/parameters/consumer_name_or_id'
+      - $ref: '#/components/parameters/plugin_id'
+  /key-sets:
+    get:
+      description: |
+        Retrieve a list of all Key Sets in the system. A Key Set object holds a collection of asymmetric key objects. This entity allows to logically group keys by their purpose. Key Sets can be both tagged and filtered by tags.
+      operationId: list-key-set
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/key-set-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all Key Sets
+      tags:
+        - Key-sets
+    post:
+      description: |
+        This endpoint allows creating a new Key Set by sending a JSON object that describes the Key Set to be created.The request body must contain all the fields required to create a new Key Set.
+      operationId: create-key-set
+      responses:
+        '201':
+          $ref: '#/components/responses/key-set-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Key Set
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  fields:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                  message:
+                    type: string
+                  name:
+                    type: string
+                  code:
+                    type: integer
+                x-examples:
+                  Example 1:
+                    fields:
+                      name: my-key_set
+                    message: UNIQUE violation detected on `{name="my-key_set"}`
+                    name: unique constraint violation
+                    code: 5
+              examples:
+                Not Found:
+                  value:
+                    fields:
+                      name: my-key_set
+                    message: UNIQUE violation detected on `{name="my-key_set"}`
+                    name: unique constraint violation
+                    code: 5
+      summary: Create a new Key Set
+      tags:
+        - Key-sets
+      requestBody:
+        $ref: '#/components/requestBodies/key-set-request'
+  '/key-sets/{key-set_id_or_name}':
+    delete:
+      description: Delete a Key Set
+      operationId: delete-key-set
+      responses:
+        '204':
+          description: Successfully deleted Key Set or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a Key Set
+      tags:
+        - Key-sets
+    get:
+      description: |
+        Get a Key Set using ID or name. This endpoint retrieves information about a specific key-set based on its ID or name.
+      operationId: get-key-set
+      responses:
+        '200':
+          $ref: '#/components/responses/key-set-response'
+        '404':
+          description: Resource does not exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Fetch a Key Set
+      tags:
+        - Key-sets
+    patch:
+      description: |-
+        Update a Key Set using ID or name.
+
+        Note: This API is not available in DB-less mode.
+
+        Inserts (or replaces) the Key Set under the requested resource with the definition specified in the body. The Key Set will be identified via the name or id attribute.
+
+        When the name or id attribute has the structure of a UUID, the Key Set being inserted/replaced will be identified by its id. Otherwise it will be identified by its name.
+
+        When creating a new Key Set without specifying id (neither in the URL nor in the body), then it will be auto-generated.
+
+        Notice that specifying a name in the URL and a different one in the request body is not allowed.
+      operationId: update-key-set
+      responses:
+        '200':
+          $ref: '#/components/responses/key-set-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Key Set
+        '404':
+          description: Resource does not exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Update a Key Set
+      tags:
+        - Key-sets
+      requestBody:
+        $ref: '#/components/requestBodies/key-set-request'
+    put:
+      description: |
+        Update a Key Set using ID or name.
+      operationId: upsert-key-set
+      responses:
+        '200':
+          $ref: '#/components/responses/key-set-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Key Set
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Update key-set
+      tags:
+        - Key-sets
+      requestBody:
+        $ref: '#/components/requestBodies/key-set-request'
+    parameters:
+      - $ref: '#/components/parameters/key-set_id_or_name'
+  /keys:
+    get:
+      description: List all Keys
+      operationId: list-key
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/Key'
+                    type: array
+                  offset:
+                    $ref: '#/components/schemas/pagination-offset-response'
+          description: A successful response listing Keys
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all Keys
+      tags:
+        - Keys
+    post:
+      description: This API endpoint allows you to create a new key. When the request is successful, the API will respond with a 200 status code and a JSON object that represents the newly created key. If the request is invalid, the API will respond with a 400 status code and an error message in the response body.
+      operationId: create-key
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Key'
+          description: Successfully created Key
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Key
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new Key
+      tags:
+        - Keys
+      requestBody:
+        $ref: '#/components/requestBodies/keys-request'
+  '/keys/{key_id_or_name}':
+    delete:
+      description: Delete a Key
+      operationId: delete-key
+      responses:
+        '204':
+          description: Successfully deleted Key or the resource didn't exist
+      summary: Delete a Key
+      tags:
+        - Keys
+    get:
+      description: Get a Key using ID or name.
+      operationId: get-key
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Key'
+          description: Successfully fetched Key
+        '404':
+          description: Resource does not exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Fetch a Key
+      tags:
+        - Keys
+    patch:
+      description: Update a Key
+      operationId: update-key
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Key'
+          description: Successfully updated Key
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Key
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a Key
+      tags:
+        - Keys
+      requestBody:
+        $ref: '#/components/requestBodies/keys-request'
+    put:
+      description: |
+        Create or update a key using ID or name.
+      operationId: upsert-key
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Key'
+          description: Successfully upserted Key
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Key
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a Key
+      tags:
+        - Keys
+      requestBody:
+        $ref: '#/components/requestBodies/keys-request'
+    parameters:
+      - $ref: '#/components/parameters/key_id_or_name'
+  /plugins:
+    get:
+      description: |
+        List all plugins
+
+      operationId: list-plugin
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all plugins
+      tags:
+        - Plugins
+    post:
+      description: Create a new plugin
+      operationId: create-plugin
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new plugin
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+  '/plugins/{plugin_id}':
+    delete:
+      description: Delete a plugin
+      operationId: delete-plugin
+      responses:
+        '204':
+          description: Successfully deleted plugin or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a plugin
+      tags:
+        - Plugins
+    get:
+      description: Get a plugin using ID.
+      operationId: get-plugin
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '404':
+          description: Resource does not exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Fetch a plugin
+      tags:
+        - Plugins
+    patch:
+      description: Update a plugin
+      operationId: update-plugin
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '404':
+          description: Resource does not exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Update a plugin
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+    put:
+      description: Create or Update plugin using ID.
+      operationId: upsert-plugin
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a plugin
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+    parameters:
+      - $ref: '#/components/parameters/plugin_id'
+  /routes:
+    get:
+      description: |-
+        List all routes
+
+        route entities define rules to match client requests. Each route is associated with a service, and a service may have multiple routes associated to it. Every request matching a given route will be proxied to its associated service.
+
+        Note: Path handling algorithms v1 was deprecated in Kong 3.0. From Kong 3.0, when router_flavor is set to expressions, route.path_handling will be unconfigurable and the path handling behavior will be "v0"; when router_flavor is set to traditional_compatible, the path handling behavior will be "v0" regardless of the value of route.path_handling. Only router_flavor = traditional will support path_handling "v1' behavior.
+      operationId: list-route
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/Route'
+                    type: array
+                  offset:
+                    $ref: '#/components/schemas/pagination-offset-response'
+          description: A successful response listing routes
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all routes
+      tags:
+        - Routes
+    post:
+      description: Create a new route
+      operationId: create-route
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Route'
+          description: Successfully created route
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid route
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new route
+      tags:
+        - Routes
+      requestBody:
+        $ref: '#/components/requestBodies/route-request'
+  '/routes/{route_id_or_name}':
+    delete:
+      description: Delete a route
+      operationId: delete-route
+      responses:
+        '204':
+          description: Successfully deleted route or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a route
+      tags:
+        - Routes
+    get:
+      description: Get a route using ID or name.
+      operationId: get-route
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Route'
+          description: Successfully fetched route
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch a route
+      tags:
+        - Routes
+    patch:
+      description: Update a route
+      operationId: update-route
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Route'
+          description: Successfully updated route
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid route
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a route
+      tags:
+        - Routes
+      requestBody:
+        $ref: '#/components/requestBodies/route-request'
+    put:
+      description: Create or update a route using ID or name.
+      operationId: upsert-route
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Route'
+          description: Successfully upserted route
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid route
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Update a route
+      tags:
+        - Routes
+      requestBody:
+        $ref: '#/components/requestBodies/route-request'
+    parameters:
+      - $ref: '#/components/parameters/route_id_or_name'
+  '/routes/{route_id_or_name}/plugins':
+    get:
+      description: List all plugins associated with a route
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/Plugin'
+                    type: array
+                  offset:
+                    $ref: '#/components/schemas/pagination-offset-response'
+          description: A successful response listing plugins
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all plugins associated with a route
+      tags:
+        - Plugins
+      operationId: list-plugins-with-route
+    post:
+      description: Create a new plugin associated with a route
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Plugin'
+          description: Successfully created plugin
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new plugin associated with a route
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+      operationId: create-plugin-with-route
+    parameters:
+      - $ref: '#/components/parameters/route_id_or_name'
+  '/routes/{route_id_or_name}/plugins/{plugin_id}':
+    delete:
+      description: Delete a plugin associated with a route using ID.
+      responses:
+        '204':
+          description: Successfully deleted plugin or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a plugin associated with a route
+      tags:
+        - Plugins
+      operationId: delete-plugin-with-route
+    get:
+      description: Get a plugin associated with a route using ID.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch a plugin associated with a route
+      tags:
+        - Plugins
+      operationId: fetch-plugin-with-route
+    patch:
+      description: Update a plugin associated with a route using ID.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a plugin associated with a route
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+      operationId: update-plugin-with-route
+    put:
+      description: Create or Update a plugin associated with a route using ID.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a plugin associated with a route
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+      operationId: upsert-plugin-with-route
+    parameters:
+      - $ref: '#/components/parameters/route_id_or_name'
+      - $ref: '#/components/parameters/plugin_id'
+  /services:
+    get:
+      description: List all Services
+      operationId: list-service
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/Service'
+                    type: array
+                  offset:
+                    $ref: '#/components/schemas/pagination-offset-response'
+          description: A successful response listing Services
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        
+      summary: List all services
+      tags:
+        - Services
+    post:
+      description: Create a new service
+      operationId: create-service
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Service'
+          description: Successfully created Service
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Service
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new service
+      tags:
+        - Services
+      requestBody:
+        $ref: '#/components/requestBodies/service-request'
+  '/services/{service_id_or_name}':
+    delete:
+      description: Delete a Service
+      operationId: delete-service
+      responses:
+        '204':
+          description: Successfully deleted Service or the resource didn't exist
+      summary: Delete a Service
+      tags:
+        - Services
+    get:
+      description: Get a Service using ID or name.
+      operationId: get-service
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Service'
+          description: Successfully fetched Service
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch a Service
+      tags:
+        - Services
+    patch:
+      description: Update a Service
+      operationId: update-service
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Service'
+          description: Successfully updated Service
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Service
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a Service
+      tags:
+        - Services
+      requestBody:
+        $ref: '#/components/requestBodies/service-request'
+    put:
+      description: Create or Update Service using ID or name.
+      operationId: upsert-service
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Service'
+          description: Successfully upserted Service
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Service
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a Service
+      tags:
+        - Services
+      requestBody:
+        $ref: '#/components/requestBodies/service-request'
+    parameters:
+      - $ref: '#/components/parameters/service_id_or_name'
+  '/services/{service_id_or_name}/plugins':
+    get:
+      description: List all plugins associated with a Service
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/Plugin'
+                    type: array
+                  offset:
+                    $ref: '#/components/schemas/pagination-offset-response'
+          description: A successful response listing plugins
+      summary: List all plugins associated with a Service
+      tags:
+        - Plugins
+      operationId: list-plugins-with-service
+    post:
+      description: Create a new plugin associated with a Service
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Plugin'
+          description: Successfully created plugin
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new plugin associated with a Service
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+      operationId: create-plugin-with-service
+    parameters:
+      - $ref: '#/components/parameters/service_id_or_name'
+  '/services/{service_id_or_name}/plugins/{plugin_id}':
+    delete:
+      description: Delete a plugin associated with a Service using ID.
+      responses:
+        '204':
+          description: Successfully deleted plugin or the resource didn't exist
+      summary: Delete a plugin associated with a Service
+      tags:
+        - Plugins
+      operationId: delete-plugin-with-service
+    get:
+      description: Get a plugin associated with a Service using ID.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch a plugin associated with a Service
+      tags:
+        - Plugins
+      operationId: fetch-plugin-with-service
+    patch:
+      description: Update a plugin associated with a Service using ID.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a plugin associated with a Service
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+      operationId: update-plugin-with-service
+    put:
+      description: Create or Update a plugin associated with a Service using ID.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a plugin associated with a Service
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+      operationId: upsert-plugin-with-service
+    parameters:
+      - $ref: '#/components/parameters/service_id_or_name'
+      - $ref: '#/components/parameters/plugin_id'
+  '/services/{service_id_or_name}/routes':
+    get:
+      description: List all routes associated with a Service
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/Route'
+                    type: array
+                  offset:
+                    $ref: '#/components/schemas/pagination-offset-response'
+          description: A successful response listing routes
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all routes associated with a Service
+      tags:
+        - Routes
+      operationId: list-routes-with-service
+    post:
+      description: Create a new route associated with a Service
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Route'
+          description: Successfully created route
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid route
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new route associated with a Service
+      tags:
+        - Routes
+      requestBody:
+        $ref: '#/components/requestBodies/route-request'
+      operationId: create-route-with-service
+    parameters:
+      - $ref: '#/components/parameters/service_id_or_name'
+  '/services/{service_id_or_name}/routes/{route_id_or_name}':
+    delete:
+      description: Delete a route associated with a Service using ID or name.
+      responses:
+        '204':
+          description: Successfully deleted route or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a route associated with a Service
+      tags:
+        - Routes
+      operationId: delete-route-with-service
+    get:
+      description: Get a route associated with a service using ID or name.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Route'
+          description: Successfully fetched route
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch a route associated with a Service
+      tags:
+        - Routes
+      operationId: fetch-route-with-service
+    patch:
+      description: Update a route associated with a Service using ID or name.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Route'
+          description: Successfully updated route
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid route
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a route associated with a Service
+      tags:
+        - Routes
+      requestBody:
+        $ref: '#/components/requestBodies/route-request'
+      operationId: update-route-with-service
+    put:
+      description: Create or Update a route associated with a Service using ID or name.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Route'
+          description: Successfully upserted route
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid route
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a route associated with a Service
+      tags:
+        - Routes
+      requestBody:
+        $ref: '#/components/requestBodies/route-request'
+      operationId: upsert-route-with-service
+    parameters:
+      - $ref: '#/components/parameters/service_id_or_name'
+      - $ref: '#/components/parameters/route_id_or_name'
+  /snis:
+    get:
+      description: List all SNIs
+      operationId: list-sni
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/sni-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all SNIs
+      tags:
+        - SNIs
+    post:
+      description: Create a new SNI
+      operationId: create-sni
+      responses:
+        '200':
+          $ref: '#/components/responses/sni-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid SNI
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new SNI
+      tags:
+        - SNIs
+      requestBody:
+        $ref: '#/components/requestBodies/create-sni'
+  '/snis/{sni_name_or_id}':
+    delete:
+      description: Delete an SNI
+      operationId: delete-sni
+      responses:
+        '204':
+          description: Successfully deleted SNI or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete an SNI
+      tags:
+        - SNIs
+    get:
+      description: Get an SNI using ID or name.
+      operationId: get-sni
+      responses:
+        '200':
+          $ref: '#/components/responses/sni-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch an SNI
+      tags:
+        - SNIs
+    patch:
+      description: Update an SNI
+      operationId: update-sni
+      responses:
+        '200':
+          $ref: '#/components/responses/sni-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid SNI
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update an SNI
+      tags:
+        - SNIs
+      requestBody:
+        $ref: '#/components/requestBodies/create-sni'
+    put:
+      description: Create or Update SNI using ID or name.
+      operationId: upsert-sni
+      responses:
+        '200':
+          $ref: '#/components/responses/sni-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid SNI
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a SNI
+      tags:
+        - SNIs
+      requestBody:
+        $ref: '#/components/requestBodies/create-sni'
+    parameters:
+      - $ref: '#/components/parameters/sni_name_or_id'
+  /upstreams:
+    get:
+      description: |
+        List all registered upstreams. You can filter the results by pagination size, offset, or tags like /upstreams?size=10&offset=0.
+      operationId: list-upstream
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/Upstream'
+                    type: array
+                  offset:
+                    $ref: '#/components/schemas/pagination-offset-response'
+          description: A successful response listing Upstreams
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all Upstreams
+      tags:
+        - Upstreams
+    post:
+      description: Create a new Upstream
+      operationId: create-upstream
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upstream'
+          description: Successfully created Upstream
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Upstream
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new Upstream
+      tags:
+        - Upstreams
+      requestBody:
+        $ref: '#/components/requestBodies/upstream-request'
+  '/upstreams/{upstream_id_or_name}':
+    delete:
+      description: Delete an Upstream
+      operationId: delete-upstream
+      responses:
+        '204':
+          description: Successfully deleted Upstream or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete an Upstream
+      tags:
+        - Upstreams
+    get:
+      description: Get an Upstream using ID or name.
+      operationId: get-upstream
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upstream'
+          description: Successfully fetched Upstream
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch an Upstream
+      tags:
+        - Upstreams
+    patch:
+      description: Update an Upstream
+      operationId: update-upstream
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upstream'
+          description: Successfully updated Upstream
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Upstream
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update an Upstream
+      tags:
+        - Upstreams
+      requestBody:
+        $ref: '#/components/requestBodies/upstream-request'
+    put:
+      description: Create or Update Upstream using ID or name.
+      operationId: upsert-upstream
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upstream'
+          description: Successfully upserted Upstream
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Upstream
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a Upstream
+      tags:
+        - Upstreams
+      requestBody:
+        $ref: '#/components/requestBodies/upstream-request'
+    parameters:
+      - $ref: '#/components/parameters/upstream_id_or_name'
+  '/upstreams/{upstream_id_or_name}/targets':
+    get:
+      description: List all Targets associated with a an Upstream
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/Target'
+                    type: array
+                  offset:
+                    $ref: '#/components/schemas/pagination-offset-response'
+          description: A successful response listing Targets
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all Targets associated with an Upstream
+      tags:
+        - Targets
+      operationId: list-target-with-upstream
+    post:
+      description: Create a new Target associated with an Upstream
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Target'
+          description: Successfully created Target
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Target
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new Target associated with an Upstream
+      tags:
+        - Targets
+      requestBody:
+        $ref: '#/components/requestBodies/target-request'
+      operationId: create-target-with-upstream
+    parameters:
+      - $ref: '#/components/parameters/upstream_id_or_name'
+  '/upstreams/{upstream_id_or_name}/targets/{target_id_or_target}':
+    delete:
+      description: Delete a Target associated with a an Upstream using ID or target.
+      responses:
+        '204':
+          description: Successfully deleted Target or the resource didn't exist
+      summary: Delete a Target associated with a an Upstream
+      tags:
+        - Targets
+      operationId: delete-target-with-upstream
+    get:
+      description: Get a Target associated with an Upstream using ID or target.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Target'
+          description: Successfully fetched Target
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch a Target associated with an Upstream
+      tags:
+        - Targets
+      operationId: fetch-target-with-upstream
+    patch:
+      description: Update a Target associated with a an Upstream using ID or target.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Target'
+          description: Successfully updated Target
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Target
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a Target associated with a an Upstream
+      tags:
+        - Targets
+      requestBody:
+        $ref: '#/components/requestBodies/target-request'
+      operationId: update-target-with-upstream
+    put:
+      description: Create or Update a Target associated with an Upstream using ID or target.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Target'
+          description: Successfully upserted Target
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Target
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a Target associated with an Upstream
+      tags:
+        - Targets
+      requestBody:
+        $ref: '#/components/requestBodies/target-request'
+      operationId: upsert-target-with-upstream
+    parameters:
+      - $ref: '#/components/parameters/upstream_id_or_name'
+      - $ref: '#/components/parameters/target_id_or_target'
+  /vaults:
+    get:
+      description: List all Vaults
+      operationId: list-vault
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/Vault'
+                    type: array
+                  offset:
+                    $ref: '#/components/schemas/pagination-offset-response'
+          description: A successful response listing Vaults
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all Vaults
+      tags:
+        - Vaults
+    post:
+      description: Create a new Vault
+      operationId: create-vault
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vault'
+          description: Successfully created Vault
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Vault
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new Vault
+      tags:
+        - Vaults
+      requestBody:
+        $ref: '#/components/requestBodies/vault-request'
+  '/vaults/{vault_id_or_prefix}':
+    delete:
+      description: Delete a Vault
+      operationId: delete-vault
+      responses:
+        '204':
+          description: Successfully deleted Vault or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a Vault
+      tags:
+        - Vaults
+    get:
+      description: |
+        Fetch a Vault using ID or prefix.
+
+        Vault entities are used to configure different Vault connectors.
+      operationId: get-vault
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vault'
+          description: Successfully fetched Vault
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch a Vault
+      tags:
+        - Vaults
+    patch:
+      description: Update a Vault
+      operationId: update-vault
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vault'
+          description: Successfully updated Vault
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Vault
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a Vault
+      tags:
+        - Vaults
+      requestBody:
+        $ref: '#/components/requestBodies/vault-request'
+    put:
+      description: Create or Update Vault using ID or prefix.
+      operationId: upsert-vault
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vault'
+          description: Successfully upserted Vault
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Vault
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a Vault
+      tags:
+        - Vaults
+      requestBody:
+        $ref: '#/components/requestBodies/vault-request'
+    parameters:
+      - $ref: '#/components/parameters/vault_id_or_prefix'
+  /workspaces:
+    get:
+      description: |-
+        List all Workspaces
+
+        For workspace use cases and configuration examples, see [Workspace examples](https://docs.konghq.com/gateway/latest/kong-enterprise/workspaces/). This endpoint will only return workspaces that the current user has access to.
+      operationId: list-workspace
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/Workspace'
+                    type: array
+                  offset:
+                    $ref: '#/components/schemas/pagination-offset-response'
+          description: A successful response listing Workspaces
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all Workspaces
+      tags:
+        - Workspaces
+    post:
+      description: |
+        Create a new Workspace
+
+        For workspace use cases and configuration examples, see [Workspace examples](https://docs.konghq.com/gateway/3.2.x/kong-enterprise/workspaces/).
+      operationId: create-workspace
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Workspace'
+        description: Description of the new Workspace for creation
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Workspace'
+          description: Successfully created Workspace
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Workspace
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new Workspace
+      tags:
+        - Workspaces
+  '/workspaces/{workspace_id_or_name}':
+    delete:
+      description: Delete a Workspace
+      operationId: delete-workspace
+      responses:
+        '204':
+          description: Successfully deleted Workspace or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a Workspace
+      tags:
+        - Workspaces
+      parameters:
+        - schema:
+            type: boolean
+            example: true
+          in: query
+          name: cascade
+          description: The `cascade` option lets you delete a workspace and all of its entities in one request.
+    get:
+      description: Get a Workspace using ID or name.
+      operationId: get-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Workspace'
+          description: Successfully fetched Workspace
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch a Workspace
+      tags:
+        - Workspaces
+    patch:
+      description: Update a Workspace
+      operationId: update-workspace
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Workspace'
+        description: Fields of the Workspace that need to be updated
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Workspace'
+          description: Successfully updated Workspace
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Workspace
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a Workspace
+      tags:
+        - Workspaces
+    put:
+      description: Create or Update Workspace using ID or name.
+      operationId: upsert-workspace
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Workspace'
+        description: Description of the Workspace
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Workspace'
+          description: Successfully upserted Workspace
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Workspace
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a Workspace
+      tags:
+        - Workspaces
+    parameters:
+      - $ref: '#/components/parameters/workspace_id_or_name'
+  '/{workspace}/certificates':
+    get:
+      description: List all Certificates in a workspace
+      operationId: list-certificate-in-workspace
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/Certificate'
+                    type: array
+                  offset:
+                    $ref: '#/components/schemas/pagination-offset-response'
+          description: A successful response listing Certificates
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all Certificates in a workspace
+      tags:
+        - Certificates
+    post:
+      description: Create a new Certificate in a workspace
+      operationId: create-certificate-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Certificate'
+          description: Successfully created Certificate
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Certificate
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new Certificate in a workspace
+      tags:
+        - Certificates
+      requestBody:
+        $ref: '#/components/requestBodies/cert-request'
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+  '/{workspace}/certificates/{certificate_id}':
+    delete:
+      description: Delete a Certificate in a workspace
+      operationId: delete-certificate-in-workspace
+      responses:
+        '204':
+          description: Successfully deleted Certificate or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a Certificate in a workspace
+      tags:
+        - Certificates
+    get:
+      description: Get a Certificate using ID in a workspace.
+      operationId: get-certificate-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Certificate'
+          description: Successfully fetched Certificate
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch a Certificate in a workspace
+      tags:
+        - Certificates
+    patch:
+      description: Update a Certificate in a workspace
+      operationId: update-certificate-in-workspace
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Certificate'
+        description: Fields of the Certificate that need to be updated
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Certificate'
+          description: Successfully updated Certificate
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Certificate
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a Certificate in a workspace
+      tags:
+        - Certificates
+    put:
+      description: Create or Update Certificate using ID in a workspace.
+      operationId: upsert-certificate-in-workspace
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Certificate'
+        description: Description of the Certificate
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Certificate'
+          description: Successfully upserted Certificate
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Certificate
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a Certificate in a workspace
+      tags:
+        - Certificates
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/certificate_id'
+  '/{workspace}/certificates/{certificate_id}/snis':
+    get:
+      description: List all SNIs associated with a Certificate in a workspace
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/sni-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all SNIs associated with a Certificate in a workspace
+      tags:
+        - SNIs
+      operationId: list-sni-with-cert-in-workspace
+    post:
+      description: Create a new SNI associated with a Certificate in a workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/sni-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid SNI
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new SNI associated with a Certificate in a workspace
+      tags:
+        - SNIs
+      requestBody:
+        $ref: '#/components/requestBodies/create-sni'
+      operationId: create-sni-with-cert-in-workspace
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/certificate_id'
+  '/{workspace}/certificates/{certificate_id}/snis/{sni_name_or_id}':
+    delete:
+      description: Delete a an SNI associated with a Certificate using ID or name in a workspace.
+      responses:
+        '204':
+          description: Successfully deleted SNI or the resource didn't exist
+      summary: Delete an SNI associated with a Certificate in a workspace
+      tags:
+        - SNIs
+      operationId: delete-sni-with-cert-in-workspace
+    get:
+      description: Get an SNI associated with a Certificate using ID or name in a workspace.
+      responses:
+        '200':
+          $ref: '#/components/responses/sni-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch an SNI associated with a Certificate in a workspace
+      tags:
+        - SNIs
+      operationId: fetch-sni-with-cert-in-workspace
+    patch:
+      description: Update a an SNI associated with a Certificate using ID or name in a workspace.
+      responses:
+        '200':
+          $ref: '#/components/responses/sni-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid SNI
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update an SNI associated with a Certificate in a workspace
+      tags:
+        - SNIs
+      requestBody:
+        $ref: '#/components/requestBodies/create-sni'
+      operationId: update-sni-with-cert-in-workspace
+    put:
+      description: Create or Update an SNI associated with a Certificate using ID or name in a workspace.
+      responses:
+        '200':
+          $ref: '#/components/responses/sni-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid SNI
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert an SNI associated with a Certificate in a workspace
+      tags:
+        - SNIs
+      requestBody:
+        $ref: '#/components/requestBodies/create-sni'
+      operationId: upsert-sni-with-cert-in-workspace
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/certificate_id'
+      - $ref: '#/components/parameters/sni_name_or_id'
+  '/{workspace}/consumers':
+    get:
+      description: List all Consumers in a workspace
+      operationId: list-consumer-in-workspace
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all Consumers in a workspace
+      tags:
+        - Consumers
+    post:
+      description: Create a new Consumer in a workspace
+      operationId: create-consumer-in-workspace
+      parameters:
+        - description: Name or ID of workspace
+          example: team-a
+          in: path
+          name: workspace
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Consumer
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new Consumer in a workspace
+      tags:
+        - Consumers
+      requestBody:
+        $ref: '#/components/requestBodies/consumer-request'
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+  '/{workspace}/consumers/{consumer_username_or_id}':
+    delete:
+      description: Delete a Consumer in a workspace
+      operationId: delete-consumer-in-workspace
+      responses:
+        '204':
+          description: Successfully deleted Consumer or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a Consumer in a workspace
+      tags:
+        - Consumers
+    get:
+      description: Get a Consumer using ID or username in a workspace.
+      operationId: get-consumer-in-workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch a Consumer in a workspace
+      tags:
+        - Consumers
+    patch:
+      description: Update a Consumer in a workspace
+      operationId: update-consumer-in-workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Consumer
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a Consumer in a workspace
+      tags:
+        - Consumers
+      requestBody:
+        $ref: '#/components/requestBodies/consumer-request'
+    put:
+      description: Create or Update Consumer using ID or username in a workspace.
+      operationId: upsert-consumer-in-workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Consumer
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a Consumer in a workspace
+      tags:
+        - Consumers
+      requestBody:
+        $ref: '#/components/requestBodies/consumer-request'
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/consumer_username_or_id'
+  '/{workspace}/consumers/{consumer_username_or_id}/plugins':
+    get:
+      description: List all plugins associated with a Consumer in a workspace
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all plugins associated with a Consumer in a workspace
+      tags:
+        - Plugins
+      operationId: list-plugins-consumer-workspace
+    post:
+      description: Create a new plugin associated with a Consumer in a workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new plugin associated with a Consumer in a workspace
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+      operationId: create-plugin-with-consumer-workspace
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/consumer_username_or_id'
+  '/{workspace}/consumers/{consumer_username_or_id}/plugins/{plugin_id}':
+    delete:
+      description: Delete a plugin associated with a Consumer using ID in a workspace.
+      responses:
+        '204':
+          description: Successfully deleted plugin or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a plugin associated with a Consumer in a workspace
+      tags:
+        - Plugins
+      operationId: delete-plugin-with-consumer-workspace
+    get:
+      description: Get a plugin associated with a Consumer using ID in a workspace.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '404':
+          description: Resource does not exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Fetch a plugin associated with a Consumer in a workspace
+      tags:
+        - Plugins
+      operationId: fetch-plugin-with-consumer-workspace
+    patch:
+      description: Update a plugin associated with a Consumer using ID in a workspace.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a plugin associated with a Consumer in a workspace
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+      operationId: update-plugin-with-consumer-workspace
+    put:
+      description: Create or Update a plugin associated with a Consumer using ID in a workspace.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a plugin associated with a Consumer in a workspace
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+      operationId: upsert-plugin-with-consumer-workspace
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/consumer_username_or_id'
+      - $ref: '#/components/parameters/plugin_id'
+  '/{workspace}/key-sets':
+    get:
+      description: List all Key-sets in a workspace
+      operationId: list-key-set-in-workspace
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/key-set-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all Key-sets in a workspace
+      tags:
+        - Key-sets
+    post:
+      description: Create a new Key Set in a workspace
+      operationId: create-key-set-in-workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/key-set-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Key Set
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new Key Set in a workspace
+      tags:
+        - Key-sets
+      requestBody:
+        $ref: '#/components/requestBodies/key-set-request'
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+  '/{workspace}/key-sets/{key-set_id_or_name}':
+    delete:
+      description: Delete a Key Set in a workspace
+      operationId: delete-key-set-in-workspace
+      responses:
+        '204':
+          description: Successfully deleted Key Set or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a Key Set in a workspace
+      tags:
+        - Key-sets
+    get:
+      description: Get a Key Set using ID or name in a workspace.
+      operationId: get-key-set-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Key-set'
+          description: Successfully fetched Key-set
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch a Key Set in a workspace
+      tags:
+        - Key-sets
+    patch:
+      description: Update a Key Set in a workspace
+      operationId: update-key-set-in-workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/key-set-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Key-set
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a Key Set in a workspace
+      tags:
+        - Key-sets
+      requestBody:
+        $ref: '#/components/requestBodies/key-set-request'
+    put:
+      description: Create or Update Key Set using ID or name in a workspace.
+      operationId: upsert-key-set-in-workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/key-set-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Key-set
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a Key Set in a workspace
+      tags:
+        - Key-sets
+      requestBody:
+        $ref: '#/components/requestBodies/key-set-request'
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/key-set_id_or_name'
+  '/{workspace}/keys':
+    get:
+      description: List all Keys in a workspace
+      operationId: list-key-in-workspace
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Key'
+              examples:
+                Example 1:
+                  value:
+                    id: d958f66b-8e99-44d2-b0b4-edd5bbf24658
+                    jwk: '{"alg":"RSA",  "kid": "42",  ...}'
+                    kid: '42'
+                    name: a-key
+                    pem:
+                      private_key: '-----BEGIN'
+                      public_key: '-----BEGIN'
+                    set:
+                      id: b86b331c-dcd0-4b3e-97ce-47c5a9543031
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all Keys in a workspace
+      tags:
+        - Keys
+    post:
+      description: Create a new Key in a workspace
+      operationId: create-key-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Key'
+              examples:
+                Successfully created Key:
+                  value:
+                    id: d958f66b-8e99-44d2-b0b4-edd5bbf24658
+                    jwk: '{"alg":"RSA",  "kid": "42",  ...}'
+                    kid: '42'
+                    name: a-key
+                    pem:
+                      private_key: '-----BEGIN'
+                      public_key: '-----BEGIN'
+                    set:
+                      id: b86b331c-dcd0-4b3e-97ce-47c5a9543031
+          description: Successfully created Key
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Key
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new Key in a workspace
+      tags:
+        - Keys
+      requestBody:
+        $ref: '#/components/requestBodies/keys-request'
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+  '/{workspace}/keys/{key_id_or_name}':
+    delete:
+      description: Delete a Key in a workspace
+      operationId: delete-key-in-workspace
+      responses:
+        '204':
+          description: Successfully deleted Key or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a Key in a workspace
+      tags:
+        - Keys
+    get:
+      description: Get a Key using ID or name in a workspace.
+      operationId: get-key-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Key'
+              examples:
+                Example 1:
+                  value:
+                    id: d958f66b-8e99-44d2-b0b4-edd5bbf24658
+                    jwk: '{"alg":"RSA",  "kid": "42",  ...}'
+                    kid: '42'
+                    name: a-key
+                    pem:
+                      private_key: '-----BEGIN'
+                      public_key: '-----BEGIN'
+                    set:
+                      id: b86b331c-dcd0-4b3e-97ce-47c5a9543031
+          description: Successfully fetched Key
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch a Key in a workspace
+      tags:
+        - Keys
+    patch:
+      description: Update a Key in a workspace
+      operationId: update-key-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Key'
+          description: Successfully updated Key
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Key
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a Key in a workspace
+      tags:
+        - Keys
+      requestBody:
+        $ref: '#/components/requestBodies/keys-request'
+    put:
+      description: Create or Update Key using ID or name in a workspace.
+      operationId: upsert-key-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Key'
+              examples:
+                Example 1:
+                  value:
+                    id: d958f66b-8e99-44d2-b0b4-edd5bbf24658
+                    jwk: '{"alg":"RSA",  "kid": "42",  ...}'
+                    kid: '42'
+                    name: a-key
+                    pem:
+                      private_key: '-----BEGIN'
+                      public_key: '-----BEGIN'
+                    set:
+                      id: b86b331c-dcd0-4b3e-97ce-47c5a9543031
+          description: Successfully upserted Key
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Key
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a Key in a workspace
+      tags:
+        - Keys
+      requestBody:
+        $ref: '#/components/requestBodies/keys-request'
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/key_id_or_name'
+  '/{workspace}/plugins':
+    get:
+      description: List all plugins in a workspace
+      operationId: list-plugin-in-workspace
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/Plugin'
+                    type: array
+                  offset:
+                    $ref: '#/components/schemas/pagination-offset-response'
+          description: A successful response listing plugins
+      summary: List all plugins in a workspace
+      tags:
+        - Plugins
+    post:
+      description: Create a new plugin in a workspace
+      operationId: create-plugin-in-workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new plugin in a workspace
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+  '/{workspace}/plugins/{plugin_id}':
+    delete:
+      description: Delete a plugin in a workspace
+      operationId: delete-plugin-in-workspace
+      responses:
+        '204':
+          description: Successfully deleted plugin or the resource didn't exist
+      summary: Delete a plugin in a workspace
+      tags:
+        - Plugins
+    get:
+      description: Get a plugin using ID in a workspace.
+      operationId: get-plugin-in-workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch a plugin in a workspace
+      tags:
+        - Plugins
+    patch:
+      description: Update a plugin in a workspace
+      operationId: update-plugin-in-workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a plugin in a workspace
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+    put:
+      description: Create or Update plugin using ID in a workspace.
+      operationId: upsert-plugin-in-workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a plugin in a workspace
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/plugin_id'
+  '/{workspace}/routes':
+    get:
+      description: List all routes in a workspace
+      operationId: list-route-in-workspace
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/Route'
+                    type: array
+                  offset:
+                    $ref: '#/components/schemas/pagination-offset-response'
+          description: A successful response listing routes
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all routes in a workspace
+      tags:
+        - Routes
+    post:
+      description: Create a new route in a workspace
+      operationId: create-route-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Route'
+          description: Successfully created route
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid route
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new route in a workspace
+      tags:
+        - Routes
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+  '/{workspace}/routes/{route_id_or_name}':
+    delete:
+      description: Delete a route in a workspace
+      operationId: delete-route-in-workspace
+      responses:
+        '204':
+          description: Successfully deleted route or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a route in a workspace
+      tags:
+        - Routes
+    get:
+      description: Get a route using ID or name in a workspace.
+      operationId: get-route-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Route'
+          description: Successfully fetched route
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch a route in a workspace
+      tags:
+        - Routes
+    patch:
+      description: Update a route in a workspace
+      operationId: update-route-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Route'
+          description: Successfully updated route
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid route
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a route in a workspace
+      tags:
+        - Routes
+      requestBody:
+        $ref: '#/components/requestBodies/route-request'
+    put:
+      description: Create or Update route using ID or name in a workspace.
+      operationId: upsert-route-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Route'
+          description: Successfully upserted route
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid route
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a route in a workspace
+      tags:
+        - Routes
+      requestBody:
+        $ref: '#/components/requestBodies/route-request'
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/route_id_or_name'
+  '/{workspace}/routes/{route_id_or_name}/plugins':
+    get:
+      description: List all plugins associated with a route in a workspace
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all plugins associated with a route in a workspace
+      tags:
+        - Plugins
+      operationId: list-plugins-with-route-workspace
+    post:
+      description: Create a new plugin associated with a route in a workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Plugin'
+          description: Successfully created plugin
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new plugin associated with a route in a workspace
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+      operationId: create-plugin-with-route-workspace
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/route_id_or_name'
+  '/{workspace}/routes/{route_id_or_name}/plugins/{plugin_id}':
+    delete:
+      description: Delete a plugin associated with a route using ID in a workspace.
+      responses:
+        '204':
+          description: Successfully deleted plugin or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a plugin associated with a route in a workspace
+      tags:
+        - Plugins
+      operationId: delete-plugin-with-route-workspace
+    get:
+      description: Get a plugin associated with a route using ID in a workspace.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch a plugin associated with a route in a workspace
+      tags:
+        - Plugins
+      operationId: fetch-plugin-with-route-workspace
+    patch:
+      description: Update a plugin associated with a route using ID in a workspace.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a plugin associated with a route in a workspace
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+      operationId: update-plugin-with-route-workspace
+    put:
+      description: Create or Update a plugin associated with a route using ID in a workspace.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a plugin associated with a route in a workspace
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+      operationId: upsert-plugin-with-route-workspace
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/route_id_or_name'
+      - $ref: '#/components/parameters/plugin_id'
+  '/{workspace}/services':
+    get:
+      description: List all Services in a workspace
+      operationId: list-service-in-workspace
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Service'
+          description: A successful response listing Services
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all Services in a workspace
+      tags:
+        - Services
+    post:
+      description: Create a new Service in a workspace
+      operationId: create-service-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Service'
+          description: Successfully created Service
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Service
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new Service in a workspace
+      tags:
+        - Services
+      requestBody:
+        $ref: '#/components/requestBodies/service-request'
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+  '/{workspace}/services/{service_id_or_name}':
+    delete:
+      description: Delete a Service in a workspace
+      operationId: delete-service-in-workspace
+      responses:
+        '204':
+          description: Successfully deleted Service or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a Service in a workspace
+      tags:
+        - Services
+    get:
+      description: Get a Service using ID or name in a workspace.
+      operationId: get-service-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Service'
+          description: Successfully fetched Service
+        '404':
+          description: Resource does not exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Fetch a Service in a workspace
+      tags:
+        - Services
+    patch:
+      description: Update a Service in a workspace
+      operationId: update-service-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Service'
+          description: Successfully updated Service
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Service
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a Service in a workspace
+      tags:
+        - Services
+      requestBody:
+        $ref: '#/components/requestBodies/service-request'
+    put:
+      description: Create or Update Service using ID or name in a workspace.
+      operationId: upsert-service-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Service'
+          description: Successfully upserted Service
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Service
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a Service in a workspace
+      tags:
+        - Services
+      requestBody:
+        $ref: '#/components/requestBodies/service-request'
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/service_id_or_name'
+  '/{workspace}/services/{service_id_or_name}/plugins':
+    get:
+      description: List all plugins associated with a Service in a workspace
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+      summary: List all plugins associated with a Service in a workspace
+      tags:
+        - Plugins
+      operationId: list-plugins-with-service-workspace
+    post:
+      description: Create a new plugin associated with a Service in a workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new plugin associated with a Service in a workspace
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+      operationId: create-plugin-with-service-workspace
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/service_id_or_name'
+  '/{workspace}/services/{service_id_or_name}/plugins/{plugin_id}':
+    delete:
+      description: Delete a plugin associated with a Service using ID in a workspace.
+      responses:
+        '204':
+          description: Successfully deleted plugin or the resource didn't exist
+      summary: Delete a plugin associated with a Service in a workspace
+      tags:
+        - Plugins
+      operationId: delete-plugin-with-service-workspace
+    get:
+      description: Get a plugin associated with a Service using ID in a workspace.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch a plugin associated with a Service in a workspace
+      tags:
+        - Plugins
+      operationId: fetch-plugin-with-service-workspace
+    patch:
+      description: Update a plugin associated with a Service using ID in a workspace.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a plugin associated with a Service in a workspace
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+      operationId: update-plugin-with-service-workspace
+    put:
+      description: Create or Update a plugin associated with a Service using ID in a workspace.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a plugin associated with a Service in a workspace
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+      operationId: upsert-plugin-with-service-workspace
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/service_id_or_name'
+      - $ref: '#/components/parameters/plugin_id'
+  '/{workspace}/services/{service_id_or_name}/routes':
+    get:
+      description: List all routes associated with a Service in a workspace
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Route'
+          description: A successful response listing routes
+      summary: List all routes associated with a Service in a workspace
+      tags:
+        - Routes
+      operationId: list-routes-with-service-workspace
+    post:
+      description: Create a new route associated with a Service in a workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Route'
+          description: Successfully created route
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid route
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new route associated with a Service in a workspace
+      tags:
+        - Routes
+      requestBody:
+        $ref: '#/components/requestBodies/route-request'
+      operationId: create-route-with-service-workspace
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/service_id_or_name'
+  '/{workspace}/services/{service_id_or_name}/routes/{route_id_or_name}':
+    delete:
+      description: Delete a route associated with a Service using ID or name in a workspace.
+      responses:
+        '204':
+          description: Successfully deleted route or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a route associated with a Service in a workspace
+      tags:
+        - Routes
+      operationId: delete-route-with-service-workspace
+    get:
+      description: Get a route associated with a Service using ID or name in a workspace.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Route'
+          description: Successfully fetched route
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch a route associated with a Service in a workspace
+      tags:
+        - Routes
+      operationId: fetch-route-with-service-workspace
+    patch:
+      description: Update a route associated with a Service using ID or name in a workspace.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Route'
+          description: Successfully updated route
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid route
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a route associated with a Service in a workspace
+      tags:
+        - Routes
+      requestBody:
+        $ref: '#/components/requestBodies/route-request'
+      operationId: update-route-with-service-workspace
+    put:
+      description: Create or Update a route associated with a Service using ID or name in a workspace.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Route'
+          description: Successfully upserted route
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid route
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a route associated with a Service in a workspace
+      tags:
+        - Routes
+      requestBody:
+        $ref: '#/components/requestBodies/route-request'
+      operationId: upsert-route-with-service-workspace
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/service_id_or_name'
+      - $ref: '#/components/parameters/route_id_or_name'
+  '/{workspace}/snis':
+    get:
+      description: List all SNIs in a workspace
+      operationId: list-sni-in-workspace
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/sni-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all SNIs in a workspace
+      tags:
+        - SNIs
+    post:
+      description: Create a new SNI in a workspace
+      operationId: create-sni-in-workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/sni-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid SNI
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new SNI in a workspace
+      tags:
+        - SNIs
+      requestBody:
+        $ref: '#/components/requestBodies/create-sni'
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+  '/{workspace}/snis/{sni_name_or_id}':
+    delete:
+      description: Delete an SNI in a workspace
+      operationId: delete-sni-in-workspace
+      responses:
+        '204':
+          description: Successfully deleted SNI or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete an SNI in a workspace
+      tags:
+        - SNIs
+    get:
+      description: Get an SNI using ID or name in a workspace.
+      operationId: get-sni-in-workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/sni-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch an SNI in a workspace
+      tags:
+        - SNIs
+    patch:
+      description: Update an SNI in a workspace
+      operationId: update-sni-in-workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/sni-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid SNI
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update an SNI in a workspace
+      tags:
+        - SNIs
+      requestBody:
+        $ref: '#/components/requestBodies/create-sni'
+    put:
+      description: Create or Update SNI using ID or name in a workspace.
+      operationId: upsert-sni-in-workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/sni-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid SNI
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a SNI in a workspace
+      tags:
+        - SNIs
+      requestBody:
+        $ref: '#/components/requestBodies/create-sni'
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/sni_name_or_id'
+  '/{workspace}/upstreams':
+    get:
+      description: List all Upstreams in a workspace
+      operationId: list-upstream-in-workspace
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/Upstream'
+                    type: array
+                  offset:
+                    $ref: '#/components/schemas/pagination-offset-response'
+          description: A successful response listing Upstreams
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all Upstreams in a workspace
+      tags:
+        - Upstreams
+    post:
+      description: Create a new Upstream in a workspace
+      operationId: create-upstream-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upstream'
+          description: Successfully created Upstream
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Upstream
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new Upstream in a workspace
+      tags:
+        - Upstreams
+      requestBody:
+        $ref: '#/components/requestBodies/upstream-request'
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+  '/{workspace}/upstreams/{upstream_id_or_name}':
+    delete:
+      description: Delete an Upstream in a workspace
+      operationId: delete-upstream-in-workspace
+      responses:
+        '204':
+          description: Successfully deleted Upstream or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete an Upstream in a workspace
+      tags:
+        - Upstreams
+    get:
+      description: Get an Upstream using ID or name in a workspace.
+      operationId: get-upstream-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upstream'
+          description: Successfully fetched Upstream
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch an Upstream in a workspace
+      tags:
+        - Upstreams
+    patch:
+      description: Update an Upstream in a workspace
+      operationId: update-upstream-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upstream'
+          description: Successfully updated Upstream
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Upstream
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update an Upstream in a workspace
+      tags:
+        - Upstreams
+      requestBody:
+        $ref: '#/components/requestBodies/upstream-request'
+    put:
+      description: Create or Update Upstream using ID or name in a workspace.
+      operationId: upsert-upstream-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Upstream'
+          description: Successfully upserted Upstream
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Upstream
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a Upstream in a workspace
+      tags:
+        - Upstreams
+      requestBody:
+        $ref: '#/components/requestBodies/upstream-request'
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/upstream_id_or_name'
+  '/{workspace}/upstreams/{upstream_id_or_name}/targets':
+    get:
+      description: List all Targets associated with a an Upstream in a workspace
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Target'
+          description: A successful response listing Targets
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all Targets associated with an Upstream in a workspace
+      tags:
+        - Targets
+      operationId: list-targets-with-upstream-workspace
+    post:
+      description: Create a new Target associated with an Upstream in a workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Target'
+          description: Successfully created Target
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Target
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new Target associated with an Upstream in a workspace
+      tags:
+        - Targets
+      requestBody:
+        $ref: '#/components/requestBodies/target-request'
+      operationId: create-target-with-upstream-workspace
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/upstream_id_or_name'
+  '/{workspace}/upstreams/{upstream_id_or_name}/targets/{target_id_or_target}':
+    delete:
+      description: Delete a Target associated with a an Upstream using ID or target in a workspace.
+      responses:
+        '204':
+          description: Successfully deleted Target or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a Target associated with a an Upstream in a workspace
+      tags:
+        - Targets
+      operationId: delete-target-with-upstream-workspace
+    get:
+      description: Get a Target associated with an Upstream using ID or target in a workspace.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Target'
+          description: Successfully fetched Target
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch a Target associated with an Upstream in a workspace
+      tags:
+        - Targets
+      operationId: fetch-target-with-upstream-workspace
+    patch:
+      description: Update a Target associated with a an Upstream using ID or target in a workspace.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Target'
+          description: Successfully updated Target
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Target
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a Target associated with a an Upstream in a workspace
+      tags:
+        - Targets
+      requestBody:
+        $ref: '#/components/requestBodies/target-request'
+      operationId: update-target-with-upstream-workspace
+    put:
+      description: Create or Update a Target associated with an Upstream using ID or target in a workspace.
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Target'
+          description: Successfully upserted Target
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Target
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a Target associated with an Upstream in a workspace
+      tags:
+        - Targets
+      requestBody:
+        $ref: '#/components/requestBodies/target-request'
+      operationId: upsert-target-with-upstream-workspace
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/upstream_id_or_name'
+      - $ref: '#/components/parameters/target_id_or_target'
+  '/{workspace}/vaults':
+    get:
+      description: List all Vaults in a workspace
+      operationId: list-vault-in-workspace
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/Vault'
+                    type: array
+                  offset:
+                    $ref: '#/components/schemas/pagination-offset-response'
+          description: A successful response listing Vaults
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all Vaults in a workspace
+      tags:
+        - Vaults
+    post:
+      description: Create a new Vault in a workspace
+      operationId: create-vault-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vault'
+          description: Successfully created Vault
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Vault
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new Vault in a workspace
+      tags:
+        - Vaults
+      requestBody:
+        $ref: '#/components/requestBodies/vault-request'
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+  '/{workspace}/vaults/{vault_id_or_prefix}':
+    delete:
+      description: Delete a Vault in a workspace
+      operationId: delete-vault-in-workspace
+      responses:
+        '204':
+          description: Successfully deleted Vault or the resource didn't exist
+      summary: Delete a Vault in a workspace
+      tags:
+        - Vaults
+    get:
+      description: Get a Vault using ID or prefix in a workspace.
+      operationId: get-vault-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vault'
+          description: Successfully fetched Vault
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Fetch a Vault in a workspace
+      tags:
+        - Vaults
+    patch:
+      description: Update a Vault in a workspace
+      operationId: update-vault-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vault'
+          description: Successfully updated Vault
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Vault
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a Vault in a workspace
+      tags:
+        - Vaults
+      requestBody:
+        $ref: '#/components/requestBodies/vault-request'
+    put:
+      description: Create or Update Vault using ID or prefix in a workspace.
+      operationId: upsert-vault-in-workspace
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vault'
+          description: Successfully upserted Vault
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid Vault
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a Vault in a workspace
+      tags:
+        - Vaults
+      requestBody:
+        $ref: '#/components/requestBodies/vault-request'
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/vault_id_or_prefix'
+  /consumer_groups:
+    get:
+      summary: List consumer groups
+      tags:
+        - consumer_groups
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_group_response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-consumer_groups
+      description: |
+        List all consumer groups
+
+        Use consumer groups to manage consumer affiliation.
+    post:
+      summary: Create a consumer group
+      operationId: post-consumer_groups
+      responses:
+        '201':
+          $ref: '#/components/responses/consumer_group_response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: Create a new consumer group.
+      requestBody:
+        $ref: '#/components/requestBodies/consumer_group_request'
+      tags:
+        - consumer_groups
+  '/consumer_groups/{group_name_or_id}':
+    parameters:
+      - $ref: '#/components/parameters/group_name_or_id'
+    get:
+      summary: List a specific consumer group
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_group_response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-consumer_groups-group_name
+      description: Returns a consumer group by passing either the `group_name` or `group_id` as a path parameter.
+      tags:
+        - consumer_groups
+    put:
+      summary: Create consumer group
+      operationId: put-consumer_groups-group_name_or_id
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_group_response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: Create a consumer group by passing a new group name as the path parameter
+      requestBody:
+        $ref: '#/components/requestBodies/consumer_group_request'
+      tags:
+        - consumer_groups
+    delete:
+      summary: Delete a consumer group
+      operationId: delete-consumer_groups-group_name_or_id
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |
+        Delete a consumer group. Deleting a consumer group removes all consumers from that group. This operation does not delete existing consuemrs.
+      tags:
+        - consumer_groups
+  '/consumers/{consumer_username_or_id}/consumer_groups':
+    parameters:
+      - $ref: '#/components/parameters/Gatewayapi_Consumer_username_or_id'
+    get:
+      summary: List consumer groups for a consumer
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_group_response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-consumers-consumer_name_or_id-consumer_groups
+      description: |
+        View all consumer groups that a consumer is assigned to.
+      tags:
+        - consumer_groups
+      parameters:
+      - $ref: '#/components/parameters/pagination-offset'
+      - $ref: '#/components/parameters/pagination-size'
+    post:
+      summary: Add a consumer to a specific consumer group.
+      operationId: post-consumers-consumer_username_or_id-consumer_groups
+      responses:
+        '200':
+          $ref: '#/components/responses/add_consumer_to_group_response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |
+        Add a consumer to a specific consumer group.
+
+        If you add a consumer to multiple groups:
+
+        If all groups are allowed by the Rate Limiting Advanced plugin, only the first group's settings will apply.
+        Otherwise, whichever group is specified in the Rate Limiting Advanced plugin will be active.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                group:
+                  type: string
+                  description: |
+                    The name or ID of the group to add the consumer to.
+                  example: 288f2bfc-04e2-4ec3-b6f3-40408dff5417
+              required:
+                - group
+            examples:
+              Example request body:
+                value:
+                  group: 288f2bfc-04e2-4ec3-b6f3-40408dff5417
+        description: The request body contains the group ID for the group that you are adding a consumer into.
+      tags:
+        - consumer_groups
+    delete:
+      summary: Remove a consumer from all groups
+      operationId: delete-consumers-consumer_username_or_id-consumer_groups
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+      description: Remove a consumer from all groups.
+      tags:
+        - consumer_groups
+  '/consumer_groups/{group_name_or_id}/consumers':
+    parameters:
+      - $ref: '#/components/parameters/group_name_or_id'
+    get:
+      summary: List all consumers in a consumer group
+      tags:
+        - consumer_groups
+      operationId: get-consumer_groups-group_name_or_id-consumers
+      description: List all consumers in a consumer group
+      parameters:
+        - $ref: '#/components/parameters/Gatewayapi_Pagination-tags-filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+    post:
+      summary: Add a consumer to a group
+      operationId: post-consumer_groups-group_name_or_id-consumers
+      responses:
+        '200':
+          $ref: '#/components/responses/add_consumer_to_group_response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |-
+        Add a consumer to a specific consumer group.
+
+        If you add a consumer to multiple groups:
+
+        If all groups are allowed by the Rate Limiting Advanced plugin, only the first group's settings will apply.
+        Otherwise, whichever group is specified in the Rate Limiting Advanced plugin will be active.
+      tags:
+        - consumer_groups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                consumer:
+                  type: string
+                  description: |
+                    The name or ID of the consumer to add to this group.
+                  example: 8a4bba3c-7f82-45f0-8121-ed4d2847c4a4
+    delete:
+      summary: Remove all consumers from a consumer group
+      operationId: delete-consumer_groups-group_name_or_id-consumers
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: Removes all consumers from a specified consumer group.
+      tags:
+        - consumer_groups
+  '/consumers/{consumer_name_or_id}/consumer_groups/{group_name_or_id}':
+    parameters:
+      - $ref: '#/components/parameters/consumer_name_or_id'
+      - $ref: '#/components/parameters/group_name_or_id'
+    delete:
+      summary: Remove a consumer from a consumer group
+      operationId: delete-consumers-consumer_name_or_id-consumer_groups-group_name_or_id
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: Removes a consumer from a consumer group. This operation does not delete the consumer group.
+      tags:
+        - consumer_groups
+  '/consumer_groups/{group_name_or_id}/consumers/{consumer_username_or_id}':
+    parameters:
+      - $ref: '#/components/parameters/group_name_or_id'
+      - $ref: '#/components/parameters/consumer_username_or_id'
+    delete:
+      summary: Remove a consumer from a consumer group
+      operationId: delete-consumer_groups-group_name_or_id-consumers-consumer_name_or_id
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: The consumer groups endpoint for removing a consumer from a specified consumer group.
+      tags:
+        - consumer_groups
+  '/consumer_groups/{group_name_or_id}/overrides/plugins/rate-limiting-advanced':
+    parameters:
+      - $ref: '#/components/parameters/group_name_or_id'
+    put:
+      summary: Configure rate limiting for a consumer group.
+      operationId: put-consumer_groups-group_name_or_id-overrides-plugins-rate-limiting-advanced
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  Example 1:
+                    config:
+                      limit:
+                        - 10
+                      retry_after_jitter_max: 0
+                      window_size:
+                        - 10
+                      window_type: sliding
+                    group: test-group
+                    plugin: rate-limiting-advanced
+                properties:
+                  config:
+                    type: object
+                    properties:
+                      limit:
+                        type: array
+                        description: |
+                          An array of one or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified. 
+                        items:
+                          type: integer
+                          example: 10
+                      retry_after_jitter_max:
+                        type: integer
+                        description: |
+                          The upper bound of a jitter (random delay) in seconds to be added to the Retry-After header of denied requests (status = 429) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is 0; in this case, the Retry-After header is equal to the RateLimit-Reset header.
+                      window_size:
+                        type: array
+                        description: |
+                          An array of one or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified.
+                        items:
+                          type: integer
+                          example: 10
+                      window_type:
+                        type: string
+                        description: |
+                          Set the time window type to either sliding (default) or fixed.
+                        example: sliding
+                  group:
+                    type: string
+                    description: The consumer group
+                    example: test-group
+                  plugin:
+                    type: string
+                    description: The name of the plugin
+                    example: rate-limiting-advanced
+              examples:
+                'Example ':
+                  value:
+                    config:
+                      limit:
+                        - 10
+                      retry_after_jitter_max: 0
+                      window_size:
+                        - 10
+                      window_type: sliding
+                    group: test-group
+                    plugin: rate-limiting-advanced
+      description: |
+        Define custom rate limiting settings for a consumer group. This endpoint overrides the settings of the Rate Limiting Advanced plugin. As of Kong Gateway 3.4, you can scope plugins to consumer groups using only the `/consumer_groups` endpoint. Using `overrides` is deprecated, and no longer recommended.
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                config.limit:
+                  type: string
+                  description: |
+                    An array of one or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified.
+                config.window_size:
+                  type: string
+                  description: |
+                    An array of one or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified.
+                  example: ' 10'
+                config.window_type:
+                  type: string
+                  description: |
+                    Set the time window type to either sliding (default) or fixed.
+                  default: sliding
+                  enum:
+                    - sliding
+                    - fixed
+                config.retry_after_jitter_max:
+                  type: string
+                  description: The upper bound of a jitter (random delay) in seconds to be added to the Retry-After header of denied requests (status = 429) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is 0; in this case, the Retry-After header is equal to the RateLimit-Reset header.
+              required:
+                - config.limit
+                - config.window_size
+            examples:
+              Request body:
+                value:
+                  config.limit: string
+                  config.window_size: ' 10'
+                  config.window_type: sliding
+                  config.retry_after_jitter_max: string
+        description: |
+          Request Body
+      tags:
+        - consumer_groups
+    delete:
+      summary: Delete the configurations for a consumer group
+      operationId: delete-consumer_groups-group_name_or_id-overrides-plugins-rate-limiting-advanced
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |
+        Delete custom rate limiting settings for a consumer group. As of Kong Gateway 3.4, you can scope plugins to consumer groups using only the `/consumer_groups` endpoint. Using `overrides` is deprecated, and no longer recommended.
+      tags:
+        - consumer_groups
+  '/consumer_groups/{consumer_username_or_id}/plugins':
+    get:
+      description: Retrieve a list of all plugins associated with a consumer group.
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/Plugin'
+                    type: array
+                  offset:
+                    $ref: '#/components/schemas/pagination-offset-response'
+          description: A successful response listing plugins
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all plugins associated with a consumer group
+      tags:
+        - Plugins
+      operationId: list-plugins-consumer-group
+    post:
+      description: Create a new plugin associated with a Consumer Group
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Plugin'
+          description: Successfully created plugin
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new plugin associated with a consumer group
+      tags:
+        - Plugins
+      operationId: create-plugin-for-consumer-group
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+    parameters:
+      - $ref: '#/components/parameters/consumer_username_or_id'
+  '/consumer_groups/{consumer_group_name_or_id}/plugins/{plugin_id}':
+    delete:
+      description: Delete a plugin associated with a a consumer group using ID.
+      responses:
+        '204':
+          description: Successfully deleted plugin or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a plugin associated with a consumer group
+      tags:
+        - Plugins
+      operationId: delete-plugin-for-consumer-group
+    get:
+      description: Get a plugin associated with a Consumer Group using ID.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  Example 1:
+                    message: Not found
+                properties:
+                  message:
+                    type: string
+                    example: Not Found
+                    description: 404 Not Found
+              examples:
+                Not Found:
+                  value:
+                    message: Not Found
+      summary: Fetch a plugin associated with a Consumer Group
+      tags:
+        - Plugins
+      operationId: fetch-plugin-with-consumer-group
+    patch:
+      description: Update a plugin associated with a consumer group using the consumergroup name or ID.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a plugin associated with a consumer group
+      tags:
+        - Plugins
+      operationId: update-plugin-with-consumer-group
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+    put:
+      description: Create or Update a plugin associated with a Consumer Group using ID.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a plugin associated with a Consumer Group
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+      operationId: upsert-plugin-for-customer-group
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/consumer_group_name_or_id'
+      - $ref: '#/components/parameters/plugin_id'
+  '/{workspace}/consumer_groups':
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+    get:
+      summary: List consumer groups
+      tags:
+        - consumer_groups
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_group_response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-consumer_groups_with_workspace
+      description: |
+        List all consumer groups
+
+        Use consumer groups to manage consumer affiliation.
+    post:
+      summary: Create a consumer group
+      operationId: post-consumer_groups_with_workspace
+      responses:
+        '201':
+          $ref: '#/components/responses/consumer_group_response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: Create a new consumer group.
+      requestBody:
+        $ref: '#/components/requestBodies/consumer_group_request'
+      tags:
+        - consumer_groups
+  '/{workspace}/consumer_groups/{group_name_or_id}':
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/group_name_or_id'
+    get:
+      summary: List a specific consumer group
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_group_response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-consumer_groups-group_name_with_workspace
+      description: Returns a consumer group by passing either the `group_name` or `group_id` as a path parameter.
+      tags:
+        - consumer_groups
+    put:
+      summary: Create consumer group
+      operationId: put-consumer_groups-group_name_or_id_with_workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_group_response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: Create a consumer group by passing a new group name as the path parameter
+      requestBody:
+        $ref: '#/components/requestBodies/consumer_group_request'
+      tags:
+        - consumer_groups
+    delete:
+      summary: Delete a consumer group
+      operationId: delete-consumer_groups-group_name_or_id_with_workspace
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |
+        Delete a consumer group. Deleting a consumer group removes all consumers from that group. This operation does not delete existing consuemrs.
+      tags:
+        - consumer_groups
+  '/{workspace}/consumers/{consumer_username_or_id}/consumer_groups':
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/Gatewayapi_Consumer_username_or_id'
+    get:
+      summary: List consumer groups for a consumer
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_group_response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-consumers-consumer_name_or_id-consumer_groups_with_workspace
+      description: |
+        View all consumer groups that a consumer is assigned to.
+      tags:
+        - consumer_groups
+      parameters:
+      - $ref: '#/components/parameters/pagination-offset'
+      - $ref: '#/components/parameters/pagination-size'
+    post:
+      summary: Add a consumer to a specific consumer group.
+      operationId: post-consumers-consumer_username_or_id-consumer_groups_with_workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/add_consumer_to_group_response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |
+        Add a consumer to a specific consumer group.
+
+        If you add a consumer to multiple groups:
+
+        If all groups are allowed by the Rate Limiting Advanced plugin, only the first group's settings will apply.
+        Otherwise, whichever group is specified in the Rate Limiting Advanced plugin will be active.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                group:
+                  type: string
+                  description: |
+                    The name or ID of the group to add the consumer to.
+                  example: 288f2bfc-04e2-4ec3-b6f3-40408dff5417
+              required:
+                - group
+            examples:
+              Example request body:
+                value:
+                  group: 288f2bfc-04e2-4ec3-b6f3-40408dff5417
+        description: The request body contains the group ID for the group that you are adding a consumer into.
+      tags:
+        - consumer_groups
+    delete:
+      summary: Remove a consumer from all groups
+      operationId: delete-consumers-consumer_username_or_id-consumer_groups_with_workspace
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+      description: Remove a consumer from all groups.
+      tags:
+        - consumer_groups
+  '/{workspace}/consumer_groups/{group_name_or_id}/consumers':
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/group_name_or_id'
+    get:
+      summary: List all consumers in a consumer group
+      tags:
+        - consumer_groups
+      operationId: get-consumer_groups-group_name_or_id-consumers_with_workspace
+      description: List all consumers in a consumer group
+      parameters:
+        - $ref: '#/components/parameters/Gatewayapi_Pagination-tags-filter'
+      responses:
+        '200':
+          $ref: '#/components/responses/consumer_response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+    post:
+      summary: Add a consumer to a group
+      operationId: post-consumer_groups-group_name_or_id-consumers_with_workspace
+      responses:
+        '200':
+          $ref: '#/components/responses/add_consumer_to_group_response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |-
+        Add a consumer to a specific consumer group.
+
+        If you add a consumer to multiple groups:
+
+        If all groups are allowed by the Rate Limiting Advanced plugin, only the first group's settings will apply.
+        Otherwise, whichever group is specified in the Rate Limiting Advanced plugin will be active.
+      tags:
+        - consumer_groups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                consumer:
+                  type: string
+                  description: |
+                    The name or ID of the consumer to add to this group.
+                  example: 8a4bba3c-7f82-45f0-8121-ed4d2847c4a4
+    delete:
+      summary: Remove all consumers from a consumer group
+      operationId: delete-consumer_groups-group_name_or_id-consumers_with_workspace
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: Removes all consumers from a specified consumer group.
+      tags:
+        - consumer_groups
+  '/{workspace}/consumers/{consumer_name_or_id}/consumer_groups/{group_name_or_id}':
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/consumer_name_or_id'
+      - $ref: '#/components/parameters/group_name_or_id'
+    delete:
+      summary: Remove a consumer from a consumer group
+      operationId: delete-consumers-consumer_name_or_id-consumer_groups-group_name_or_id_with_workspace
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: Removes a consumer from a consumer group. This operation does not delete the consumer group.
+      tags:
+        - consumer_groups
+  '/{workspace}/consumer_groups/{group_name_or_id}/consumers/{consumer_username_or_id}':
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/group_name_or_id'
+      - $ref: '#/components/parameters/consumer_username_or_id'
+    delete:
+      summary: Remove a consumer from a consumer group
+      operationId: delete-consumer_groups-group_name_or_id-consumers-consumer_name_or_id_with_workspace
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: The consumer groups endpoint for removing a consumer from a specified consumer group.
+      tags:
+        - consumer_groups
+  '/{workspace}/consumer_groups/{group_name_or_id}/overrides/plugins/rate-limiting-advanced':
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/group_name_or_id'
+    put:
+      summary: Configure rate limiting for a consumer group.
+      operationId: put-consumer_groups-group_name_or_id-overrides-plugins-rate-limiting-advanced_with_workspace
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  Example 1:
+                    config:
+                      limit:
+                        - 10
+                      retry_after_jitter_max: 0
+                      window_size:
+                        - 10
+                      window_type: sliding
+                    group: test-group
+                    plugin: rate-limiting-advanced
+                properties:
+                  config:
+                    type: object
+                    properties:
+                      limit:
+                        type: array
+                        description: |
+                          An array of one or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified. 
+                        items:
+                          type: integer
+                          example: 10
+                      retry_after_jitter_max:
+                        type: integer
+                        description: |
+                          The upper bound of a jitter (random delay) in seconds to be added to the Retry-After header of denied requests (status = 429) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is 0; in this case, the Retry-After header is equal to the RateLimit-Reset header.
+                      window_size:
+                        type: array
+                        description: |
+                          An array of one or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified.
+                        items:
+                          type: integer
+                          example: 10
+                      window_type:
+                        type: string
+                        description: |
+                          Set the time window type to either sliding (default) or fixed.
+                        example: sliding
+                  group:
+                    type: string
+                    description: The consumer group
+                    example: test-group
+                  plugin:
+                    type: string
+                    description: The name of the plugin
+                    example: rate-limiting-advanced
+              examples:
+                'Example ':
+                  value:
+                    config:
+                      limit:
+                        - 10
+                      retry_after_jitter_max: 0
+                      window_size:
+                        - 10
+                      window_type: sliding
+                    group: test-group
+                    plugin: rate-limiting-advanced
+      description: |
+        Define custom rate limiting settings for a consumer group. This endpoint overrides the settings of the Rate Limiting Advanced plugin. As of Kong Gateway 3.4, you can scope plugins to consumer groups using only the `/consumer_groups` endpoint. Using `overrides` is deprecated, and no longer recommended.
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                config.limit:
+                  type: string
+                  description: |
+                    An array of one or more requests-per-window limits to apply. There must be a matching number of window limits and sizes specified.
+                config.window_size:
+                  type: string
+                  description: |
+                    An array of one or more window sizes to apply a limit to (defined in seconds). There must be a matching number of window limits and sizes specified.
+                  example: ' 10'
+                config.window_type:
+                  type: string
+                  description: |
+                    Set the time window type to either sliding (default) or fixed.
+                  default: sliding
+                  enum:
+                    - sliding
+                    - fixed
+                config.retry_after_jitter_max:
+                  type: string
+                  description: The upper bound of a jitter (random delay) in seconds to be added to the Retry-After header of denied requests (status = 429) in order to prevent all the clients from coming back at the same time. The lower bound of the jitter is 0; in this case, the Retry-After header is equal to the RateLimit-Reset header.
+              required:
+                - config.limit
+                - config.window_size
+            examples:
+              Request body:
+                value:
+                  config.limit: string
+                  config.window_size: ' 10'
+                  config.window_type: sliding
+                  config.retry_after_jitter_max: string
+        description: |
+          Request Body
+      tags:
+        - consumer_groups
+    delete:
+      summary: Delete the configurations for a consumer group
+      operationId: delete-consumer_groups-group_name_or_id-overrides-plugins-rate-limiting-advanced_with_workspace
+      responses:
+        '204':
+          description: |
+            HTTP/1.1 204 No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |
+        Delete custom rate limiting settings for a consumer group. As of Kong Gateway 3.4, you can scope plugins to consumer groups using only the `/consumer_groups` endpoint. Using `overrides` is deprecated, and no longer recommended.
+      tags:
+        - consumer_groups
+  '/{workspace}/consumer_groups/{consumer_username_or_id}/plugins':
+    get:
+      description: Retrieve a list of all plugins associated with a consumer group.
+      parameters:
+        - $ref: '#/components/parameters/pagination-size'
+        - $ref: '#/components/parameters/pagination-offset'
+        - $ref: '#/components/parameters/pagination-tags-filter'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  data:
+                    items:
+                      $ref: '#/components/schemas/Plugin'
+                    type: array
+                  offset:
+                    $ref: '#/components/schemas/pagination-offset-response'
+          description: A successful response listing plugins
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: List all plugins associated with a consumer group
+      tags:
+        - Plugins
+      operationId: list-plugins-consumer-group_with_workspace
+    post:
+      description: Create a new plugin associated with a Consumer Group
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Plugin'
+          description: Successfully created plugin
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Create a new plugin associated with a consumer group
+      tags:
+        - Plugins
+      operationId: create-plugin-for-consumer-group_with_workspace
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/consumer_username_or_id'
+  '/{workspace}/consumer_groups/{consumer_group_name_or_id}/plugins/{plugin_id}':
+    delete:
+      description: Delete a plugin associated with a a consumer group using ID.
+      responses:
+        '204':
+          description: Successfully deleted plugin or the resource didn't exist
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Delete a plugin associated with a consumer group
+      tags:
+        - Plugins
+      operationId: delete-plugin-for-consumer-group_with_workspace
+    get:
+      description: Get a plugin associated with a Consumer Group using ID.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  Example 1:
+                    message: Not found
+                properties:
+                  message:
+                    type: string
+                    example: Not Found
+                    description: 404 Not Found
+              examples:
+                Not Found:
+                  value:
+                    message: Not Found
+      summary: Fetch a plugin associated with a Consumer Group
+      tags:
+        - Plugins
+      operationId: fetch-plugin-with-consumer-group_with_workspace
+    patch:
+      description: Update a plugin associated with a consumer group using the consumergroup name or ID.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: Resource does not exist
+      summary: Update a plugin associated with a consumer group
+      tags:
+        - Plugins
+      operationId: update-plugin-with-consumer-group_with_workspace
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+    put:
+      description: Create or Update a plugin associated with a Consumer Group using ID.
+      responses:
+        '200':
+          $ref: '#/components/responses/plugin-response'
+        '400':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: Invalid plugin
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      summary: Upsert a plugin associated with a Consumer Group
+      tags:
+        - Plugins
+      requestBody:
+        $ref: '#/components/requestBodies/plugin-request'
+      operationId: upsert-plugin-for-customer-group_with_workspace
+    parameters:
+      - $ref: '#/components/parameters/workspace'
+      - $ref: '#/components/parameters/consumer_group_name_or_id'
+      - $ref: '#/components/parameters/plugin_id'
+  /licenses:
+    get:
+      summary: List licenses
+      tags:
+        - licenses
+      responses:
+        '200':
+          $ref: '#/components/responses/license-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-licenses
+      description: |
+        List active licenses. The data planes use the most recent updated_at license.
+    post:
+      summary: Add a license
+      operationId: post-licenses
+      responses:
+        '201':
+          $ref: '#/components/responses/license-response'
+        '400':
+          description: Bad Request
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |-
+        Create a license using an auto-generated UUID. When using `POST`, if the request payload does contain a valid Kong Gateway license, the license will be added.
+
+        If the request payload does not contain a valid licence, a `400 BAD REQUEST` will be returned.
+      requestBody:
+        $ref: '#/components/requestBodies/license-request'
+      tags:
+        - licenses
+  '/licenses/{license-id}':
+    parameters:
+      - $ref: '#/components/parameters/license-id'
+    get:
+      summary: List a specific license
+      responses:
+        '200':
+          $ref: '#/components/responses/license-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-licenses-license-id
+      description: List a specific license using the license id parameter.
+      tags:
+        - licenses
+    put:
+      summary: Update or add a license
+      operationId: put-licenses-license-id
+      responses:
+        '200':
+          $ref: '#/components/responses/license-response'
+        '400':
+          description: Bad Request
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '405':
+          description: Method Not Allowed
+      description: |-
+        When using `PUT`, if the request payload does not contain an entity's primary key (`id` for licenses), the license will be added and assigned the given ID.
+
+        If the request payload does contain an entity's primary key (id for Licenses), the license will be replaced with the given payload attribute. If the ID is not a valid UUID, a `400 BAD REQUEST` will be returned. If the ID is omitted, a `405 NOT ALLOWED` will be returned.
+      requestBody:
+        $ref: '#/components/requestBodies/license-request'
+      tags:
+        - licenses
+    patch:
+      summary: Update a license
+      operationId: patch-licenses-license-id
+      responses:
+        '200':
+          $ref: '#/components/responses/license-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |-
+        When using `PATCH`, if the request payload does contain an entity's primary key (`id` for licenses), the license will be replaced with the given payload attribute.
+
+        If the request payload does not contain an entity's primary key (`id` for licenses), a `404 NOT FOUND `will be returned or if the request payload contains a invalid licence, a `400 BAD REQUEST` will be returned.
+      requestBody:
+        $ref: '#/components/requestBodies/license-request'
+      tags:
+        - licenses
+    delete:
+      summary: Delete a license
+      operationId: delete-licenses-license-id
+      responses:
+        '204':
+          description: No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: Delete a license by passing the license ID as a path parameter.
+      tags:
+        - licenses
+  /license/report:
+    get:
+      summary: Generate a report
+      tags:
+        - licenses
+      responses:
+        '200':
+          $ref: '#/components/responses/report-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-license-report
+      description: |
+            Generate a report on the Kong Gateway instance to gather monthly usage data.
+  /keyring:
+    get:
+      summary: Fetch cluster Keyring
+      tags:
+        - Keyring
+      responses:
+        '200':
+          $ref: '#/components/responses/key-ring-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-keyring
+      description: Kong Gateway provides a mechanism to store sensitive data fields, such as consumer secrets, in an encrypted format within the database.This provides for encryption-at-rest security controls in a Kong cluster. For more information review the [keyring and data encryption documentation](https://docs.konghq.com/gateway/latest/kong-enterprise/db-encryption/#getting-started).
+  /endpoints:
+    get:
+      summary: List all endpoints
+      tags:
+        - Information
+      responses:
+        '200':
+          $ref: '#/components/responses/get-endpoints'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-endpoints
+      description: List all available endpoints provided by the Admin API.
+  '/{endpoint}':
+    parameters:
+      - schema:
+          type: string
+          example: key
+        name: endpoint
+        in: path
+        required: true
+        description: Any available endpoint
+    head:
+      summary: Check endpoint or entity existence
+      operationId: head-endpoints
+      responses:
+        '204':
+          description: No Content
+          headers:
+            Date:
+              description: The date and time at which the message was originated
+              schema:
+                type: string
+              example: 'Fri, 14 Apr 2023 17:38:29 GMT'
+            Content-Type:
+              description: The media type of the message content
+              schema:
+                type: string
+                example: text/html; charset=UTF-8
+            Connection:
+              description: Indicates whether the connection will be closed after the message is completed
+              schema:
+                type: string
+                enum:
+                  - keep-alive
+                  - close
+              example: keep-alive
+            Access-Control-Allow-Origin:
+              description: Indicates whether the resource can be accessed by any origin
+              schema:
+                type: string
+                example: '*'
+            X-Kong-Admin-Request-ID:
+              description: A unique identifier for the request, generated by Kong
+              schema:
+                type: string
+                example: aqETeVmkeiGnAMzdUT2JRWroB2myY1lB
+            X-Kong-Admin-Latency:
+              description: The time taken to process the request on the server, in milliseconds
+              schema:
+                type: integer
+                example: 5
+            Server:
+              description: The software used by the origin server to handle the request
+              schema:
+                type: string
+                example: kong/3.2.2.0-enterprise-edition
+        '404':
+          description: Endpoint does not exist
+          headers: {}
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |
+        Similar to `HTTP` GET, but does not return the body. Returns HTTP 200 when the endpoint exits or HTTP 404 when it does not. Other status codes are possible.
+      tags:
+        - Information
+    options:
+      summary: List method by endpoint
+      operationId: options-endpoint
+      responses:
+        '204':
+          description: No Content
+          headers:
+            Date:
+              description: The date and time at which the message was originated
+              schema:
+                type: string
+              example: 'Fri, 14 Apr 2023 17:24:17 GMT'
+            Connection:
+              description: Indicates whether the connection will be closed after the message is completed
+              schema:
+                type: string
+                enum:
+                  - keep-alive
+                  - close
+              example: keep-alive
+            Access-Control-Allow-Origin:
+              description: Indicates whether the resource can be accessed by any origin
+              schema:
+                type: string
+                example: '*'
+            Access-Control-Allow-Headers:
+              description: Used in response to a preflight request to indicate which HTTP headers can be used during the actual request
+              schema:
+                type: string
+                example: 'Content-Type, Kong-Admin-Token, Kong-Request-Type, Cache-Control'
+            X-Kong-Admin-Request-ID:
+              description: A unique identifier for the request, generated by Kong
+              schema:
+                type: string
+                example: gDP1cF3OsNbrgcKPhRNE0RXRNfS7NcoG
+            Allow:
+              description: Lists the HTTP methods that are supported for the resource
+              schema:
+                type: string
+                example: 'OPTIONS, PATCH, POST'
+            Access-Control-Allow-Methods:
+              description: Indicates the methods allowed when accessing the resource in response to a preflight request
+              schema:
+                type: string
+                example: 'OPTIONS, PATCH, POST'
+            X-Kong-Admin-Latency:
+              description: The time taken to process the request on the server, in milliseconds
+              schema:
+                type: integer
+                example: 5
+            Server:
+              description: The software used by the origin server to handle the request
+              schema:
+                type: string
+                example: kong/3.2.2.0-enterprise-edition
+        '400':
+          description: Bad Request
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |
+        List all the supported HTTP methods by an endpoint. This can also be used with a CORS preflight request.
+      tags:
+        - Information
+  '/schemas/{entity}/validate':
+    parameters:
+      - schema:
+          type: string
+        name: entity
+        in: path
+        required: true
+    get:
+      summary: Retrieve entity schema
+      tags:
+        - Information
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  Example 1:
+                    fields:
+                      - id:
+                          auto: true
+                          type: string
+                          uuid: true
+                properties:
+                  fields:
+                    type: array
+                    description: A value of a schema
+                    items:
+                      type: object
+                      properties:
+                        id:
+                          type: object
+                          description: A value of a schema
+                          properties:
+                            auto:
+                              type: boolean
+                              description: A value of a schema
+                            type:
+                              type: string
+                              description: A value of a schema
+                            uuid:
+                              type: boolean
+                              description: A value of a schema
+              examples:
+                A mock schema:
+                  value:
+                    fields:
+                      - id:
+                          auto: true
+                          type: string
+                          uuid: true
+                      - created_at:
+                          auto: true
+                          timestamp: true
+                          type: integer
+      operationId: get-schemas-entity
+      description: Retrieve the schema of an entity. This is useful to understand what fields an entity accepts, and can be used for building third-party integrations with Kong.
+    post:
+      summary: Validate a configuration against a schema
+      operationId: post-schemas-entity-validate
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  Message:
+                    type: string
+                    example: schema validation successful
+                    description: A success message
+              examples:
+                schema validation successful:
+                  value:
+                    Message: schema validation successful
+      description: |-
+        Check validity of a configuration against its entity schema. This allows you to test your input before submitting a request to the entity endpoints of the Admin API.
+
+        A requests to the entity endpoint using the given configuration may still fail due to other reasons, such as invalid foreign key relationships or uniqueness check failures against the contents of the data store.
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      tags:
+        - Information
+  
+  '/schemas/plugins/{plugin_name}':
+    parameters:
+      - schema:
+          type: string
+          example: basic-auth
+        name: plugin_name
+        in: path
+        required: true
+        description: The name of a Kong plugin
+    get:
+      summary: Retrieve Plugin Schema
+      tags:
+        - Information
+      responses:
+        '200':
+          description: OK
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-schemas-plugins-plugin_name
+      description: |
+        Retrieve the schema of a plugin's configuration. This is useful to understand what fields a plugin accepts, and can be used for building third-party integrations to the Kong's plugin system.
+  /schemas/plugins/validate:
+    post:
+      summary: Validate plugin schema
+      operationId: post-schemas-plugins-validate
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  Example 1:
+                    message: schema validation successful
+                properties:
+                  message:
+                    type: string
+                    description: A successful message
+                    example: schema validation successful
+              examples:
+                schema validation successful:
+                  value:
+                    message: schema validation successful
+      description: |-
+        Check validity of a plugin configuration against the plugins entity schema. This allows you to test your input before submitting a request to the entity endpoints of the Admin API.
+
+
+        This only performs the schema validation checks, checking that the input configuration is well-formed. A requests to the entity endpoint using the given configuration may still fail due to other reasons, such as invalid foreign key relationships or uniqueness check failures against the contents of the data store
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      tags:
+        - Information
+  /timers:
+    get:
+      summary: Retrieve Runtime Debugging Info of Kong's Timers
+      tags:
+        - Information
+      responses:
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  Example 1:
+                    stats:
+                      sys:
+                        total: 13
+                        waiting: 12
+                        runs: 6771
+                        pending: 0
+                        running: 1
+                      flamegraph:
+                        pending: ''
+                        running: ''
+                        elapsed_time: ''
+                      timers:
+                        router-rebuild:
+                          is_running: false
+                          name: router-rebuild
+                          stats:
+                            runs: 464
+                            elapsed_time:
+                              avg: 0
+                              min: 9999999
+                              max: -1
+                              variance: 0
+                            finish: 464
+                            last_err_msg: ''
+                          meta:
+                            callstack: debug off
+                            name: debug off
+                        'unix_timestamp=1681492692484.000000;counter=7:meta=debug off':
+                          is_running: false
+                          name: 'unix_timestamp=1681492692484.000000;counter=7:meta=debug off'
+                          stats:
+                            runs: 3
+                            elapsed_time:
+                              avg: 0
+                              min: 9999999
+                              max: -1
+                              variance: 0
+                            finish: 3
+                            last_err_msg: ''
+                          meta:
+                            callstack: debug off
+                            name: debug off
+                    worker:
+                      id: 0
+                      count: 5
+                properties:
+                  stats:
+                    type: object
+                    description: Statistics about the worker
+                    properties:
+                      sys:
+                        type: object
+                        description: List of the number of different type of timers
+                        properties:
+                          total:
+                            description: The total number of timers (running + pending + waiting)
+                            type: integer
+                            default: 7
+                            example: 7
+                          waiting:
+                            description: The number of unexpired timers
+                            type: integer
+                            default: 7
+                            example: 7
+                          runs:
+                            description: The total number of runs for the timers
+                            type: integer
+                            default: 7
+                            example: 7
+                          pending:
+                            description: The number of pending timers
+                            type: integer
+                            default: 0
+                            example: 0
+                          running:
+                            description: The number of running timers
+                            type: integer
+                            default: 0
+                            example: 0
+                      flamegraph:
+                        type: object
+                        description: String-encoded timer-related flamegraph data
+                        properties:
+                          pending:
+                            description: The number of pending timers for the flamegraph
+                            type: string
+                            example: |
+                              @./kong/init.lua:706:init_worker();@./kong/runloop/handler.lua:1086:before() 0
+                          running:
+                            description: The number of running timers for the flamegraph
+                            type: string
+                            example: |
+                              @./kong/init.lua:706:init_worker();@./kong/runloop/handler.lua:1086:before() 0
+                          elapsed_time:
+                            description: The elapsed time for the flamegraph
+                            type: string
+                            example: |
+                              @./kong/init.lua:706:init_worker();@./kong/runloop/handler.lua:1086:before() 17
+                      timers:
+                        description: Timer statistics for the worker
+                        type: object
+                        properties:
+                          meta:
+                            description: Program callstack of created timers
+                            type: object
+                            properties:
+                              name:
+                                description: The name of the timer's metadata
+                                type: string
+                                example: '@/build/luarocks/share/lua/5.1/resty/counter.lua:71:new()'
+                  worker:
+                    type: object
+                    properties:
+                      id:
+                        type: integer
+                        description: The ordinal number of the current Nginx worker processes (starting from number 0).
+                      count:
+                        type: integer
+                        description: The total number of the Nginx worker processes.
+      operationId: get-timers
+      description: Retrieve runtime stats data from [lua-resty-timer-ng](https://github.com/Kong/lua-resty-timer-ng).
+    
+  /status:
+    get:
+      summary: Health Routes
+      tags:
+        - Information
+      responses:
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  Example 1:
+                    memory:
+                      lua_shared_dicts:
+                        kong_core_db_cache:
+                          capacity: 128.00 MiB
+                          allocated_slabs: 0.76 MiB
+                        kong_core_db_cache_miss:
+                          capacity: 12.00 MiB
+                          allocated_slabs: 0.08 MiB
+                        kong_db_cache:
+                          capacity: 128.00 MiB
+                          allocated_slabs: 0.78 MiB
+                        kong_db_cache_miss:
+                          capacity: 12.00 MiB
+                          allocated_slabs: 0.08 MiB
+                        kong_vitals_counters:
+                          capacity: 50.00 MiB
+                          allocated_slabs: 0.30 MiB
+                        kong_vitals_lists:
+                          capacity: 1.00 MiB
+                          allocated_slabs: 0.02 MiB
+                        kong_vitals:
+                          capacity: 1.00 MiB
+                          allocated_slabs: 0.02 MiB
+                        kong_counters:
+                          capacity: 1.00 MiB
+                          allocated_slabs: 0.02 MiB
+                        kong_reports_consumers:
+                          capacity: 10.00 MiB
+                          allocated_slabs: 0.07 MiB
+                        kong_reports_routes:
+                          capacity: 1.00 MiB
+                          allocated_slabs: 0.02 MiB
+                        kong_reports_services:
+                          capacity: 1.00 MiB
+                          allocated_slabs: 0.02 MiB
+                        kong_reports_workspaces:
+                          capacity: 1.00 MiB
+                          allocated_slabs: 0.02 MiB
+                        kong_keyring:
+                          capacity: 5.00 MiB
+                          allocated_slabs: 0.04 MiB
+                        kong_profiling_state:
+                          capacity: 1.50 MiB
+                          allocated_slabs: 0.02 MiB
+                        prometheus_metrics:
+                          capacity: 5.00 MiB
+                          allocated_slabs: 0.04 MiB
+                        kong:
+                          capacity: 5.00 MiB
+                          allocated_slabs: 0.04 MiB
+                        kong_locks:
+                          capacity: 8.00 MiB
+                          allocated_slabs: 0.06 MiB
+                        kong_healthchecks:
+                          capacity: 5.00 MiB
+                          allocated_slabs: 0.04 MiB
+                        kong_process_events:
+                          capacity: 5.00 MiB
+                          allocated_slabs: 0.04 MiB
+                        kong_cluster_events:
+                          capacity: 5.00 MiB
+                          allocated_slabs: 0.04 MiB
+                        kong_rate_limiting_counters:
+                          capacity: 12.00 MiB
+                          allocated_slabs: 0.08 MiB
+                      workers_lua_vms:
+                        - http_allocated_gc: 51.92 MiB
+                          pid: 2323
+                        - http_allocated_gc: 51.48 MiB
+                          pid: 2324
+                        - http_allocated_gc: 51.48 MiB
+                          pid: 2325
+                        - http_allocated_gc: 51.48 MiB
+                          pid: 2326
+                        - http_allocated_gc: 51.48 MiB
+                          pid: 2327
+                    database:
+                      reachable: true
+                    server:
+                      connections_reading: 0
+                      connections_writing: 6
+                      total_requests: 28
+                      connections_waiting: 0
+                      connections_handled: 15
+                      connections_active: 6
+                      connections_accepted: 15
+                properties:
+                  memory:
+                    type: object
+                    description: Metrics about the memory usage.
+                    properties:
+                      lua_shared_dicts:
+                        type: object
+                        description: An array of dictionary objects that are shared with all workers in a Kong node, where each array node contains how much memory is dedicated for the specific shared dictionary (`capacity`) and how much of said memory is in use (`allocated_slabs`).
+                        properties:
+                          kong_core_db_cache:
+                            type: object
+                            properties:
+                              capacity:
+                                type: string
+                                example: 128.00 MiB
+                                description: Memory capacity
+                              allocated_slabs:
+                                type: string
+                                example: 128.00 MiB
+                                description: Total allocated memory
+                      workers_lua_vms:
+                        type: array
+                        description: An array with all workers of the Kong node, each entry contains a `http_allocated_gc` string and a `pid`.
+                        items:
+                          type: object
+                          properties:
+                            http_allocated_gc:
+                              type: string
+                              description: |
+                                HTTP submodule's Lua virtual machine's memory usage information.
+                            pid:
+                              type: integer
+                              description: A worker's process identification number.
+                              example: 18478
+                  database:
+                    type: object
+                    description: Metrics about the database
+                    properties:
+                      reachable:
+                        type: boolean
+                        description: A boolean value reflecting the state of the database connection. Please note that this flag does not reflect the health of the database itself.
+                  server:
+                    type: object
+                    description: Metrics about the nginx HTTP/S server
+                    properties:
+                      connections_reading:
+                        type: integer
+                        description: The current number of connections where Kong is reading the request header.
+                        example: 3
+                      connections_writing:
+                        type: integer
+                        description: The current number of connections where nginx is writing the response back to the client.
+                        example: 1
+                      total_requests:
+                        type: integer
+                        description: The total number of client requests.
+                        example: 1
+                      connections_waiting:
+                        type: integer
+                        description: The current number of idle client connections waiting for a request.
+                        example: 1
+                      connections_handled:
+                        type: integer
+                        description: The total number of handled connections. Generally, the parameter value is the same as the `connections_accepted` parameter unless some resource limits have been reached.
+                        example: 1
+                      connections_active:
+                        type: integer
+                        description: The current number of active client connections including waiting connections.
+                        example: 1
+                      connections_accepted:
+                        type: integer
+                        description: The total number of accepted client connections.
+                        example: 1
+              examples:
+                Status endpoint response:
+                  value:
+                    memory:
+                      lua_shared_dicts:
+                        kong_core_db_cache:
+                          capacity: 128.00 MiB
+                          allocated_slabs: 0.76 MiB
+                        kong_core_db_cache_miss:
+                          capacity: 12.00 MiB
+                          allocated_slabs: 0.08 MiB
+                        kong_db_cache:
+                          capacity: 128.00 MiB
+                          allocated_slabs: 0.78 MiB
+                        kong_db_cache_miss:
+                          capacity: 12.00 MiB
+                          allocated_slabs: 0.08 MiB
+                        kong_vitals_counters:
+                          capacity: 50.00 MiB
+                          allocated_slabs: 0.30 MiB
+                        kong_vitals_lists:
+                          capacity: 1.00 MiB
+                          allocated_slabs: 0.02 MiB
+                        kong_vitals:
+                          capacity: 1.00 MiB
+                          allocated_slabs: 0.02 MiB
+                        kong_counters:
+                          capacity: 1.00 MiB
+                          allocated_slabs: 0.02 MiB
+                        kong_reports_consumers:
+                          capacity: 10.00 MiB
+                          allocated_slabs: 0.07 MiB
+                        kong_reports_routes:
+                          capacity: 1.00 MiB
+                          allocated_slabs: 0.02 MiB
+                        kong_reports_services:
+                          capacity: 1.00 MiB
+                          allocated_slabs: 0.02 MiB
+                        kong_reports_workspaces:
+                          capacity: 1.00 MiB
+                          allocated_slabs: 0.02 MiB
+                        kong_keyring:
+                          capacity: 5.00 MiB
+                          allocated_slabs: 0.04 MiB
+                        kong_profiling_state:
+                          capacity: 1.50 MiB
+                          allocated_slabs: 0.02 MiB
+                        prometheus_metrics:
+                          capacity: 5.00 MiB
+                          allocated_slabs: 0.04 MiB
+                        kong:
+                          capacity: 5.00 MiB
+                          allocated_slabs: 0.04 MiB
+                        kong_locks:
+                          capacity: 8.00 MiB
+                          allocated_slabs: 0.06 MiB
+                        kong_healthchecks:
+                          capacity: 5.00 MiB
+                          allocated_slabs: 0.04 MiB
+                        kong_process_events:
+                          capacity: 5.00 MiB
+                          allocated_slabs: 0.04 MiB
+                        kong_cluster_events:
+                          capacity: 5.00 MiB
+                          allocated_slabs: 0.04 MiB
+                        kong_rate_limiting_counters:
+                          capacity: 12.00 MiB
+                          allocated_slabs: 0.08 MiB
+                      workers_lua_vms:
+                        - http_allocated_gc: 51.92 MiB
+                          pid: 2323
+                        - http_allocated_gc: 51.48 MiB
+                          pid: 2324
+                        - http_allocated_gc: 51.48 MiB
+                          pid: 2325
+                        - http_allocated_gc: 51.48 MiB
+                          pid: 2326
+                        - http_allocated_gc: 51.48 MiB
+                          pid: 2327
+                    database:
+                      reachable: true
+                    server:
+                      connections_reading: 0
+                      connections_writing: 6
+                      total_requests: 28
+                      connections_waiting: 0
+                      connections_handled: 15
+                      connections_active: 6
+                      connections_accepted: 15
+      operationId: get-status
+      description: |-
+        Retrieve usage information about a node, with some basic information about the connections being processed by the underlying nginx process, the status of the database connection, and node's memory usage.
+
+        `status_listen` listens on port `8007` by default, however `8001` can be used for status checks as well. The status endpoint provides detailed metrics regarding memory usage, worker process stats, database connection status, and server connection metrics.
+
+        If you want to monitor the Kong process, since Kong is built on top of nginx, every existing nginx monitoring tool or agent can be used.
+
+  /status/dns:
+    get:
+      summary: DNS Status
+      tags:
+        - Information
+      operationId: getDnsStatus
+      description: |
+        Retrieve DNS worker and stats information. If the legacy DNS client is in use, it returns a 501 status with a message.
+      responses:
+        '200':
+          description: DNS worker and stats information
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  worker:
+                    type: object
+                    description: Worker information.
+                    properties:
+                      id:
+                        type: integer
+                        description: The worker ID.
+                        example: 1
+                      count:
+                        type: integer
+                        description: The total number of workers.
+                        example: 4
+                  stats:
+                    type: object
+                    description: DNS stats information (specific details depend on the Kong instance).
+        '501':
+          description: Legacy DNS client in use
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: Message indicating that the endpoint is not implemented with the legacy DNS client.
+                    example: "not implemented with the legacy DNS client"
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+  /keyring/generate:
+    post:
+      summary: Generate key
+      operationId: post-keyring-generate
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  Example 1:
+                    key: t6NWgbj3g9cbNVC3/D6oZ2Md1Br5gWtRrqb1T2FZy44=
+                    id: 8zgITLQh
+                properties:
+                  key:
+                    type: string
+                    description: Key material
+                    example: t6NWgbj3g9cbNVC3/D6oZ2Md1Br5gWtRrqb1T2FZy44=
+                  id:
+                    type: string
+                    description: The key's ID
+                    example: 8zgITLQh
+      description: |-
+        Generate key material.
+
+        Kong supports rotating keys by allowing for multiple keys to exist on the keyring at the same time. This allows for data fields written by one key to be read back, while a fresher encryption key is used for write operations. Rotating keys is a matter of importing or generating a new key into the keyring, and marking it as active.
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      tags:
+        - Keyring
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              x-examples:
+                Example 1:
+                  key: t6NWgbj3g9cbNVC3/D6oZ2Md1Br5gWtRrqb1T2FZy44=
+                  id: 8zgITLQh
+              properties:
+                key:
+                  type: string
+                  example: t6NWgbj3g9cbNVC3/D6oZ2Md1Br5gWtRrqb1T2FZy44=
+                id:
+                  type: string
+                  example: 8zgITLQh
+            examples:
+              Example 1:
+                value:
+                  key: t6NWgbj3g9cbNVC3/D6oZ2Md1Br5gWtRrqb1T2FZy44=
+                  id: 8zgITLQh
+  /keyring/activate:
+    post:
+      summary: Activate key
+      operationId: post-keyring-activate
+      responses:
+        '204':
+          description: No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: Kong can write new sensitive data fields with the current active key, and read previously written fields in the database with the prior key, provided that key is in the keyring. Kong automatically selects the appropriate key to use when decrypting fields from the database.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              x-examples:
+                Example 1:
+                  key: 3Rwvk223
+              properties:
+                key:
+                  type: string
+                  description: The key ID
+                  example: 3Rwvk223
+        description: The request body contains a key ID that can be generated from the `/keyring/generate` endpoint.
+      tags:
+        - Keyring
+  /keyring/recover:
+    post:
+      summary: Recover keyring
+      operationId: post-keyring-recover
+      responses:
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  Example 1:
+                    message: successfully recovered 1 keys
+                    recovered:
+                      - RfsDJ2Ol
+                    not_recovered:
+                      - xSD219lH
+                properties:
+                  message:
+                    type: string
+                    description: A message containing details about your request.
+                    example: successfully recovered 1 keys
+                  recovered:
+                    type: array
+                    items:
+                      type: string
+                      example: RfsDJ2Ol
+                  not_recovered:
+                    type: array
+                    items:
+                      type: string
+                      example: xSD219lH
+              examples:
+                example:
+                  value:
+                    message: successfully recovered 1 keys
+                    recovered:
+                      - RfsDJ2Ol
+                    not_recovered:
+                      - xSD219lH
+      description: |
+        The keyring material is then encrypted with the public RSA key defined with the `keyring_recovery_public_key` Kong configuration value in the database. The corresponding private key can be used to decrypt the keyring material in the database.
+
+        The response contains a list of keys that were successfully recovered and that could not be recovered. The Kong error log will contain the detailed reason why the keys could not be recovered.
+      requestBody:
+        description: |-
+          The request body contains a single file named `recovery_private_key` that represents a private RSA key used for decrypting a keyring material stored in the database.
+
+          The private key is uploaded in the PEM format, which is a binary format used for storing cryptographic keys and certificates. The contents of the file are encoded as a string using a specified encoding (such as base64) and included in the request body
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              properties:
+                recovery_private_key:
+                  type: string
+                  format: binary
+                  example: /path/to/generated/<base64-encoded-contents-of-key.pem>
+                  description: Private key in PEM format.
+            examples:
+              Example 1:
+                value:
+                  recovery_private_key: /path/to/generated/<base64-encoded-contents-of-key.pem>
+      tags:
+        - Keyring
+  /keyring/remove:
+    post:
+      summary: Remove key
+      operationId: post-keyring-remove
+      responses:
+        '204':
+          description: No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: Remove a key from the keyring.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              x-examples:
+                Example 1:
+                  key: 3Rwvk223
+              properties:
+                key:
+                  type: string
+                  description: The key ID
+                  example: 3Rwvk223
+        description: The request body contains a key ID that can be generated from the `/keyring/generate` endpoint.
+      tags:
+        - Keyring
+  /keyring/export:
+    post:
+      summary: Export keyring
+      operationId: post-keyring-export
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  Example 1:
+                    data: eyJrIjoIn0=
+                description: opaque blob containing a keyring.
+                properties:
+                  data:
+                    type: string
+                    example: eyJrIjoiV1JZeTdubDlYeFZpR3VVQWtWTXBcL0JiVW1jMWZrWHluc0dKd
+              examples:
+                Example:
+                  value:
+                    data: eyJrIjoiV1JZeTdubDlYeFZpR3VVQWtWTXBcL0JiVW1jMWZrWHluc0dKd
+      description: |
+        Export the keyring. The exported material can be re-imported to the cluster in the event of an outage or to restore a previously-deleted key.
+        The exported keyring should be stored in a safe location for disaster recovery purposes. It is not designed to be modified or decrypted before being used during a disaster recovery process.
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      tags:
+        - Keyring
+  /keyring/vault/sync:
+   post:
+    summary: Synchronize Vault keyring
+    operationId: post-keyring-vault-sync
+    responses:
+      '204':
+        description: No Content
+    description: | 
+      Kong reads the keyring material from Vault when the Kong process starts.
+      Any changes to the Vault KV store are not reflected on the Kong node until Kong syncs with Vault via the `/keyring/vault/sync` Admin API endpoint. 
+      This allows Kong to receive a Vault token with a low TTL, as the list and read operation only occur once.
+    requestBody:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              token:
+                type: string
+                description: Optional token for Vault synchronization.
+                example: "example-token"
+          examples:
+            Example 1:
+              value:
+                token: "example-token"
+    tags:
+      - Keyring
+  /tags:
+    get:
+      summary: List all tags
+      tags:
+        - Tags
+      responses:
+        '200':
+          $ref: '#/components/responses/tags-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-tags
+      description: |-
+        Returns a paginated list of all the tags in the system.
+
+        The list of entities isn't restricted to a single entity type. All the entities tagged with tags are present in this list.
+
+        If an entity is tagged with more than one tag, the `entity_id` for that entity appears more than once in the resulting list. Similarly, if several entities have been tagged with the same tag, the tag appears in several items of this list.
+  '/tags/{tags}':
+    parameters:
+      - $ref: '#/components/parameters/tag'
+    get:
+      summary: List entity by tag
+      tags:
+        - Tags
+      responses:
+        '200':
+          $ref: '#/components/responses/tags-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-tags-tags
+      description: |-
+        Returns the entities that have been tagged with the specified tag.
+
+        The list of entities isn't restricted to a single entity type. All the entities tagged with tags are present in this list.
+  /keyring/import:
+    post:
+      summary: Import Keyring
+      operationId: post-keyring-import
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                x-examples:
+                  Example 1:
+                    created_at: 1576518704
+                    consumer:
+                      id: 6375b5fd-9c95-4822-b2dd-80ffbccb7ec9
+                    id: fc46ce48-c1d6-4078-9f51-5a777350a8a2
+                    password: da61c0083b6d19ef3db2490d0da96a71572da0fa
+                    username: bob
+                properties:
+                  created_at:
+                    type: integer
+                    description: Datetime representation of the keyring creation date.
+                  consumer:
+                    type: object
+                    description: The consumer object.
+                    properties:
+                      id:
+                        type: string
+                        example: 6375b5fd-9c95-4822-b2dd-80ffbccb7ec9
+                        description: ID of the consumer object.
+                  id:
+                    type: string
+                    example: 6375b5fd-9c95-4822-b2dd-80ffbccb7ec9
+                    description: UUID of the keyring
+                  password:
+                    type: string
+                    example: da61c0083b6d19ef3db2490d0da96a71572da0fa
+                    description: Password associated with the keyring.
+                  username:
+                    type: string
+                    example: user
+                    description: Username associated with the keyring
+      description: Restart Kong and re-import the previously exported keyring. This operation requires that the keyring_private_key point to the private RSA key associated with the public key used during the initial keyring export.
+      tags:
+        - Keyring
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              x-examples:
+                Example 1:
+                  key: t6NWgbj3g9cbNVC3/D6oZ2Md1Br5gWtRrqb1T2FZy44=
+                  id: 8zgITLQh
+              properties:
+                key:
+                  type: string
+                  example: t6NWgbj3g9cbNVC3/D6oZ2Md1Br5gWtRrqb1T2FZy44=
+                id:
+                  type: string
+                  example: 8zgITLQh
+            examples:
+              Example 1:
+                value: {}
+        description: Import Keyring
+  '/schemas/vaults/{vault_name}':
+    parameters:
+      - schema:
+          type: string
+        name: vault_name
+        in: path
+        required: true
+        description: The vault schema to be returned
+    get:
+      summary: Retrieve Vault Schema
+      tags:
+        - Information
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Vault'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        '404':
+          description: No vault named
+      operationId: get-schemas-vaults-vault_name
+      description: Retrieve the schema of a vault.
+    post:
+      summary: Validate Vault Schema
+      tags:
+        - Validation
+      requestBody:
+        description: Payload containing the schema data to validate
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                schemaData:
+                  type: string
+                  description: JSON string containing the vault schema data
+      responses:
+        '200':
+          description: Validation successful
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  validation:
+                    type: boolean
+                    description: Indicates if the schema is valid
+        '400':
+          description: Bad request due to invalid schema data
+        '405':
+          description: Method Not Allowed
+      operationId: post-schemas-vaults-validate
+      description: Validates the given vault schema data against predefined validation rules.
+  /admins:
+    get:
+      summary: List Admins
+      tags:
+        - admins
+      responses:
+        '200':
+          $ref: '#/components/responses/admins-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-admins
+      description: Returns a list of admins. To query all admins, add a parameter `all_workspaces=true` to the `/admins` endpoint. The `status` field in the response indicates the state of the admins invitation. `0`= Approved, `1`= Pending, `2`= Rejected, `3`= Revoked, `4` = Invited, `5`= Unverified.
+    post:
+      summary: Invite an Admin
+      operationId: post-admins
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  admin:
+                    type: object
+                    properties:
+                      created_at:
+                        type: integer
+                      id:
+                        type: string
+                      updated_at:
+                        type: integer
+                      status:
+                        type: integer
+                      username:
+                        type: string
+                      email:
+                        type: string
+                      rbac_token_enabled:
+                        type: boolean
+                x-examples:
+                  Example 1:
+                    admin:
+                      created_at: 1556638641
+                      id: 8f0a742f-07f3-49e0-90d7-4fc7eea7e6a4
+                      updated_at: 1556638641
+                      status: 4
+                      username: test-case-3
+                      email: test3@test.com
+                      rbac_token_enabled: true
+              examples:
+                Example admin response:
+                  value:
+                    admin:
+                      created_at: 0
+                      id: string
+                      updated_at: 0
+                      status: 0
+                      username: string
+                      email: string
+                      rbac_token_enabled: true
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    description: Detail about the conflict
+                    example: user already exists with same username, email, or custom_id
+                x-exmples:
+                  Example 1:
+                    message: user already exists with same username, email, or custom_id
+              examples:
+                Constraint violation:
+                  value:
+                    message: user already exists with same username, email, or custom_id
+      tags:
+        - admins
+      description: Invite an admin to your organization.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  example: email@example.com
+                  description: The admin's email address.
+                username:
+                  type: string
+                  description: The admin's username
+                  example: myusername
+                custom_id:
+                  type: string
+                  description: The admin's custom ID
+                rbac_token_enabled:
+                  type: boolean
+                  description: Allows the admin to use and reset their RBAC token.
+                  default: true
+            examples:
+              Invite an admin:
+                value:
+                  username: test-case-3
+                  email: test3@test.com
+                  custom_id: customId
+                  rbac_token_enabled: true
+  /admins/register:
+    post:
+      summary: Register an Admin’s Credentials
+      operationId: post-admins-register
+      responses:
+        '201':
+          description: Created
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: Register an Admin's Credentials
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                token:
+                  type: string
+                 
+                username:
+                  type: string
+                  
+                email:
+                  type: string
+                  
+                  format: email
+                password:
+                  type: string
+                  
+                  format: password
+            examples:
+              Example registration request:
+                value:
+                  token: string
+                  username: string
+                  email: user@example.com
+                  password: pa$$word
+      tags:
+        - admins
+  /admins/password_resets:
+    post:
+      summary: Send a Password Reset Email to an Admin
+      tags:
+        - admins
+      responses:
+        '201':
+          description: Created
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-admins-password_resets
+      description: Using a registered admin's email address issue a password reset email to the admin.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                 
+                  description: The registered admin's email.
+                  example: admin@example.com
+            examples:
+              Example reset body:
+                value:
+                  email: admin@example.com
+    patch:
+      summary: Reset an Admin’s Password
+      operationId: patch-admins-password_resets
+      responses:
+        '200':
+          description: OK
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: Reset an admin's password.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                email:
+                  type: string
+                  
+                password:
+                  type: string
+                 
+                token:
+                  type: string
+                  
+            examples:
+              Example 1:
+                value:
+                  email: string
+                  password: string
+                  token: string
+      tags:
+        - admins
+  '/admins/{name_or_id}':
+    parameters:
+      - schema:
+          type: string
+        name: name_or_id
+        in: path
+        required: true
+        description: The admin’s username or ID.
+    get:
+      summary: Retrieve an Admin
+      tags:
+        - admins
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  created_at:
+                    type: integer
+                  id:
+                    type: string
+                  updated_at:
+                    type: integer
+                  status:
+                    type: integer
+                  username:
+                    type: string
+                  email:
+                    type: string
+                  rbac_token_enabled:
+                    type: boolean
+                x-examples:
+                  Example 1:
+                    created_at: 1556638385
+                    id: 665b4070-541f-48bf-82c1-53030babaa81
+                    updated_at: 1556638385
+                    status: 4
+                    username: test-admin
+                    email: test@test.com
+                    rbac_token_enabled: true
+              examples:
+                Example response body:
+                  value:
+                    created_at: 1556638385
+                    id: 665b4070-541f-48bf-82c1-53030babaa81
+                    updated_at: 1556638385
+                    status: 4
+                    username: test-admin
+                    email: test@test.com
+                    rbac_token_enabled: true
+      operationId: get-admins-name_or_id
+      description: Retrieve an admin using their name or ID. Using `generate_register_url`, you can generate a unique registration URL if the admin's invitation status is `4`. `generate_register_url` overrides the previous registration URL for the particular admin each time it is requested.
+    patch:
+      tags:
+        - admins
+      summary: Update an Admin
+      operationId: patch-admins-name_or_id-generate_register_url
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name_or_id:
+                  type: string
+                username:
+                  type: string
+                email:
+                  type: string
+                rbac_token_enabled:
+                  type: boolean
+              x-examples:
+                Example 1:
+                  name_or_id: 665b4070-541f-48bf-82c1-53030babaa81
+                  username: test-renamed
+                  email: test@test.com
+                  rbac_token_enabled: true
+            examples:
+              Example 1:
+                value:
+                  name_or_id: string
+                  username: string
+                  email: string
+                  rbac_token_enabled: true
+      description: Update information about an admin
+    delete:
+      tags:
+        - admins
+      summary: Delete an Admin
+      operationId: delete-admins-name_or_id
+      responses:
+        '204':
+          description: No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: Delete an admin by specifying the admin's username or ID.
+  '/admins/{name_or_id}/roles':
+    parameters:
+      - schema:
+          type: string
+        name: name_or_id
+        in: path
+        required: true
+        description: The admin’s username or ID
+    get:
+      summary: List an Admin’s Roles
+      tags:
+        - admins
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  roles:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        comment:
+                          type: string
+                        created_at:
+                          type: integer
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        is_default:
+                          type: boolean
+                x-examples:
+                  Example 1:
+                    roles:
+                      - comment: 'Read access to all endpoints, across all workspaces'
+                        created_at: 1556563122
+                        id: 7574eb1d-c9fa-46a9-bd3a-3f1b4b196287
+                        name: read-only
+                        is_default: false
+                      - comment: 'Full access to all endpoints, across all workspaces—except RBAC Admin API'
+                        created_at: 1556563122
+                        id: 7fdea5c8-2bfa-4aa9-9c21-7bb9e607186d
+                        name: admin
+                        is_default: false
+              examples:
+                Example role list:
+                  value:
+                    roles:
+                      - comment: 'Read access to all endpoints, across all workspaces'
+                        created_at: 1556563122
+                        id: 7574eb1d-c9fa-46a9-bd3a-3f1b4b196287
+                        name: read-only
+                        is_default: false
+                      - comment: 'Full access to all endpoints, across all workspaces—except RBAC Admin API'
+                        created_at: 1556563122
+                        id: 7fdea5c8-2bfa-4aa9-9c21-7bb9e607186d
+                        name: admin
+                        is_default: false
+      operationId: get-admins-name_or_id-roles
+      description: List all roles related to a registered admin.
+    post:
+      summary: Create or Update an Admin’s Roles
+      operationId: post-admins-name_or_id-roles
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  roles:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        comment:
+                          type: string
+                        created_at:
+                          type: integer
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        is_default:
+                          type: boolean
+                x-examples:
+                  Example 1:
+                    roles:
+                      - comment: 'Read access to all endpoints, across all workspaces'
+                        created_at: 1556563122
+                        id: 7574eb1d-c9fa-46a9-bd3a-3f1b4b196287
+                        name: read-only
+                        is_default: false
+                      - comment: 'Full access to all endpoints, across all workspaces—except RBAC Admin API'
+                        created_at: 1556563122
+                        id: 7fdea5c8-2bfa-4aa9-9c21-7bb9e607186d
+                        name: admin
+                        is_default: false
+                      - comment: 'Full access to all endpoints, across all workspaces'
+                        created_at: 1556563122
+                        id: 99bd8d18-f5b6-410e-aefe-d75f4252f13c
+                        name: super-admin
+                        is_default: false
+              examples:
+                Example role assignment:
+                  value:
+                    roles:
+                      - comment: 'Read access to all endpoints, across all workspaces'
+                        created_at: 1556563122
+                        id: 7574eb1d-c9fa-46a9-bd3a-3f1b4b196287
+                        name: read-only
+                        is_default: false
+                      - comment: 'Full access to all endpoints, across all workspaces—except RBAC Admin API'
+                        created_at: 1556563122
+                        id: 7fdea5c8-2bfa-4aa9-9c21-7bb9e607186d
+                        name: admin
+                        is_default: false
+                      - comment: 'Full access to all endpoints, across all workspaces'
+                        created_at: 1556563122
+                        id: 99bd8d18-f5b6-410e-aefe-d75f4252f13c
+                        name: super-admin
+                        is_default: false
+      tags:
+        - admins
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                roles:
+                  type: string
+              x-examples:
+                Example 1:
+                  roles: read-only
+        description: Comma-separated string of role names to create or update for an admin.
+      description: Create or update roles for an admin
+    delete:
+      tags:
+        - admins
+      summary: Delete an Admin’s Role
+      operationId: delete-admins-name_or_id-roles
+      responses:
+        '204':
+          description: No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: Delete an admin's roles by passing a comma-separated string of names of specific roles to remove from an admin.
+  '/admins/{name_or_id}/workspaces':
+    parameters:
+      - schema:
+          type: string
+        name: name_or_id
+        in: path
+        required: true
+        description: The admin’s username or ID
+    get:
+      summary: List an Admin’s Workspaces
+      tags:
+        - admins
+      responses:
+        '200':
+          $ref: '#/components/responses/workspace-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-admins-name_or_id-workspaces
+      description: Return workspaces associated with an admin.
+  /groups:
+    get:
+      summary: List Groups
+      tags:
+        - groups
+      responses:
+        '200':
+          $ref: '#/components/responses/groups-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-groups
+      description: Returns a list of groups.
+    post:
+      summary: Create a new group
+      operationId: post-groups
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  created_at:
+                    type: integer
+                  id:
+                    type: string
+                  updated_at:
+                    type: integer
+                  name:
+                    type: string
+                  comment:
+                    type: string
+                x-examples:
+                  Example 1:
+                    created_at: 1556638641
+                    id: 8f0a742f-07f3-49e0-90d7-4fc7eea7e897
+                    updated_at: 1556638641
+                    name: demo-group
+                    comment: comment
+              examples:
+                Example group response:
+                  value:
+                    created_at: 0
+                    id: string
+                    updated_at: 0
+                    name: string
+                    comment: string
+      tags:
+        - groups
+      description: Create a group to your organization.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: The group's name
+                  example: my_group
+            examples:
+              Create a group:
+                value:
+                  name: demo-group
+                  comment: comment
+  '/groups/{name_or_id}':
+    parameters:
+      - schema:
+          type: string
+        name: name_or_id
+        in: path
+        required: true
+        description: The group’s name or ID.
+    get:
+      summary: Retrieve a Group
+      tags:
+        - groups
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  created_at:
+                    type: integer
+                  id:
+                    type: string
+                  updated_at:
+                    type: integer
+                  name:
+                    type: string
+                  comment:
+                    type: string
+                x-examples:
+                  Example 1:
+                    created_at: 1556638385
+                    id: 665b4070-541f-48bf-82c1-53030babaa81
+                    updated_at: 1556638385
+                    name: test-group
+                    comment: comment1
+              examples:
+                Example response body:
+                  value:
+                    created_at: 1556638385
+                    id: 665b4070-541f-48bf-82c1-53030babaa81
+                    updated_at: 1556638385
+                    username: test-group
+                    comment: comment
+      operationId: get-groups-name_or_id
+      description: Retrieve a group using their name or ID.
+    patch:
+      tags:
+        - groups
+      summary: Update a Group
+      operationId: patch-groups-name_or_id
+      responses:
+        '200':
+          description: OK
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                comment:
+                  type: string
+              x-examples:
+                Example 1:
+                  name: test-group
+                  comment: comment1
+            examples:
+              Example 1:
+                value:
+                  name: string
+                  comment: string
+      description: Update information about a group
+    delete:
+      tags:
+        - groups
+      summary: Delete an Group
+      operationId: delete-groups-name_or_id
+      responses:
+        '204':
+          description: No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: Delete a group by specifying the group's name or ID.
+  '/groups/{name_or_id}/roles':
+    parameters:
+      - schema:
+          type: string
+        name: name_or_id
+        in: path
+        required: true
+        description: The group’s username or ID
+    get:
+      summary: List an Group’s Roles
+      tags:
+        - groups
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        group:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                            comment:
+                              type: string
+                            updated_at:
+                              type: string
+                              format: date-time
+                        rbac_role:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                            name:
+                              type: string
+                        workspace:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                        next:
+                          nullable: true
+                x-examples:
+                  Example 1:
+                    data:
+                      - group:
+                          comment: 'comment1'
+                          created_at: 1556563122
+                          id: 7574eb1d-c9fa-46a9-bd3a-3f1b4b196287
+                          name: demo-group
+                        rbac_role:
+                          id: 7fdea5c8-2bfa-4aa9-9c21-7bb9e607186d
+                          name: admin
+                        workspace:
+                          id: 99bd8d18-f5b6-410e-aefe-d75f4252f13c
+              examples:
+                Example role list:
+                  value:
+                    data:
+                      - group:
+                          comment: 'comment1'
+                          created_at: 1556563122
+                          id: 7574eb1d-c9fa-46a9-bd3a-3f1b4b196287
+                          name: demo-group
+                        rbac_role:
+                          id: 7fdea5c8-2bfa-4aa9-9c21-7bb9e607186d
+                          name: admin
+                        workspace:
+                          id: 99bd8d18-f5b6-410e-aefe-d75f4252f13c
+      operationId: get-groups-name_or_id-roles
+      description: List all roles related to a group.
+    post:
+      summary: Create or Update a Group's Roles
+      operationId: post-groups-name_or_id-roles
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  group:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      comment:
+                        type: string
+                      updated_at:
+                        type: string
+                        format: date-time
+                  rbac_role:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      name:
+                        type: string
+                  workspace:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                x-examples:
+                  Example 1:
+                    group:
+                      comment: 'Read access to all endpoints, across all workspaces'
+                      created_at: 1556563122
+                      id: 7574eb1d-c9fa-46a9-bd3a-3f1b4b196287
+                      name: read-only
+                      is_default: false
+                    rbac_role:
+                      id: 7fdea5c8-2bfa-4aa9-9c21-7bb9e607186d
+                      name: admin
+                    workspace:
+                      id: 99bd8d18-f5b6-410e-aefe-d75f4252f13c
+              examples:
+                Example role assignment:
+                  value:
+                    group:
+                      comment: 'Read access to all endpoints, across all workspaces'
+                      created_at: 1556563122
+                      id: 7574eb1d-c9fa-46a9-bd3a-3f1b4b196287
+                      name: read-only
+                      is_default: false
+                    rbac_role:
+                      id: 7fdea5c8-2bfa-4aa9-9c21-7bb9e607186d
+                      name: admin
+                    workspace:
+                      id: 99bd8d18-f5b6-410e-aefe-d75f4252f13c
+      tags:
+        - groups
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                rbac_role_id:
+                  type: string
+                workspace_id: 
+                  type: string
+              x-examples:
+                Example 1:
+                  rbac_role_id: 12773c9a-7f7c-45f2-bcea-5285eb18fd2f
+                  workspace_id: d107bce7-dd86-4124-93c8-667ecc34b32e
+        description: Comma-separated string of role names to create or update for a group.
+      description: Create or update roles for a admin
+    delete:
+      tags:
+        - groups
+      summary: Delete a group’s Role
+      operationId: delete-groups-name_or_id-roles
+      parameters:
+        - name: rbac_role_id
+          in: query
+          required: true
+          schema:
+            type: string
+          example: 12773c9a-7f7c-45f2-bcea-5285eb18fd2f
+        - name: workspace_id
+          in: query
+          required: true
+          schema:
+            type: string
+          example: d107bce7-dd86-4124-93c8-667ecc34b32e
+      responses:
+        '204':
+          description: No Content
+        '401':
+          $ref: '#/components/responses/HTTP401Error'
+      description: Delete a group's roles.
+  '/debug/cluster/control-planes-nodes/log-level/{log_level}':
+    parameters:
+      - schema:
+          type: string
+          enum:
+            - debug
+            - info
+            - notice
+            - warn
+            - error
+            - crit
+        name: log_level
+        in: path
+        required: true
+        description: The log level
+    put:
+      summary: Set Node Log Level of All Control Plane Nodes
+      operationId: put-debug-cluster-control-planes-nodes-log-level-log_level
+      responses:
+        '200':
+          description: log level changed
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |-
+        Change the log level of all control plane nodes deployed in a hybrid (CP/DP) cluster.
+        Be careful when changing the log level of a node to debug in a production environment because the disk could fill up quickly. As soon as the debug logging finishes, revert back to a higher level, such as notice.
+        It’s currently not possible to change the log level of data plane and DB-less nodes.
+
+        This endpoint can be protected with RBAC, and changes will be reflected in the audit logs. 
+        The log level change is propagated to all Nginx workers of a node, including to newly spawned workers.
+
+        Log levels are set in Kong’s configuration. Possible log levels in increasing order of severity: `debug`, `info`, `notice`, `warn`, `error`, and `crit`. For more information, review the [logging reference](https://docs.konghq.com/gateway/latest/production/logging/).
+
+        When a user dynamically changes the log level for the entire cluster, if a new node joins the cluster, the new node will run at the previous log level, not at the log level that was previously set dynamically for the entire cluster. To work around that, make sure the new node starts with the proper level by setting the startup `kong.conf` setting [`KONG_LOG_LEVEL`](https://docs.konghq.com/gateway/latest/reference/configuration/#log_level).
+      tags:
+        - debug
+  '/debug/cluster/log-level/{log_level}':
+    parameters:
+      - schema:
+          type: string
+          enum:
+            - debug
+            - info
+            - notice
+            - warn
+            - error
+            - crit
+        name: log_level
+        in: path
+        required: true
+        description: The log level
+    put:
+      summary: Set Node Log Level of All Nodes
+      operationId: put-debug-cluster-log-level-log_level
+      responses:
+        '200':
+          description: log level changed
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      tags:
+        - debug
+      description: |-
+        Change the log level of all nodes in a cluster.
+        
+        Be careful when changing the log level of a node to debug in a production environment because the disk could fill up quickly. As soon as the debug logging finishes, revert back to a higher level, such as notice.
+        It’s currently not possible to change the log level of data plane and DB-less nodes.
+        
+        This endpoint can be protected with RBAC, and changes will be reflected in the audit logs. 
+        The log level change is propagated to all Nginx workers of a node, including to newly spawned workers.
+
+        Log levels are set in Kong’s configuration. Possible log levels in increasing order of severity: `debug`, `info`, `notice`, `warn`, `error`, and `crit`. For more information, review the [logging reference](https://docs.konghq.com/gateway/latest/production/logging/).
+
+        Currently, when a user dynamically changes the log level for the entire cluster, if a new node joins the cluster, the new node will run at the previous log level, not at the log level that was previously set dynamically for the entire cluster. To work around that, make sure the new node starts with the proper level by setting the startup `kong.conf` setting [`KONG_LOG_LEVEL`](https://docs.konghq.com/gateway/latest/reference/configuration/#log_level).
+  /debug/node/log-level:
+    get:
+      summary: Retrieve Node Log Level of A Node
+      tags:
+        - debug
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                x-examples:
+                  Example 1:
+                    message: 'log level: debug'
+              examples:
+                Retrieved debug level:
+                  value:
+                    message: string
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-debug-node-log-level
+      description: |
+        Retrieve the current log level of a node.
+
+        See the [Nginx Documentation](https://nginx.org/en/docs/ngx_core_module.html#error_log) for the list of possible return values.
+  '/debug/node/log-level/{log_level}':
+    parameters:
+      - schema:
+          type: string
+          enum:
+            - debug
+            - info
+            - notice
+            - warn
+            - error
+            - crit
+        name: log_level
+        in: path
+        required: true
+        description: The log level
+    put:
+      summary: Set Log Level of A Single Node
+      tags:
+        - debug
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                x-examples:
+                  Example 1:
+                    message: log level changed
+              examples:
+                Example 1:
+                  value:
+                    message: log level changed
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-debug-node-log-level-log_level
+      description: |
+        Change the log level of a node.
+  /rbac/users:
+    get:
+      summary: List Users
+      tags:
+        - RBAC
+      responses:
+        '200':
+          $ref: '#/components/responses/rbac-user-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-rbac-users
+      description: |-
+        List all users.
+
+        Note: RBAC users associated with admin aren't listed with `GET /rbac/users`. Instead, use `GET /admins` to list all admins.
+    post:
+      summary: Add a User
+      operationId: post-rbac-users
+      responses:
+        '200':
+          $ref: '#/components/responses/rbac-user-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      tags:
+        - RBAC
+      requestBody:
+        $ref: '#/components/requestBodies/rbac-request'
+      description: Add a User
+  '/rbac/users/{name_or_id}':
+    parameters:
+      - schema:
+          type: string
+        name: name_or_id
+        in: path
+        required: true
+        description: The RBAC username or UUID.
+    get:
+      summary: Retrieve a User
+      tags:
+        - RBAC
+      responses:
+        '200':
+          $ref: '#/components/responses/rbac-user-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-rbac-users-name_or_id
+      description: Retrieve a user by passing a name or ID in the path.
+    patch:
+      summary: Update a User
+      operationId: patch-rbac-users-name_or_id
+      responses:
+        '200':
+          $ref: '#/components/responses/rbac-user-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      tags:
+        - RBAC
+      description: Update a user. Users are unable to update their own roles.
+      requestBody:
+        $ref: '#/components/requestBodies/rbac-request'
+    delete:
+      summary: Delete a User
+      operationId: delete-rbac-users-name_or_id
+      responses:
+        '204':
+          description: No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |
+        Delete a user.
+      tags:
+        - RBAC
+  /rbac/roles:
+    get:
+      summary: List Roles
+      tags:
+        - RBAC
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        comment:
+                          type: string
+                        created_at:
+                          type: integer
+                        id:
+                          type: string
+                        name:
+                          type: string
+                  next:
+                    type: string
+                x-examples:
+                  Example 1:
+                    data:
+                      - comment: 'Full access to all endpoints, across all workspaces—except RBAC Admin API'
+                        created_at: 1557506249
+                        id: 38a03d47-faae-4366-b430-f6c10aee5029
+                        name: admin
+                      - comment: 'Read access to all endpoints, across all workspaces'
+                        created_at: 1557506249
+                        id: 4141675c-8beb-41a5-aa04-6258ab2d2f7f
+                        name: read-only
+                      - comment: 'Full access to all endpoints, across all workspaces'
+                        created_at: 1557506249
+                        id: 888117e0-f2b3-404d-823b-dee595423505
+                        name: super-admin
+                      - comment: null
+                        created_at: 1557532241
+                        id: b5c5cfd4-3330-4796-9b7b-6026e91e3ad6
+                        name: doc_lord
+                    next: null
+              examples:
+                Multiple roles:
+                  value:
+                    data:
+                      - comment: 'Full access to all endpoints, across all workspaces—except RBAC Admin API'
+                        created_at: 1557506249
+                        id: 38a03d47-faae-4366-b430-f6c10aee5029
+                        name: admin
+                      - comment: 'Read access to all endpoints, across all workspaces'
+                        created_at: 1557506249
+                        id: 4141675c-8beb-41a5-aa04-6258ab2d2f7f
+                        name: read-only
+                      - comment: 'Full access to all endpoints, across all workspaces'
+                        created_at: 1557506249
+                        id: 888117e0-f2b3-404d-823b-dee595423505
+                        name: super-admin
+                      - comment: null
+                        created_at: 1557532241
+                        id: b5c5cfd4-3330-4796-9b7b-6026e91e3ad6
+                        name: doc_lord
+                    next: null
+      operationId: get-rbac-roles
+      description: List all roles.
+    post:
+      summary: Add a Role
+      operationId: post-rbac-roles
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  comment:
+                    type: string
+                  created_at:
+                    type: integer
+                  id:
+                    type: string
+                  is_default:
+                    type: boolean
+                  name:
+                    type: string
+                x-examples:
+                  Example 1:
+                    comment: null
+                    created_at: 1557532241
+                    id: b5c5cfd4-3330-4796-9b7b-6026e91e3ad6
+                    is_default: false
+                    name: service_reader
+              examples:
+                New role response body:
+                  value:
+                    comment: null
+                    created_at: 1557532241
+                    id: b5c5cfd4-3330-4796-9b7b-6026e91e3ad6
+                    is_default: false
+                    name: service_reader
+      tags:
+        - RBAC
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                 
+
+                  description: The RBAC role name.
+                comment:
+                  type: string
+                 
+                  description: A string describing the RBAC user object.
+        description: The request body contains the name of the role and an optional attribute. 
+      description: Add a role.
+  '/rbac/roles/{name_or_id}':
+    parameters:
+      - schema:
+          type: string
+        name: name_or_id
+        in: path
+        required: true
+        description: The RBAC role name or UUID.
+    get:
+      summary: Retrieve a Role
+      tags:
+        - RBAC
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  created_at:
+                    type: integer
+                  id:
+                    type: string
+                  is_default:
+                    type: boolean
+                  name:
+                    type: string
+                x-examples:
+                  Example 1:
+                    created_at: 1557532241
+                    id: b5c5cfd4-3330-4796-9b7b-6026e91e3ad6
+                    is_default: false
+                    name: service_reader
+              examples:
+                Example 1:
+                  value:
+                    created_at: 1557532241
+                    id: b5c5cfd4-3330-4796-9b7b-6026e91e3ad6
+                    is_default: false
+                    name: service_reader
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-rbac-roles-name_or_id
+      description: Retrieve a role by passing the name or UUID as a path parameter.
+    put:
+      summary: Update or Create a Role
+      operationId: put-rbac-roles-name_or_id
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  comment:
+                    type: string
+                  created_at:
+                    type: integer
+                  id:
+                    type: string
+                  is_default:
+                    type: boolean
+                  name:
+                    type: string
+                x-examples:
+                  Example 1:
+                    comment: the best
+                    created_at: 1557532566
+                    id: b5c5cfd4-3330-4796-9b7b-6026e91e3ad6
+                    is_default: false
+                    name: doc_lord
+              examples:
+                Example entity replacement:
+                  value:
+                    comment: the best
+                    created_at: 1557532566
+                    id: b5c5cfd4-3330-4796-9b7b-6026e91e3ad6
+                    is_default: false
+                    name: doc_lord
+        '201':
+          description: Created
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      tags:
+        - RBAC
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                 
+                comment:
+                  type: string
+                 
+      description: |
+        With a `PUT` request, if the request payload contains an existing entity’s primary key, the payload replaces the entity specified by the given primary key. If the primary key is not that of an existing entity, the entity is created with the given payload.
+    patch:
+      summary: Update a Role
+      operationId: patch-rbac-roles-name_or_id
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  comment:
+                    type: string
+                  created_at:
+                    type: integer
+                  id:
+                    type: string
+                  is_default:
+                    type: boolean
+                  name:
+                    type: string
+                x-examples:
+                  Example 1:
+                    comment: comment from patch request
+                    created_at: 1557532566
+                    id: b5c5cfd4-3330-4796-9b7b-6026e91e3ad6
+                    is_default: false
+                    name: service_reader
+              examples:
+                Patch request response:
+                  value:
+                    comment: comment from patch request
+                    created_at: 1557532566
+                    id: b5c5cfd4-3330-4796-9b7b-6026e91e3ad6
+                    is_default: false
+                    name: service_reader
+      tags:
+        - RBAC
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                attribute:
+                  type: string
+                
+                  description: |
+                    A string describing the RBAC role object.
+        description: Attribute request body
+      description: Updates a role by passing an optional attribute.
+    delete:
+      summary: Delete a Role
+      operationId: delete-rbac-roles-name_or_id
+      responses:
+        '204':
+          description: No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      tags:
+        - RBAC
+      description: Delete a role
+  '/rbac/roles/{name_or_id}/endpoints':
+    parameters:
+      - schema:
+          type: string
+        name: name_or_id
+        in: path
+        required: true
+        description: The RBAC role name or UUID.
+    get:
+      summary: List Role Endpoints Permissions
+      tags:
+        - RBAC
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        actions:
+                          type: array
+                          items:
+                            type: string
+                        created_at:
+                          type: integer
+                        endpoint:
+                          type: string
+                        negative:
+                          type: boolean
+                        role:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                        role_source:
+                          description: The origin of the RBAC user role. Specifies where the user role is defined, either locally or through an identity provider (IdP).
+                          type: string
+                          default: "local"
+                          enum:
+                            - "local"
+                            - "idp"
+                        workspace:
+                          type: string
+                x-examples:
+                  Example 1:
+                    data:
+                      - actions:
+                          - delete
+                          - create
+                          - update
+                          - read
+                        created_at: 1557764505
+                        endpoint: /consumers
+                        negative: false
+                        role:
+                          id: 23df9f20-e7cc-4da4-bc89-d3a08f976e50
+                        workspace: default
+                      - actions:
+                          - read
+                        created_at: 1557764438
+                        endpoint: /services
+                        negative: false
+                        role:
+                          id: 23df9f20-e7cc-4da4-bc89-d3a08f976e50
+                        workspace: default
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-rbac-roles-name_or_id-endpoints
+      description: Lists all of a role's associated endpoint permissions.
+    post:
+      summary: Add a Role Endpoint Permission
+      operationId: post-rbac-roles-name_or_id-endpoints
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  actions:
+                    type: array
+                    items:
+                      type: string
+                  created_at:
+                    type: integer
+                  endpoint:
+                    type: string
+                  negative:
+                    type: boolean
+                  role:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                  role_source:
+                    description: The origin of the RBAC user role. Specifies where the user role is defined, either locally or through an identity provider (IdP).
+                    type: string
+                    default: "local"
+                    enum:
+                      - "local"
+                      - "idp"
+                  workspace:
+                    type: string
+                x-examples:
+                  Example 1:
+                    actions:
+                      - delete
+                      - create
+                      - update
+                      - read
+                    created_at: 1557764505
+                    endpoint: /consumers
+                    negative: false
+                    role:
+                      id: 23df9f20-e7cc-4da4-bc89-d3a08f976e50
+                    workspace: default
+              examples:
+                Basic example:
+                  value:
+                    actions:
+                      - delete
+                      - create
+                      - update
+                      - read
+                    created_at: 1557764505
+                    endpoint: /consumers
+                    negative: false
+                    role:
+                      id: 23df9f20-e7cc-4da4-bc89-d3a08f976e50
+                    workspace: default
+      tags:
+        - RBAC
+      description: |-
+        Add a role endpoint permission for the path of the associated endpoint. Permissions can be exact matches, or contain wildcards, represented by `*`.
+
+        Exact matches:
+        - `/services/`
+        - `/services/foo`
+        
+        Wildcards:
+        - `/services/*`
+        - `/services/*/plugins`
+        Where `*` replaces exactly one segment between slashes (or the end of the path).
+
+        Note that wildcards can be nested. For example, `/rbac/*`, `/rbac/*/*`, `/rbac/*/*/*` would refer to all paths under `/rbac/`.
+        <br><br>
+         For the `admin` role in the default workspace, CRUD actions on `/groups` and `/groups/*` endpoints are disallowed.
+         For the `workspace-admin` role in non-default workspaces, CRUD actions on `/groups` and `/groups/*` endpoints are disallowed.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                workspace:
+                  type: string
+                
+                  description: Workspace tied to the endpoint. Defaults to the default permission. Using the wildcard `*` means all workspaces are affected.
+                endpoint:
+                  type: string
+                
+                  description: |
+                    Endpoint associated with this permission.
+                negative:
+                  type: string
+                
+                  description: |
+                    If true, explicitly disallow the actions associated with the permissions tied to this endpoint. By default, this value is false.
+                actions:
+                  type: string
+                
+                  description: |
+                    One or more actions associated with this permission, written as a comma-separated string. 
+                    For example, `read,create,update,delete`.
+                comment:
+                  type: string
+                 
+                  description: A string describing the RBAC permission object.
+  '/rbac/roles/{name_or_id}/endpoints/{workspace_name_or_id}/{endpoint}':
+    parameters:
+      - schema:
+          type: string
+        name: name_or_id
+        in: path
+        required: true
+        description: The RBAC role name or UUID.
+      - schema:
+          type: string
+        name: workspace_name_or_id
+        in: path
+        required: true
+        description: The workspace name or UUID.
+      - schema:
+          type: string
+        name: endpoint
+        in: path
+        required: true
+        description: The endpoint associated with this permission.
+    get:
+      summary: Retrieve a Role Endpoint Permission
+      tags:
+        - RBAC
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  actions:
+                    type: array
+                    items:
+                      type: string
+                  created_at:
+                    type: integer
+                  endpoint:
+                    type: string
+                  negative:
+                    type: boolean
+                  role:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                  role_source:
+                    description: The origin of the RBAC user role. Specifies where the user role is defined, either locally or through an identity provider (IdP).
+                    type: string
+                    default: "local"
+                    enum:
+                      - "local"
+                      - "idp"
+                  workspace:
+                    type: string
+                x-examples:
+                  Example 1:
+                    actions:
+                      - delete
+                      - create
+                      - update
+                      - read
+                    created_at: 1557764505
+                    endpoint: /consumers
+                    negative: false
+                    role:
+                      id: 23df9f20-e7cc-4da4-bc89-d3a08f976e50
+                    workspace: default
+              examples:
+                basic example:
+                  value:
+                    actions:
+                      - delete
+                      - create
+                      - update
+                      - read
+                    created_at: 1557764505
+                    endpoint: /consumers
+                    negative: false
+                    role:
+                      id: 23df9f20-e7cc-4da4-bc89-d3a08f976e50
+                    workspace: default
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-rbac-roles-name_or_id-endpoints-workspace_name_or_id-endpoint
+      description: |
+        Retrieve a Role Endpoint Permission
+    patch:
+      summary: Update a Role Endpoint Permission
+      operationId: patch-rbac-roles-name_or_id-endpoints-workspace_name_or_id-endpoint
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  actions:
+                    type: array
+                    items:
+                      type: string
+                  created_at:
+                    type: integer
+                  endpoint:
+                    type: string
+                  negative:
+                    type: boolean
+                  role:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                  role_source:
+                    description: The origin of the RBAC user role. Specifies where the user role is defined, either locally or through an identity provider (IdP).
+                    type: string
+                    default: "local"
+                    enum:
+                      - "local"
+                      - "idp"
+                  workspace:
+                    type: string
+                x-examples:
+                  Example 1:
+                    actions:
+                      - delete
+                      - create
+                      - update
+                      - read
+                    created_at: 1557764438
+                    endpoint: /services
+                    negative: false
+                    role:
+                      id: 23df9f20-e7cc-4da4-bc89-d3a08f976e50
+                    workspace: default
+              examples:
+                Example 1:
+                  value:
+                    actions:
+                      - delete
+                      - create
+                      - update
+                      - read
+                    created_at: 1557764438
+                    endpoint: /services
+                    negative: false
+                    role:
+                      id: 23df9f20-e7cc-4da4-bc89-d3a08f976e50
+                    workspace: default
+      tags:
+        - RBAC
+      description: |
+        Update a Role Endpoint Permission
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                negative:
+                  type: string
+                 
+                  description: |
+                    If true, explicitly disallow the actions associated with the permissions tied to this resource. By default this value is false.
+                actions:
+                  type: string
+                 
+                  description: |
+                    One or more actions associated with this permission.
+    delete:
+      summary: Delete a Role Endpoint Permission
+      operationId: delete-rbac-roles-name_or_id-endpoints-workspace_name_or_id-endpoint
+      responses:
+        '204':
+          description: No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |
+        Delete a Role Endpoint Permission
+      tags:
+        - RBAC
+  '/rbac/roles/{name_or_id}/entities':
+    parameters:
+      - schema:
+          type: string
+        name: name_or_id
+        in: path
+        required: true
+        description: The RBAC role name or UUID.
+    get:
+      summary: List Entity Permissions
+      tags:
+        - RBAC
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        actions:
+                          type: array
+                          items:
+                            type: string
+                        created_at:
+                          type: integer
+                        entity_id:
+                          type: string
+                        entity_type:
+                          type: string
+                        negative:
+                          type: boolean
+                        role:
+                          type: object
+                          properties:
+                            id:
+                              type: string
+                        role_source:
+                          description: The origin of the RBAC user role. Specifies where the user role is defined, either locally or through an identity provider (IdP).
+                          type: string
+                          default: "local"
+                          enum:
+                            - "local"
+                            - "idp"
+                x-examples:
+                  Example 1:
+                    data:
+                      - actions:
+                          - delete
+                          - create
+                          - read
+                        created_at: 1557771505
+                        entity_id: '*'
+                        entity_type: wildcard
+                        negative: false
+                        role:
+                          id: bba049fa-bf7e-40ef-8e89-553dda292e99
+              examples:
+                Example 1:
+                  value:
+                    data:
+                      - actions:
+                          - delete
+                          - create
+                          - read
+                        created_at: 1557771505
+                        entity_id: '*'
+                        entity_type: wildcard
+                        negative: false
+                        role:
+                          id: bba049fa-bf7e-40ef-8e89-553dda292e99
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-rbac-roles-name_or_id-entities
+      description: |
+        Add a Role Entity Permission
+    post:
+      summary: Add a Role Entity Permission
+      operationId: post-rbac-roles-name_or_id-entities
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  actions:
+                    type: array
+                    items:
+                      type: string
+                  created_at:
+                    type: integer
+                  entity_id:
+                    type: string
+                  entity_type:
+                    type: string
+                  negative:
+                    type: boolean
+                  role:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                x-examples:
+                  Example 1:
+                    actions:
+                      - delete
+                      - create
+                      - read
+                    created_at: 1557771505
+                    entity_id: '*'
+                    entity_type: wildcard
+                    negative: false
+                    role:
+                      id: bba049fa-bf7e-40ef-8e89-553dda292e99
+              examples:
+                example response:
+                  value:
+                    actions:
+                      - delete
+                      - create
+                      - read
+                    created_at: 1557771505
+                    entity_id: '*'
+                    entity_type: wildcard
+                    negative: false
+                    role:
+                      id: bba049fa-bf7e-40ef-8e89-553dda292e99
+      tags:
+        - RBAC
+      description: The `entity_id` must be the ID of an entity in Kong. If you provide the ID of a workspace, the permission applies to all entities in that workspace. Future entities belonging to that workspace will get the same permissions. A wildcard (`*`) will be interpreted as all entities in the system.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              description: If true, explicitly disallow the actions associated with the permissions tied to this resource. By default this value is false.
+              properties:
+                negative:
+                  type: string
+                 
+                  description: ID of the entity associated with this permission.
+                entity_id:
+                  type: string
+                 
+                  description: Type of the entity of a given `entity_id`.
+                entity_type:
+                  type: string
+                 
+                  description: One or more actions associated with this permission.
+                actions:
+                  type: string
+                 
+                  description: |
+                    One or more actions associated with this permission.
+                comment:
+                  type: string
+                  
+                  description: A string describing the RBAC permission object.
+        description: |
+          Request Body
+  '/rbac/roles/{name_or_id}/entities/{entity_id}':
+    parameters:
+      - schema:
+          type: string
+        name: name_or_id
+        in: path
+        required: true
+        description: The RBAC permission name or UUID.
+      - schema:
+          type: string
+        name: entity_id
+        in: path
+        required: true
+        description: ID of the entity associated with this permission.
+    get:
+      summary: Retrieve a Role Entity Permission
+      tags:
+        - RBAC
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  actions:
+                    type: array
+                    items:
+                      type: string
+                  created_at:
+                    type: integer
+                  entity_id:
+                    type: string
+                  entity_type:
+                    type: string
+                  negative:
+                    type: boolean
+                  role:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                  role_source:
+                    description: The origin of the RBAC user role. Specifies where the user role is defined, either locally or through an identity provider (IdP).
+                    type: string
+                    default: "local"
+                    enum:
+                      - "local"
+                      - "idp"
+                x-examples:
+                  Example 1:
+                    actions:
+                      - delete
+                      - create
+                      - read
+                    created_at: 1557771505
+                    entity_id: '*'
+                    entity_type: wildcard
+                    negative: false
+                    role:
+                      id: bba049fa-bf7e-40ef-8e89-553dda292e99
+              examples:
+                example-response:
+                  value:
+                    actions:
+                      - string
+                    created_at: 0
+                    entity_id: string
+                    entity_type: string
+                    negative: true
+                    role:
+                      id: string
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-rbac-roles-name_or_id-entities-entity_id
+      description: |
+        Retrieve a Role Entity Permission
+    patch:
+      summary: Update an Entity Permission
+      operationId: patch-rbac-roles-name_or_id-entities-entity_id
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  actions:
+                    type: array
+                    items:
+                      type: string
+                  created_at:
+                    type: integer
+                  entity_id:
+                    type: string
+                  entity_type:
+                    type: string
+                  negative:
+                    type: boolean
+                  role:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                x-examples:
+                  Example 1:
+                    actions:
+                      - update
+                    created_at: 1557771505
+                    entity_id: '*'
+                    entity_type: wildcard
+                    negative: false
+                    role:
+                      id: bba049fa-bf7e-40ef-8e89-553dda292e99
+              examples:
+                example-response:
+                  value:
+                    actions:
+                      - update
+                    created_at: 1557771505
+                    entity_id: '*'
+                    entity_type: wildcard
+                    negative: false
+                    role:
+                      id: bba049fa-bf7e-40ef-8e89-553dda292e99
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      tags:
+        - RBAC
+      description: Update an Entity Permission
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                negative:
+                  type: boolean
+                 
+                  description: |
+                    If true, explicitly disallow the actions associated with the permissions tied to this resource. By default this value is false.
+                actions:
+                  type: string
+                 
+                  description: One or more actions associated with this permission.
+    delete:
+      summary: Delete an Entity Permission
+      operationId: delete-rbac-roles-name_or_id-entities-entity_id
+      responses:
+        '204':
+          description: No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |
+        Delete an Entity Permission
+      tags:
+        - RBAC
+  '/rbac/roles/{name_or_id}/permissions':
+    parameters:
+      - schema:
+          type: string
+        name: name_or_id
+        in: path
+        required: true
+        description: The RBAC role name or UUID.
+    get:
+      summary: List Role Permissions
+      tags:
+        - RBAC
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  endpoints:
+                    type: object
+                    properties:
+                      '*':
+                        type: object
+                        properties:
+                          '*':
+                            type: object
+                            properties:
+                              actions:
+                                type: array
+                                items:
+                                  type: string
+                              negative:
+                                type: boolean
+                          /*/rbac/*:
+                            type: object
+                            properties:
+                              actions:
+                                type: array
+                                items:
+                                  type: string
+                              negative:
+                                type: boolean
+                  entities:
+                    type: object
+                    properties: {}
+                x-examples:
+                  Example 1:
+                    endpoints:
+                      '*':
+                        '*':
+                          actions:
+                            - delete
+                            - create
+                            - update
+                            - read
+                          negative: false
+                        /*/rbac/*:
+                          actions:
+                            - delete
+                            - create
+                            - update
+                            - read
+                          negative: true
+                    entities: {}
+              examples:
+                role-permission-example:
+                  value:
+                    endpoints:
+                      '*':
+                        '*':
+                          actions:
+                            - delete
+                            - create
+                            - update
+                            - read
+                          negative: false
+                        /*/rbac/*:
+                          actions:
+                            - delete
+                            - create
+                            - update
+                            - read
+                          negative: true
+                    entities: {}
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-rbac-roles-name_or_id-permissions
+      description: List Role Permissions
+  '/rbac/users/{name_or_id}/roles':
+    parameters:
+      - schema:
+          type: string
+        name: name_or_id
+        in: path
+        required: true
+        description: The RBAC user name or UUID.
+    get:
+      summary: List a User’s Roles
+      tags:
+        - RBAC
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  roles:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        comment:
+                          type: string
+                        created_at:
+                          type: integer
+                        id:
+                          type: string
+                        name:
+                          type: string
+                  user:
+                    type: object
+                    properties:
+                      comment:
+                        type: string
+                      created_at:
+                        type: integer
+                      enabled:
+                        type: boolean
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      user_token:
+                        type: string
+                      user_token_ident:
+                        type: string
+                x-examples:
+                  Example 1:
+                    roles:
+                      - comment: 'Read access to all endpoints, across all workspaces'
+                        created_at: 1557765500
+                        id: a1c810ee-8366-4654-ba0c-963ffb9ccf2e
+                        name: read-only
+                      - created_at: 1557772263
+                        id: aae80073-095f-4553-ba9a-bee5ed3b8b91
+                        name: doc-knight
+                    user:
+                      comment: null
+                      created_at: 1557772232
+                      enabled: true
+                      id: b65ca712-7ceb-4114-87f4-5c310492582c
+                      name: gruce-wayne
+                      user_token: $2b$09$gZnMKK/mm/d2rAXN7gL63uL43mjdX/62iwMqdyCQwLyC0af3ce/1K
+                      user_token_ident: 88ea3
+              examples:
+                Example 1:
+                  value:
+                    roles:
+                      - comment: 'Read access to all endpoints, across all workspaces'
+                        created_at: 1557765500
+                        id: a1c810ee-8366-4654-ba0c-963ffb9ccf2e
+                        name: read-only
+                      - created_at: 1557772263
+                        id: aae80073-095f-4553-ba9a-bee5ed3b8b91
+                        name: doc-knight
+                    user:
+                      comment: null
+                      created_at: 1557772232
+                      enabled: true
+                      id: b65ca712-7ceb-4114-87f4-5c310492582c
+                      name: gruce-wayne
+                      user_token: $2b$09$gZnMKK/mm/d2rAXN7gL63uL43mjdX/62iwMqdyCQwLyC0af3ce/1K
+                      user_token_ident: 88ea3
+      operationId: get-rbac-users-name_or_id-roles
+      description: |
+        Add a User to a Role
+    post:
+      summary: Add a User to a Role
+      operationId: post-rbac-users-name_or_id-roles
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  roles:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        created_at:
+                          type: integer
+                        id:
+                          type: string
+                        name:
+                          type: string
+                  user:
+                    type: object
+                    properties:
+                      comment:
+                        type: string
+                      created_at:
+                        type: integer
+                      enabled:
+                        type: boolean
+                      id:
+                        type: string
+                      name:
+                        type: string
+                      user_token:
+                        type: string
+                      user_token_ident:
+                        type: string
+                x-examples:
+                  Example 1:
+                    roles:
+                      - created_at: 1557772263
+                        id: aae80073-095f-4553-ba9a-bee5ed3b8b91
+                        name: doc-knight
+                    user:
+                      comment: null
+                      created_at: 1557772232
+                      enabled: true
+                      id: b65ca712-7ceb-4114-87f4-5c310492582c
+                      name: gruce-wayne
+                      user_token: $2b$09$gZnMKK/mm/d2rAXN7gL63uL43mjdX/62iwMqdyCQwLyC0af3ce/1K
+                      user_token_ident: 88ea3
+              examples:
+                example-role-created:
+                  value:
+                    roles:
+                      - created_at: 1557772263
+                        id: aae80073-095f-4553-ba9a-bee5ed3b8b91
+                        name: doc-knight
+                    user:
+                      comment: null
+                      created_at: 1557772232
+                      enabled: true
+                      id: b65ca712-7ceb-4114-87f4-5c310492582c
+                      name: gruce-wayne
+                      user_token: $2b$09$gZnMKK/mm/d2rAXN7gL63uL43mjdX/62iwMqdyCQwLyC0af3ce/1K
+                      user_token_ident: 88ea3
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |
+        Add a User to a Role
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                roles:
+                  type: string
+                  
+                  description: Comma-separated list of role names to assign to the user.
+      tags:
+        - RBAC
+    delete:
+      summary: Delete a Role from a User
+      operationId: delete-rbac-users-name_or_id-roles
+      responses:
+        '204':
+          description: No Content
+      tags:
+        - RBAC
+      description: Delete a Role from a User
+  '/rbac/users/{name_or_id}/permissions':
+    parameters:
+      - schema:
+          type: string
+        name: name_or_id
+        in: path
+        required: true
+        description: The RBAC user name or UUID.
+    get:
+      summary: List a User’s Permissions
+      tags:
+        - RBAC
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  endpoints:
+                    type: object
+                    properties:
+                      '*':
+                        type: object
+                        properties:
+                          '*':
+                            type: object
+                            properties:
+                              actions:
+                                type: array
+                                items:
+                                  type: string
+                              negative:
+                                type: boolean
+                  entities:
+                    type: object
+                    properties: {}
+                x-examples:
+                  Example 1:
+                    endpoints:
+                      '*':
+                        '*':
+                          actions:
+                            - read
+                          negative: false
+                    entities: {}
+              examples:
+                Example 1:
+                  value:
+                    endpoints:
+                      '*':
+                        '*':
+                          actions:
+                            - read
+                          negative: false
+                    entities: {}
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-rbac-users-name_or_id-permissions
+      description: |
+        List a User’s Permissions
+  /filter-chains:
+    post:
+      summary: Add Filter Chain
+      operationId: post-filter-chains
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Filter-chains'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      tags:
+        - filter-chains
+      description: |
+        Create Filter Chain
+        Note: This API is not available in DB-less mode.
+      requestBody:
+        $ref: '#/components/requestBodies/filter-chains-request'
+    get:
+      summary: List Filter Chains
+      operationId: get-filter-chains
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Filter-chains'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      tags:
+        - filter-chains
+      description: |
+        List All Filter Chains
+  '/routes/{route_id_or_name}/filter-chains':
+    parameters:
+      - name: route_id_or_name
+        in: path
+        required: true
+        schema:
+          type: string
+          example: my-route
+        description: The unique identifier or the name of the route to retrieve.
+    post:
+      summary: Add Filter Chain
+      tags:
+        - filter-chains
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Filter-chains'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-routes-route_name_or_id-filter-chains
+      description: |
+        Create Filter Chain Associated to a Specific Route
+      requestBody:
+        $ref: '#/components/requestBodies/filter-chains-request'
+    get:
+      summary: List Filter Chains Associated to a Specific Route
+      operationId: get-routes-route_id_or_name-filter-chains
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Filter-chains'
+      tags:
+        - filter-chains
+      description: |
+        List Filter Chains Associated to a Specific Route
+    patch:
+      summary: Update Filter Chain Associated to a Specific Route
+      operationId: patch-routes-route_id_or_name-filter-chains
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Filter-chains'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      tags:
+        - filter-chains
+      description: |
+        Update Filter Chain Associated to a Specific Route
+      requestBody:
+        $ref: '#/components/requestBodies/filter-chains-request'
+  '/services/{service_id_or_name}/filter-chains':
+    parameters:
+      - $ref: '#/components/parameters/service_id_or_name'
+    post:
+      summary: Create Filter Chain Associated to a Specific Service
+      tags:
+        - filter-chains
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Filter-chains'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-services-service_id_or_name-filter-chains
+      description: |
+        Add filter chain Associated to a Specific Service
+      requestBody:
+        $ref: '#/components/requestBodies/filter-chains-request'
+    get:
+      summary: List Filter Chains Associated to a Specific Service
+      operationId: get-service_id_or_name-filter-chains
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Filter-chains'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |
+        List Filter Chains Associated to a Specific Service
+      tags:
+        - filter-chains
+  '/filter-chains/{filter_chain_id}':
+    parameters:
+      - $ref: '#/components/parameters/filter_chain_id'
+    get:
+      summary: Retrieve Filter Chain
+      tags:
+        - filter-chains
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Filter-chains'
+      operationId: get-filter-chains-filter_chain_id
+      description: |
+        Retrieve Filter Chain
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+    patch:
+      summary: Update Filter Chain
+      operationId: patch-filter-chains-filter_chain_id
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Filter-chains'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      tags:
+        - filter-chains
+      description: |
+        Update Filter Chain
+        Note: This API is not available in DB-less mode.
+      requestBody:
+        $ref: '#/components/requestBodies/filter-chains-request'
+    put:
+      summary: Update Or Create Filter Chain
+      operationId: put-filter-chains-filter_chain_id
+      responses:
+        '200':
+          description: OK
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      tags:
+        - filter-chains
+      description: |-
+        Inserts (or replaces) the filter chain under the requested resource with the definition specified in the body. The filter chain is identified via the name or ID attribute.
+
+        When the name or ID attribute has the structure of a UUID, the filter chain being inserted or replaced is identified by its ID. Otherwise, it is identified by its name.
+
+        When creating a new filter chain without specifying an ID (neither in the URL nor in the body), the ID will be auto-generated.
+
+        Notice that specifying a name in the URL and a different one in the request body is not allowed.
+      requestBody:
+        $ref: '#/components/requestBodies/filter-chains-request'
+    delete:
+      summary: Delete Filter Chain
+      operationId: delete-filter-chains-filter_chain_id
+      responses:
+        '204':
+          description: No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |
+        Delete filter chain.
+      tags:
+        - filter-chains
+  '/routes/{route_id_or_name}/filter-chains/{filter_chain_id}':
+    parameters:
+      - $ref: '#/components/parameters/route_id_or_name'
+      - $ref: '#/components/parameters/filter_chain_id'
+    get:
+      summary: List Filter Chains Associated to a Specific Route
+      tags:
+        - filter-chains
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Filter-chains'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-routes-route_id_or_name-filter-chains-filter_chain_id
+      description: |
+        Retrieve filter chain associated to a specific route.
+    put:
+      summary: Create Or Update Filter Chain Associated to a Specific Route
+      operationId: put-routes-route_id_or_name-filter-chains-filter_chain_id
+      responses:
+        '200':
+          description: OK
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |
+        Create or update filter chain associated to a specific route.
+      requestBody:
+        $ref: '#/components/requestBodies/filter-chains-request'
+      tags:
+        - filter-chains
+  '/routes/{route_id_or_name}/{filter_chain_id}':
+    parameters:
+      - $ref: '#/components/parameters/filter_chain_id'
+      - $ref: '#/components/parameters/route_id_or_name'
+    delete:
+      summary: Delete Filter Chain Associated to a Specific Route
+      tags:
+        - filter-chains
+      responses:
+        '204':
+          description: No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-routes-route_id_or_name-filter_chain_id
+      description: |
+        Delete filter chain associated to a specific route.
+  '/services/{service_id_or_name}/filter-chains/{filter_chain_id}':
+    parameters:
+      - $ref: '#/components/parameters/service_id_or_name'
+      - $ref: '#/components/parameters/filter_chain_id'
+    delete:
+      summary: Delete Filter Chain Associated to a Specific Service
+      operationId: delete-services-service_id_or_name-filter-chains-filter_chain_id
+      responses:
+        '204':
+          description: No Content
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |
+        Delete filter chain associated to a specific service.
+      tags:
+        - filter-chains
+  /audit/requests:
+    get:
+      summary: List request audit logs
+      parameters:
+        - $ref: '#/components/parameters/beforeAuditLogFilter'
+        - $ref: '#/components/parameters/afterAuditLogFilter'
+      tags:
+        - audit-logs
+      responses:
+        '200':
+          $ref: '#/components/responses/audit-objects-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-audit-requests
+      description: |-
+        You can access request and database audit logs through the Admin API.
+        The default order of audit log is by request timestamp - latest to oldest.
+        For usage examples, see [Audit Logging in Kong Gateway](https://docs.konghq.com/gateway/latest/kong-enterprise/audit-log/).
+  /audit/objects:
+    get:
+      summary: List database audit logs
+      parameters:
+        - $ref: '#/components/parameters/beforeAuditLogFilter'
+        - $ref: '#/components/parameters/afterAuditLogFilter'
+      responses:
+        '200':
+          $ref: '#/components/responses/database-audit-log-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-audit-objects
+      tags:
+        - audit-logs
+      description: List database audit logs (ordered by request timestamp - latest to oldest)
+  /event-hooks:
+    get:
+      summary: List all event hooks
+      tags:
+        - Event-hooks
+      responses:
+        '200':
+          $ref: '#/components/responses/event-hooks-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-event-hooks
+      description: List all event hooks and return information about the event hooks.
+    post:
+      summary: Add a webhook
+      operationId: post-event-hooks
+      responses:
+        '200':
+          $ref: '#/components/responses/event-hooks-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      tags:
+        - Event-hooks
+      description: |
+        Add a webhook
+      requestBody:
+        $ref: '#/components/requestBodies/add-webhook'
+  /event-hooks/sources:
+    get:
+      summary: List all sources
+      tags:
+        - Event-hooks
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      balancer:
+                        type: object
+                        properties:
+                          health:
+                            type: object
+                            properties:
+                              fields:
+                                type: array
+                                items:
+                                  type: string
+                      crud:
+                        type: object
+                        properties:
+                          acls:
+                            type: object
+                            properties:
+                              fields:
+                                type: array
+                                items:
+                                  type: string
+                      rate-limiting-advanced:
+                        type: object
+                        properties:
+                          rate-limit-exceeded:
+                            type: object
+                            properties:
+                              description:
+                                type: string
+                              fields:
+                                type: array
+                                items:
+                                  type: string
+                              unique:
+                                type: array
+                                items:
+                                  type: string
+                x-examples:
+                  Example 1:
+                    data:
+                      balancer:
+                        health:
+                          fields:
+                            - upstream_id
+                            - ip
+                            - port
+                            - hostname
+                            - health
+                      crud:
+                        acls:
+                          fields:
+                            - operation
+                            - entity
+                            - old_entity
+                            - schema
+                      rate-limiting-advanced:
+                        rate-limit-exceeded:
+                          description: Run an event when a rate limit has been exceeded
+                          fields:
+                            - consumer
+                            - ip
+                            - service
+                            - rate
+                            - limit
+                            - window
+                          unique:
+                            - consumer
+                            - ip
+                            - service
+              examples:
+                sources example:
+                  value:
+                    data:
+                      balancer:
+                        health:
+                          fields:
+                            - string
+                      crud:
+                        acls:
+                          fields:
+                            - string
+                      rate-limiting-advanced:
+                        rate-limit-exceeded:
+                          description: string
+                          fields:
+                            - string
+                          unique:
+                            - string
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-event-hooks-sources
+      description: |
+        Sources are the actions that trigger the event hook. The `/sources` JSON output follows the following pattern:
+
+        * 1st level = The source, which is the action that triggers the event hook.
+        * 2nd level = The event, which is the Kong entity the event hook listens to for events.
+        * 3rd level = The available template parameters for use in `webhook-custom` payloads.
+
+        For instance, in the example below `balancer` is the source, `health` is the event, and `upstream_id`, `ip`, `port`, `hostname`, and `health` are the available template parameters.
+  '/event-hooks/sources/{source}':
+    parameters:
+      - schema:
+          type: string
+        name: source
+        in: path
+        required: true
+        description: The source you want to list events from.
+    get:
+      summary: List all events for a source
+      tags:
+        - Event-hooks
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: object
+                    properties:
+                      create:
+                        type: object
+                        properties:
+                          fields:
+                            type: array
+                            items:
+                              type: string
+                      delete:
+                        type: object
+                        properties:
+                          fields:
+                            type: array
+                            items:
+                              type: string
+                      update:
+                        type: object
+                        properties:
+                          fields:
+                            type: array
+                            items:
+                              type: string
+                x-examples:
+                  Example 1:
+                    data:
+                      create:
+                        fields:
+                          - operation
+                          - entity
+                          - old_entity
+                          - schema
+                      delete:
+                        fields:
+                          - operation
+                          - entity
+                          - old_entity
+                          - schema
+                      update:
+                        fields:
+                          - operation
+                          - entity
+                          - old_entity
+                          - schema
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-event-hooks-sources-source
+      description: Events are the Kong entities the event hook listens for events. With this endpoint, you can list all of the events associated with a particular source.
+  '/event-hooks/{event-hook-id}/test':
+    parameters:
+      - schema:
+          type: string
+        name: event-hook-id
+        in: path
+        required: true
+        description: The event hook id
+    post:
+      summary: Test an event hook
+      operationId: post-event-hooks-event-hook-id-test
+      responses:
+        '200':
+          $ref: '#/components/responses/event-hooks-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      description: |-
+        It’s useful to manually trigger an event hook without provoking the event to be triggered. For instance, you might want to test the integration, or see if your hook’s service is receiving a payload from Kong.
+
+        POST any data to `/event-hooks/:id-of-hook/test`, and the `/test` endpoint executes the with the provided data as the event payload.
+      tags:
+        - Event-hooks
+  '/event-hooks/{event-hook-id}':
+      delete:
+        summary: Delete an event hook
+        description: Deletes a specific event hook by its ID.
+        operationId: deleteEventHook
+        parameters:
+          - name: event-hook-id
+            in: path
+            required: true
+            description: The ID of the event hook to delete.
+            schema:
+              type: string
+        responses:
+          '204':
+            description: Event hook successfully deleted.
+          '404':
+            description: Event hook not found.
+        tags:
+        - Event-hooks
+  '/event-hooks/{event-hook-id}/ping':
+    get:
+      summary: Ping a webhook event hook
+      parameters:
+        - name: event-hook-id
+          in: path
+          required: true
+          description: The ID of the event hook to delete.
+          schema:
+            type: string
+      tags:
+        - Event-hooks
+      responses:
+        '200':
+          $ref: '#/components/responses/event-hooks-response'
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: get-event-hooks-event-hook-id-ping
+      description: |
+        Ping a webhook event hook.
+  '/{workspace}/rbac/roles':
+    parameters:
+      - schema:
+          type: string
+        name: workspace
+        in: path
+        required: true
+        description: The workspace name or UUID.
+    get:
+      summary: List roles for a workspace
+      tags: 
+        - RBAC
+      responses:
+        '200': 
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        comment:
+                          type: string
+                        created_at:
+                          type: integer
+                        id:
+                          type: string
+                        name:
+                          type: string
+                  next:
+                    type: string
+                x-examples:
+                    Example 1:
+                      data:
+                        - comment: 'Full access to all endpoints, across all workspaces—except RBAC Admin API'
+                          created_at: 1557506249
+                          id: 38a03d47-faae-4366-b430-f6c10aee5029
+                          name: admin
+                        - comment: 'Read access to all endpoints, across all workspaces'
+                          created_at: 1557506249
+                          id: 4141675c-8beb-41a5-aa04-6258ab2d2f7f
+                          name: read-only
+                        - comment: 'Full access to all endpoints, across all workspaces'
+                          created_at: 1557506249
+                          id: 888117e0-f2b3-404d-823b-dee595423505
+                          name: super-admin
+                        - comment: null
+                          created_at: 1557532241
+                          id: b5c5cfd4-3330-4796-9b7b-6026e91e3ad6
+                          name: doc_lord
+                      next: null
+              examples:
+                Multiple roles:
+                  value:
+                    data:
+                      - comment: 'Full access to all endpoints, across all workspaces—except RBAC Admin API'
+                        created_at: 1557506249
+                        id: 38a03d47-faae-4366-b430-f6c10aee5029
+                        name: admin
+                      - comment: 'Read access to all endpoints, across all workspaces'
+                        created_at: 1557506249
+                        id: 4141675c-8beb-41a5-aa04-6258ab2d2f7f
+                        name: read-only
+                      - comment: 'Full access to all endpoints, across all workspaces'
+                        created_at: 1557506249
+                        id: 888117e0-f2b3-404d-823b-dee595423505
+                        name: super-admin
+                      - comment: null
+                        created_at: 1557532241
+                        id: b5c5cfd4-3330-4796-9b7b-6026e91e3ad6
+                        name: doc_lord
+                    next: null
+      operationId: get-rbac-roles-by-workspace
+      description: List all roles by workspace
+    post: 
+      summary: Add a role
+      operationId: post-rbac-roles-workspace
+      responses:
+          '201':
+            description: Created
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    comment:
+                      type: string
+                    created_at:
+                      type: integer
+                    id:
+                      type: string
+                    is_default:
+                      type: boolean
+                    name:
+                      type: string
+                  x-examples:
+                    Example 1:
+                      comment: null
+                      created_at: 1557532241
+                      id: b5c5cfd4-3330-4796-9b7b-6026e91e3ad6
+                      is_default: false
+                      name: service_reader
+                examples:
+                  New role response body:
+                    value:
+                      comment: null
+                      created_at: 1557532241
+                      id: b5c5cfd4-3330-4796-9b7b-6026e91e3ad6
+                      is_default: false
+                      name: service_reader
+      tags:
+        - RBAC
+      requestBody:
+        content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  
+
+                    description: The RBAC role name.
+                  comment:
+                    type: string
+                  
+                    description: A string describing the RBAC user object.
+        description: The request body contains the name of the role and an optional attribute. 
+      description: Add a role.
+  '/{workspace}/rbac/roles/{role}/endpoints/{endpoint}/':
+    get:
+      summary: Get role-specific permissions for an endpoint within a workspace
+      parameters:
+        - in: path
+          name: workspace
+          required: true
+          schema:
+            type: string
+          description: The workspace name or UUID.
+        - in: path
+          name: role
+          required: true
+          schema:
+            type: string
+          description: The RBAC role ID.
+        - in: path
+          name: endpoint
+          required: true
+          schema:
+            type: string
+          description: The specific endpoint to retrieve permissions for.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  actions:
+                    type: array
+                    items:
+                      type: string
+                  created_at:
+                    type: integer
+                  endpoint:
+                    type: string
+                  negative:
+                    type: boolean
+                  role:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                  role_source:
+                    description: The origin of the RBAC user role. Specifies where the user role is defined, either locally or through an identity provider (IdP).
+                    type: string
+                    default: "local"
+                    enum:
+                      - "local"
+                      - "idp"
+                  workspace:
+                    type: string
+              example: 
+                actions:
+                  - "delete"
+                  - "create"
+                  - "update"
+                  - "read"
+                created_at: 1557764505
+                endpoint: "/consumers"
+                negative: false
+                role:
+                  id: "23df9f20-e7cc-4da4-bc89-d3a08f976e50"
+                workspace: "default"
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+      operationId: getRoleSpecificEndpointPermissions
+      tags:
+        - RBAC
+
+  '/fips-status':
+    get:
+      summary: FIPS Mode Status
+      tags:
+        - licenses
+      description: >-
+        Retrieves the current FIPS mode status. This endpoint indicates whether FIPS mode is active and provides the version of the FIPS module. 
+      responses:
+        '401': 
+          $ref: '#/components/responses/HTTP401Error'
+        200:
+          description: FIPS mode status retrieved successfully.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  active:
+                    type: boolean
+                    description: Indicates if FIPS mode is currently active (true) or inactive (false).
+                  version:
+                    type: string
+                    description: The version of the FIPS module, or 'unknown' if the version cannot be determined.
+              examples:
+                fips_enabled:
+                  value: {"active": true, "version": "2.0.16"}
+                  summary: FIPS mode is enabled. This may occur after a license configuration change that enables FIPS mode.
+                fips_disabled:
+                  value: {"active": false, "version": "unknown"}
+                  summary: FIPS mode is disabled or not supported. This may be the default state or result from a license configuration that does not enable FIPS mode.
+  '/workspace_/groups':
+      get:
+          operationId: list-groups
+          responses:
+              "200":
+                  content:
+                      application/json:
+                          schema:
+                              items:
+                                  properties:
+                                      created_at:
+                                          format: date-time
+                                          type: string
+                                      id:
+                                          type: string
+                                      name:
+                                          type: string
+                                  type: object
+                              type: array
+                  description: Successfully retrieved the list of groups
+          summary: Retrieve a list of all groups
+          tags:
+              - Workspaces
+      post:
+          operationId: create-group
+          requestBody:
+              content:
+                  application/json:
+                      schema:
+                          properties:
+                              name:
+                                  type: string
+                          required:
+                              - name
+                          type: object
+          responses:
+              "201":
+                  content:
+                      application/json:
+                          schema:
+                              properties:
+                                  created_at:
+                                      format: date-time
+                                      type: string
+                                  id:
+                                      type: string
+                                  name:
+                                      type: string
+                              type: object
+                  description: Successfully created the group
+          summary: Create a new group
+          tags:
+              - Workspaces
+  '/workspace_/groups/{groups}':
+      parameters:
+          - in: path
+            name: groups
+            required: true
+            schema:
+              type: string
+      patch:
+          operationId: update-group
+          requestBody:
+              content:
+                  application/json:
+                      schema:
+                          properties:
+                              name:
+                                  type: string
+                          type: object
+          responses:
+              "200":
+                  description: Successfully updated the group
+          summary: Update details of a specific group
+          tags:
+              - Workspaces
+  '/workspace_/groups/{groups}/roles':
+      delete:
+          operationId: remove-role-from-group
+          parameters:
+              - in: query
+                name: rbac_role_id
+                required: true
+                schema:
+                  type: string
+              - in: query
+                name: workspace_id
+                required: true
+                schema:
+                  type: string
+          responses:
+              "204":
+                  description: Successfully removed the role association
+          summary: Remove a role association from a group
+          tags:
+              - Workspaces
+      get:
+          operationId: list-group-roles
+          responses:
+              "200":
+                  content:
+                      application/json:
+                          schema:
+                              items:
+                                  properties:
+                                      group:
+                                          properties:
+                                              id:
+                                                  type: string
+                                              name:
+                                                  type: string
+                                          type: object
+                                      rbac_role:
+                                          properties:
+                                              id:
+                                                  type: string
+                                              name:
+                                                  type: string
+                                          type: object
+                                      workspace:
+                                          properties:
+                                              id:
+                                                  type: string
+                                          type: object
+                                  type: object
+                              type: array
+                  description: Successfully retrieved the roles
+          summary: Retrieve roles associated with a specific group
+          tags:
+              - Workspaces
+      parameters:
+          - in: path
+            name: groups
+            required: true
+            schema:
+              type: string
+      post:
+          operationId: add-role-to-group
+          requestBody:
+              content:
+                  application/json:
+                      schema:
+                          properties:
+                              rbac_role_id:
+                                  type: string
+                              workspace_id:
+                                  type: string
+                          required:
+                              - rbac_role_id
+                              - workspace_id
+                          type: object
+          responses:
+              "201":
+                  content:
+                      application/json:
+                          schema:
+                              properties:
+                                  group:
+                                      properties:
+                                          id:
+                                              type: string
+                                          name:
+                                              type: string
+                                      type: object
+                                  rbac_role:
+                                      properties:
+                                          id:
+                                              type: string
+                                          name:
+                                              type: string
+                                      type: object
+                                  workspace:
+                                      properties:
+                                          id:
+                                              type: string
+                                      type: object
+                              type: object
+                  description: Successfully associated the role with the group
+          summary: Associate a role with a group
+          tags:
+              - Workspaces
+  '/clustering/data-planes':
+    get:
+      summary: Retrieve connected data planes
+      description: >
+        Retrieve a list of all data planes connected to the control plane. This endpoint is only accessible when Kong Gateway is running in hybrid mode.
+      operationId: getDataPlanes
+      responses:
+        '200':
+          description: A list of connected data planes.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        ip:
+                          type: string
+                          description: The IP address of the data plane.
+                        updated_at:
+                          type: integer
+                          description: Unix timestamp of the last update.
+                        config_hash:
+                          type: string
+                          description: The hash of the current configuration on the data plane.
+                        sync_status:
+                          type: string
+                          description: The sync status of the data plane.
+                        version:
+                          type: string
+                          description: The version of Kong running on the data plane.
+                        id:
+                          type: string
+                          description: Unique identifier of the data plane.
+                        hostname:
+                          type: string
+                          description: The hostname of the data plane.
+                        ttl:
+                          type: integer
+                          description: Time-to-live for the connection.
+                        last_seen:
+                          type: integer
+                          description: Unix timestamp when the data plane was last seen by the control plane.
+                        labels:
+                          type: object
+                          description: Metadata labels attached to the data plane.
+                          properties:
+                            deployment:
+                              type: string
+                              description: The deployment name.
+                            region:
+                              type: string
+                              description: The region of the data plane.
+                        cert_details:
+                          type: object
+                          properties:
+                            expiry_timestamp:
+                              type: integer
+                              description: Timestamp for when the certificate expires.
+        '400':
+          description: Kong Gatewat is not running as a control plane.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: This endpoint is only available when Kong is running as a control plane for the cluster.
+      tags:
+        - clustering
+
+  '/clustering/status':
+    get:
+      summary: Retrieve the status of connected data planes
+      description: >
+        Retrieve a status report for all data planes connected to the control plane. It includes information like the config hash, hostname, IP address, and last seen timestamp.
+        This endpoint is only accessible when Kong Gateway is running in hybrid mode.
+      operationId: getDataPlaneStatus
+      responses:
+        '200':
+          description: The status of all connected data planes.
+          headers:
+            Deprecation:
+              description: >
+                Indicates that the endpoint may be deprecated in the future.
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: object
+                  properties:
+                    config_hash:
+                      type: string
+                      description: Hash of the configuration running on the data plane.
+                    hostname:
+                      type: string
+                      description: Hostname of the data plane.
+                    ip:
+                      type: string
+                      description: The IP address of the data plane.
+                    last_seen:
+                      type: integer
+                      description: Unix timestamp of the last interaction between the data plane and control plane.
+        '400':
+          description: Kong Gatewat is not running as a control plane.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: This endpoint is only available when Kong is running as a control plane for the cluster.
+      tags:
+      - clustering
+  '/cache/{key}':
+    get:
+      summary: Get cache value by key
+      description: >
+        Retrieve the cached value for a specific key. This endpoint probes both `kong.cache` and `kong.core_cache`. 
+        If the key exists, it returns the associated value and TTL. If not found, it returns a 404.
+      operationId: getCacheByKey
+      parameters:
+        - name: key
+          in: path
+          required: true
+          description: The cache key to retrieve.
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Cached value found.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ttl:
+                    type: integer
+                    description: Time-to-live (TTL) of the cached entry.
+                  message:
+                    type: string
+                    description: Cached value or a message.
+        '404':
+          description: Cache key not found.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                    example: Not found
+      tags:
+      - cache
+    delete:
+      summary: Invalidate cache by key
+      description: >
+        Invalidate the cache for a specific key in both `kong.cache` and `kong.core_cache`.
+      operationId: deleteCacheByKey
+      parameters:
+        - name: key
+          in: path
+          required: true
+          description: The cache key to invalidate.
+          schema:
+            type: string
+      responses:
+        '204':
+          description: Cache invalidated successfully.
+      tags:
+      - cache
+  
+  '/cache':
+    delete:
+      summary: Purge all cache entries
+      description: >
+        Purge all cache entries in both `kong.cache` and `kong.core_cache`.
+      operationId: purgeAllCache
+      responses:
+        '204':
+          description: All cache entries purged successfully.
+      tags:
+      - cache
+
+  /partials:
+    get:
+      summary: List all Partials
+      tags:
+        - Partials
+      operationId: listPartials
+      description: Retrieve a list of all Partials.
+      responses:
+        '200':
+          description: A list of all Partials.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Partial'
+                  next:
+                    type: string
+                    nullable: true
+    post:
+      summary: Create a new Partial
+      tags:
+        - Partials
+      operationId: createPartial
+      description: Create a new Partial.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Partial'
+      responses:
+        '201':
+          description: Partial successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Partial'
+
+  '/partials/{PartialId}':
+    parameters:
+      - $ref: '#/components/parameters/PartialId'
+    get:
+      summary: Get a specific Partial
+      tags:
+        - Partials
+      operationId: getPartial
+      description: Retrieve details of a specific Partial.
+      responses:
+        '200':
+          description: Details of the specified Partial.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Partial'
+    put:
+      summary: Update / Upsert a specific Partial
+      tags:
+        - Partials
+      operationId: upsertPartial
+      description: Update or create a specific Partial
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Partial'
+      responses:
+        '201':
+          description: Partial successfully created.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Partial'
+servers:
+  - description: Default Admin API URL
+    url: '{protocol}://{hostname}:{port}{path}'
+    variables:
+      hostname:
+        default: localhost
+        description: Hostname for Kong's Admin API
+      path:
+        default: /
+        description: Base path for Kong's Admin API
+      port:
+        default: '8001'
+        description: Port for Kong's Admin API
+      protocol:
+        default: http
+        description: Protocol for requests to Kong's Admin API
+        enum:
+          - http
+          - https
+security:
+  - kongAdminToken: []
+tags:
+  - description: |
+      Service entities are abstractions of your microservice interfaces or formal APIs. For example, a service could be a data transformation microservice or a billing API.
+      <br><br>
+      The main attribute of a service is the destination URL for proxying traffic. This URL can be set as a single string or by specifying its protocol, host, port and path individually. 
+      <br><br>
+      Services are associated to routes, and a single service can have many routes associated with it. Routes are entrypoints in Kong Gateway which define rules to match client requests. Once a route is matched, Kong Gateway proxies the request to its associated service. See the [Proxy Reference](https://docs.konghq.com/gateway/latest/how-kong-works/routing-traffic/) for a detailed explanation of how Kong proxies traffic.
+      <br><br>
+      Services can be both [tagged and filtered by tags](https://docs.konghq.com/gateway/latest/admin-api/#tags).
+    name: Services
+  - description: |
+      Route entities define rules to match client requests. Each route is associated with a service, and a service may have multiple routes associated to it. Every request matching a given route will be proxied to the associated service. You need at least one matching rule that applies to the protocol being matched by the route.
+      <br><br>
+      The combination of routes and services, and the separation of concerns between them, offers a powerful routing mechanism with which it is possible to define fine-grained entrypoints in Kong Gateway leading to different upstream services of your infrastructure.
+      <br><br>
+      Depending on the protocol, one of the following attributes must be set:
+      <br>
+      * `http`: At least one of `methods`, `hosts`, `headers`, or `paths`
+      * `https`:  At least one of `methods`, `hosts`, `headers`, `paths`, or `snis`
+      *  `tcp`: At least one of `sources` or `destinations`
+      * `tls`: at least one of `sources`, `destinations`, or `snis`
+      * `tls_passthrough`: set `snis`
+      * `grpc`: At least one of `hosts`, `headers`, or `paths`
+      * `grpcs`: At least one of `hosts`, `headers`, `paths`, or `snis`
+      * `ws`: At least one of `hosts`, `headers`, or `paths`
+      * `wss`: At least one of `hosts`, `headers`, `paths`, or `snis` 
+      <br>
+
+      A route can't have both `tls` and `tls_passthrough` protocols at same time.
+      <br><br>
+
+      Learn more about the router: 
+      * [Configure routes using expressions](https://docs.konghq.com/gateway/latest/key-concepts/routes/expressions/)
+      * [Router Expressions language reference](https://docs.konghq.com/gateway/latest/reference/expressions-language/)
+    name: Routes
+  - description: |
+      A plugin entity represents a plugin configuration that will be executed during the HTTP request/response lifecycle. Plugins let you add functionality to services that run behind a Kong Gateway instance, like authentication or rate limiting.
+      You can find more information about available plugins and which values each plugin accepts at the [Plugin Hub](https://docs.konghq.com/hub/).
+      <br><br>
+      When adding a plugin configuration to a service, the plugin will run on every request made by a client to that service. If a plugin needs to be tuned to different values for some specific consumers, you can do so by creating a separate plugin instance that specifies both the service and the consumer, through the service and consumer fields.
+      <br><br>
+      Plugins can be both [tagged and filtered by tags](https://docs.konghq.com/gateway/latest/admin-api/#tags).
+      <br><br>
+        **Bracket syntax for keys with periods:**
+        When submitting form data, keys that contain dots (e.g., `service.name`) should be enclosed in square brackets to avoid ambiguity:
+        
+        - Example: `config.resource_attributes[service.name]=kong-dev`
+        
+        - If necessary, URL encode the square brackets: `%5Bservice.name%5D`.
+    name: Plugins
+  - description: |
+      The consumer object represents a consumer - or a user - of a service. 
+      You can either rely on Kong Gateway as the primary datastore, or you can map the consumer list with your database to keep consistency between Kong Gateway and your existing primary datastore.
+    name: Consumers
+  - description: |
+      A certificate object represents a public certificate, and can be optionally paired with the corresponding private key. These objects are used by Kong Gateway to handle SSL/TLS termination for encrypted requests, or for use as a trusted CA store when validating peer certificate of client/service. 
+      <br><br>
+      Certificates are optionally associated with SNI objects to tie a cert/key pair to one or more hostnames. 
+      <br><br>
+      If intermediate certificates are required in addition to the main certificate, they should be concatenated together into one string.
+    name: Certificates
+  - description: |
+      An SNI object represents a many-to-one mapping of hostnames to a certificate. 
+      <br><br>
+      A certificate object can have many hostnames associated with it. When Kong Gateway receives an SSL request, it uses the SNI field in the Client Hello to look up the certificate object based on the SNI associated with the certificate.
+    name: SNIs
+  - description: |
+      A target is an IP address or hostname with a port that identifies an instance of a backend service. Every upstream can have many targets, and the targets can be dynamically added, modified, or deleted. Changes take effect on the fly.
+      <br><br>
+      To disable a target, post a new one with `weight=0`, or use the `DELETE` method to accomplish the same.
+    name: Targets
+  - description: |
+      A CA certificate object represents a trusted certificate authority. 
+      These objects are used by Kong Gateway to verify the validity of a client or server certificate.
+    name: CA Certificates
+  - description: |
+      The upstream object represents a virtual hostname and can be used to load balance incoming requests over multiple services (targets). 
+      <br><br>
+      An upstream also includes a [health checker](https://docs.konghq.com/gateway/latest/how-kong-works/health-checks/), which can enable and disable targets based on their ability or inability to serve requests. 
+      The configuration for the health checker is stored in the upstream object, and applies to all of its targets.
+    name: Upstreams
+  - description: |
+      Vault objects are used to configure different vault connectors for [managing secrets](https://docs.konghq.com/gateway/latest/kong-enterprise/secrets-management/). 
+      Configuring a vault lets you reference secrets from other entities.
+      This allows for a proper separation of secrets and configuration and prevents secret sprawl. 
+      <br><br>
+      For example, you could store a certificate and a key in a vault, then reference them from a certificate entity. This way, the certificate and key are not stored in the entity directly and are more secure.
+      <br><br>
+      Secrets rotation can be managed using [TTLs](https://docs.konghq.com/gateway/latest/kong-enterprise/secrets-management/advanced-usage/).
+    name: Vaults
+  - description: |
+      A key object holds a representation of asymmetric keys in various formats. When Kong Gateway or a Kong plugin requires a specific public or private key to perform certain operations, it can use this entity.
+    name: Keys
+  - description: |
+      Keyring is the mechanism for storing sensitive data fields, such as consumer secrets, in an encrypted format within the database. This provides for encryption-at-rest security controls in a Kong Gateway cluster.
+    name: Keyring
+  - description: |
+      A JSON Web Key Set. Key sets are the preferred way to expose keys to plugins because they tell the plugin where to look for keys or have a scoping mechanism to restrict plugins to specific keys.
+    name: Key-sets
+  - description: |
+      The workspace object describes the workspace entity, which has an ID and a name.
+      <br><br>
+      Workspaces provide a way to segment Kong Gateway entities. Entities in a workspace are isolated from those in other workspaces. 
+    name: Workspaces
+  - description: |
+      A license entity lets you configure a license in your Kong Gateway cluster, in both traditional and hybrid mode deployments. 
+      In hybrid mode deployments, the control plane sends licenses configured through the `/licenses` endpoint to all data planes in the cluster.
+      The data planes use the most recent `updated_at` license.
+    name: licenses
+  - description: |
+      Consumer groups enable the organization and categorization of consumers (users or applications) within an API ecosystem. 
+      By grouping consumers together, you eliminate the need to manage them individually, providing a scalable, efficient approach to managing configurations.
+    name: consumer_groups
+  - description: |
+      Information routes
+    name: Information
+  - description: |
+      Admin routes
+    name: admins
+  - description: |
+      Group routes
+    name: groups
+  - description: |
+      Debug Routes
+    name: debug
+  - description: |
+      Kong Gateway's RBAC feature is configurable through Kong's Admin API or using Kong Manager.
+      <br><br>
+      There are four basic entities involving RBAC:
+      <br><br>
+      * User: The entity interacting with the system. Can be associated with zero, one, or more roles. For example: The user `bob` has the token `1234`.
+      * Role: Set of permissions (`role_endpoint` and `role_entity`). Has a name and can be associated with zero, one, or more permissions. For example: The user `bob` is associated with the role `developer`.
+      * `role_source`: The origin of the RBAC user role. Specifies where the user role is defined, either locally or through an identity provider (IdP).
+      * `role_endpoint`: A set of enabled or disabled actions. For example: The role `developer` has one `role_endpoint` and reads and writes to `/routes`.
+      * `role_entity`: A set of enabled or disabled actions. For example: The role `developer` has one `role_entity` attached to a UUID.
+      For the admin role in the default workspace, CRUD actions on /groups and /groups/* endpoints are disallowed. 
+      For the workspace-admin role in non-default workspaces, CRUD actions on /groups and /groups/* endpoints are disallowed.
+    name: RBAC
+  - description: |
+      A filter chain is the database entity representing one or more WebAssembly filters executed for each request to a particular service or route, each one with its configuration.
+    name: filter-chains
+  - description: |
+      You can access request and database audit logs through the Admin API. The default order of audit log is by request timestamp - latest to oldest.
+      <br><br>
+      For usage examples, see [Audit Logging in Kong Gateway](https://docs.konghq.com/gateway/latest/admin-api/audit-logs/).
+    name: audit-logs
+  - description: |
+      Event hooks are outbound calls from Kong Gateway. With event hooks, the Kong Gateway can communicate with target services or resources, letting the target know that an event was triggered. When an event is triggered in Kong, it calls a URL with information about that event. Event hooks add a layer of configuration for subscribing to worker events using the admin interface. Worker events are integrated into Kong Gateway to communicate within the gateway context. For example, when an entity is created, the Kong Gateway fires an event with information about the entity. Parts of the Kong Gateway codebase can subscribe to these events, then process the events using callbacks.
+      <br><br>
+      Depending on the protocol, one of the following attributes must be set:
+      <br>
+      * `webhook`: Makes a JSON POST request to a provided URL with the event data as a payload. Useful for building a middle tier integration (your own webhook that receives Kong hooks). Specific headers can be configured for the request.
+      * `webhook-custom`: Fully configurable request. Useful for building a direct integration with a service (for example, a Slack webhook). Because it’s fully configurable, it’s more complex to configure. It supports templating on a configurable body, a configurable form payload, and headers.
+      *  `log`: This handler, which requires no configuration, logs the event and the content of the payload into the Kong Gateway logs. If using hybrid mode, the crud and dao:crud sources will log on the control plane logs and the balancer and rate-limiting-advanced sources will log on the data plane logs.
+      * `lambda`: This handler runs specified Lua code after an event is triggered.
+      <br><br>
+      Event hooks do not work with Konnect yet.
+      <br><br>
+    name: Event-hooks
+  - description: |
+      Retrieve information about the status of data planes when Kong Gateway is running in hybrid mode.
+    name: clustering
+  - description: |
+      Querying and managing cache entries.
+    name: cache

--- a/app/_data/kong-conf/3.10.json
+++ b/app/_data/kong-conf/3.10.json
@@ -1,0 +1,1774 @@
+{
+  "sections": [
+    {
+      "title": "GENERAL",
+      "start": 22,
+      "end": 275,
+      "description": ""
+    },
+    {
+      "title": "HYBRID MODE",
+      "start": 276,
+      "end": 376,
+      "description": ""
+    },
+    {
+      "title": "HYBRID MODE DATA PLANE",
+      "start": 377,
+      "end": 421,
+      "description": ""
+    },
+    {
+      "title": "HYBRID MODE CONTROL PLANE",
+      "start": 422,
+      "end": 498,
+      "description": ""
+    },
+    {
+      "title": "NGINX",
+      "start": 499,
+      "end": 1128,
+      "description": ""
+    },
+    {
+      "title": "NGINX injected directives",
+      "start": 1129,
+      "end": 1283,
+      "description": "Nginx directives can be dynamically injected in the runtime nginx.conf file\nwithout requiring a custom Nginx configuration template.\n\nAll configuration properties following the naming scheme\n`nginx_<namespace>_<directive>` will result in `<directive>` being injected in\nthe Nginx configuration block corresponding to the property's `<namespace>`.\nExample:\n`nginx_proxy_large_client_header_buffers = 8 24k`\n\nWill inject the following directive in Kong's proxy `server {}` block:\n\n`large_client_header_buffers 8 24k;`\n\nThe following namespaces are supported:\n\n- `nginx_main_<directive>`: Injects `<directive>` in Kong's configuration\n`main` context.\n- `nginx_events_<directive>`: Injects `<directive>` in Kong's `events {}`\nblock.\n- `nginx_http_<directive>`: Injects `<directive>` in Kong's `http {}` block.\n- `nginx_proxy_<directive>`: Injects `<directive>` in Kong's proxy\n`server {}` block.\n- `nginx_location_<directive>`: Injects `<directive>` in Kong's proxy `/`\nlocation block (nested under Kong's proxy `server {}` block).\n- `nginx_upstream_<directive>`: Injects `<directive>` in Kong's proxy\n`upstream {}` block.\n- `nginx_admin_<directive>`: Injects `<directive>` in Kong's Admin API\n`server {}` block.\n- `nginx_status_<directive>`: Injects `<directive>` in Kong's Status API\n`server {}` block (only effective if `status_listen` is enabled).\n- `nginx_debug_<directive>`: Injects `<directive>` in Kong's Debug API\n`server{}` block (only effective if `debug_listen` or `debug_listen_local`\nis enabled).\n- `nginx_stream_<directive>`: Injects `<directive>` in Kong's stream module\n`stream {}` block (only effective if `stream_listen` is enabled).\n- `nginx_sproxy_<directive>`: Injects `<directive>` in Kong's stream module\n`server {}` block (only effective if `stream_listen` is enabled).\n- `nginx_supstream_<directive>`: Injects `<directive>` in Kong's stream\nmodule `upstream {}` block.\n\nAs with other configuration properties, Nginx directives can be injected via\nenvironment variables when capitalized and prefixed with `KONG_`.\nExample:\n`KONG_NGINX_HTTP_SSL_PROTOCOLS` -> `nginx_http_ssl_protocols`\n\nWill inject the following directive in Kong's `http {}` block:\n\n`ssl_protocols <value>;`\n\nIf different sets of protocols are desired between the proxy and Admin API\nserver, you may specify `nginx_proxy_ssl_protocols` and/or\n`nginx_admin_ssl_protocols`, both of which take precedence over the\n`http {}` block.\n"
+    },
+    {
+      "title": "DATASTORE",
+      "start": 1284,
+      "end": 1566,
+      "description": "Kong can run with a database to store coordinated data between Kong nodes in\na cluster, or without a database, where each node stores its information\nindependently in memory.\n\nWhen using a database, Kong will store data for all its entities (such as\nroutes, services, consumers, and plugins) in PostgreSQL,\nand all Kong nodes belonging to the same cluster must connect to the same database.\n\nKong supports PostgreSQL versions 9.5 and above.\n\nWhen not using a database, Kong is said to be in \"DB-less mode\": it will keep\nits entities in memory, and each node needs to have this data entered via a\ndeclarative configuration file, which can be specified through the\n`declarative_config` property, or via the Admin API using the `/config`\nendpoint.\n\nWhen using Postgres as the backend storage, you can optionally enable Kong\nto serve read queries from a separate database instance.\nWhen the number of proxies is large, this can greatly reduce the load\non the main Postgres instance and achieve better scalability. It may also\nreduce the latency jitter if the Kong proxy node's latency to the main\nPostgres instance is high.\n\nThe read-only Postgres instance only serves read queries, and write\nqueries still go to the main connection. The read-only Postgres instance\ncan be eventually consistent while replicating changes from the main\ninstance.\n\nAt least the `pg_ro_host` config is needed to enable this feature.\nBy default, all other database config for the read-only connection is\ninherited from the corresponding main connection config described above but\nmay be optionally overwritten explicitly using the `pg_ro_*` config below.\n"
+    },
+    {
+      "title": "DATASTORE CACHE",
+      "start": 1567,
+      "end": 1642,
+      "description": "In order to avoid unnecessary communication with the datastore, Kong caches\nentities (such as APIs, consumers, credentials...) for a configurable period\nof time. It also handles invalidations if such an entity is updated.\n\nThis section allows for configuring the behavior of Kong regarding the\ncaching of such configuration entities.\n"
+    },
+    {
+      "title": "DNS RESOLVER",
+      "start": 1643,
+      "end": 1724,
+      "description": "By default, the DNS resolver will use the standard configuration files\n`/etc/hosts` and `/etc/resolv.conf`. The settings in the latter file will be\noverridden by the environment variables `LOCALDOMAIN` and `RES_OPTIONS` if\nthey have been set.\n\nKong will resolve hostnames as either `SRV` or `A` records (in that order, and\n`CNAME` records will be dereferenced in the process).\nIn case a name is resolved as an `SRV` record, it will also override any given\nport number with the `port` field contents received from the DNS server.\n\nThe DNS options `SEARCH` and `NDOTS` (from the `/etc/resolv.conf` file) will\nbe used to expand short names to fully qualified ones. So it will first try\nthe entire `SEARCH` list for the `SRV` type, if that fails it will try the\n`SEARCH` list for `A`, etc.\n\nFor the duration of the `ttl`, the internal DNS resolver will load balance each\nrequest it gets over the entries in the DNS record. For `SRV` records, the\n`weight` fields will be honored, but it will only use the lowest `priority`\nfield entries in the record.\n\nFor DNS records returned with a TTL value of 0, Kong will default to caching\nthese records for 1 second. Strict adherence to the requirement of not caching\nTTL 0 records could generate excessive query frequency to upstream DNS servers,\nleading to unsustainable load and potential service degradation. As a result,\nmost DNS resolver implementations deviate from this requirement in practice.\n"
+    },
+    {
+      "title": "New DNS RESOLVER",
+      "start": 1725,
+      "end": 1823,
+      "description": "This DNS resolver introduces global caching for DNS records across workers,\nsignificantly reducing the query load on DNS servers.\n\nIt provides observable statistics, you can retrieve them through the Admin API\n`/status/dns`.\n"
+    },
+    {
+      "title": "VAULTS",
+      "start": 1824,
+      "end": 2049,
+      "description": "A secret is any sensitive piece of information required for API gateway\noperations. Secrets may be part of the core Kong Gateway configuration,\nused in plugins, or part of the configuration associated with APIs serviced\nby the gateway.\n\nSome of the most common types of secrets used by Kong Gateway include:\n\n- Data store usernames and passwords, used with PostgreSQL and Redis\n- Private X.509 certificates\n- API keys\n\nSensitive plugin configuration fields are generally used for authentication,\nhashing, signing, or encryption. Kong Gateway lets you store certain values\nin a vault. Here are the vault specific configuration options.\n"
+    },
+    {
+      "title": "TUNING & BEHAVIOR",
+      "start": 2050,
+      "end": 2170,
+      "description": ""
+    },
+    {
+      "title": "MISCELLANEOUS",
+      "start": 2171,
+      "end": 2292,
+      "description": "Additional settings inherited from lua-nginx-module allowing for more\nflexibility and advanced usage.\n\nSee the lua-nginx-module documentation for more information:\nhttps://github.com/openresty/lua-nginx-module\n"
+    },
+    {
+      "title": "KONG MANAGER",
+      "start": 2293,
+      "end": 2564,
+      "description": "\nThe Admin GUI for Kong Enterprise.\n\n"
+    },
+    {
+      "title": "Konnect",
+      "start": 2565,
+      "end": 2571,
+      "description": ""
+    },
+    {
+      "title": "Analytics for Konnect",
+      "start": 2572,
+      "end": 2592,
+      "description": ""
+    },
+    {
+      "title": "ADMIN SMTP CONFIGURATION",
+      "start": 2593,
+      "end": 2607,
+      "description": ""
+    },
+    {
+      "title": "GENERAL SMTP CONFIGURATION",
+      "start": 2608,
+      "end": 2658,
+      "description": ""
+    },
+    {
+      "title": "DATA & ADMIN AUDIT",
+      "start": 2659,
+      "end": 2704,
+      "description": "When enabled, Kong will store detailed audit data regarding Admin API and\ndatabase access. In most cases, updates to the database are associated with\nAdmin API requests. As such, database object audit log data is tied to a\ngiven HTTP request via a unique identifier, providing built-in association of\nAdmin API and database traffic.\n\n"
+    },
+    {
+      "title": "ROUTE COLLISION DETECTION/PREVENTION",
+      "start": 2705,
+      "end": 2752,
+      "description": ""
+    },
+    {
+      "title": "DATABASE ENCRYPTION & KEYRING MANAGEMENT",
+      "start": 2753,
+      "end": 2981,
+      "description": "When enabled, Kong will transparently encrypt sensitive fields, such as consumer\ncredentials, TLS private keys, and RBAC user tokens, among others. A full list\nof encrypted fields is available from the Kong Enterprise documentation site.\nEncrypted data is transparently decrypted before being displayed to the Admin\nAPI or made available to plugins or core routing logic.\n\nWhile this feature is GA, do note that we currently do not provide normal semantic\nversioning compatibility guarantees on the keyring feature's APIs in that Kong may\nmake a breaking change to the feature in a minor version. Also note that\nmismanagement of keyring data may result in irrecoverable data loss.\n\n"
+    },
+    {
+      "title": "CLUSTER FALLBACK CONFIGURATION",
+      "start": 2982,
+      "end": 3030,
+      "description": ""
+    },
+    {
+      "title": "WEBASSEMBLY (WASM)",
+      "start": 3031,
+      "end": 3093,
+      "description": ""
+    },
+    {
+      "title": "WASM injected directives",
+      "start": 3094,
+      "end": 3177,
+      "description": "The Nginx Wasm module (i.e., ngx_wasm_module) has its own settings, which can\nbe tuned via `wasm_*` directives in the Nginx configuration file. Kong\nsupports configuration of these directives via its Nginx directive injection\nmechanism.\n\nThe following namespaces are supported:\n\n- `nginx_wasm_<directive>`: Injects `<directive>` into the `wasm {}` block.\n- `nginx_wasm_shm_kv`: Injects `shm_kv *` into the `wasm {}` block,\nallowing operators to define a general memory zone which is usable by\nthe `get_shared_data`/`set_shared_data` Proxy-Wasm SDK functions as\nan in-memory key-value store of data shareable across filters.\n- `nginx_wasm_shm_kv_<name>`: Injects `shm_kv <name>` into the `wasm {}` block,\nallowing operators to define custom shared memory zones which are usable by\nthe `get_shared_data`/`set_shared_data` Proxy-Wasm SDK functions as\nseparate namespaces in the `\"<name>/<key>\"` format.\nFor using these functions with non-namespaced keys, the Nginx template needs\na `shm_kv *` entry, which can be defined using `nginx_wasm_shm_kv`.\n- `nginx_wasm_wasmtime_<flag>`: Injects `flag <flag>` into the `wasmtime {}`\nblock, allowing various Wasmtime-specific flags to be set.\n- `nginx_<http|proxy>_<directive>`: Injects `<directive>` into the\n`http {}` or `server {}` blocks, as specified in the Nginx injected directives\nsection.\n\nThe documentation for all supported directives can be found in the Nginx Wasm\nmodule repository:\n\nhttps://github.com/Kong/ngx_wasm_module/blob/main/docs/DIRECTIVES.md\n\nThe Wasmtime flag documentation can be found here:\n\nhttps://docs.wasmtime.dev/c-api/config_8h.html\n\nThere are several noteworthy ngx_wasm_module behaviors which can be tuned via\n`http {}`/`server {}` level directive injection (identical behavior in either\nlevel), for example:\n\n- `nginx_http_proxy_wasm_socket_<connect|read|send>_timeout`: sets connection/read/send\ntimeouts for Wasm dispatches.\n- `nginx_http_proxy_wasm_socket_buffer_size`: sets a buffer size for\nreading Wasm dispatch responses.\n\nThe values for these settings are inherited from their `nginx_*_lua_*`\ncounterparts if they have not been explicitly set. For instance, if you set\n`nginx_http_lua_socket_connect_timeout`, the value\nof this setting will be propagated to `nginx_http_wasm_socket_connect_timeout`\nunless you _also_ set `nginx_http_wasm_socket_connect_timeout`.\n\nSome TLS-related settings receive special treatment as well:\n\n- `lua_ssl_trusted_certificate`: when set, the value is propagated to the\n`nginx_wasm_tls_trusted_certificate` directive.\n- `lua_ssl_verify_depth`: when set (to a value greater than zero), several\nTLS-related `nginx_wasm_*` settings are enabled:\n- `nginx_wasm_tls_verify_cert`\n- `nginx_wasm_tls_verify_host`\n- `nginx_wasm_tls_no_verify_warn`\n\nLike other `kong.conf` fields, all injected Nginx directives documented here\ncan be set via environment variable. For instance, setting:\n\n`KONG_NGINX_WASM_TLS_VERIFY_CERT=<value>`\n\nWill inject the following into the `wasm {}` block:\n\n`tls_verify_cert <value>;`\n\nThere are several Nginx directives supported by ngx_wasm_module which should\nnot be used because they are irrelevant to or unsupported by Kong, or they may\nconflict with Kong's own management of Proxy-Wasm. Use of these directives may\nresult in unintentional breakage:\n\n- `wasm_call`\n- `module`\n- `proxy_wasm`\n- `resolver_add`\n- `proxy_wasm_request_headers_in_access`\n- `shm_queue`\n\n"
+    },
+    {
+      "title": "REQUEST DEBUGGING",
+      "start": 3178,
+      "end": 3240,
+      "description": "Request debugging is a mechanism that allows admins to collect the timing of\nproxy path requests in the response header (X-Kong-Request-Debug-Output)\nand optionally, the error log.\n\nThis feature provides insights into the time spent within various components of Kong,\nsuch as plugins, DNS resolution, load balancing, and more. It also provides contextual\ninformation such as domain names tried during these processes.\n\n"
+    }
+  ],
+  "params": {
+    "prefix": {
+      "defaultValue": "/usr/local/kong/",
+      "description": "Working directory. Equivalent to Nginx's\nprefix path, containing temporary files\nand logs.\nEach Kong process must have a separate\nworking directory.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "log_level": {
+      "defaultValue": "notice",
+      "description": "Log level of the Nginx server. Logs are\nfound at `<prefix>/logs/error.log`.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "proxy_access_log": {
+      "defaultValue": "logs/access.log",
+      "description": "Path for proxy port request access\nlogs. Set this value to `off` to\ndisable logging proxy requests.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "proxy_error_log": {
+      "defaultValue": "logs/error.log",
+      "description": "Path for proxy port request error logs.\nThe granularity of these logs is adjusted by the `log_level` property.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "proxy_stream_access_log": {
+      "defaultValue": "logs/access.log basic",
+      "description": "Path for TCP streams proxy port access logs.\nSet to `off` to disable logging proxy requests.\nIf this value is a relative path, it will be placed under the `prefix` location.\n`basic` is defined as `'$remote_addr [$time_local] '\n'$protocol $status $bytes_sent $bytes_received '\n'$session_time'`\n",
+      "sectionTitle": "GENERAL"
+    },
+    "proxy_stream_error_log": {
+      "defaultValue": "logs/error.log",
+      "description": "Path for tcp streams proxy port request error\nlogs. The granularity of these logs\nis adjusted by the `log_level`\nproperty.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "admin_access_log": {
+      "defaultValue": "logs/admin_access.log",
+      "description": "Path for Admin API request access logs.\nIf hybrid mode is enabled and the current node is set\nto be the control plane, then the connection requests\nfrom data planes are also written to this file with\nserver name \"kong_cluster_listener\".\n\nSet this value to `off` to disable logging Admin API requests.\nIf this value is a relative path, it will be placed under the `prefix` location.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "admin_error_log": {
+      "defaultValue": "logs/error.log",
+      "description": "Path for Admin API request error logs.\nThe granularity of these logs is adjusted by the `log_level` property.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "status_access_log": {
+      "defaultValue": "off",
+      "description": "Path for Status API request access logs.\nThe default value of `off` implies that logging for this API\nis disabled by default.\nIf this value is a relative path, it will be placed under the `prefix` location.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "status_error_log": {
+      "defaultValue": "logs/status_error.log",
+      "description": "Path for Status API request error logs.\nThe granularity of these logs is adjusted by the `log_level` property.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "debug_access_log": {
+      "defaultValue": "off",
+      "description": "Path for Debug API request access\nlogs. The default value `off`\nimplies that logging for this API\nis disabled by default.\nIf this value is a relative path,\nit will be placed under the\n`prefix` location.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "debug_error_log": {
+      "defaultValue": "logs/debug_error.log",
+      "description": "Path for Debug API request error\nlogs. The granularity of these logs\nis adjusted using the `log_level`\nproperty.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "vaults": {
+      "defaultValue": "bundled",
+      "description": "Comma-separated list of vaults this node should load.\nBy default, all the bundled vaults are enabled.\n\nThe specified name(s) will be substituted as\nsuch in the Lua namespace:\n`kong.vaults.{name}.*`.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "opentelemetry_tracing": {
+      "defaultValue": "off",
+      "description": "Deprecated: use `tracing_instrumentations` instead.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "tracing_instrumentations": {
+      "defaultValue": "off",
+      "description": "Comma-separated list of tracing instrumentations this node should load.\nBy default, no instrumentations are enabled.\n\nValid values for this setting are:\n\n- `off`: do not enable instrumentations.\n- `request`: only enable request-level instrumentations.\n- `all`: enable all the following instrumentations.\n- `db_query`: trace database queries.\n- `dns_query`: trace DNS queries.\n- `router`: trace router execution, including router rebuilding.\n- `http_client`: trace OpenResty HTTP client requests.\n- `balancer`: trace balancer retries.\n- `plugin_rewrite`: trace plugin iterator execution with rewrite phase.\n- `plugin_access`: trace plugin iterator execution with access phase.\n- `plugin_header_filter`: trace plugin iterator execution with header_filter phase.\n\n**Note:** In the current implementation, tracing instrumentations are not enabled in stream mode.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "opentelemetry_tracing_sampling_rate": {
+      "defaultValue": "1.0",
+      "description": "Deprecated: use `tracing_sampling_rate` instead.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "tracing_sampling_rate": {
+      "defaultValue": "0.01",
+      "description": "Tracing instrumentation sampling rate.\nTracer samples a fixed percentage of all spans\nfollowing the sampling rate.\n\nExample: `0.25`, this accounts for 25% of all traces.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "plugins": {
+      "defaultValue": "bundled",
+      "description": "Comma-separated list of plugins this node should load.\nBy default, only plugins bundled in official distributions\nare loaded via the `bundled` keyword.\n\nLoading a plugin does not enable it by default, but only\ninstructs Kong to load its source code and allows\nconfiguration via the various related Admin API endpoints.\n\nThe specified name(s) will be substituted as such in the\nLua namespace: `kong.plugins.{name}.*`.\n\nWhen the `off` keyword is specified as the only value,\nno plugins will be loaded.\n\n`bundled` and plugin names can be mixed together, as the\nfollowing examples suggest:\n\n- `plugins = bundled,custom-auth,custom-log`\n  will include the bundled plugins plus two custom ones.\n- `plugins = custom-auth,custom-log` will\n  *only* include the `custom-auth` and `custom-log` plugins.\n- `plugins = off` will not include any plugins.\n\n**Note:** Kong will not start if some plugins were previously\nconfigured (i.e. have rows in the database) and are not\nspecified in this list. Before disabling a plugin, ensure\nall instances of it are removed before restarting Kong.\n\n**Note:** Limiting the amount of available plugins can\nimprove P99 latency when experiencing LRU churning in the\ndatabase cache (i.e. when the configured `mem_cache_size`) is full.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "dedicated_config_processing": {
+      "defaultValue": "on",
+      "description": "Enables or disables a special worker\nprocess for configuration processing. This process\nincreases memory usage a little bit while\nallowing to reduce latencies by moving some\nbackground tasks, such as CP/DP connection\nhandling, to an additional worker process specific\nto handling these background tasks.\nCurrently this has effect only on data planes.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "pluginserver_names": {
+      "defaultValue": null,
+      "description": "Comma-separated list of names for pluginserver\nprocesses. The actual names are used for\nlog messages and to relate the actual settings.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "pluginserver_XXX_socket": {
+      "defaultValue": "<prefix>/<XXX>.socket",
+      "description": "Path to the unix socket\nused by the <XXX> pluginserver.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "pluginserver_XXX_start_cmd": {
+      "defaultValue": "/usr/local/bin/<XXX>",
+      "description": "Full command (including\nany needed arguments) to\nstart the <XXX>\npluginserver.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "pluginserver_XXX_query_cmd": {
+      "defaultValue": "/usr/local/bin/query_<XXX>",
+      "description": "Full command to \"query\" the\n<XXX> pluginserver.  Should\nproduce a JSON with the\ndump info of the plugin it\nmanages.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "port_maps": {
+      "defaultValue": null,
+      "description": "With this configuration parameter, you can\nlet Kong Gateway know the port from\nwhich the packets are forwarded to it. This\nis fairly common when running Kong in a\ncontainerized or virtualized environment.\nFor example, `port_maps=80:8000, 443:8443`\ninstructs Kong that the port 80 is mapped\nto 8000 (and the port 443 to 8443), where\n8000 and 8443 are the ports that Kong is\nlistening to.\n\nThis parameter helps Kong set a proper\nforwarded upstream HTTP request header or to\nget the proper forwarded port with the Kong PDK\n(in case other means determining it has\nfailed). It changes routing by a destination\nport to route by a port from which packets\nare forwarded to Kong, and similarly it\nchanges the default plugin log serializer to\nuse the port according to this mapping\ninstead of reporting the port Kong is\nlistening to.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "anonymous_reports": {
+      "defaultValue": "on",
+      "description": "Send anonymous usage data such as error\nstack traces to help improve Kong.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "proxy_server": {
+      "defaultValue": null,
+      "description": "Proxy server defined as an encoded URL. Kong will only\nuse this option if a component is explicitly configured\nto use a proxy.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "proxy_server_ssl_verify": {
+      "defaultValue": "off",
+      "description": "Toggles server certificate verification if\n`proxy_server` is in HTTPS.\nSee the `lua_ssl_trusted_certificate`\nsetting to specify a certificate authority.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "error_template_html": {
+      "defaultValue": null,
+      "description": "Path to the custom html error template to\noverride the default html kong error\ntemplate.\n\nThe template may contain up to two `%s`\nplaceholders. The first one will expand to\nthe error message. The second one will\nexpand to the request ID. Both placeholders\nare optional, but recommended.\nAdding more than two placeholders will\nresult in a runtime error when trying to\nrender the template:\n```\n<html>\n  <body>\n    <h1>My custom error template</h1>\n    <p>error: %s</p>\n    <p>request_id: %s</p>\n  </body>\n</html>\n```\n",
+      "sectionTitle": "GENERAL"
+    },
+    "error_template_json": {
+      "defaultValue": null,
+      "description": "Path to the custom json error template to\noverride the default json kong error\ntemplate.\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "error_template_xml": {
+      "defaultValue": null,
+      "description": "Path to the custom xml error template to\noverride the default xml kong error template\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "error_template_plain": {
+      "defaultValue": null,
+      "description": "Path to the custom plain error template to\noverride the default plain kong error\ntemplate\n\nSimilarly to `error_template_html`, the\ntemplate may contain up to two `%s`\nplaceholders for the error message and the\nrequest ID respectively.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "role": {
+      "defaultValue": "traditional",
+      "description": "Use this setting to enable hybrid mode,\nThis allows running some Kong nodes in a\ncontrol plane role with a database and\nhave them deliver configuration updates\nto other nodes running to DB-less running in\na data plane role.\n\nValid values for this setting are:\n\n- `traditional`: do not use hybrid mode.\n- `control_plane`: this node runs in a\n  control plane role. It can use a database\n  and will deliver configuration updates\n  to data plane nodes.\n- `data_plane`: this is a data plane node.\n  It runs DB-less and receives configuration\n  updates from a control plane node.\n",
+      "sectionTitle": "HYBRID MODE"
+    },
+    "cluster_mtls": {
+      "defaultValue": "shared",
+      "description": "Sets the verification method between nodes of the cluster.\n\nValid values for this setting are:\n\n- `shared`: use a shared certificate/key pair specified with\n  the `cluster_cert` and `cluster_cert_key` settings.\n  Note that CP and DP nodes must present the same certificate\n  to establish mTLS connections.\n- `pki`: use `cluster_ca_cert`, `cluster_server_name`, and\n  `cluster_cert` for verification. These are different\n  certificates for each DP node, but issued by a cluster-wide\n  common CA certificate: `cluster_ca_cert`.\n- `pki_check_cn`: similar to `pki` but additionally checks\n  for the common name of the data plane certificate specified\n  in `cluster_allowed_common_names`.\n",
+      "sectionTitle": "HYBRID MODE"
+    },
+    "cluster_cert": {
+      "defaultValue": null,
+      "description": "Cluster certificate to use when establishing secure communication\nbetween control and data plane nodes.\nYou can use the `kong hybrid` command to generate the certificate/key pair.\nUnder `shared` mode, it must be the same for all nodes.\nUnder `pki` mode, it should be a different certificate for each DP node.\n\nThe certificate can be configured on this property with any of the following values:\n- absolute path to the certificate\n- certificate content\n- base64 encoded certificate content\n",
+      "sectionTitle": "HYBRID MODE"
+    },
+    "cluster_cert_key": {
+      "defaultValue": null,
+      "description": "Cluster certificate key to\nuse when establishing secure communication\nbetween control and data plane nodes.\nYou can use the `kong hybrid` command to\ngenerate the certificate/key pair.\nUnder `shared` mode, it must be the same\nfor all nodes.  Under `pki` mode it\nshould be a different certificate for each\nDP node.\n\nThe certificate key can be configured on this\nproperty with either of the following values:\n- absolute path to the certificate key\n- certificate key content\n- base64 encoded certificate key content\n",
+      "sectionTitle": "HYBRID MODE"
+    },
+    "cluster_ca_cert": {
+      "defaultValue": null,
+      "description": "The trusted CA certificate file in PEM format used for:\n- Control plane to verify data plane's certificate\n- Data plane to verify control plane's certificate\n\nRequired on data plane if `cluster_mtls` is set to `pki`.\nIf the control plane certificate is issued by a well-known CA,\nset `lua_ssl_trusted_certificate=system` on the data plane and leave this field empty.\n\nThis field is ignored if `cluster_mtls` is set to `shared`.\n\nThe certificate can be configured on this property with any of the following values:\n- absolute path to the certificate\n- certificate content\n- base64 encoded certificate content\n",
+      "sectionTitle": "HYBRID MODE"
+    },
+    "cluster_allowed_common_names": {
+      "defaultValue": null,
+      "description": "The list of Common Names that are allowed to\nconnect to control plane. Multiple entries may\nbe supplied in a comma-separated string. When not\nset, only data plane with the same parent domain as the\ncontrol plane cert is allowed to connect.\n\nThis field is ignored if `cluster_mtls` is\nnot set to `pki_check_cn`.\n",
+      "sectionTitle": "HYBRID MODE"
+    },
+    "incremental_sync": {
+      "defaultValue": "off",
+      "description": "The setting to enable or disable the incremental\nsynchronization of configuration changes.\nInstead of sending the entire entity config to data planes on\neach config update, incremental config sync lets you send only\nthe changed configuration to data planes for hybrid mode deployments.\nThe valid values are `on` and `off`.\nTo enable, set this value to `on`.\n\nIn hybrid mode, this setting must be configured\non both control plane and data plane nodes.\n",
+      "sectionTitle": "HYBRID MODE"
+    },
+    "cluster_server_name": {
+      "defaultValue": null,
+      "description": "The server name used in the SNI of the TLS\nconnection from a DP node to a CP node.\nMust match the Common Name (CN) or Subject\nAlternative Name (SAN) found in the CP\ncertificate.\nIf `cluster_mtls` is set to\n`shared`, this setting is ignored and\n`kong_clustering` is used.\n",
+      "sectionTitle": "HYBRID MODE DATA PLANE"
+    },
+    "cluster_control_plane": {
+      "defaultValue": null,
+      "description": "To be used by data plane nodes only:\naddress of the control plane node from which\nconfiguration updates will be fetched,\nin `host:port` format.\n",
+      "sectionTitle": "HYBRID MODE DATA PLANE"
+    },
+    "cluster_telemetry_endpoint": {
+      "defaultValue": null,
+      "description": "To be used by data plane nodes only:\ntelemetry address of the control plane node\nto which telemetry updates will be posted\nin `host:port` format.\n",
+      "sectionTitle": "HYBRID MODE DATA PLANE"
+    },
+    "cluster_telemetry_server_name": {
+      "defaultValue": null,
+      "description": "The SNI (Server Name Indication extension)\nto use for Vitals telemetry data.\n",
+      "sectionTitle": "HYBRID MODE DATA PLANE"
+    },
+    "cluster_dp_labels": {
+      "defaultValue": null,
+      "description": "Comma-separated list of labels for the data plane.\nLabels are key-value pairs that provide additional\ncontext information for each DP.\nEach label must be configured as a string in the\nformat `key:value`.\n\nLabels are only compatible with hybrid mode\ndeployments with Kong Konnect (SaaS).\nThis configuration doesn't work with\nself-hosted deployments.\n\nKeys and values follow the AIP standards:\nhttps://kong-aip.netlify.app/aip/129/\n\nExample:\n`deployment:mycloud,region:us-east-1`\n",
+      "sectionTitle": "HYBRID MODE DATA PLANE"
+    },
+    "cluster_listen": {
+      "defaultValue": "0.0.0.0:8005",
+      "description": "Comma-separated list of addresses and ports on\nwhich the cluster control plane server should listen\nfor data plane connections.\nThe cluster communication port of the control plane\nmust be accessible by all the data planes\nwithin the same cluster. This port is mTLS protected\nto ensure end-to-end security and integrity.\n\nThis setting has no effect if `role` is not set to\n`control_plane`.\n\nConnections made to this endpoint are logged\nto the same location as Admin API access logs.\nSee `admin_access_log` config description for more\ninformation.\n",
+      "sectionTitle": "HYBRID MODE CONTROL PLANE"
+    },
+    "cluster_telemetry_listen": {
+      "defaultValue": "0.0.0.0:8006",
+      "description": "Comma-separated list of addresses and ports on\nwhich the cluster control plane server should listen\nfor data plane telemetry connections.\nThe cluster communication port of the control plane\nmust be accessible by all the data planes\nwithin the same cluster.\n\nThis setting has no effect if `role` is not set to\n`control_plane`.\n",
+      "sectionTitle": "HYBRID MODE CONTROL PLANE"
+    },
+    "cluster_data_plane_purge_delay": {
+      "defaultValue": "1209600",
+      "description": "How many seconds must pass from the time a DP node\nbecomes offline to the time its entry gets removed\nfrom the database, as returned by the\n/clustering/data-planes Admin API endpoint.\n\nThis is to prevent the cluster data plane table from\ngrowing indefinitely. The default is set to\n14 days. That is, if the CP hasn't heard from a DP for\n14 days, its entry will be removed.\n",
+      "sectionTitle": "HYBRID MODE CONTROL PLANE"
+    },
+    "cluster_ocsp": {
+      "defaultValue": "off",
+      "description": "Whether to check for revocation status of DP\ncertificates using OCSP (Online Certificate Status Protocol).\nIf enabled, the DP certificate should contain the\n\"Certificate Authority Information Access\" extension\nand the OCSP method with URI of which the OCSP responder\ncan be reached from CP.\n\nOCSP checks are only performed on CP nodes, it has no\neffect on DP nodes.\n\nValid values for this setting are:\n\n- `on`: OCSP revocation check is enabled and DP\n  must pass the check in order to establish\n  connection with CP.\n- `off`: OCSP revocation check is disabled.\n- `optional`: OCSP revocation check will be attempted,\n  however, if the required extension is not\n  found inside DP-provided certificate\n  or communication with the OCSP responder\n  failed, then DP is still allowed through.\n",
+      "sectionTitle": "HYBRID MODE CONTROL PLANE"
+    },
+    "cluster_use_proxy": {
+      "defaultValue": "off",
+      "description": "Whether to turn on HTTP CONNECT proxy support for\nhybrid mode connections. `proxy_server` will be used\nfor hybrid mode connections if this option is turned on.\n",
+      "sectionTitle": "HYBRID MODE CONTROL PLANE"
+    },
+    "cluster_max_payload": {
+      "defaultValue": "16777216",
+      "description": "This sets the maximum compressed payload size allowed\nto be sent from CP to DP in hybrid mode.\nDefault is 16MB - 16 * 1024 * 1024.\n",
+      "sectionTitle": "HYBRID MODE CONTROL PLANE"
+    },
+    "proxy_listen": {
+      "defaultValue": [
+        "0.0.0.0:8000 reuseport backlog=16384",
+        "0.0.0.0:8443 http2 ssl reuseport backlog=16384"
+      ],
+      "description": "Comma-separated list of addresses and ports on\nwhich the proxy server should listen for\nHTTP/HTTPS traffic.\nThe proxy server is the public entry point of Kong,\nwhich proxies traffic from your consumers to your\nbackend services. This value accepts IPv4, IPv6, and\nhostnames.\n\nSome suffixes can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's proxy server.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `deferred` instructs to use a deferred accept on\n  Linux (the `TCP_DEFER_ACCEPT` socket option).\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process,\n  allowing the kernel to better distribute incoming\n  connections between worker processes.\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small to prevent clients\n  seeing \"Connection refused\" errors when connecting to\n  a busy Kong instance.\n  **Note:** On Linux, this value is limited by the\n  setting of the `net.core.somaxconn` kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect, it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` specifies whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections.\n- `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]`\n  configures the TCP keepalive behavior for the listening\n  socket. If this parameter is omitted, the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value `on`, the `SO_KEEPALIVE` option is turned\n  on for the socket. If it is set to the value `off`, the\n  `SO_KEEPALIVE` option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the `TCP_KEEPIDLE`,` TCP_KEEPINTVL`,\n  and `TCP_KEEPCNT` socket options.\n\nThis value can be set to `off`, thus disabling\nthe HTTP/HTTPS proxy port for this node.\nIf `stream_listen` is also set to `off`, this enables\ncontrol plane mode for this node\n(in which all traffic proxying capabilities are\ndisabled). This node can then be used only to\nconfigure a cluster of Kong\nnodes connected to the same datastore.\n\nExample:\n`proxy_listen = 0.0.0.0:443 ssl, 0.0.0.0:444 http2 ssl`\n\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#listen\nfor a description of the accepted formats for this\nand other `*_listen` values.\n\nSee https://www.nginx.com/resources/admin-guide/proxy-protocol/\nfor more details about the `proxy_protocol`\nparameter.\n\nNot all `*_listen` values accept all formats\nspecified in nginx's documentation.\n",
+      "sectionTitle": "NGINX"
+    },
+    "proxy_url": {
+      "defaultValue": null,
+      "description": "Kong Proxy URL\n\nThe lookup, or balancer, address for your Kong Proxy nodes.\n\nThis value is commonly used in a microservices\nor service-mesh oriented architecture.\n\nAccepted format (parts in parentheses are optional):\n\n  `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`\n\nExamples:\n\n- `<scheme>://<IP>:<PORT>` -> `proxy_url = http://127.0.0.1:8000`\n- `SSL <scheme>://<HOSTNAME>` -> `proxy_url = https://proxy.domain.tld`\n- `<scheme>://<HOSTNAME>/<PATH>` -> `proxy_url = http://dev-machine/dev-285`\n\nBy default, Kong Manager and Kong Portal will use\nthe window request host and append the resolved\nlistener port depending on the requested protocol.\n",
+      "sectionTitle": "NGINX"
+    },
+    "stream_listen": {
+      "defaultValue": "off",
+      "description": "Comma-separated list of addresses and ports on\nwhich the stream mode should listen.\n\nThis value accepts IPv4, IPv6, and hostnames.\nSome suffixes can be specified for each pair:\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process,\n  allowing the kernel to better distribute incoming\n  connections between worker processes.\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small to prevent clients\n  seeing \"Connection refused\" errors when connecting to\n  a busy Kong instance.\n  **Note:** On Linux, this value is limited by the\n  setting of the `net.core.somaxconn` kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect, it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` specifies whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections\n- so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]\n  configures the \"TCP keepalive\" behavior for the listening\n  socket. If this parameter is omitted then the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value \"on\", the SO_KEEPALIVE option is turned\n  on for the socket. If it is set to the value \"off\", the\n  SO_KEEPALIVE option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the` TCP_KEEPIDLE`, `TCP_KEEPINTVL`,\n  and `TCP_KEEPCNT` socket options.\n\nExamples:\n\n```\nstream_listen = 127.0.0.1:7000 reuseport backlog=16384\nstream_listen = 0.0.0.0:989 reuseport backlog=65536, 0.0.0.0:20\nstream_listen = [::1]:1234 backlog=16384\n```\n\nBy default, this value is set to `off`, thus\ndisabling the stream proxy port for this node.\n",
+      "sectionTitle": "NGINX"
+    },
+    "admin_api_uri": {
+      "defaultValue": null,
+      "description": "Deprecated: Use admin_gui_api_url instead\n",
+      "sectionTitle": "NGINX"
+    },
+    "admin_listen": {
+      "defaultValue": [
+        "127.0.0.1:8001 reuseport backlog=16384",
+        "127.0.0.1:8444 http2 ssl reuseport backlog=16384"
+      ],
+      "description": "Comma-separated list of addresses and ports on\nwhich the Admin interface should listen.\nThe Admin interface is the API allowing you to\nconfigure and manage Kong.\nAccess to this interface should be *restricted*\nto Kong administrators *only*. This value accepts\nIPv4, IPv6, and hostnames.\n\nIt is highly recommended to avoid exposing the Admin API to public\ninterfaces, by using values such as `0.0.0.0:8001`\n\nSee https://docs.konghq.com/gateway/latest/production/running-kong/secure-admin-api/\nfor more information about how to secure your Admin API.\n\nSome suffixes can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's proxy server.\n- `proxy_protocol` will enable usage of the\n  PROXY protocol for a given address/port.\n- `deferred` instructs to use a deferred accept on\n  Linux (the `TCP_DEFER_ACCEPT` socket option).\n- `bind` instructs to make a separate bind() call\n  for a given address:port pair.\n- `reuseport` instructs to create an individual\n  listening socket for each worker process,\n  allowing the Kernel to better distribute incoming\n  connections between worker processes.\n- `backlog=N` sets the maximum length for the queue\n  of pending TCP connections. This number should\n  not be too small to prevent clients\n  seeing \"Connection refused\" errors when connecting to\n  a busy Kong instance.\n  **Note:** On Linux, this value is limited by the\n  setting of the `net.core.somaxconn` kernel parameter.\n  In order for the larger `backlog` set here to take\n  effect, it is necessary to raise\n  `net.core.somaxconn` at the same time to match or\n  exceed the `backlog` number set.\n- `ipv6only=on|off` specifies whether an IPv6 socket listening\n  on a wildcard address [::] will accept only IPv6\n  connections or both IPv6 and IPv4 connections.\n- `so_keepalive=on|off|[keepidle]:[keepintvl]:[keepcnt]`\n  configures the “TCP keepalive” behavior for the listening\n  socket. If this parameter is omitted, the operating\n  system’s settings will be in effect for the socket. If it\n  is set to the value `on`, the `SO_KEEPALIVE` option is turned\n  on for the socket. If it is set to the value `off`, the\n  `SO_KEEPALIVE` option is turned off for the socket. Some\n  operating systems support setting of TCP keepalive parameters\n  on a per-socket basis using the `TCP_KEEPIDLE`, `TCP_KEEPINTVL`,\n  and `TCP_KEEPCNT` socket options.\n\nThis value can be set to `off`, thus disabling\nthe Admin interface for this node, enabling a\ndata plane mode (without configuration\ncapabilities) pulling its configuration changes\nfrom the database.\n\nExample: `admin_listen = 127.0.0.1:8444 http2 ssl`\n",
+      "sectionTitle": "NGINX"
+    },
+    "status_listen": {
+      "defaultValue": "127.0.0.1:8007 reuseport backlog=16384",
+      "description": "Comma-separated list of addresses and ports on\nwhich the Status API should listen.\nThe Status API is a read-only endpoint\nallowing monitoring tools to retrieve metrics,\nhealthiness, and other non-sensitive information\nof the current Kong node.\n\nThe following suffix can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's Status API server.\n- `proxy_protocol` will enable usage of the PROXY protocol.\n\nThis value can be set to `off`, disabling\nthe Status API for this node.\n\nExample: `status_listen = 0.0.0.0:8100 ssl http2`\n",
+      "sectionTitle": "NGINX"
+    },
+    "debug_listen": {
+      "defaultValue": "off",
+      "description": "Comma-separated list of addresses and ports on\nwhich the Debug API should listen.\n\nThe following suffix can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's Debug API server.\n\nThis value can be set to `off`, disabling\nthe Debug API for this node.\n\nExample: `debug_listen = 0.0.0.0:8200 ssl http2`\n",
+      "sectionTitle": "NGINX"
+    },
+    "debug_listen_local": {
+      "defaultValue": "on",
+      "description": "Expose `debug_listen` functionalities via a\nUnix domain socket under the Kong prefix.\n\nThis option allows local users to use `kong debug` command\nto invoke various debug functionalities without needing to\nenable `debug_listen` ahead of time.\n",
+      "sectionTitle": "NGINX"
+    },
+    "nginx_user": {
+      "defaultValue": "kong kong",
+      "description": "Defines user and group credentials used by\nworker processes. If group is omitted, a\ngroup whose name equals that of user is\nused.\n\nExample: `nginx_user = nginx www`\n\n**Note**: If the `kong` user and the `kong`\ngroup are not available, the default user\nand group credentials will be\n`nobody nobody`.\n",
+      "sectionTitle": "NGINX"
+    },
+    "nginx_worker_processes": {
+      "defaultValue": "auto",
+      "description": "Determines the number of worker processes\nspawned by Nginx.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_processes\nfor detailed usage of the equivalent Nginx\ndirective and a description of accepted\nvalues.\n",
+      "sectionTitle": "NGINX"
+    },
+    "nginx_daemon": {
+      "defaultValue": "on",
+      "description": "Determines whether Nginx will run as a daemon\nor as a foreground process. Mainly useful\nfor development or when running Kong inside\na Docker environment.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#daemon.\n",
+      "sectionTitle": "NGINX"
+    },
+    "mem_cache_size": {
+      "defaultValue": "128m",
+      "description": "Size of each of the two shared memory caches\nfor traditional mode database entities\nand runtime data, `kong_core_cache` and\n`kong_cache`.\n\nThe accepted units are `k` and `m`, with a minimum\nrecommended value of a few MBs.\n\n**Note**: As this option controls the size of two\ndifferent cache zones, the total memory Kong\nuses to cache entities might be double this value.\nThe created zones are shared by all worker\nprocesses and do not become larger when more\nworkers are used.\n",
+      "sectionTitle": "NGINX"
+    },
+    "consumers_mem_cache_size": {
+      "defaultValue": "128m",
+      "description": "Size of the shared memory cache for consumers\nand credentials.\n\nThe accepted units are `k` and `m`, with a minimum\nrecommended value of a few MBs.\n\n**Note**: This is only used when the \"externalized consumers\"\nfeature is active.\n",
+      "sectionTitle": "NGINX"
+    },
+    "ssl_cipher_suite": {
+      "defaultValue": "intermediate",
+      "description": "Defines the TLS ciphers served by Nginx.\nAccepted values are `modern`,\n`intermediate`, `old`, `fips` or `custom`.\nIf you want to enable TLSv1.1, this value has to be `old`.\n\nSee https://wiki.mozilla.org/Security/Server_Side_TLS\nfor detailed descriptions of each cipher\nsuite. `fips` cipher suites are as described in\nhttps://wiki.openssl.org/index.php/FIPS_mode_and_TLS.\n",
+      "sectionTitle": "NGINX"
+    },
+    "ssl_ciphers": {
+      "defaultValue": null,
+      "description": "Defines a custom list of TLS ciphers to be\nserved by Nginx. This list must conform to\nthe pattern defined by `openssl ciphers`.\nThis value is ignored if `ssl_cipher_suite`\nis not `custom`.\nIf you use DHE ciphers, you must also\nconfigure the `ssl_dhparam` parameter.\n",
+      "sectionTitle": "NGINX"
+    },
+    "ssl_protocols": {
+      "defaultValue": "TLSv1.2 TLSv1.3",
+      "description": "Enables the specified protocols for\nclient-side connections. The set of\nsupported protocol versions also depends\non the version of OpenSSL Kong was built\nwith. This value is ignored if\n`ssl_cipher_suite` is not `custom`.\nIf you want to enable TLSv1.1, you should\nset `ssl_cipher_suite` to `old`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_protocols\n",
+      "sectionTitle": "NGINX"
+    },
+    "ssl_prefer_server_ciphers": {
+      "defaultValue": "on",
+      "description": "Specifies that server ciphers should be\npreferred over client ciphers when using\nthe SSLv3 and TLS protocols. This value is\nignored if `ssl_cipher_suite` is not `custom`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_prefer_server_ciphers\n",
+      "sectionTitle": "NGINX"
+    },
+    "ssl_dhparam": {
+      "defaultValue": null,
+      "description": "Defines DH parameters for DHE ciphers from the\npredefined groups: `ffdhe2048`, `ffdhe3072`,\n`ffdhe4096`, `ffdhe6144`, `ffdhe8192`,\nfrom the absolute path to a parameters file, or\ndirectly from the parameters content.\n\nThis value is ignored if `ssl_cipher_suite`\nis `modern` or `intermediate`. The reason is\nthat `modern` has no ciphers that need this,\nand `intermediate` uses `ffdhe2048`.\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_dhparam\n",
+      "sectionTitle": "NGINX"
+    },
+    "ssl_session_tickets": {
+      "defaultValue": "on",
+      "description": "Enables or disables session resumption through\nTLS session tickets. This has no impact when\nused with TLSv1.3.\n\nKong enables this by default for performance\nreasons, but it has security implications:\nhttps://github.com/mozilla/server-side-tls/issues/135\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_tickets\n",
+      "sectionTitle": "NGINX"
+    },
+    "ssl_session_timeout": {
+      "defaultValue": "1d",
+      "description": "Specifies a time during which a client may\nreuse the session parameters. See the rationale:\nhttps://github.com/mozilla/server-side-tls/issues/198\n\nSee http://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_timeout\n",
+      "sectionTitle": "NGINX"
+    },
+    "ssl_session_cache_size": {
+      "defaultValue": "10m",
+      "description": "Sets the size of the caches that store session parameters.\n\nSee https://nginx.org/en/docs/http/ngx_http_ssl_module.html#ssl_session_cache\n",
+      "sectionTitle": "NGINX"
+    },
+    "ssl_cert": {
+      "defaultValue": null,
+      "description": "Comma-separated list of certificates for `proxy_listen` values with TLS enabled.\n\nIf more than one certificate is specified, it can be used to provide\nalternate types of certificates (for example, ECC certificates) that will be served\nto clients that support them. Note that to properly serve using ECC certificates,\nit is recommended to also set `ssl_cipher_suite` to\n`modern` or `intermediate`.\n\nUnless this option is explicitly set, Kong will auto-generate\na pair of default certificates (RSA + ECC) the first time it starts up and use\nthem for serving TLS requests.\n\nCertificates can be configured on this property with any of the following\nvalues:\n- absolute path to the certificate\n- certificate content\n- base64 encoded certificate content\n",
+      "sectionTitle": "NGINX"
+    },
+    "ssl_cert_key": {
+      "defaultValue": null,
+      "description": "Comma-separated list of keys for `proxy_listen` values with TLS enabled.\n\nIf more than one certificate was specified for `ssl_cert`, then this\noption should contain the corresponding key for all certificates\nprovided in the same order.\n\nUnless this option is explicitly set, Kong will auto-generate\na pair of default private keys (RSA + ECC) the first time it starts up and use\nthem for serving TLS requests.\n\nKeys can be configured on this property with any of the following\nvalues:\n- absolute path to the certificate key\n- certificate key content\n- base64 encoded certificate key content\n",
+      "sectionTitle": "NGINX"
+    },
+    "client_ssl": {
+      "defaultValue": "off",
+      "description": "Determines if Nginx should attempt to send client-side\nTLS certificates and perform Mutual TLS Authentication\nwith upstream service when proxying requests.\n",
+      "sectionTitle": "NGINX"
+    },
+    "client_ssl_cert": {
+      "defaultValue": null,
+      "description": "If `client_ssl` is enabled, the client certificate\nfor the `proxy_ssl_certificate` directive.\n\nThis value can be overwritten dynamically with the `client_certificate`\nattribute of the `Service` object.\n\nThe certificate can be configured on this property with any of the following\nvalues:\n- absolute path to the certificate\n- certificate content\n- base64 encoded certificate content\n",
+      "sectionTitle": "NGINX"
+    },
+    "client_ssl_cert_key": {
+      "defaultValue": null,
+      "description": "If `client_ssl` is enabled, the client TLS key\nfor the `proxy_ssl_certificate_key` directive.\n\nThis value can be overwritten dynamically with the `client_certificate`\nattribute of the `Service` object.\n\nThe certificate key can be configured on this property with any of the following\nvalues:\n- absolute path to the certificate key\n- certificate key content\n- base64 encoded certificate key content\n",
+      "sectionTitle": "NGINX"
+    },
+    "admin_ssl_cert": {
+      "defaultValue": null,
+      "description": "Comma-separated list of certificates for `admin_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n",
+      "sectionTitle": "NGINX"
+    },
+    "admin_ssl_cert_key": {
+      "defaultValue": null,
+      "description": "Comma-separated list of keys for `admin_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n",
+      "sectionTitle": "NGINX"
+    },
+    "status_ssl_cert": {
+      "defaultValue": null,
+      "description": "Comma-separated list of certificates for `status_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n",
+      "sectionTitle": "NGINX"
+    },
+    "status_ssl_cert_key": {
+      "defaultValue": null,
+      "description": "Comma-separated list of keys for `status_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n",
+      "sectionTitle": "NGINX"
+    },
+    "debug_ssl_cert": {
+      "defaultValue": null,
+      "description": "Comma-separated list of certificates for `debug_listen` values with TLS enabled.\n\nSee docs for `ssl_cert` for detailed usage.\n",
+      "sectionTitle": "NGINX"
+    },
+    "debug_ssl_cert_key": {
+      "defaultValue": null,
+      "description": "Comma-separated list of keys for `debug_listen` values with TLS enabled.\n\nSee docs for `ssl_cert_key` for detailed usage.\n",
+      "sectionTitle": "NGINX"
+    },
+    "headers": {
+      "defaultValue": [
+        "server_tokens",
+        "latency_tokens",
+        "X-Kong-Request-Id"
+      ],
+      "description": "Comma-separated list of headers Kong should\ninject in client responses.\n\nAccepted values are:\n- `Server`: Injects `Server: kong/x.y.z`\n  on Kong-produced responses (e.g., Admin\n  API, rejected requests from auth plugin).\n- `Via`: Injects `Via: kong/x.y.z` for\n  successfully proxied requests.\n- `X-Kong-Proxy-Latency`: Time taken\n  (in milliseconds) by Kong to process\n  a request and run all plugins before\n  proxying the request upstream.\n- `X-Kong-Response-Latency`: Time taken\n  (in milliseconds) by Kong to produce\n  a response in case of, e.g., a plugin\n  short-circuiting the request, or in\n  case of an error.\n- `X-Kong-Upstream-Latency`: Time taken\n  (in milliseconds) by the upstream\n  service to send response headers.\n- `X-Kong-Admin-Latency`: Time taken\n  (in milliseconds) by Kong to process\n  an Admin API request.\n- `X-Kong-Upstream-Status`: The HTTP status\n  code returned by the upstream service.\n  This is particularly useful for clients to\n  distinguish upstream statuses if the\n  response is rewritten by a plugin.\n- `X-Kong-Request-Id`: Unique identifier of\n  the request.\n- `server_tokens`: Same as specifying both\n  `Server` and `Via`.\n- `latency_tokens`: Same as specifying\n  `X-Kong-Proxy-Latency`,\n  `X-Kong-Response-Latency`,\n  `X-Kong-Admin-Latency`, and\n  `X-Kong-Upstream-Latency`.\n\nIn addition to these, this value can be set\nto `off`, which prevents Kong from injecting\nany of the above headers. Note that this\ndoes not prevent plugins from injecting\nheaders of their own.\n\nExample: `headers = via, latency_tokens`\n",
+      "sectionTitle": "NGINX"
+    },
+    "headers_upstream": {
+      "defaultValue": "X-Kong-Request-Id",
+      "description": "Comma-separated list of headers Kong should\ninject in requests to upstream.\n\nAt this time, the only accepted value is:\n- `X-Kong-Request-Id`: Unique identifier of\n  the request.\n\nIn addition, this value can be set\nto `off`, which prevents Kong from injecting\nthe above header. Note that this\ndoes not prevent plugins from injecting\nheaders of their own.\n",
+      "sectionTitle": "NGINX"
+    },
+    "trusted_ips": {
+      "defaultValue": null,
+      "description": "Defines trusted IP address blocks that are\nknown to send correct `X-Forwarded-*`\nheaders.\nRequests from trusted IPs make Kong forward\ntheir `X-Forwarded-*` headers upstream.\nNon-trusted requests make Kong insert its\nown `X-Forwarded-*` headers.\n\nThis property also sets the\n`set_real_ip_from` directive(s) in the Nginx\nconfiguration. It accepts the same type of\nvalues (CIDR blocks) but as a\ncomma-separated list.\n\nTo trust *all* IPs, set this value to\n`0.0.0.0/0,::/0`.\n\nIf the special value `unix:` is specified,\nall UNIX-domain sockets will be trusted.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#set_real_ip_from\nfor examples of accepted values.\n",
+      "sectionTitle": "NGINX"
+    },
+    "real_ip_header": {
+      "defaultValue": "X-Real-IP",
+      "description": "Defines the request header field whose value\nwill be used to replace the client address.\nThis value sets the `ngx_http_realip_module`\ndirective of the same name in the Nginx\nconfiguration.\n\nIf this value receives `proxy_protocol`:\n\n- at least one of the `proxy_listen` entries\n  must have the `proxy_protocol` flag\n  enabled.\n- the `proxy_protocol` parameter will be\n  appended to the `listen` directive of the\n  Nginx template.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_header\nfor a description of this directive.\n",
+      "sectionTitle": "NGINX"
+    },
+    "real_ip_recursive": {
+      "defaultValue": "off",
+      "description": "This value sets the `ngx_http_realip_module`\ndirective of the same name in the Nginx\nconfiguration.\n\nSee http://nginx.org/en/docs/http/ngx_http_realip_module.html#real_ip_recursive\nfor a description of this directive.\n",
+      "sectionTitle": "NGINX"
+    },
+    "error_default_type": {
+      "defaultValue": "text/plain",
+      "description": "Default MIME type to use when the request\n`Accept` header is missing and Nginx\nis returning an error for the request.\nAccepted values are `text/plain`,\n`text/html`, `application/json`, and\n`application/xml`.\n",
+      "sectionTitle": "NGINX"
+    },
+    "upstream_keepalive_pool_size": {
+      "defaultValue": "512",
+      "description": "Sets the default size of the upstream\nkeepalive connection pools.\nUpstream keepalive connection pools\nare segmented by the `dst ip/dst\nport/SNI` attributes of a connection.\nA value of `0` will disable upstream\nkeepalive connections by default, forcing\neach upstream request to open a new\nconnection.\n",
+      "sectionTitle": "NGINX"
+    },
+    "upstream_keepalive_max_requests": {
+      "defaultValue": "10000",
+      "description": "Sets the default maximum number of\nrequests that can be proxied upstream\nthrough one keepalive connection.\nAfter the maximum number of requests\nis reached, the connection will be\nclosed.\nA value of `0` will disable this\nbehavior, and a keepalive connection\ncan be used to proxy an indefinite\nnumber of requests.\n",
+      "sectionTitle": "NGINX"
+    },
+    "upstream_keepalive_idle_timeout": {
+      "defaultValue": "60",
+      "description": "Sets the default timeout (in seconds)\nfor which an upstream keepalive\nconnection should be kept open. When\nthe timeout is reached while the\nconnection has not been reused, it\nwill be closed.\nA value of `0` will disable this\nbehavior, and an idle keepalive\nconnection may be kept open\nindefinitely.\n",
+      "sectionTitle": "NGINX"
+    },
+    "allow_debug_header": {
+      "defaultValue": "off",
+      "description": "Enable the `Kong-Debug` header function.\nIf it is `on`, Kong will add\n`Kong-Route-Id`, `Kong-Route-Name`, `Kong-Service-Id`,\nand `Kong-Service-Name` debug headers to the response when\nthe client request header `Kong-Debug: 1` is present.\n",
+      "sectionTitle": "NGINX"
+    },
+    "nginx_main_worker_rlimit_nofile": {
+      "defaultValue": "auto",
+      "description": "Changes the limit on the maximum number of open files\nfor worker processes.\n\nThe special and default value of `auto` sets this\nvalue to `ulimit -n` with the upper bound limited to\n16384 as a measure to protect against excess memory use,\nand the lower bound of 1024 as a good default.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_rlimit_nofile\n",
+      "sectionTitle": "NGINX injected directives"
+    },
+    "nginx_events_worker_connections": {
+      "defaultValue": "auto",
+      "description": "Sets the maximum number of simultaneous\nconnections that can be opened by a worker process.\n\nThe special and default value of `auto` sets this\nvalue to `ulimit -n` with the upper bound limited to\n16384 as a measure to protect against excess memory use,\nand the lower bound of 1024 as a good default.\n\nSee http://nginx.org/en/docs/ngx_core_module.html#worker_connections\n",
+      "sectionTitle": "NGINX injected directives"
+    },
+    "nginx_http_client_header_buffer_size": {
+      "defaultValue": "1k",
+      "description": "Sets buffer size for reading the\nclient request headers.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_header_buffer_size\n",
+      "sectionTitle": "NGINX injected directives"
+    },
+    "nginx_http_large_client_header_buffers": {
+      "defaultValue": "4 8k",
+      "description": "Sets the maximum number and\nsize of buffers used for\nreading large client\nrequest headers.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#large_client_header_buffers\n",
+      "sectionTitle": "NGINX injected directives"
+    },
+    "nginx_http_client_max_body_size": {
+      "defaultValue": "0",
+      "description": "Defines the maximum request body size\nallowed by requests proxied by Kong,\nspecified in the Content-Length request\nheader. If a request exceeds this\nlimit, Kong will respond with a 413\n(Request Entity Too Large). Setting\nthis value to 0 disables checking the\nrequest body size.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size\n",
+      "sectionTitle": "NGINX injected directives"
+    },
+    "nginx_admin_client_max_body_size": {
+      "defaultValue": "10m",
+      "description": "Defines the maximum request body size for\nAdmin API.\n",
+      "sectionTitle": "NGINX injected directives"
+    },
+    "nginx_http_charset": {
+      "defaultValue": "UTF-8",
+      "description": "Adds the specified charset to the \"Content-Type\"\nresponse header field. If this charset is different\nfrom the charset specified in the `source_charset`\ndirective, a conversion is performed.\n\nThe parameter `off` cancels the addition of\ncharset to the \"Content-Type\" response header field.\nSee http://nginx.org/en/docs/http/ngx_http_charset_module.html#charset\n",
+      "sectionTitle": "NGINX injected directives"
+    },
+    "nginx_http_client_body_buffer_size": {
+      "defaultValue": "8k",
+      "description": "Defines the buffer size for reading\nthe request body. If the client\nrequest body is larger than this\nvalue, the body will be buffered to\ndisk. Note that when the body is\nbuffered to disk, Kong plugins that\naccess or manipulate the request\nbody may not work, so it is\nadvisable to set this value as high\nas possible (e.g., set it as high\nas `client_max_body_size` to force\nrequest bodies to be kept in\nmemory). Do note that\nhigh-concurrency environments will\nrequire significant memory\nallocations to process many\nconcurrent large request bodies.\nSee http://nginx.org/en/docs/http/ngx_http_core_module.html#client_body_buffer_size\n",
+      "sectionTitle": "NGINX injected directives"
+    },
+    "nginx_admin_client_body_buffer_size": {
+      "defaultValue": "10m",
+      "description": "Defines the buffer size for reading\nthe request body on Admin API.\n",
+      "sectionTitle": "NGINX injected directives"
+    },
+    "nginx_http_lua_regex_match_limit": {
+      "defaultValue": "100000",
+      "description": "Global `MATCH_LIMIT` for PCRE\nregex matching. The default of `100000` should ensure\nat worst any regex Kong executes could finish within\nroughly 2 seconds.\n",
+      "sectionTitle": "NGINX injected directives"
+    },
+    "nginx_http_lua_regex_cache_max_entries": {
+      "defaultValue": "8192",
+      "description": "Specifies the maximum number of entries allowed\nin the worker process level PCRE JIT compiled regex cache.\nIt is recommended to set it to at least (number of regex paths * 2)\nto avoid high CPU usages if you manually specified `router_flavor` to\n`traditional`. `expressions` and `traditional_compat` router do\nnot make use of the PCRE library and their behavior\nis unaffected by this setting.\n",
+      "sectionTitle": "NGINX injected directives"
+    },
+    "nginx_http_keepalive_requests": {
+      "defaultValue": "10000",
+      "description": "Sets the maximum number of client requests that can be served through one\nkeep-alive connection. After the maximum number of requests are made,\nthe connection is closed.\nClosing connections periodically is necessary to free per-connection\nmemory allocations. Therefore, using too high a maximum number of requests\ncould result in excessive memory usage and is not recommended.\nSee: https://nginx.org/en/docs/http/ngx_http_core_module.html#keepalive_requests\n",
+      "sectionTitle": "NGINX injected directives"
+    },
+    "database": {
+      "defaultValue": "postgres",
+      "description": "Determines the database (or no database) for\nthis node\nAccepted values are `postgres` and `off`.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_host": {
+      "defaultValue": "127.0.0.1",
+      "description": "Host of the Postgres server.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_port": {
+      "defaultValue": "5432",
+      "description": "Port of the Postgres server.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_timeout": {
+      "defaultValue": "5000",
+      "description": "Defines the timeout (in ms), for connecting,\nreading and writing.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_user": {
+      "defaultValue": "kong",
+      "description": "Postgres user.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_password": {
+      "defaultValue": null,
+      "description": "Postgres user's password.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_iam_auth": {
+      "defaultValue": "off",
+      "description": "Determines whether the AWS IAM database\nAuthentication will be used. When switch to\n`on`, the username defined in `pg_user` will\nbe used as the database account, and the\ndatabase connection will be forced to using\nTLS. `pg_password` will not be used when\nthe switch is `on`. Note that the corresponding\nIAM policy must be correct, otherwise connecting\nwill fail.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_iam_auth_assume_role_arn": {
+      "defaultValue": null,
+      "description": "The target AWS IAM role ARN that will be\nassumed when using AWS IAM database\nauthentication. Typically this is used\nfor operating between multiple roles\nor cross-accounts.\nIf you are not using assume role\nyou should not specify this value.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_iam_auth_role_session_name": {
+      "defaultValue": "KongPostgres",
+      "description": "The role session name used for role\nassuming in AWS IAM Database\nAuthentication. The default value is\n`KongPostgres`.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_iam_auth_sts_endpoint_url": {
+      "defaultValue": null,
+      "description": "The custom STS endpoint URL used for role assuming\nin AWS IAM Database Authentication.\n\nNote that this value will override the default\nSTS endpoint URL(which should be\n`https://sts.amazonaws.com`, or\n`https://sts.<region>.amazonaws.com` if you have\n`AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).\n\nIf you are not using private VPC endpoint for STS\nservice, you should not specify this value.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_database": {
+      "defaultValue": "kong",
+      "description": "The database name to connect to.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_schema": {
+      "defaultValue": null,
+      "description": "The database schema to use. If unspecified,\nKong will respect the `search_path` value of\nyour PostgreSQL instance.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ssl": {
+      "defaultValue": "off",
+      "description": "Toggles client-server TLS connections\nbetween Kong and PostgreSQL.\nBecause PostgreSQL uses the same port for TLS\nand non-TLS, this is only a hint. If the\nserver does not support TLS, the established\nconnection will be a plain one.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ssl_version": {
+      "defaultValue": "tlsv1_2",
+      "description": "When using ssl between Kong and PostgreSQL,\nthe version of tls to use. Accepted values are\n`tlsv1_1`, `tlsv1_2`, `tlsv1_3`, or 'any'. When\n`any` is set, the client negotiates the highest\nversion with the server which can't be lower\nthan `tlsv1_1`.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ssl_required": {
+      "defaultValue": "off",
+      "description": "When `pg_ssl` is on this determines if\nTLS must be used between Kong and PostgreSQL.\nIt aborts the connection if the server does\nnot support SSL connections.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ssl_verify": {
+      "defaultValue": "off",
+      "description": "Toggles server certificate verification if\n`pg_ssl` is enabled.\nSee the `lua_ssl_trusted_certificate`\nsetting to specify a certificate authority.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ssl_cert": {
+      "defaultValue": null,
+      "description": "The absolute path to the PEM encoded client\nTLS certificate for the PostgreSQL connection.\nMutual TLS authentication against\nPostgreSQL is only enabled if this value is set.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ssl_cert_key": {
+      "defaultValue": null,
+      "description": "If `pg_ssl_cert` is set, the absolute path to\nthe PEM encoded client TLS private key for the\nPostgreSQL connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_max_concurrent_queries": {
+      "defaultValue": "0",
+      "description": "Sets the maximum number of concurrent queries\nthat can be executing at any given time. This\nlimit is enforced per worker process; the\ntotal number of concurrent queries for this\nnode will be will be:\n`pg_max_concurrent_queries * nginx_worker_processes`.\n\nThe default value of 0 removes this\nconcurrency limitation.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_semaphore_timeout": {
+      "defaultValue": "60000",
+      "description": "Defines the timeout (in ms) after which\nPostgreSQL query semaphore resource\nacquisition attempts will fail. Such\nfailures will generally result in the\nassociated proxy or Admin API request\nfailing with an HTTP 500 status code.\nDetailed discussion of this behavior is\navailable in the online documentation.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_keepalive_timeout": {
+      "defaultValue": null,
+      "description": "Specify the maximal idle timeout (in ms)\nfor the postgres connections in the pool.\nIf this value is set to 0 then the timeout interval\nis unlimited.\n\nIf not specified this value will be same as\n`lua_socket_keepalive_timeout`\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_pool_size": {
+      "defaultValue": null,
+      "description": "Specifies the size limit (in terms of connection\ncount) for the Postgres server.\nNote that this connection pool is intended\nper Nginx worker rather than per Kong instance.\n\nIf not specified, the default value is the same as\n`lua_socket_pool_size`\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_backlog": {
+      "defaultValue": null,
+      "description": "If specified, this value will limit the total\nnumber of open connections to the Postgres\nserver to `pg_pool_size`. If the connection\npool is full, subsequent connect operations\nwill be inserted in a queue with size equal\nto this option's value.\n\nIf the number of queued connect operations\nreaches `pg_backlog`, exceeding connections will fail.\n\nIf not specified, then number of open connections\nto the Postgres server is not limited.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_host": {
+      "defaultValue": null,
+      "description": "Same as `pg_host`, but for the\nread-only connection.\n**Note:** Refer to the documentation\nsection above for detailed usage.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_port": {
+      "defaultValue": "<pg_port>",
+      "description": "Same as `pg_port`, but for the\nread-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_timeout": {
+      "defaultValue": "<pg_timeout>",
+      "description": "Same as `pg_timeout`, but for the\nread-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_user": {
+      "defaultValue": "<pg_user>",
+      "description": "Same as `pg_user`, but for the\nread-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_password": {
+      "defaultValue": "<pg_password>",
+      "description": "Same as `pg_password`, but for the\nread-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_iam_auth": {
+      "defaultValue": "<pg_iam_auth>",
+      "description": "Same as `pg_iam_auth`, but for the\nread-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_iam_auth_assume_role_arn": {
+      "defaultValue": null,
+      "description": "Same as `pg_iam_auth_assume_role_arn',\nbut for the read-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_iam_auth_role_session_name": {
+      "defaultValue": "KongPostgres",
+      "description": "Same as `pg_iam_auth_role_session_name`,\nbut for the read-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_iam_auth_sts_endpoint_url": {
+      "defaultValue": null,
+      "description": "Same as `pg_iam_auth_sts_endpoint_url`,\nbut for the read-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_database": {
+      "defaultValue": "<pg_database>",
+      "description": "Same as `pg_database`, but for the\nread-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_schema": {
+      "defaultValue": "<pg_schema>",
+      "description": "Same as `pg_schema`, but for the\nread-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_ssl": {
+      "defaultValue": "<pg_ssl>",
+      "description": "Same as `pg_ssl`, but for the\nread-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_ssl_required": {
+      "defaultValue": "<pg_ssl_required>",
+      "description": "Same as `pg_ssl_required`, but for the\nread-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_ssl_verify": {
+      "defaultValue": "<pg_ssl_verify>",
+      "description": "Same as `pg_ssl_verify`, but for the\nread-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_ssl_version": {
+      "defaultValue": "<pg_ssl_version>",
+      "description": "Same as `pg_ssl_version`, but for the\nread-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_max_concurrent_queries": {
+      "defaultValue": "<pg_max_concurrent_queries>",
+      "description": "Same as `pg_max_concurrent_queries`, but for\nthe read-only connection.\nNote: read-only concurrency is not shared\nwith the main (read-write) connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_semaphore_timeout": {
+      "defaultValue": "<pg_semaphore_timeout>",
+      "description": "Same as `pg_semaphore_timeout`, but for the\nread-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_keepalive_timeout": {
+      "defaultValue": "<pg_keepalive_timeout>",
+      "description": "Same as `pg_keepalive_timeout`, but for the\nread-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_pool_size": {
+      "defaultValue": "<pg_pool_size>",
+      "description": "Same as `pg_pool_size`, but for the\nread-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_backlog": {
+      "defaultValue": "<pg_backlog>",
+      "description": "Same as `pg_backlog`, but for the\nread-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "declarative_config": {
+      "defaultValue": null,
+      "description": "The path to the declarative configuration\nfile which holds the specification of all\nentities (routes, services, consumers, etc.)\nto be used when the `database` is set to\n`off`.\n\nEntities are stored in Kong's LMDB cache,\nso you must ensure that enough headroom is\nallocated to it via the `lmdb_map_size`\nproperty.\n\nIf the hybrid mode `role` is set to `data_plane`\nand there's no configuration cache file,\nthis configuration is used before connecting\nto the control plane node as a user-controlled\nfallback.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "declarative_config_string": {
+      "defaultValue": null,
+      "description": "The declarative configuration as a string\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "lmdb_environment_path": {
+      "defaultValue": "dbless.lmdb",
+      "description": "Directory where the LMDB database files used by\nDB-less and hybrid mode to store Kong\nconfigurations reside.\n\nThis path is relative under the Kong `prefix`.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "lmdb_map_size": {
+      "defaultValue": "2048m",
+      "description": "Maximum size of the LMDB memory map, used to store the\nDB-less and hybrid mode configurations. Default is 2048m.\n\nThis config defines the limit of LMDB file size; the\nactual file size growth will be on-demand and\nproportional to the actual config size.\n\nNote this value can be set very large, say a couple of GBs,\nto accommodate future database growth and\nMulti-Version Concurrency Control (MVCC) headroom needs.\nThe file size of the LMDB database file should stabilize\nafter a few config reloads/hybrid mode syncs, and the actual\nmemory used by the LMDB database will be smaller than\nthe file size due to dynamic swapping of database pages by\nthe OS.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "db_update_frequency": {
+      "defaultValue": "5",
+      "description": "Frequency (in seconds) at which to check for\nupdated entities with the datastore.\n\nWhen a node creates, updates, or deletes an\nentity via the Admin API, other nodes need\nto wait for the next poll (configured by\nthis value) to eventually purge the old\ncached entity and start using the new one.\n",
+      "sectionTitle": "DATASTORE CACHE"
+    },
+    "db_update_propagation": {
+      "defaultValue": "0",
+      "description": "Time (in seconds) taken for an entity in the\ndatastore to be propagated to replica nodes\nof another datacenter.\n\nWhen set, this property will increase the\ntime taken by Kong to propagate the change\nof an entity.\n\nSingle-datacenter setups or PostgreSQL\nservers should suffer no such delays, and\nthis value can be safely set to 0.\nPostgres setups with read replicas should\nset this value to the maximum expected replication\nlag between the writer and reader instances.\n",
+      "sectionTitle": "DATASTORE CACHE"
+    },
+    "db_cache_ttl": {
+      "defaultValue": "0",
+      "description": "Time-to-live (in seconds) of an entity from\nthe datastore when cached by this node.\n\nDatabase misses (no entity) are also cached\naccording to this setting if you do not\nconfigure `db_cache_neg_ttl`.\n\nIf set to 0 (default), such cached entities\nor misses never expire.\n",
+      "sectionTitle": "DATASTORE CACHE"
+    },
+    "db_cache_neg_ttl": {
+      "defaultValue": null,
+      "description": "Time-to-live (in seconds) of a datastore\nmiss (no entity).\n\nIf not specified (default), `db_cache_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n",
+      "sectionTitle": "DATASTORE CACHE"
+    },
+    "db_resurrect_ttl": {
+      "defaultValue": "30",
+      "description": "Time (in seconds) for which stale entities\nfrom the datastore should be resurrected\nwhen they cannot be refreshed (e.g., the\ndatastore is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nentities will be made.\n",
+      "sectionTitle": "DATASTORE CACHE"
+    },
+    "db_cache_warmup_entities": {
+      "defaultValue": "services",
+      "description": "Entities to be pre-loaded from the datastore\ninto the in-memory cache at Kong start-up.\nThis speeds up the first access of endpoints\nthat use the given entities.\n\nWhen the `services` entity is configured\nfor warmup, the DNS entries for values in\nits `host` attribute are pre-resolved\nasynchronously as well.\n\nCache size set in `mem_cache_size` should\nbe set to a value large enough to hold all\ninstances of the specified entities.\nIf the size is insufficient, Kong will log\na warning.\n",
+      "sectionTitle": "DATASTORE CACHE"
+    },
+    "dns_resolver": {
+      "defaultValue": null,
+      "description": "Comma-separated list of nameservers, each\nentry in `ip[:port]` format to be used by\nKong. If not specified, the nameservers in\nthe local `resolv.conf` file will be used.\nPort defaults to 53 if omitted. Accepts\nboth IPv4 and IPv6 addresses.\n",
+      "sectionTitle": "DNS RESOLVER"
+    },
+    "dns_hostsfile": {
+      "defaultValue": "/etc/hosts",
+      "description": "The hosts file to use. This file is read\nonce and its content is static in memory.\nTo read the file again after modifying it,\nKong must be reloaded.\n",
+      "sectionTitle": "DNS RESOLVER"
+    },
+    "dns_order": {
+      "defaultValue": [
+        "LAST",
+        "SRV",
+        "A",
+        "CNAME"
+      ],
+      "description": "The order in which to resolve different\nrecord types. The `LAST` type means the\ntype of the last successful lookup (for the\nspecified name). The format is a (case\ninsensitive) comma-separated list.\n",
+      "sectionTitle": "DNS RESOLVER"
+    },
+    "dns_valid_ttl": {
+      "defaultValue": null,
+      "description": "By default, DNS records are cached using\nthe TTL value of a response. If this\nproperty receives a value (in seconds), it\nwill override the TTL for all records.\n",
+      "sectionTitle": "DNS RESOLVER"
+    },
+    "dns_stale_ttl": {
+      "defaultValue": "3600",
+      "description": "Defines, in seconds, how long a record will\nremain in cache past its TTL. This value\nwill be used while the new DNS record is\nfetched in the background.\nStale data will be used from expiry of a\nrecord until either the refresh query\ncompletes, or the `dns_stale_ttl` number of\nseconds have passed.\nThis configuration enables Kong to be more\nresilient during resolver downtime.\n",
+      "sectionTitle": "DNS RESOLVER"
+    },
+    "dns_cache_size": {
+      "defaultValue": "10000",
+      "description": "Defines the maximum allowed number of\nDNS records stored in memory cache.\nLeast recently used DNS records are discarded\nfrom cache if it is full. Both errors and\ndata are cached; therefore, a single name query\ncan easily take up 10-15 slots.\n",
+      "sectionTitle": "DNS RESOLVER"
+    },
+    "dns_not_found_ttl": {
+      "defaultValue": "30",
+      "description": "TTL in seconds for empty DNS responses and\n\"(3) name error\" responses.\n",
+      "sectionTitle": "DNS RESOLVER"
+    },
+    "dns_error_ttl": {
+      "defaultValue": "1",
+      "description": "TTL in seconds for error responses.\n",
+      "sectionTitle": "DNS RESOLVER"
+    },
+    "dns_no_sync": {
+      "defaultValue": "off",
+      "description": "If enabled, then upon a cache-miss every\nrequest will trigger its own DNS query.\nWhen disabled, multiple requests for the\nsame name/type will be synchronized to a\nsingle query.\n",
+      "sectionTitle": "DNS RESOLVER"
+    },
+    "new_dns_client": {
+      "defaultValue": "off",
+      "description": "Enable or disable the new DNS resolver\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_address": {
+      "defaultValue": "<name servers parsed from resolv.conf>",
+      "description": "Comma-separated list of nameservers, each\nentry in `ip[:port]` format to be used by\nKong. If not specified, the nameservers in\nthe local `resolv.conf` file will be used.\nPort defaults to 53 if omitted. Accepts\nboth IPv4 and IPv6 addresses.\n\nExamples:\n\n```\nresolver_address = 8.8.8.8\nresolver_address = 8.8.8.8, [::1]\nresolver_address = 8.8.8.8:53, [::1]:53\n```\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_hosts_file": {
+      "defaultValue": "/etc/hosts",
+      "description": "The hosts file to use. This file is read\nonce and its content is static in memory.\nTo read the file again after modifying it,\nKong must be reloaded.\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_family": {
+      "defaultValue": [
+        "A",
+        "SRV"
+      ],
+      "description": "The supported query types.\n\nFor a domain name, Kong will only query\neither IP addresses (A or AAAA) or SRV\nrecords, but not both.\n\nIt will query SRV records only when the\ndomain matches the\n\"_<proto>._<service>.<name>\" format, for\nexample, \"_ldap._tcp.example.com\".\n\nFor IP addresses (A or AAAA) resolution, it\nfirst attempts IPv4 (A) and then queries\nIPv6 (AAAA).\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_valid_ttl": {
+      "defaultValue": "<TTL from responses>",
+      "description": "By default, DNS records are cached using\nthe TTL value of a response. This optional\nparameter (in seconds) allows overriding it.\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_error_ttl": {
+      "defaultValue": "1",
+      "description": "TTL in seconds for error responses and empty\nresponses.\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_stale_ttl": {
+      "defaultValue": "3600",
+      "description": "Defines, in seconds, how long a record will\nremain in cache past its TTL. This value\nwill be used while the new DNS record is\nfetched in the background.\n\nStale data will be used from expiry of a\nrecord until either the refresh query\ncompletes, or the `resolver_stale_ttl` number\nof seconds have passed.\n\nThis configuration enables Kong to be more\nresilient during the DNS server downtime.\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_lru_cache_size": {
+      "defaultValue": "10000",
+      "description": "The DNS client uses a two-layer cache system:\nL1 - worker-level LRU Lua VM cache\nL2 - across-workers shared memory cache\n\nThis value specifies the maximum allowed\nnumber of DNS responses stored in the L1 LRU\nlua VM cache.\n\nA single name query can easily take up 1~10\nslots, depending on attempted query types and\nextended domains from /etc/resolv.conf\noptions `domain` or `search`.\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_mem_cache_size": {
+      "defaultValue": "5m",
+      "description": "This value specifies the size of the L2\nshared memory cache for DNS responses,\n`kong_dns_cache`.\n\nAccepted units are `k` and `m`, with a\nminimum recommended value of a few MBs.\n\n5MB shared memory size could store\n~20000 DNS responeses with single A record or\n~10000 DNS responeses with 2~3 A records.\n\n10MB shared memory size could store\n~40000 DNS responeses with single A record or\n~20000 DNS responeses with 2~3 A records.\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "vault_env_prefix": {
+      "defaultValue": null,
+      "description": "Defines the environment variable vault's\ndefault prefix. For example if you have\nall your secrets stored in environment\nvariables prefixed with `SECRETS_`, it\ncan be configured here so that it isn't\nnecessary to repeat them in Vault\nreferences.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_aws_region": {
+      "defaultValue": null,
+      "description": "The AWS region your vault is located in.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_aws_endpoint_url": {
+      "defaultValue": null,
+      "description": "The AWS SecretsManager service endpoint url.\nIf not specified, the value used by vault will\nbe the official AWS SecretsManager service url\nwhich is\n`https://secretsmanager.<region>.amazonaws.com`\nYou can specify a complete URL(including\nthe \"http/https\" scheme) to override the\nendpoint that vault will connect to.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_aws_assume_role_arn": {
+      "defaultValue": null,
+      "description": "The target AWS IAM role ARN that will be\nassumed. Typically this is used for\noperating between multiple roles\nor cross-accounts.\nIf you are not using assume role\nyou should not specify this value.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_aws_role_session_name": {
+      "defaultValue": "KongVault",
+      "description": "The role session name used for role\nassuming. The default value is\n`KongVault`.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_aws_sts_endpoint_url": {
+      "defaultValue": null,
+      "description": "The custom STS endpoint URL used for role assuming\nin AWS Vault.\n\nNote that this value will override the default\nSTS endpoint URL(which should be\n`https://sts.amazonaws.com`, or\n`https://sts.<region>.amazonaws.com` if you have\n`AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).\n\nIf you are not using private VPC endpoint for STS\nservice, you should not specify this value.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_aws_ttl": {
+      "defaultValue": "0",
+      "description": "Time-to-live (in seconds) of a secret from\nthe AWS vault when cached by this node.\n\nAWS vault misses (no secret) are also cached\naccording to this setting if you do not\nconfigure `vault_aws_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_aws_neg_ttl": {
+      "defaultValue": null,
+      "description": "Time-to-live (in seconds) of a AWS vault\nmiss (no secret).\n\nIf not specified (default), `vault_aws_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_aws_resurrect_ttl": {
+      "defaultValue": null,
+      "description": "Time (in seconds) for which stale secrets\nfrom the AWS vault should be resurrected for\nwhen they cannot be refreshed (e.g., the\nAWS vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_gcp_project_id": {
+      "defaultValue": null,
+      "description": "The project ID from your Google API Console.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_gcp_ttl": {
+      "defaultValue": "0",
+      "description": "Time-to-live (in seconds) of a secret from\nthe GCP vault when cached by this node.\n\nGCP vault misses (no secret) are also cached\naccording to this setting if you do not\nconfigure `vault_gcp_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_gcp_neg_ttl": {
+      "defaultValue": null,
+      "description": "Time-to-live (in seconds) of a AWS vault\nmiss (no secret).\n\nIf not specified (default), `vault_gcp_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_gcp_resurrect_ttl": {
+      "defaultValue": null,
+      "description": "Time (in seconds) for which stale secrets\nfrom the GCP vault should be resurrected for\nwhen they cannot be refreshed (e.g., the\nGCP vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_hcv_protocol": {
+      "defaultValue": "http",
+      "description": "The protocol to connect with. Accepts one of\n`http` or `https`.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_hcv_host": {
+      "defaultValue": "127.0.0.1",
+      "description": "The hostname of your HashiCorp vault.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_hcv_port": {
+      "defaultValue": "8200",
+      "description": "The port number of your HashiCorp vault.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_hcv_namespace": {
+      "defaultValue": null,
+      "description": "Namespace for the HashiCorp Vault. Vault\nEnterprise requires a namespace to\nsuccessfully connect to it.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_hcv_mount": {
+      "defaultValue": "secret",
+      "description": "The mount point.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_hcv_kv": {
+      "defaultValue": "v1",
+      "description": "The secrets engine version. Accepts `v1` or\n`v2`.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_hcv_token": {
+      "defaultValue": null,
+      "description": "A token string.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_hcv_auth_method": {
+      "defaultValue": "token",
+      "description": "Defines the authentication mechanism when\nconnecting to the Hashicorp Vault service.\nAccepted values are: `token`,\n`kubernetes` or `approle`.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_hcv_kube_role": {
+      "defaultValue": null,
+      "description": "Defines the HashiCorp Vault role for the\nKubernetes service account of the running\npod. `vault_hcv_auth_method` must be\nset to `kubernetes` for this to activate.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_hcv_kube_auth_path": {
+      "defaultValue": "kubernetes",
+      "description": "Place where the Kubernetes auth method will be\naccessible: `/v1/auth/<vault_hcv_kube_auth_path>`\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_hcv_kube_api_token_file": {
+      "defaultValue": null,
+      "description": "Defines where the Kubernetes service account\ntoken should be read from the pod's\nfilesystem, if using a non-standard\ncontainer platform setup.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_hcv_approle_auth_path": {
+      "defaultValue": "approle",
+      "description": "Place where the Approle auth method will be\naccessible: `/v1/auth/<vault_hcv_approle_auth_path>`\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_hcv_approle_role_id": {
+      "defaultValue": null,
+      "description": "The Role ID of the Approle in HashiCorp Vault.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_hcv_approle_secret_id": {
+      "defaultValue": null,
+      "description": "The Secret ID of the Approle in HashiCorp Vault.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_hcv_approle_secret_id_file": {
+      "defaultValue": null,
+      "description": "Defines where the Secret ID should be read from\nthe pod's filesystem. This is usually used with\nHashiCorp Vault's response wrapping.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_hcv_approle_response_wrapping": {
+      "defaultValue": "false",
+      "description": "Defines whether the Secret ID read from configuration\nor file is actually a response-wrapping token instead\nof a real Secret ID.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_hcv_ttl": {
+      "defaultValue": "0",
+      "description": "Time-to-live (in seconds) of a secret from\nthe HashiCorp vault when cached by this node.\n\nHashiCorp vault misses (no secret) are also\ncached according to this setting if you do not\nconfigure `vault_hcv_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_hcv_neg_ttl": {
+      "defaultValue": null,
+      "description": "Time-to-live (in seconds) of a HashiCorp vault\nmiss (no secret).\n\nIf not specified (default), `vault_hcv_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_hcv_resurrect_ttl": {
+      "defaultValue": null,
+      "description": "Time (in seconds) for which stale secrets\nfrom the HashiCorp vault should be resurrected\nfor when they cannot be refreshed (e.g., the\nHashiCorp vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_azure_vault_uri": {
+      "defaultValue": null,
+      "description": "The URI the vault is reachable from.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_azure_client_id": {
+      "defaultValue": null,
+      "description": "The client ID from your registered Application. Visit your Azure Dashboard and select *App Registrations* to check your client ID.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_azure_tenant_id": {
+      "defaultValue": null,
+      "description": "The DirectoryId and TenantId both equate to the GUID representing the ActiveDirectory Tenant. Depending on context, either term may be used by Microsoft documentation and products, which can be confusing. In other words, the \"Tenant ID\" IS the \"Directory ID\"\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_azure_type": {
+      "defaultValue": "secrets",
+      "description": "Azure Key Vault enables Microsoft Azure applications and users to store and use several types of secret/key data: keys, secrets, and certificates. Kong currently only supports the `Secrets`\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_azure_ttl": {
+      "defaultValue": "0",
+      "description": "Time-to-live (in seconds) of a secret from\nthe Azure Key Vault when cached by this node.\n\nKey Vault misses (no secret) are also\ncached according to this setting if you do not\nconfigure `vault_azure_neg_ttl`.\n\nIf set to 0 (default), such cached secrets\nor misses never expire.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_azure_neg_ttl": {
+      "defaultValue": null,
+      "description": "Time-to-live (in seconds) of a Azure Key Vault\nmiss (no secret).\n\nIf not specified (default), `vault_azure_ttl`\nvalue will be used instead.\n\nIf set to 0, misses will never expire.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_azure_resurrect_ttl": {
+      "defaultValue": null,
+      "description": "Time (in seconds) for which stale secrets\nfrom the Azure Key Vault should be resurrected\nfor when they cannot be refreshed (e.g., the\nthe vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "worker_consistency": {
+      "defaultValue": "eventual",
+      "description": "Defines whether this node should rebuild its\nstate synchronously or asynchronously (the\nbalancers and the router are rebuilt on\nupdates that affect them, e.g., updates to\nroutes, services, or upstreams via the admin\nAPI or loading a declarative configuration\nfile). (This option is deprecated and will be\nremoved in future releases. The new default\nis `eventual`.)\n\nAccepted values are:\n\n- `strict`: the router will be rebuilt\n  synchronously, causing incoming requests to\n  be delayed until the rebuild is finished.\n  (This option is deprecated and will be removed\n   in future releases. The new default is `eventual`)\n- `eventual`: the router will be rebuilt\n  asynchronously via a recurring background\n  job running every second inside of each\n  worker.\n\nNote that `strict` ensures that all workers\nof a given node will always proxy requests\nwith an identical router, but increased\nlong-tail latency can be observed if\nfrequent routes and services updates are\nexpected.\nUsing `eventual` will help prevent long-tail\nlatency issues in such cases, but may\ncause workers to route requests differently\nfor a short period of time after routes and\nservices updates.\n",
+      "sectionTitle": "TUNING & BEHAVIOR"
+    },
+    "worker_state_update_frequency": {
+      "defaultValue": "5",
+      "description": "Defines how often the worker state changes are\nchecked with a background job. When a change\nis detected, a new router or balancer will be\nbuilt, as needed. Raising this value will\ndecrease the load on database servers and\nresult in less jitter in proxy latency, but\nit might take more time to propagate changes\nto each individual worker.\n",
+      "sectionTitle": "TUNING & BEHAVIOR"
+    },
+    "router_flavor": {
+      "defaultValue": "traditional_compatible",
+      "description": "Selects the router implementation to use when\nperforming request routing. Incremental router\nrebuild is available when the flavor is set\nto either `expressions` or\n`traditional_compatible`, which could\nsignificantly shorten rebuild time for a large\nnumber of routes.\n\nAccepted values are:\n\n- `traditional_compatible`: the DSL-based expression\n  router engine will be used under the hood. However,\n  the router config interface will be the same\n  as `traditional`, and expressions are\n  automatically generated at router build time.\n  The `expression` field on the `route` object\n  is not visible.\n- `expressions`: the DSL-based expression router engine\n  will be used under the hood. The traditional router\n  config interface is still visible, and you can also write\n  router Expressions manually and provide them in the\n  `expression` field on the `route` object.\n- `traditional`: the pre-3.0 router engine will be\n  used. The config interface will be the same as\n  pre-3.0 Kong, and the `expression` field on the\n  `route` object is not visible.\n\n  Deprecation warning: In Kong 3.0, `traditional`\n  mode should be avoided and only be used if\n  `traditional_compatible` does not work as expected.\n  This flavor of the router will be removed in the next\n  major release of Kong.\n",
+      "sectionTitle": "TUNING & BEHAVIOR"
+    },
+    "lua_max_req_headers": {
+      "defaultValue": "100",
+      "description": "Maximum number of request headers to parse by default.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request headers,\nand this setting does not have any effect. It is used\nto limit Kong and its plugins from reading too many\nrequest headers.\n",
+      "sectionTitle": "TUNING & BEHAVIOR"
+    },
+    "lua_max_resp_headers": {
+      "defaultValue": "100",
+      "description": "Maximum number of response headers to parse by default.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong returns all the response headers,\nand this setting does not have any effect. It is used\nto limit Kong and its plugins from reading too many\nresponse headers.\n",
+      "sectionTitle": "TUNING & BEHAVIOR"
+    },
+    "lua_max_uri_args": {
+      "defaultValue": "100",
+      "description": "Maximum number of request URI arguments to parse by\ndefault.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request query\narguments, and this setting does not have any effect.\nIt is used to limit Kong and its plugins from reading\ntoo many query arguments.\n",
+      "sectionTitle": "TUNING & BEHAVIOR"
+    },
+    "lua_max_post_args": {
+      "defaultValue": "100",
+      "description": "Maximum number of request post arguments to parse by\ndefault.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request post\narguments, and this setting does not have any effect.\nIt is used to limit Kong and its plugins from reading\ntoo many post arguments.\n",
+      "sectionTitle": "TUNING & BEHAVIOR"
+    },
+    "lua_ssl_trusted_certificate": {
+      "defaultValue": "system",
+      "description": "Comma-separated list of certificate authorities\nfor Lua cosockets in PEM format.\n\nThe special value `system` attempts to search for the\n\"usual default\" provided by each distro, according\nto an arbitrary heuristic. In the current implementation,\nthe following pathnames will be tested in order,\nand the first one found will be used:\n\n- `/etc/ssl/certs/ca-certificates.crt` (Debian/Ubuntu/Gentoo)\n- `/etc/pki/tls/certs/ca-bundle.crt` (Fedora/RHEL 6)\n- `/etc/ssl/ca-bundle.pem` (OpenSUSE)\n- `/etc/pki/tls/cacert.pem` (OpenELEC)\n- `/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem` (CentOS/RHEL 7)\n- `/etc/ssl/cert.pem` (OpenBSD, Alpine)\n\n`system` can be used by itself or in conjunction with other\nCA file paths.\n\nWhen `pg_ssl_verify` is enabled, these\ncertificate authority files will be\nused for verifying Kong's database connections.\n\nCertificates can be configured on this property\nwith any of the following values:\n- `system`\n- absolute path to the certificate\n- certificate content\n- base64 encoded certificate content\n\nSee https://github.com/openresty/lua-nginx-module#lua_ssl_trusted_certificate\n",
+      "sectionTitle": "MISCELLANEOUS"
+    },
+    "lua_ssl_verify_depth": {
+      "defaultValue": "1",
+      "description": "Sets the verification depth in the server\ncertificates chain used by Lua cosockets,\nset by `lua_ssl_trusted_certificate`.\nThis includes the certificates configured\nfor Kong's database connections.\nIf the maximum depth is reached before\nreaching the end of the chain, verification\nwill fail. This helps mitigate certificate\nbased DoS attacks.\n\nSee https://github.com/openresty/lua-nginx-module#lua_ssl_verify_depth\n",
+      "sectionTitle": "MISCELLANEOUS"
+    },
+    "lua_ssl_protocols": {
+      "defaultValue": "TLSv1.2 TLSv1.3",
+      "description": "Defines the TLS versions supported\nwhen handshaking with OpenResty's\nTCP cosocket APIs.\n\nThis affects connections made by Lua\ncode, such as connections to the\ndatabase Kong uses, or when sending logs\nusing a logging plugin. It does *not*\naffect connections made to the upstream\nService or from downstream clients.\n",
+      "sectionTitle": "MISCELLANEOUS"
+    },
+    "lua_package_path": {
+      "defaultValue": "./?.lua;./?/init.lua;",
+      "description": "Sets the Lua module search path\n(LUA_PATH). Useful when developing\nor using custom plugins not stored\nin the default search path.\n\nSee https://github.com/openresty/lua-nginx-module#lua_package_path\n",
+      "sectionTitle": "MISCELLANEOUS"
+    },
+    "lua_package_cpath": {
+      "defaultValue": null,
+      "description": "Sets the Lua C module search path\n(LUA_CPATH).\n\nSee https://github.com/openresty/lua-nginx-module#lua_package_cpath\n",
+      "sectionTitle": "MISCELLANEOUS"
+    },
+    "lua_socket_pool_size": {
+      "defaultValue": "256",
+      "description": "Specifies the size limit for every cosocket\nconnection pool associated with every remote\nserver.\n\nSee https://github.com/openresty/lua-nginx-module#lua_socket_pool_size\n",
+      "sectionTitle": "MISCELLANEOUS"
+    },
+    "enforce_rbac": {
+      "defaultValue": "off",
+      "description": "Specifies whether Admin API RBAC is enforced.\nAccepts one of `entity`, `both`, `on`, or\n`off`.\n\n- `on`: only endpoint-level authorization\n  is enforced.\n- `entity`: entity-level authorization\n  applies.\n- `both`: enables both endpoint and\n  entity-level authorization.\n- `off`: disables both endpoint and\n  entity-level authorization.\n\nWhen enabled, Kong will deny requests to the\nAdmin API when a nonexistent or invalid RBAC\nauthorization token is passed, or the RBAC\nuser with which the token is associated does\nnot have permissions to access/modify the\nrequested resource.\n",
+      "sectionTitle": "MISCELLANEOUS"
+    },
+    "rbac_auth_header": {
+      "defaultValue": "Kong-Admin-Token",
+      "description": "Defines the name of the HTTP request\nheader from which the Admin API will\nattempt to authenticate the RBAC user.\n",
+      "sectionTitle": "MISCELLANEOUS"
+    },
+    "event_hooks_enabled": {
+      "defaultValue": "on",
+      "description": "When enabled, event hook entities represent a relationship\nbetween an event (source and event) and an action\n(handler). Similar to web hooks, event hooks can be used to\ncommunicate Kong Gateway service events. When a particular\nevent happens on a service, the event hook calls a URL with\ninformation about that event. Event hook configurations\ndiffer depending on the handler. The events that are\ntriggered send associated data.\n\nSee: https://docs.konghq.com/gateway/api/admin-ee/latest/#/Event-hooks/get-event-hooks\n",
+      "sectionTitle": "MISCELLANEOUS"
+    },
+    "fips": {
+      "defaultValue": "off",
+      "description": "Turn on FIPS mode; this mode is only available on a FIPS build.\n",
+      "sectionTitle": "MISCELLANEOUS"
+    },
+    "admin_gui_listen": {
+      "defaultValue": [
+        "0.0.0.0:8002",
+        "0.0.0.0:8445 ssl"
+      ],
+      "description": "Kong Manager Listeners\n\nComma-separated list of addresses and ports on which\nKong will expose Kong Manager. This web application\nlets you configure and manage Kong, and therefore\nshould be kept secured.\n\nSuffixes can be specified for each pair, similarly to\nthe `admin_listen` directive.\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_url": {
+      "defaultValue": null,
+      "description": "Kong Manager URL\n\nComma-separated list of addresses (the lookup or balancer) for Kong Manager.\n\nAccepted format (items in square brackets are optional):\n\n  `<scheme>://<IP / HOSTNAME>[:<PORT>][<PATH>][, <scheme>://<IP / HOSTNAME>[:<PORT>][<PATH>]]`\n\nExamples:\n\n- `http://127.0.0.1:8003`\n- `https://kong-admin.test`\n- `http://dev-machine`\n- `http://127.0.0.1:8003, https://exmple.com/manager`\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_path": {
+      "defaultValue": "/",
+      "description": "Kong Manager base path\n\nThis configuration parameter allows the user to customize\nthe path prefix where Kong Manager is served. When updating\nthis parameter, it's recommended to update the path in `admin_gui_url`\nas well.\n\nAccepted format:\n\n- Path must start with a `/`\n- Path must not end with a `/` (except for the `/`)\n- Path can only contain letters, digits, hyphens (`-`),\nunderscores (`_`), and slashes (`/`)\n- Path must not contain continuous slashes (e.g., `//` and `///`)\n\nExamples:\n\n- `/`\n- `/manager`\n- `/kong-manager`\n- `/kong/manager`\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_api_url": {
+      "defaultValue": null,
+      "description": "Hierarchical part of a URI which is composed\noptionally of a host, port, and path at which the\nAdmin API accepts HTTP or HTTPS traffic. When\nthis config is disabled, Kong Manager will\nuse the window protocol + host and append the\nresolved admin_listen HTTP/HTTPS port.\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_csp_header": {
+      "defaultValue": "off",
+      "description": "Enable or disable the `Content-Security-Policy` (CSP) header for Kong Manager\n\nThis configuration controls the presence of the CSP header when serving\nKong Manager. The default CSP header value will be used unless customized.\n\nTo modify the value of the served CSP header, refer to the `admin_gui_csp_header_value`\nconfiguration.\n\nSet this configuration to `on` to enable the CSP header.\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_csp_header_value": {
+      "defaultValue": null,
+      "description": "The value of the `Content-Security-Policy` (CSP) header for Kong Manager.\n\nThis configuration controls the value of the CSP header when serving\nKong Manager. If omitted or left empty, the default CSP header value\nwill be used.\n\nThis is an advanced configuration intended for cases where the default\nCSP header value does not meet your requirements. Use with caution.\n\nFor more information on the CSP header, see:\nhttps://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_ssl_protocols": {
+      "defaultValue": "TLSv1.2 TLSv1.3",
+      "description": "Defines the TLS versions supported\nfor Kong Manager\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_ssl_cert": {
+      "defaultValue": null,
+      "description": "The SSL certificate for `admin_gui_listen` values\nwith SSL enabled.\n\nvalues:\n- absolute path to the certificate\n- certificate content\n- base64 encoded certificate content\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_ssl_cert_key": {
+      "defaultValue": null,
+      "description": "The SSL key for `admin_gui_listen` values with SSL\nenabled.\n\nvalues:\n- absolute path to the certificate key\n- certificate key content\n- base64 encoded certificate key content\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_flags": {
+      "defaultValue": "{}",
+      "description": "Alters the layout Admin GUI (JSON)\nto enable Kong Immunity in the Admin GUI.\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_access_log": {
+      "defaultValue": "logs/admin_gui_access.log",
+      "description": "Kong Manager Access Logs\n\nHere you can set an absolute or relative path for Kong\nManager access logs. When the path is relative,\nlogs are placed in the `prefix` location.\n\nSetting this value to `off` disables access logs\nfor Kong Manager.\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_error_log": {
+      "defaultValue": "logs/admin_gui_error.log",
+      "description": "Kong Manager Error Logs\n\nHere you can set an absolute or relative path for Kong\nManager access logs. When the path is relative,\nlogs are placed in the `prefix` location.\n\nSetting this value to `off` disables error logs for\nKong Manager.\n\nGranularity can be adjusted through the `log_level`\ndirective.\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_auth": {
+      "defaultValue": null,
+      "description": "Kong Manager Authentication Plugin Name\n\nSecures access to Kong Manager by specifying an\nauthentication plugin to use.\n\nSupported Plugins:\n\n- `basic-auth`: Basic Authentication plugin\n- `ldap-auth-advanced`: LDAP Authentication plugin\n- `openid-connect`: OpenID Connect Authentication\n  plugin\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_auth_conf": {
+      "defaultValue": null,
+      "description": "Kong Manager Authentication Plugin Config (JSON)\n\nSpecifies the configuration for the authentication\nplugin specified in `admin_gui_auth`.\n\nFor information about Plugin Configuration\nconsult the associated plugin documentation.\n\nExample for `basic-auth`:\n\n`admin_gui_auth_conf = { \"hide_credentials\": true }`\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_auth_password_complexity": {
+      "defaultValue": null,
+      "description": "Kong Manager Authentication Password Complexity (JSON)\n\nWhen `admin_gui_auth = basic-auth`, this property defines\nthe rules required for Kong Manager passwords. Choose\nfrom preset rules or write your own.\n\nExample using preset rules:\n\n`admin_gui_auth_password_complexity = { \"kong-preset\": \"min_8\" }`\n\nAll values for kong-preset require the password to contain\ncharacters from at least three of the following categories:\n\n1. Uppercase characters (A through Z)\n\n2. Lowercase characters (a through z)\n\n3. Base-10 digits (0 through 9)\n\n4. Special characters (for example, &, $, #, %)\n\nSupported preset rules:\n- `min_8`: minimum length of 8\n- `min_12`: minimum length of 12\n- `min_20`: minimum length of 20\n\nTo write your own rules, see\nhttps://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.\n\nNOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.\n\nExample:\n\n`admin_gui_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_session_conf": {
+      "defaultValue": null,
+      "description": "Kong Manager Session Config (JSON)\n\nSpecifies the configuration for the Session plugin as\nused by Kong Manager.\n\nFor information about plugin configuration, consult\nthe Kong Session plugin documentation.\n\nExample:\n```\nadmin_gui_session_conf = { \"cookie_name\": \"kookie\", \\\n                           \"secret\": \"changeme\" }\n```\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_auth_header": {
+      "defaultValue": "Kong-Admin-User",
+      "description": "Defines the name of the HTTP request header from which\nthe Admin API will attempt to identify the Kong Admin\nuser.\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_auth_login_attempts": {
+      "defaultValue": "0",
+      "description": "Number of times a user can attempt to login to Kong\nManager. 0 means infinite attempts allowed.\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_auth_login_attempts_ttl": {
+      "defaultValue": "604800",
+      "description": "Length, in seconds, of the TTL for changing login attempts\nrecords. Records in the database older than\ntheir TTL are automatically purged.\n\nThis argument can be set to an integer between 0 and 100000000.\n\nExample, 7 days: `7 * 24 * 60 * 60 = 604800.`\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_auth_change_password_attempts": {
+      "defaultValue": "0",
+      "description": "Number of times a user can attempt to change password.\n0 means infinite attempts allowed.\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_auth_change_password_ttl": {
+      "defaultValue": "86400",
+      "description": "Length, in seconds, of the TTL for changing password attempts\nrecords. Records in the database older than\ntheir TTL are automatically purged.\n\nExample, 1 days: `1 * 24 * 60 * 60 = 86400.`\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_header_txt": {
+      "defaultValue": null,
+      "description": "Sets the text for the Kong Manager header banner.\nHeader banner is not shown if this config is empty.\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_header_bg_color": {
+      "defaultValue": null,
+      "description": "Sets the background color for the Kong Manager header banner.\nAccepts CSS color keyword, #-hexadecimal, or RGB\nformat. Invalid values are ignored by Manager.\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_header_txt_color": {
+      "defaultValue": null,
+      "description": "Sets the text color for the Kong Manager header banner.\nAccepts CSS color keyword, #-hexadecimal, or RGB\nformat. Invalid values are ignored by Kong Manager.\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_footer_txt": {
+      "defaultValue": null,
+      "description": "Sets the text for the Kong Manager footer banner. Footer banner\nis not shown if this config is empty.\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_footer_bg_color": {
+      "defaultValue": null,
+      "description": "Sets the background color for the Kong Manager footer banner.\nAccepts CSS color keyword, #-hexadecimal, or RGB\nformat. Invalid values are ignored by manager.\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_footer_txt_color": {
+      "defaultValue": null,
+      "description": "Sets the text color for the Kong Manager footer banner.\nAccepts CSS color keyword, #-hexadecimal, or RGB\nformat. Invalid values are ignored by Kong Manager.\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_login_banner_title": {
+      "defaultValue": null,
+      "description": "Sets the title text for the Kong Manager login banner.\nLogin banner is not shown if both\n`admin_gui_login_banner_title` and\n`admin_gui_login_banner_body` are empty.\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_login_banner_body": {
+      "defaultValue": null,
+      "description": "Sets the body text for the Kong Manager login banner.\nLogin banner is not shown if both\n`admin_gui_login_banner_title` and\n`admin_gui_login_banner_body` are empty.\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "konnect_mode": {
+      "defaultValue": "off",
+      "description": "When enabled, the dataplane is connected to Konnect\n",
+      "sectionTitle": "Konnect"
+    },
+    "analytics_flush_interval": {
+      "defaultValue": "1",
+      "description": "Specify the maximum frequency, in seconds,\nat which local analytics and licensing\ndata are flushed to the database or\nKonnect, depending on the installation mode.\nKong also triggers a flush when the number\nof messages in the buffer is less than\n`analytics_buffer_size_limit`, regardless\nof whether the specified time interval has\nelapsed.\n",
+      "sectionTitle": "Analytics for Konnect"
+    },
+    "analytics_buffer_size_limit": {
+      "defaultValue": "100000",
+      "description": "Max number of messages can be buffered locally\nbefore dropping data in case there is no\nnetwork connection to Konnect.\n",
+      "sectionTitle": "Analytics for Konnect"
+    },
+    "analytics_debug": {
+      "defaultValue": "off",
+      "description": "Outputs analytics payload to Kong logs.\n",
+      "sectionTitle": "Analytics for Konnect"
+    },
+    "admin_emails_from": {
+      "defaultValue": "\"\"",
+      "description": "The email address for the `From` header\nfor admin emails.\n",
+      "sectionTitle": "ADMIN SMTP CONFIGURATION"
+    },
+    "admin_emails_reply_to": {
+      "defaultValue": null,
+      "description": "Email address for the `Reply-To` header\nfor admin emails.\n",
+      "sectionTitle": "ADMIN SMTP CONFIGURATION"
+    },
+    "admin_invitation_expiry": {
+      "defaultValue": "259200",
+      "description": "Expiration time for the admin invitation link\n(in seconds). 0 means no expiration.\n\nExample, 72 hours: `72 * 60 * 60 = 259200`\n",
+      "sectionTitle": "ADMIN SMTP CONFIGURATION"
+    },
+    "smtp_mock": {
+      "defaultValue": "on",
+      "description": "This flag will mock the sending of emails. This can be\nused for testing before the SMTP client is fully\nconfigured.\n",
+      "sectionTitle": "GENERAL SMTP CONFIGURATION"
+    },
+    "smtp_host": {
+      "defaultValue": "localhost",
+      "description": "The hostname of the SMTP server to connect to.\n",
+      "sectionTitle": "GENERAL SMTP CONFIGURATION"
+    },
+    "smtp_port": {
+      "defaultValue": "25",
+      "description": "The port number on the SMTP server to connect to.\n",
+      "sectionTitle": "GENERAL SMTP CONFIGURATION"
+    },
+    "smtp_starttls": {
+      "defaultValue": "off",
+      "description": "When set to `on`, STARTTLS is used to encrypt\ncommunication with the SMTP server. This is normally\nused in conjunction with port 587.\n",
+      "sectionTitle": "GENERAL SMTP CONFIGURATION"
+    },
+    "smtp_username": {
+      "defaultValue": null,
+      "description": "Username used for authentication with SMTP server\n",
+      "sectionTitle": "GENERAL SMTP CONFIGURATION"
+    },
+    "smtp_password": {
+      "defaultValue": null,
+      "description": "Password used for authentication with SMTP server\n",
+      "sectionTitle": "GENERAL SMTP CONFIGURATION"
+    },
+    "smtp_ssl": {
+      "defaultValue": "off",
+      "description": "When set to `on`, SMTPS is used to encrypt\ncommunication with the SMTP server. This is normally\nused in conjunction with port 465.\n",
+      "sectionTitle": "GENERAL SMTP CONFIGURATION"
+    },
+    "smtp_auth_type": {
+      "defaultValue": null,
+      "description": "The method used to authenticate with the SMTP server\nValid options are `plain`, `login`, or `nil`\n",
+      "sectionTitle": "GENERAL SMTP CONFIGURATION"
+    },
+    "smtp_domain": {
+      "defaultValue": "localhost.localdomain",
+      "description": "The domain used in the `EHLO` connection and part of\nthe `Message-ID` header\n",
+      "sectionTitle": "GENERAL SMTP CONFIGURATION"
+    },
+    "smtp_timeout_connect": {
+      "defaultValue": "60000",
+      "description": "The timeout (in milliseconds) for connecting to the\nSMTP server.\n",
+      "sectionTitle": "GENERAL SMTP CONFIGURATION"
+    },
+    "smtp_timeout_send": {
+      "defaultValue": "60000",
+      "description": "The timeout (in milliseconds) for sending data to the\nSMTP server.\n",
+      "sectionTitle": "GENERAL SMTP CONFIGURATION"
+    },
+    "smtp_timeout_read": {
+      "defaultValue": "60000",
+      "description": "The timeout (in milliseconds) for reading data from\nthe SMTP server.\n",
+      "sectionTitle": "GENERAL SMTP CONFIGURATION"
+    },
+    "smtp_admin_emails": {
+      "defaultValue": null,
+      "description": "Comma separated list of admin emails to receive\nnotifications.\nExample `admin1@example.com, admin2@example.com`\n",
+      "sectionTitle": "GENERAL SMTP CONFIGURATION"
+    },
+    "audit_log": {
+      "defaultValue": "off",
+      "description": "When enabled, Kong will log information about\nAdmin API access and database row insertions,\nupdates, and deletions.\n",
+      "sectionTitle": "DATA & ADMIN AUDIT"
+    },
+    "audit_log_ignore_methods": {
+      "defaultValue": null,
+      "description": "Comma-separated list of HTTP methods that\nwill not generate audit log entries. By\ndefault, all HTTP requests will be logged.\n",
+      "sectionTitle": "DATA & ADMIN AUDIT"
+    },
+    "audit_log_ignore_paths": {
+      "defaultValue": null,
+      "description": "Comma-separated list of request paths that\nwill not generate audit log entries. By\ndefault, all HTTP requests will be logged.\n",
+      "sectionTitle": "DATA & ADMIN AUDIT"
+    },
+    "audit_log_ignore_tables": {
+      "defaultValue": null,
+      "description": "Comma-separated list of database tables that\nwill not generate audit log entries. By\ndefault, updates to all database tables will\nbe logged (the term \"updates\" refers to the\ncreation, update, or deletion of a row).\n",
+      "sectionTitle": "DATA & ADMIN AUDIT"
+    },
+    "audit_log_payload_exclude": {
+      "defaultValue": [
+        "token",
+        "secret",
+        "password"
+      ],
+      "description": "Comma-separated list of keys that will be\nfiltered out of the payload. Keys that were\nfiltered will be recorded in the audit log.\n",
+      "sectionTitle": "DATA & ADMIN AUDIT"
+    },
+    "audit_log_record_ttl": {
+      "defaultValue": "2592000",
+      "description": "Length, in seconds, of the TTL for audit log\nrecords. Records in the database older than\ntheir TTL are automatically purged.\n\nExample, 30 days: `30 * 24 * 60 * 60 = 2592000`\n",
+      "sectionTitle": "DATA & ADMIN AUDIT"
+    },
+    "audit_log_signing_key": {
+      "defaultValue": null,
+      "description": "Defines the path to a private RSA signing key\nthat can be used to insert a signature of\naudit records, adjacent to the record. The\ncorresponding public key should be stored\noffline, and can be used to validate audit\nentries in the future. If this value is\nundefined, no signature will be generated.\n",
+      "sectionTitle": "DATA & ADMIN AUDIT"
+    },
+    "route_validation_strategy": {
+      "defaultValue": "smart",
+      "description": "The strategy used to validate\nroutes when creating or updating them.\nDifferent strategies are available to tune\nhow to enforce splitting traffic of\nworkspaces.\n- `smart` is the default option and uses the\n  algorithm described in\n  https://docs.konghq.com/gateway/latest/kong-enterprise/workspaces/.\n- `off` disables any check.\n- `path` enforces routes to comply with the pattern\n  described in config `enforce_route_path_pattern`.\n- `static` relies on the PostgreSQL database.\nBefore creating a new route, it checks if the\nroute is unique across all workspaces based on\nthe following params: `paths`, `methods`, and\n`hosts`. If all fields of the new route overlap\nwith an existing one, a 409 is returned with the\nroute of the collision. The array order is not\nimportant for the overlap filter.\n",
+      "sectionTitle": "ROUTE COLLISION DETECTION/PREVENTION"
+    },
+    "enforce_route_path_pattern": {
+      "defaultValue": null,
+      "description": "Specifies the Lua pattern which will\nbe enforced on the `paths` attribute of a\nroute object. You can also add a placeholder\nfor the workspace in the pattern, which\nwill be rendered during runtime based on the\nworkspace to which the `route` belongs.\nThis setting is only relevant if\n`route_validation_strategy` is set to `path`.\n\n\n**Note:** The collision detection is only supported\nfor plain text routes, do not rely on this feature\nto validate regex routes.\n\nExample\nFor Pattern `/$(workspace)/v%d/.*` valid paths\nare:\n\n1. `/group1/v1/` if route belongs to\n  workspace `group1`.\n\n2. `/group2/v1/some_path` if route belongs to\n  workspace `group2`.\n",
+      "sectionTitle": "ROUTE COLLISION DETECTION/PREVENTION"
+    },
+    "keyring_enabled": {
+      "defaultValue": "off",
+      "description": "When enabled, Kong will encrypt sensitive\nfield values before writing them to the\ndatabase, and subsequently decrypt them when\nretrieving data for the Admin API, Developer\nPortal, or proxy business logic. Symmetric\nencryption keys are managed based on the\nstrategy defined below.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_strategy": {
+      "defaultValue": "cluster",
+      "description": "Defines the strategy implementation by which\nKong nodes will manage symmetric encryption\nkeys. Please see the Kong Enterprise\ndocumentation for a detailed description of\neach strategy. Acceptable values for this\noption are `cluster` and `vault`.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_public_key": {
+      "defaultValue": null,
+      "description": "Defines the public key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nValues:\n- absolute path to the public key\n- public key content\n- base64 encoded public key content\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_private_key": {
+      "defaultValue": null,
+      "description": "Defines the private key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nValues:\n- absolute path to the private key\n- private key content\n- base64 encoded private key content\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_recovery_public_key": {
+      "defaultValue": null,
+      "description": "Defines the public key to optionally encrypt\nall keyring materials and back them up in the\ndatabase.\n\nValues:\n- absolute path to the public key\n- public key content\n- base64 encoded public key content\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_blob_path": {
+      "defaultValue": null,
+      "description": "Defines the filesystem path at which Kong\nwill back up the initial keyring material.\nThis option is useful largely for development\npurposes.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_host": {
+      "defaultValue": null,
+      "description": "Defines the Vault host at which Kong will\nfetch the encryption material. This value\nshould be defined in the format:\n\n`<scheme>://<IP / HOSTNAME>:<PORT>`\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_mount": {
+      "defaultValue": null,
+      "description": "Defines the name of the Vault v2 KV secrets\nengine at which symmetric keys are found.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_path": {
+      "defaultValue": null,
+      "description": "Defines the name of the Vault v2 KV path\nat which symmetric keys are found.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_auth_method": {
+      "defaultValue": "token",
+      "description": "Defines the authentication mechanism when\nconnecting to the Hashicorp Vault service.\n\nAccepted values are: `token`, or `kubernetes`:\n\n- `token`: Uses the static token defined in\n           the `keyring_vault_token`\n           configuration property.\n\n- `kubernetes`: Uses the Kubernetes authentication\n                mechanism, with the running pod's\n                mapped service account, to assume\n                the Hashicorp Vault role name that is\n                defined in the `keyring_vault_kube_role`\n                configuration property.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_token": {
+      "defaultValue": null,
+      "description": "Defines the token value used to communicate\nwith the v2 KV Vault HTTP(S) API.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_kube_role": {
+      "defaultValue": "default",
+      "description": "Defines the Hashicorp Vault role that will be\nassumed using the Kubernetes service account of\nthe running pod.\n\n`keyring_vault_auth_method` must be set to `kubernetes`\nfor this to activate.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_kube_api_token_file": {
+      "defaultValue": "/run/secrets/kubernetes.io/serviceaccount/token",
+      "description": "Defines where the Kubernetes service account token\nshould be read from the pod's filesystem, if using\na non-standard container platform setup.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_encrypt_license": {
+      "defaultValue": "off",
+      "description": "Enables keyring encryption for license payloads stored\nin the database.\n\n**Warning:** For Kong deployments that rely entirely on\nthe database for license provisioning (i.e. not using\n`KONG_LICENSE_DATA` or `KONG_LICENSE_PATH`), enabling\nthis option will delay license activation until after\nthe node's keyring has been activated.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "untrusted_lua": {
+      "defaultValue": "sandbox",
+      "description": "Controls loading of Lua functions from admin-supplied\nsources such as the Admin API. LuaJIT bytecode\nloading is always disabled.\n\n**Warning:** LuaJIT is not designed as a secure\nruntime for running malicious code, therefore\nyou should properly protect your Admin API endpoint\neven with sandboxing enabled. The sandbox only\nprovides protection against trivial attackers or\nunintentional modification of the Kong global\nenvironment.\n\nAccepted values are: `off`, `sandbox`, or\n`on`:\n\n- `off`: Disallow loading of any arbitrary\n         Lua functions. The `off` option\n         disables any functionality that runs\n         arbitrary Lua code, including the\n         Serverless Functions plugins and any\n         transformation plugin that allows\n         custom Lua functions.\n\n- `sandbox`: Allow loading of Lua functions,\n             but use a sandbox when executing\n             them. The sandboxed function has\n             restricted access to the global\n             environment and only has access\n             to Kong PDK, OpenResty, and\n             standard Lua functions that will\n             generally not cause harm to the\n             Kong Gateway node.\n\n- `on`: Functions have unrestricted\n        access to the global environment and\n        can load any Lua modules. This is\n        similar to the behavior in\n        Kong Gateway prior to 2.3.0.\n\nThe default `sandbox` environment does not\nallow importing other modules or libraries,\nor executing anything at the OS level (for\nexample, file read/write). The global\nenvironment is also not accessible.\n\nExamples of `untrusted_lua = sandbox`\nbehavior:\n\n- You can't access or change global values\n  such as `kong.configuration.pg_password`\n- You can run harmless Lua:\n  `local foo = 1 + 1`. However, OS level\n  functions are not allowed, like:\n  `os.execute(`rm -rf /*`)`.\n\nTo customize the sandbox environment, use\nthe `untrusted_lua_sandbox_requires` and\n`untrusted_lua_sandbox_environment`\nparameters below.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "untrusted_lua_sandbox_requires": {
+      "defaultValue": null,
+      "description": "Comma-separated list of modules allowed to\nbe loaded with `require` inside the\nsandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\nFor example, say you have configured the\nServerless pre-function plugin and it\ncontains the following `requires`:\n\n```\nlocal template = require \"resty.template\"\nlocal split = require \"kong.tools.string\".split\n```\n\nTo run the plugin, add the modules to the\nallowed list:\n```\nuntrusted_lua_sandbox_requires = resty.template, kong.tools.utils\n```\n\n**Warning:** Allowing certain modules may\ncreate opportunities to escape the\nsandbox. For example, allowing `os` or\n`luaposix` may be unsafe.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "untrusted_lua_sandbox_environment": {
+      "defaultValue": null,
+      "description": "Comma-separated list of global Lua\nvariables that should be made available\ninside the sandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\n**Warning**: Certain variables, when made\navailable, may create opportunities to\nescape the sandbox.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "openresty_path": {
+      "defaultValue": null,
+      "description": "Path to the OpenResty installation that Kong\nwill use. When this is empty (the default),\nKong determines the OpenResty installation\nby searching for a system-installed OpenResty\nand falling back to searching $PATH for the\nnginx binary.\n\nSetting this attribute disables the search\nbehavior and explicitly instructs Kong which\nOpenResty installation to use.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "node_id": {
+      "defaultValue": null,
+      "description": "Node ID for the Kong node. Every Kong node\nin a Kong cluster must have a unique and\nvalid UUID. When empty, node ID is\nautomatically generated.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "cluster_fallback_config_import": {
+      "defaultValue": "off",
+      "description": "Enable fallback configuration imports.\n\nThis should only be enabled for data planes.\n",
+      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
+    },
+    "cluster_fallback_config_storage": {
+      "defaultValue": null,
+      "description": "Storage definition used by `cluster_fallback_config_import`\nand `cluster_fallback_config_export`.\n\nSupported storage types:\n- S3-like storages\n- GCP storage service\n\nTo use S3 with a bucket named b and place all configs\nto with a key prefix named p, set it to:\n`s3://b/p`\nTo use GCP for the same bucket and prefix, set it to:\n`gcs://b/p`\n\nThe credentials (and the endpoint URL for S3-like) for S3\nare passed with environment variables:\n`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,\nand `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where\n`AWS_CONFIG_STORAGE_ENDPOINT`\nis the endpoint that hosts S3-like storage.\n\nThe credentials for GCP are provided via the environment\nvariable `GCP_SERVICE_ACCOUNT`.\n",
+      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
+    },
+    "cluster_fallback_export_s3_config": {
+      "defaultValue": null,
+      "description": "Fallback config export S3 configuration.\nThis is used only when `cluster_fallback_config_storage` is an S3-like schema.\nIf set, it will add the config table to the Kong exporter config S3 putObject request.\nThe config table should be in JSON format and can be unserialized into a table.\nIt should contain the necessary parameters as described in the documentation:\nhttps://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property.\nFor example, if you want to set the ServerSideEncryption headers/KMS Key ID\nfor the S3 putObject request, you can set the config table to:\n`{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"your-kms-key-id\"}`\n",
+      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
+    },
+    "cluster_fallback_config_export": {
+      "defaultValue": "off",
+      "description": "Enable fallback configuration exports.\n",
+      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
+    },
+    "cluster_fallback_config_export_delay": {
+      "defaultValue": "60",
+      "description": "The fallback configuration export interval.\n\nIf the interval is set to 60 and configuration A is exported\nand there are new configurations B, C, and D in the next 60 seconds,\nit will wait until 60 seconds passed and export D, skipping B and C.\n",
+      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
+    },
+    "wasm": {
+      "defaultValue": "off",
+      "description": "Enable/disable wasm support. This must be enabled in\norder to use wasm filters and filter chains.\n",
+      "sectionTitle": "WEBASSEMBLY (WASM)"
+    },
+    "wasm_filters_path": {
+      "defaultValue": null,
+      "description": "Path to the directory containing wasm filter modules.\n\nAt startup, Kong discovers available wasm filters by\nscanning this directory for files with the `.wasm`\nfile extension.\n\nThe name of a wasm filter module is derived from the\nfilename itself, with the .wasm extension removed. So,\ngiven the following tree:\n\n```\n/path/to/wasm_filters\n├── my_module.wasm\n├── my_other_module.wasm\n└── not_a_wasm_module.txt\n```\n\nThe resulting filter modules available for use in Kong\nwill be:\n\n- `my_module`\n- `my_other_module`\n\nNotes:\n\n- No recursion is performed. Only .wasm files at the\n  top level are registered.\n- This path _may_ be a symlink to a directory.\n",
+      "sectionTitle": "WEBASSEMBLY (WASM)"
+    },
+    "wasm_filters": {
+      "defaultValue": [
+        "bundled",
+        "user"
+      ],
+      "description": "Comma-separated list of Wasm filters to be made\navailable for use in filter chains.\n\nWhen the `off` keyword is specified as the\nonly value, no filters will be available for use.\n\nWhen the `bundled` keyword is specified, all filters\nbundled with Kong will be available.\n\nWhen the `user` keyword is specified, all filters\nwithin the `wasm_filters_path` will be available.\n\n**Examples:**\n\n- `wasm_filters = bundled,user` enables _all_ bundled\n  and user-supplied filters\n- `wasm_filters = user` enables _only_ user-supplied\n  filters\n- `wasm_filters = filter-a,filter-b` enables _only_\n  filters named `filter-a` or `filter-b` (whether\n  bundled _or_ user-supplied)\n\nIf a conflict occurs where a bundled filter and a\nuser-supplied filter share the same name, a warning\nwill be logged, and the user-supplied filter will\nbe used instead.\n",
+      "sectionTitle": "WEBASSEMBLY (WASM)"
+    },
+    "test": {
+      "defaultValue": "on",
+      "description": "test\n",
+      "sectionTitle": "WASM injected directives"
+    },
+    "request_debug": {
+      "defaultValue": "on",
+      "description": "When enabled, Kong will provide detailed timing information\nfor its components to the client and the error log\nif the following headers are present in the proxy request:\n- `X-Kong-Request-Debug`:\n  If the value is set to `*`,\n  timing information will be collected and exported for the current request.\n  If this header is not present or contains an unknown value,\n  timing information will not be collected for the current request.\n  You can also specify a list of filters, separated by commas,\n  to filter the scope of the time information that is collected.\nThe following filters are supported for `X-Kong-Request-Debug`:\n- `rewrite`: Collect timing information from the `rewrite` phase.\n- `access`: Collect timing information from the `access` phase.\n- `balancer`: Collect timing information from the `balancer` phase.\n- `response`: Collect timing information from the `response` phase.\n- `header_filter`: Collect timing information from the `header_filter` phase.\n- `body_filter`: Collect timing information from the `body_filter` phase.\n- `log`: Collect timing information from the `log` phase.\n- `upstream`: Collect timing information from the `upstream` phase.\n\n- `X-Kong-Request-Debug-Log`:\n  If set to `true`, timing information will also be logged\n  in the Kong error log with a log level of `notice`.\n  Defaults to `false`.\n\n- `X-Kong-Request-Debug-Token`:\n  Token for authenticating the client making the debug\n  request to prevent abuse.\n  ** Note: Debug requests originating from loopback\n  addresses do not require this header. Deploying Kong behind\n  other proxies may result in exposing the debug interface to\n  the public.**\n\n",
+      "sectionTitle": "REQUEST DEBUGGING"
+    },
+    "request_debug_token": {
+      "defaultValue": "<random>",
+      "description": "The Request Debug Token is used in the\n`X-Kong-Request-Debug-Token` header to prevent abuse.\nIf this value is not set (the default),\na random token will be generated\nwhen Kong starts, restarts, or reloads. If a token is\nspecified manually, then the provided token will be used.\n\nYou can locate the generated debug token in two locations:\n- Kong error log:\n  Debug token will be logged in the error log (notice level)\n  when Kong starts, restarts, or reloads.\n  The log line will have the: `[request-debug]` prefix to aid searching.\n- Filesystem:\n  Debug token will also be stored in a file located at\n  `{prefix}/.request_debug_token` and updated\n  when Kong starts, restarts, or reloads.\n",
+      "sectionTitle": "REQUEST DEBUGGING"
+    }
+  }
+}

--- a/app/_data/kong-conf/index.json
+++ b/app/_data/kong-conf/index.json
@@ -55,6 +55,12 @@
       "description": "By default, the DNS resolver will use the standard configuration files\n`/etc/hosts` and `/etc/resolv.conf`. The settings in the latter file will be\noverridden by the environment variables `LOCALDOMAIN` and `RES_OPTIONS` if\nthey have been set.\n\nKong will resolve hostnames as either `SRV` or `A` records (in that order, and\n`CNAME` records will be dereferenced in the process).\nIn case a name is resolved as an `SRV` record, it will also override any given\nport number with the `port` field contents received from the DNS server.\n\nThe DNS options `SEARCH` and `NDOTS` (from the `/etc/resolv.conf` file) will\nbe used to expand short names to fully qualified ones. So it will first try\nthe entire `SEARCH` list for the `SRV` type, if that fails it will try the\n`SEARCH` list for `A`, etc.\n\nFor the duration of the `ttl`, the internal DNS resolver will load balance each\nrequest it gets over the entries in the DNS record. For `SRV` records, the\n`weight` fields will be honored, but it will only use the lowest `priority`\nfield entries in the record.\n"
     },
     {
+      "title": "New DNS RESOLVER",
+      "start": 1699,
+      "end": 1797,
+      "description": "This DNS resolver introduces global caching for DNS records across workers,\nsignificantly reducing the query load on DNS servers.\n\nIt provides observable statistics, you can retrieve them through the Admin API\n`/status/dns`.\n"
+    },
+    {
       "title": "VAULTS",
       "start": 1798,
       "end": 2023,
@@ -79,12 +85,6 @@
       "description": "\nThe Admin GUI for Kong Enterprise.\n\n"
     },
     {
-      "title": "VITALS",
-      "start": 2415,
-      "end": 2480,
-      "description": ""
-    },
-    {
       "title": "Konnect",
       "start": 2517,
       "end": 2523,
@@ -94,6 +94,66 @@
       "title": "Analytics for Konnect",
       "start": 2524,
       "end": 2544,
+      "description": ""
+    },
+    {
+      "title": "ADMIN SMTP CONFIGURATION",
+      "start": 2545,
+      "end": 2559,
+      "description": ""
+    },
+    {
+      "title": "GENERAL SMTP CONFIGURATION",
+      "start": 2560,
+      "end": 2610,
+      "description": ""
+    },
+    {
+      "title": "DATA & ADMIN AUDIT",
+      "start": 2611,
+      "end": 2656,
+      "description": "When enabled, Kong will store detailed audit data regarding Admin API and\ndatabase access. In most cases, updates to the database are associated with\nAdmin API requests. As such, database object audit log data is tied to a\ngiven HTTP request via a unique identifier, providing built-in association of\nAdmin API and database traffic.\n\n"
+    },
+    {
+      "title": "ROUTE COLLISION DETECTION/PREVENTION",
+      "start": 2657,
+      "end": 2704,
+      "description": ""
+    },
+    {
+      "title": "DATABASE ENCRYPTION & KEYRING MANAGEMENT",
+      "start": 2705,
+      "end": 2933,
+      "description": "When enabled, Kong will transparently encrypt sensitive fields, such as consumer\ncredentials, TLS private keys, and RBAC user tokens, among others. A full list\nof encrypted fields is available from the Kong Enterprise documentation site.\nEncrypted data is transparently decrypted before being displayed to the Admin\nAPI or made available to plugins or core routing logic.\n\nWhile this feature is GA, do note that we currently do not provide normal semantic\nversioning compatibility guarantees on the keyring feature's APIs in that Kong may\nmake a breaking change to the feature in a minor version. Also note that\nmismanagement of keyring data may result in irrecoverable data loss.\n\n"
+    },
+    {
+      "title": "CLUSTER FALLBACK CONFIGURATION",
+      "start": 2934,
+      "end": 2982,
+      "description": ""
+    },
+    {
+      "title": "WEBASSEMBLY (WASM)",
+      "start": 2983,
+      "end": 3045,
+      "description": ""
+    },
+    {
+      "title": "WASM injected directives",
+      "start": 3046,
+      "end": 3129,
+      "description": "The Nginx Wasm module (i.e., ngx_wasm_module) has its own settings, which can\nbe tuned via `wasm_*` directives in the Nginx configuration file. Kong\nsupports configuration of these directives via its Nginx directive injection\nmechanism.\n\nThe following namespaces are supported:\n\n- `nginx_wasm_<directive>`: Injects `<directive>` into the `wasm {}` block.\n- `nginx_wasm_shm_kv`: Injects `shm_kv *` into the `wasm {}` block,\nallowing operators to define a general memory zone which is usable by\nthe `get_shared_data`/`set_shared_data` Proxy-Wasm SDK functions as\nan in-memory key-value store of data shareable across filters.\n- `nginx_wasm_shm_kv_<name>`: Injects `shm_kv <name>` into the `wasm {}` block,\nallowing operators to define custom shared memory zones which are usable by\nthe `get_shared_data`/`set_shared_data` Proxy-Wasm SDK functions as\nseparate namespaces in the `\"<name>/<key>\"` format.\nFor using these functions with non-namespaced keys, the Nginx template needs\na `shm_kv *` entry, which can be defined using `nginx_wasm_shm_kv`.\n- `nginx_wasm_wasmtime_<flag>`: Injects `flag <flag>` into the `wasmtime {}`\nblock, allowing various Wasmtime-specific flags to be set.\n- `nginx_<http|proxy>_<directive>`: Injects `<directive>` into the\n`http {}` or `server {}` blocks, as specified in the Nginx injected directives\nsection.\n\nThe documentation for all supported directives can be found in the Nginx Wasm\nmodule repository:\n\nhttps://github.com/Kong/ngx_wasm_module/blob/main/docs/DIRECTIVES.md\n\nThe Wasmtime flag documentation can be found here:\n\nhttps://docs.wasmtime.dev/c-api/config_8h.html\n\nThere are several noteworthy ngx_wasm_module behaviors which can be tuned via\n`http {}`/`server {}` level directive injection (identical behavior in either\nlevel), for example:\n\n- `nginx_http_proxy_wasm_socket_<connect|read|send>_timeout`: sets connection/read/send\ntimeouts for Wasm dispatches.\n- `nginx_http_proxy_wasm_socket_buffer_size`: sets a buffer size for\nreading Wasm dispatch responses.\n\nThe values for these settings are inherited from their `nginx_*_lua_*`\ncounterparts if they have not been explicitly set. For instance, if you set\n`nginx_http_lua_socket_connect_timeout`, the value\nof this setting will be propagated to `nginx_http_wasm_socket_connect_timeout`\nunless you _also_ set `nginx_http_wasm_socket_connect_timeout`.\n\nSome TLS-related settings receive special treatment as well:\n\n- `lua_ssl_trusted_certificate`: when set, the value is propagated to the\n`nginx_wasm_tls_trusted_certificate` directive.\n- `lua_ssl_verify_depth`: when set (to a value greater than zero), several\nTLS-related `nginx_wasm_*` settings are enabled:\n- `nginx_wasm_tls_verify_cert`\n- `nginx_wasm_tls_verify_host`\n- `nginx_wasm_tls_no_verify_warn`\n\nLike other `kong.conf` fields, all injected Nginx directives documented here\ncan be set via environment variable. For instance, setting:\n\n`KONG_NGINX_WASM_TLS_VERIFY_CERT=<value>`\n\nWill inject the following into the `wasm {}` block:\n\n`tls_verify_cert <value>;`\n\nThere are several Nginx directives supported by ngx_wasm_module which should\nnot be used because they are irrelevant to or unsupported by Kong, or they may\nconflict with Kong's own management of Proxy-Wasm. Use of these directives may\nresult in unintentional breakage:\n\n- `wasm_call`\n- `module`\n- `proxy_wasm`\n- `resolver_add`\n- `proxy_wasm_request_headers_in_access`\n- `shm_queue`\n\n"
+    },
+    {
+      "title": "REQUEST DEBUGGING",
+      "start": 3130,
+      "end": 3190,
+      "description": "Request debugging is a mechanism that allows admins to collect the timing of\nproxy path requests in the response header (X-Kong-Request-Debug-Output)\nand optionally, the error log.\n\nThis feature provides insights into the time spent within various components of Kong,\nsuch as plugins, DNS resolution, load balancing, and more. It also provides contextual\ninformation such as domain names tried during these processes.\n\n"
+    },
+    {
+      "title": "VITALS",
+      "start": 2415,
+      "end": 2480,
       "description": ""
     },
     {
@@ -115,70 +175,10 @@
       "description": "Referenced on workspace creation to set SMTP defaults in the database\nfor that particular workspace.\n\n"
     },
     {
-      "title": "ADMIN SMTP CONFIGURATION",
-      "start": 2545,
-      "end": 2559,
-      "description": ""
-    },
-    {
-      "title": "GENERAL SMTP CONFIGURATION",
-      "start": 2560,
-      "end": 2610,
-      "description": ""
-    },
-    {
-      "title": "DATA & ADMIN AUDIT",
-      "start": 2611,
-      "end": 2656,
-      "description": "When enabled, Kong will store detailed audit data regarding Admin API and\ndatabase access. In most cases, updates to the database are associated with\nAdmin API requests. As such, database object audit log data is tied to a\ngiven HTTP request via a unique identifier, providing built-in association of\nAdmin API and database traffic.\n\n"
-    },
-    {
       "title": "GRANULAR TRACING",
       "start": 2580,
       "end": 2686,
       "description": "{:.warning}\n> **Deprecation warning**: Granular tracing is deprecated. This means the feature will eventually be removed.\nOur target for Granular tracing removal is the Kong Gateway 4.0 release.\n\nGranular tracing offers a mechanism to expose metrics and detailed debug data\nabout the lifecycle of Kong in a human- or machine-consumable format.\n\n"
-    },
-    {
-      "title": "ROUTE COLLISION DETECTION/PREVENTION",
-      "start": 2657,
-      "end": 2704,
-      "description": ""
-    },
-    {
-      "title": "DATABASE ENCRYPTION & KEYRING MANAGEMENT",
-      "start": 2705,
-      "end": 2933,
-      "description": "When enabled, Kong will transparently encrypt sensitive fields, such as consumer\ncredentials, TLS private keys, and RBAC user tokens, among others. A full list\nof encrypted fields is available from the Kong Enterprise documentation site.\nEncrypted data is transparently decrypted before being displayed to the Admin\nAPI or made available to plugins or core routing logic.\n\nWhile this feature is GA, do note that we currently do not provide normal semantic\nversioning compatibility guarantees on the keyring feature's APIs in that Kong may\nmake a breaking change to the feature in a minor version. Also note that\nmismanagement of keyring data may result in irrecoverable data loss.\n\n"
-    },
-    {
-      "title": "WEBASSEMBLY (WASM)",
-      "start": 2983,
-      "end": 3045,
-      "description": ""
-    },
-    {
-      "title": "REQUEST DEBUGGING",
-      "start": 3130,
-      "end": 3190,
-      "description": "Request debugging is a mechanism that allows admins to collect the timing of\nproxy path requests in the response header (X-Kong-Request-Debug-Output)\nand optionally, the error log.\n\nThis feature provides insights into the time spent within various components of Kong,\nsuch as plugins, DNS resolution, load balancing, and more. It also provides contextual\ninformation such as domain names tried during these processes.\n\n"
-    },
-    {
-      "title": "CLUSTER FALLBACK CONFIGURATION",
-      "start": 2934,
-      "end": 2982,
-      "description": ""
-    },
-    {
-      "title": "New DNS RESOLVER",
-      "start": 1699,
-      "end": 1797,
-      "description": "This DNS resolver introduces global caching for DNS records across workers,\nsignificantly reducing the query load on DNS servers.\n\nIt provides observable statistics, you can retrieve them through the Admin API\n`/status/dns`.\n"
-    },
-    {
-      "title": "WASM injected directives",
-      "start": 3046,
-      "end": 3129,
-      "description": "The Nginx Wasm module (i.e., ngx_wasm_module) has its own settings, which can\nbe tuned via `wasm_*` directives in the Nginx configuration file. Kong\nsupports configuration of these directives via its Nginx directive injection\nmechanism.\n\nThe following namespaces are supported:\n\n- `nginx_wasm_<directive>`: Injects `<directive>` into the `wasm {}` block.\n- `nginx_wasm_shm_kv`: Injects `shm_kv *` into the `wasm {}` block,\nallowing operators to define a general memory zone which is usable by\nthe `get_shared_data`/`set_shared_data` Proxy-Wasm SDK functions as\nan in-memory key-value store of data shareable across filters.\n- `nginx_wasm_shm_kv_<name>`: Injects `shm_kv <name>` into the `wasm {}` block,\nallowing operators to define custom shared memory zones which are usable by\nthe `get_shared_data`/`set_shared_data` Proxy-Wasm SDK functions as\nseparate namespaces in the `\"<name>/<key>\"` format.\nFor using these functions with non-namespaced keys, the Nginx template needs\na `shm_kv *` entry, which can be defined using `nginx_wasm_shm_kv`.\n- `nginx_wasm_wasmtime_<flag>`: Injects `flag <flag>` into the `wasmtime {}`\nblock, allowing various Wasmtime-specific flags to be set.\n- `nginx_<http|proxy>_<directive>`: Injects `<directive>` into the\n`http {}` or `server {}` blocks, as specified in the Nginx injected directives\nsection.\n\nThe documentation for all supported directives can be found in the Nginx Wasm\nmodule repository:\n\nhttps://github.com/Kong/ngx_wasm_module/blob/main/docs/DIRECTIVES.md\n\nThe Wasmtime flag documentation can be found here:\n\nhttps://docs.wasmtime.dev/c-api/config_8h.html\n\nThere are several noteworthy ngx_wasm_module behaviors which can be tuned via\n`http {}`/`server {}` level directive injection (identical behavior in either\nlevel), for example:\n\n- `nginx_http_proxy_wasm_socket_<connect|read|send>_timeout`: sets connection/read/send\ntimeouts for Wasm dispatches.\n- `nginx_http_proxy_wasm_socket_buffer_size`: sets a buffer size for\nreading Wasm dispatch responses.\n\nThe values for these settings are inherited from their `nginx_*_lua_*`\ncounterparts if they have not been explicitly set. For instance, if you set\n`nginx_http_lua_socket_connect_timeout`, the value\nof this setting will be propagated to `nginx_http_wasm_socket_connect_timeout`\nunless you _also_ set `nginx_http_wasm_socket_connect_timeout`.\n\nSome TLS-related settings receive special treatment as well:\n\n- `lua_ssl_trusted_certificate`: when set, the value is propagated to the\n`nginx_wasm_tls_trusted_certificate` directive.\n- `lua_ssl_verify_depth`: when set (to a value greater than zero), several\nTLS-related `nginx_wasm_*` settings are enabled:\n- `nginx_wasm_tls_verify_cert`\n- `nginx_wasm_tls_verify_host`\n- `nginx_wasm_tls_no_verify_warn`\n\nLike other `kong.conf` fields, all injected Nginx directives documented here\ncan be set via environment variable. For instance, setting:\n\n`KONG_NGINX_WASM_TLS_VERIFY_CERT=<value>`\n\nWill inject the following into the `wasm {}` block:\n\n`tls_verify_cert <value>;`\n\nThere are several Nginx directives supported by ngx_wasm_module which should\nnot be used because they are irrelevant to or unsupported by Kong, or they may\nconflict with Kong's own management of Proxy-Wasm. Use of these directives may\nresult in unintentional breakage:\n\n- `wasm_call`\n- `module`\n- `proxy_wasm`\n- `resolver_add`\n- `proxy_wasm_request_headers_in_access`\n- `shm_queue`\n\n"
     }
   ],
   "params": {
@@ -272,6 +272,11 @@
       "description": "Comma-separated list of plugins this node should load.\nBy default, only plugins bundled in official distributions\nare loaded via the `bundled` keyword.\n\nLoading a plugin does not enable it by default, but only\ninstructs Kong to load its source code and allows\nconfiguration via the various related Admin API endpoints.\n\nThe specified name(s) will be substituted as such in the\nLua namespace: `kong.plugins.{name}.*`.\n\nWhen the `off` keyword is specified as the only value,\nno plugins will be loaded.\n\n`bundled` and plugin names can be mixed together, as the\nfollowing examples suggest:\n\n- `plugins = bundled,custom-auth,custom-log`\n  will include the bundled plugins plus two custom ones.\n- `plugins = custom-auth,custom-log` will\n  *only* include the `custom-auth` and `custom-log` plugins.\n- `plugins = off` will not include any plugins.\n\n**Note:** Kong will not start if some plugins were previously\nconfigured (i.e. have rows in the database) and are not\nspecified in this list. Before disabling a plugin, ensure\nall instances of it are removed before restarting Kong.\n\n**Note:** Limiting the amount of available plugins can\nimprove P99 latency when experiencing LRU churning in the\ndatabase cache (i.e. when the configured `mem_cache_size`) is full.\n",
       "sectionTitle": "GENERAL"
     },
+    "dedicated_config_processing": {
+      "defaultValue": "on",
+      "description": "Enables or disables a special worker\nprocess for configuration processing. This process\nincreases memory usage a little bit while\nallowing to reduce latencies by moving some\nbackground tasks, such as CP/DP connection\nhandling, to an additional worker process specific\nto handling these background tasks.\nCurrently this has effect only on data planes.\n",
+      "sectionTitle": "GENERAL"
+    },
     "pluginserver_names": {
       "defaultValue": null,
       "description": "Comma-separated list of names for pluginserver\nprocesses. The actual names are used for\nlog messages and to relate the actual settings.\n",
@@ -361,6 +366,14 @@
       "defaultValue": null,
       "description": "The list of Common Names that are allowed to\nconnect to control plane. Multiple entries may\nbe supplied in a comma-separated string. When not\nset, only data plane with the same parent domain as the\ncontrol plane cert is allowed to connect.\n\nThis field is ignored if `cluster_mtls` is\nnot set to `pki_check_cn`.\n",
       "sectionTitle": "HYBRID MODE"
+    },
+    "incremental_sync": {
+      "defaultValue": "off",
+      "description": "The setting to enable or disable the incremental\nsynchronization of configuration changes.\nInstead of sending the entire entity config to data planes on\neach config update, incremental config sync lets you send only\nthe changed configuration to data planes for hybrid mode deployments.\nThe valid values are `on` and `off`.\nTo enable, set this value to `on`.\n\nIn hybrid mode, this setting must be configured\non both control plane and data plane nodes.\n",
+      "sectionTitle": "HYBRID MODE",
+      "removed_in": {
+        "gateway": "3.4"
+      }
     },
     "cluster_server_name": {
       "defaultValue": null,
@@ -458,6 +471,11 @@
       "description": "Comma-separated list of addresses and ports on\nwhich the Debug API should listen.\n\nThe following suffix can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's Debug API server.\n\nThis value can be set to `off`, disabling\nthe Debug API for this node.\n\nExample: `debug_listen = 0.0.0.0:8200 ssl http2`\n",
       "sectionTitle": "NGINX"
     },
+    "debug_listen_local": {
+      "defaultValue": "on",
+      "description": "Expose `debug_listen` functionalities via a\nUnix domain socket under the Kong prefix.\n\nThis option allows local users to use `kong debug` command\nto invoke various debug functionalities without needing to\nenable `debug_listen` ahead of time.\n",
+      "sectionTitle": "NGINX"
+    },
     "nginx_user": {
       "defaultValue": "kong kong",
       "description": "Defines user and group credentials used by\nworker processes. If group is omitted, a\ngroup whose name equals that of user is\nused.\n\nExample: `nginx_user = nginx www`\n\n**Note**: If the `kong` user and the `kong`\ngroup are not available, the default user\nand group credentials will be\n`nobody nobody`.\n",
@@ -477,6 +495,14 @@
       "defaultValue": "128m",
       "description": "Size of each of the two shared memory caches\nfor traditional mode database entities\nand runtime data, `kong_core_cache` and\n`kong_cache`.\n\nThe accepted units are `k` and `m`, with a minimum\nrecommended value of a few MBs.\n\n**Note**: As this option controls the size of two\ndifferent cache zones, the total memory Kong\nuses to cache entities might be double this value.\nThe created zones are shared by all worker\nprocesses and do not become larger when more\nworkers are used.\n",
       "sectionTitle": "NGINX"
+    },
+    "consumers_mem_cache_size": {
+      "defaultValue": "128m",
+      "description": "Size of the shared memory cache for consumers\nand credentials.\n\nThe accepted units are `k` and `m`, with a minimum\nrecommended value of a few MBs.\n\n**Note**: This is only used when the \"externalized consumers\"\nfeature is active.\n",
+      "sectionTitle": "NGINX",
+      "removed_in": {
+        "gateway": "3.4"
+      }
     },
     "ssl_cipher_suite": {
       "defaultValue": "intermediate",
@@ -1002,6 +1028,54 @@
       "description": "If enabled, then upon a cache-miss every\nrequest will trigger its own DNS query.\nWhen disabled, multiple requests for the\nsame name/type will be synchronized to a\nsingle query.\n",
       "sectionTitle": "DNS RESOLVER"
     },
+    "new_dns_client": {
+      "defaultValue": "off",
+      "description": "Enable or disable the new DNS resolver\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_address": {
+      "defaultValue": "<name servers parsed from resolv.conf>",
+      "description": "Comma-separated list of nameservers, each\nentry in `ip[:port]` format to be used by\nKong. If not specified, the nameservers in\nthe local `resolv.conf` file will be used.\nPort defaults to 53 if omitted. Accepts\nboth IPv4 and IPv6 addresses.\n\nExamples:\n\n```\nresolver_address = 8.8.8.8\nresolver_address = 8.8.8.8, [::1]\nresolver_address = 8.8.8.8:53, [::1]:53\n```\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_hosts_file": {
+      "defaultValue": "/etc/hosts",
+      "description": "The hosts file to use. This file is read\nonce and its content is static in memory.\nTo read the file again after modifying it,\nKong must be reloaded.\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_family": {
+      "defaultValue": [
+        "A",
+        "SRV"
+      ],
+      "description": "The supported query types.\n\nFor a domain name, Kong will only query\neither IP addresses (A or AAAA) or SRV\nrecords, but not both.\n\nIt will query SRV records only when the\ndomain matches the\n\"_<proto>._<service>.<name>\" format, for\nexample, \"_ldap._tcp.example.com\".\n\nFor IP addresses (A or AAAA) resolution, it\nfirst attempts IPv4 (A) and then queries\nIPv6 (AAAA).\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_valid_ttl": {
+      "defaultValue": "<TTL from responses>",
+      "description": "By default, DNS records are cached using\nthe TTL value of a response. This optional\nparameter (in seconds) allows overriding it.\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_error_ttl": {
+      "defaultValue": "1",
+      "description": "TTL in seconds for error responses and empty\nresponses.\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_stale_ttl": {
+      "defaultValue": "3600",
+      "description": "Defines, in seconds, how long a record will\nremain in cache past its TTL. This value\nwill be used while the new DNS record is\nfetched in the background.\n\nStale data will be used from expiry of a\nrecord until either the refresh query\ncompletes, or the `resolver_stale_ttl` number\nof seconds have passed.\n\nThis configuration enables Kong to be more\nresilient during the DNS server downtime.\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_lru_cache_size": {
+      "defaultValue": "10000",
+      "description": "The DNS client uses a two-layer cache system:\nL1 - worker-level LRU Lua VM cache\nL2 - across-workers shared memory cache\n\nThis value specifies the maximum allowed\nnumber of DNS responses stored in the L1 LRU\nlua VM cache.\n\nA single name query can easily take up 1~10\nslots, depending on attempted query types and\nextended domains from /etc/resolv.conf\noptions `domain` or `search`.\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_mem_cache_size": {
+      "defaultValue": "5m",
+      "description": "This value specifies the size of the L2\nshared memory cache for DNS responses,\n`kong_dns_cache`.\n\nAccepted units are `k` and `m`, with a\nminimum recommended value of a few MBs.\n\n5MB shared memory size could store\n~20000 DNS responeses with single A record or\n~10000 DNS responeses with 2~3 A records.\n\n10MB shared memory size could store\n~40000 DNS responeses with single A record or\n~20000 DNS responeses with 2~3 A records.\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
     "vault_env_prefix": {
       "defaultValue": null,
       "description": "Defines the environment variable vault's\ndefault prefix. For example if you have\nall your secrets stored in environment\nvariables prefixed with `SECRETS_`, it\ncan be configured here so that it isn't\nnecessary to repeat them in Vault\nreferences.\n",
@@ -1305,6 +1379,27 @@
       "description": "Hierarchical part of a URI which is composed\noptionally of a host, port, and path at which the\nAdmin API accepts HTTP or HTTPS traffic. When\nthis config is disabled, Kong Manager will\nuse the window protocol + host and append the\nresolved admin_listen HTTP/HTTPS port.\n",
       "sectionTitle": "KONG MANAGER"
     },
+    "admin_gui_csp_header": {
+      "defaultValue": "off",
+      "description": "Enable or disable the `Content-Security-Policy` (CSP) header for Kong Manager\n\nThis configuration controls the presence of the CSP header when serving\nKong Manager. The default CSP header value will be used unless customized.\n\nTo modify the value of the served CSP header, refer to the `admin_gui_csp_header_value`\nconfiguration.\n\nSet this configuration to `on` to enable the CSP header.\n",
+      "sectionTitle": "KONG MANAGER",
+      "removed_in": {
+        "gateway": "3.4"
+      }
+    },
+    "admin_gui_csp_header_value": {
+      "defaultValue": null,
+      "description": "The value of the `Content-Security-Policy` (CSP) header for Kong Manager.\n\nThis configuration controls the value of the CSP header when serving\nKong Manager. If omitted or left empty, the default CSP header value\nwill be used.\n\nThis is an advanced configuration intended for cases where the default\nCSP header value does not meet your requirements. Use with caution.\n\nFor more information on the CSP header, see:\nhttps://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy\n",
+      "sectionTitle": "KONG MANAGER",
+      "removed_in": {
+        "gateway": "3.4"
+      }
+    },
+    "admin_gui_ssl_protocols": {
+      "defaultValue": "TLSv1.2 TLSv1.3",
+      "description": "Defines the TLS versions supported\nfor Kong Manager\n",
+      "sectionTitle": "KONG MANAGER"
+    },
     "admin_gui_ssl_cert": {
       "defaultValue": null,
       "description": "The SSL certificate for `admin_gui_listen` values\nwith SSL enabled.\n\nvalues:\n- absolute path to the certificate\n- certificate content\n- base64 encoded certificate content\n",
@@ -1360,6 +1455,21 @@
       "description": "Number of times a user can attempt to login to Kong\nManager. 0 means infinite attempts allowed.\n",
       "sectionTitle": "KONG MANAGER"
     },
+    "admin_gui_auth_login_attempts_ttl": {
+      "defaultValue": "604800",
+      "description": "Length, in seconds, of the TTL for changing login attempts\nrecords. Records in the database older than\ntheir TTL are automatically purged.\n\nThis argument can be set to an integer between 0 and 100000000.\n\nExample, 7 days: `7 * 24 * 60 * 60 = 604800.`\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_auth_change_password_attempts": {
+      "defaultValue": "0",
+      "description": "Number of times a user can attempt to change password.\n0 means infinite attempts allowed.\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_auth_change_password_ttl": {
+      "defaultValue": "86400",
+      "description": "Length, in seconds, of the TTL for changing password attempts\nrecords. Records in the database older than\ntheir TTL are automatically purged.\n\nExample, 1 days: `1 * 24 * 60 * 60 = 86400.`\n",
+      "sectionTitle": "KONG MANAGER"
+    },
     "admin_gui_header_txt": {
       "defaultValue": null,
       "description": "Sets the text for the Kong Manager header banner.\nHeader banner is not shown if this config is empty.\n",
@@ -1400,51 +1510,6 @@
       "description": "Sets the body text for the Kong Manager login banner.\nLogin banner is not shown if both\n`admin_gui_login_banner_title` and\n`admin_gui_login_banner_body` are empty.\n",
       "sectionTitle": "KONG MANAGER"
     },
-    "vitals": {
-      "defaultValue": "on",
-      "description": "When enabled, Kong will store and report\nmetrics about its performance.\n\nWhen running Kong in a multi-node setup,\n`vitals` entails two separate meanings\ndepending on the node.\n\nOn a Proxy-only node, `vitals` determines\nwhether to collect data for Vitals.\n\nOn an Admin-only node, `vitals` determines\nwhether to display Vitals metrics and\nvisualizations on the dashboard.\n",
-      "sectionTitle": "VITALS"
-    },
-    "vitals_strategy": {
-      "defaultValue": "database",
-      "description": "Determines whether to use the Kong database or\na separate storage engine for Vitals metrics.\nAccepted values are `database`, `prometheus`,\nor `influxdb`.\n",
-      "sectionTitle": "VITALS"
-    },
-    "vitals_tsdb_address": {
-      "defaultValue": null,
-      "description": "Defines the host and port of the TSDB server\nto which Vitals data is written and read.\nThis value is only applied when the\n`vitals_strategy` option is set to\n`prometheus` or `influxdb`. This value\naccepts IPv4, IPv6, and hostname values.\nIf the `vitals_strategy` is set to\n`prometheus`, this value determines the\naddress of the Prometheus server from which\nVitals data will be read. For `influxdb`\nstrategies, this value controls both the read\nand write source for Vitals data.\n",
-      "sectionTitle": "VITALS"
-    },
-    "vitals_tsdb_user": {
-      "defaultValue": null,
-      "description": "Influxdb user\n",
-      "sectionTitle": "VITALS"
-    },
-    "vitals_tsdb_password": {
-      "defaultValue": null,
-      "description": "Influxdb password\n",
-      "sectionTitle": "VITALS"
-    },
-    "vitals_statsd_address": {
-      "defaultValue": null,
-      "description": "Defines the host and port (and an optional\nprotocol) of the StatsD server to which\nKong should write Vitals metics. This value\nis only applied when the `vitals_strategy` is\nset to `prometheus`. This value accepts IPv4,\nIPv6, and, hostnames. Additionally, the suffix\n`tcp` can be specified; doing so will result\nin Kong sending StatsD metrics via TCP\ninstead of the UDP (default).\n",
-      "sectionTitle": "VITALS"
-    },
-    "vitals_statsd_prefix": {
-      "defaultValue": "kong",
-      "description": "Defines the prefix value attached to all\nVitals StatsD events. This prefix is useful\nwhen writing metrics to a multi-tenant StatsD\nexporter or server.\n",
-      "sectionTitle": "VITALS"
-    },
-    "vitals_statsd_udp_packet_size": {
-      "defaultValue": "1024",
-      "description": "Defines the maximum buffer size in\nwhich Vitals statsd metrics will be\nheld and sent in batches.\nThis value is defined in bytes.\n",
-      "sectionTitle": "VITALS"
-    },
-    "vitals_prometheus_scrape_interval": {
-      "defaultValue": "5",
-      "description": "Defines the scrape_interval query\nparameter sent to the Prometheus\nserver when reading Vitals data.\nThis should be same as the scrape\ninterval (in seconds) of the\nPrometheus server.\n",
-      "sectionTitle": "VITALS"
-    },
     "konnect_mode": {
       "defaultValue": "off",
       "description": "When enabled, the dataplane is connected to Konnect\n",
@@ -1460,191 +1525,10 @@
       "description": "Max number of messages can be buffered locally\nbefore dropping data in case there is no\nnetwork connection to Konnect.\n",
       "sectionTitle": "Analytics for Konnect"
     },
-    "portal": {
+    "analytics_debug": {
       "defaultValue": "off",
-      "description": "Developer Portal Switch\n\nWhen enabled:\n\n  Kong will expose the Dev Portal interface and\n  read-only APIs on the `portal_gui_listen` address,\n  and endpoints on the Admin API to manage assets.\n\nWhen enabled along with `portal_auth`:\n\n  Kong will expose management endpoints for developer\n  accounts on the Admin API and the Dev Portal API.\n",
-      "sectionTitle": "DEVELOPER PORTAL"
-    },
-    "portal_gui_listen": {
-      "defaultValue": [
-        "0.0.0.0:8003",
-        "0.0.0.0:8446 ssl"
-      ],
-      "description": "Developer Portal GUI Listeners\n\nComma-separated list of addresses on which Kong will\nexpose the Developer Portal GUI. Suffixes can be\nspecified for each pair, similarly to\nthe `admin_listen` directive.\n",
-      "sectionTitle": "DEVELOPER PORTAL"
-    },
-    "portal_gui_protocol": {
-      "defaultValue": "http",
-      "description": "Developer Portal GUI protocol\n\nThe protocol used in conjunction with\n`portal_gui_host` to construct the lookup, or balancer\naddress for your Kong Proxy nodes.\n\nExamples: `http`,`https`\n",
-      "sectionTitle": "DEVELOPER PORTAL"
-    },
-    "portal_gui_host": {
-      "defaultValue": "127.0.0.1:8003",
-      "description": "Developer Portal GUI host\n\nThe host used in conjunction with\n`portal_gui_protocol` to construct the lookup,\nor balancer address for your Kong Proxy nodes.\n\nExamples:\n\n- `<IP>:<PORT>`\n  -> `portal_gui_host = 127.0.0.1:8003`\n- `<HOSTNAME>`\n  -> `portal_gui_host = portal_api.domain.tld`\n- `<HOSTNAME>/<PATH>`\n  -> `portal_gui_host = dev-machine/dev-285`\n",
-      "sectionTitle": "DEVELOPER PORTAL"
-    },
-    "portal_cors_origins": {
-      "defaultValue": null,
-      "description": "Developer Portal CORS Origins\n\nA comma separated list of allowed domains for\n`Access-Control-Allow-Origin` header. This can be used to\nresolve CORS issues in custom networking environments.\n\nExamples:\n- list of domains:\n  `portal_cors_origins = http://localhost:8003, https://localhost:8004`\n- single domain:\n  `portal_cors_origins = http://localhost:8003`\n- all domains:\n  `portal_cors_origins = *`\n\nNOTE: In most cases, the Developer Portal is able to derive\nvalid CORS origins by using `portal_gui_protocol`, `portal_gui_host`,\nand if applicable, `portal_gui_use_subdomains`. In these cases,\n`portal_cors_origins` is not needed and can remain unset.\n",
-      "sectionTitle": "DEVELOPER PORTAL"
-    },
-    "portal_gui_use_subdomains": {
-      "defaultValue": "off",
-      "description": "Developer Portal GUI subdomain toggle\n\nBy default Kong Portal uses the first namespace in\nthe request path to determine workspace. By turning\n`portal_gui_subdomains` on, Kong Portal will expect\nworkspace to be included in the request url as a subdomain.\n\nExample (off):\n  - `<scheme>://<HOSTNAME>/<WORKSPACE>/<PATH>` ->\n    `http://kong-portal.com/example-workspace/index`\n\nExample (on):\n  - `<scheme>://<WORKSPACE>.<HOSTNAME>` ->\n    `http://example-workspace.kong-portal.com/index`\n",
-      "sectionTitle": "DEVELOPER PORTAL"
-    },
-    "portal_gui_ssl_cert": {
-      "defaultValue": null,
-      "description": "Developer Portal GUI SSL Certificate\n\nThe SSL certificate for `portal_gui_listen` values\nwith SSL enabled.\n\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n",
-      "sectionTitle": "DEVELOPER PORTAL"
-    },
-    "portal_gui_ssl_cert_key": {
-      "defaultValue": null,
-      "description": "Developer Portal GUI SSL Certificate Key\n\nThe SSL key for `portal_gui_listen` values with\nSSL enabled.\n\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n",
-      "sectionTitle": "DEVELOPER PORTAL"
-    },
-    "portal_gui_access_log": {
-      "defaultValue": "logs/portal_gui_access.log",
-      "description": "Developer Portal GUI Access Log location\n\nHere you can set an absolute or relative path for your\nPortal GUI access logs.\n\nSetting this value to `off` will disable logging\nPortal GUI access logs.\n\nWhen using relative pathing, logs will be placed under\nthe `prefix` location.\n",
-      "sectionTitle": "DEVELOPER PORTAL"
-    },
-    "portal_gui_error_log": {
-      "defaultValue": "logs/portal_gui_error.log",
-      "description": "Developer Portal GUI Error Log location\n\nHere you can set an absolute or relative path for your\nPortal GUI error logs.\n\nSetting this value to `off` will disable logging\nPortal GUI error logs.\n\nWhen using relative pathing, logs will be placed under\nthe `prefix` location.\n\nGranularity can be adjusted through the `log_level`\ndirective.\n",
-      "sectionTitle": "DEVELOPER PORTAL"
-    },
-    "portal_api_listen": {
-      "defaultValue": [
-        "0.0.0.0:8004",
-        "0.0.0.0:8447 ssl"
-      ],
-      "description": "Developer Portal API Listeners\n\nComma-separated list of addresses on which Kong will\nexpose the Developer Portal API. Suffixes can be\nspecified for each pair, similarly to\nthe `admin_listen` directive.\n",
-      "sectionTitle": "DEVELOPER PORTAL"
-    },
-    "portal_api_url": {
-      "defaultValue": null,
-      "description": "Developer Portal API URL\n\nThe lookup, or balancer, address for your Developer\nPortal nodes.\n\nThis value is commonly used in a microservices\nor service-mesh oriented architecture.\n\n`portal_api_url` is the address on which your\nKong Dev Portal API is accessible by Kong. You\nshould only set this value if your Kong Dev Portal API\nlives on a different node than your Kong Proxy.\n\nAccepted format (parts in parenthesis are optional):\n\n  `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`\n\nExamples:\n\n- `<scheme>://<IP>:<PORT>`\n  -> `portal_api_url = http://127.0.0.1:8003`\n- `SSL <scheme>://<HOSTNAME>`\n  -> `portal_api_url = https://portal_api.domain.tld`\n- `<scheme>://<HOSTNAME>/<PATH>`\n  -> `portal_api_url = http://dev-machine/dev-285`\n\nBy default this value points to the local interface:\n\n- `http://0.0.0.0:8004`\n",
-      "sectionTitle": "DEVELOPER PORTAL"
-    },
-    "portal_api_ssl_cert": {
-      "defaultValue": null,
-      "description": "Developer Portal API SSL Certificate\n\nThe SSL certificate for `portal_api_listen` values\nwith SSL enabled.\n\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n",
-      "sectionTitle": "DEVELOPER PORTAL"
-    },
-    "portal_api_ssl_cert_key": {
-      "defaultValue": null,
-      "description": "Developer Portal API SSL Certificate Key\n\nThe SSL key for `portal_api_listen` values with\nSSL enabled.\n\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n",
-      "sectionTitle": "DEVELOPER PORTAL"
-    },
-    "portal_api_access_log": {
-      "defaultValue": "logs/portal_api_access.log",
-      "description": "Developer Portal API Access Log location\n\nHere you can set an absolute or relative path for your\nPortal API access logs.\n\nSetting this value to `off` will disable logging\nPortal API access logs.\n\nWhen using relative pathing, logs will be placed under\nthe `prefix` location.\n",
-      "sectionTitle": "DEVELOPER PORTAL"
-    },
-    "portal_api_error_log": {
-      "defaultValue": "logs/portal_api_error.log",
-      "description": "Developer Portal API Error Log location\n\nHere you can set an absolute or relative path for your\nPortal API error logs.\n\nSetting this value to `off` will disable logging\nPortal API error logs.\n\nWhen using relative pathing, logs will be placed under\nthe `prefix` location.\n\nGranularity can be adjusted through the `log_level`\ndirective.\n",
-      "sectionTitle": "DEVELOPER PORTAL"
-    },
-    "portal_is_legacy": {
-      "defaultValue": "off",
-      "description": "Developer Portal legacy support\n\nSetting this value to `on` will cause all new\nportals to render using the legacy rendering system by default.\n\nSetting this value to `off` will cause all new\nportals to render using the current rendering system.\n",
-      "sectionTitle": "DEVELOPER PORTAL"
-    },
-    "portal_app_auth": {
-      "defaultValue": "kong-oauth2",
-      "description": "Developer Portal application registration\nauth provider and strategy. Must be set to enable\napplication_registration plugin\n",
-      "sectionTitle": "DEVELOPER PORTAL"
-    },
-    "portal_auth": {
-      "defaultValue": null,
-      "description": "Developer Portal Authentication Plugin Name\n\nSpecifies the authentication plugin\nto apply to your Developer Portal. Developers\nwill use the specified form of authentication\nto request access, register, and login to your\nDeveloper Portal.\n\nSupported Plugins:\n\n- Basic Authentication: `portal_auth = basic-auth`\n- OIDC Authentication: `portal_auth = openid-connect`\n\n",
-      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION"
-    },
-    "portal_auth_password_complexity": {
-      "defaultValue": null,
-      "description": "Kong Portal Authentication Password Complexity (JSON)\n\nWhen portal_auth = basic-auth, this property defines\nthe rules required for Kong Portal passwords. Choose\nfrom preset rules or write your own.\n\nExample using preset rules:\n\n`portal_auth_password_complexity = { \"kong-preset\": \"min_8\" }`\n\nAll values for kong-preset require the password to contain\ncharacters from at least three of the following categories:\n\n1. Uppercase characters (A through Z)\n\n2. Lowercase characters (a through z)\n\n3. Base-10 digits (0 through 9)\n\n4. Special characters (for example, &, $, #, %)\n\nSupported preset rules:\n- `min_8`: minimum length of 8\n- `min_12`: minimum length of 12\n- `min_20`: minimum length of 20\n\nTo write your own rules, see\nhttps://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.\n\nNOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.\n\nExample:\n\n`portal_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`\n",
-      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION"
-    },
-    "portal_auth_conf": {
-      "defaultValue": null,
-      "description": "Developer Portal Authentication Plugin Config (JSON)\n\nSpecifies the plugin configuration object\nin JSON format to be applied to your Developer\nPortal authentication.\n\nFor information about Plugin Configuration\nconsult the associated plugin documentation.\n\nExample for `basic-auth`:\n\n`portal_auth_conf = { \"hide_credentials\": true }`\n",
-      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION"
-    },
-    "portal_auth_login_attempts": {
-      "defaultValue": "0",
-      "description": "Number of times a user can attempt to login to the\nDev Portal before password must be reset.\n\n0 (default) means infinite attempts allowed.\n\nNote: Any value greater than 0 will only affect\nDev Portals secured with basic-auth.\n",
-      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION"
-    },
-    "portal_session_conf": {
-      "defaultValue": null,
-      "description": "Portal Session Config (JSON)\n\nSpecifies the configuration for the\nSession plugin as used by Kong Portal.\n\nFor information about Plugin Configuration consult\nthe Kong Session Plugin documentation.\n\nExample:\n```\nportal_session_conf = { \"cookie_name\": \"portal_session\", \\\n                         \"secret\": \"changeme\", \\\n                         \"storage\": \"kong\" }\n```\n",
-      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION"
-    },
-    "portal_auto_approve": {
-      "defaultValue": "off",
-      "description": "Developer Portal Auto Approve Access\n\nWhen set to `on`, a developer will\nautomatically be marked as \"approved\" after completing\nregistration. Access can still be revoked through\nKong Manager or the Admin API.\n\nWhen set to `off`, a Kong admin will have to manually approve the Developer\nusing Kong Manager or the Admin API.\n",
-      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION"
-    },
-    "portal_token_exp": {
-      "defaultValue": "21600",
-      "description": "Duration in seconds for the expiration of the Dev Portal\nreset password token. Default is `21600` (six hours).\n",
-      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION"
-    },
-    "portal_email_verification": {
-      "defaultValue": "off",
-      "description": "Portal Developer Email Verification.\n\nWhen enabled Developers will receive an email upon\nregistration to verify their account. Developers will\nnot be able to use the Developer Portal until they\nverify their account, even if auto-approve is enabled.\n\nNote: SMTP must be turned on in order to use this feature.\n",
-      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION"
-    },
-    "portal_invite_email": {
-      "defaultValue": "on",
-      "description": "When enabled, Kong admins can invite developers to a Dev Portal by using\nthe Invite button in Kong Manager.\n\nThe email looks like the following:\n\n```\nSubject: Invite to access Dev Portal <WORKSPACE_NAME>\n\nHello Developer!\n\nYou have been invited to create a Dev Portal account at %s.\nPlease visit `<DEV_PORTAL_URL/register>` to create your account.\n```\n",
-      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION"
-    },
-    "portal_access_request_email": {
-      "defaultValue": "on",
-      "description": "When enabled, Kong admins specified by `smtp_admin_emails`\nwill receive an email when a developer requests access\nto a Dev Portal.\n\nWhen disabled, Kong admins will have to manually check\nthe Kong Manager to view any requests.\n\nThe email looks like the following:\n\n```\nSubject: Request to access Dev Portal <WORKSPACE NAME>\n\nHello Admin!\n\n<DEVELOPER NAME> has requested Dev Portal access for <WORKSPACE_NAME>.\nPlease visit <KONG_MANAGER_URL/developers/requested> to review this request.\n```\n",
-      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION"
-    },
-    "portal_approved_email": {
-      "defaultValue": "on",
-      "description": "When enabled, developers will receive an email when\naccess to a Dev Portal has been approved.\n\nWhen disabled, developers will receive no indication\nthat they have beenapproved. It is suggested to only\ndisable this feature if `portal_auto_approve`\nis enabled.\n\nThe email looks like the following:\n\n```\nSubject: Dev Portal access approved\n\nHello Developer!\nYou have been approved to access <WORKSPACE_NAME>.\nPlease visit <DEV PORTAL URL/login> to login.\n```\n",
-      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION"
-    },
-    "portal_reset_email": {
-      "defaultValue": "on",
-      "description": "When enabled, developers will be able to use the\nReset Password flow on a Dev Portal and will\nreceive an email with password reset instructions.\n\nNote: When disabled, developers will *not* be able to reset their account\npasswords. The password resetting email is the only way to reset developer\npasswords.\n\nThe email looks like the following:\n\n```\nSubject: Password Reset Instructions for Dev Portal <WORKSPACE_NAME>.\n\nHello Developer,\n\nPlease click the link below to reset your Dev Portal password.\n\n<DEV_PORTAL_URL/reset?token=12345>\n\nThis link will expire in <portal_reset_token_exp>\n\nIf you didn't make this request, keep your account secure by clicking\nthe link above to change your password.\n```\n",
-      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION"
-    },
-    "portal_reset_success_email": {
-      "defaultValue": "on",
-      "description": "When enabled, developers will receive an email\nafter successfully resetting their Dev Portal\naccount password.\n\nWhen disabled, developers will still be able\nto reset their account passwords, but will not\nreceive a confirmation email.\n\nThe email looks like the following:\n\n```\nSubject: Dev Portal password change success\n\nHello Developer,\nWe are emailing you to let you know that your Dev Portal password at <DEV_PORTAL_URL> has been changed.\n\nClick the link below to sign in with your new credentials.\n\n<DEV_PORTAL_URL>\n```\n",
-      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION"
-    },
-    "portal_application_status_email": {
-      "defaultValue": "off",
-      "description": "When enabled, developers will receive an email\nwhen the status changes for their appliciation\nservice requests.\n\nWhen disabled, developers will still be able\nto view the status in their developer portal\napplication page.\n\nThe email looks like the following:\n\n```\nSubject: Dev Portal application request <REQUEST_STATUS> (<DEV_PORTAL_URL>)\n\nHello Developer,\nWe are emailing you to let you know that your request for application access from the\nDeveloper Portal account at <DEV_PORTAL_URL> is <REQUEST_STATUS>.\n\nApplication: <APPLICATION_NAME>\nService: <SERVICE_NAME>\n\nYou will receive another email when your access has been approved.\n```\n",
-      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION"
-    },
-    "portal_application_request_email": {
-      "defaultValue": "off",
-      "description": "When enabled, Kong admins specified by `smtp_admin_emails`\nwill receive an email when a developer requests access\nto service through an application.\n\nWhen disabled, Kong admins will have to manually check\nthe Kong Manager to view any requests.\n\nBy default, `smtp_admin_emails` will be the recipients.\nThis can be overriden by `portal_smtp_admin_emails`,\nwhich can be set dynamically per workspace through\nthe Admin API.\n\nThe email looks like the following:\n\n```\nSubject: Request to access Dev Portal (<DEV_PORTAL_URL>) service from <DEVELOPER_EMAIL>\n\nHello Admin,\n\n<DEVELOPER NAME> (<DEVELOPER_EMAIL>) has requested application access for <DEV_PORTAL_URL>.\n\nRequested workspace: <WORKSPACE_NAME>\nRequested application: <APPLICATION_NAME>\nRequested service: <SERVICE_NAME>\n\nPlease visit <KONG_MANAGER_URL/WORKSPACE_NAME/applications/APPLICATION_ID#requested> to review this request.\n```\n",
-      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION"
-    },
-    "portal_emails_from": {
-      "defaultValue": null,
-      "description": "The name and email address for the `From` header\nincluded in all Dev Portal emails.\n\nExample:\n`portal_emails_from = Your Name <example@example.com>`\n\nNote: Some SMTP servers will not use\nthis value, but instead insert the email and name\nassociated with the account.\n",
-      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION"
-    },
-    "portal_emails_reply_to": {
-      "defaultValue": null,
-      "description": "Email address for the `Reply-To` header for\nportal emails\n\nExample:\n`portal_emails_reply_to = example@example.com`\n\nNote: Some SMTP servers will not use\nthis value, but instead insert the email\nassociated with the account.\n",
-      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION"
-    },
-    "portal_smtp_admin_emails": {
-      "defaultValue": null,
-      "description": "Comma separated list of admin emails to receive\nportal notifications. Can be dynamically set per\nworkspace through the Admin API.\n\nIf not set, `smtp_admin_emails` will be used.\n\nExample `admin1@example.com, admin2@example.com`\n",
-      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION"
+      "description": "Outputs analytics payload to Kong logs.\n",
+      "sectionTitle": "Analytics for Konnect"
     },
     "admin_emails_from": {
       "defaultValue": "\"\"",
@@ -1765,6 +1649,535 @@
       "description": "Defines the path to a private RSA signing key\nthat can be used to insert a signature of\naudit records, adjacent to the record. The\ncorresponding public key should be stored\noffline, and can be used to validate audit\nentries in the future. If this value is\nundefined, no signature will be generated.\n",
       "sectionTitle": "DATA & ADMIN AUDIT"
     },
+    "route_validation_strategy": {
+      "defaultValue": "smart",
+      "description": "The strategy used to validate\nroutes when creating or updating them.\nDifferent strategies are available to tune\nhow to enforce splitting traffic of\nworkspaces.\n- `smart` is the default option and uses the\n  algorithm described in\n  https://docs.konghq.com/gateway/latest/kong-enterprise/workspaces/.\n- `off` disables any check.\n- `path` enforces routes to comply with the pattern\n  described in config `enforce_route_path_pattern`.\n- `static` relies on the PostgreSQL database.\nBefore creating a new route, it checks if the\nroute is unique across all workspaces based on\nthe following params: `paths`, `methods`, and\n`hosts`. If all fields of the new route overlap\nwith an existing one, a 409 is returned with the\nroute of the collision. The array order is not\nimportant for the overlap filter.\n",
+      "sectionTitle": "ROUTE COLLISION DETECTION/PREVENTION"
+    },
+    "enforce_route_path_pattern": {
+      "defaultValue": null,
+      "description": "Specifies the Lua pattern which will\nbe enforced on the `paths` attribute of a\nroute object. You can also add a placeholder\nfor the workspace in the pattern, which\nwill be rendered during runtime based on the\nworkspace to which the `route` belongs.\nThis setting is only relevant if\n`route_validation_strategy` is set to `path`.\n\n\n**Note:** The collision detection is only supported\nfor plain text routes, do not rely on this feature\nto validate regex routes.\n\nExample\nFor Pattern `/$(workspace)/v%d/.*` valid paths\nare:\n\n1. `/group1/v1/` if route belongs to\n  workspace `group1`.\n\n2. `/group2/v1/some_path` if route belongs to\n  workspace `group2`.\n",
+      "sectionTitle": "ROUTE COLLISION DETECTION/PREVENTION"
+    },
+    "keyring_enabled": {
+      "defaultValue": "off",
+      "description": "When enabled, Kong will encrypt sensitive\nfield values before writing them to the\ndatabase, and subsequently decrypt them when\nretrieving data for the Admin API, Developer\nPortal, or proxy business logic. Symmetric\nencryption keys are managed based on the\nstrategy defined below.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_strategy": {
+      "defaultValue": "cluster",
+      "description": "Defines the strategy implementation by which\nKong nodes will manage symmetric encryption\nkeys. Please see the Kong Enterprise\ndocumentation for a detailed description of\neach strategy. Acceptable values for this\noption are `cluster` and `vault`.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_public_key": {
+      "defaultValue": null,
+      "description": "Defines the public key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nValues:\n- absolute path to the public key\n- public key content\n- base64 encoded public key content\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_private_key": {
+      "defaultValue": null,
+      "description": "Defines the private key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nValues:\n- absolute path to the private key\n- private key content\n- base64 encoded private key content\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_recovery_public_key": {
+      "defaultValue": null,
+      "description": "Defines the public key to optionally encrypt\nall keyring materials and back them up in the\ndatabase.\n\nValues:\n- absolute path to the public key\n- public key content\n- base64 encoded public key content\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_blob_path": {
+      "defaultValue": null,
+      "description": "Defines the filesystem path at which Kong\nwill back up the initial keyring material.\nThis option is useful largely for development\npurposes.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_host": {
+      "defaultValue": null,
+      "description": "Defines the Vault host at which Kong will\nfetch the encryption material. This value\nshould be defined in the format:\n\n`<scheme>://<IP / HOSTNAME>:<PORT>`\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_mount": {
+      "defaultValue": null,
+      "description": "Defines the name of the Vault v2 KV secrets\nengine at which symmetric keys are found.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_path": {
+      "defaultValue": null,
+      "description": "Defines the name of the Vault v2 KV path\nat which symmetric keys are found.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_auth_method": {
+      "defaultValue": "token",
+      "description": "Defines the authentication mechanism when\nconnecting to the Hashicorp Vault service.\n\nAccepted values are: `token`, or `kubernetes`:\n\n- `token`: Uses the static token defined in\n           the `keyring_vault_token`\n           configuration property.\n\n- `kubernetes`: Uses the Kubernetes authentication\n                mechanism, with the running pod's\n                mapped service account, to assume\n                the Hashicorp Vault role name that is\n                defined in the `keyring_vault_kube_role`\n                configuration property.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_token": {
+      "defaultValue": null,
+      "description": "Defines the token value used to communicate\nwith the v2 KV Vault HTTP(S) API.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_kube_role": {
+      "defaultValue": "default",
+      "description": "Defines the Hashicorp Vault role that will be\nassumed using the Kubernetes service account of\nthe running pod.\n\n`keyring_vault_auth_method` must be set to `kubernetes`\nfor this to activate.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_kube_api_token_file": {
+      "defaultValue": "/run/secrets/kubernetes.io/serviceaccount/token",
+      "description": "Defines where the Kubernetes service account token\nshould be read from the pod's filesystem, if using\na non-standard container platform setup.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_encrypt_license": {
+      "defaultValue": "off",
+      "description": "Enables keyring encryption for license payloads stored\nin the database.\n\n**Warning:** For Kong deployments that rely entirely on\nthe database for license provisioning (i.e. not using\n`KONG_LICENSE_DATA` or `KONG_LICENSE_PATH`), enabling\nthis option will delay license activation until after\nthe node's keyring has been activated.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "untrusted_lua": {
+      "defaultValue": "sandbox",
+      "description": "Controls loading of Lua functions from admin-supplied\nsources such as the Admin API. LuaJIT bytecode\nloading is always disabled.\n\n**Warning:** LuaJIT is not designed as a secure\nruntime for running malicious code, therefore\nyou should properly protect your Admin API endpoint\neven with sandboxing enabled. The sandbox only\nprovides protection against trivial attackers or\nunintentional modification of the Kong global\nenvironment.\n\nAccepted values are: `off`, `sandbox`, or\n`on`:\n\n- `off`: Disallow loading of any arbitrary\n         Lua functions. The `off` option\n         disables any functionality that runs\n         arbitrary Lua code, including the\n         Serverless Functions plugins and any\n         transformation plugin that allows\n         custom Lua functions.\n\n- `sandbox`: Allow loading of Lua functions,\n             but use a sandbox when executing\n             them. The sandboxed function has\n             restricted access to the global\n             environment and only has access\n             to Kong PDK, OpenResty, and\n             standard Lua functions that will\n             generally not cause harm to the\n             Kong Gateway node.\n\n- `on`: Functions have unrestricted\n        access to the global environment and\n        can load any Lua modules. This is\n        similar to the behavior in\n        Kong Gateway prior to 2.3.0.\n\nThe default `sandbox` environment does not\nallow importing other modules or libraries,\nor executing anything at the OS level (for\nexample, file read/write). The global\nenvironment is also not accessible.\n\nExamples of `untrusted_lua = sandbox`\nbehavior:\n\n- You can't access or change global values\n  such as `kong.configuration.pg_password`\n- You can run harmless Lua:\n  `local foo = 1 + 1`. However, OS level\n  functions are not allowed, like:\n  `os.execute(`rm -rf /*`)`.\n\nTo customize the sandbox environment, use\nthe `untrusted_lua_sandbox_requires` and\n`untrusted_lua_sandbox_environment`\nparameters below.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "untrusted_lua_sandbox_requires": {
+      "defaultValue": null,
+      "description": "Comma-separated list of modules allowed to\nbe loaded with `require` inside the\nsandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\nFor example, say you have configured the\nServerless pre-function plugin and it\ncontains the following `requires`:\n\n```\nlocal template = require \"resty.template\"\nlocal split = require \"kong.tools.string\".split\n```\n\nTo run the plugin, add the modules to the\nallowed list:\n```\nuntrusted_lua_sandbox_requires = resty.template, kong.tools.utils\n```\n\n**Warning:** Allowing certain modules may\ncreate opportunities to escape the\nsandbox. For example, allowing `os` or\n`luaposix` may be unsafe.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "untrusted_lua_sandbox_environment": {
+      "defaultValue": null,
+      "description": "Comma-separated list of global Lua\nvariables that should be made available\ninside the sandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\n**Warning**: Certain variables, when made\navailable, may create opportunities to\nescape the sandbox.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "openresty_path": {
+      "defaultValue": null,
+      "description": "Path to the OpenResty installation that Kong\nwill use. When this is empty (the default),\nKong determines the OpenResty installation\nby searching for a system-installed OpenResty\nand falling back to searching $PATH for the\nnginx binary.\n\nSetting this attribute disables the search\nbehavior and explicitly instructs Kong which\nOpenResty installation to use.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "node_id": {
+      "defaultValue": null,
+      "description": "Node ID for the Kong node. Every Kong node\nin a Kong cluster must have a unique and\nvalid UUID. When empty, node ID is\nautomatically generated.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "cluster_fallback_config_import": {
+      "defaultValue": "off",
+      "description": "Enable fallback configuration imports.\n\nThis should only be enabled for data planes.\n",
+      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
+    },
+    "cluster_fallback_config_storage": {
+      "defaultValue": null,
+      "description": "Storage definition used by `cluster_fallback_config_import`\nand `cluster_fallback_config_export`.\n\nSupported storage types:\n- S3-like storages\n- GCP storage service\n\nTo use S3 with a bucket named b and place all configs\nto with a key prefix named p, set it to:\n`s3://b/p`\nTo use GCP for the same bucket and prefix, set it to:\n`gcs://b/p`\n\nThe credentials (and the endpoint URL for S3-like) for S3\nare passed with environment variables:\n`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,\nand `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where\n`AWS_CONFIG_STORAGE_ENDPOINT`\nis the endpoint that hosts S3-like storage.\n\nThe credentials for GCP are provided via the environment\nvariable `GCP_SERVICE_ACCOUNT`.\n",
+      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
+    },
+    "cluster_fallback_export_s3_config": {
+      "defaultValue": null,
+      "description": "Fallback config export S3 configuration.\nThis is used only when `cluster_fallback_config_storage` is an S3-like schema.\nIf set, it will add the config table to the Kong exporter config S3 putObject request.\nThe config table should be in JSON format and can be unserialized into a table.\nIt should contain the necessary parameters as described in the documentation:\nhttps://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property.\nFor example, if you want to set the ServerSideEncryption headers/KMS Key ID\nfor the S3 putObject request, you can set the config table to:\n`{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"your-kms-key-id\"}`\n",
+      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
+    },
+    "cluster_fallback_config_export": {
+      "defaultValue": "off",
+      "description": "Enable fallback configuration exports.\n",
+      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
+    },
+    "cluster_fallback_config_export_delay": {
+      "defaultValue": "60",
+      "description": "The fallback configuration export interval.\n\nIf the interval is set to 60 and configuration A is exported\nand there are new configurations B, C, and D in the next 60 seconds,\nit will wait until 60 seconds passed and export D, skipping B and C.\n",
+      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
+    },
+    "wasm": {
+      "defaultValue": "off",
+      "description": "Enable/disable wasm support. This must be enabled in\norder to use wasm filters and filter chains.\n",
+      "sectionTitle": "WEBASSEMBLY (WASM)"
+    },
+    "wasm_filters_path": {
+      "defaultValue": null,
+      "description": "Path to the directory containing wasm filter modules.\n\nAt startup, Kong discovers available wasm filters by\nscanning this directory for files with the `.wasm`\nfile extension.\n\nThe name of a wasm filter module is derived from the\nfilename itself, with the .wasm extension removed. So,\ngiven the following tree:\n\n```\n/path/to/wasm_filters\n├── my_module.wasm\n├── my_other_module.wasm\n└── not_a_wasm_module.txt\n```\n\nThe resulting filter modules available for use in Kong\nwill be:\n\n- `my_module`\n- `my_other_module`\n\nNotes:\n\n- No recursion is performed. Only .wasm files at the\n  top level are registered.\n- This path _may_ be a symlink to a directory.\n",
+      "sectionTitle": "WEBASSEMBLY (WASM)"
+    },
+    "wasm_filters": {
+      "defaultValue": [
+        "bundled",
+        "user"
+      ],
+      "description": "Comma-separated list of Wasm filters to be made\navailable for use in filter chains.\n\nWhen the `off` keyword is specified as the\nonly value, no filters will be available for use.\n\nWhen the `bundled` keyword is specified, all filters\nbundled with Kong will be available.\n\nWhen the `user` keyword is specified, all filters\nwithin the `wasm_filters_path` will be available.\n\n**Examples:**\n\n- `wasm_filters = bundled,user` enables _all_ bundled\n  and user-supplied filters\n- `wasm_filters = user` enables _only_ user-supplied\n  filters\n- `wasm_filters = filter-a,filter-b` enables _only_\n  filters named `filter-a` or `filter-b` (whether\n  bundled _or_ user-supplied)\n\nIf a conflict occurs where a bundled filter and a\nuser-supplied filter share the same name, a warning\nwill be logged, and the user-supplied filter will\nbe used instead.\n",
+      "sectionTitle": "WEBASSEMBLY (WASM)"
+    },
+    "test": {
+      "defaultValue": "on",
+      "description": "test\n",
+      "sectionTitle": "WASM injected directives"
+    },
+    "request_debug": {
+      "defaultValue": "on",
+      "description": "When enabled, Kong will provide detailed timing information\nfor its components to the client and the error log\nif the following headers are present in the proxy request:\n- `X-Kong-Request-Debug`:\n  If the value is set to `*`,\n  timing information will be collected and exported for the current request.\n  If this header is not present or contains an unknown value,\n  timing information will not be collected for the current request.\n  You can also specify a list of filters, separated by commas,\n  to filter the scope of the time information that is collected.\nThe following filters are supported for `X-Kong-Request-Debug`:\n- `rewrite`: Collect timing information from the `rewrite` phase.\n- `access`: Collect timing information from the `access` phase.\n- `balancer`: Collect timing information from the `balancer` phase.\n- `response`: Collect timing information from the `response` phase.\n- `header_filter`: Collect timing information from the `header_filter` phase.\n- `body_filter`: Collect timing information from the `body_filter` phase.\n- `log`: Collect timing information from the `log` phase.\n- `upstream`: Collect timing information from the `upstream` phase.\n\n- `X-Kong-Request-Debug-Log`:\n  If set to `true`, timing information will also be logged\n  in the Kong error log with a log level of `notice`.\n  Defaults to `false`.\n\n- `X-Kong-Request-Debug-Token`:\n  Token for authenticating the client making the debug\n  request to prevent abuse.\n  ** Note: Debug requests originating from loopback\n  addresses do not require this header. Deploying Kong behind\n  other proxies may result in exposing the debug interface to\n  the public.**\n\n",
+      "sectionTitle": "REQUEST DEBUGGING"
+    },
+    "request_debug_token": {
+      "defaultValue": "<random>",
+      "description": "The Request Debug Token is used in the\n`X-Kong-Request-Debug-Token` header to prevent abuse.\nIf this value is not set (the default),\na random token will be generated\nwhen Kong starts, restarts, or reloads. If a token is\nspecified manually, then the provided token will be used.\n\nYou can locate the generated debug token in two locations:\n- Kong error log:\n  Debug token will be logged in the error log (notice level)\n  when Kong starts, restarts, or reloads.\n  The log line will have the: `[request-debug]` prefix to aid searching.\n- Filesystem:\n  Debug token will also be stored in a file located at\n  `{prefix}/.request_debug_token` and updated\n  when Kong starts, restarts, or reloads.\n",
+      "sectionTitle": "REQUEST DEBUGGING"
+    },
+    "vitals": {
+      "defaultValue": "on",
+      "description": "When enabled, Kong will store and report\nmetrics about its performance.\n\nWhen running Kong in a multi-node setup,\n`vitals` entails two separate meanings\ndepending on the node.\n\nOn a Proxy-only node, `vitals` determines\nwhether to collect data for Vitals.\n\nOn an Admin-only node, `vitals` determines\nwhether to display Vitals metrics and\nvisualizations on the dashboard.\n",
+      "sectionTitle": "VITALS",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "vitals_strategy": {
+      "defaultValue": "database",
+      "description": "Determines whether to use the Kong database or\na separate storage engine for Vitals metrics.\nAccepted values are `database`, `prometheus`,\nor `influxdb`.\n",
+      "sectionTitle": "VITALS",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "vitals_tsdb_address": {
+      "defaultValue": null,
+      "description": "Defines the host and port of the TSDB server\nto which Vitals data is written and read.\nThis value is only applied when the\n`vitals_strategy` option is set to\n`prometheus` or `influxdb`. This value\naccepts IPv4, IPv6, and hostname values.\nIf the `vitals_strategy` is set to\n`prometheus`, this value determines the\naddress of the Prometheus server from which\nVitals data will be read. For `influxdb`\nstrategies, this value controls both the read\nand write source for Vitals data.\n",
+      "sectionTitle": "VITALS",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "vitals_tsdb_user": {
+      "defaultValue": null,
+      "description": "Influxdb user\n",
+      "sectionTitle": "VITALS",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "vitals_tsdb_password": {
+      "defaultValue": null,
+      "description": "Influxdb password\n",
+      "sectionTitle": "VITALS",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "vitals_statsd_address": {
+      "defaultValue": null,
+      "description": "Defines the host and port (and an optional\nprotocol) of the StatsD server to which\nKong should write Vitals metics. This value\nis only applied when the `vitals_strategy` is\nset to `prometheus`. This value accepts IPv4,\nIPv6, and, hostnames. Additionally, the suffix\n`tcp` can be specified; doing so will result\nin Kong sending StatsD metrics via TCP\ninstead of the UDP (default).\n",
+      "sectionTitle": "VITALS",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "vitals_statsd_prefix": {
+      "defaultValue": "kong",
+      "description": "Defines the prefix value attached to all\nVitals StatsD events. This prefix is useful\nwhen writing metrics to a multi-tenant StatsD\nexporter or server.\n",
+      "sectionTitle": "VITALS",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "vitals_statsd_udp_packet_size": {
+      "defaultValue": "1024",
+      "description": "Defines the maximum buffer size in\nwhich Vitals statsd metrics will be\nheld and sent in batches.\nThis value is defined in bytes.\n",
+      "sectionTitle": "VITALS",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "vitals_prometheus_scrape_interval": {
+      "defaultValue": "5",
+      "description": "Defines the scrape_interval query\nparameter sent to the Prometheus\nserver when reading Vitals data.\nThis should be same as the scrape\ninterval (in seconds) of the\nPrometheus server.\n",
+      "sectionTitle": "VITALS",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal": {
+      "defaultValue": "off",
+      "description": "Developer Portal Switch\n\nWhen enabled:\n\n  Kong will expose the Dev Portal interface and\n  read-only APIs on the `portal_gui_listen` address,\n  and endpoints on the Admin API to manage assets.\n\nWhen enabled along with `portal_auth`:\n\n  Kong will expose management endpoints for developer\n  accounts on the Admin API and the Dev Portal API.\n",
+      "sectionTitle": "DEVELOPER PORTAL",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_gui_listen": {
+      "defaultValue": [
+        "0.0.0.0:8003",
+        "0.0.0.0:8446 ssl"
+      ],
+      "description": "Developer Portal GUI Listeners\n\nComma-separated list of addresses on which Kong will\nexpose the Developer Portal GUI. Suffixes can be\nspecified for each pair, similarly to\nthe `admin_listen` directive.\n",
+      "sectionTitle": "DEVELOPER PORTAL",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_gui_protocol": {
+      "defaultValue": "http",
+      "description": "Developer Portal GUI protocol\n\nThe protocol used in conjunction with\n`portal_gui_host` to construct the lookup, or balancer\naddress for your Kong Proxy nodes.\n\nExamples: `http`,`https`\n",
+      "sectionTitle": "DEVELOPER PORTAL",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_gui_host": {
+      "defaultValue": "127.0.0.1:8003",
+      "description": "Developer Portal GUI host\n\nThe host used in conjunction with\n`portal_gui_protocol` to construct the lookup,\nor balancer address for your Kong Proxy nodes.\n\nExamples:\n\n- `<IP>:<PORT>`\n  -> `portal_gui_host = 127.0.0.1:8003`\n- `<HOSTNAME>`\n  -> `portal_gui_host = portal_api.domain.tld`\n- `<HOSTNAME>/<PATH>`\n  -> `portal_gui_host = dev-machine/dev-285`\n",
+      "sectionTitle": "DEVELOPER PORTAL",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_cors_origins": {
+      "defaultValue": null,
+      "description": "Developer Portal CORS Origins\n\nA comma separated list of allowed domains for\n`Access-Control-Allow-Origin` header. This can be used to\nresolve CORS issues in custom networking environments.\n\nExamples:\n- list of domains:\n  `portal_cors_origins = http://localhost:8003, https://localhost:8004`\n- single domain:\n  `portal_cors_origins = http://localhost:8003`\n- all domains:\n  `portal_cors_origins = *`\n\nNOTE: In most cases, the Developer Portal is able to derive\nvalid CORS origins by using `portal_gui_protocol`, `portal_gui_host`,\nand if applicable, `portal_gui_use_subdomains`. In these cases,\n`portal_cors_origins` is not needed and can remain unset.\n",
+      "sectionTitle": "DEVELOPER PORTAL",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_gui_use_subdomains": {
+      "defaultValue": "off",
+      "description": "Developer Portal GUI subdomain toggle\n\nBy default Kong Portal uses the first namespace in\nthe request path to determine workspace. By turning\n`portal_gui_subdomains` on, Kong Portal will expect\nworkspace to be included in the request url as a subdomain.\n\nExample (off):\n  - `<scheme>://<HOSTNAME>/<WORKSPACE>/<PATH>` ->\n    `http://kong-portal.com/example-workspace/index`\n\nExample (on):\n  - `<scheme>://<WORKSPACE>.<HOSTNAME>` ->\n    `http://example-workspace.kong-portal.com/index`\n",
+      "sectionTitle": "DEVELOPER PORTAL",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_gui_ssl_cert": {
+      "defaultValue": null,
+      "description": "Developer Portal GUI SSL Certificate\n\nThe SSL certificate for `portal_gui_listen` values\nwith SSL enabled.\n\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n",
+      "sectionTitle": "DEVELOPER PORTAL",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_gui_ssl_cert_key": {
+      "defaultValue": null,
+      "description": "Developer Portal GUI SSL Certificate Key\n\nThe SSL key for `portal_gui_listen` values with\nSSL enabled.\n\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n",
+      "sectionTitle": "DEVELOPER PORTAL",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_gui_access_log": {
+      "defaultValue": "logs/portal_gui_access.log",
+      "description": "Developer Portal GUI Access Log location\n\nHere you can set an absolute or relative path for your\nPortal GUI access logs.\n\nSetting this value to `off` will disable logging\nPortal GUI access logs.\n\nWhen using relative pathing, logs will be placed under\nthe `prefix` location.\n",
+      "sectionTitle": "DEVELOPER PORTAL",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_gui_error_log": {
+      "defaultValue": "logs/portal_gui_error.log",
+      "description": "Developer Portal GUI Error Log location\n\nHere you can set an absolute or relative path for your\nPortal GUI error logs.\n\nSetting this value to `off` will disable logging\nPortal GUI error logs.\n\nWhen using relative pathing, logs will be placed under\nthe `prefix` location.\n\nGranularity can be adjusted through the `log_level`\ndirective.\n",
+      "sectionTitle": "DEVELOPER PORTAL",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_api_listen": {
+      "defaultValue": [
+        "0.0.0.0:8004",
+        "0.0.0.0:8447 ssl"
+      ],
+      "description": "Developer Portal API Listeners\n\nComma-separated list of addresses on which Kong will\nexpose the Developer Portal API. Suffixes can be\nspecified for each pair, similarly to\nthe `admin_listen` directive.\n",
+      "sectionTitle": "DEVELOPER PORTAL",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_api_url": {
+      "defaultValue": null,
+      "description": "Developer Portal API URL\n\nThe lookup, or balancer, address for your Developer\nPortal nodes.\n\nThis value is commonly used in a microservices\nor service-mesh oriented architecture.\n\n`portal_api_url` is the address on which your\nKong Dev Portal API is accessible by Kong. You\nshould only set this value if your Kong Dev Portal API\nlives on a different node than your Kong Proxy.\n\nAccepted format (parts in parenthesis are optional):\n\n  `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`\n\nExamples:\n\n- `<scheme>://<IP>:<PORT>`\n  -> `portal_api_url = http://127.0.0.1:8003`\n- `SSL <scheme>://<HOSTNAME>`\n  -> `portal_api_url = https://portal_api.domain.tld`\n- `<scheme>://<HOSTNAME>/<PATH>`\n  -> `portal_api_url = http://dev-machine/dev-285`\n\nBy default this value points to the local interface:\n\n- `http://0.0.0.0:8004`\n",
+      "sectionTitle": "DEVELOPER PORTAL",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_api_ssl_cert": {
+      "defaultValue": null,
+      "description": "Developer Portal API SSL Certificate\n\nThe SSL certificate for `portal_api_listen` values\nwith SSL enabled.\n\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n",
+      "sectionTitle": "DEVELOPER PORTAL",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_api_ssl_cert_key": {
+      "defaultValue": null,
+      "description": "Developer Portal API SSL Certificate Key\n\nThe SSL key for `portal_api_listen` values with\nSSL enabled.\n\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n",
+      "sectionTitle": "DEVELOPER PORTAL",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_api_access_log": {
+      "defaultValue": "logs/portal_api_access.log",
+      "description": "Developer Portal API Access Log location\n\nHere you can set an absolute or relative path for your\nPortal API access logs.\n\nSetting this value to `off` will disable logging\nPortal API access logs.\n\nWhen using relative pathing, logs will be placed under\nthe `prefix` location.\n",
+      "sectionTitle": "DEVELOPER PORTAL",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_api_error_log": {
+      "defaultValue": "logs/portal_api_error.log",
+      "description": "Developer Portal API Error Log location\n\nHere you can set an absolute or relative path for your\nPortal API error logs.\n\nSetting this value to `off` will disable logging\nPortal API error logs.\n\nWhen using relative pathing, logs will be placed under\nthe `prefix` location.\n\nGranularity can be adjusted through the `log_level`\ndirective.\n",
+      "sectionTitle": "DEVELOPER PORTAL",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_is_legacy": {
+      "defaultValue": "off",
+      "description": "Developer Portal legacy support\n\nSetting this value to `on` will cause all new\nportals to render using the legacy rendering system by default.\n\nSetting this value to `off` will cause all new\nportals to render using the current rendering system.\n",
+      "sectionTitle": "DEVELOPER PORTAL",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_app_auth": {
+      "defaultValue": "kong-oauth2",
+      "description": "Developer Portal application registration\nauth provider and strategy. Must be set to enable\napplication_registration plugin\n",
+      "sectionTitle": "DEVELOPER PORTAL",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_auth": {
+      "defaultValue": null,
+      "description": "Developer Portal Authentication Plugin Name\n\nSpecifies the authentication plugin\nto apply to your Developer Portal. Developers\nwill use the specified form of authentication\nto request access, register, and login to your\nDeveloper Portal.\n\nSupported Plugins:\n\n- Basic Authentication: `portal_auth = basic-auth`\n- OIDC Authentication: `portal_auth = openid-connect`\n\n",
+      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_auth_password_complexity": {
+      "defaultValue": null,
+      "description": "Kong Portal Authentication Password Complexity (JSON)\n\nWhen portal_auth = basic-auth, this property defines\nthe rules required for Kong Portal passwords. Choose\nfrom preset rules or write your own.\n\nExample using preset rules:\n\n`portal_auth_password_complexity = { \"kong-preset\": \"min_8\" }`\n\nAll values for kong-preset require the password to contain\ncharacters from at least three of the following categories:\n\n1. Uppercase characters (A through Z)\n\n2. Lowercase characters (a through z)\n\n3. Base-10 digits (0 through 9)\n\n4. Special characters (for example, &, $, #, %)\n\nSupported preset rules:\n- `min_8`: minimum length of 8\n- `min_12`: minimum length of 12\n- `min_20`: minimum length of 20\n\nTo write your own rules, see\nhttps://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.\n\nNOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.\n\nExample:\n\n`portal_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`\n",
+      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_auth_conf": {
+      "defaultValue": null,
+      "description": "Developer Portal Authentication Plugin Config (JSON)\n\nSpecifies the plugin configuration object\nin JSON format to be applied to your Developer\nPortal authentication.\n\nFor information about Plugin Configuration\nconsult the associated plugin documentation.\n\nExample for `basic-auth`:\n\n`portal_auth_conf = { \"hide_credentials\": true }`\n",
+      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_auth_login_attempts": {
+      "defaultValue": "0",
+      "description": "Number of times a user can attempt to login to the\nDev Portal before password must be reset.\n\n0 (default) means infinite attempts allowed.\n\nNote: Any value greater than 0 will only affect\nDev Portals secured with basic-auth.\n",
+      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_session_conf": {
+      "defaultValue": null,
+      "description": "Portal Session Config (JSON)\n\nSpecifies the configuration for the\nSession plugin as used by Kong Portal.\n\nFor information about Plugin Configuration consult\nthe Kong Session Plugin documentation.\n\nExample:\n```\nportal_session_conf = { \"cookie_name\": \"portal_session\", \\\n                         \"secret\": \"changeme\", \\\n                         \"storage\": \"kong\" }\n```\n",
+      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_auto_approve": {
+      "defaultValue": "off",
+      "description": "Developer Portal Auto Approve Access\n\nWhen set to `on`, a developer will\nautomatically be marked as \"approved\" after completing\nregistration. Access can still be revoked through\nKong Manager or the Admin API.\n\nWhen set to `off`, a Kong admin will have to manually approve the Developer\nusing Kong Manager or the Admin API.\n",
+      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_token_exp": {
+      "defaultValue": "21600",
+      "description": "Duration in seconds for the expiration of the Dev Portal\nreset password token. Default is `21600` (six hours).\n",
+      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_email_verification": {
+      "defaultValue": "off",
+      "description": "Portal Developer Email Verification.\n\nWhen enabled Developers will receive an email upon\nregistration to verify their account. Developers will\nnot be able to use the Developer Portal until they\nverify their account, even if auto-approve is enabled.\n\nNote: SMTP must be turned on in order to use this feature.\n",
+      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_invite_email": {
+      "defaultValue": "on",
+      "description": "When enabled, Kong admins can invite developers to a Dev Portal by using\nthe Invite button in Kong Manager.\n\nThe email looks like the following:\n\n```\nSubject: Invite to access Dev Portal <WORKSPACE_NAME>\n\nHello Developer!\n\nYou have been invited to create a Dev Portal account at %s.\nPlease visit `<DEV_PORTAL_URL/register>` to create your account.\n```\n",
+      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_access_request_email": {
+      "defaultValue": "on",
+      "description": "When enabled, Kong admins specified by `smtp_admin_emails`\nwill receive an email when a developer requests access\nto a Dev Portal.\n\nWhen disabled, Kong admins will have to manually check\nthe Kong Manager to view any requests.\n\nThe email looks like the following:\n\n```\nSubject: Request to access Dev Portal <WORKSPACE NAME>\n\nHello Admin!\n\n<DEVELOPER NAME> has requested Dev Portal access for <WORKSPACE_NAME>.\nPlease visit <KONG_MANAGER_URL/developers/requested> to review this request.\n```\n",
+      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_approved_email": {
+      "defaultValue": "on",
+      "description": "When enabled, developers will receive an email when\naccess to a Dev Portal has been approved.\n\nWhen disabled, developers will receive no indication\nthat they have beenapproved. It is suggested to only\ndisable this feature if `portal_auto_approve`\nis enabled.\n\nThe email looks like the following:\n\n```\nSubject: Dev Portal access approved\n\nHello Developer!\nYou have been approved to access <WORKSPACE_NAME>.\nPlease visit <DEV PORTAL URL/login> to login.\n```\n",
+      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_reset_email": {
+      "defaultValue": "on",
+      "description": "When enabled, developers will be able to use the\nReset Password flow on a Dev Portal and will\nreceive an email with password reset instructions.\n\nNote: When disabled, developers will *not* be able to reset their account\npasswords. The password resetting email is the only way to reset developer\npasswords.\n\nThe email looks like the following:\n\n```\nSubject: Password Reset Instructions for Dev Portal <WORKSPACE_NAME>.\n\nHello Developer,\n\nPlease click the link below to reset your Dev Portal password.\n\n<DEV_PORTAL_URL/reset?token=12345>\n\nThis link will expire in <portal_reset_token_exp>\n\nIf you didn't make this request, keep your account secure by clicking\nthe link above to change your password.\n```\n",
+      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_reset_success_email": {
+      "defaultValue": "on",
+      "description": "When enabled, developers will receive an email\nafter successfully resetting their Dev Portal\naccount password.\n\nWhen disabled, developers will still be able\nto reset their account passwords, but will not\nreceive a confirmation email.\n\nThe email looks like the following:\n\n```\nSubject: Dev Portal password change success\n\nHello Developer,\nWe are emailing you to let you know that your Dev Portal password at <DEV_PORTAL_URL> has been changed.\n\nClick the link below to sign in with your new credentials.\n\n<DEV_PORTAL_URL>\n```\n",
+      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_application_status_email": {
+      "defaultValue": "off",
+      "description": "When enabled, developers will receive an email\nwhen the status changes for their appliciation\nservice requests.\n\nWhen disabled, developers will still be able\nto view the status in their developer portal\napplication page.\n\nThe email looks like the following:\n\n```\nSubject: Dev Portal application request <REQUEST_STATUS> (<DEV_PORTAL_URL>)\n\nHello Developer,\nWe are emailing you to let you know that your request for application access from the\nDeveloper Portal account at <DEV_PORTAL_URL> is <REQUEST_STATUS>.\n\nApplication: <APPLICATION_NAME>\nService: <SERVICE_NAME>\n\nYou will receive another email when your access has been approved.\n```\n",
+      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_application_request_email": {
+      "defaultValue": "off",
+      "description": "When enabled, Kong admins specified by `smtp_admin_emails`\nwill receive an email when a developer requests access\nto service through an application.\n\nWhen disabled, Kong admins will have to manually check\nthe Kong Manager to view any requests.\n\nBy default, `smtp_admin_emails` will be the recipients.\nThis can be overriden by `portal_smtp_admin_emails`,\nwhich can be set dynamically per workspace through\nthe Admin API.\n\nThe email looks like the following:\n\n```\nSubject: Request to access Dev Portal (<DEV_PORTAL_URL>) service from <DEVELOPER_EMAIL>\n\nHello Admin,\n\n<DEVELOPER NAME> (<DEVELOPER_EMAIL>) has requested application access for <DEV_PORTAL_URL>.\n\nRequested workspace: <WORKSPACE_NAME>\nRequested application: <APPLICATION_NAME>\nRequested service: <SERVICE_NAME>\n\nPlease visit <KONG_MANAGER_URL/WORKSPACE_NAME/applications/APPLICATION_ID#requested> to review this request.\n```\n",
+      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_emails_from": {
+      "defaultValue": null,
+      "description": "The name and email address for the `From` header\nincluded in all Dev Portal emails.\n\nExample:\n`portal_emails_from = Your Name <example@example.com>`\n\nNote: Some SMTP servers will not use\nthis value, but instead insert the email and name\nassociated with the account.\n",
+      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_emails_reply_to": {
+      "defaultValue": null,
+      "description": "Email address for the `Reply-To` header for\nportal emails\n\nExample:\n`portal_emails_reply_to = example@example.com`\n\nNote: Some SMTP servers will not use\nthis value, but instead insert the email\nassociated with the account.\n",
+      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
+    "portal_smtp_admin_emails": {
+      "defaultValue": null,
+      "description": "Comma separated list of admin emails to receive\nportal notifications. Can be dynamically set per\nworkspace through the Admin API.\n\nIf not set, `smtp_admin_emails` will be used.\n\nExample `admin1@example.com, admin2@example.com`\n",
+      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION",
+      "min_version": {
+        "gateway": "3.4"
+      }
+    },
     "tracing": {
       "defaultValue": "off",
       "description": "When enabled, Kong will generate granular\ndebug data about various portions of the\nrequest lifecycle, such as DB or DNS queries,\nplugin execution, core handler timing, etc.\n",
@@ -1819,255 +2232,6 @@
       "sectionTitle": "GRANULAR TRACING",
       "removed_in": {
         "gateway": "3.7"
-      }
-    },
-    "route_validation_strategy": {
-      "defaultValue": "smart",
-      "description": "The strategy used to validate\nroutes when creating or updating them.\nDifferent strategies are available to tune\nhow to enforce splitting traffic of\nworkspaces.\n- `smart` is the default option and uses the\n  algorithm described in\n  https://docs.konghq.com/gateway/latest/kong-enterprise/workspaces/.\n- `off` disables any check.\n- `path` enforces routes to comply with the pattern\n  described in config `enforce_route_path_pattern`.\n- `static` relies on the PostgreSQL database.\nBefore creating a new route, it checks if the\nroute is unique across all workspaces based on\nthe following params: `paths`, `methods`, and\n`hosts`. If all fields of the new route overlap\nwith an existing one, a 409 is returned with the\nroute of the collision. The array order is not\nimportant for the overlap filter.\n",
-      "sectionTitle": "ROUTE COLLISION DETECTION/PREVENTION"
-    },
-    "enforce_route_path_pattern": {
-      "defaultValue": null,
-      "description": "Specifies the Lua pattern which will\nbe enforced on the `paths` attribute of a\nroute object. You can also add a placeholder\nfor the workspace in the pattern, which\nwill be rendered during runtime based on the\nworkspace to which the `route` belongs.\nThis setting is only relevant if\n`route_validation_strategy` is set to `path`.\n\n\n**Note:** The collision detection is only supported\nfor plain text routes, do not rely on this feature\nto validate regex routes.\n\nExample\nFor Pattern `/$(workspace)/v%d/.*` valid paths\nare:\n\n1. `/group1/v1/` if route belongs to\n  workspace `group1`.\n\n2. `/group2/v1/some_path` if route belongs to\n  workspace `group2`.\n",
-      "sectionTitle": "ROUTE COLLISION DETECTION/PREVENTION"
-    },
-    "keyring_enabled": {
-      "defaultValue": "off",
-      "description": "When enabled, Kong will encrypt sensitive\nfield values before writing them to the\ndatabase, and subsequently decrypt them when\nretrieving data for the Admin API, Developer\nPortal, or proxy business logic. Symmetric\nencryption keys are managed based on the\nstrategy defined below.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_strategy": {
-      "defaultValue": "cluster",
-      "description": "Defines the strategy implementation by which\nKong nodes will manage symmetric encryption\nkeys. Please see the Kong Enterprise\ndocumentation for a detailed description of\neach strategy. Acceptable values for this\noption are `cluster` and `vault`.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_public_key": {
-      "defaultValue": null,
-      "description": "Defines the public key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nValues:\n- absolute path to the public key\n- public key content\n- base64 encoded public key content\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_private_key": {
-      "defaultValue": null,
-      "description": "Defines the private key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nValues:\n- absolute path to the private key\n- private key content\n- base64 encoded private key content\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_blob_path": {
-      "defaultValue": null,
-      "description": "Defines the filesystem path at which Kong\nwill back up the initial keyring material.\nThis option is useful largely for development\npurposes.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_vault_host": {
-      "defaultValue": null,
-      "description": "Defines the Vault host at which Kong will\nfetch the encryption material. This value\nshould be defined in the format:\n\n`<scheme>://<IP / HOSTNAME>:<PORT>`\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_vault_mount": {
-      "defaultValue": null,
-      "description": "Defines the name of the Vault v2 KV secrets\nengine at which symmetric keys are found.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_vault_path": {
-      "defaultValue": null,
-      "description": "Defines the name of the Vault v2 KV path\nat which symmetric keys are found.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_vault_auth_method": {
-      "defaultValue": "token",
-      "description": "Defines the authentication mechanism when\nconnecting to the Hashicorp Vault service.\n\nAccepted values are: `token`, or `kubernetes`:\n\n- `token`: Uses the static token defined in\n           the `keyring_vault_token`\n           configuration property.\n\n- `kubernetes`: Uses the Kubernetes authentication\n                mechanism, with the running pod's\n                mapped service account, to assume\n                the Hashicorp Vault role name that is\n                defined in the `keyring_vault_kube_role`\n                configuration property.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_vault_token": {
-      "defaultValue": null,
-      "description": "Defines the token value used to communicate\nwith the v2 KV Vault HTTP(S) API.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_vault_kube_role": {
-      "defaultValue": "default",
-      "description": "Defines the Hashicorp Vault role that will be\nassumed using the Kubernetes service account of\nthe running pod.\n\n`keyring_vault_auth_method` must be set to `kubernetes`\nfor this to activate.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_vault_kube_api_token_file": {
-      "defaultValue": "/run/secrets/kubernetes.io/serviceaccount/token",
-      "description": "Defines where the Kubernetes service account token\nshould be read from the pod's filesystem, if using\na non-standard container platform setup.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "untrusted_lua": {
-      "defaultValue": "sandbox",
-      "description": "Controls loading of Lua functions from admin-supplied\nsources such as the Admin API. LuaJIT bytecode\nloading is always disabled.\n\n**Warning:** LuaJIT is not designed as a secure\nruntime for running malicious code, therefore\nyou should properly protect your Admin API endpoint\neven with sandboxing enabled. The sandbox only\nprovides protection against trivial attackers or\nunintentional modification of the Kong global\nenvironment.\n\nAccepted values are: `off`, `sandbox`, or\n`on`:\n\n- `off`: Disallow loading of any arbitrary\n         Lua functions. The `off` option\n         disables any functionality that runs\n         arbitrary Lua code, including the\n         Serverless Functions plugins and any\n         transformation plugin that allows\n         custom Lua functions.\n\n- `sandbox`: Allow loading of Lua functions,\n             but use a sandbox when executing\n             them. The sandboxed function has\n             restricted access to the global\n             environment and only has access\n             to Kong PDK, OpenResty, and\n             standard Lua functions that will\n             generally not cause harm to the\n             Kong Gateway node.\n\n- `on`: Functions have unrestricted\n        access to the global environment and\n        can load any Lua modules. This is\n        similar to the behavior in\n        Kong Gateway prior to 2.3.0.\n\nThe default `sandbox` environment does not\nallow importing other modules or libraries,\nor executing anything at the OS level (for\nexample, file read/write). The global\nenvironment is also not accessible.\n\nExamples of `untrusted_lua = sandbox`\nbehavior:\n\n- You can't access or change global values\n  such as `kong.configuration.pg_password`\n- You can run harmless Lua:\n  `local foo = 1 + 1`. However, OS level\n  functions are not allowed, like:\n  `os.execute(`rm -rf /*`)`.\n\nTo customize the sandbox environment, use\nthe `untrusted_lua_sandbox_requires` and\n`untrusted_lua_sandbox_environment`\nparameters below.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "untrusted_lua_sandbox_requires": {
-      "defaultValue": null,
-      "description": "Comma-separated list of modules allowed to\nbe loaded with `require` inside the\nsandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\nFor example, say you have configured the\nServerless pre-function plugin and it\ncontains the following `requires`:\n\n```\nlocal template = require \"resty.template\"\nlocal split = require \"kong.tools.string\".split\n```\n\nTo run the plugin, add the modules to the\nallowed list:\n```\nuntrusted_lua_sandbox_requires = resty.template, kong.tools.utils\n```\n\n**Warning:** Allowing certain modules may\ncreate opportunities to escape the\nsandbox. For example, allowing `os` or\n`luaposix` may be unsafe.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "untrusted_lua_sandbox_environment": {
-      "defaultValue": null,
-      "description": "Comma-separated list of global Lua\nvariables that should be made available\ninside the sandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\n**Warning**: Certain variables, when made\navailable, may create opportunities to\nescape the sandbox.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "openresty_path": {
-      "defaultValue": null,
-      "description": "Path to the OpenResty installation that Kong\nwill use. When this is empty (the default),\nKong determines the OpenResty installation\nby searching for a system-installed OpenResty\nand falling back to searching $PATH for the\nnginx binary.\n\nSetting this attribute disables the search\nbehavior and explicitly instructs Kong which\nOpenResty installation to use.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "node_id": {
-      "defaultValue": null,
-      "description": "Node ID for the Kong node. Every Kong node\nin a Kong cluster must have a unique and\nvalid UUID. When empty, node ID is\nautomatically generated.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "cluster_fallback_config_import": {
-      "defaultValue": "off",
-      "description": "Enable fallback configuration imports.\n\nThis should only be enabled for data planes.\n",
-      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
-    },
-    "cluster_fallback_config_storage": {
-      "defaultValue": null,
-      "description": "Storage definition used by `cluster_fallback_config_import`\nand `cluster_fallback_config_export`.\n\nSupported storage types:\n- S3-like storages\n- GCP storage service\n\nTo use S3 with a bucket named b and place all configs\nto with a key prefix named p, set it to:\n`s3://b/p`\nTo use GCP for the same bucket and prefix, set it to:\n`gcs://b/p`\n\nThe credentials (and the endpoint URL for S3-like) for S3\nare passed with environment variables:\n`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,\nand `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where\n`AWS_CONFIG_STORAGE_ENDPOINT`\nis the endpoint that hosts S3-like storage.\n\nThe credentials for GCP are provided via the environment\nvariable `GCP_SERVICE_ACCOUNT`.\n",
-      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
-    },
-    "cluster_fallback_config_export": {
-      "defaultValue": "off",
-      "description": "Enable fallback configuration exports.\n",
-      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
-    },
-    "cluster_fallback_config_export_delay": {
-      "defaultValue": "60",
-      "description": "The fallback configuration export interval.\n\nIf the interval is set to 60 and configuration A is exported\nand there are new configurations B, C, and D in the next 60 seconds,\nit will wait until 60 seconds passed and export D, skipping B and C.\n",
-      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
-    },
-    "wasm": {
-      "defaultValue": "off",
-      "description": "Enable/disable wasm support. This must be enabled in\norder to use wasm filters and filter chains.\n",
-      "sectionTitle": "WEBASSEMBLY (WASM)"
-    },
-    "wasm_filters_path": {
-      "defaultValue": null,
-      "description": "Path to the directory containing wasm filter modules.\n\nAt startup, Kong discovers available wasm filters by\nscanning this directory for files with the `.wasm`\nfile extension.\n\nThe name of a wasm filter module is derived from the\nfilename itself, with the .wasm extension removed. So,\ngiven the following tree:\n\n```\n/path/to/wasm_filters\n├── my_module.wasm\n├── my_other_module.wasm\n└── not_a_wasm_module.txt\n```\n\nThe resulting filter modules available for use in Kong\nwill be:\n\n- `my_module`\n- `my_other_module`\n\nNotes:\n\n- No recursion is performed. Only .wasm files at the\n  top level are registered.\n- This path _may_ be a symlink to a directory.\n",
-      "sectionTitle": "WEBASSEMBLY (WASM)"
-    },
-    "request_debug": {
-      "defaultValue": "on",
-      "description": "When enabled, Kong will provide detailed timing information\nfor its components to the client and the error log\nif the following headers are present in the proxy request:\n- `X-Kong-Request-Debug`:\n  If the value is set to `*`,\n  timing information will be collected and exported for the current request.\n  If this header is not present or contains an unknown value,\n  timing information will not be collected for the current request.\n  You can also specify a list of filters, separated by commas,\n  to filter the scope of the time information that is collected.\nThe following filters are supported for `X-Kong-Request-Debug`:\n- `rewrite`: Collect timing information from the `rewrite` phase.\n- `access`: Collect timing information from the `access` phase.\n- `balancer`: Collect timing information from the `balancer` phase.\n- `response`: Collect timing information from the `response` phase.\n- `header_filter`: Collect timing information from the `header_filter` phase.\n- `body_filter`: Collect timing information from the `body_filter` phase.\n- `log`: Collect timing information from the `log` phase.\n- `upstream`: Collect timing information from the `upstream` phase.\n\n- `X-Kong-Request-Debug-Log`:\n  If set to `true`, timing information will also be logged\n  in the Kong error log with a log level of `notice`.\n  Defaults to `false`.\n\n- `X-Kong-Request-Debug-Token`:\n  Token for authenticating the client making the debug\n  request to prevent abuse.\n  ** Note: Debug requests originating from loopback\n  addresses do not require this header. Deploying Kong behind\n  other proxies may result in exposing the debug interface to\n  the public.**\n\n",
-      "sectionTitle": "REQUEST DEBUGGING"
-    },
-    "request_debug_token": {
-      "defaultValue": "<random>",
-      "description": "The Request Debug Token is used in the\n`X-Kong-Request-Debug-Token` header to prevent abuse.\nIf this value is not set (the default),\na random token will be generated\nwhen Kong starts, restarts, or reloads. If a token is\nspecified manually, then the provided token will be used.\n\nYou can locate the generated debug token in two locations:\n- Kong error log:\n  Debug token will be logged in the error log (notice level)\n  when Kong starts, restarts, or reloads.\n  The log line will have the: `[request-debug]` prefix to aid searching.\n- Filesystem:\n  Debug token will also be stored in a file located at\n  `{prefix}/.request_debug_token` and updated\n  when Kong starts, restarts, or reloads.\n",
-      "sectionTitle": "REQUEST DEBUGGING"
-    },
-    "dedicated_config_processing": {
-      "defaultValue": "on",
-      "description": "Enables or disables a special worker\nprocess for configuration processing. This process\nincreases memory usage a little bit while\nallowing to reduce latencies by moving some\nbackground tasks, such as CP/DP connection\nhandling, to an additional worker process specific\nto handling these background tasks.\nCurrently this has effect only on data planes.\n",
-      "sectionTitle": "GENERAL"
-    },
-    "debug_listen_local": {
-      "defaultValue": "on",
-      "description": "Expose `debug_listen` functionalities via a\nUnix domain socket under the Kong prefix.\n\nThis option allows local users to use `kong debug` command\nto invoke various debug functionalities without needing to\nenable `debug_listen` ahead of time.\n",
-      "sectionTitle": "NGINX"
-    },
-    "admin_gui_ssl_protocols": {
-      "defaultValue": "TLSv1.2 TLSv1.3",
-      "description": "Defines the TLS versions supported\nfor Kong Manager\n",
-      "sectionTitle": "KONG MANAGER"
-    },
-    "analytics_debug": {
-      "defaultValue": "off",
-      "description": "Outputs analytics payload to Kong logs.\n",
-      "sectionTitle": "Analytics for Konnect"
-    },
-    "cluster_fallback_export_s3_config": {
-      "defaultValue": null,
-      "description": "Fallback config export S3 configuration.\nThis is used only when `cluster_fallback_config_storage` is an S3-like schema.\nIf set, it will add the config table to the Kong exporter config S3 putObject request.\nThe config table should be in JSON format and can be unserialized into a table.\nIt should contain the necessary parameters as described in the documentation:\nhttps://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property.\nFor example, if you want to set the ServerSideEncryption headers/KMS Key ID\nfor the S3 putObject request, you can set the config table to:\n`{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"your-kms-key-id\"}`\n",
-      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
-    },
-    "wasm_filters": {
-      "defaultValue": [
-        "bundled",
-        "user"
-      ],
-      "description": "Comma-separated list of Wasm filters to be made\navailable for use in filter chains.\n\nWhen the `off` keyword is specified as the\nonly value, no filters will be available for use.\n\nWhen the `bundled` keyword is specified, all filters\nbundled with Kong will be available.\n\nWhen the `user` keyword is specified, all filters\nwithin the `wasm_filters_path` will be available.\n\n**Examples:**\n\n- `wasm_filters = bundled,user` enables _all_ bundled\n  and user-supplied filters\n- `wasm_filters = user` enables _only_ user-supplied\n  filters\n- `wasm_filters = filter-a,filter-b` enables _only_\n  filters named `filter-a` or `filter-b` (whether\n  bundled _or_ user-supplied)\n\nIf a conflict occurs where a bundled filter and a\nuser-supplied filter share the same name, a warning\nwill be logged, and the user-supplied filter will\nbe used instead.\n",
-      "sectionTitle": "WEBASSEMBLY (WASM)"
-    },
-    "new_dns_client": {
-      "defaultValue": "off",
-      "description": "Enable or disable the new DNS resolver\n",
-      "sectionTitle": "New DNS RESOLVER"
-    },
-    "resolver_address": {
-      "defaultValue": "<name servers parsed from resolv.conf>",
-      "description": "Comma-separated list of nameservers, each\nentry in `ip[:port]` format to be used by\nKong. If not specified, the nameservers in\nthe local `resolv.conf` file will be used.\nPort defaults to 53 if omitted. Accepts\nboth IPv4 and IPv6 addresses.\n\nExamples:\n\n```\nresolver_address = 8.8.8.8\nresolver_address = 8.8.8.8, [::1]\nresolver_address = 8.8.8.8:53, [::1]:53\n```\n",
-      "sectionTitle": "New DNS RESOLVER"
-    },
-    "resolver_hosts_file": {
-      "defaultValue": "/etc/hosts",
-      "description": "The hosts file to use. This file is read\nonce and its content is static in memory.\nTo read the file again after modifying it,\nKong must be reloaded.\n",
-      "sectionTitle": "New DNS RESOLVER"
-    },
-    "resolver_family": {
-      "defaultValue": [
-        "A",
-        "SRV"
-      ],
-      "description": "The supported query types.\n\nFor a domain name, Kong will only query\neither IP addresses (A or AAAA) or SRV\nrecords, but not both.\n\nIt will query SRV records only when the\ndomain matches the\n\"_<proto>._<service>.<name>\" format, for\nexample, \"_ldap._tcp.example.com\".\n\nFor IP addresses (A or AAAA) resolution, it\nfirst attempts IPv4 (A) and then queries\nIPv6 (AAAA).\n",
-      "sectionTitle": "New DNS RESOLVER"
-    },
-    "resolver_valid_ttl": {
-      "defaultValue": "<TTL from responses>",
-      "description": "By default, DNS records are cached using\nthe TTL value of a response. This optional\nparameter (in seconds) allows overriding it.\n",
-      "sectionTitle": "New DNS RESOLVER"
-    },
-    "resolver_error_ttl": {
-      "defaultValue": "1",
-      "description": "TTL in seconds for error responses and empty\nresponses.\n",
-      "sectionTitle": "New DNS RESOLVER"
-    },
-    "resolver_stale_ttl": {
-      "defaultValue": "3600",
-      "description": "Defines, in seconds, how long a record will\nremain in cache past its TTL. This value\nwill be used while the new DNS record is\nfetched in the background.\n\nStale data will be used from expiry of a\nrecord until either the refresh query\ncompletes, or the `resolver_stale_ttl` number\nof seconds have passed.\n\nThis configuration enables Kong to be more\nresilient during the DNS server downtime.\n",
-      "sectionTitle": "New DNS RESOLVER"
-    },
-    "resolver_lru_cache_size": {
-      "defaultValue": "10000",
-      "description": "The DNS client uses a two-layer cache system:\nL1 - worker-level LRU Lua VM cache\nL2 - across-workers shared memory cache\n\nThis value specifies the maximum allowed\nnumber of DNS responses stored in the L1 LRU\nlua VM cache.\n\nA single name query can easily take up 1~10\nslots, depending on attempted query types and\nextended domains from /etc/resolv.conf\noptions `domain` or `search`.\n",
-      "sectionTitle": "New DNS RESOLVER"
-    },
-    "resolver_mem_cache_size": {
-      "defaultValue": "5m",
-      "description": "This value specifies the size of the L2\nshared memory cache for DNS responses,\n`kong_dns_cache`.\n\nAccepted units are `k` and `m`, with a\nminimum recommended value of a few MBs.\n\n5MB shared memory size could store\n~20000 DNS responeses with single A record or\n~10000 DNS responeses with 2~3 A records.\n\n10MB shared memory size could store\n~40000 DNS responeses with single A record or\n~20000 DNS responeses with 2~3 A records.\n",
-      "sectionTitle": "New DNS RESOLVER"
-    },
-    "admin_gui_auth_change_password_attempts": {
-      "defaultValue": "0",
-      "description": "Number of times a user can attempt to change password.\n0 means infinite attempts allowed.\n",
-      "sectionTitle": "KONG MANAGER"
-    },
-    "admin_gui_auth_change_password_ttl": {
-      "defaultValue": "86400",
-      "description": "Length, in seconds, of the TTL for changing password attempts\nrecords. Records in the database older than\ntheir TTL are automatically purged.\n\nExample, 1 days: `1 * 24 * 60 * 60 = 86400.`\n",
-      "sectionTitle": "KONG MANAGER"
-    },
-    "keyring_recovery_public_key": {
-      "defaultValue": null,
-      "description": "Defines the public key to optionally encrypt\nall keyring materials and back them up in the\ndatabase.\n\nValues:\n- absolute path to the public key\n- public key content\n- base64 encoded public key content\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_encrypt_license": {
-      "defaultValue": "off",
-      "description": "Enables keyring encryption for license payloads stored\nin the database.\n\n**Warning:** For Kong deployments that rely entirely on\nthe database for license provisioning (i.e. not using\n`KONG_LICENSE_DATA` or `KONG_LICENSE_PATH`), enabling\nthis option will delay license activation until after\nthe node's keyring has been activated.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "test": {
-      "defaultValue": "on",
-      "description": "test\n",
-      "sectionTitle": "WASM injected directives"
-    },
-    "admin_gui_auth_login_attempts_ttl": {
-      "defaultValue": "604800",
-      "description": "Length, in seconds, of the TTL for changing login attempts\nrecords. Records in the database older than\ntheir TTL are automatically purged.\n\nThis argument can be set to an integer between 0 and 100000000.\n\nExample, 7 days: `7 * 24 * 60 * 60 = 604800.`\n",
-      "sectionTitle": "KONG MANAGER",
-      "min_version": {
-        "gateway": "3.9"
       }
     }
   }

--- a/app/_data/kong-conf/index.json
+++ b/app/_data/kong-conf/index.json
@@ -9,151 +9,91 @@
     {
       "title": "HYBRID MODE",
       "start": 276,
-      "end": 365,
+      "end": 376,
       "description": ""
     },
     {
       "title": "HYBRID MODE DATA PLANE",
-      "start": 366,
-      "end": 410,
+      "start": 377,
+      "end": 421,
       "description": ""
     },
     {
       "title": "HYBRID MODE CONTROL PLANE",
-      "start": 411,
-      "end": 487,
+      "start": 422,
+      "end": 498,
       "description": ""
     },
     {
       "title": "NGINX",
-      "start": 488,
-      "end": 1108,
+      "start": 499,
+      "end": 1128,
       "description": ""
     },
     {
       "title": "NGINX injected directives",
-      "start": 1109,
-      "end": 1263,
+      "start": 1129,
+      "end": 1283,
       "description": "Nginx directives can be dynamically injected in the runtime nginx.conf file\nwithout requiring a custom Nginx configuration template.\n\nAll configuration properties following the naming scheme\n`nginx_<namespace>_<directive>` will result in `<directive>` being injected in\nthe Nginx configuration block corresponding to the property's `<namespace>`.\nExample:\n`nginx_proxy_large_client_header_buffers = 8 24k`\n\nWill inject the following directive in Kong's proxy `server {}` block:\n\n`large_client_header_buffers 8 24k;`\n\nThe following namespaces are supported:\n\n- `nginx_main_<directive>`: Injects `<directive>` in Kong's configuration\n`main` context.\n- `nginx_events_<directive>`: Injects `<directive>` in Kong's `events {}`\nblock.\n- `nginx_http_<directive>`: Injects `<directive>` in Kong's `http {}` block.\n- `nginx_proxy_<directive>`: Injects `<directive>` in Kong's proxy\n`server {}` block.\n- `nginx_location_<directive>`: Injects `<directive>` in Kong's proxy `/`\nlocation block (nested under Kong's proxy `server {}` block).\n- `nginx_upstream_<directive>`: Injects `<directive>` in Kong's proxy\n`upstream {}` block.\n- `nginx_admin_<directive>`: Injects `<directive>` in Kong's Admin API\n`server {}` block.\n- `nginx_status_<directive>`: Injects `<directive>` in Kong's Status API\n`server {}` block (only effective if `status_listen` is enabled).\n- `nginx_debug_<directive>`: Injects `<directive>` in Kong's Debug API\n`server{}` block (only effective if `debug_listen` or `debug_listen_local`\nis enabled).\n- `nginx_stream_<directive>`: Injects `<directive>` in Kong's stream module\n`stream {}` block (only effective if `stream_listen` is enabled).\n- `nginx_sproxy_<directive>`: Injects `<directive>` in Kong's stream module\n`server {}` block (only effective if `stream_listen` is enabled).\n- `nginx_supstream_<directive>`: Injects `<directive>` in Kong's stream\nmodule `upstream {}` block.\n\nAs with other configuration properties, Nginx directives can be injected via\nenvironment variables when capitalized and prefixed with `KONG_`.\nExample:\n`KONG_NGINX_HTTP_SSL_PROTOCOLS` -> `nginx_http_ssl_protocols`\n\nWill inject the following directive in Kong's `http {}` block:\n\n`ssl_protocols <value>;`\n\nIf different sets of protocols are desired between the proxy and Admin API\nserver, you may specify `nginx_proxy_ssl_protocols` and/or\n`nginx_admin_ssl_protocols`, both of which take precedence over the\n`http {}` block.\n"
     },
     {
       "title": "DATASTORE",
-      "start": 1264,
-      "end": 1546,
+      "start": 1284,
+      "end": 1566,
       "description": "Kong can run with a database to store coordinated data between Kong nodes in\na cluster, or without a database, where each node stores its information\nindependently in memory.\n\nWhen using a database, Kong will store data for all its entities (such as\nroutes, services, consumers, and plugins) in PostgreSQL,\nand all Kong nodes belonging to the same cluster must connect to the same database.\n\nKong supports PostgreSQL versions 9.5 and above.\n\nWhen not using a database, Kong is said to be in \"DB-less mode\": it will keep\nits entities in memory, and each node needs to have this data entered via a\ndeclarative configuration file, which can be specified through the\n`declarative_config` property, or via the Admin API using the `/config`\nendpoint.\n\nWhen using Postgres as the backend storage, you can optionally enable Kong\nto serve read queries from a separate database instance.\nWhen the number of proxies is large, this can greatly reduce the load\non the main Postgres instance and achieve better scalability. It may also\nreduce the latency jitter if the Kong proxy node's latency to the main\nPostgres instance is high.\n\nThe read-only Postgres instance only serves read queries, and write\nqueries still go to the main connection. The read-only Postgres instance\ncan be eventually consistent while replicating changes from the main\ninstance.\n\nAt least the `pg_ro_host` config is needed to enable this feature.\nBy default, all other database config for the read-only connection is\ninherited from the corresponding main connection config described above but\nmay be optionally overwritten explicitly using the `pg_ro_*` config below.\n"
     },
     {
       "title": "DATASTORE CACHE",
-      "start": 1547,
-      "end": 1622,
+      "start": 1567,
+      "end": 1642,
       "description": "In order to avoid unnecessary communication with the datastore, Kong caches\nentities (such as APIs, consumers, credentials...) for a configurable period\nof time. It also handles invalidations if such an entity is updated.\n\nThis section allows for configuring the behavior of Kong regarding the\ncaching of such configuration entities.\n"
     },
     {
       "title": "DNS RESOLVER",
-      "start": 1623,
-      "end": 1698,
-      "description": "By default, the DNS resolver will use the standard configuration files\n`/etc/hosts` and `/etc/resolv.conf`. The settings in the latter file will be\noverridden by the environment variables `LOCALDOMAIN` and `RES_OPTIONS` if\nthey have been set.\n\nKong will resolve hostnames as either `SRV` or `A` records (in that order, and\n`CNAME` records will be dereferenced in the process).\nIn case a name is resolved as an `SRV` record, it will also override any given\nport number with the `port` field contents received from the DNS server.\n\nThe DNS options `SEARCH` and `NDOTS` (from the `/etc/resolv.conf` file) will\nbe used to expand short names to fully qualified ones. So it will first try\nthe entire `SEARCH` list for the `SRV` type, if that fails it will try the\n`SEARCH` list for `A`, etc.\n\nFor the duration of the `ttl`, the internal DNS resolver will load balance each\nrequest it gets over the entries in the DNS record. For `SRV` records, the\n`weight` fields will be honored, but it will only use the lowest `priority`\nfield entries in the record.\n"
-    },
-    {
-      "title": "New DNS RESOLVER",
-      "start": 1699,
-      "end": 1797,
-      "description": "This DNS resolver introduces global caching for DNS records across workers,\nsignificantly reducing the query load on DNS servers.\n\nIt provides observable statistics, you can retrieve them through the Admin API\n`/status/dns`.\n"
+      "start": 1643,
+      "end": 1724,
+      "description": "By default, the DNS resolver will use the standard configuration files\n`/etc/hosts` and `/etc/resolv.conf`. The settings in the latter file will be\noverridden by the environment variables `LOCALDOMAIN` and `RES_OPTIONS` if\nthey have been set.\n\nKong will resolve hostnames as either `SRV` or `A` records (in that order, and\n`CNAME` records will be dereferenced in the process).\nIn case a name is resolved as an `SRV` record, it will also override any given\nport number with the `port` field contents received from the DNS server.\n\nThe DNS options `SEARCH` and `NDOTS` (from the `/etc/resolv.conf` file) will\nbe used to expand short names to fully qualified ones. So it will first try\nthe entire `SEARCH` list for the `SRV` type, if that fails it will try the\n`SEARCH` list for `A`, etc.\n\nFor the duration of the `ttl`, the internal DNS resolver will load balance each\nrequest it gets over the entries in the DNS record. For `SRV` records, the\n`weight` fields will be honored, but it will only use the lowest `priority`\nfield entries in the record.\n\nFor DNS records returned with a TTL value of 0, Kong will default to caching\nthese records for 1 second. Strict adherence to the requirement of not caching\nTTL 0 records could generate excessive query frequency to upstream DNS servers,\nleading to unsustainable load and potential service degradation. As a result,\nmost DNS resolver implementations deviate from this requirement in practice.\n"
     },
     {
       "title": "VAULTS",
-      "start": 1798,
-      "end": 2023,
+      "start": 1824,
+      "end": 2049,
       "description": "A secret is any sensitive piece of information required for API gateway\noperations. Secrets may be part of the core Kong Gateway configuration,\nused in plugins, or part of the configuration associated with APIs serviced\nby the gateway.\n\nSome of the most common types of secrets used by Kong Gateway include:\n\n- Data store usernames and passwords, used with PostgreSQL and Redis\n- Private X.509 certificates\n- API keys\n\nSensitive plugin configuration fields are generally used for authentication,\nhashing, signing, or encryption. Kong Gateway lets you store certain values\nin a vault. Here are the vault specific configuration options.\n"
     },
     {
       "title": "TUNING & BEHAVIOR",
-      "start": 2024,
-      "end": 2144,
+      "start": 2050,
+      "end": 2170,
       "description": ""
     },
     {
       "title": "MISCELLANEOUS",
-      "start": 2145,
-      "end": 2266,
+      "start": 2171,
+      "end": 2292,
       "description": "Additional settings inherited from lua-nginx-module allowing for more\nflexibility and advanced usage.\n\nSee the lua-nginx-module documentation for more information:\nhttps://github.com/openresty/lua-nginx-module\n"
     },
     {
       "title": "KONG MANAGER",
-      "start": 2267,
-      "end": 2516,
+      "start": 2293,
+      "end": 2564,
       "description": "\nThe Admin GUI for Kong Enterprise.\n\n"
-    },
-    {
-      "title": "Konnect",
-      "start": 2517,
-      "end": 2523,
-      "description": ""
-    },
-    {
-      "title": "Analytics for Konnect",
-      "start": 2524,
-      "end": 2544,
-      "description": ""
-    },
-    {
-      "title": "ADMIN SMTP CONFIGURATION",
-      "start": 2545,
-      "end": 2559,
-      "description": ""
-    },
-    {
-      "title": "GENERAL SMTP CONFIGURATION",
-      "start": 2560,
-      "end": 2610,
-      "description": ""
-    },
-    {
-      "title": "DATA & ADMIN AUDIT",
-      "start": 2611,
-      "end": 2656,
-      "description": "When enabled, Kong will store detailed audit data regarding Admin API and\ndatabase access. In most cases, updates to the database are associated with\nAdmin API requests. As such, database object audit log data is tied to a\ngiven HTTP request via a unique identifier, providing built-in association of\nAdmin API and database traffic.\n\n"
-    },
-    {
-      "title": "ROUTE COLLISION DETECTION/PREVENTION",
-      "start": 2657,
-      "end": 2704,
-      "description": ""
-    },
-    {
-      "title": "DATABASE ENCRYPTION & KEYRING MANAGEMENT",
-      "start": 2705,
-      "end": 2933,
-      "description": "When enabled, Kong will transparently encrypt sensitive fields, such as consumer\ncredentials, TLS private keys, and RBAC user tokens, among others. A full list\nof encrypted fields is available from the Kong Enterprise documentation site.\nEncrypted data is transparently decrypted before being displayed to the Admin\nAPI or made available to plugins or core routing logic.\n\nWhile this feature is GA, do note that we currently do not provide normal semantic\nversioning compatibility guarantees on the keyring feature's APIs in that Kong may\nmake a breaking change to the feature in a minor version. Also note that\nmismanagement of keyring data may result in irrecoverable data loss.\n\n"
-    },
-    {
-      "title": "CLUSTER FALLBACK CONFIGURATION",
-      "start": 2934,
-      "end": 2982,
-      "description": ""
-    },
-    {
-      "title": "WEBASSEMBLY (WASM)",
-      "start": 2983,
-      "end": 3045,
-      "description": ""
-    },
-    {
-      "title": "WASM injected directives",
-      "start": 3046,
-      "end": 3129,
-      "description": "The Nginx Wasm module (i.e., ngx_wasm_module) has its own settings, which can\nbe tuned via `wasm_*` directives in the Nginx configuration file. Kong\nsupports configuration of these directives via its Nginx directive injection\nmechanism.\n\nThe following namespaces are supported:\n\n- `nginx_wasm_<directive>`: Injects `<directive>` into the `wasm {}` block.\n- `nginx_wasm_shm_kv`: Injects `shm_kv *` into the `wasm {}` block,\nallowing operators to define a general memory zone which is usable by\nthe `get_shared_data`/`set_shared_data` Proxy-Wasm SDK functions as\nan in-memory key-value store of data shareable across filters.\n- `nginx_wasm_shm_kv_<name>`: Injects `shm_kv <name>` into the `wasm {}` block,\nallowing operators to define custom shared memory zones which are usable by\nthe `get_shared_data`/`set_shared_data` Proxy-Wasm SDK functions as\nseparate namespaces in the `\"<name>/<key>\"` format.\nFor using these functions with non-namespaced keys, the Nginx template needs\na `shm_kv *` entry, which can be defined using `nginx_wasm_shm_kv`.\n- `nginx_wasm_wasmtime_<flag>`: Injects `flag <flag>` into the `wasmtime {}`\nblock, allowing various Wasmtime-specific flags to be set.\n- `nginx_<http|proxy>_<directive>`: Injects `<directive>` into the\n`http {}` or `server {}` blocks, as specified in the Nginx injected directives\nsection.\n\nThe documentation for all supported directives can be found in the Nginx Wasm\nmodule repository:\n\nhttps://github.com/Kong/ngx_wasm_module/blob/main/docs/DIRECTIVES.md\n\nThe Wasmtime flag documentation can be found here:\n\nhttps://docs.wasmtime.dev/c-api/config_8h.html\n\nThere are several noteworthy ngx_wasm_module behaviors which can be tuned via\n`http {}`/`server {}` level directive injection (identical behavior in either\nlevel), for example:\n\n- `nginx_http_proxy_wasm_socket_<connect|read|send>_timeout`: sets connection/read/send\ntimeouts for Wasm dispatches.\n- `nginx_http_proxy_wasm_socket_buffer_size`: sets a buffer size for\nreading Wasm dispatch responses.\n\nThe values for these settings are inherited from their `nginx_*_lua_*`\ncounterparts if they have not been explicitly set. For instance, if you set\n`nginx_http_lua_socket_connect_timeout`, the value\nof this setting will be propagated to `nginx_http_wasm_socket_connect_timeout`\nunless you _also_ set `nginx_http_wasm_socket_connect_timeout`.\n\nSome TLS-related settings receive special treatment as well:\n\n- `lua_ssl_trusted_certificate`: when set, the value is propagated to the\n`nginx_wasm_tls_trusted_certificate` directive.\n- `lua_ssl_verify_depth`: when set (to a value greater than zero), several\nTLS-related `nginx_wasm_*` settings are enabled:\n- `nginx_wasm_tls_verify_cert`\n- `nginx_wasm_tls_verify_host`\n- `nginx_wasm_tls_no_verify_warn`\n\nLike other `kong.conf` fields, all injected Nginx directives documented here\ncan be set via environment variable. For instance, setting:\n\n`KONG_NGINX_WASM_TLS_VERIFY_CERT=<value>`\n\nWill inject the following into the `wasm {}` block:\n\n`tls_verify_cert <value>;`\n\nThere are several Nginx directives supported by ngx_wasm_module which should\nnot be used because they are irrelevant to or unsupported by Kong, or they may\nconflict with Kong's own management of Proxy-Wasm. Use of these directives may\nresult in unintentional breakage:\n\n- `wasm_call`\n- `module`\n- `proxy_wasm`\n- `resolver_add`\n- `proxy_wasm_request_headers_in_access`\n- `shm_queue`\n\n"
-    },
-    {
-      "title": "REQUEST DEBUGGING",
-      "start": 3130,
-      "end": 3190,
-      "description": "Request debugging is a mechanism that allows admins to collect the timing of\nproxy path requests in the response header (X-Kong-Request-Debug-Output)\nand optionally, the error log.\n\nThis feature provides insights into the time spent within various components of Kong,\nsuch as plugins, DNS resolution, load balancing, and more. It also provides contextual\ninformation such as domain names tried during these processes.\n\n"
     },
     {
       "title": "VITALS",
       "start": 2415,
       "end": 2480,
+      "description": ""
+    },
+    {
+      "title": "Konnect",
+      "start": 2565,
+      "end": 2571,
+      "description": ""
+    },
+    {
+      "title": "Analytics for Konnect",
+      "start": 2572,
+      "end": 2592,
       "description": ""
     },
     {
@@ -175,10 +115,70 @@
       "description": "Referenced on workspace creation to set SMTP defaults in the database\nfor that particular workspace.\n\n"
     },
     {
+      "title": "ADMIN SMTP CONFIGURATION",
+      "start": 2593,
+      "end": 2607,
+      "description": ""
+    },
+    {
+      "title": "GENERAL SMTP CONFIGURATION",
+      "start": 2608,
+      "end": 2658,
+      "description": ""
+    },
+    {
+      "title": "DATA & ADMIN AUDIT",
+      "start": 2659,
+      "end": 2704,
+      "description": "When enabled, Kong will store detailed audit data regarding Admin API and\ndatabase access. In most cases, updates to the database are associated with\nAdmin API requests. As such, database object audit log data is tied to a\ngiven HTTP request via a unique identifier, providing built-in association of\nAdmin API and database traffic.\n\n"
+    },
+    {
       "title": "GRANULAR TRACING",
       "start": 2580,
       "end": 2686,
       "description": "{:.warning}\n> **Deprecation warning**: Granular tracing is deprecated. This means the feature will eventually be removed.\nOur target for Granular tracing removal is the Kong Gateway 4.0 release.\n\nGranular tracing offers a mechanism to expose metrics and detailed debug data\nabout the lifecycle of Kong in a human- or machine-consumable format.\n\n"
+    },
+    {
+      "title": "ROUTE COLLISION DETECTION/PREVENTION",
+      "start": 2705,
+      "end": 2752,
+      "description": ""
+    },
+    {
+      "title": "DATABASE ENCRYPTION & KEYRING MANAGEMENT",
+      "start": 2753,
+      "end": 2981,
+      "description": "When enabled, Kong will transparently encrypt sensitive fields, such as consumer\ncredentials, TLS private keys, and RBAC user tokens, among others. A full list\nof encrypted fields is available from the Kong Enterprise documentation site.\nEncrypted data is transparently decrypted before being displayed to the Admin\nAPI or made available to plugins or core routing logic.\n\nWhile this feature is GA, do note that we currently do not provide normal semantic\nversioning compatibility guarantees on the keyring feature's APIs in that Kong may\nmake a breaking change to the feature in a minor version. Also note that\nmismanagement of keyring data may result in irrecoverable data loss.\n\n"
+    },
+    {
+      "title": "WEBASSEMBLY (WASM)",
+      "start": 3031,
+      "end": 3093,
+      "description": ""
+    },
+    {
+      "title": "REQUEST DEBUGGING",
+      "start": 3178,
+      "end": 3240,
+      "description": "Request debugging is a mechanism that allows admins to collect the timing of\nproxy path requests in the response header (X-Kong-Request-Debug-Output)\nand optionally, the error log.\n\nThis feature provides insights into the time spent within various components of Kong,\nsuch as plugins, DNS resolution, load balancing, and more. It also provides contextual\ninformation such as domain names tried during these processes.\n\n"
+    },
+    {
+      "title": "CLUSTER FALLBACK CONFIGURATION",
+      "start": 2982,
+      "end": 3030,
+      "description": ""
+    },
+    {
+      "title": "New DNS RESOLVER",
+      "start": 1725,
+      "end": 1823,
+      "description": "This DNS resolver introduces global caching for DNS records across workers,\nsignificantly reducing the query load on DNS servers.\n\nIt provides observable statistics, you can retrieve them through the Admin API\n`/status/dns`.\n"
+    },
+    {
+      "title": "WASM injected directives",
+      "start": 3094,
+      "end": 3177,
+      "description": "The Nginx Wasm module (i.e., ngx_wasm_module) has its own settings, which can\nbe tuned via `wasm_*` directives in the Nginx configuration file. Kong\nsupports configuration of these directives via its Nginx directive injection\nmechanism.\n\nThe following namespaces are supported:\n\n- `nginx_wasm_<directive>`: Injects `<directive>` into the `wasm {}` block.\n- `nginx_wasm_shm_kv`: Injects `shm_kv *` into the `wasm {}` block,\nallowing operators to define a general memory zone which is usable by\nthe `get_shared_data`/`set_shared_data` Proxy-Wasm SDK functions as\nan in-memory key-value store of data shareable across filters.\n- `nginx_wasm_shm_kv_<name>`: Injects `shm_kv <name>` into the `wasm {}` block,\nallowing operators to define custom shared memory zones which are usable by\nthe `get_shared_data`/`set_shared_data` Proxy-Wasm SDK functions as\nseparate namespaces in the `\"<name>/<key>\"` format.\nFor using these functions with non-namespaced keys, the Nginx template needs\na `shm_kv *` entry, which can be defined using `nginx_wasm_shm_kv`.\n- `nginx_wasm_wasmtime_<flag>`: Injects `flag <flag>` into the `wasmtime {}`\nblock, allowing various Wasmtime-specific flags to be set.\n- `nginx_<http|proxy>_<directive>`: Injects `<directive>` into the\n`http {}` or `server {}` blocks, as specified in the Nginx injected directives\nsection.\n\nThe documentation for all supported directives can be found in the Nginx Wasm\nmodule repository:\n\nhttps://github.com/Kong/ngx_wasm_module/blob/main/docs/DIRECTIVES.md\n\nThe Wasmtime flag documentation can be found here:\n\nhttps://docs.wasmtime.dev/c-api/config_8h.html\n\nThere are several noteworthy ngx_wasm_module behaviors which can be tuned via\n`http {}`/`server {}` level directive injection (identical behavior in either\nlevel), for example:\n\n- `nginx_http_proxy_wasm_socket_<connect|read|send>_timeout`: sets connection/read/send\ntimeouts for Wasm dispatches.\n- `nginx_http_proxy_wasm_socket_buffer_size`: sets a buffer size for\nreading Wasm dispatch responses.\n\nThe values for these settings are inherited from their `nginx_*_lua_*`\ncounterparts if they have not been explicitly set. For instance, if you set\n`nginx_http_lua_socket_connect_timeout`, the value\nof this setting will be propagated to `nginx_http_wasm_socket_connect_timeout`\nunless you _also_ set `nginx_http_wasm_socket_connect_timeout`.\n\nSome TLS-related settings receive special treatment as well:\n\n- `lua_ssl_trusted_certificate`: when set, the value is propagated to the\n`nginx_wasm_tls_trusted_certificate` directive.\n- `lua_ssl_verify_depth`: when set (to a value greater than zero), several\nTLS-related `nginx_wasm_*` settings are enabled:\n- `nginx_wasm_tls_verify_cert`\n- `nginx_wasm_tls_verify_host`\n- `nginx_wasm_tls_no_verify_warn`\n\nLike other `kong.conf` fields, all injected Nginx directives documented here\ncan be set via environment variable. For instance, setting:\n\n`KONG_NGINX_WASM_TLS_VERIFY_CERT=<value>`\n\nWill inject the following into the `wasm {}` block:\n\n`tls_verify_cert <value>;`\n\nThere are several Nginx directives supported by ngx_wasm_module which should\nnot be used because they are irrelevant to or unsupported by Kong, or they may\nconflict with Kong's own management of Proxy-Wasm. Use of these directives may\nresult in unintentional breakage:\n\n- `wasm_call`\n- `module`\n- `proxy_wasm`\n- `resolver_add`\n- `proxy_wasm_request_headers_in_access`\n- `shm_queue`\n\n"
     }
   ],
   "params": {
@@ -272,11 +272,6 @@
       "description": "Comma-separated list of plugins this node should load.\nBy default, only plugins bundled in official distributions\nare loaded via the `bundled` keyword.\n\nLoading a plugin does not enable it by default, but only\ninstructs Kong to load its source code and allows\nconfiguration via the various related Admin API endpoints.\n\nThe specified name(s) will be substituted as such in the\nLua namespace: `kong.plugins.{name}.*`.\n\nWhen the `off` keyword is specified as the only value,\nno plugins will be loaded.\n\n`bundled` and plugin names can be mixed together, as the\nfollowing examples suggest:\n\n- `plugins = bundled,custom-auth,custom-log`\n  will include the bundled plugins plus two custom ones.\n- `plugins = custom-auth,custom-log` will\n  *only* include the `custom-auth` and `custom-log` plugins.\n- `plugins = off` will not include any plugins.\n\n**Note:** Kong will not start if some plugins were previously\nconfigured (i.e. have rows in the database) and are not\nspecified in this list. Before disabling a plugin, ensure\nall instances of it are removed before restarting Kong.\n\n**Note:** Limiting the amount of available plugins can\nimprove P99 latency when experiencing LRU churning in the\ndatabase cache (i.e. when the configured `mem_cache_size`) is full.\n",
       "sectionTitle": "GENERAL"
     },
-    "dedicated_config_processing": {
-      "defaultValue": "on",
-      "description": "Enables or disables a special worker\nprocess for configuration processing. This process\nincreases memory usage a little bit while\nallowing to reduce latencies by moving some\nbackground tasks, such as CP/DP connection\nhandling, to an additional worker process specific\nto handling these background tasks.\nCurrently this has effect only on data planes.\n",
-      "sectionTitle": "GENERAL"
-    },
     "pluginserver_names": {
       "defaultValue": null,
       "description": "Comma-separated list of names for pluginserver\nprocesses. The actual names are used for\nlog messages and to relate the actual settings.\n",
@@ -366,14 +361,6 @@
       "defaultValue": null,
       "description": "The list of Common Names that are allowed to\nconnect to control plane. Multiple entries may\nbe supplied in a comma-separated string. When not\nset, only data plane with the same parent domain as the\ncontrol plane cert is allowed to connect.\n\nThis field is ignored if `cluster_mtls` is\nnot set to `pki_check_cn`.\n",
       "sectionTitle": "HYBRID MODE"
-    },
-    "incremental_sync": {
-      "defaultValue": "off",
-      "description": "The setting to enable or disable the incremental\nsynchronization of configuration changes.\nInstead of sending the entire entity config to data planes on\neach config update, incremental config sync lets you send only\nthe changed configuration to data planes for hybrid mode deployments.\nThe valid values are `on` and `off`.\nTo enable, set this value to `on`.\n\nIn hybrid mode, this setting must be configured\non both control plane and data plane nodes.\n",
-      "sectionTitle": "HYBRID MODE",
-      "removed_in": {
-        "gateway": "3.4"
-      }
     },
     "cluster_server_name": {
       "defaultValue": null,
@@ -471,11 +458,6 @@
       "description": "Comma-separated list of addresses and ports on\nwhich the Debug API should listen.\n\nThe following suffix can be specified for each pair:\n\n- `ssl` will require that all connections made\n  through a particular address/port be made with TLS\n  enabled.\n- `http2` will allow for clients to open HTTP/2\n  connections to Kong's Debug API server.\n\nThis value can be set to `off`, disabling\nthe Debug API for this node.\n\nExample: `debug_listen = 0.0.0.0:8200 ssl http2`\n",
       "sectionTitle": "NGINX"
     },
-    "debug_listen_local": {
-      "defaultValue": "on",
-      "description": "Expose `debug_listen` functionalities via a\nUnix domain socket under the Kong prefix.\n\nThis option allows local users to use `kong debug` command\nto invoke various debug functionalities without needing to\nenable `debug_listen` ahead of time.\n",
-      "sectionTitle": "NGINX"
-    },
     "nginx_user": {
       "defaultValue": "kong kong",
       "description": "Defines user and group credentials used by\nworker processes. If group is omitted, a\ngroup whose name equals that of user is\nused.\n\nExample: `nginx_user = nginx www`\n\n**Note**: If the `kong` user and the `kong`\ngroup are not available, the default user\nand group credentials will be\n`nobody nobody`.\n",
@@ -495,14 +477,6 @@
       "defaultValue": "128m",
       "description": "Size of each of the two shared memory caches\nfor traditional mode database entities\nand runtime data, `kong_core_cache` and\n`kong_cache`.\n\nThe accepted units are `k` and `m`, with a minimum\nrecommended value of a few MBs.\n\n**Note**: As this option controls the size of two\ndifferent cache zones, the total memory Kong\nuses to cache entities might be double this value.\nThe created zones are shared by all worker\nprocesses and do not become larger when more\nworkers are used.\n",
       "sectionTitle": "NGINX"
-    },
-    "consumers_mem_cache_size": {
-      "defaultValue": "128m",
-      "description": "Size of the shared memory cache for consumers\nand credentials.\n\nThe accepted units are `k` and `m`, with a minimum\nrecommended value of a few MBs.\n\n**Note**: This is only used when the \"externalized consumers\"\nfeature is active.\n",
-      "sectionTitle": "NGINX",
-      "removed_in": {
-        "gateway": "3.4"
-      }
     },
     "ssl_cipher_suite": {
       "defaultValue": "intermediate",
@@ -1028,54 +1002,6 @@
       "description": "If enabled, then upon a cache-miss every\nrequest will trigger its own DNS query.\nWhen disabled, multiple requests for the\nsame name/type will be synchronized to a\nsingle query.\n",
       "sectionTitle": "DNS RESOLVER"
     },
-    "new_dns_client": {
-      "defaultValue": "off",
-      "description": "Enable or disable the new DNS resolver\n",
-      "sectionTitle": "New DNS RESOLVER"
-    },
-    "resolver_address": {
-      "defaultValue": "<name servers parsed from resolv.conf>",
-      "description": "Comma-separated list of nameservers, each\nentry in `ip[:port]` format to be used by\nKong. If not specified, the nameservers in\nthe local `resolv.conf` file will be used.\nPort defaults to 53 if omitted. Accepts\nboth IPv4 and IPv6 addresses.\n\nExamples:\n\n```\nresolver_address = 8.8.8.8\nresolver_address = 8.8.8.8, [::1]\nresolver_address = 8.8.8.8:53, [::1]:53\n```\n",
-      "sectionTitle": "New DNS RESOLVER"
-    },
-    "resolver_hosts_file": {
-      "defaultValue": "/etc/hosts",
-      "description": "The hosts file to use. This file is read\nonce and its content is static in memory.\nTo read the file again after modifying it,\nKong must be reloaded.\n",
-      "sectionTitle": "New DNS RESOLVER"
-    },
-    "resolver_family": {
-      "defaultValue": [
-        "A",
-        "SRV"
-      ],
-      "description": "The supported query types.\n\nFor a domain name, Kong will only query\neither IP addresses (A or AAAA) or SRV\nrecords, but not both.\n\nIt will query SRV records only when the\ndomain matches the\n\"_<proto>._<service>.<name>\" format, for\nexample, \"_ldap._tcp.example.com\".\n\nFor IP addresses (A or AAAA) resolution, it\nfirst attempts IPv4 (A) and then queries\nIPv6 (AAAA).\n",
-      "sectionTitle": "New DNS RESOLVER"
-    },
-    "resolver_valid_ttl": {
-      "defaultValue": "<TTL from responses>",
-      "description": "By default, DNS records are cached using\nthe TTL value of a response. This optional\nparameter (in seconds) allows overriding it.\n",
-      "sectionTitle": "New DNS RESOLVER"
-    },
-    "resolver_error_ttl": {
-      "defaultValue": "1",
-      "description": "TTL in seconds for error responses and empty\nresponses.\n",
-      "sectionTitle": "New DNS RESOLVER"
-    },
-    "resolver_stale_ttl": {
-      "defaultValue": "3600",
-      "description": "Defines, in seconds, how long a record will\nremain in cache past its TTL. This value\nwill be used while the new DNS record is\nfetched in the background.\n\nStale data will be used from expiry of a\nrecord until either the refresh query\ncompletes, or the `resolver_stale_ttl` number\nof seconds have passed.\n\nThis configuration enables Kong to be more\nresilient during the DNS server downtime.\n",
-      "sectionTitle": "New DNS RESOLVER"
-    },
-    "resolver_lru_cache_size": {
-      "defaultValue": "10000",
-      "description": "The DNS client uses a two-layer cache system:\nL1 - worker-level LRU Lua VM cache\nL2 - across-workers shared memory cache\n\nThis value specifies the maximum allowed\nnumber of DNS responses stored in the L1 LRU\nlua VM cache.\n\nA single name query can easily take up 1~10\nslots, depending on attempted query types and\nextended domains from /etc/resolv.conf\noptions `domain` or `search`.\n",
-      "sectionTitle": "New DNS RESOLVER"
-    },
-    "resolver_mem_cache_size": {
-      "defaultValue": "5m",
-      "description": "This value specifies the size of the L2\nshared memory cache for DNS responses,\n`kong_dns_cache`.\n\nAccepted units are `k` and `m`, with a\nminimum recommended value of a few MBs.\n\n5MB shared memory size could store\n~20000 DNS responeses with single A record or\n~10000 DNS responeses with 2~3 A records.\n\n10MB shared memory size could store\n~40000 DNS responeses with single A record or\n~20000 DNS responeses with 2~3 A records.\n",
-      "sectionTitle": "New DNS RESOLVER"
-    },
     "vault_env_prefix": {
       "defaultValue": null,
       "description": "Defines the environment variable vault's\ndefault prefix. For example if you have\nall your secrets stored in environment\nvariables prefixed with `SECRETS_`, it\ncan be configured here so that it isn't\nnecessary to repeat them in Vault\nreferences.\n",
@@ -1379,27 +1305,6 @@
       "description": "Hierarchical part of a URI which is composed\noptionally of a host, port, and path at which the\nAdmin API accepts HTTP or HTTPS traffic. When\nthis config is disabled, Kong Manager will\nuse the window protocol + host and append the\nresolved admin_listen HTTP/HTTPS port.\n",
       "sectionTitle": "KONG MANAGER"
     },
-    "admin_gui_csp_header": {
-      "defaultValue": "off",
-      "description": "Enable or disable the `Content-Security-Policy` (CSP) header for Kong Manager\n\nThis configuration controls the presence of the CSP header when serving\nKong Manager. The default CSP header value will be used unless customized.\n\nTo modify the value of the served CSP header, refer to the `admin_gui_csp_header_value`\nconfiguration.\n\nSet this configuration to `on` to enable the CSP header.\n",
-      "sectionTitle": "KONG MANAGER",
-      "removed_in": {
-        "gateway": "3.4"
-      }
-    },
-    "admin_gui_csp_header_value": {
-      "defaultValue": null,
-      "description": "The value of the `Content-Security-Policy` (CSP) header for Kong Manager.\n\nThis configuration controls the value of the CSP header when serving\nKong Manager. If omitted or left empty, the default CSP header value\nwill be used.\n\nThis is an advanced configuration intended for cases where the default\nCSP header value does not meet your requirements. Use with caution.\n\nFor more information on the CSP header, see:\nhttps://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy\n",
-      "sectionTitle": "KONG MANAGER",
-      "removed_in": {
-        "gateway": "3.4"
-      }
-    },
-    "admin_gui_ssl_protocols": {
-      "defaultValue": "TLSv1.2 TLSv1.3",
-      "description": "Defines the TLS versions supported\nfor Kong Manager\n",
-      "sectionTitle": "KONG MANAGER"
-    },
     "admin_gui_ssl_cert": {
       "defaultValue": null,
       "description": "The SSL certificate for `admin_gui_listen` values\nwith SSL enabled.\n\nvalues:\n- absolute path to the certificate\n- certificate content\n- base64 encoded certificate content\n",
@@ -1455,21 +1360,6 @@
       "description": "Number of times a user can attempt to login to Kong\nManager. 0 means infinite attempts allowed.\n",
       "sectionTitle": "KONG MANAGER"
     },
-    "admin_gui_auth_login_attempts_ttl": {
-      "defaultValue": "604800",
-      "description": "Length, in seconds, of the TTL for changing login attempts\nrecords. Records in the database older than\ntheir TTL are automatically purged.\n\nThis argument can be set to an integer between 0 and 100000000.\n\nExample, 7 days: `7 * 24 * 60 * 60 = 604800.`\n",
-      "sectionTitle": "KONG MANAGER"
-    },
-    "admin_gui_auth_change_password_attempts": {
-      "defaultValue": "0",
-      "description": "Number of times a user can attempt to change password.\n0 means infinite attempts allowed.\n",
-      "sectionTitle": "KONG MANAGER"
-    },
-    "admin_gui_auth_change_password_ttl": {
-      "defaultValue": "86400",
-      "description": "Length, in seconds, of the TTL for changing password attempts\nrecords. Records in the database older than\ntheir TTL are automatically purged.\n\nExample, 1 days: `1 * 24 * 60 * 60 = 86400.`\n",
-      "sectionTitle": "KONG MANAGER"
-    },
     "admin_gui_header_txt": {
       "defaultValue": null,
       "description": "Sets the text for the Kong Manager header banner.\nHeader banner is not shown if this config is empty.\n",
@@ -1510,6 +1400,51 @@
       "description": "Sets the body text for the Kong Manager login banner.\nLogin banner is not shown if both\n`admin_gui_login_banner_title` and\n`admin_gui_login_banner_body` are empty.\n",
       "sectionTitle": "KONG MANAGER"
     },
+    "vitals": {
+      "defaultValue": "on",
+      "description": "When enabled, Kong will store and report\nmetrics about its performance.\n\nWhen running Kong in a multi-node setup,\n`vitals` entails two separate meanings\ndepending on the node.\n\nOn a Proxy-only node, `vitals` determines\nwhether to collect data for Vitals.\n\nOn an Admin-only node, `vitals` determines\nwhether to display Vitals metrics and\nvisualizations on the dashboard.\n",
+      "sectionTitle": "VITALS"
+    },
+    "vitals_strategy": {
+      "defaultValue": "database",
+      "description": "Determines whether to use the Kong database or\na separate storage engine for Vitals metrics.\nAccepted values are `database`, `prometheus`,\nor `influxdb`.\n",
+      "sectionTitle": "VITALS"
+    },
+    "vitals_tsdb_address": {
+      "defaultValue": null,
+      "description": "Defines the host and port of the TSDB server\nto which Vitals data is written and read.\nThis value is only applied when the\n`vitals_strategy` option is set to\n`prometheus` or `influxdb`. This value\naccepts IPv4, IPv6, and hostname values.\nIf the `vitals_strategy` is set to\n`prometheus`, this value determines the\naddress of the Prometheus server from which\nVitals data will be read. For `influxdb`\nstrategies, this value controls both the read\nand write source for Vitals data.\n",
+      "sectionTitle": "VITALS"
+    },
+    "vitals_tsdb_user": {
+      "defaultValue": null,
+      "description": "Influxdb user\n",
+      "sectionTitle": "VITALS"
+    },
+    "vitals_tsdb_password": {
+      "defaultValue": null,
+      "description": "Influxdb password\n",
+      "sectionTitle": "VITALS"
+    },
+    "vitals_statsd_address": {
+      "defaultValue": null,
+      "description": "Defines the host and port (and an optional\nprotocol) of the StatsD server to which\nKong should write Vitals metics. This value\nis only applied when the `vitals_strategy` is\nset to `prometheus`. This value accepts IPv4,\nIPv6, and, hostnames. Additionally, the suffix\n`tcp` can be specified; doing so will result\nin Kong sending StatsD metrics via TCP\ninstead of the UDP (default).\n",
+      "sectionTitle": "VITALS"
+    },
+    "vitals_statsd_prefix": {
+      "defaultValue": "kong",
+      "description": "Defines the prefix value attached to all\nVitals StatsD events. This prefix is useful\nwhen writing metrics to a multi-tenant StatsD\nexporter or server.\n",
+      "sectionTitle": "VITALS"
+    },
+    "vitals_statsd_udp_packet_size": {
+      "defaultValue": "1024",
+      "description": "Defines the maximum buffer size in\nwhich Vitals statsd metrics will be\nheld and sent in batches.\nThis value is defined in bytes.\n",
+      "sectionTitle": "VITALS"
+    },
+    "vitals_prometheus_scrape_interval": {
+      "defaultValue": "5",
+      "description": "Defines the scrape_interval query\nparameter sent to the Prometheus\nserver when reading Vitals data.\nThis should be same as the scrape\ninterval (in seconds) of the\nPrometheus server.\n",
+      "sectionTitle": "VITALS"
+    },
     "konnect_mode": {
       "defaultValue": "off",
       "description": "When enabled, the dataplane is connected to Konnect\n",
@@ -1525,10 +1460,191 @@
       "description": "Max number of messages can be buffered locally\nbefore dropping data in case there is no\nnetwork connection to Konnect.\n",
       "sectionTitle": "Analytics for Konnect"
     },
-    "analytics_debug": {
+    "portal": {
       "defaultValue": "off",
-      "description": "Outputs analytics payload to Kong logs.\n",
-      "sectionTitle": "Analytics for Konnect"
+      "description": "Developer Portal Switch\n\nWhen enabled:\n\n  Kong will expose the Dev Portal interface and\n  read-only APIs on the `portal_gui_listen` address,\n  and endpoints on the Admin API to manage assets.\n\nWhen enabled along with `portal_auth`:\n\n  Kong will expose management endpoints for developer\n  accounts on the Admin API and the Dev Portal API.\n",
+      "sectionTitle": "DEVELOPER PORTAL"
+    },
+    "portal_gui_listen": {
+      "defaultValue": [
+        "0.0.0.0:8003",
+        "0.0.0.0:8446 ssl"
+      ],
+      "description": "Developer Portal GUI Listeners\n\nComma-separated list of addresses on which Kong will\nexpose the Developer Portal GUI. Suffixes can be\nspecified for each pair, similarly to\nthe `admin_listen` directive.\n",
+      "sectionTitle": "DEVELOPER PORTAL"
+    },
+    "portal_gui_protocol": {
+      "defaultValue": "http",
+      "description": "Developer Portal GUI protocol\n\nThe protocol used in conjunction with\n`portal_gui_host` to construct the lookup, or balancer\naddress for your Kong Proxy nodes.\n\nExamples: `http`,`https`\n",
+      "sectionTitle": "DEVELOPER PORTAL"
+    },
+    "portal_gui_host": {
+      "defaultValue": "127.0.0.1:8003",
+      "description": "Developer Portal GUI host\n\nThe host used in conjunction with\n`portal_gui_protocol` to construct the lookup,\nor balancer address for your Kong Proxy nodes.\n\nExamples:\n\n- `<IP>:<PORT>`\n  -> `portal_gui_host = 127.0.0.1:8003`\n- `<HOSTNAME>`\n  -> `portal_gui_host = portal_api.domain.tld`\n- `<HOSTNAME>/<PATH>`\n  -> `portal_gui_host = dev-machine/dev-285`\n",
+      "sectionTitle": "DEVELOPER PORTAL"
+    },
+    "portal_cors_origins": {
+      "defaultValue": null,
+      "description": "Developer Portal CORS Origins\n\nA comma separated list of allowed domains for\n`Access-Control-Allow-Origin` header. This can be used to\nresolve CORS issues in custom networking environments.\n\nExamples:\n- list of domains:\n  `portal_cors_origins = http://localhost:8003, https://localhost:8004`\n- single domain:\n  `portal_cors_origins = http://localhost:8003`\n- all domains:\n  `portal_cors_origins = *`\n\nNOTE: In most cases, the Developer Portal is able to derive\nvalid CORS origins by using `portal_gui_protocol`, `portal_gui_host`,\nand if applicable, `portal_gui_use_subdomains`. In these cases,\n`portal_cors_origins` is not needed and can remain unset.\n",
+      "sectionTitle": "DEVELOPER PORTAL"
+    },
+    "portal_gui_use_subdomains": {
+      "defaultValue": "off",
+      "description": "Developer Portal GUI subdomain toggle\n\nBy default Kong Portal uses the first namespace in\nthe request path to determine workspace. By turning\n`portal_gui_subdomains` on, Kong Portal will expect\nworkspace to be included in the request url as a subdomain.\n\nExample (off):\n  - `<scheme>://<HOSTNAME>/<WORKSPACE>/<PATH>` ->\n    `http://kong-portal.com/example-workspace/index`\n\nExample (on):\n  - `<scheme>://<WORKSPACE>.<HOSTNAME>` ->\n    `http://example-workspace.kong-portal.com/index`\n",
+      "sectionTitle": "DEVELOPER PORTAL"
+    },
+    "portal_gui_ssl_cert": {
+      "defaultValue": null,
+      "description": "Developer Portal GUI SSL Certificate\n\nThe SSL certificate for `portal_gui_listen` values\nwith SSL enabled.\n\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n",
+      "sectionTitle": "DEVELOPER PORTAL"
+    },
+    "portal_gui_ssl_cert_key": {
+      "defaultValue": null,
+      "description": "Developer Portal GUI SSL Certificate Key\n\nThe SSL key for `portal_gui_listen` values with\nSSL enabled.\n\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n",
+      "sectionTitle": "DEVELOPER PORTAL"
+    },
+    "portal_gui_access_log": {
+      "defaultValue": "logs/portal_gui_access.log",
+      "description": "Developer Portal GUI Access Log location\n\nHere you can set an absolute or relative path for your\nPortal GUI access logs.\n\nSetting this value to `off` will disable logging\nPortal GUI access logs.\n\nWhen using relative pathing, logs will be placed under\nthe `prefix` location.\n",
+      "sectionTitle": "DEVELOPER PORTAL"
+    },
+    "portal_gui_error_log": {
+      "defaultValue": "logs/portal_gui_error.log",
+      "description": "Developer Portal GUI Error Log location\n\nHere you can set an absolute or relative path for your\nPortal GUI error logs.\n\nSetting this value to `off` will disable logging\nPortal GUI error logs.\n\nWhen using relative pathing, logs will be placed under\nthe `prefix` location.\n\nGranularity can be adjusted through the `log_level`\ndirective.\n",
+      "sectionTitle": "DEVELOPER PORTAL"
+    },
+    "portal_api_listen": {
+      "defaultValue": [
+        "0.0.0.0:8004",
+        "0.0.0.0:8447 ssl"
+      ],
+      "description": "Developer Portal API Listeners\n\nComma-separated list of addresses on which Kong will\nexpose the Developer Portal API. Suffixes can be\nspecified for each pair, similarly to\nthe `admin_listen` directive.\n",
+      "sectionTitle": "DEVELOPER PORTAL"
+    },
+    "portal_api_url": {
+      "defaultValue": null,
+      "description": "Developer Portal API URL\n\nThe lookup, or balancer, address for your Developer\nPortal nodes.\n\nThis value is commonly used in a microservices\nor service-mesh oriented architecture.\n\n`portal_api_url` is the address on which your\nKong Dev Portal API is accessible by Kong. You\nshould only set this value if your Kong Dev Portal API\nlives on a different node than your Kong Proxy.\n\nAccepted format (parts in parenthesis are optional):\n\n  `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`\n\nExamples:\n\n- `<scheme>://<IP>:<PORT>`\n  -> `portal_api_url = http://127.0.0.1:8003`\n- `SSL <scheme>://<HOSTNAME>`\n  -> `portal_api_url = https://portal_api.domain.tld`\n- `<scheme>://<HOSTNAME>/<PATH>`\n  -> `portal_api_url = http://dev-machine/dev-285`\n\nBy default this value points to the local interface:\n\n- `http://0.0.0.0:8004`\n",
+      "sectionTitle": "DEVELOPER PORTAL"
+    },
+    "portal_api_ssl_cert": {
+      "defaultValue": null,
+      "description": "Developer Portal API SSL Certificate\n\nThe SSL certificate for `portal_api_listen` values\nwith SSL enabled.\n\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n",
+      "sectionTitle": "DEVELOPER PORTAL"
+    },
+    "portal_api_ssl_cert_key": {
+      "defaultValue": null,
+      "description": "Developer Portal API SSL Certificate Key\n\nThe SSL key for `portal_api_listen` values with\nSSL enabled.\n\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n",
+      "sectionTitle": "DEVELOPER PORTAL"
+    },
+    "portal_api_access_log": {
+      "defaultValue": "logs/portal_api_access.log",
+      "description": "Developer Portal API Access Log location\n\nHere you can set an absolute or relative path for your\nPortal API access logs.\n\nSetting this value to `off` will disable logging\nPortal API access logs.\n\nWhen using relative pathing, logs will be placed under\nthe `prefix` location.\n",
+      "sectionTitle": "DEVELOPER PORTAL"
+    },
+    "portal_api_error_log": {
+      "defaultValue": "logs/portal_api_error.log",
+      "description": "Developer Portal API Error Log location\n\nHere you can set an absolute or relative path for your\nPortal API error logs.\n\nSetting this value to `off` will disable logging\nPortal API error logs.\n\nWhen using relative pathing, logs will be placed under\nthe `prefix` location.\n\nGranularity can be adjusted through the `log_level`\ndirective.\n",
+      "sectionTitle": "DEVELOPER PORTAL"
+    },
+    "portal_is_legacy": {
+      "defaultValue": "off",
+      "description": "Developer Portal legacy support\n\nSetting this value to `on` will cause all new\nportals to render using the legacy rendering system by default.\n\nSetting this value to `off` will cause all new\nportals to render using the current rendering system.\n",
+      "sectionTitle": "DEVELOPER PORTAL"
+    },
+    "portal_app_auth": {
+      "defaultValue": "kong-oauth2",
+      "description": "Developer Portal application registration\nauth provider and strategy. Must be set to enable\napplication_registration plugin\n",
+      "sectionTitle": "DEVELOPER PORTAL"
+    },
+    "portal_auth": {
+      "defaultValue": null,
+      "description": "Developer Portal Authentication Plugin Name\n\nSpecifies the authentication plugin\nto apply to your Developer Portal. Developers\nwill use the specified form of authentication\nto request access, register, and login to your\nDeveloper Portal.\n\nSupported Plugins:\n\n- Basic Authentication: `portal_auth = basic-auth`\n- OIDC Authentication: `portal_auth = openid-connect`\n\n",
+      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION"
+    },
+    "portal_auth_password_complexity": {
+      "defaultValue": null,
+      "description": "Kong Portal Authentication Password Complexity (JSON)\n\nWhen portal_auth = basic-auth, this property defines\nthe rules required for Kong Portal passwords. Choose\nfrom preset rules or write your own.\n\nExample using preset rules:\n\n`portal_auth_password_complexity = { \"kong-preset\": \"min_8\" }`\n\nAll values for kong-preset require the password to contain\ncharacters from at least three of the following categories:\n\n1. Uppercase characters (A through Z)\n\n2. Lowercase characters (a through z)\n\n3. Base-10 digits (0 through 9)\n\n4. Special characters (for example, &, $, #, %)\n\nSupported preset rules:\n- `min_8`: minimum length of 8\n- `min_12`: minimum length of 12\n- `min_20`: minimum length of 20\n\nTo write your own rules, see\nhttps://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.\n\nNOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.\n\nExample:\n\n`portal_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`\n",
+      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION"
+    },
+    "portal_auth_conf": {
+      "defaultValue": null,
+      "description": "Developer Portal Authentication Plugin Config (JSON)\n\nSpecifies the plugin configuration object\nin JSON format to be applied to your Developer\nPortal authentication.\n\nFor information about Plugin Configuration\nconsult the associated plugin documentation.\n\nExample for `basic-auth`:\n\n`portal_auth_conf = { \"hide_credentials\": true }`\n",
+      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION"
+    },
+    "portal_auth_login_attempts": {
+      "defaultValue": "0",
+      "description": "Number of times a user can attempt to login to the\nDev Portal before password must be reset.\n\n0 (default) means infinite attempts allowed.\n\nNote: Any value greater than 0 will only affect\nDev Portals secured with basic-auth.\n",
+      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION"
+    },
+    "portal_session_conf": {
+      "defaultValue": null,
+      "description": "Portal Session Config (JSON)\n\nSpecifies the configuration for the\nSession plugin as used by Kong Portal.\n\nFor information about Plugin Configuration consult\nthe Kong Session Plugin documentation.\n\nExample:\n```\nportal_session_conf = { \"cookie_name\": \"portal_session\", \\\n                         \"secret\": \"changeme\", \\\n                         \"storage\": \"kong\" }\n```\n",
+      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION"
+    },
+    "portal_auto_approve": {
+      "defaultValue": "off",
+      "description": "Developer Portal Auto Approve Access\n\nWhen set to `on`, a developer will\nautomatically be marked as \"approved\" after completing\nregistration. Access can still be revoked through\nKong Manager or the Admin API.\n\nWhen set to `off`, a Kong admin will have to manually approve the Developer\nusing Kong Manager or the Admin API.\n",
+      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION"
+    },
+    "portal_token_exp": {
+      "defaultValue": "21600",
+      "description": "Duration in seconds for the expiration of the Dev Portal\nreset password token. Default is `21600` (six hours).\n",
+      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION"
+    },
+    "portal_email_verification": {
+      "defaultValue": "off",
+      "description": "Portal Developer Email Verification.\n\nWhen enabled Developers will receive an email upon\nregistration to verify their account. Developers will\nnot be able to use the Developer Portal until they\nverify their account, even if auto-approve is enabled.\n\nNote: SMTP must be turned on in order to use this feature.\n",
+      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION"
+    },
+    "portal_invite_email": {
+      "defaultValue": "on",
+      "description": "When enabled, Kong admins can invite developers to a Dev Portal by using\nthe Invite button in Kong Manager.\n\nThe email looks like the following:\n\n```\nSubject: Invite to access Dev Portal <WORKSPACE_NAME>\n\nHello Developer!\n\nYou have been invited to create a Dev Portal account at %s.\nPlease visit `<DEV_PORTAL_URL/register>` to create your account.\n```\n",
+      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION"
+    },
+    "portal_access_request_email": {
+      "defaultValue": "on",
+      "description": "When enabled, Kong admins specified by `smtp_admin_emails`\nwill receive an email when a developer requests access\nto a Dev Portal.\n\nWhen disabled, Kong admins will have to manually check\nthe Kong Manager to view any requests.\n\nThe email looks like the following:\n\n```\nSubject: Request to access Dev Portal <WORKSPACE NAME>\n\nHello Admin!\n\n<DEVELOPER NAME> has requested Dev Portal access for <WORKSPACE_NAME>.\nPlease visit <KONG_MANAGER_URL/developers/requested> to review this request.\n```\n",
+      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION"
+    },
+    "portal_approved_email": {
+      "defaultValue": "on",
+      "description": "When enabled, developers will receive an email when\naccess to a Dev Portal has been approved.\n\nWhen disabled, developers will receive no indication\nthat they have beenapproved. It is suggested to only\ndisable this feature if `portal_auto_approve`\nis enabled.\n\nThe email looks like the following:\n\n```\nSubject: Dev Portal access approved\n\nHello Developer!\nYou have been approved to access <WORKSPACE_NAME>.\nPlease visit <DEV PORTAL URL/login> to login.\n```\n",
+      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION"
+    },
+    "portal_reset_email": {
+      "defaultValue": "on",
+      "description": "When enabled, developers will be able to use the\nReset Password flow on a Dev Portal and will\nreceive an email with password reset instructions.\n\nNote: When disabled, developers will *not* be able to reset their account\npasswords. The password resetting email is the only way to reset developer\npasswords.\n\nThe email looks like the following:\n\n```\nSubject: Password Reset Instructions for Dev Portal <WORKSPACE_NAME>.\n\nHello Developer,\n\nPlease click the link below to reset your Dev Portal password.\n\n<DEV_PORTAL_URL/reset?token=12345>\n\nThis link will expire in <portal_reset_token_exp>\n\nIf you didn't make this request, keep your account secure by clicking\nthe link above to change your password.\n```\n",
+      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION"
+    },
+    "portal_reset_success_email": {
+      "defaultValue": "on",
+      "description": "When enabled, developers will receive an email\nafter successfully resetting their Dev Portal\naccount password.\n\nWhen disabled, developers will still be able\nto reset their account passwords, but will not\nreceive a confirmation email.\n\nThe email looks like the following:\n\n```\nSubject: Dev Portal password change success\n\nHello Developer,\nWe are emailing you to let you know that your Dev Portal password at <DEV_PORTAL_URL> has been changed.\n\nClick the link below to sign in with your new credentials.\n\n<DEV_PORTAL_URL>\n```\n",
+      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION"
+    },
+    "portal_application_status_email": {
+      "defaultValue": "off",
+      "description": "When enabled, developers will receive an email\nwhen the status changes for their appliciation\nservice requests.\n\nWhen disabled, developers will still be able\nto view the status in their developer portal\napplication page.\n\nThe email looks like the following:\n\n```\nSubject: Dev Portal application request <REQUEST_STATUS> (<DEV_PORTAL_URL>)\n\nHello Developer,\nWe are emailing you to let you know that your request for application access from the\nDeveloper Portal account at <DEV_PORTAL_URL> is <REQUEST_STATUS>.\n\nApplication: <APPLICATION_NAME>\nService: <SERVICE_NAME>\n\nYou will receive another email when your access has been approved.\n```\n",
+      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION"
+    },
+    "portal_application_request_email": {
+      "defaultValue": "off",
+      "description": "When enabled, Kong admins specified by `smtp_admin_emails`\nwill receive an email when a developer requests access\nto service through an application.\n\nWhen disabled, Kong admins will have to manually check\nthe Kong Manager to view any requests.\n\nBy default, `smtp_admin_emails` will be the recipients.\nThis can be overriden by `portal_smtp_admin_emails`,\nwhich can be set dynamically per workspace through\nthe Admin API.\n\nThe email looks like the following:\n\n```\nSubject: Request to access Dev Portal (<DEV_PORTAL_URL>) service from <DEVELOPER_EMAIL>\n\nHello Admin,\n\n<DEVELOPER NAME> (<DEVELOPER_EMAIL>) has requested application access for <DEV_PORTAL_URL>.\n\nRequested workspace: <WORKSPACE_NAME>\nRequested application: <APPLICATION_NAME>\nRequested service: <SERVICE_NAME>\n\nPlease visit <KONG_MANAGER_URL/WORKSPACE_NAME/applications/APPLICATION_ID#requested> to review this request.\n```\n",
+      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION"
+    },
+    "portal_emails_from": {
+      "defaultValue": null,
+      "description": "The name and email address for the `From` header\nincluded in all Dev Portal emails.\n\nExample:\n`portal_emails_from = Your Name <example@example.com>`\n\nNote: Some SMTP servers will not use\nthis value, but instead insert the email and name\nassociated with the account.\n",
+      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION"
+    },
+    "portal_emails_reply_to": {
+      "defaultValue": null,
+      "description": "Email address for the `Reply-To` header for\nportal emails\n\nExample:\n`portal_emails_reply_to = example@example.com`\n\nNote: Some SMTP servers will not use\nthis value, but instead insert the email\nassociated with the account.\n",
+      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION"
+    },
+    "portal_smtp_admin_emails": {
+      "defaultValue": null,
+      "description": "Comma separated list of admin emails to receive\nportal notifications. Can be dynamically set per\nworkspace through the Admin API.\n\nIf not set, `smtp_admin_emails` will be used.\n\nExample `admin1@example.com, admin2@example.com`\n",
+      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION"
     },
     "admin_emails_from": {
       "defaultValue": "\"\"",
@@ -1649,535 +1765,6 @@
       "description": "Defines the path to a private RSA signing key\nthat can be used to insert a signature of\naudit records, adjacent to the record. The\ncorresponding public key should be stored\noffline, and can be used to validate audit\nentries in the future. If this value is\nundefined, no signature will be generated.\n",
       "sectionTitle": "DATA & ADMIN AUDIT"
     },
-    "route_validation_strategy": {
-      "defaultValue": "smart",
-      "description": "The strategy used to validate\nroutes when creating or updating them.\nDifferent strategies are available to tune\nhow to enforce splitting traffic of\nworkspaces.\n- `smart` is the default option and uses the\n  algorithm described in\n  https://docs.konghq.com/gateway/latest/kong-enterprise/workspaces/.\n- `off` disables any check.\n- `path` enforces routes to comply with the pattern\n  described in config `enforce_route_path_pattern`.\n- `static` relies on the PostgreSQL database.\nBefore creating a new route, it checks if the\nroute is unique across all workspaces based on\nthe following params: `paths`, `methods`, and\n`hosts`. If all fields of the new route overlap\nwith an existing one, a 409 is returned with the\nroute of the collision. The array order is not\nimportant for the overlap filter.\n",
-      "sectionTitle": "ROUTE COLLISION DETECTION/PREVENTION"
-    },
-    "enforce_route_path_pattern": {
-      "defaultValue": null,
-      "description": "Specifies the Lua pattern which will\nbe enforced on the `paths` attribute of a\nroute object. You can also add a placeholder\nfor the workspace in the pattern, which\nwill be rendered during runtime based on the\nworkspace to which the `route` belongs.\nThis setting is only relevant if\n`route_validation_strategy` is set to `path`.\n\n\n**Note:** The collision detection is only supported\nfor plain text routes, do not rely on this feature\nto validate regex routes.\n\nExample\nFor Pattern `/$(workspace)/v%d/.*` valid paths\nare:\n\n1. `/group1/v1/` if route belongs to\n  workspace `group1`.\n\n2. `/group2/v1/some_path` if route belongs to\n  workspace `group2`.\n",
-      "sectionTitle": "ROUTE COLLISION DETECTION/PREVENTION"
-    },
-    "keyring_enabled": {
-      "defaultValue": "off",
-      "description": "When enabled, Kong will encrypt sensitive\nfield values before writing them to the\ndatabase, and subsequently decrypt them when\nretrieving data for the Admin API, Developer\nPortal, or proxy business logic. Symmetric\nencryption keys are managed based on the\nstrategy defined below.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_strategy": {
-      "defaultValue": "cluster",
-      "description": "Defines the strategy implementation by which\nKong nodes will manage symmetric encryption\nkeys. Please see the Kong Enterprise\ndocumentation for a detailed description of\neach strategy. Acceptable values for this\noption are `cluster` and `vault`.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_public_key": {
-      "defaultValue": null,
-      "description": "Defines the public key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nValues:\n- absolute path to the public key\n- public key content\n- base64 encoded public key content\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_private_key": {
-      "defaultValue": null,
-      "description": "Defines the private key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nValues:\n- absolute path to the private key\n- private key content\n- base64 encoded private key content\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_recovery_public_key": {
-      "defaultValue": null,
-      "description": "Defines the public key to optionally encrypt\nall keyring materials and back them up in the\ndatabase.\n\nValues:\n- absolute path to the public key\n- public key content\n- base64 encoded public key content\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_blob_path": {
-      "defaultValue": null,
-      "description": "Defines the filesystem path at which Kong\nwill back up the initial keyring material.\nThis option is useful largely for development\npurposes.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_vault_host": {
-      "defaultValue": null,
-      "description": "Defines the Vault host at which Kong will\nfetch the encryption material. This value\nshould be defined in the format:\n\n`<scheme>://<IP / HOSTNAME>:<PORT>`\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_vault_mount": {
-      "defaultValue": null,
-      "description": "Defines the name of the Vault v2 KV secrets\nengine at which symmetric keys are found.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_vault_path": {
-      "defaultValue": null,
-      "description": "Defines the name of the Vault v2 KV path\nat which symmetric keys are found.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_vault_auth_method": {
-      "defaultValue": "token",
-      "description": "Defines the authentication mechanism when\nconnecting to the Hashicorp Vault service.\n\nAccepted values are: `token`, or `kubernetes`:\n\n- `token`: Uses the static token defined in\n           the `keyring_vault_token`\n           configuration property.\n\n- `kubernetes`: Uses the Kubernetes authentication\n                mechanism, with the running pod's\n                mapped service account, to assume\n                the Hashicorp Vault role name that is\n                defined in the `keyring_vault_kube_role`\n                configuration property.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_vault_token": {
-      "defaultValue": null,
-      "description": "Defines the token value used to communicate\nwith the v2 KV Vault HTTP(S) API.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_vault_kube_role": {
-      "defaultValue": "default",
-      "description": "Defines the Hashicorp Vault role that will be\nassumed using the Kubernetes service account of\nthe running pod.\n\n`keyring_vault_auth_method` must be set to `kubernetes`\nfor this to activate.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_vault_kube_api_token_file": {
-      "defaultValue": "/run/secrets/kubernetes.io/serviceaccount/token",
-      "description": "Defines where the Kubernetes service account token\nshould be read from the pod's filesystem, if using\na non-standard container platform setup.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "keyring_encrypt_license": {
-      "defaultValue": "off",
-      "description": "Enables keyring encryption for license payloads stored\nin the database.\n\n**Warning:** For Kong deployments that rely entirely on\nthe database for license provisioning (i.e. not using\n`KONG_LICENSE_DATA` or `KONG_LICENSE_PATH`), enabling\nthis option will delay license activation until after\nthe node's keyring has been activated.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "untrusted_lua": {
-      "defaultValue": "sandbox",
-      "description": "Controls loading of Lua functions from admin-supplied\nsources such as the Admin API. LuaJIT bytecode\nloading is always disabled.\n\n**Warning:** LuaJIT is not designed as a secure\nruntime for running malicious code, therefore\nyou should properly protect your Admin API endpoint\neven with sandboxing enabled. The sandbox only\nprovides protection against trivial attackers or\nunintentional modification of the Kong global\nenvironment.\n\nAccepted values are: `off`, `sandbox`, or\n`on`:\n\n- `off`: Disallow loading of any arbitrary\n         Lua functions. The `off` option\n         disables any functionality that runs\n         arbitrary Lua code, including the\n         Serverless Functions plugins and any\n         transformation plugin that allows\n         custom Lua functions.\n\n- `sandbox`: Allow loading of Lua functions,\n             but use a sandbox when executing\n             them. The sandboxed function has\n             restricted access to the global\n             environment and only has access\n             to Kong PDK, OpenResty, and\n             standard Lua functions that will\n             generally not cause harm to the\n             Kong Gateway node.\n\n- `on`: Functions have unrestricted\n        access to the global environment and\n        can load any Lua modules. This is\n        similar to the behavior in\n        Kong Gateway prior to 2.3.0.\n\nThe default `sandbox` environment does not\nallow importing other modules or libraries,\nor executing anything at the OS level (for\nexample, file read/write). The global\nenvironment is also not accessible.\n\nExamples of `untrusted_lua = sandbox`\nbehavior:\n\n- You can't access or change global values\n  such as `kong.configuration.pg_password`\n- You can run harmless Lua:\n  `local foo = 1 + 1`. However, OS level\n  functions are not allowed, like:\n  `os.execute(`rm -rf /*`)`.\n\nTo customize the sandbox environment, use\nthe `untrusted_lua_sandbox_requires` and\n`untrusted_lua_sandbox_environment`\nparameters below.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "untrusted_lua_sandbox_requires": {
-      "defaultValue": null,
-      "description": "Comma-separated list of modules allowed to\nbe loaded with `require` inside the\nsandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\nFor example, say you have configured the\nServerless pre-function plugin and it\ncontains the following `requires`:\n\n```\nlocal template = require \"resty.template\"\nlocal split = require \"kong.tools.string\".split\n```\n\nTo run the plugin, add the modules to the\nallowed list:\n```\nuntrusted_lua_sandbox_requires = resty.template, kong.tools.utils\n```\n\n**Warning:** Allowing certain modules may\ncreate opportunities to escape the\nsandbox. For example, allowing `os` or\n`luaposix` may be unsafe.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "untrusted_lua_sandbox_environment": {
-      "defaultValue": null,
-      "description": "Comma-separated list of global Lua\nvariables that should be made available\ninside the sandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\n**Warning**: Certain variables, when made\navailable, may create opportunities to\nescape the sandbox.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "openresty_path": {
-      "defaultValue": null,
-      "description": "Path to the OpenResty installation that Kong\nwill use. When this is empty (the default),\nKong determines the OpenResty installation\nby searching for a system-installed OpenResty\nand falling back to searching $PATH for the\nnginx binary.\n\nSetting this attribute disables the search\nbehavior and explicitly instructs Kong which\nOpenResty installation to use.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "node_id": {
-      "defaultValue": null,
-      "description": "Node ID for the Kong node. Every Kong node\nin a Kong cluster must have a unique and\nvalid UUID. When empty, node ID is\nautomatically generated.\n",
-      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
-    },
-    "cluster_fallback_config_import": {
-      "defaultValue": "off",
-      "description": "Enable fallback configuration imports.\n\nThis should only be enabled for data planes.\n",
-      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
-    },
-    "cluster_fallback_config_storage": {
-      "defaultValue": null,
-      "description": "Storage definition used by `cluster_fallback_config_import`\nand `cluster_fallback_config_export`.\n\nSupported storage types:\n- S3-like storages\n- GCP storage service\n\nTo use S3 with a bucket named b and place all configs\nto with a key prefix named p, set it to:\n`s3://b/p`\nTo use GCP for the same bucket and prefix, set it to:\n`gcs://b/p`\n\nThe credentials (and the endpoint URL for S3-like) for S3\nare passed with environment variables:\n`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,\nand `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where\n`AWS_CONFIG_STORAGE_ENDPOINT`\nis the endpoint that hosts S3-like storage.\n\nThe credentials for GCP are provided via the environment\nvariable `GCP_SERVICE_ACCOUNT`.\n",
-      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
-    },
-    "cluster_fallback_export_s3_config": {
-      "defaultValue": null,
-      "description": "Fallback config export S3 configuration.\nThis is used only when `cluster_fallback_config_storage` is an S3-like schema.\nIf set, it will add the config table to the Kong exporter config S3 putObject request.\nThe config table should be in JSON format and can be unserialized into a table.\nIt should contain the necessary parameters as described in the documentation:\nhttps://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property.\nFor example, if you want to set the ServerSideEncryption headers/KMS Key ID\nfor the S3 putObject request, you can set the config table to:\n`{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"your-kms-key-id\"}`\n",
-      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
-    },
-    "cluster_fallback_config_export": {
-      "defaultValue": "off",
-      "description": "Enable fallback configuration exports.\n",
-      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
-    },
-    "cluster_fallback_config_export_delay": {
-      "defaultValue": "60",
-      "description": "The fallback configuration export interval.\n\nIf the interval is set to 60 and configuration A is exported\nand there are new configurations B, C, and D in the next 60 seconds,\nit will wait until 60 seconds passed and export D, skipping B and C.\n",
-      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
-    },
-    "wasm": {
-      "defaultValue": "off",
-      "description": "Enable/disable wasm support. This must be enabled in\norder to use wasm filters and filter chains.\n",
-      "sectionTitle": "WEBASSEMBLY (WASM)"
-    },
-    "wasm_filters_path": {
-      "defaultValue": null,
-      "description": "Path to the directory containing wasm filter modules.\n\nAt startup, Kong discovers available wasm filters by\nscanning this directory for files with the `.wasm`\nfile extension.\n\nThe name of a wasm filter module is derived from the\nfilename itself, with the .wasm extension removed. So,\ngiven the following tree:\n\n```\n/path/to/wasm_filters\n├── my_module.wasm\n├── my_other_module.wasm\n└── not_a_wasm_module.txt\n```\n\nThe resulting filter modules available for use in Kong\nwill be:\n\n- `my_module`\n- `my_other_module`\n\nNotes:\n\n- No recursion is performed. Only .wasm files at the\n  top level are registered.\n- This path _may_ be a symlink to a directory.\n",
-      "sectionTitle": "WEBASSEMBLY (WASM)"
-    },
-    "wasm_filters": {
-      "defaultValue": [
-        "bundled",
-        "user"
-      ],
-      "description": "Comma-separated list of Wasm filters to be made\navailable for use in filter chains.\n\nWhen the `off` keyword is specified as the\nonly value, no filters will be available for use.\n\nWhen the `bundled` keyword is specified, all filters\nbundled with Kong will be available.\n\nWhen the `user` keyword is specified, all filters\nwithin the `wasm_filters_path` will be available.\n\n**Examples:**\n\n- `wasm_filters = bundled,user` enables _all_ bundled\n  and user-supplied filters\n- `wasm_filters = user` enables _only_ user-supplied\n  filters\n- `wasm_filters = filter-a,filter-b` enables _only_\n  filters named `filter-a` or `filter-b` (whether\n  bundled _or_ user-supplied)\n\nIf a conflict occurs where a bundled filter and a\nuser-supplied filter share the same name, a warning\nwill be logged, and the user-supplied filter will\nbe used instead.\n",
-      "sectionTitle": "WEBASSEMBLY (WASM)"
-    },
-    "test": {
-      "defaultValue": "on",
-      "description": "test\n",
-      "sectionTitle": "WASM injected directives"
-    },
-    "request_debug": {
-      "defaultValue": "on",
-      "description": "When enabled, Kong will provide detailed timing information\nfor its components to the client and the error log\nif the following headers are present in the proxy request:\n- `X-Kong-Request-Debug`:\n  If the value is set to `*`,\n  timing information will be collected and exported for the current request.\n  If this header is not present or contains an unknown value,\n  timing information will not be collected for the current request.\n  You can also specify a list of filters, separated by commas,\n  to filter the scope of the time information that is collected.\nThe following filters are supported for `X-Kong-Request-Debug`:\n- `rewrite`: Collect timing information from the `rewrite` phase.\n- `access`: Collect timing information from the `access` phase.\n- `balancer`: Collect timing information from the `balancer` phase.\n- `response`: Collect timing information from the `response` phase.\n- `header_filter`: Collect timing information from the `header_filter` phase.\n- `body_filter`: Collect timing information from the `body_filter` phase.\n- `log`: Collect timing information from the `log` phase.\n- `upstream`: Collect timing information from the `upstream` phase.\n\n- `X-Kong-Request-Debug-Log`:\n  If set to `true`, timing information will also be logged\n  in the Kong error log with a log level of `notice`.\n  Defaults to `false`.\n\n- `X-Kong-Request-Debug-Token`:\n  Token for authenticating the client making the debug\n  request to prevent abuse.\n  ** Note: Debug requests originating from loopback\n  addresses do not require this header. Deploying Kong behind\n  other proxies may result in exposing the debug interface to\n  the public.**\n\n",
-      "sectionTitle": "REQUEST DEBUGGING"
-    },
-    "request_debug_token": {
-      "defaultValue": "<random>",
-      "description": "The Request Debug Token is used in the\n`X-Kong-Request-Debug-Token` header to prevent abuse.\nIf this value is not set (the default),\na random token will be generated\nwhen Kong starts, restarts, or reloads. If a token is\nspecified manually, then the provided token will be used.\n\nYou can locate the generated debug token in two locations:\n- Kong error log:\n  Debug token will be logged in the error log (notice level)\n  when Kong starts, restarts, or reloads.\n  The log line will have the: `[request-debug]` prefix to aid searching.\n- Filesystem:\n  Debug token will also be stored in a file located at\n  `{prefix}/.request_debug_token` and updated\n  when Kong starts, restarts, or reloads.\n",
-      "sectionTitle": "REQUEST DEBUGGING"
-    },
-    "vitals": {
-      "defaultValue": "on",
-      "description": "When enabled, Kong will store and report\nmetrics about its performance.\n\nWhen running Kong in a multi-node setup,\n`vitals` entails two separate meanings\ndepending on the node.\n\nOn a Proxy-only node, `vitals` determines\nwhether to collect data for Vitals.\n\nOn an Admin-only node, `vitals` determines\nwhether to display Vitals metrics and\nvisualizations on the dashboard.\n",
-      "sectionTitle": "VITALS",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "vitals_strategy": {
-      "defaultValue": "database",
-      "description": "Determines whether to use the Kong database or\na separate storage engine for Vitals metrics.\nAccepted values are `database`, `prometheus`,\nor `influxdb`.\n",
-      "sectionTitle": "VITALS",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "vitals_tsdb_address": {
-      "defaultValue": null,
-      "description": "Defines the host and port of the TSDB server\nto which Vitals data is written and read.\nThis value is only applied when the\n`vitals_strategy` option is set to\n`prometheus` or `influxdb`. This value\naccepts IPv4, IPv6, and hostname values.\nIf the `vitals_strategy` is set to\n`prometheus`, this value determines the\naddress of the Prometheus server from which\nVitals data will be read. For `influxdb`\nstrategies, this value controls both the read\nand write source for Vitals data.\n",
-      "sectionTitle": "VITALS",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "vitals_tsdb_user": {
-      "defaultValue": null,
-      "description": "Influxdb user\n",
-      "sectionTitle": "VITALS",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "vitals_tsdb_password": {
-      "defaultValue": null,
-      "description": "Influxdb password\n",
-      "sectionTitle": "VITALS",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "vitals_statsd_address": {
-      "defaultValue": null,
-      "description": "Defines the host and port (and an optional\nprotocol) of the StatsD server to which\nKong should write Vitals metics. This value\nis only applied when the `vitals_strategy` is\nset to `prometheus`. This value accepts IPv4,\nIPv6, and, hostnames. Additionally, the suffix\n`tcp` can be specified; doing so will result\nin Kong sending StatsD metrics via TCP\ninstead of the UDP (default).\n",
-      "sectionTitle": "VITALS",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "vitals_statsd_prefix": {
-      "defaultValue": "kong",
-      "description": "Defines the prefix value attached to all\nVitals StatsD events. This prefix is useful\nwhen writing metrics to a multi-tenant StatsD\nexporter or server.\n",
-      "sectionTitle": "VITALS",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "vitals_statsd_udp_packet_size": {
-      "defaultValue": "1024",
-      "description": "Defines the maximum buffer size in\nwhich Vitals statsd metrics will be\nheld and sent in batches.\nThis value is defined in bytes.\n",
-      "sectionTitle": "VITALS",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "vitals_prometheus_scrape_interval": {
-      "defaultValue": "5",
-      "description": "Defines the scrape_interval query\nparameter sent to the Prometheus\nserver when reading Vitals data.\nThis should be same as the scrape\ninterval (in seconds) of the\nPrometheus server.\n",
-      "sectionTitle": "VITALS",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal": {
-      "defaultValue": "off",
-      "description": "Developer Portal Switch\n\nWhen enabled:\n\n  Kong will expose the Dev Portal interface and\n  read-only APIs on the `portal_gui_listen` address,\n  and endpoints on the Admin API to manage assets.\n\nWhen enabled along with `portal_auth`:\n\n  Kong will expose management endpoints for developer\n  accounts on the Admin API and the Dev Portal API.\n",
-      "sectionTitle": "DEVELOPER PORTAL",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_gui_listen": {
-      "defaultValue": [
-        "0.0.0.0:8003",
-        "0.0.0.0:8446 ssl"
-      ],
-      "description": "Developer Portal GUI Listeners\n\nComma-separated list of addresses on which Kong will\nexpose the Developer Portal GUI. Suffixes can be\nspecified for each pair, similarly to\nthe `admin_listen` directive.\n",
-      "sectionTitle": "DEVELOPER PORTAL",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_gui_protocol": {
-      "defaultValue": "http",
-      "description": "Developer Portal GUI protocol\n\nThe protocol used in conjunction with\n`portal_gui_host` to construct the lookup, or balancer\naddress for your Kong Proxy nodes.\n\nExamples: `http`,`https`\n",
-      "sectionTitle": "DEVELOPER PORTAL",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_gui_host": {
-      "defaultValue": "127.0.0.1:8003",
-      "description": "Developer Portal GUI host\n\nThe host used in conjunction with\n`portal_gui_protocol` to construct the lookup,\nor balancer address for your Kong Proxy nodes.\n\nExamples:\n\n- `<IP>:<PORT>`\n  -> `portal_gui_host = 127.0.0.1:8003`\n- `<HOSTNAME>`\n  -> `portal_gui_host = portal_api.domain.tld`\n- `<HOSTNAME>/<PATH>`\n  -> `portal_gui_host = dev-machine/dev-285`\n",
-      "sectionTitle": "DEVELOPER PORTAL",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_cors_origins": {
-      "defaultValue": null,
-      "description": "Developer Portal CORS Origins\n\nA comma separated list of allowed domains for\n`Access-Control-Allow-Origin` header. This can be used to\nresolve CORS issues in custom networking environments.\n\nExamples:\n- list of domains:\n  `portal_cors_origins = http://localhost:8003, https://localhost:8004`\n- single domain:\n  `portal_cors_origins = http://localhost:8003`\n- all domains:\n  `portal_cors_origins = *`\n\nNOTE: In most cases, the Developer Portal is able to derive\nvalid CORS origins by using `portal_gui_protocol`, `portal_gui_host`,\nand if applicable, `portal_gui_use_subdomains`. In these cases,\n`portal_cors_origins` is not needed and can remain unset.\n",
-      "sectionTitle": "DEVELOPER PORTAL",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_gui_use_subdomains": {
-      "defaultValue": "off",
-      "description": "Developer Portal GUI subdomain toggle\n\nBy default Kong Portal uses the first namespace in\nthe request path to determine workspace. By turning\n`portal_gui_subdomains` on, Kong Portal will expect\nworkspace to be included in the request url as a subdomain.\n\nExample (off):\n  - `<scheme>://<HOSTNAME>/<WORKSPACE>/<PATH>` ->\n    `http://kong-portal.com/example-workspace/index`\n\nExample (on):\n  - `<scheme>://<WORKSPACE>.<HOSTNAME>` ->\n    `http://example-workspace.kong-portal.com/index`\n",
-      "sectionTitle": "DEVELOPER PORTAL",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_gui_ssl_cert": {
-      "defaultValue": null,
-      "description": "Developer Portal GUI SSL Certificate\n\nThe SSL certificate for `portal_gui_listen` values\nwith SSL enabled.\n\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n",
-      "sectionTitle": "DEVELOPER PORTAL",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_gui_ssl_cert_key": {
-      "defaultValue": null,
-      "description": "Developer Portal GUI SSL Certificate Key\n\nThe SSL key for `portal_gui_listen` values with\nSSL enabled.\n\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n",
-      "sectionTitle": "DEVELOPER PORTAL",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_gui_access_log": {
-      "defaultValue": "logs/portal_gui_access.log",
-      "description": "Developer Portal GUI Access Log location\n\nHere you can set an absolute or relative path for your\nPortal GUI access logs.\n\nSetting this value to `off` will disable logging\nPortal GUI access logs.\n\nWhen using relative pathing, logs will be placed under\nthe `prefix` location.\n",
-      "sectionTitle": "DEVELOPER PORTAL",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_gui_error_log": {
-      "defaultValue": "logs/portal_gui_error.log",
-      "description": "Developer Portal GUI Error Log location\n\nHere you can set an absolute or relative path for your\nPortal GUI error logs.\n\nSetting this value to `off` will disable logging\nPortal GUI error logs.\n\nWhen using relative pathing, logs will be placed under\nthe `prefix` location.\n\nGranularity can be adjusted through the `log_level`\ndirective.\n",
-      "sectionTitle": "DEVELOPER PORTAL",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_api_listen": {
-      "defaultValue": [
-        "0.0.0.0:8004",
-        "0.0.0.0:8447 ssl"
-      ],
-      "description": "Developer Portal API Listeners\n\nComma-separated list of addresses on which Kong will\nexpose the Developer Portal API. Suffixes can be\nspecified for each pair, similarly to\nthe `admin_listen` directive.\n",
-      "sectionTitle": "DEVELOPER PORTAL",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_api_url": {
-      "defaultValue": null,
-      "description": "Developer Portal API URL\n\nThe lookup, or balancer, address for your Developer\nPortal nodes.\n\nThis value is commonly used in a microservices\nor service-mesh oriented architecture.\n\n`portal_api_url` is the address on which your\nKong Dev Portal API is accessible by Kong. You\nshould only set this value if your Kong Dev Portal API\nlives on a different node than your Kong Proxy.\n\nAccepted format (parts in parenthesis are optional):\n\n  `<scheme>://<IP / HOSTNAME>(:<PORT>(/<PATH>))`\n\nExamples:\n\n- `<scheme>://<IP>:<PORT>`\n  -> `portal_api_url = http://127.0.0.1:8003`\n- `SSL <scheme>://<HOSTNAME>`\n  -> `portal_api_url = https://portal_api.domain.tld`\n- `<scheme>://<HOSTNAME>/<PATH>`\n  -> `portal_api_url = http://dev-machine/dev-285`\n\nBy default this value points to the local interface:\n\n- `http://0.0.0.0:8004`\n",
-      "sectionTitle": "DEVELOPER PORTAL",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_api_ssl_cert": {
-      "defaultValue": null,
-      "description": "Developer Portal API SSL Certificate\n\nThe SSL certificate for `portal_api_listen` values\nwith SSL enabled.\n\nvalues:\n* absolute path to the certificate\n* certificate content\n* base64 encoded certificate content\n",
-      "sectionTitle": "DEVELOPER PORTAL",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_api_ssl_cert_key": {
-      "defaultValue": null,
-      "description": "Developer Portal API SSL Certificate Key\n\nThe SSL key for `portal_api_listen` values with\nSSL enabled.\n\nvalues:\n* absolute path to the certificate key\n* certificate key content\n* base64 encoded certificate key content\n",
-      "sectionTitle": "DEVELOPER PORTAL",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_api_access_log": {
-      "defaultValue": "logs/portal_api_access.log",
-      "description": "Developer Portal API Access Log location\n\nHere you can set an absolute or relative path for your\nPortal API access logs.\n\nSetting this value to `off` will disable logging\nPortal API access logs.\n\nWhen using relative pathing, logs will be placed under\nthe `prefix` location.\n",
-      "sectionTitle": "DEVELOPER PORTAL",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_api_error_log": {
-      "defaultValue": "logs/portal_api_error.log",
-      "description": "Developer Portal API Error Log location\n\nHere you can set an absolute or relative path for your\nPortal API error logs.\n\nSetting this value to `off` will disable logging\nPortal API error logs.\n\nWhen using relative pathing, logs will be placed under\nthe `prefix` location.\n\nGranularity can be adjusted through the `log_level`\ndirective.\n",
-      "sectionTitle": "DEVELOPER PORTAL",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_is_legacy": {
-      "defaultValue": "off",
-      "description": "Developer Portal legacy support\n\nSetting this value to `on` will cause all new\nportals to render using the legacy rendering system by default.\n\nSetting this value to `off` will cause all new\nportals to render using the current rendering system.\n",
-      "sectionTitle": "DEVELOPER PORTAL",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_app_auth": {
-      "defaultValue": "kong-oauth2",
-      "description": "Developer Portal application registration\nauth provider and strategy. Must be set to enable\napplication_registration plugin\n",
-      "sectionTitle": "DEVELOPER PORTAL",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_auth": {
-      "defaultValue": null,
-      "description": "Developer Portal Authentication Plugin Name\n\nSpecifies the authentication plugin\nto apply to your Developer Portal. Developers\nwill use the specified form of authentication\nto request access, register, and login to your\nDeveloper Portal.\n\nSupported Plugins:\n\n- Basic Authentication: `portal_auth = basic-auth`\n- OIDC Authentication: `portal_auth = openid-connect`\n\n",
-      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_auth_password_complexity": {
-      "defaultValue": null,
-      "description": "Kong Portal Authentication Password Complexity (JSON)\n\nWhen portal_auth = basic-auth, this property defines\nthe rules required for Kong Portal passwords. Choose\nfrom preset rules or write your own.\n\nExample using preset rules:\n\n`portal_auth_password_complexity = { \"kong-preset\": \"min_8\" }`\n\nAll values for kong-preset require the password to contain\ncharacters from at least three of the following categories:\n\n1. Uppercase characters (A through Z)\n\n2. Lowercase characters (a through z)\n\n3. Base-10 digits (0 through 9)\n\n4. Special characters (for example, &, $, #, %)\n\nSupported preset rules:\n- `min_8`: minimum length of 8\n- `min_12`: minimum length of 12\n- `min_20`: minimum length of 20\n\nTo write your own rules, see\nhttps://manpages.debian.org/jessie/passwdqc/passwdqc.conf.5.en.html.\n\nNOTE: Only keywords \"min\", \"max\" and \"passphrase\" are supported.\n\nExample:\n\n`portal_auth_password_complexity = { \"min\": \"disabled,24,11,9,8\" }`\n",
-      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_auth_conf": {
-      "defaultValue": null,
-      "description": "Developer Portal Authentication Plugin Config (JSON)\n\nSpecifies the plugin configuration object\nin JSON format to be applied to your Developer\nPortal authentication.\n\nFor information about Plugin Configuration\nconsult the associated plugin documentation.\n\nExample for `basic-auth`:\n\n`portal_auth_conf = { \"hide_credentials\": true }`\n",
-      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_auth_login_attempts": {
-      "defaultValue": "0",
-      "description": "Number of times a user can attempt to login to the\nDev Portal before password must be reset.\n\n0 (default) means infinite attempts allowed.\n\nNote: Any value greater than 0 will only affect\nDev Portals secured with basic-auth.\n",
-      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_session_conf": {
-      "defaultValue": null,
-      "description": "Portal Session Config (JSON)\n\nSpecifies the configuration for the\nSession plugin as used by Kong Portal.\n\nFor information about Plugin Configuration consult\nthe Kong Session Plugin documentation.\n\nExample:\n```\nportal_session_conf = { \"cookie_name\": \"portal_session\", \\\n                         \"secret\": \"changeme\", \\\n                         \"storage\": \"kong\" }\n```\n",
-      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_auto_approve": {
-      "defaultValue": "off",
-      "description": "Developer Portal Auto Approve Access\n\nWhen set to `on`, a developer will\nautomatically be marked as \"approved\" after completing\nregistration. Access can still be revoked through\nKong Manager or the Admin API.\n\nWhen set to `off`, a Kong admin will have to manually approve the Developer\nusing Kong Manager or the Admin API.\n",
-      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_token_exp": {
-      "defaultValue": "21600",
-      "description": "Duration in seconds for the expiration of the Dev Portal\nreset password token. Default is `21600` (six hours).\n",
-      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_email_verification": {
-      "defaultValue": "off",
-      "description": "Portal Developer Email Verification.\n\nWhen enabled Developers will receive an email upon\nregistration to verify their account. Developers will\nnot be able to use the Developer Portal until they\nverify their account, even if auto-approve is enabled.\n\nNote: SMTP must be turned on in order to use this feature.\n",
-      "sectionTitle": "DEFAULT DEVELOPER PORTAL AUTHENTICATION",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_invite_email": {
-      "defaultValue": "on",
-      "description": "When enabled, Kong admins can invite developers to a Dev Portal by using\nthe Invite button in Kong Manager.\n\nThe email looks like the following:\n\n```\nSubject: Invite to access Dev Portal <WORKSPACE_NAME>\n\nHello Developer!\n\nYou have been invited to create a Dev Portal account at %s.\nPlease visit `<DEV_PORTAL_URL/register>` to create your account.\n```\n",
-      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_access_request_email": {
-      "defaultValue": "on",
-      "description": "When enabled, Kong admins specified by `smtp_admin_emails`\nwill receive an email when a developer requests access\nto a Dev Portal.\n\nWhen disabled, Kong admins will have to manually check\nthe Kong Manager to view any requests.\n\nThe email looks like the following:\n\n```\nSubject: Request to access Dev Portal <WORKSPACE NAME>\n\nHello Admin!\n\n<DEVELOPER NAME> has requested Dev Portal access for <WORKSPACE_NAME>.\nPlease visit <KONG_MANAGER_URL/developers/requested> to review this request.\n```\n",
-      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_approved_email": {
-      "defaultValue": "on",
-      "description": "When enabled, developers will receive an email when\naccess to a Dev Portal has been approved.\n\nWhen disabled, developers will receive no indication\nthat they have beenapproved. It is suggested to only\ndisable this feature if `portal_auto_approve`\nis enabled.\n\nThe email looks like the following:\n\n```\nSubject: Dev Portal access approved\n\nHello Developer!\nYou have been approved to access <WORKSPACE_NAME>.\nPlease visit <DEV PORTAL URL/login> to login.\n```\n",
-      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_reset_email": {
-      "defaultValue": "on",
-      "description": "When enabled, developers will be able to use the\nReset Password flow on a Dev Portal and will\nreceive an email with password reset instructions.\n\nNote: When disabled, developers will *not* be able to reset their account\npasswords. The password resetting email is the only way to reset developer\npasswords.\n\nThe email looks like the following:\n\n```\nSubject: Password Reset Instructions for Dev Portal <WORKSPACE_NAME>.\n\nHello Developer,\n\nPlease click the link below to reset your Dev Portal password.\n\n<DEV_PORTAL_URL/reset?token=12345>\n\nThis link will expire in <portal_reset_token_exp>\n\nIf you didn't make this request, keep your account secure by clicking\nthe link above to change your password.\n```\n",
-      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_reset_success_email": {
-      "defaultValue": "on",
-      "description": "When enabled, developers will receive an email\nafter successfully resetting their Dev Portal\naccount password.\n\nWhen disabled, developers will still be able\nto reset their account passwords, but will not\nreceive a confirmation email.\n\nThe email looks like the following:\n\n```\nSubject: Dev Portal password change success\n\nHello Developer,\nWe are emailing you to let you know that your Dev Portal password at <DEV_PORTAL_URL> has been changed.\n\nClick the link below to sign in with your new credentials.\n\n<DEV_PORTAL_URL>\n```\n",
-      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_application_status_email": {
-      "defaultValue": "off",
-      "description": "When enabled, developers will receive an email\nwhen the status changes for their appliciation\nservice requests.\n\nWhen disabled, developers will still be able\nto view the status in their developer portal\napplication page.\n\nThe email looks like the following:\n\n```\nSubject: Dev Portal application request <REQUEST_STATUS> (<DEV_PORTAL_URL>)\n\nHello Developer,\nWe are emailing you to let you know that your request for application access from the\nDeveloper Portal account at <DEV_PORTAL_URL> is <REQUEST_STATUS>.\n\nApplication: <APPLICATION_NAME>\nService: <SERVICE_NAME>\n\nYou will receive another email when your access has been approved.\n```\n",
-      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_application_request_email": {
-      "defaultValue": "off",
-      "description": "When enabled, Kong admins specified by `smtp_admin_emails`\nwill receive an email when a developer requests access\nto service through an application.\n\nWhen disabled, Kong admins will have to manually check\nthe Kong Manager to view any requests.\n\nBy default, `smtp_admin_emails` will be the recipients.\nThis can be overriden by `portal_smtp_admin_emails`,\nwhich can be set dynamically per workspace through\nthe Admin API.\n\nThe email looks like the following:\n\n```\nSubject: Request to access Dev Portal (<DEV_PORTAL_URL>) service from <DEVELOPER_EMAIL>\n\nHello Admin,\n\n<DEVELOPER NAME> (<DEVELOPER_EMAIL>) has requested application access for <DEV_PORTAL_URL>.\n\nRequested workspace: <WORKSPACE_NAME>\nRequested application: <APPLICATION_NAME>\nRequested service: <SERVICE_NAME>\n\nPlease visit <KONG_MANAGER_URL/WORKSPACE_NAME/applications/APPLICATION_ID#requested> to review this request.\n```\n",
-      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_emails_from": {
-      "defaultValue": null,
-      "description": "The name and email address for the `From` header\nincluded in all Dev Portal emails.\n\nExample:\n`portal_emails_from = Your Name <example@example.com>`\n\nNote: Some SMTP servers will not use\nthis value, but instead insert the email and name\nassociated with the account.\n",
-      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_emails_reply_to": {
-      "defaultValue": null,
-      "description": "Email address for the `Reply-To` header for\nportal emails\n\nExample:\n`portal_emails_reply_to = example@example.com`\n\nNote: Some SMTP servers will not use\nthis value, but instead insert the email\nassociated with the account.\n",
-      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
-    "portal_smtp_admin_emails": {
-      "defaultValue": null,
-      "description": "Comma separated list of admin emails to receive\nportal notifications. Can be dynamically set per\nworkspace through the Admin API.\n\nIf not set, `smtp_admin_emails` will be used.\n\nExample `admin1@example.com, admin2@example.com`\n",
-      "sectionTitle": "DEFAULT PORTAL SMTP CONFIGURATION",
-      "min_version": {
-        "gateway": "3.4"
-      }
-    },
     "tracing": {
       "defaultValue": "off",
       "description": "When enabled, Kong will generate granular\ndebug data about various portions of the\nrequest lifecycle, such as DB or DNS queries,\nplugin execution, core handler timing, etc.\n",
@@ -2232,6 +1819,284 @@
       "sectionTitle": "GRANULAR TRACING",
       "removed_in": {
         "gateway": "3.7"
+      }
+    },
+    "route_validation_strategy": {
+      "defaultValue": "smart",
+      "description": "The strategy used to validate\nroutes when creating or updating them.\nDifferent strategies are available to tune\nhow to enforce splitting traffic of\nworkspaces.\n- `smart` is the default option and uses the\n  algorithm described in\n  https://docs.konghq.com/gateway/latest/kong-enterprise/workspaces/.\n- `off` disables any check.\n- `path` enforces routes to comply with the pattern\n  described in config `enforce_route_path_pattern`.\n- `static` relies on the PostgreSQL database.\nBefore creating a new route, it checks if the\nroute is unique across all workspaces based on\nthe following params: `paths`, `methods`, and\n`hosts`. If all fields of the new route overlap\nwith an existing one, a 409 is returned with the\nroute of the collision. The array order is not\nimportant for the overlap filter.\n",
+      "sectionTitle": "ROUTE COLLISION DETECTION/PREVENTION"
+    },
+    "enforce_route_path_pattern": {
+      "defaultValue": null,
+      "description": "Specifies the Lua pattern which will\nbe enforced on the `paths` attribute of a\nroute object. You can also add a placeholder\nfor the workspace in the pattern, which\nwill be rendered during runtime based on the\nworkspace to which the `route` belongs.\nThis setting is only relevant if\n`route_validation_strategy` is set to `path`.\n\n\n**Note:** The collision detection is only supported\nfor plain text routes, do not rely on this feature\nto validate regex routes.\n\nExample\nFor Pattern `/$(workspace)/v%d/.*` valid paths\nare:\n\n1. `/group1/v1/` if route belongs to\n  workspace `group1`.\n\n2. `/group2/v1/some_path` if route belongs to\n  workspace `group2`.\n",
+      "sectionTitle": "ROUTE COLLISION DETECTION/PREVENTION"
+    },
+    "keyring_enabled": {
+      "defaultValue": "off",
+      "description": "When enabled, Kong will encrypt sensitive\nfield values before writing them to the\ndatabase, and subsequently decrypt them when\nretrieving data for the Admin API, Developer\nPortal, or proxy business logic. Symmetric\nencryption keys are managed based on the\nstrategy defined below.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_strategy": {
+      "defaultValue": "cluster",
+      "description": "Defines the strategy implementation by which\nKong nodes will manage symmetric encryption\nkeys. Please see the Kong Enterprise\ndocumentation for a detailed description of\neach strategy. Acceptable values for this\noption are `cluster` and `vault`.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_public_key": {
+      "defaultValue": null,
+      "description": "Defines the public key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nValues:\n- absolute path to the public key\n- public key content\n- base64 encoded public key content\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_private_key": {
+      "defaultValue": null,
+      "description": "Defines the private key of an RSA keypair.\nThis keypair is used for symmetric keyring\nimport/export, e.g., for disaster recovery\nand optional bootstrapping.\n\nValues:\n- absolute path to the private key\n- private key content\n- base64 encoded private key content\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_blob_path": {
+      "defaultValue": null,
+      "description": "Defines the filesystem path at which Kong\nwill back up the initial keyring material.\nThis option is useful largely for development\npurposes.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_host": {
+      "defaultValue": null,
+      "description": "Defines the Vault host at which Kong will\nfetch the encryption material. This value\nshould be defined in the format:\n\n`<scheme>://<IP / HOSTNAME>:<PORT>`\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_mount": {
+      "defaultValue": null,
+      "description": "Defines the name of the Vault v2 KV secrets\nengine at which symmetric keys are found.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_path": {
+      "defaultValue": null,
+      "description": "Defines the name of the Vault v2 KV path\nat which symmetric keys are found.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_auth_method": {
+      "defaultValue": "token",
+      "description": "Defines the authentication mechanism when\nconnecting to the Hashicorp Vault service.\n\nAccepted values are: `token`, or `kubernetes`:\n\n- `token`: Uses the static token defined in\n           the `keyring_vault_token`\n           configuration property.\n\n- `kubernetes`: Uses the Kubernetes authentication\n                mechanism, with the running pod's\n                mapped service account, to assume\n                the Hashicorp Vault role name that is\n                defined in the `keyring_vault_kube_role`\n                configuration property.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_token": {
+      "defaultValue": null,
+      "description": "Defines the token value used to communicate\nwith the v2 KV Vault HTTP(S) API.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_kube_role": {
+      "defaultValue": "default",
+      "description": "Defines the Hashicorp Vault role that will be\nassumed using the Kubernetes service account of\nthe running pod.\n\n`keyring_vault_auth_method` must be set to `kubernetes`\nfor this to activate.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_vault_kube_api_token_file": {
+      "defaultValue": "/run/secrets/kubernetes.io/serviceaccount/token",
+      "description": "Defines where the Kubernetes service account token\nshould be read from the pod's filesystem, if using\na non-standard container platform setup.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "untrusted_lua": {
+      "defaultValue": "sandbox",
+      "description": "Controls loading of Lua functions from admin-supplied\nsources such as the Admin API. LuaJIT bytecode\nloading is always disabled.\n\n**Warning:** LuaJIT is not designed as a secure\nruntime for running malicious code, therefore\nyou should properly protect your Admin API endpoint\neven with sandboxing enabled. The sandbox only\nprovides protection against trivial attackers or\nunintentional modification of the Kong global\nenvironment.\n\nAccepted values are: `off`, `sandbox`, or\n`on`:\n\n- `off`: Disallow loading of any arbitrary\n         Lua functions. The `off` option\n         disables any functionality that runs\n         arbitrary Lua code, including the\n         Serverless Functions plugins and any\n         transformation plugin that allows\n         custom Lua functions.\n\n- `sandbox`: Allow loading of Lua functions,\n             but use a sandbox when executing\n             them. The sandboxed function has\n             restricted access to the global\n             environment and only has access\n             to Kong PDK, OpenResty, and\n             standard Lua functions that will\n             generally not cause harm to the\n             Kong Gateway node.\n\n- `on`: Functions have unrestricted\n        access to the global environment and\n        can load any Lua modules. This is\n        similar to the behavior in\n        Kong Gateway prior to 2.3.0.\n\nThe default `sandbox` environment does not\nallow importing other modules or libraries,\nor executing anything at the OS level (for\nexample, file read/write). The global\nenvironment is also not accessible.\n\nExamples of `untrusted_lua = sandbox`\nbehavior:\n\n- You can't access or change global values\n  such as `kong.configuration.pg_password`\n- You can run harmless Lua:\n  `local foo = 1 + 1`. However, OS level\n  functions are not allowed, like:\n  `os.execute(`rm -rf /*`)`.\n\nTo customize the sandbox environment, use\nthe `untrusted_lua_sandbox_requires` and\n`untrusted_lua_sandbox_environment`\nparameters below.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "untrusted_lua_sandbox_requires": {
+      "defaultValue": null,
+      "description": "Comma-separated list of modules allowed to\nbe loaded with `require` inside the\nsandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\nFor example, say you have configured the\nServerless pre-function plugin and it\ncontains the following `requires`:\n\n```\nlocal template = require \"resty.template\"\nlocal split = require \"kong.tools.string\".split\n```\n\nTo run the plugin, add the modules to the\nallowed list:\n```\nuntrusted_lua_sandbox_requires = resty.template, kong.tools.utils\n```\n\n**Warning:** Allowing certain modules may\ncreate opportunities to escape the\nsandbox. For example, allowing `os` or\n`luaposix` may be unsafe.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "untrusted_lua_sandbox_environment": {
+      "defaultValue": null,
+      "description": "Comma-separated list of global Lua\nvariables that should be made available\ninside the sandboxed environment. Ignored\nif `untrusted_lua` is not `sandbox`.\n\n**Warning**: Certain variables, when made\navailable, may create opportunities to\nescape the sandbox.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "openresty_path": {
+      "defaultValue": null,
+      "description": "Path to the OpenResty installation that Kong\nwill use. When this is empty (the default),\nKong determines the OpenResty installation\nby searching for a system-installed OpenResty\nand falling back to searching $PATH for the\nnginx binary.\n\nSetting this attribute disables the search\nbehavior and explicitly instructs Kong which\nOpenResty installation to use.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "node_id": {
+      "defaultValue": null,
+      "description": "Node ID for the Kong node. Every Kong node\nin a Kong cluster must have a unique and\nvalid UUID. When empty, node ID is\nautomatically generated.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "cluster_fallback_config_import": {
+      "defaultValue": "off",
+      "description": "Enable fallback configuration imports.\n\nThis should only be enabled for data planes.\n",
+      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
+    },
+    "cluster_fallback_config_storage": {
+      "defaultValue": null,
+      "description": "Storage definition used by `cluster_fallback_config_import`\nand `cluster_fallback_config_export`.\n\nSupported storage types:\n- S3-like storages\n- GCP storage service\n\nTo use S3 with a bucket named b and place all configs\nto with a key prefix named p, set it to:\n`s3://b/p`\nTo use GCP for the same bucket and prefix, set it to:\n`gcs://b/p`\n\nThe credentials (and the endpoint URL for S3-like) for S3\nare passed with environment variables:\n`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`,\nand `AWS_CONFIG_STORAGE_ENDPOINT` (extension), where\n`AWS_CONFIG_STORAGE_ENDPOINT`\nis the endpoint that hosts S3-like storage.\n\nThe credentials for GCP are provided via the environment\nvariable `GCP_SERVICE_ACCOUNT`.\n",
+      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
+    },
+    "cluster_fallback_config_export": {
+      "defaultValue": "off",
+      "description": "Enable fallback configuration exports.\n",
+      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
+    },
+    "cluster_fallback_config_export_delay": {
+      "defaultValue": "60",
+      "description": "The fallback configuration export interval.\n\nIf the interval is set to 60 and configuration A is exported\nand there are new configurations B, C, and D in the next 60 seconds,\nit will wait until 60 seconds passed and export D, skipping B and C.\n",
+      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
+    },
+    "wasm": {
+      "defaultValue": "off",
+      "description": "Enable/disable wasm support. This must be enabled in\norder to use wasm filters and filter chains.\n",
+      "sectionTitle": "WEBASSEMBLY (WASM)"
+    },
+    "wasm_filters_path": {
+      "defaultValue": null,
+      "description": "Path to the directory containing wasm filter modules.\n\nAt startup, Kong discovers available wasm filters by\nscanning this directory for files with the `.wasm`\nfile extension.\n\nThe name of a wasm filter module is derived from the\nfilename itself, with the .wasm extension removed. So,\ngiven the following tree:\n\n```\n/path/to/wasm_filters\n├── my_module.wasm\n├── my_other_module.wasm\n└── not_a_wasm_module.txt\n```\n\nThe resulting filter modules available for use in Kong\nwill be:\n\n- `my_module`\n- `my_other_module`\n\nNotes:\n\n- No recursion is performed. Only .wasm files at the\n  top level are registered.\n- This path _may_ be a symlink to a directory.\n",
+      "sectionTitle": "WEBASSEMBLY (WASM)"
+    },
+    "request_debug": {
+      "defaultValue": "on",
+      "description": "When enabled, Kong will provide detailed timing information\nfor its components to the client and the error log\nif the following headers are present in the proxy request:\n- `X-Kong-Request-Debug`:\n  If the value is set to `*`,\n  timing information will be collected and exported for the current request.\n  If this header is not present or contains an unknown value,\n  timing information will not be collected for the current request.\n  You can also specify a list of filters, separated by commas,\n  to filter the scope of the time information that is collected.\nThe following filters are supported for `X-Kong-Request-Debug`:\n- `rewrite`: Collect timing information from the `rewrite` phase.\n- `access`: Collect timing information from the `access` phase.\n- `balancer`: Collect timing information from the `balancer` phase.\n- `response`: Collect timing information from the `response` phase.\n- `header_filter`: Collect timing information from the `header_filter` phase.\n- `body_filter`: Collect timing information from the `body_filter` phase.\n- `log`: Collect timing information from the `log` phase.\n- `upstream`: Collect timing information from the `upstream` phase.\n\n- `X-Kong-Request-Debug-Log`:\n  If set to `true`, timing information will also be logged\n  in the Kong error log with a log level of `notice`.\n  Defaults to `false`.\n\n- `X-Kong-Request-Debug-Token`:\n  Token for authenticating the client making the debug\n  request to prevent abuse.\n  ** Note: Debug requests originating from loopback\n  addresses do not require this header. Deploying Kong behind\n  other proxies may result in exposing the debug interface to\n  the public.**\n\n",
+      "sectionTitle": "REQUEST DEBUGGING"
+    },
+    "request_debug_token": {
+      "defaultValue": "<random>",
+      "description": "The Request Debug Token is used in the\n`X-Kong-Request-Debug-Token` header to prevent abuse.\nIf this value is not set (the default),\na random token will be generated\nwhen Kong starts, restarts, or reloads. If a token is\nspecified manually, then the provided token will be used.\n\nYou can locate the generated debug token in two locations:\n- Kong error log:\n  Debug token will be logged in the error log (notice level)\n  when Kong starts, restarts, or reloads.\n  The log line will have the: `[request-debug]` prefix to aid searching.\n- Filesystem:\n  Debug token will also be stored in a file located at\n  `{prefix}/.request_debug_token` and updated\n  when Kong starts, restarts, or reloads.\n",
+      "sectionTitle": "REQUEST DEBUGGING"
+    },
+    "dedicated_config_processing": {
+      "defaultValue": "on",
+      "description": "Enables or disables a special worker\nprocess for configuration processing. This process\nincreases memory usage a little bit while\nallowing to reduce latencies by moving some\nbackground tasks, such as CP/DP connection\nhandling, to an additional worker process specific\nto handling these background tasks.\nCurrently this has effect only on data planes.\n",
+      "sectionTitle": "GENERAL"
+    },
+    "debug_listen_local": {
+      "defaultValue": "on",
+      "description": "Expose `debug_listen` functionalities via a\nUnix domain socket under the Kong prefix.\n\nThis option allows local users to use `kong debug` command\nto invoke various debug functionalities without needing to\nenable `debug_listen` ahead of time.\n",
+      "sectionTitle": "NGINX"
+    },
+    "admin_gui_ssl_protocols": {
+      "defaultValue": "TLSv1.2 TLSv1.3",
+      "description": "Defines the TLS versions supported\nfor Kong Manager\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "analytics_debug": {
+      "defaultValue": "off",
+      "description": "Outputs analytics payload to Kong logs.\n",
+      "sectionTitle": "Analytics for Konnect"
+    },
+    "cluster_fallback_export_s3_config": {
+      "defaultValue": null,
+      "description": "Fallback config export S3 configuration.\nThis is used only when `cluster_fallback_config_storage` is an S3-like schema.\nIf set, it will add the config table to the Kong exporter config S3 putObject request.\nThe config table should be in JSON format and can be unserialized into a table.\nIt should contain the necessary parameters as described in the documentation:\nhttps://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/S3.html#putObject-property.\nFor example, if you want to set the ServerSideEncryption headers/KMS Key ID\nfor the S3 putObject request, you can set the config table to:\n`{\"ServerSideEncryption\": \"aws:kms\", \"SSEKMSKeyId\": \"your-kms-key-id\"}`\n",
+      "sectionTitle": "CLUSTER FALLBACK CONFIGURATION"
+    },
+    "wasm_filters": {
+      "defaultValue": [
+        "bundled",
+        "user"
+      ],
+      "description": "Comma-separated list of Wasm filters to be made\navailable for use in filter chains.\n\nWhen the `off` keyword is specified as the\nonly value, no filters will be available for use.\n\nWhen the `bundled` keyword is specified, all filters\nbundled with Kong will be available.\n\nWhen the `user` keyword is specified, all filters\nwithin the `wasm_filters_path` will be available.\n\n**Examples:**\n\n- `wasm_filters = bundled,user` enables _all_ bundled\n  and user-supplied filters\n- `wasm_filters = user` enables _only_ user-supplied\n  filters\n- `wasm_filters = filter-a,filter-b` enables _only_\n  filters named `filter-a` or `filter-b` (whether\n  bundled _or_ user-supplied)\n\nIf a conflict occurs where a bundled filter and a\nuser-supplied filter share the same name, a warning\nwill be logged, and the user-supplied filter will\nbe used instead.\n",
+      "sectionTitle": "WEBASSEMBLY (WASM)"
+    },
+    "new_dns_client": {
+      "defaultValue": "off",
+      "description": "Enable or disable the new DNS resolver\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_address": {
+      "defaultValue": "<name servers parsed from resolv.conf>",
+      "description": "Comma-separated list of nameservers, each\nentry in `ip[:port]` format to be used by\nKong. If not specified, the nameservers in\nthe local `resolv.conf` file will be used.\nPort defaults to 53 if omitted. Accepts\nboth IPv4 and IPv6 addresses.\n\nExamples:\n\n```\nresolver_address = 8.8.8.8\nresolver_address = 8.8.8.8, [::1]\nresolver_address = 8.8.8.8:53, [::1]:53\n```\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_hosts_file": {
+      "defaultValue": "/etc/hosts",
+      "description": "The hosts file to use. This file is read\nonce and its content is static in memory.\nTo read the file again after modifying it,\nKong must be reloaded.\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_family": {
+      "defaultValue": [
+        "A",
+        "SRV"
+      ],
+      "description": "The supported query types.\n\nFor a domain name, Kong will only query\neither IP addresses (A or AAAA) or SRV\nrecords, but not both.\n\nIt will query SRV records only when the\ndomain matches the\n\"_<proto>._<service>.<name>\" format, for\nexample, \"_ldap._tcp.example.com\".\n\nFor IP addresses (A or AAAA) resolution, it\nfirst attempts IPv4 (A) and then queries\nIPv6 (AAAA).\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_valid_ttl": {
+      "defaultValue": "<TTL from responses>",
+      "description": "By default, DNS records are cached using\nthe TTL value of a response. This optional\nparameter (in seconds) allows overriding it.\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_error_ttl": {
+      "defaultValue": "1",
+      "description": "TTL in seconds for error responses and empty\nresponses.\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_stale_ttl": {
+      "defaultValue": "3600",
+      "description": "Defines, in seconds, how long a record will\nremain in cache past its TTL. This value\nwill be used while the new DNS record is\nfetched in the background.\n\nStale data will be used from expiry of a\nrecord until either the refresh query\ncompletes, or the `resolver_stale_ttl` number\nof seconds have passed.\n\nThis configuration enables Kong to be more\nresilient during the DNS server downtime.\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_lru_cache_size": {
+      "defaultValue": "10000",
+      "description": "The DNS client uses a two-layer cache system:\nL1 - worker-level LRU Lua VM cache\nL2 - across-workers shared memory cache\n\nThis value specifies the maximum allowed\nnumber of DNS responses stored in the L1 LRU\nlua VM cache.\n\nA single name query can easily take up 1~10\nslots, depending on attempted query types and\nextended domains from /etc/resolv.conf\noptions `domain` or `search`.\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "resolver_mem_cache_size": {
+      "defaultValue": "5m",
+      "description": "This value specifies the size of the L2\nshared memory cache for DNS responses,\n`kong_dns_cache`.\n\nAccepted units are `k` and `m`, with a\nminimum recommended value of a few MBs.\n\n5MB shared memory size could store\n~20000 DNS responeses with single A record or\n~10000 DNS responeses with 2~3 A records.\n\n10MB shared memory size could store\n~40000 DNS responeses with single A record or\n~20000 DNS responeses with 2~3 A records.\n",
+      "sectionTitle": "New DNS RESOLVER"
+    },
+    "admin_gui_auth_change_password_attempts": {
+      "defaultValue": "0",
+      "description": "Number of times a user can attempt to change password.\n0 means infinite attempts allowed.\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_auth_change_password_ttl": {
+      "defaultValue": "86400",
+      "description": "Length, in seconds, of the TTL for changing password attempts\nrecords. Records in the database older than\ntheir TTL are automatically purged.\n\nExample, 1 days: `1 * 24 * 60 * 60 = 86400.`\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "keyring_recovery_public_key": {
+      "defaultValue": null,
+      "description": "Defines the public key to optionally encrypt\nall keyring materials and back them up in the\ndatabase.\n\nValues:\n- absolute path to the public key\n- public key content\n- base64 encoded public key content\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "keyring_encrypt_license": {
+      "defaultValue": "off",
+      "description": "Enables keyring encryption for license payloads stored\nin the database.\n\n**Warning:** For Kong deployments that rely entirely on\nthe database for license provisioning (i.e. not using\n`KONG_LICENSE_DATA` or `KONG_LICENSE_PATH`), enabling\nthis option will delay license activation until after\nthe node's keyring has been activated.\n",
+      "sectionTitle": "DATABASE ENCRYPTION & KEYRING MANAGEMENT"
+    },
+    "test": {
+      "defaultValue": "on",
+      "description": "test\n",
+      "sectionTitle": "WASM injected directives"
+    },
+    "admin_gui_auth_login_attempts_ttl": {
+      "defaultValue": "604800",
+      "description": "Length, in seconds, of the TTL for changing login attempts\nrecords. Records in the database older than\ntheir TTL are automatically purged.\n\nThis argument can be set to an integer between 0 and 100000000.\n\nExample, 7 days: `7 * 24 * 60 * 60 = 604800.`\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "incremental_sync": {
+      "defaultValue": "off",
+      "description": "The setting to enable or disable the incremental\nsynchronization of configuration changes.\nInstead of sending the entire entity config to data planes on\neach config update, incremental config sync lets you send only\nthe changed configuration to data planes for hybrid mode deployments.\nThe valid values are `on` and `off`.\nTo enable, set this value to `on`.\n\nIn hybrid mode, this setting must be configured\non both control plane and data plane nodes.\n",
+      "sectionTitle": "HYBRID MODE",
+      "min_version": {
+        "gateway": "3.10"
+      }
+    },
+    "consumers_mem_cache_size": {
+      "defaultValue": "128m",
+      "description": "Size of the shared memory cache for consumers\nand credentials.\n\nThe accepted units are `k` and `m`, with a minimum\nrecommended value of a few MBs.\n\n**Note**: This is only used when the \"externalized consumers\"\nfeature is active.\n",
+      "sectionTitle": "NGINX",
+      "min_version": {
+        "gateway": "3.10"
+      }
+    },
+    "admin_gui_csp_header": {
+      "defaultValue": "off",
+      "description": "Enable or disable the `Content-Security-Policy` (CSP) header for Kong Manager\n\nThis configuration controls the presence of the CSP header when serving\nKong Manager. The default CSP header value will be used unless customized.\n\nTo modify the value of the served CSP header, refer to the `admin_gui_csp_header_value`\nconfiguration.\n\nSet this configuration to `on` to enable the CSP header.\n",
+      "sectionTitle": "KONG MANAGER",
+      "min_version": {
+        "gateway": "3.10"
+      }
+    },
+    "admin_gui_csp_header_value": {
+      "defaultValue": null,
+      "description": "The value of the `Content-Security-Policy` (CSP) header for Kong Manager.\n\nThis configuration controls the value of the CSP header when serving\nKong Manager. If omitted or left empty, the default CSP header value\nwill be used.\n\nThis is an advanced configuration intended for cases where the default\nCSP header value does not meet your requirements. Use with caution.\n\nFor more information on the CSP header, see:\nhttps://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy\n",
+      "sectionTitle": "KONG MANAGER",
+      "min_version": {
+        "gateway": "3.10"
       }
     }
   }

--- a/app/_data/products/gateway.yml
+++ b/app/_data/products/gateway.yml
@@ -529,7 +529,6 @@ releases:
   - release: "3.9"
     ee-version: "3.9.1.1"
     ce-version: "3.9.0"
-    latest: true
     eol: Dec 2025
     distributions:
       - amazonlinux2:
@@ -701,9 +700,8 @@ releases:
               - Confluent Cloud
   - release: "3.10"
     ee-version: "3.10.0.0"
-    ce-version: "3.10.0"
-    label: unreleased
     lts: true
+    latest: true
     distributions:
       - amazonlinux2:
           package: true
@@ -872,6 +870,176 @@ releases:
               - 3.2
               - Confluent Cloud
 
+  - release: "3.11"
+    ee-version: "3.11.0.0"
+    label: unreleased
+    distributions:
+      - amazonlinux2:
+          package: true
+          package_support:
+            fips: false
+            arm: true
+            graviton: true
+          docker: true
+      - amazonlinux2023:
+          package: true
+          package_support:
+            fips: false
+            arm: true
+            graviton: true
+          docker: true
+          default: true
+      - debian11:
+          package: true
+          package_support:
+            fips: false
+            arm: true
+            graviton: true
+          docker: true
+      - debian12:
+          package: true
+          package_support:
+            fips: false
+            arm: true
+            graviton: true
+          docker: true
+          default: true
+      - rhel8:
+          package: true
+          package_support:
+            arm: false
+            graviton: false
+            fips: true
+          docker: false
+      - rhel9:
+          package: true
+          package_support:
+            graviton: false
+            arm: true
+            fips: true
+          docker: true
+          default: true
+      - ubuntu2004:
+          package: true
+          package_support:
+            graviton: false
+            arm: false
+            fips: true
+          docker: false
+          eol: April 2025
+      - ubuntu2204:
+          package: true
+          package_support:
+            arm: true
+            graviton: true
+            fips: true
+          docker: true
+      - ubuntu2404:
+          package: true
+          package_support:
+            arm: true
+            graviton: true
+            fips: true
+          docker: true
+          default: true
+    third_party_support:
+      ai_providers:
+        - openai:
+        - cohere:
+        - azure_ai:
+        - anthropic:
+        - mistral:
+        - llama2:
+            format:
+              - Raw
+              - OLLAMA
+              - OpenAI
+        - bedrock:
+        - gemini:
+
+      s3_api:
+        - s3
+        - minio
+
+      log_provider:
+        - splunk
+        - datadog
+        - loggly
+
+      service_mesh:
+        - kongmesh:
+            versions:
+              - 2.0
+        - istio:
+            versions:
+              - 1.16
+              - 1.15
+              - 1.14
+
+      identity_provider:
+        - auth0
+        - cognito
+        - connect2id
+        - curity
+        - dex
+        - gluu
+        - google
+        - identityserver
+        - keycloak
+        - azure-ad
+        - microsoft-adfs
+        - microsoft-live-connect
+        - okta
+        - onelogin
+        - openam
+        - paypal
+        - pingfederate
+        - salesforce
+        - wso2
+        - yahoo
+
+      vault:
+        - vaultproject:
+          versions:
+            - 1.12
+        - aws-sm:
+        - azure-key-vaults:
+        - gcp-sm:
+
+      metrics:
+        - prometheus:
+            versions:
+              - 2.40
+              - 2.37
+        - statsd:
+            versions:
+              - 0.9
+        - opentelemetry:
+        - zipkin:
+            versions:
+              - 2.23
+              - 2.22
+
+      datastore:
+        - postgres:
+            versions:
+              - 16
+              - 15
+              - 14
+              - 13
+              - 12
+              - Amazon RDS
+              - Amazon Aurora
+        - redis:
+            versions:
+              - 6
+              - 7
+              - AWS Elasticache
+        - kafka:
+            versions:
+              - 3.3
+              - 3.2
+              - Confluent Cloud
 
 cloud_deployment_platforms:
   - AWS EKS

--- a/tools/kong-conf-to-json/index-file.js
+++ b/tools/kong-conf-to-json/index-file.js
@@ -21,8 +21,20 @@ function mergeSections(obj1, obj2) {
 function generateIndexFile() {
   let reference = {};
   let previousVersion;
-  const files = fg.sync("../../app/_data/kong-conf/*", {
+  let files = fg.sync("../../app/_data/kong-conf/*", {
     ignore: ["../../app/_data/kong-conf/index.json"],
+  });
+
+  files = files.sort((a, b) => {
+    const versionA = a
+      .match(/(\d+\.\d+)/)[0]
+      .split(".")
+      .map(Number);
+    const versionB = b
+      .match(/(\d+\.\d+)/)[0]
+      .split(".")
+      .map(Number);
+    return versionA[0] - versionB[0] || versionA[1] - versionB[1];
   });
 
   files.forEach((file, index) => {

--- a/tools/kong-conf-to-json/run.js
+++ b/tools/kong-conf-to-json/run.js
@@ -103,7 +103,7 @@ function parseSections(filePath) {
 }
 
 (function main() {
-  const args = minimist(process.argv.slice(2));
+  const args = minimist(process.argv.slice(2), { string: ["version"] });
 
   try {
     if (!args.file) {


### PR DESCRIPTION
## Description

Bumps latest version to 3.10 so that we can easily see all new docs.

This is what I found needed bumping:
* Plugin toolkit - generated the schemas, examples, and data files
* kong.conf - ran the conf tool at tools/kong-conf-to-json
* copied over the 3.10 admin api spec
* new product version in site.data.products.gateway

Issues/questions:
* Should we retire the plugin examples from the docs-plugin-toolkit? We won't need them for the dev site, so maybe I didn't need to generate 3.11
* When generating kong.conf, passing `3.10` made the tool read it as `3.1`, so it generated `3.1.json`. Not a big deal, but something to look out for:
```
node run --file=../../kong.conf.default --version=3.10
kong.conf file in json format written to ../../app/_data/kong-conf/3.1.json.
```

## Preview Links


## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
