### PR TITLE
OIDC client credentials grant

### DIFF
--- a/app/_how-tos/configure-oidc-with-client-credentials.md
+++ b/app/_how-tos/configure-oidc-with-client-credentials.md
@@ -1,5 +1,5 @@
 ---
-title: Configure OpenID Connect with session authentication
+title: Configure OpenID Connect with client credentials
 content_type: how_to
 
 related_resources:
@@ -7,8 +7,8 @@ related_resources:
     url: /gateway/authentication/
   - text: OpenID Connect authentication flows and grants
     url: /plugins/openid-connect/#authentication
-  - text: Session auth workflow
-    url: /plugins/openid-connect/#session-authentication-workflow
+  - text: Client credentials grant workflow
+    url: /plugins/openid-connect/#client-credentials-grant-workflow
 
 plugins:
   - openid-connect
@@ -46,12 +46,8 @@ tags:
   - openid-connect
 
 tldr:
-  q: How do I use a session cookie to authenticate directly with my identity provider?
-  a: Using the OpenID Connect plugin, set up the [session auth flow](/plugins/openid-connect/#session-authentication-workflow) to connect to an identity provider (IdP) to retrieve, store, and use session cookies for authentication.
-
-faqs:
-  - q: How do I disable session creation?
-    a: If you want to disable session creation with some grants, use the [`config.disable_session`](/plugins/openid-connect/reference/#schema--config-disable-session) configuration parameter.
+  q: How do I use a client ID and client secret to authenticate directly with my identity provider?
+  a: Using the OpenID Connect plugin, set up the [client credentials grant flow](/plugins/openid-connect/#client-credentials-grant-workflow) to connect to an identity provider (IdP) by passing a client ID and client secret in a header.
 
 cleanup:
   inline:
@@ -64,14 +60,12 @@ cleanup:
 
 ---
 
-## 1. Enable the OpenID Connect plugin with session auth
+## 1. Enable the OpenID Connect plugin with the client credentials grant
 
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
-set up an instance of the OpenID Connect plugin with the session auth flow.
+set up an instance of the OpenID Connect plugin with the client credentials grant.
 
-We're also enabling the password grant so that we can test retrieving the session cookie.
-
-Enable the OpenID Connect plugin on the `example-service` Service:
+Enable the OpenID Connect plugin on the `example-service` service:
 
 {% entity_examples %}
 entities:
@@ -87,8 +81,9 @@ entities:
         client_auth:
         - client_secret_post
         auth_methods:
-        - session
-        - password
+        - client_credentials
+        client_credentials_param_type:
+        - header
 variables:
   issuer:
     value: $ISSUER
@@ -99,36 +94,25 @@ variables:
 {% endentity_examples %}
 
 In this example:
-* `issuer`, `client ID`, `client secret`, and `client auth`: Settings that connect the plugin to your IdP (in this case, the sample Keycloak app).
-* `auth_methods`: Session auth and password grant.
+* `issuer`, `client ID`, `client secret`, and `client auth`: Settings that connect the plugin to your IdP (in this case, the sample Keycloak app). 
+* `auth_methods`: Client credentials (client ID and secret).
+* `client_credentials_param_type`: We want to search for client credentials in headers only.
 
 {% include_cached plugins/oidc/client-auth.md %}
 
-## 2. Store the session cookie
+## 2. Validate the client credentials grant
 
-Request the Service with the basic authentication credentials created in the [prerequisites](#prerequisites) and store the session:
+At this point you have created a Gateway Service, routed traffic to the Service, and enabled the OpenID Connect plugin.
+You can now test the client credentials grant.
 
-<!--vale off-->
-{% validation request-check %}
-url: /anything
-method: GET
-status_code: 200
-user: "john:doe"
-display_headers: true
-cookie_jar: example-user
-{% endvalidation %}
-<!--vale on-->
-
-## 3. Validate session authentication
-
-Make a request with the stored session cookie:
+Access the `example-route` Route by passing the credentials in `client-id:client-secret` format:
 
 {% validation request-check %}
 url: /anything
 method: GET
 status_code: 200
+user: "$DECK_CLIENT_ID:$DECK_CLIENT_SECRET"
 display_headers: true
-cookie: example-user
 {% endvalidation %}
 
 {% include_cached plugins/oidc/cache.md %}

--- a/app/_how-tos/configure-oidc-with-password-grant.md
+++ b/app/_how-tos/configure-oidc-with-password-grant.md
@@ -82,7 +82,7 @@ entities:
         - client_secret_post
         auth_methods:
         - password
-        client_credentials_param_type:
+        password_param_type:
         - header
 variables:
   issuer:
@@ -96,7 +96,9 @@ variables:
 In this example:
 * `issuer`, `client ID`, `client secret`, and `client auth`: Settings that connect the plugin to your IdP (in this case, the sample Keycloak app).
 * `auth_methods`: Password grant.
-* `client_credentials_param_type`: We want to search for client credentials in headers only.
+* `password_param_type`: We want to search for the username and password in headers only.
+
+{% include_cached plugins/oidc/client-auth.md %}
 
 ## 2. Validate the password grant
 
@@ -114,11 +116,4 @@ user: "john:doe"
 display_headers: true
 {% endvalidation %}
 
-If {{site.base_gateway}} successfully authenticates with Keycloak, you'll see a `200` response with your bearer token in the Authorization header.
-
-If you make another request using the same credentials, you'll see that {{site.base_gateway}} adds less latency to the request because it has cached the token endpoint call to Keycloak:
-
-```
-X-Kong-Proxy-Latency: 25
-```
-{:.no-copy-code}
+{% include_cached plugins/oidc/cache.md %}

--- a/app/_how-tos/configure-oidc-with-refresh-token.md
+++ b/app/_how-tos/configure-oidc-with-refresh-token.md
@@ -103,6 +103,8 @@ In this example:
 * `auth_methods`: Refresh token and password grant.
 * `refresh_token_param_type`: We want to search for the refresh token in headers only.
 
+{% include_cached plugins/oidc/client-auth.md %}
+
 ## 2. Retrieve the refresh token
 
 Check that you can recover the refresh token by requesting the Service with the basic authentication credentials created in the [prerequisites](#prerequisites):
@@ -139,14 +141,7 @@ headers:
   - "Refresh-Token: $REFRESH_TOKEN"
 {% endvalidation %}
 
-If {{site.base_gateway}} successfully authenticates with Keycloak, you'll see a `200` response with a `Refresh-Token` header.
-
-If you make another request using the same credentials, you'll see that {{site.base_gateway}} adds less latency to the request because it has cached the token endpoint call to Keycloak:
-
-```
-X-Kong-Proxy-Latency: 25
-```
-{:.no-copy-code}
+{% include_cached plugins/oidc/cache.md %}
 
 Alternatively, you can use jq to pass the credentials and retrieve the most recent refresh token every time:
 

--- a/app/_includes/plugins/oidc/cache.md
+++ b/app/_includes/plugins/oidc/cache.md
@@ -1,0 +1,8 @@
+If {{site.base_gateway}} successfully authenticates with Keycloak, you'll see a `200` response with your bearer token in the Authorization header.
+
+If you make another request using the same credentials, you'll see that {{site.base_gateway}} adds less latency to the request because it has cached the token endpoint call to Keycloak:
+
+```
+X-Kong-Proxy-Latency: 25
+```
+{:.no-copy-code}

--- a/app/_includes/plugins/oidc/client-auth.md
+++ b/app/_includes/plugins/oidc/client-auth.md
@@ -1,0 +1,3 @@
+{:.warning}
+> **Note**: Setting `config.client_auth` to `client_secret_post` lets you easily test the connection to your IdP, but we recommend using a more secure auth method in production. 
+You use any [supported client auth method](/plugins/openid-connect/reference/#schema--config-client-auth) here. 

--- a/app/_includes/prereqs/auth/oidc/keycloak-password.md
+++ b/app/_includes/prereqs/auth/oidc/keycloak-password.md
@@ -20,7 +20,7 @@ This tutorial requires an identity provider (IdP). If you don't have one, you ca
 Section | Settings
 --------|----------
 **General settings** | - Client type: **OpenID Connect** <br> - Client ID: any unique name, for example `kong`
-**Capability config** | - Toggle **Client authentication** to **on** <br> - Make sure that **Standard flow** and **Direct access grants** are checked.
+**Capability config** | - Toggle **Client authentication** to **on** <br> - Make sure that **Standard flow**, **Direct access grants**, and **Service accounts roles** are checked.
 **Login settings** |  **Valid redirect URIs**: `http://localhost:8000/*`
 
 #### Set up keys and credentials

--- a/app/_kong_plugins/openid-connect/examples/client-credentials.yaml
+++ b/app/_kong_plugins/openid-connect/examples/client-credentials.yaml
@@ -5,17 +5,23 @@ description: |
   In this example, the plugin will only accept client credentials sent in a header, 
   but you can also set the `client_credentials_param_type` parameter to `body`, `query`, or any combination of these values.
 
+  For an example of using the client credentials grant with Keycloak, see the tutorial for [configuring OpenID Connect with the client credentials grant](/how-to/configure-oidc-with-client-credentials/).
+
+  {% include_cached plugins/oidc/client-auth.md %}
+
 weight: 899
 
 requirements:
   - A configured identity provider (IdP)
 
 config:
-  issuer: $ISSUER_URL
+  issuer: ${issuer}
   client_id:
-    - $CLIENT_ID
+    - ${client-id}
+  client_secret:
+    - ${client-secret}
   client_auth:
-    - private_key_jwt
+    - client_secret_post
   auth_methods:
     - client_credentials
   client_credentials_param_type:
@@ -23,9 +29,16 @@ config:
 
 variables:
   issuer:
-    value: "http://keycloak.test:8080/realms/master"
-  client_id:
-    value: kong
+    value: $ISSUER
+    description: |
+      The issuer authentication URL for your IdP. 
+      For example, if you're using Keycloak as your IdP, the issuer URL looks like this: `http://example-keycloak-host:8080/realms/example-realm`
+  client-id:
+    value: $CLIENT_ID
+    description: The client ID that the plugin uses when it calls authenticated endpoints of the IdP.
+  client-secret:
+    value: $CLIENT_SECRET
+    description: The client secret needed to connect to your IdP.
 
 tools:
   - deck

--- a/app/_kong_plugins/openid-connect/examples/password.yaml
+++ b/app/_kong_plugins/openid-connect/examples/password.yaml
@@ -12,6 +12,8 @@ description: |
   You can pass the secret in more secure ways by using a different [`config.client_auth`](/plugins/openid-connect/reference/#schema--config-client-auth) option.
 
   For an example of using the password grant with Keycloak, see the tutorial for [configuring OpenID Connect with the password grant](/how-to/configure-oidc-with-password-grant/).
+  
+  {% include_cached plugins/oidc/client-auth.md %}
 
 weight: 895
 

--- a/app/_kong_plugins/openid-connect/examples/refresh-token.yaml
+++ b/app/_kong_plugins/openid-connect/examples/refresh-token.yaml
@@ -6,6 +6,8 @@ description: |
   but you can also set the `refresh_token_param_type` parameter to `body`, `query`, or any combination of these values.
 
   For an example of using refresh tokens with Keycloak, see the tutorial for [configuring OpenID Connect with the refresh token grant](/how-to/configure-oidc-with-refresh-token/).
+  
+  {% include_cached plugins/oidc/client-auth.md %}
 
 weight: 894
 

--- a/app/_kong_plugins/openid-connect/examples/session-auth.yaml
+++ b/app/_kong_plugins/openid-connect/examples/session-auth.yaml
@@ -3,6 +3,8 @@ description: |
   Configure the OpenID Connect plugin to issue session cookies that can be used for further session authentication.
 
   For an example of retrieving, storing, and using session cookies with Keycloak, see the tutorial for [configuring OpenID Connect with session authentication](/how-to/configure-oidc-with-session-auth/).
+  
+  {% include_cached plugins/oidc/client-auth.md %}
 
 weight: 893
 

--- a/tools/track-docs-changes/config/sources.yml
+++ b/tools/track-docs-changes/config/sources.yml
@@ -222,7 +222,8 @@ app/_how-tos/validate-gateway-audit-log-signatures.md:
   - app/_src/gateway/kong-enterprise/audit-log.md
 app/_how-tos/configure-oidc-with-session-auth.md:
   - app/_hub/kong-inc/openid-connect/how-to/authentication/_session.md
-
+app/_how-tos/configure-oidc-with-client-credentials.md:
+  - app/_hub/kong-inc/openid-connect/how-to/authentication/_client-credentials.md
 app/_how-tos/plugin-dev-add-plugin-configuration.md:
   - app/_src/gateway/plugin-development/get-started/config.md
 app/_how-tos/plugin-dev-add-plugin-testing.md:


### PR DESCRIPTION
## Description

Fixes #1151 

**Reviewers:** if you've reviewed an OIDC guide before and already have a keycloak instance configured, take note of the change to one of the prereqs. There's a setting that you need to enable in the keycloak config that you didn't need for the previous guides.

Besides the client credentials how-to, there's also:
* Fixing some copy/paste errors on the password grant doc
* Moving the caching check into an include
* Adding a note to the client_auth setting to warn users against using insecure auth methods in production. The original docs used `private_key_jwt` in examples, but we can't do that because Konnect doesn't support that method (or rather, we can, but it would double the number of examples/work needed)

## Preview Links


## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
