### PR TITLE
Fix: Update Konnect tutorial

### DIFF
--- a/app/_includes/prereqs/products/konnect.md
+++ b/app/_includes/prereqs/products/konnect.md
@@ -22,7 +22,7 @@ If you don't have a Konnect account, you can get started quickly with our [onboa
     ```sh
     export DECK_KONNECT_TOKEN=your-token
     export DECK_KONNECT_CONTROL_PLANE_NAME=your-control-plane-name
-    export KONNECT_CONTROL_PLANE_URL=https://{region}.api.konghq.com
+    export KONNECT_PROXY_URL=konnect-proxy-url
     ```
 {% else %}
     ```sh

--- a/app/_includes/prereqs/products/konnect.md
+++ b/app/_includes/prereqs/products/konnect.md
@@ -2,7 +2,7 @@
 
 {% capture details_content %}
 
-This is a Konnect tutorial. 
+This is a Konnect tutorial.
 If you don't have a Konnect account, you can get started quickly with our [onboarding wizard](https://konghq.com/products/kong-konnect/register?utm_medium=referral&utm_source=docs).
 
 1. The following Konnect items are required to complete this tutorial:
@@ -23,7 +23,6 @@ If you don't have a Konnect account, you can get started quickly with our [onboa
     export DECK_KONNECT_TOKEN=your-token
     export DECK_KONNECT_CONTROL_PLANE_NAME=your-control-plane-name
     export KONNECT_CONTROL_PLANE_URL=https://{region}.api.konghq.com
-    export KONNECT_PROXY_URL=konnect-proxy-url
     ```
 {% else %}
     ```sh


### PR DESCRIPTION
## Description

This PR fixes conditional Konnect instruction for `deck`. I 've removed redundant `KONNECT_CONTROL_PLANE_URL` from the codeblock for `if page.tools contains 'deck'` condition.

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
