### PR TITLE
KIC Migration guides

### DIFF
--- a/.github/styles/base/Dictionary.txt
+++ b/.github/styles/base/Dictionary.txt
@@ -719,6 +719,7 @@ Tal
 Tal
 targetRef
 tbl
+ingresses
 tcp
 tcpdump
 TCPIngress

--- a/app/kubernetes-ingress-controller/faq/migrate-ingress-to-gateway.md
+++ b/app/kubernetes-ingress-controller/faq/migrate-ingress-to-gateway.md
@@ -15,7 +15,7 @@ works_on:
   - konnect
 
 related_resources:
-  - text: ingress2gateway guide
+  - text: Ingress to Gateway
     url: /kubernetes-ingress-controller/migrate/ingress-to-gateway/
 ---
 

--- a/app/kubernetes-ingress-controller/faq/migrate-ingress-to-gateway.md
+++ b/app/kubernetes-ingress-controller/faq/migrate-ingress-to-gateway.md
@@ -13,6 +13,10 @@ products:
 works_on:
   - on-prem
   - konnect
+
+related_resources:
+  - text: ingress2gateway guide
+    url: /kubernetes-ingress-controller/migrate/ingress-to-gateway/
 ---
 
 Kong contributed to the kubernetes-sigs project [`ingress2gateway`](https://github.com/kubernetes-sigs/ingress2gateway) by creating a Kong provider able to convert ingress resources into Gateway resources. The `ingress2Gateway` tool provides a `print` command that gets ingress resources and displays the Gateway API equivalent. The output of this operation can be either directly applied to the cluster, or it can generate a new set of YAML files containing the converted configuration.

--- a/app/kubernetes-ingress-controller/migrate/credential-kongcredtype-label.md
+++ b/app/kubernetes-ingress-controller/migrate/credential-kongcredtype-label.md
@@ -1,0 +1,125 @@
+---
+title: Rewriting hosts
+
+description: |
+  Customize the Host header that is sent to your upstream service
+
+content_type: reference
+layout: reference
+
+products:
+  - kic
+
+works_on:
+  - on-prem
+  - konnect
+
+related_resources:
+  - text: Using the konghq.com/rewrite annotation
+    url: /kubernetes-ingress-controller/routing/rewriting-paths/
+  - text: Rewriting paths
+    url: /kubernetes-ingress-controller/reference/path-manipulation/
+---
+
+{{ site.kic_product_name }} provides two annotations for manipulating the `Host` header. These annotations allow for three different behaviours:
+
+* Preserve the user-provided `Host` header
+* Default to the `Host` of the upstream service
+* Explicitly set the `Host` header to a known value
+
+{% capture preserve_host %}
+{% navtabs api %}
+{% navtab "Gateway API" %}
+```bash
+kubectl patch httproute NAME --type merge -p '{"metadata":{"annotations":{"konghq.com/preserve-host":"false"}}}'
+```
+{% endnavtab %}
+{% navtab "Ingress" %}
+```bash
+kubectl patch ingress NAME -p '{"metadata":{"annotations":{"konghq.com/preserve-host":"false"}}}'
+``` 
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+### Preserve the Host header
+
+{{ site.kic_product_name }} preserves the hostname in the request by default.
+
+```bash
+curl -H 'Host:kong.example' "$PROXY_IP/echo?details=true"
+```
+
+```text
+HTTP request details
+---------------------
+Protocol: HTTP/1.1
+Host: kong.example
+Method: GET
+URL: /?details=true
+```
+
+The `Host` header in the request to the upstream matches the `Host` header in the request to {{ site.base_gateway }}.
+
+### Use the upstream Host name
+
+You can disable `preserve-host` if you want the `Host` header to contain the upstream hostname of your service.
+
+Add the `konghq.com/preserve-host` annotation to your Route:
+
+{{ preserve_host }}
+
+The `Host` header in the response now contains the upstream host and port.
+
+```text
+HTTP request details
+---------------------
+Protocol: HTTP/1.1
+Host: 192.168.194.11:1027
+Method: GET
+URL: /?details=true
+```
+### Set the Host header explicitly
+
+#### Using Gateway API {% new_in 3.2 %}
+
+You can set the Host header explicitly when using Gateway API's HTTPRoute with [`URLRewrite`](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPURLRewriteFilter) 
+filter's `hostname` field. You only need to add a `URLRewrite` filter to your HTTPRoute rule.
+
+```yaml
+...
+filters:
+- type: URLRewrite
+  urlRewrite:
+    hostname: internal.myapp.example.com
+```
+
+#### Using the `konghq.com/host-header` annotation
+
+You can set the Host header explicitly if needed by disabling `konghq.com/preserve-host` and setting the `konghq.com/host-header` annotation.
+
+1. Add the [`konghq.com/preserve-host` annotation](/kubernetes-ingress-controller/reference/annotations/#konghq-com-preserve-host) to your Ingress, to disable `preserve-host` and send the hostname provided in the `host-header` annotation:
+
+{{ preserve_host | indent }}
+
+1. Add the [`konghq.com/host-header` annotation](/kubernetes-ingress-controller/reference/annotations/#konghq-com-host-header) to your Service, which sets
+  the `Host` header directly:
+  ```bash
+  kubectl patch service NAME -p '{"metadata":{"annotations":{"konghq.com/host-header":"internal.myapp.example.com"}}}'
+  ```
+
+1. Make a `curl` request with a `Host` header:
+
+    ```bash
+    curl -H 'Host:kong.example' "$PROXY_IP/echo?details=true"
+    ```
+
+    The request upstream now uses the header from the `host-header` annotation:
+    ```
+    HTTP request details
+    ---------------------
+    Protocol: HTTP/1.1
+    Host: internal.myapp.example.com:1027
+    Method: GET
+    URL: /?details=true
+    ```

--- a/app/kubernetes-ingress-controller/migrate/credential-kongcredtype-label.md
+++ b/app/kubernetes-ingress-controller/migrate/credential-kongcredtype-label.md
@@ -1,8 +1,8 @@
 ---
-title: Rewriting hosts
+title: Add Credential Type Labels
 
 description: |
-  Customize the Host header that is sent to your upstream service
+  Add the `konghq.com/credential` label to your Secrets to improve performance and security
 
 content_type: reference
 layout: reference
@@ -14,112 +14,30 @@ works_on:
   - on-prem
   - konnect
 
-related_resources:
-  - text: Using the konghq.com/rewrite annotation
-    url: /kubernetes-ingress-controller/routing/rewriting-paths/
-  - text: Rewriting paths
-    url: /kubernetes-ingress-controller/reference/path-manipulation/
 ---
 
-{{ site.kic_product_name }} provides two annotations for manipulating the `Host` header. These annotations allow for three different behaviours:
+In versions prior to {{ site.kic_product_name }} 3.0, credential Secrets used a `kongCredType` field in the Secret to indicate the Secret type. Version 3.0 replaces this field with a `konghq.com/credential` label to allow the admission controller and resource cache to filter out Secrets that {{ site.kic_product_name }} do not use to improve performance and avoid interference with non-{{ site.kic_product_name }} Secret updates.
 
-* Preserve the user-provided `Host` header
-* Default to the `Host` of the upstream service
-* Explicitly set the `Host` header to a known value
+The `kongCredType` field is now deprecated and will be removed in a future release.
 
-{% capture preserve_host %}
-{% navtabs api %}
-{% navtab "Gateway API" %}
-```bash
-kubectl patch httproute NAME --type merge -p '{"metadata":{"annotations":{"konghq.com/preserve-host":"false"}}}'
-```
-{% endnavtab %}
-{% navtab "Ingress" %}
-```bash
-kubectl patch ingress NAME -p '{"metadata":{"annotations":{"konghq.com/preserve-host":"false"}}}'
-``` 
-{% endnavtab %}
-{% endnavtabs %}
-{% endcapture %}
-
-### Preserve the Host header
-
-{{ site.kic_product_name }} preserves the hostname in the request by default.
+You can use a simple [jq](https://jqlang.github.io/jq/) and kubectl script to find your credential Secrets and generate commands to add an appropriate label:
 
 ```bash
-curl -H 'Host:kong.example' "$PROXY_IP/echo?details=true"
+kubectl get secret -A -ojson | jq -r '.items[] | select(.data.kongCredType != null) | "kubectl label secret -n \(.metadata.namespace) \(.metadata.name) konghq.com/credential=\(.data.kongCredType | @base64d )"'
 ```
 
-```text
-HTTP request details
----------------------
-Protocol: HTTP/1.1
-Host: kong.example
-Method: GET
-URL: /?details=true
+Or, if you do not have access to all namespaces (replace `default other` with a space-separated list of namespaces to search):
+
+```bash
+for namespace in default other; do kubectl get secret -n $namespace -ojson | jq -r '.items[] | select(.data.kongCredType != null) | "kubectl label secret -n \(.metadata.namespace) \(.metadata.name) konghq.com/credential=\(.data.kongCredType | @base64d )"'; done
 ```
 
-The `Host` header in the request to the upstream matches the `Host` header in the request to {{ site.base_gateway }}.
+The output is a list of `kubectl` commands to copy and paste in order to apply the label. For example:
 
-### Use the upstream Host name
-
-You can disable `preserve-host` if you want the `Host` header to contain the upstream hostname of your service.
-
-Add the `konghq.com/preserve-host` annotation to your Route:
-
-{{ preserve_host }}
-
-The `Host` header in the response now contains the upstream host and port.
-
-```text
-HTTP request details
----------------------
-Protocol: HTTP/1.1
-Host: 192.168.194.11:1027
-Method: GET
-URL: /?details=true
-```
-### Set the Host header explicitly
-
-#### Using Gateway API {% new_in 3.2 %}
-
-You can set the Host header explicitly when using Gateway API's HTTPRoute with [`URLRewrite`](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPURLRewriteFilter) 
-filter's `hostname` field. You only need to add a `URLRewrite` filter to your HTTPRoute rule.
-
-```yaml
-...
-filters:
-- type: URLRewrite
-  urlRewrite:
-    hostname: internal.myapp.example.com
+```bash
+kubectl label secret -n default consumer-5-key-auth konghq.com/credential=key-auth
+kubectl label secret -n other consumer-10-key-auth konghq.com/credential=bee-auth
 ```
 
-#### Using the `konghq.com/host-header` annotation
-
-You can set the Host header explicitly if needed by disabling `konghq.com/preserve-host` and setting the `konghq.com/host-header` annotation.
-
-1. Add the [`konghq.com/preserve-host` annotation](/kubernetes-ingress-controller/reference/annotations/#konghq-com-preserve-host) to your Ingress, to disable `preserve-host` and send the hostname provided in the `host-header` annotation:
-
-{{ preserve_host | indent }}
-
-1. Add the [`konghq.com/host-header` annotation](/kubernetes-ingress-controller/reference/annotations/#konghq-com-host-header) to your Service, which sets
-  the `Host` header directly:
-  ```bash
-  kubectl patch service NAME -p '{"metadata":{"annotations":{"konghq.com/host-header":"internal.myapp.example.com"}}}'
-  ```
-
-1. Make a `curl` request with a `Host` header:
-
-    ```bash
-    curl -H 'Host:kong.example' "$PROXY_IP/echo?details=true"
-    ```
-
-    The request upstream now uses the header from the `host-header` annotation:
-    ```
-    HTTP request details
-    ---------------------
-    Protocol: HTTP/1.1
-    Host: internal.myapp.example.com:1027
-    Method: GET
-    URL: /?details=true
-    ```
+You do not need to remove the `kongCredType` field from Secrets after you have
+added the label, but once you have added the label, the value of the label is used instead of the field.

--- a/app/kubernetes-ingress-controller/migrate/ingress-to-gateway.md
+++ b/app/kubernetes-ingress-controller/migrate/ingress-to-gateway.md
@@ -35,7 +35,7 @@ export PATH=${PATH}:$(pwd)
 In order to migrate your resources from `Ingress` API to Gateway API you need all the `Ingress`-based `yaml` manifests. You can use these manifests as the source to migrate to the new API by creating copies that replace the `Ingress` resources with Gateway API resources. Then, use the `ingress2gateway` tool to create new manifests
 containing the gateway API configurations.
 
-> **Note**: In this guide the Ingress resources refers to Kubernetes networkingv1 `Ingress`es, Kong `TCPIngress`es, and Kong `UDPIngress`es. This means that **All** these resources should be included in the files used as a source for the conversion.
+> **Note**: In this guide the Ingress resources refers to Kubernetes networkingv1 `Ingresses, Kong TCPIngresses, and Kong UDPIngresses. This means that **All** these resources should be included in the files used as a source for the conversion.
 
 1. Export your source and destination paths.
 

--- a/app/kubernetes-ingress-controller/migrate/ingress-to-gateway.md
+++ b/app/kubernetes-ingress-controller/migrate/ingress-to-gateway.md
@@ -15,7 +15,7 @@ works_on:
   - konnect
 
 related_resources:
-  - text: ingress2gateway FAQ
+  - text: Ingress to Gateway FAQ
     url: /kubernetes-ingress-controller/faq/migrate-ingress-to-gateway/
 
 ---
@@ -66,9 +66,9 @@ containing the gateway API configurations.
 
 The manifests conversion are as follows:
 
-- `Ingress`es are converted to `Gateway` and `HTTPRoute`s
-- `TCPIngress`es are converted to `Gateway` and `TCPRoute`s and `TLSRoute`s
-- `UDPIngress`es are converted to `Gateway` and `UDPRoute`s
+- Ingresses are converted to `Gateway` and `HTTPRoute`s
+- TCPIngresses are converted to `Gateway` and `TCPRoute`s and `TLSRoute`s
+- UDPIngresses are converted to `Gateway` and `UDPRoute`s
 
 ## Migrate from Ingress to Gateway
 

--- a/app/kubernetes-ingress-controller/migrate/ingress-to-gateway.md
+++ b/app/kubernetes-ingress-controller/migrate/ingress-to-gateway.md
@@ -1,0 +1,125 @@
+---
+title: Rewriting hosts
+
+description: |
+  Customize the Host header that is sent to your upstream service
+
+content_type: reference
+layout: reference
+
+products:
+  - kic
+
+works_on:
+  - on-prem
+  - konnect
+
+related_resources:
+  - text: Using the konghq.com/rewrite annotation
+    url: /kubernetes-ingress-controller/routing/rewriting-paths/
+  - text: Rewriting paths
+    url: /kubernetes-ingress-controller/reference/path-manipulation/
+---
+
+{{ site.kic_product_name }} provides two annotations for manipulating the `Host` header. These annotations allow for three different behaviours:
+
+* Preserve the user-provided `Host` header
+* Default to the `Host` of the upstream service
+* Explicitly set the `Host` header to a known value
+
+{% capture preserve_host %}
+{% navtabs api %}
+{% navtab "Gateway API" %}
+```bash
+kubectl patch httproute NAME --type merge -p '{"metadata":{"annotations":{"konghq.com/preserve-host":"false"}}}'
+```
+{% endnavtab %}
+{% navtab "Ingress" %}
+```bash
+kubectl patch ingress NAME -p '{"metadata":{"annotations":{"konghq.com/preserve-host":"false"}}}'
+``` 
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+### Preserve the Host header
+
+{{ site.kic_product_name }} preserves the hostname in the request by default.
+
+```bash
+curl -H 'Host:kong.example' "$PROXY_IP/echo?details=true"
+```
+
+```text
+HTTP request details
+---------------------
+Protocol: HTTP/1.1
+Host: kong.example
+Method: GET
+URL: /?details=true
+```
+
+The `Host` header in the request to the upstream matches the `Host` header in the request to {{ site.base_gateway }}.
+
+### Use the upstream Host name
+
+You can disable `preserve-host` if you want the `Host` header to contain the upstream hostname of your service.
+
+Add the `konghq.com/preserve-host` annotation to your Route:
+
+{{ preserve_host }}
+
+The `Host` header in the response now contains the upstream host and port.
+
+```text
+HTTP request details
+---------------------
+Protocol: HTTP/1.1
+Host: 192.168.194.11:1027
+Method: GET
+URL: /?details=true
+```
+### Set the Host header explicitly
+
+#### Using Gateway API {% new_in 3.2 %}
+
+You can set the Host header explicitly when using Gateway API's HTTPRoute with [`URLRewrite`](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPURLRewriteFilter) 
+filter's `hostname` field. You only need to add a `URLRewrite` filter to your HTTPRoute rule.
+
+```yaml
+...
+filters:
+- type: URLRewrite
+  urlRewrite:
+    hostname: internal.myapp.example.com
+```
+
+#### Using the `konghq.com/host-header` annotation
+
+You can set the Host header explicitly if needed by disabling `konghq.com/preserve-host` and setting the `konghq.com/host-header` annotation.
+
+1. Add the [`konghq.com/preserve-host` annotation](/kubernetes-ingress-controller/reference/annotations/#konghq-com-preserve-host) to your Ingress, to disable `preserve-host` and send the hostname provided in the `host-header` annotation:
+
+{{ preserve_host | indent }}
+
+1. Add the [`konghq.com/host-header` annotation](/kubernetes-ingress-controller/reference/annotations/#konghq-com-host-header) to your Service, which sets
+  the `Host` header directly:
+  ```bash
+  kubectl patch service NAME -p '{"metadata":{"annotations":{"konghq.com/host-header":"internal.myapp.example.com"}}}'
+  ```
+
+1. Make a `curl` request with a `Host` header:
+
+    ```bash
+    curl -H 'Host:kong.example' "$PROXY_IP/echo?details=true"
+    ```
+
+    The request upstream now uses the header from the `host-header` annotation:
+    ```
+    HTTP request details
+    ---------------------
+    Protocol: HTTP/1.1
+    Host: internal.myapp.example.com:1027
+    Method: GET
+    URL: /?details=true
+    ```

--- a/app/kubernetes-ingress-controller/migrate/ingress-to-gateway.md
+++ b/app/kubernetes-ingress-controller/migrate/ingress-to-gateway.md
@@ -35,7 +35,7 @@ export PATH=${PATH}:$(pwd)
 In order to migrate your resources from `Ingress` API to Gateway API you need all the `Ingress`-based `yaml` manifests. You can use these manifests as the source to migrate to the new API by creating copies that replace the `Ingress` resources with Gateway API resources. Then, use the `ingress2gateway` tool to create new manifests
 containing the gateway API configurations.
 
-> **Note**: In this guide the Ingress resources refers to Kubernetes networkingv1 `Ingresses, Kong TCPIngresses, and Kong UDPIngresses. This means that **All** these resources should be included in the files used as a source for the conversion.
+> **Note**: In this guide the Ingress resources refers to Kubernetes networkingv1 Ingresses, Kong TCPIngresses, and Kong UDPIngresses. This means that **All** these resources should be included in the files used as a source for the conversion.
 
 1. Export your source and destination paths.
 

--- a/app/kubernetes-ingress-controller/migrate/kongingress.md
+++ b/app/kubernetes-ingress-controller/migrate/kongingress.md
@@ -1,0 +1,80 @@
+---
+title: Migrating from KongIngress to KongUpstreamPolicy
+
+description: |
+  How to remove the deprecated KongIngress resource from your deployment
+
+content_type: reference
+layout: reference
+
+products:
+  - kic
+
+works_on:
+  - on-prem
+  - konnect
+
+---
+
+## konghq.com/headers.* annotation
+
+The [`konghq.com/headers.*` annotation](/kubernetes-ingress-controller/reference/annotations/#konghq-com-headers) uses a special format to set headers. The string after the `.` in the annotation name is the header name and the annotation value is the header value. For example, to apply `x-custom-header-a: example,otherexample` and `x-custom-header-b: example` headers to requests, the KongIngress configuration is:
+
+```yaml
+route:
+  headers:
+    x-custom-header-a:
+    - example
+    - otherexample
+    x-custom-header-b:
+    - example
+```
+
+The equivalent annotation configuration looks like:
+
+```text
+konghq.com/headers.x-custom-header-a: example,otherexample
+konghq.com/headers.x-custom-header-b: example
+```
+
+You cannot apply multiple instances of the same header annotation to set multiple header values. You must set the CSV format within a single header.
+
+## KongUpstreamPolicy
+
+The `upstream` section of `KongIngress` resources contains a complex object that does not easily fit in annotations. Version 3.x uses the new `KongUpstreamPolicy` resource to configure upstream settings. The `spec` field of `KongUpstreamPolicy` is similar to the `upstream` section of KongIngress, with the following differences:
+
+- Field names now use `lowerCamelCase` instead of `snake_case` to be consistent with Kubernetes APIs.
+- `hash_on`, `hash_fallback`, and their related `has_on_*`, `hash_fallback_*` fields are now `hashOn` and `hashOnFallback` objects. To define the primary hashing strategy, use `hashOn` with one of its fields filled (e.g. when you want to hash on a header, fill `hashOn.header` with a header name). Similarly, to define the secondary hashing strategy, use `hashOnFallback`.
+
+For the exact schema please refer to [KongUpstreamPolicy reference](/kubernetes-ingress-controller/reference/custom-resources/#kongupstreampolicy). 
+
+For example, if you previously used a KongIngress like:
+
+```yaml
+apiVersion: configuration.konghq.com/v1
+kind: KongIngress
+metadata:
+  name: sample-customization
+upstream:
+  hash_on: header
+  hash_on_header: x-lb
+  hash_fallback: ip
+  algorithm: consistent-hashing
+```
+
+You need to use a `KongUpstreamPolicy`:
+
+```yaml
+apiVersion: configuration.konghq.com/v1beta1
+kind: KongUpstreamPolicy
+metadata:
+  name: sample-customization
+spec:
+  hashOn: 
+    header: x-lb
+  hashOnFallback: 
+    input: ip
+  algorithm: consistent-hashing
+```
+
+Apply it to a Service resource with a `konghq.com/upstream-policy: sample-customization` annotation.

--- a/tools/track-docs-changes/config/sources.yml
+++ b/tools/track-docs-changes/config/sources.yml
@@ -372,7 +372,12 @@ app/kubernetes-ingress-controller/faq/upgrading-gateway.md:
 app/kubernetes-ingress-controller/faq/custom-entities.md:
   - app/_src/kubernetes-ingress-controller/guides/services/custom-entity.md
 
-
+app/kubernetes-ingress-controller/migrate/kongingress.md:
+  - app/_src/kubernetes-ingress-controller/guides/migrate/kongingress.md
+app/kubernetes-ingress-controller/migrate/ingress-to-gateway.md:
+  - app/_src/kubernetes-ingress-controller/guides/migrate/ingress-to-gateway.md
+app/kubernetes-ingress-controller/migrate/credential-kongcredtype-label.md:
+  - app/_src/kubernetes-ingress-controller/guides/migrate/credential-kongcredtype-label.md
 
 # plugins
 app/_kong_plugins/session/changelog.md:


### PR DESCRIPTION
## Description

Resolves #750
Resolves #751
Resolves #752

## Preview Links

[/kubernetes-ingress-controller/migrate/credential-kongcredtype-label/](https://deploy-preview-1278--kongdeveloper.netlify.app/kubernetes-ingress-controller/migrate/credential-kongcredtype-label/)
[/kubernetes-ingress-controller/migrate/ingress-to-gateway/](https://deploy-preview-1278--kongdeveloper.netlify.app/kubernetes-ingress-controller/migrate/ingress-to-gateway/)
[/kubernetes-ingress-controller/migrate/kongingress/](https://deploy-preview-1278--kongdeveloper.netlify.app/kubernetes-ingress-controller/migrate/kongingress/)

## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
