### PR TITLE
fix: Config Store how tos

### DIFF
--- a/app/_how-tos/configure-the-konnect-config-store.md
+++ b/app/_how-tos/configure-the-konnect-config-store.md
@@ -36,8 +36,14 @@ faqs:
   - q: Can I reference {{site.konnect_short_name}} Config Store Vault secrets in `kong.conf`?
     a: No. You can't reference secrets stored in a {{site.konnect_short_name}} Config Store Vault in `kong.conf` because {{site.konnect_short_name}} resolves the secret after {{site.base_gateway}} connects to the control plane. For more information about the fields you can reference as secrets, see [What can be stored as a secret?](/gateway/entities/vault/#what-can-be-stored-as-a-secret).
 
+prereqs:
+  inline:
+    - title: Konnect API
+      include_content: prereqs/konnect-api-for-curl
+
 tools:
-  - konnect-api
+  - deck
+  # - konnect-api
  
 cleanup:
   inline:
@@ -65,7 +71,7 @@ method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $KONNECT_TOKEN'
+    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     name: my-config-store
 {% endcontrol_plane_request %}
@@ -74,30 +80,27 @@ body:
 Export the Config Store ID in the response body as an environment variable so you can use it later:
 
 ```sh
-export CONFIG_STORE_ID=config-store-uuid
+export DECK_CONFIG_STORE_ID=config-store-uuid
 ```
 
 ## 2. Configure {{site.konnect_short_name}} as your Vault
 
