### PR TITLE
OIDC: client auth + 3rd party examples

### DIFF
--- a/app/_includes/components/entity_example/format/snippets/admin-api.md
+++ b/app/_includes/components/entity_example/format/snippets/admin-api.md
@@ -4,6 +4,6 @@ curl -i -X POST {{ include.presenter.url }} \
     --header "Content-Type: application/json" \{% if include.presenter.headers %}{%- for header in include.presenter.headers %}
     --header "{{header}}" \{% endfor %}{% endif %}
     --data '
-{{ include.presenter.data | json_prettify | indent: 4 }}
+{{ include.presenter.data | json_prettify | escape_env_variables | indent: 4 }}
     '
 ```

--- a/app/_includes/components/entity_example/format/snippets/konnect-api.md
+++ b/app/_includes/components/entity_example/format/snippets/konnect-api.md
@@ -4,6 +4,6 @@ curl -X POST {{ include.presenter.url }} \
     --header "Content-Type: application/json" \
     --header "Authorization: Bearer ${{ include.presenter.pat }}" \
     --data '
-{{ include.presenter.data | json_prettify | indent: 4 }}
+{{ include.presenter.data | json_prettify | escape_env_variables | indent: 4 }}
     '
 ```

--- a/app/_kong_plugins/openid-connect/examples/amazon-cognito.yaml
+++ b/app/_kong_plugins/openid-connect/examples/amazon-cognito.yaml
@@ -1,6 +1,7 @@
 title: OpenID Connect with Amazon Cognito
 description: |
-  Configure the OpenID Connect plugin with Amazon Cognito.
+  Configure the OpenID Connect plugin with [Amazon Cognito User Pools](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools.html).
+  User Pools are a multi-tenant LDAP-like user repository combined with an OAuth2 and an OpenID Connect interface.
 
 weight: 800
 
@@ -8,23 +9,24 @@ requirements:
   - Set up an Amazon Cognito User Pool and Application Definition before configuring the plugin.
 
 config:
-  issuer: $ISSUER
+  issuer: ${issuer}
   client_id: 
-    - $CLIENT_ID
+    - ${client-id}
   client_secret: 
-    - $CLIENT_SECRET
+    - ${client-secret}
+
 variables: 
-  issuer: 
-    value: "https://cognito-idp.$REGION.amazonaws.com/$USER_POOL_ID"
-    description: Replace with the discovery endpoint or issuer identifier of your IdP.
-  client_id: 
+  issuer:
+    value: $ISSUER
+    description: |
+      The issuer authentication URL for your IdP. For Amazon Cognito, that typically looks like this:
+      `https://cognito-idp.${REGION}.amazonaws.com/${REGION}_${POOL_ID}/.well-known/openid-configuration`
+  client-id: 
     value: $CLIENT_ID
-    description: Replace with the client ID of your IdP. The OpenID Connect plugin uses this value when it calls authenticated endpoints on the identity provider.
-  client_secret: 
+    description: The client ID that the plugin uses when it calls authenticated endpoints of the IdP.
+  client-secret: 
     value: $CLIENT_SECRET
-    description: Replace with your IdP client secret.
-
-
+    description: The client secret needed to connect to your IdP.
 
 tools:
   - deck

--- a/app/_kong_plugins/openid-connect/examples/auth0.yaml
+++ b/app/_kong_plugins/openid-connect/examples/auth0.yaml
@@ -1,23 +1,33 @@
 title: OpenID Connect with Auth0
 description: |
