### PR TITLE
custom-plugins-dcg

### DIFF
--- a/app/_landing_pages/dedicated-cloud-gateways.yaml
+++ b/app/_landing_pages/dedicated-cloud-gateways.yaml
@@ -161,3 +161,13 @@ rows:
               cta:
                 text: Learn more
                 url: /dedicated-cloud-gateways/reference/
+      - blocks:
+          - type: card
+            config:
+              title: Custom Plugins
+              description: |
+                Custom Plugin streaming
+              icon: /assets/icons/gateway.svg
+              cta:
+                text: Learn more
+                url: /dedicated-cloud-gateways/custom-plugins/

--- a/app/dedicated-cloud-gateways/custom-plugins.md
+++ b/app/dedicated-cloud-gateways/custom-plugins.md
@@ -1,0 +1,58 @@
+---
+title: "Custom Plugins in Dedicated Cloud Gateways"
+description: "Use the {{site.konnect_short_name}} Control Plane to distribute and manage custom Lua plugins across all Dedicated Cloud Gateways."
+content_type: reference
+layout: reference
+products:
+  - gateway
+tags:
+  - dedicated-gateways
+  - plugins
+works_on:
+  - konnect
+faqs:
+  - q: How do I manage custom plugins after uploading them?
+    a: |
+      Once uploaded, you can manage custom plugins using any of the following methods:
+
+      * [decK](/deck/)
+      * [Control Plane Config API](/api/konnect/control-planes-config/v2/)
+      * [{{site.konnect_short_name}} UI](https://cloud.konghq.com/)
+
+related_resources:
+  - text: Dedicated Cloud Gateways
+    url: /dedicated-cloud-gateways/
+  - text: Azure Peering
+    url: /dedicated-cloud-gateways/azure-peering/
+---
+
+With Dedicated Cloud Gateways, {{site.konnect_short_name}} can stream custom plugins from the Control Plane to the Data Plane.
+
+The Control Plane becomes the single source of truth for plugin versions. You only need to upload the plugin once, and {{site.konnect_short_name}} handles distribution to all Data Planes in the same Control Plane.
+
+A [custom plugin](/custom-plugins/) that meets the following requirements:
+
+* Unique name per plugin
+* One `handler.lua` and one `schema.lua` file
+* Cannot run in the `init_worker` phase or create timers
+* Must be written in Lua
+* A [personal or system access token](https://cloud.konghq.com/global/account/tokens) for the {{site.konnect_short_name}} API
+
+## How do I add a custom plugin?
+
+You can use the following request with [jq](https://jqlang.org/) as a template for adding a custom plugin: 
+
+
+```sh
+curl -X POST https://{region}.api.konghq.com/v2/control-planes/{control-plane-id}/core-entities/custom-plugins \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer {your-access-token}" \
+  -d "$(jq -n \
+      --arg handler "$(cat handler.lua)" \
+      --arg schema "$(cat schema.lua)" \
+      '{"handler":$handler,"name":"streaming-headers","schema":$schema}')" \
+    | jq
+```
+You can also upload plugins using the Plugins menu in the [{{site.konnect_short_name}} UI](https://cloud.konghq.com/gateway-manager/).
+headers:
+

--- a/app/dedicated-cloud-gateways/custom-plugins.md
+++ b/app/dedicated-cloud-gateways/custom-plugins.md
@@ -26,7 +26,8 @@ related_resources:
     url: /dedicated-cloud-gateways/azure-peering/
 ---
 
-With Dedicated Cloud Gateways, {{site.konnect_short_name}} can stream custom plugins from the Control Plane to the Data Plane.
+
+## How does custom plugin streaming work? 
 
 The Control Plane becomes the single source of truth for plugin versions. You only need to upload the plugin once, and {{site.konnect_short_name}} handles distribution to all Data Planes in the same Control Plane.
 

--- a/app/dedicated-cloud-gateways/reference.md
+++ b/app/dedicated-cloud-gateways/reference.md
@@ -227,3 +227,8 @@ If you are using Dedicated Cloud Gateways and your upstream services are hosted 
 
 ### Azure VNet Peering
 If you are using Dedicated Cloud Gateways and your upstream services are hosted in Azure, VNet Peering is the preferred method for most users. For more information and a guide on how to attach your Dedicated Cloud Gateway, see the [Azure Peering](/dedicated-cloud-gateways/azure-peering/) documentation.
+
+## Custom Plugins
+
+With Dedicated Cloud Gateways, {{site.konnect_short_name}} can stream custom plugins from the Control Plane to the Data Plane. This means that the Control Plane becomes a single source of truth for plugin versions. You only need to upload a plugin once, to the Control Plane, and {{site.konnect_short_name}} handles distributing the plugin code to all Data Planes in that Control Plane. For more information on adding a custom plugin to a Dedicated Cloud Gateway deployment, see the [custom plugin reference](/dedicated-cloud-gateways/custom-plugins/) documentation.
+

--- a/tools/track-docs-changes/config/sources.yml
+++ b/tools/track-docs-changes/config/sources.yml
@@ -922,7 +922,8 @@ app/dedicated-cloud-gateways/reference.md:
   - app/konnect/gateway-manager/dedicated-cloud-gateways/custom-dns.md
 app/dedicated-cloud-gateways/aws-private-link.md:
   - app/konnect/private-connections/aws-privatelink.md
-
+app/dedicated-cloud-gateways/custom-plugins.md:
+  - app/konnect/gateway-manager/dedicated-cloud-gateways/custom-plugins.md
 app/dedicated-cloud-gateways/transit-gateways.md:
   - app/konnect/gateway-manager/dedicated-cloud-gateways/transit-gateways.md
 app/gateway-manager/control-plane-groups.md:


### PR DESCRIPTION
## Description

In the request the original doc has a custom request with `jq`. I kept that but it means I had to use a standard three back-tick curl request. I could use a control plane request block but then you can't use the `jq` snippet. I think this is okay, but let me know if it isn't. 

Fixes #1107 

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
