### PR TITLE
Add KIC license page

### DIFF
--- a/app/_indices/kubernetes-ingress-controller.yaml
+++ b/app/_indices/kubernetes-ingress-controller.yaml
@@ -13,6 +13,11 @@ sections:
       - path: /kubernetes-ingress-controller/get-started/rate-limiting/
       - path: /kubernetes-ingress-controller/get-started/proxy-caching/
       - path: /kubernetes-ingress-controller/get-started/key-authentication/
+  - title: Production Deployments
+    allow_duplicates: true
+    items:
+      - path: /kubernetes-ingress-controller/install/
+      - path: /kubernetes-ingress-controller/license/
   - title: Routing
     items:
       - path: /kubernetes-ingress-controller/routing/http/

--- a/app/kubernetes-ingress-controller/license.md
+++ b/app/kubernetes-ingress-controller/license.md
@@ -15,8 +15,7 @@ works_on:
   - konnect
 ---
 
-{{ site.kic_product_name }} can manage {{ site.base_gateway }} instances. This page explains how to apply an enterprise license to {{ site.base_gateway }}.
-
+This page explains how to apply an enterprise license to {{ site.kic_product_name }} managed {{ site.base_gateway }} instances.
 ## Applying a license using the KongLicense CRD {% new_in 3.1 %}
 
 {{ site.kic_product_name }} v3.1 introduced a `KongLicense` CRD ([reference](/kubernetes-ingress-controller/reference/custom-resources/#konglicense)) that applies a license to {{ site.base_gateway }} using the Admin API.
@@ -67,7 +66,9 @@ works_on:
      Controller Name:        konghq.com/kong-ingress-controller/5b374a9e.konghq.com
    ```
 
-All {{ site.base_gateway }} instances that are configured by the {{ site.kic_product_name }} will have the license provided in `KongLicense` applied. To update your license, update the `KongLicense` resource and {{ site.kic_product_name }} will dynamically propagate it to all {{site.base_gateway}} instances with no downtime. There is no need to restart your Pods when updating a license.
+All {{ site.base_gateway }} instances that are configured by the {{ site.kic_product_name }} will have the license provided in `KongLicense` applied to them.
+To update your license, update the `KongLicense` resource and {{ site.kic_product_name }} will dynamically propagate across all {{site.base_gateway}} instances with no downtime.
+There is no need to restart your Pods when updating a license.
 
 ## Applying a static license
 

--- a/app/kubernetes-ingress-controller/license.md
+++ b/app/kubernetes-ingress-controller/license.md
@@ -1,0 +1,101 @@
+---
+title: "Apply an Enterprise License"
+
+description: |
+  Learn how to apply a {{ site.base_gateway }} enterprise license using the `KongLicense` CRD or Kubernetes secrets
+
+content_type: reference
+layout: reference
+
+products:
+  - kic
+
+works_on:
+  - on-prem
+  - konnect
+---
+
+{{ site.kic_product_name }} can manage {{ site.base_gateway }} instances. This page explains how to apply an enterprise license to {{ site.base_gateway }}.
+
+## Applying a license using the KongLicense CRD {% new_in 3.1 %}
+
+{{ site.kic_product_name }} v3.1 introduced a `KongLicense` CRD ([reference](/kubernetes-ingress-controller/reference/custom-resources/#konglicense)) that applies a license to {{ site.base_gateway }} using the Admin API.
+
+1. Create a file named `license.json` containing your {{site.base_gateway}} license.
+
+1. Create a `KongLicense` object with the `rawLicenseString` field set to your license:
+
+   ```bash
+   echo "
+   apiVersion: configuration.konghq.com/v1alpha1
+   kind: KongLicense
+   metadata:
+     name: kong-license
+   rawLicenseString: '$(cat ./license.json)'
+   " | kubectl apply -f -
+   ```
+
+1. Verify that {{ site.kic_product_name }} is using the license:
+
+   ```bash
+   kubectl describe konglicense kong-license
+   ```
+
+   The results should look like this, including the `Programmed` condition with `True` status:
+
+   ```text
+   Name:         kong-license
+   Namespace:
+   Labels:       <none>
+   Annotations:  <none>
+   API Version:  configuration.konghq.com/v1alpha1
+   Enabled:      true
+   Kind:         KongLicense
+   Metadata:
+    Creation Timestamp:  2024-02-06T15:37:58Z
+    Generation:          1
+    Resource Version:    2888
+   Raw License String:   <your-license-string>   
+   Status:
+    Controllers:
+     Conditions:
+      Last Transition Time:  2024-02-06T15:37:58Z
+      Message:
+      Reason:                PickedAsLatest
+      Status:                True
+      Type:                  Programmed
+     Controller Name:        konghq.com/kong-ingress-controller/5b374a9e.konghq.com
+   ```
+
+All {{ site.base_gateway }} instances that are configured by the {{ site.kic_product_name }} will have the license provided in `KongLicense` applied. To update your license, update the `KongLicense` resource and {{ site.kic_product_name }} will dynamically propagate it to all {{site.base_gateway}} instances with no downtime. There is no need to restart your Pods when updating a license.
+
+## Applying a static license
+
+An alternative option is to use a static license Secret that will be used to populate {{ site.base_gateway }}'s `KONG_LICENSE_DATA` environment variable. This option allows you to store the license in Kubernetes secrets, but requires a Pod restart when the value of the secret changes.
+
+1. Create a file named `license.json` containing your {{site.base_gateway}} license and store it in a Kubernetes secret:
+
+    ```bash
+    kubectl create namespace kong
+    kubectl create secret generic kong-enterprise-license --from-file=license=./license.json -n kong
+    ```
+
+1. Create a `values.yaml` file:
+
+    ```yaml
+    gateway:
+      image:
+        repository: kong/kong-gateway
+      env:
+        LICENSE_DATA:
+          valueFrom:
+            secretKeyRef:
+              name: kong-enterprise-license
+              key: license
+    ```
+
+1. Install {{site.kic_product_name}} and {{ site.base_gateway }} with Helm:
+
+    ```bash
+    helm upgrade --install kong kong/ingress -n kong --create-namespace --values ./values.yaml
+    ```

--- a/tools/track-docs-changes/config/sources.yml
+++ b/tools/track-docs-changes/config/sources.yml
@@ -346,6 +346,8 @@ app/kubernetes-ingress-controller/observability/events.md:
   - app/_src/kubernetes-ingress-controller/production/observability/events.md
 app/kubernetes-ingress-controller/observability/prometheus.md:
   - app/_src/kubernetes-ingress-controller/production/observability/prometheus.md
+app/kubernetes-ingress-controller/license.md:
+  - app/_src/kubernetes-ingress-controller/license.md
 
 # plugins
 app/_kong_plugins/session/changelog.md:


### PR DESCRIPTION
## Description

Resolves #722

This might be two how-tos in the future, but this works for now

## Preview Links

[/kubernetes-ingress-controller/license/](https://deploy-preview-1249--kongdeveloper.netlify.app/kubernetes-ingress-controller/license/)

## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
