### PR TITLE
Fix tab selection when a tab is rendered multiple times

### DIFF
--- a/app/_assets/javascripts/components/tabs.js
+++ b/app/_assets/javascripts/components/tabs.js
@@ -89,22 +89,22 @@ class TabsComponent {
       setFocus = true;
     }
     this.tabs.forEach((tab) => {
-      const tabPanel = document.getElementById(
-        tab.getAttribute("aria-controls")
-      );
-      if (currentTab === tab) {
-        tab.setAttribute("aria-selected", "true");
-        tab.tabIndex = 0;
-        this.toggleTabClasses(tab, true);
-        tabPanel.classList.remove("hidden");
-        if (setFocus) {
-          tab.focus();
+      const panels = document.querySelectorAll('[data-id="'+tab.getAttribute("aria-controls")+'"]');
+      for (const tabPanel of panels){
+        if (currentTab === tab) {
+          tab.setAttribute("aria-selected", "true");
+          tab.tabIndex = 0;
+          this.toggleTabClasses(tab, true);
+          tabPanel.classList.remove("hidden");
+          if (setFocus) {
+            tab.focus();
+          }
+        } else {
+          tab.setAttribute("aria-selected", "false");
+          tab.tabIndex = -1;
+          this.toggleTabClasses(tab, false);
+          tabPanel.classList.add("hidden");
         }
-      } else {
-        tab.setAttribute("aria-selected", "false");
-        tab.tabIndex = -1;
-        this.toggleTabClasses(tab, false);
-        tabPanel.classList.add("hidden");
       }
     });
 

--- a/app/_includes/components/tabs.html
+++ b/app/_includes/components/tabs.html
@@ -29,7 +29,7 @@
       <div
         class="navtab-content flex flex-col gap-3 prose-ol:{% unless forloop.first %} hidden {% endunless %}"
         role="tabpanel"
-        id="navtab-{{ navtabs_id }}-tabpanel-{{ forloop.index }}"
+        data-id="navtab-{{ navtabs_id }}-tabpanel-{{ forloop.index }}"
         tabindex="0"
         aria-labelledby="navtab-{{ navtabs_id }}-tab-{{ forloop.index }}"
         data-panel="{{ slug }}"


### PR DESCRIPTION
There's a page that captures `tab` output and uses it multiple times:

```
{% capture preserve_host %}
{% navtabs api %}
{% navtab "Gateway API" %}
```bash
kubectl patch httproute NAME --type merge -p '{"metadata":{"annotations":{"konghq.com/preserve-host":"false"}}}'
```
{% endnavtab %}
{% navtab "Ingress" %}
```bash
kubectl patch ingress NAME -p '{"metadata":{"annotations":{"konghq.com/preserve-host":"false"}}}'
``` 
{% endnavtab %}
{% endnavtabs %}
{% endcapture %}
```

Using `getElementById` means that we only switch tab in the first rendered doc. This PR makes it work for all instances