### PR TITLE
fix: Traditional mode clustering info

### DIFF
--- a/app/gateway/traditional-mode.md
+++ b/app/gateway/traditional-mode.md
@@ -65,14 +65,14 @@ Each node manages its own configuration._
 
 ## About {{site.base_gateway}} clusters
 
-A {{site.base_gateway}} cluster does not load balance client traffic across Data Plane nodes out-of-the-box. You still need a
-[load-balancer](/gateway/load-balancing/) in front of your Data Plane nodes to distribute your traffic. Instead,
-a {{site.base_gateway}} cluster means that those nodes will share the same configuration.
+Data Plane nodes in the same {{site.base_gateway}} cluster share the same configuration.
+
+To load balance traffic across Data Plane nodes in a cluster, configure a [load balancer](/gateway/load-balancing/) in front of your nodes to distribute the traffic. 
 
 For performance reasons, {{site.base_gateway}} avoids database connections when proxying
 requests, and caches the contents of your database in memory. The cached
 [entities](/gateway/entities/) include Gateway Services, Routes, Consumers, plugins, credentials, and so on. Since those
-values are in memory, any change made via the Admin API of one of the nodes
+values are stored in memory, any change made via the Admin API of one of the nodes
 must be propagated to the other nodes.
 
 ## Single node clusters

--- a/app/gateway/traditional-mode.md
+++ b/app/gateway/traditional-mode.md
@@ -63,6 +63,18 @@ style D stroke:none,fill:#0E44A2,color:#fff
 > _Figure 1: In a traditional deployment, all {{site.base_gateway}} nodes connect to the database. 
 Each node manages its own configuration._
 
+## About {{site.base_gateway}} clusters
+
+A {{site.base_gateway}} cluster does not load balance client traffic accross Data Plane nodes out-of-the-box. You still need a
+[load-balancer](/gateway/load-balancing/) in front of your Data Plane nodes to distribute your traffic. Instead,
+a {{site.base_gateway}} cluster means that those nodes will share the same configuration.
+
+For performance reasons, {{site.base_gateway}} avoids database connections when proxying
+requests, and caches the contents of your database in memory. The cached
+[entities](/gateway/entities/) include Gateway Services, Routes, Consumers, plugins, credentials, and so on. Since those
+values are in memory, any change made via the Admin API of one of the nodes
+must be propagated to the other nodes.
+
 ## Single node clusters
 
 A single {{site.base_gateway}} node connected to a [supported database](/gateway/configuration/#database) creates a

--- a/app/gateway/traditional-mode.md
+++ b/app/gateway/traditional-mode.md
@@ -65,7 +65,7 @@ Each node manages its own configuration._
 
 ## About {{site.base_gateway}} clusters
 
-A {{site.base_gateway}} cluster does not load balance client traffic accross Data Plane nodes out-of-the-box. You still need a
+A {{site.base_gateway}} cluster does not load balance client traffic across Data Plane nodes out-of-the-box. You still need a
 [load-balancer](/gateway/load-balancing/) in front of your Data Plane nodes to distribute your traffic. Instead,
 a {{site.base_gateway}} cluster means that those nodes will share the same configuration.
 


### PR DESCRIPTION
## Description

Fixes #567 

## Preview Links
https://deploy-preview-1206--kongdeveloper.netlify.app/gateway/traditional-mode/#about-kong-gateway-clusters

I added the remaining section from the existing [Clustering reference](https://docs.konghq.com/gateway/latest/production/clustering/) to the traditional mode page (which is where the rest of the clustering info went).


## Checklist 

- [x] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
