### PR TITLE
Chore: Remove plugin metadata from dynatrace guide

### DIFF
--- a/app/_how-tos/set-up-dynatrace-with-otel.md
+++ b/app/_how-tos/set-up-dynatrace-with-otel.md
@@ -8,13 +8,7 @@ related_resources:
 breadcrumbs:
   - /premium-partners/
 
-act_as_plugin: true
-name: Dynatrace
-publisher: dynatrace
 premium_partner: true
-icon: /assets/icons/third-party/dynatrace.png
-categories:
-  - analytics-monitoring
 
 description: Use Dynatrace SaaS to send analytics and monitoring data to Dynatrace dashboards.
 
@@ -41,7 +35,6 @@ tags:
     - analytics
     - monitoring
     - premium
-    - plugins
     - partnership
 
 prereqs:


### PR DESCRIPTION
## Description

We've gotten many complaints and confusion around treating dynatrace as a plugin, and it's caused our users a lot of grief. Since the premium partners page exists now, we no longer need to have dynatrace exposed in this fake way.

## Preview Links


## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
