### PR TITLE
OIDC auth code flow

### DIFF
--- a/app/_how-tos/configure-oidc-with-auth-code-flow.md
+++ b/app/_how-tos/configure-oidc-with-auth-code-flow.md
@@ -1,0 +1,131 @@
+---
+title: Configure OpenID Connect with the authorization code flow
+content_type: how_to
+
+related_resources:
+  - text: Authentication in {{site.base_gateway}}
+    url: /gateway/authentication/
+  - text: OpenID Connect authentication flows and grants
+    url: /plugins/openid-connect/#authentications
+  - text: Authorization code workflow
+    url: /plugins/openid-connect/#authorization-code-flow
+
+plugins:
+  - openid-connect
+
+entities:
+  - route
+  - service
+
+products:
+  - gateway
+
+works_on:
+  - on-prem
+  - konnect
+
+min_version:
+  gateway: '3.4'
+
+tools:
+  - deck
+
+prereqs:
+  entities:
+    services:
+      - example-service
+    routes:
+      - example-route
+  inline:
+    - title: Set up Keycloak
+      include_content: prereqs/auth/oidc/keycloak-password
+      icon_url: /assets/icons/keycloak.svg
+
+tags:
+  - authentication
+  - openid-connect
+
+tldr:
+  q: How do I use an authorization code to open a session with my identity provider, letting users log in through a browser?
+  a: Using the OpenID Connect plugin, set up the [auth code flow](/plugins/openid-connect/#authorization-code-flow) to connect to an identity provider (IdP) through a browser, and use session authentication to store open sessions.
+
+cleanup:
+  inline:
+    - title: Clean up Konnect environment
+      include_content: cleanup/platform/konnect
+      icon_url: /assets/icons/gateway.svg
+    - title: Destroy the {{site.base_gateway}} container
+      include_content: cleanup/products/gateway
+      icon_url: /assets/icons/gateway.svg
+
+---
+
+## 1. Enable the OpenID Connect plugin with the auth code flow
+
+Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
+set up an instance of the OpenID Connect plugin with the auth code flow and session authentication.
+These two 
+
+Enable the OpenID Connect plugin on the `example-service` Service:
+
+{% entity_examples %}
+entities:
+  plugins:
+    - name: openid-connect
+      service: example-service
+      config:
+        issuer: ${issuer}
+        client_id:
+        - ${client-id}
+        client_secret:
+        - ${client-secret}
+        client_auth:
+        - client_secret_post
+        auth_methods:
+        - authorization_code
+        - session
+        response_mode: form_post
+        preserve_query_args: true
+        login_action: redirect
+        login_tokens: null
+        authorization_endpoint: http://localhost:8080
+variables:
+  issuer:
+    value: $ISSUER
+  client-id:
+    value: $CLIENT_ID
+  client-secret:
+    value: $CLIENT_SECRET
+{% endentity_examples %}
+
+In this example:
+* `issuer`, `client ID`, `client secret`, and `client auth`: Settings that connect the plugin to your IdP (in this case, the sample Keycloak app).
+* `auth_methods`: Specifies that the plugin should use session auth and the authorization code flow.
+* `response_mode`: Set to `form_post` so that authorization codes won’t get logged to access logs.
+* `preserve_query_args`: Preserves the original request query arguments through the authorization code flow redirection.
+* `login_action`: Redirects the client to original request URL after the authorization code flow so that the POST request is turned into a GET request, and the browser address bar is updated with the original request query arguments.
+* `login_tokens`: We don’t want to include any tokens in the browser address bar.
+* `authorization_endpoint`: Sets a custom endpoint for authorization, overriding the endpoint returned by discovery through the IdP. 
+We need this setting because we're running the example through Docker, otherwise the discovery endpoint will try to access an internal Docker host.
+
+## 2. Validate authorization code login
+
+Access the Route you configured in the [prerequisites](#prerequisites) with some query arguments. 
+The following command opens a new tab in your default browser:
+
+```sh
+open http://localhost:8000/anything?hello=world
+```
+
+The browser should be redirected to the Keycloak login page. 
+
+Let's check what happens if you access the same URL using cURL:
+
+{% validation request-check %}
+url: /anything?hello=world
+method: GET
+status_code: 302
+display_headers: true
+{% endvalidation %}
+
+You should see a `302` response with the session access token in the response, and a `Location` header that shows where the request is being redirected to.

--- a/app/_how-tos/configure-oidc-with-auth-code-flow.md
+++ b/app/_how-tos/configure-oidc-with-auth-code-flow.md
@@ -1,6 +1,7 @@
 ---
 title: Configure OpenID Connect with the authorization code flow
 content_type: how_to
+description: Learn how to configure OpenID Connect with the authorization code flow in Keycloak.
 
 related_resources:
   - text: Authentication in {{site.base_gateway}}
@@ -47,7 +48,7 @@ tags:
 
 tldr:
   q: How do I use an authorization code to open a session with my identity provider, letting users log in through a browser?
-  a: Using the OpenID Connect plugin, set up the [auth code flow](/plugins/openid-connect/#authorization-code-flow) to connect to an identity provider (IdP) through a browser, and use session authentication to store open sessions.
+  a: Using the OpenID Connect plugin, set up the [auth code flow](/plugins/openid-connect/#authorization-code-flow) to connect to an identity provider (IdP) through a browser, and use session authentication to store open sessions. You can do this by specifying `authorization_code` and `session` in the `config.auth_methods` plugin settings.
 
 cleanup:
   inline:
@@ -64,7 +65,6 @@ cleanup:
 
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin with the auth code flow and session authentication.
-These two 
 
 Enable the OpenID Connect plugin on the `example-service` Service:
 
@@ -103,18 +103,18 @@ In this example:
 * `auth_methods`: Specifies that the plugin should use session auth and the authorization code flow.
 * `response_mode`: Set to `form_post` so that authorization codes won’t get logged to access logs.
 * `preserve_query_args`: Preserves the original request query arguments through the authorization code flow redirection.
-* `login_action`: Redirects the client to original request URL after the authorization code flow so that the POST request is turned into a GET request, and the browser address bar is updated with the original request query arguments.
-* `login_tokens`: We don’t want to include any tokens in the browser address bar.
+* `login_action`: Redirects the client to the original request URL after the authorization code flow. This turns the POST request into a GET request, and the browser address bar is updated with the original request query arguments.
+* `login_tokens`: Configures the plugin so that tokens aren't included in the browser address bar.
 * `authorization_endpoint`: Sets a custom endpoint for authorization, overriding the endpoint returned by discovery through the IdP. 
 We need this setting because we're running the example through Docker, otherwise the discovery endpoint will try to access an internal Docker host.
 
 ## 2. Validate authorization code login
 
 Access the Route you configured in the [prerequisites](#prerequisites) with some query arguments. 
-The following command opens a new tab in your default browser:
+In a new browser tab, navigate to the following:
 
 ```sh
-open http://localhost:8000/anything?hello=world
+http://localhost:8000/anything?hello=world
 ```
 
 The browser should be redirected to the Keycloak login page. 

--- a/app/_kong_plugins/openid-connect/examples/authorization-code.yaml
+++ b/app/_kong_plugins/openid-connect/examples/authorization-code.yaml
@@ -2,17 +2,24 @@ title: Authorization code flow
 description: |
   Configure the OpenID Connect plugin with an authorization code flow.
 
+  For a full example that shows you how to set up the authorization code flow with Keycloak, 
+  see [Configure OpenID Connect with the auth code flow](/how-to/configure-oidc-with-auth-code-flow/).
+
+  {% include_cached plugins/oidc/client-auth.md %}
+
 weight: 900
 
 requirements:
   - A configured identity provider (IdP)
 
 config:
-  issuer: $ISSUER
+  issuer: ${issuer}
   client_id:
-    - $CLIENT_ID
+    - ${client-id}
+  client_secret:
+    - ${client-secret}
   client_auth:
-    - private_key_jwt
+    - client_secret_post
   auth_methods:
     - authorization_code
     - session
@@ -23,9 +30,16 @@ config:
 
 variables:
   issuer:
-    value: "http://keycloak.test:8080/realms/master"
-  client_id:
-    value: kong
+    value: $ISSUER
+    description: |
+      The issuer authentication URL for your IdP. 
+      For example, if you're using Keycloak as your IdP, the issuer URL looks like this: `http://example-keycloak-host:8080/realms/example-realm`
+  client-id:
+    value: $CLIENT_ID
+    description: The client ID that the plugin uses when it calls authenticated endpoints of the IdP.
+  client-secret:
+    value: $CLIENT_SECRET
+    description: The client secret needed to connect to your IdP.
 
 tools:
   - deck

--- a/app/_kong_plugins/openid-connect/examples/authorization-code.yaml
+++ b/app/_kong_plugins/openid-connect/examples/authorization-code.yaml
@@ -1,6 +1,6 @@
 title: Authorization code flow
 description: |
-  Configure the OpenID Connect plugin with an authorization code flow.
+  This example configures the OpenID Connect plugin with an authorization code flow.
 
   For a full example that shows you how to set up the authorization code flow with Keycloak, 
   see [Configure OpenID Connect with the auth code flow](/how-to/configure-oidc-with-auth-code-flow/).

--- a/tools/track-docs-changes/config/sources.yml
+++ b/tools/track-docs-changes/config/sources.yml
@@ -244,6 +244,8 @@ app/_how-tos/add-correlation-ids-to-gateway-logs.md:
   - app/_hub/kong-inc/correlation-id/overview/_index.md
 app/_how-tos/configure-oidc-with-kong-oauth2.md:
   - app/_hub/kong-inc/openid-connect/how-to/authentication/_kong-oauth-token.md
+app/_how-tos/configure-oidc-with-auth-code-flow.md:
+  - app/_hub/kong-inc/openid-connect/how-to/authentication/_authorization-code.md
 
 ## KIC
 app/_landing_pages/kubernetes-ingress-controller.yaml:


### PR DESCRIPTION
## Description

Fixes #1150 

Note that I purpose didn't include `authorization_endpoint` in the plugin example, even though it's in the how-to. That setting is necessary because the how-to uses Docker.

## Preview Links

https://deploy-preview-1224--kongdeveloper.netlify.app/how-to/configure-oidc-with-auth-code-flow/
https://deploy-preview-1224--kongdeveloper.netlify.app/plugins/openid-connect/examples/authorization-code/
## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