-Enable {{site.konnect_short_name}} as your vault with the [Vault entity](/gateway/entities/vault/). Send a `POST` request to the [`/vaults/`](/api/konnect/control-planes-config/v2/#/operations/create-vault) endpoint:
+Enable {{site.konnect_short_name}} as your vault with the [Vault entity](/gateway/entities/vault/):
 
-<!--vale off-->
-{% control_plane_request %}
-url: /v2/control-planes/$CONTROL_PLANE_ID/core-entities/vaults/
-status_code: 201
-method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
-    - 'Authorization: Bearer $KONNECT_TOKEN'
-body:
-    config:
-      config_store_id: $CONFIG_STORE_ID
-    description: Storing secrets in Konnect
-    name: konnect
+{% entity_examples %}
+entities:
+  vaults:
+  - name: konnect
     prefix: mysecretvault
-{% endcontrol_plane_request %}
-<!--vale on-->
+    description: Storing secrets in Konnect
+    config:
+      config_store_id: ${config-store-id}
+
+variables:
+  config-store-id:
+    value: $CONFIG_STORE_ID
+{% endentity_examples %}
+
 
 ## 3. Store a secret in your {{site.konnect_short_name}} Vault
 
@@ -107,13 +110,13 @@ Store your secret by sending a `POST` request to the `/secrets` endpoint:
 
 <!--vale off-->
 {% control_plane_request %}
-url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores/$CONFIG_STORE_ID/secrets/
+url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores/$DECK_CONFIG_STORE_ID/secrets/
 status_code: 201
 method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $KONNECT_TOKEN'
+    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     key: secret-key
     value: my-secret-value
@@ -126,13 +129,13 @@ You can validate that your secret was stored correctly by sending a `GET` reques
 
 <!--vale off-->
 {% control_plane_request %}
-url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores/$CONFIG_STORE_ID/secrets/
+url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores/$DECK_CONFIG_STORE_ID/secrets/
 status_code: 201
 method: GET
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $KONNECT_TOKEN'
+    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 {% endcontrol_plane_request %}
 <!--vale on-->
 

--- a/app/_how-tos/store-a-mistral-api-key-as-a-secret-in-konnect-config-store.md
+++ b/app/_how-tos/store-a-mistral-api-key-as-a-secret-in-konnect-config-store.md
@@ -50,11 +50,17 @@ prereqs:
         In this tutorial, you'll be storing your Mistral AI API key as a secret in a {{site.konnect_short_name}} Vault.
 
         In the Mistral AI console, [create an API key](https://console.mistral.ai/api-keys/) and copy it. You'll add this API key as a secret to your vault.
+
+        Export the API key as an environment variable:
+        ```sh
+        export MISTRAL_API_KEY='<your-api-key>'
+        ```
     - title: Konnect API
       include_content: prereqs/konnect-api-for-curl
 
 tools:
-  - konnect-api
+  # - konnect-api
+  - deck
 
 faqs:
   - q: How do I replace certificates used in {{site.base_gateway}} data plane nodes with a secret reference?
@@ -86,7 +92,7 @@ method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $KONNECT_TOKEN'
+    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     name: my-config-store
 {% endcontrol_plane_request %}
@@ -100,27 +106,21 @@ export CONFIG_STORE_ID=config-store-uuid
 
 ## 2. Configure {{site.konnect_short_name}} as your Vault
 
-To enable {{site.konnect_short_name}} as your vault with the [Vault entity](/gateway/entities/vault/) send a `POST` request to the [`/vaults/`](/api/konnect/control-planes-config/v2/#/operations/create-vault) endpoint:
+Enable {{site.konnect_short_name}} as your vault with the [Vault entity](/gateway/entities/vault/):
 
-
-
-<!--vale off-->
-{% control_plane_request %}
-url: /v2/control-planes/$CONTROL_PLANE_ID/core-entities/vaults/
-status_code: 201
-method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
-    - 'Authorization: Bearer $KONNECT_TOKEN'
-body:
-    config:
-      config_store_id: $CONFIG_STORE_ID
-    description: Storing secrets in Konnect
-    name: konnect
+{% entity_examples %}
+entities:
+  vaults:
+  - name: konnect
     prefix: mysecretvault
-{% endcontrol_plane_request %}
-<!--vale on-->
+    description: Storing secrets in Konnect
+    config:
+      config_store_id: ${config-store-id}
+
+variables:
+  config-store-id:
+    value: $CONFIG_STORE_ID
+{% endentity_examples %}
 
 ## 3. Store the Mistral AI key as a secret
 
@@ -130,16 +130,16 @@ Store your Mistral key as a secret by sending a `POST` request to the `/secrets`
 
 <!--vale off-->
 {% control_plane_request %}
-url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores/$CONFIG_STORE_ID/secrets/
+url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores/$DECK_CONFIG_STORE_ID/secrets/
 status_code: 201
 method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $KONNECT_TOKEN'
+    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     key: mistral-key
-    value: Bearer <mistral-key-here>
+    value: Bearer $MISTRAL_API_KEY
 {% endcontrol_plane_request %}
 <!--vale on-->
 
@@ -147,18 +147,13 @@ body:
 
 To reference your stored Mistral API key, you use the prefix from your Vault config, the name of the secret, and optionally the property in the secret you want to use. Now, you'll reference the Mistral API key as a secret in the authorization header of the AI Proxy plugin configuration.
 
-Enable the AI Proxy plugin on your route by sending a `POST` request to the [`/plugins` endpoint](/api/konnect/control-planes-config/v2/#/operations/create-plugin-with-route):
+Enable the AI Proxy plugin on your Route:
 
-<!--vale off-->
-{% control_plane_request %}
-url: /v2/control-planes/$CONTROL_PLANE_ID/core-entities/plugins
-status_code: 201
-method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
-    - 'Authorization: Bearer $KONNECT_TOKEN'
-body:
+{% entity_examples %}
+entities:
+  plugins:
+  - name: ai-proxy
+    route: example-route
     config:
       route_type: llm/v1/chat
       auth:
@@ -170,12 +165,7 @@ body:
         options: 
           mistral_format: openai
           upstream_url: https://api.mistral.ai/v1/chat/completions
-    enabled: true
-    name: ai-proxy
-    route:
-      id: $ROUTE_ID
-{% endcontrol_plane_request %}
-<!--vale on-->
+{% endentity_examples %}
 
 ## 5. Validate
 

--- a/app/_how-tos/store-a-mistral-api-key-as-a-secret-in-konnect-config-store.md
+++ b/app/_how-tos/store-a-mistral-api-key-as-a-secret-in-konnect-config-store.md
@@ -101,7 +101,7 @@ body:
 Export your Config Store ID as an environment variable so you can use it later:
 
 ```sh
-export CONFIG_STORE_ID=config-store-uuid
+export DECK_CONFIG_STORE_ID=config-store-uuid
 ```
 
 ## 2. Configure {{site.konnect_short_name}} as your Vault

--- a/app/_includes/prereqs/konnect-api-for-curl.md
+++ b/app/_includes/prereqs/konnect-api-for-curl.md
@@ -1,7 +1,8 @@
 To use the copy, paste, and run the instructions in this how-to, you must export these additional environmental variables:
 
 ```sh
+export KONNECT_CONTROL_PLANE_URL=https://{region}.api.konghq.com
 export CONTROL_PLANE_ID=your-control-plane-uuid
 ```
-
+* `{region}`: Replace with the [{{site.konnect_short_name}} region](/konnect-geos/) you're using.
 * `CONTROL_PLANE_ID`: You can find your control plane UUID by navigating to the control plane in the {{site.konnect_short_name}} UI or by sending a `GET` request to the [`/control-planes` endpoint](/api/konnect/control-planes/v2/#/operations/list-control-planes).

--- a/app/_includes/prereqs/konnect-api-for-curl.md
+++ b/app/_includes/prereqs/konnect-api-for-curl.md
@@ -1,11 +1,7 @@
 To use the copy, paste, and run the instructions in this how-to, you must export these additional environmental variables:
 
 ```sh
-export KONNECT_CONTROL_PLANE_URL=https://{region}.api.konghq.com
 export CONTROL_PLANE_ID=your-control-plane-uuid
-export EXAMPLE_ROUTE_ID=your-example-route-id
 ```
 
-* `{region}`: Replace with the [{{site.konnect_short_name}} region](/konnect-geos/) you're using.
 * `CONTROL_PLANE_ID`: You can find your control plane UUID by navigating to the control plane in the {{site.konnect_short_name}} UI or by sending a `GET` request to the [`/control-planes` endpoint](/api/konnect/control-planes/v2/#/operations/list-control-planes).
-* `EXAMPLE_ROUTE_ID`: You can find your Route ID by navigating to the Route in the {{site.konnect_short_name}} UI or by sending a `GET` request to the [`/control-planes/{controlPlaneId}/core-entities/routes` endpoint](/api/konnect/control-planes-config/v2/#/operations/list-route).


### PR DESCRIPTION
## Description

Fixes #971 

## Preview Links
- https://deploy-preview-1233--kongdeveloper.netlify.app/how-to/store-a-mistral-api-key-as-a-secret-in-konnect-config-store/
- https://deploy-preview-1233--kongdeveloper.netlify.app/how-to/configure-the-konnect-config-store/


## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
