### PR TITLE
Make jekyll exclude app/assets, it's causing jekyll to treat some assets

### DIFF
--- a/jekyll.yml
+++ b/jekyll.yml
@@ -107,6 +107,9 @@ plugin_schemas_path: app/.repos/kong-plugins/json_schemas
 plugin_referenceable_fields_path: app/.repos/kong-plugins/data/referenceable_fields
 plugin_priorities_path: app/.repos/kong-plugins/data/priorities/ee
 
+exclude:
+  - assets
+
 sitemap:
   exclude:
     - /robots.txt


### PR DESCRIPTION
as pages

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
