### PR TITLE
Fix liquid rendering

### DIFF
--- a/app/_kong_plugins/jwt/examples/verified-claim.yaml
+++ b/app/_kong_plugins/jwt/examples/verified-claim.yaml
@@ -10,9 +10,9 @@ description: |
     - title: Verification
       key: verification
   rows:
-    - claim: `exp`
+    - claim: "`exp`"
       verification: Identifies the expiration time on or after which the JWT must not be accepted for processing.
-    - claim: `nbf`
+    - claim: "`nbf`"
       verification: Identifies the time before which the JWT must not be accepted for processing.
   {% endtable %}
 

--- a/app/_plugins/filters/liquify.rb
+++ b/app/_plugins/filters/liquify.rb
@@ -4,7 +4,10 @@ module Jekyll
   module LiquifyFilter
     def liquify(input)
       if input.is_a? String
-        Liquid::Template.parse(input).render(@context.environments.first)
+        Liquid::Template.parse(input).render(
+          @context.environments.first,
+          registers: @context.registers
+        )
       else
         input
       end


### PR DESCRIPTION
The `liquify` filter needs access to the `site` context to be able to find the `markdownify` filter