-  Authenticate headless service consumers using Auth0's identity provider.
+  Authenticate headless service consumers using [Auth0's identity provider](https://auth0.com/docs/authenticate/identity-providers).
+
+  This example uses a client credentials grant as it is non-interactive, 
+  and because we expect clients to authenticate on behalf of themselves, not an end-user. 
+
 weight: 799
 requirements:
   - "Auth0 API configured with the `openid` scope. Find your `issuer` URL and `audience`
-  in your Auth0 API configuration."
-  - A Kong service with `url` configured to match your Auth0 API Identifier.
+    in your Auth0 API configuration."
+  - "Your client is authorized to access your API. 
+    After client creation in Auth0, set the client to Authorized, expand its authorization settings, and enable the `openid` scope."
+  - "A Kong service with `url` configured to match your Auth0 API Identifier."
 
 config:
+  issuer: ${issuer}
+  audience: ${audience}
   auth_methods:
-    - client_credentials
-  issuer: $ISSUER
-  audience: $AUDIENCE
+  - client_credentials
 
-variables: 
+variables:
   issuer:
-    value: "https://$AUTH0_API_NAME.auth0.com/.well-known/openid-configuration"
+    value: $ISSUER
+    description: |
+      The issuer authentication URL for your IdP. 
+      For Auth0, that typically looks like this: `https://{AUTH0_API_NAME}.auth0.com/.well-known/openid-configuration`.
   audience:
     value: $AUTH0_API_IDENTIFIER
+    description: Auth0's token endpoint requires [passing the API identifier in the audience parameter](https://auth0.com/docs/api/authentication#client-credentials), which must be added as a custom argument.
 
 tools:
   - deck

--- a/app/_kong_plugins/openid-connect/examples/auth0.yaml
+++ b/app/_kong_plugins/openid-connect/examples/auth0.yaml
@@ -11,7 +11,7 @@ requirements:
     in your Auth0 API configuration."
   - "Your client is authorized to access your API. 
     After client creation in Auth0, set the client to Authorized, expand its authorization settings, and enable the `openid` scope."
-  - "A Kong service with `url` configured to match your Auth0 API Identifier."
+  - "A [Gateway Service](/gateway/entities/service/) with the `url` configured to match your Auth0 API Identifier."
 
 config:
   issuer: ${issuer}

--- a/app/_kong_plugins/openid-connect/examples/azure-ad.yaml
+++ b/app/_kong_plugins/openid-connect/examples/azure-ad.yaml
@@ -1,41 +1,65 @@
 title: OpenID Connect with Azure AD
 description: |
-  Authenticate browser clients using an Azure AD identity provider.
+  Authenticate browser clients using an [Azure AD identity provider](https://learn.microsoft.com/en-us/entra/identity/).
+
+  The following configuration example allows users to authenticate and access the upstream service even though no Consumer was created for them. 
+  This means any user with a valid account in the directory will have access.
+  If you want to restrict access further, you have several options:
+  
+  * **Domain restrictions**: Azure AD doesn't provide identity tokens with the `hd` claim, so the OIDC plugin's domains configuration can't restrict users based on their domain. 
+  Using a single-tenant application will restrict access to users in your directory only. 
+  Multi-tenant apps allow users with Microsoft accounts from other directories and optionally any Microsoft account (for example `live.com` or Xbox accounts) to sign in.
+  * **Consumer mapping**: If you need to interact with other {{site.base_gateway}} plugins using consumer information, you can map account data received from the IdP to a Kong Consumer. 
+  See [OIDC with Consumer authorization](/how-to/configure-oidc-with-consumers/).
+  * **Pseudo-consumer mapping**: For plugins that typically require Consumers, the OIDC plugin can provide a Consumer ID based on the value of a claim without mapping to an actual Consumer. 
+  Setting `credential_claim` to a claim in your plugin configuration extracts the value of that claim and uses it where {{site.base_gateway}} would normally use a Consumer ID. 
+  Similarly, setting `authenticated_groups_claim` extracts that claim's value and uses it as a group for the [ACL plugin](/plugins/acl/).
+  
+  {:.info}
+  > **Note**: Azure AD provides two interfaces for its OAuth2/OIDC-related endpoints: v1.0 and v2.0. 
+  Support for some legacy v1.0 behavior is still available on v2.0, including use of v1.0 tokens by default, which is not compatible with Kong's OIDC implementation.
+  To force Azure AD to use v2.0 tokens, edit your application manifest and set `accessTokenAcceptedVersion` to 2 and include a `CLIENT_ID/.default` scope in your plugin configuration (see example).
 
 weight: 798
 requirements:
   - A Gateway Service and Route secured with HTTPS.
-  - In Azure AD, configure a redirect URI that is handled by your Route.
-  - In Azure AD, register an app and add a client secret credential that this plugin will use to access it.
+  - In Azure AD, configure an authorized redirect URI that is handled by your Route.
+  - In Azure AD, [register an app](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app) and add a [client secret credential](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-access-web-apis#add-credentials-to-your-web-application) that this plugin will use to access it.
 
 config:
-  issuer: $ISSUER
+  issuer: ${issuer}
   client_id:
-    - $CLIENT_ID
+    - ${client-id}
   client_secret:
-    - $CLIENT_SECRET
+    - ${client-secret}
   redirect_uri:
-    - $REDIRECT_URI
+    - ${redirect-uri}
   scopes:
     - openid
     - email
     - profile
-    - "$CLIENT_ID/.default"
+    - "${client-id}/.default"
   verify_parameters: false
 
 variables: 
   issuer:
-    value: "https://login.microsoftonline.com/$DIRECTORY_ID/v2.0/.well-known/openid-configuration"
-  client_id: 
+    value: $ISSUER
+    description: |
+      The issuer authentication URL for your IdP. 
+      For Azure AD, that typically looks like this: `https://login.microsoftonline.com/{DIRECTORY}/v2.0/.well-known/openid-configuration`.
+      You can find this URL by clicking the Endpoints button on your app registration's Overview page.
+  client-id:
     value: $CLIENT_ID
-    description: Replace with the client ID of your IdP. The OpenID Connect plugin uses this value when it calls authenticated endpoints on the identity provider.
-  client_secret: 
+    description: The client ID that the plugin uses when it calls authenticated endpoints of the IdP, shown on your Azure AD app registration's Overview page.
+  client-secret:
     value: $CLIENT_SECRET
-    description: Replace with your IdP client secret.
-  redirect_uri:
-    value: "https://example.com/api"
-
-
+    description: |
+      The URL-encoded representation of the secret you created in the Azure AD **Certificates & Secrets** section. 
+  redirect-uri:
+    value: $REDIRECT_URI
+    description: |
+      The URI you specified when configuring your app. 
+      If you didn't add one initially, you can add a redirect URI via the Authentication section of the app settings.
 
 tools:
   - deck
@@ -43,3 +67,6 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+search_aliases:
+  - Microsoft Entra ID

--- a/app/_kong_plugins/openid-connect/examples/azure-ad.yaml
+++ b/app/_kong_plugins/openid-connect/examples/azure-ad.yaml
@@ -9,20 +9,20 @@ description: |
   * **Domain restrictions**: Azure AD doesn't provide identity tokens with the `hd` claim, so the OIDC plugin's domains configuration can't restrict users based on their domain. 
   Using a single-tenant application will restrict access to users in your directory only. 
   Multi-tenant apps allow users with Microsoft accounts from other directories and optionally any Microsoft account (for example `live.com` or Xbox accounts) to sign in.
-  * **Consumer mapping**: If you need to interact with other {{site.base_gateway}} plugins using consumer information, you can map account data received from the IdP to a Kong Consumer. 
+  * **Consumer mapping**: If you need to interact with other {{site.base_gateway}} plugins using consumer information, you can map account data received from the IdP to a {{site.base_gateway}} Consumer. 
   See [OIDC with Consumer authorization](/how-to/configure-oidc-with-consumers/).
-  * **Pseudo-consumer mapping**: For plugins that typically require Consumers, the OIDC plugin can provide a Consumer ID based on the value of a claim without mapping to an actual Consumer. 
+  * **Pseudo-Consumer mapping**: For plugins that typically require Consumers, the OIDC plugin can provide a Consumer ID based on the value of a claim without mapping to an actual Consumer. 
   Setting `credential_claim` to a claim in your plugin configuration extracts the value of that claim and uses it where {{site.base_gateway}} would normally use a Consumer ID. 
   Similarly, setting `authenticated_groups_claim` extracts that claim's value and uses it as a group for the [ACL plugin](/plugins/acl/).
   
   {:.info}
   > **Note**: Azure AD provides two interfaces for its OAuth2/OIDC-related endpoints: v1.0 and v2.0. 
-  Support for some legacy v1.0 behavior is still available on v2.0, including use of v1.0 tokens by default, which is not compatible with Kong's OIDC implementation.
+  Support for some legacy v1.0 behavior is still available on v2.0, including use of v1.0 tokens by default, which is not compatible with {{site.base_gateway}}'s OIDC implementation.
   To force Azure AD to use v2.0 tokens, edit your application manifest and set `accessTokenAcceptedVersion` to 2 and include a `CLIENT_ID/.default` scope in your plugin configuration (see example).
 
 weight: 798
 requirements:
-  - A Gateway Service and Route secured with HTTPS.
+  - A [Gateway Service](/gateway/entities/service/#set-up-a-gateway-service) and [Route](/gateway/entities/route/#set-up-a-route) secured with HTTPS.
   - In Azure AD, configure an authorized redirect URI that is handled by your Route.
   - In Azure AD, [register an app](https://docs.microsoft.com/en-us/azure/active-directory/develop/quickstart-register-app) and add a [client secret credential](https://learn.microsoft.com/en-us/entra/identity-platform/quickstart-configure-app-access-web-apis#add-credentials-to-your-web-application) that this plugin will use to access it.
 
@@ -46,8 +46,8 @@ variables:
     value: $ISSUER
     description: |
       The issuer authentication URL for your IdP. 
-      For Azure AD, that typically looks like this: `https://login.microsoftonline.com/{DIRECTORY}/v2.0/.well-known/openid-configuration`.
-      You can find this URL by clicking the Endpoints button on your app registration's Overview page.
+      For Azure AD, that typically looks like this: `https://login.microsoftonline.com/{directory}/v2.0/.well-known/openid-configuration`.
+      You can find this URL by clicking **Endpoints** on your app registration's Overview page.
   client-id:
     value: $CLIENT_ID
     description: The client ID that the plugin uses when it calls authenticated endpoints of the IdP, shown on your Azure AD app registration's Overview page.

--- a/app/_kong_plugins/openid-connect/examples/cert-bound-access-tokens.yaml
+++ b/app/_kong_plugins/openid-connect/examples/cert-bound-access-tokens.yaml
@@ -1,19 +1,20 @@
 title: Cert-bound access tokens
 description: |
-  Configure the OpenID Connect plugin to use certificate-bound access tokens.
+  Configure the OpenID Connect plugin to use [certificate-bound access tokens](/plugins/openid-connect/#certificate-bound-access-tokens).
 
 weight: 819
 
 requirements:
-  - A configured identity provider (IdP) configured with mTLS and X.509 client certificate authentication
+  - "{{site.base_gateway}} is configured to use mTLS client certificate authentication. You can do this using the [TLS Handshake Modifier plugin](/plugins/tls-handshake-modifier/) or the [mTLS Authentication plugin](/plugins/mtls-auth/)"
+  - An identity provider (IdP) configured with mTLS and X.509 client certificate authentication
   - A client certificate and key pair stored in a [Certificate object](/gateway/entities/certificate/)
 
 config:
   issuer: ${issuer}
   client_id:
-    - cert-bound
+    - ${client-id}
   client_secret: 
-    - ${secret}
+    - ${client-secret}
   auth_methods:
     - bearer
   proof_of_possession_mtls: strict
@@ -22,9 +23,12 @@ variables:
   issuer:
     value: $ISSUER
     description: The well-known issuer endpoint of your IdP, for example `http://keycloak.test:8080/realms/master`.
-  secret:
+  client-id:
+    value: $CLIENT_ID
+    description: The client ID that the plugin uses when it calls authenticated endpoints of the IdP.
+  client-secret:
     value: $CLIENT_SECRET
-    description: The client secret.
+    description: The client secret needed to connect to your IdP.
 
 tools:
   - deck

--- a/app/_kong_plugins/openid-connect/examples/curity.yaml
+++ b/app/_kong_plugins/openid-connect/examples/curity.yaml
@@ -1,20 +1,25 @@
 title: OpenID Connect with Curity
 description: |
   Integrate Kong Gateway and the Curity Identity Server for introspection using the
-  Phantom Token pattern.
+  [Phantom Token pattern](https://curity.io/resources/learn/phantom-token-pattern).
+
+  The OpenID Connect plugin introspects an incoming opaque access token and receives a JWT in the introspection response from the Curity Identity Server. 
+  As part of the introspection, the OpenID Connect plugin validates that required scopes are available in the introspected token. 
+  * If the correct scopes are missing, access to the requested upstream service is denied.
+  * If access is granted, the JWT from the introspection response is added to a header and forwarded to the upstream service where it can be consumed.
 
 weight: 797
 
 requirements:
-  - Curity Identity Server installed.
-  - An introspection endpoint configured with the Token Procedure Approach.
+  - "[Curity Identity Server installed](https://curity.io/resources/getting-started)."
+  - "An introspection endpoint configured with the [Phantom Token Approach](https://curity.io/resources/learn/introspect-with-phantom-token/)."
 
 config:
-  issuer: $ISSUER
-  client_id: 
-    - $CLIENT_ID
-  client_secret: 
-    - $CLIENT_SECRET
+  issuer: ${issuer}
+  client_id:
+    - ${client-id}
+  client_secret:
+    - ${client-secret}
   scopes_required:
     - openid
   hide_credentials: true
@@ -27,15 +32,17 @@ config:
     - introspection
 
 variables: 
-  issuer: 
-    value: "https://idsvr.example.com/oauth/v2/oauth-anonymous"
-  client_id: 
+  issuer:
+    value: $ISSUER
+    description: |
+      The issuer authentication URL for your IdP. 
+      For Curity, that typically looks like this: `https://idsvr.example.com/oauth/v2/oauth-anonymous`.
+  client-id:
     value: $CLIENT_ID
-    description: Replace with the client ID of your IdP. The OpenID Connect plugin uses this value when it calls authenticated endpoints on the identity provider.
-  client_secret: 
+    description: The client ID that the plugin uses when it calls authenticated endpoints of the IdP.
+  client-secret:
     value: $CLIENT_SECRET
-    description: Replace with your IdP client secret.
-
+    description: The client secret needed to connect to Curity.
 
 tools:
   - deck

--- a/app/_kong_plugins/openid-connect/examples/dpop.yaml
+++ b/app/_kong_plugins/openid-connect/examples/dpop.yaml
@@ -1,31 +1,34 @@
 title: Demonstrating Proof-of-Possession (DPoP)
 description: |
-  Configure the OpenID Connect plugin for Demonstrating Proof-of-Possession by using the `proof_of_possession_dpop` configuration option. 
+  Configure the OpenID Connect plugin for [Demonstrating Proof-of-Possession](/plugins/openid-connect/#demonstrating-proof-of-possession-dpop) by using the `proof_of_possession_dpop` configuration option. 
+  
+  This method binds the access token to a JSON Web Key (JWK) provided by the client.
 
 weight: 820
 
 requirements:
-  - A configured identity provider (IdP)
+  - A configured identity provider (IdP) with DPoP enabled
 
 config:
-  issuer: $ISSUER
+  issuer: ${issuer}
   client_id:
-    - $CLIENT_ID
-  client_secret:
-    - $CLIENT_SECRET
+    - ${client-id}
+  client_secret: 
+    - ${client-secret}
   auth_methods:
     - bearer
   proof_of_possession_dpop: strict
 
 variables:
   issuer:
-    value: "http://keycloak.test:8080/realms/master"
-  client_id:
-    value: cert_bound
-  client_secret:
+    value: $ISSUER
+    description: The well-known issuer endpoint of your IdP, for example `http://keycloak.test:8080/realms/master`.
+  client-id:
+    value: $CLIENT_ID
+    description: The client ID that the plugin uses when it calls authenticated endpoints of the IdP.
+  client-secret:
     value: $CLIENT_SECRET
-
-
+    description: The client secret needed to connect to your IdP.
 
 tools:
   - deck

--- a/app/_kong_plugins/openid-connect/examples/google.yaml
+++ b/app/_kong_plugins/openid-connect/examples/google.yaml
@@ -1,38 +1,41 @@
 title: OpenID Connect with Google
 description: |
-  Authenticate browser clients using Google's identity provider.
+  Authenticate browser clients using [Google's identity provider](https://developers.google.com/identity).
 
 weight: 796
 
 requirements:
   - A Gateway Service and Route secured with HTTPS.
-  - Set up a Google API project and create a set of OAuth client ID credentials with the Web application class. 
+  - Set up a [Google API project](https://developers.google.com/identity/protocols/OpenIDConnect) and create a set of [OAuth client ID credentials](https://console.developers.google.com/apis/credentials) with the Web application class. 
   - An authorized redirect URI for the part of the API you want to protect.
 
 config:
-  issuer: $ISSUER
-  client_id: 
-    - $CLIENT_ID
-  client_secret: 
-    - $CLIENT_SECRET
+  issuer: ${issuer}
+  client_id:
+    - ${client-id}
+  client_secret:
+    - ${client-secret}
   redirect_uri:
-    - $REDIRECT_URI
+    - ${redirect-uri}
   scopes:
     - openid
     - email
 
 variables: 
   issuer:
-    value: "https://accounts.google.com/.well-known/openid-configuration"
-  client_id: 
+    value: $ISSUER
+    description: |
+      The issuer authentication URL for your IdP. 
+      For Google, that typically looks like this: `https://accounts.google.com/.well-known/openid-configuration`
+  client-id:
     value: $CLIENT_ID
-    description: Replace with the client ID of your IdP. The OpenID Connect plugin uses this value when it calls authenticated endpoints on the identity provider.
-  client_secret: 
+    description: The client ID that the plugin uses when it calls authenticated endpoints of the IdP.
+  client-secret:
     value: $CLIENT_SECRET
-    description: Replace with your IdP client secret.
-  redirect_uri:
-    value: "https://example.com/api"
-
+    description: The client secret needed to connect to Google.
+  redirect-uri:
+    value: $REDIRECT_URI
+    description: The authorized redirect URI that you created in Cloud Console, which determines where Google sends responses to your authentication requests.
 
 tools:
   - deck

--- a/app/_kong_plugins/openid-connect/examples/google.yaml
+++ b/app/_kong_plugins/openid-connect/examples/google.yaml
@@ -35,7 +35,7 @@ variables:
     description: The client secret needed to connect to Google.
   redirect-uri:
     value: $REDIRECT_URI
-    description: The authorized redirect URI that you created in Cloud Console, which determines where Google sends responses to your authentication requests.
+    description: The authorized redirect URI that you created in the Cloud Console, which determines where Google sends responses to your authentication requests.
 
 tools:
   - deck

--- a/app/_kong_plugins/openid-connect/examples/mtls-client-auth.yaml
+++ b/app/_kong_plugins/openid-connect/examples/mtls-client-auth.yaml
@@ -1,8 +1,11 @@
 title: Mutual TLS client authentication
 description: |
-  Configure the OpenID Connect plugin to use mutual TLS (mTLS) client authentication.
+  Configure the OpenID Connect plugin to use [mutual TLS (mTLS) client authentication](/plugins/openid-connect/#mutual-tls-client-authentication).
 
   The following uses the password grant, but you can use any supported OpenID Connect auth method.
+
+  The configuration option `config.tls_client_auth_ssl_verify` controls whether the server (IdP) certificate is verified.
+  When set to `true` (default), ensure that [trusted certificate](/gateway/configuration/#lua-ssl-trusted-certificate) and [verify depth](/gateway/configuration/#lua-ssl-verify-depth) are appropriately configured so that the IdP's server certificate is trusted by {{site.base_gateway}}.
 
 weight: 819
 
@@ -11,22 +14,28 @@ requirements:
   - A client certificate and key pair stored in a [Certificate object](/gateway/entities/certificate/)
 
 config:
-  issuer: $ISSUER
+  issuer: ${issuer}
   client_id:
-    - $CLIENT_ID
+    - ${client-id}
   client_auth:
     - tls_client_auth
   auth_methods:
     - password
-  tls_client_auth_cert_id: $CERTIFICATE_ID
+  tls_client_auth_cert_id: ${cert-id}
+  tls_client_auth_ssl_verify: true
 
 variables:
   issuer:
-    value: "http://keycloak.test:8080/realms/master"
-  client_id:
-    value: tls-client
-  tls_client_auth_cert_id:
+    value: $ISSUER
+    description: |
+      The issuer authentication URL for your IdP. 
+      For example, if you're using Keycloak as your IdP, the issuer URL looks like this: `http://example-keycloak-host:8080/realms/example-realm`.  
+  client-id:
+    value: $CLIENT_ID
+    description: The client ID that the plugin uses when it calls authenticated endpoints of the IdP.
+  cert-id:
     value: $CERTIFICATE_ID
+    description: The UUID of a Certificate object in {{site.base_gateway}}, which contains a client cert and key pair.
 
 tools:
   - deck

--- a/app/_kong_plugins/openid-connect/examples/okta.yaml
+++ b/app/_kong_plugins/openid-connect/examples/okta.yaml
@@ -1,22 +1,34 @@
 title: OpenID Connect with Okta
 description: |
-  Authenticate browser clients using Okta.
+  Authenticate browser clients using [Okta](https://help.okta.com/en-us/content/index.htm).
+
+  The following configuration example allows users to authenticate and access the upstream service even though no Consumer was created for them. 
+  This means any user with a valid account in the directory will have access.
+  If you want to restrict access further, you have several options:
+  
+  * **Consumer mapping**: If you need to interact with other {{site.base_gateway}} plugins using consumer information, you can map account data received from the IdP to a Kong Consumer. 
+  See [OIDC with Consumer authorization](/how-to/configure-oidc-with-consumers/).
+  * **Pseudo-consumer mapping**: For plugins that typically require Consumers, the OIDC plugin can provide a Consumer ID based on the value of a claim without mapping to an actual Consumer. 
+  Setting `credential_claim` to a claim in your plugin configuration extracts the value of that claim and uses it where {{site.base_gateway}} would normally use a Consumer ID. 
+  Similarly, setting `authenticated_groups_claim` extracts that claim's value and uses it as a group for the [ACL plugin](/plugins/acl/).
+  
 
 weight: 795
 
 requirements:
+  - A developer account with Okta.
   - A Gateway Service and Route secured with HTTPS.
   - A registered application in Okta pointing to the Kong Route.
   - Any network access control to your Kong node must allow traffic to and from Okta, the upstream service, and the client.
 
 config:
-  issuer: $ISSUER
-  client_id: 
-    - $CLIENT_ID
-  client_secret: 
-    - $CLIENT_SECRET
+  issuer: ${issuer}
+  client_id:
+    - ${client-id}
+  client_secret:
+    - ${client-secret}
   redirect_uri:
-    - $REDIRECT_URI
+    - ${redirect-uri}
   scopes_claim:
     - scp
   scopes:
@@ -28,15 +40,20 @@ config:
 
 variables: 
   issuer: 
-    value: "https://$OKTA_DOMAIN/oauth2/$AUTH_SERVER/.well-known/openid-configuration"
-  client_id: 
+    value: $ISSUER
+    description: |
+      The issuer authentication URL for your IdP. 
+      For Okta, that typically looks like this: `https://{OKTA_DOMAIN}/oauth2/{AUTH_SERVER}/.well-known/openid-configuration`.
+  client-id: 
     value: $CLIENT_ID
-    description: Replace with the client ID of your IdP. The OpenID Connect plugin uses this value when it calls authenticated endpoints on the identity provider.
-  client_secret: 
+    description: The client ID that the plugin uses when it calls authenticated endpoints of the IdP.
+  client-secret: 
     value: $CLIENT_SECRET
-    description: Replace with your IdP client secret.
-  redirect_uri:
-    value: "https://example.com/api"
+    description: The client secret needed to connect to your IdP.
+  redirect-uri:
+    value: $REDIRECT_URI
+    description: |
+      The `redirect_uri` of the client defined with `client_id`.
 
 tools:
   - deck

--- a/app/_kong_plugins/openid-connect/examples/okta.yaml
+++ b/app/_kong_plugins/openid-connect/examples/okta.yaml
@@ -6,9 +6,9 @@ description: |
   This means any user with a valid account in the directory will have access.
   If you want to restrict access further, you have several options:
   
-  * **Consumer mapping**: If you need to interact with other {{site.base_gateway}} plugins using consumer information, you can map account data received from the IdP to a Kong Consumer. 
+  * **Consumer mapping**: If you need to interact with other {{site.base_gateway}} plugins using Consumer information, you can map account data received from the IdP to a {{site.base_gateway}} Consumer. 
   See [OIDC with Consumer authorization](/how-to/configure-oidc-with-consumers/).
-  * **Pseudo-consumer mapping**: For plugins that typically require Consumers, the OIDC plugin can provide a Consumer ID based on the value of a claim without mapping to an actual Consumer. 
+  * **Pseudo-Consumer mapping**: For plugins that typically require Consumers, the OIDC plugin can provide a Consumer ID based on the value of a claim without mapping to an actual Consumer. 
   Setting `credential_claim` to a claim in your plugin configuration extracts the value of that claim and uses it where {{site.base_gateway}} would normally use a Consumer ID. 
   Similarly, setting `authenticated_groups_claim` extracts that claim's value and uses it as a group for the [ACL plugin](/plugins/acl/).
   
@@ -43,7 +43,7 @@ variables:
     value: $ISSUER
     description: |
       The issuer authentication URL for your IdP. 
-      For Okta, that typically looks like this: `https://{OKTA_DOMAIN}/oauth2/{AUTH_SERVER}/.well-known/openid-configuration`.
+      For Okta, that typically looks like this: `https://{oktaDomain}/oauth2/{authServer}/.well-known/openid-configuration`.
   client-id: 
     value: $CLIENT_ID
     description: The client ID that the plugin uses when it calls authenticated endpoints of the IdP.

--- a/app/_kong_plugins/openid-connect/index.md
+++ b/app/_kong_plugins/openid-connect/index.md
@@ -588,7 +588,7 @@ Demonstrating Proof-of-Possession (DPoP) is an alternative technique to the [mut
 sequenceDiagram
     autonumber
     participant client as Client <br>(e.g. mobile app)
-    participant kong as API Gateway <br>(Kong)
+    participant kong as API Gateway <br>({{site.base_gateway}})
     participant upstream as Upstream <br>(backend service,<br> e.g. httpbin)
     participant idp as Authentication Server <br>(e.g. Keycloak)
     activate client
@@ -625,8 +625,7 @@ DPoP is compatible with the following authentication methods:
 * [Introspection authentication](#introspection-authentication-flow)
 * [Session authentication](#session-authentication-workflow)
 
-Session authentication is only compatible with DPoP when used along with one of the other supported authentication methods:
-* If multiple `openid-connect` plugins are configured with the `session` authentication method, we strongly recommend configuring different values of [`config.session_secret`](/plugins/openid-connect/reference/#schema--config-session-secret) across plugin instances for additional security. This avoids sessions being shared across plugins and possibly bypassing the proof of possession validation.
+Session authentication is only compatible with DPoP when used along with one of the other supported authentication methods. If multiple `openid-connect` plugins are configured with the `session` authentication method, we strongly recommend configuring different values of [`config.session_secret`](/plugins/openid-connect/reference/#schema--config-session-secret) across plugin instances for additional security. This avoids sessions being shared across plugins and possibly bypassing the proof of possession validation.
 
 To enable DPoP for OpenID Connect:
 * Ensure that the auth server (IdP) that you're using has DPoP enabled.

--- a/tools/track-docs-changes/config/sources.yml
+++ b/tools/track-docs-changes/config/sources.yml
@@ -387,6 +387,24 @@ app/_kong_plugins/openid-connect/index.md:
   - app/_hub/kong-inc/openid-connect/how-to/_fapi.md
 app/_kong_plugins/openid-connect/changelog.md:
   - app/_hub/kong-inc/openid-connect/_changelog.md
+app/_kong_plugins/openid-connect/examples/mtls-client-auth.yaml:
+  - app/_hub/kong-inc/openid-connect/how-to/client-authentication/_mtls.md
+app/_kong_plugins/openid-connect/examples/cert-bound-access-tokens.yaml:
+  - app/_hub/kong-inc/openid-connect/how-to/_cert-bound-access-tokens.md
+app/_kong_plugins/openid-connect/examples/dpop.yaml:
+  - app/_hub/kong-inc/openid-connect/how-to/_demonstrating-proof-of-possession.md
+app/_kong_plugins/openid-connect/examples/okta.yaml:
+  - app/_hub/kong-inc/openid-connect/how-to/third-party/_okta.md
+app/_kong_plugins/openid-connect/examples/curity.yaml:
+  - app/_hub/kong-inc/openid-connect/how-to/third-party/_curity.md
+app/_kong_plugins/openid-connect/examples/amazon-cognito.yaml:
+  - app/_hub/kong-inc/openid-connect/how-to/third-party/_cognito.md
+app/_kong_plugins/openid-connect/examples/google.yaml:
+  - app/_hub/kong-inc/openid-connect/how-to/third-party/_google.md
+app/_kong_plugins/openid-connect/examples/azure-ad.yaml:
+  - app/_hub/kong-inc/openid-connect/how-to/third-party/_azure-ad.md
+app/_kong_plugins/openid-connect/examples/auth0.yaml:
+  - app/_hub/kong-inc/openid-connect/how-to/third-party/_auth0.md
 app/_kong_plugins/bot-detection/index.md:
   - app/_hub/kong-inc/bot-detection/overview/_index.md
 app/_kong_plugins/acme/index.md:


### PR DESCRIPTION
## Description

This fixes all the remaining untested OIDC examples and adds info about cert-bound access tokens and DPoP to the OIDC doc.

Not attached to a specific issue #, trying to unblock us for QA.

## Preview Links


## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
