### PR TITLE
OIDC with introspection auth

### DIFF
--- a/app/_how-tos/configure-oidc-with-introspection.md
+++ b/app/_how-tos/configure-oidc-with-introspection.md
@@ -102,7 +102,7 @@ In this example:
 * `auth_methods`: Introspection and password grant.
 * `bearer_token_param_type`: We want to search for client credentials in headers only.
 
-<!-- include_cached plugins/oidc/client-auth.md -->
+{% include_cached plugins/oidc/client-auth.md %}
 
 ## 2. Retrieve the bearer token using introspection
 
@@ -136,4 +136,4 @@ headers:
   - "Authorization: $TOKEN"
 {% endvalidation %}
 
-<!-- include_cached plugins/oidc/cache.md -->
+{% include_cached plugins/oidc/cache.md %}

--- a/app/_how-tos/configure-oidc-with-introspection.md
+++ b/app/_how-tos/configure-oidc-with-introspection.md
@@ -49,7 +49,7 @@ description: Set up OpenID Connect with introspection auth, which retrieves a be
 
 tldr:
   q: How do I retrieve a token using my identity provider's introspection endpoint?
-  a: Using the OpenID Connect plugin, set up the [introspection auth workflow](/plugins/openid-connect/#password-grant-workflow) to connect to an identity provider (IdP) to retrieve a token from the IdP's introspection endpoint, then use the token to access the upstream service.
+  a: Using the OpenID Connect plugin, set up the [introspection auth workflow](/plugins/openid-connect/#introspection-authentication-workflow) to connect to an identity provider (IdP) to retrieve a token from the IdP's introspection endpoint, then use the token to access the upstream service.
 
 cleanup:
   inline:

--- a/app/_how-tos/configure-oidc-with-introspection.md
+++ b/app/_how-tos/configure-oidc-with-introspection.md
@@ -1,0 +1,137 @@
+---
+title: Configure OpenID Connect with introspection
+content_type: how_to
+
+related_resources:
+  - text: Authentication in {{site.base_gateway}}
+    url: /gateway/authentication/
+  - text: OpenID Connect authentication flows and grants
+    url: /plugins/openid-connect/#authentication
+  - text: Introspection workflow
+    url: /plugins/openid-connect/#introspection-authentication-workflow
+
+plugins:
+  - openid-connect
+
+entities:
+  - route
+  - service
+
+products:
+  - gateway
+
+works_on:
+  - on-prem
+  - konnect
+
+min_version:
+  gateway: '3.4'
+
+tools:
+  - deck
+
+prereqs:
+  entities:
+    services:
+      - example-service
+    routes:
+      - example-route
+  inline:
+    - title: Set up Keycloak
+      include_content: prereqs/auth/oidc/keycloak-password
+      icon_url: /assets/icons/keycloak.svg
+
+tags:
+  - authentication
+  - openid-connect
+
+description: Set up OpenID Connect with introspection auth, which retrieves a bearer token from the IdP's introspection endpoint for authentication.
+
+tldr:
+  q: How do I retrieve a token using my identity provider's introspection endpoint?
+  a: Using the OpenID Connect plugin, set up the [introspection auth workflow](/plugins/openid-connect/#password-grant-workflow) to connect to an identity provider (IdP) to retrieve a token from the IdP's introspection endpoint, then use the token to access the upstream service.
+
+cleanup:
+  inline:
+    - title: Clean up Konnect environment
+      include_content: cleanup/platform/konnect
+      icon_url: /assets/icons/gateway.svg
+    - title: Destroy the {{site.base_gateway}} container
+      include_content: cleanup/products/gateway
+      icon_url: /assets/icons/gateway.svg
+
+---
+
+## 1. Enable the OpenID Connect plugin with introspection
+
+Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
+set up an instance of the OpenID Connect plugin with introspection authentication.
+We're also enabling the password grant so that you can test retrieving the auth token for introspection.
+
+Enable the OpenID Connect plugin on the `example-service` Service:
+
+{% entity_examples %}
+entities:
+  plugins:
+    - name: openid-connect
+      service: example-service
+      config:
+        issuer: ${issuer}
+        client_id:
+        - ${client-id}
+        client_secret:
+        - ${client-secret}
+        client_auth:
+        - client_secret_post
+        auth_methods:
+        - introspection
+        - password
+        bearer_token_param_type:
+        - header
+variables:
+  issuer:
+    value: $ISSUER
+  client-id:
+    value: $CLIENT_ID
+  client-secret:
+    value: $CLIENT_SECRET
+{% endentity_examples %}
+
+In this example:
+* `issuer`, `client ID`, `client secret`, and `client auth`: Settings that connect the plugin to your IdP (in this case, the sample Keycloak app).
+* `auth_methods`: Introspection and password grant.
+* `bearer_token_param_type`: We want to search for client credentials in headers only.
+
+<!-- include_cached plugins/oidc/client-auth.md -->
+
+## 2. Retrieve the bearer token using instrospection
+
+Check that you can recover the token by requesting the Service with the basic authentication credentials created in the [prerequisites](#prerequisites), and export it to an environment variable:
+
+```sh
+export TOKEN=$(curl --user john:doe http://localhost:8000/anything \
+  | jq -r .headers.Authorization)
+```
+{: data-deployment-topology="on-prem" }
+
+```sh
+export TOKEN=$(curl --user john:doe http://$KONNECT_PROXY_URL/anything \
+  | jq -r .headers.Authorization)
+```
+{: data-deployment-topology="konnect" }
+
+## 3. Validate the token
+
+At this point you have created a Gateway Service, routed traffic to the Service, enabled the OpenID Connect plugin, and retrieved the bearer token. 
+Access the `example-route` Route by passing the token you retrieved using introspection:
+
+{% validation request-check %}
+url: /anything
+method: GET
+status_code: 200
+display_headers: true
+headers:
+  - "Authorization: $TOKEN"
+{% endvalidation %}
+
+<!-- include_cached plugins/oidc/cache.md -->

--- a/app/_how-tos/configure-oidc-with-introspection.md
+++ b/app/_how-tos/configure-oidc-with-introspection.md
@@ -111,12 +111,14 @@ Check that you can recover the token by requesting the Service with the basic au
 ```sh
 export TOKEN=$(curl --user john:doe http://localhost:8000/anything \
   | jq -r .headers.Authorization)
+echo $TOKEN
 ```
 {: data-deployment-topology="on-prem" }
 
 ```sh
 export TOKEN=$(curl --user john:doe http://$KONNECT_PROXY_URL/anything \
   | jq -r .headers.Authorization)
+echo $TOKEN
 ```
 {: data-deployment-topology="konnect" }
 

--- a/app/_how-tos/configure-oidc-with-introspection.md
+++ b/app/_how-tos/configure-oidc-with-introspection.md
@@ -104,7 +104,7 @@ In this example:
 
 <!-- include_cached plugins/oidc/client-auth.md -->
 
-## 2. Retrieve the bearer token using instrospection
+## 2. Retrieve the bearer token using introspection
 
 Check that you can recover the token by requesting the Service with the basic authentication credentials created in the [prerequisites](#prerequisites), and export it to an environment variable:
 

--- a/app/_kong_plugins/openid-connect/examples/introspection-auth.yaml
+++ b/app/_kong_plugins/openid-connect/examples/introspection-auth.yaml
@@ -7,7 +7,7 @@ description: |
 
   For an example of using introspection auth with Keycloak, see the tutorial for [configuring OpenID Connect with introspection](/how-to/configure-oidc-with-introspection/).
   
-  # {% include_cached plugins/oidc/client-auth.md %}
+  {% include_cached plugins/oidc/client-auth.md %}
 
 weight: 898
 

--- a/app/_kong_plugins/openid-connect/examples/introspection-auth.yaml
+++ b/app/_kong_plugins/openid-connect/examples/introspection-auth.yaml
@@ -2,17 +2,26 @@ title: Introspection authentication
 description: |
   Configure the OpenID Connect plugin with introspection authentication.
 
+  In this example, the plugin will only accept a bearer token sent in a header, 
+  but you can also set the `bearer_token_param_type` parameter to `body`, `query`, or any combination of these values.
+
+  For an example of using introspection auth with Keycloak, see the tutorial for [configuring OpenID Connect with introspection](/how-to/configure-oidc-with-introspection/).
+  
+  # {% include_cached plugins/oidc/client-auth.md %}
+
 weight: 898
 
 requirements:
   - A configured identity provider (IdP)
 
 config:
-  issuer: $ISSUER
+  issuer: ${issuer}
   client_id:
-    - $CLIENT_ID
+    - ${client-id}
+  client_secret:
+    - ${client-secret}
   client_auth:
-    - private_key_jwt
+    - client_secret_post
   auth_methods:
     - introspection
   bearer_token_param_type:
@@ -20,10 +29,22 @@ config:
 
 variables:
   issuer:
+    value: $ISSUER
+    description: |
+      The issuer authentication URL for your IdP. 
+      For example, if you're using Keycloak as your IdP, the issuer URL looks like this: `http://example-keycloak-host:8080/realms/example-realm`
+  client-id:
+    value: $CLIENT_ID
+    description: The client ID that the plugin uses when it calls authenticated endpoints of the IdP.
+  client-secret:
+    value: $CLIENT_SECRET
+    description: The client secret needed to connect to your IdP.
+
+variables:
+  issuer:
     value: "http://keycloak.test:8080/realms/master"
   client_id:
     value: kong
-
 
 tools:
   - deck

--- a/app/_kong_plugins/openid-connect/examples/introspection-auth.yaml
+++ b/app/_kong_plugins/openid-connect/examples/introspection-auth.yaml
@@ -40,12 +40,6 @@ variables:
     value: $CLIENT_SECRET
     description: The client secret needed to connect to your IdP.
 
-variables:
-  issuer:
-    value: "http://keycloak.test:8080/realms/master"
-  client_id:
-    value: kong
-
 tools:
   - deck
   - admin-api

--- a/tools/track-docs-changes/config/sources.yml
+++ b/tools/track-docs-changes/config/sources.yml
@@ -236,6 +236,8 @@ app/_how-tos/plugin-dev-deploy-plugins.md:
   - app/_src/gateway/plugin-development/get-started/deploy.md
 app/_how-tos/plugin-dev-set-up-plugin-project.md:
   - app/_src/gateway/plugin-development/get-started/setup.md
+app/_how-tos/configure-oidc-with-introspection.md:
+  - /app/_hub/kong-inc/openid-connect/how-to/authentication/_introspection.md
 
 ## KIC
 app/_landing_pages/kubernetes-ingress-controller.yaml:


### PR DESCRIPTION
## Description

Fixes #1142 

The includes and the Keycloak prereq depend on https://github.com/Kong/developer.konghq.com/pull/1196.

## Preview Links

https://deploy-preview-1201--kongdeveloper.netlify.app/plugins/openid-connect/examples/introspection-auth/ 
https://deploy-preview-1201--kongdeveloper.netlify.app/how-to/configure-oidc-with-introspection/

## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
