### PR TITLE
fix: Tomek-qa-30-04

### DIFF
--- a/app/_how-tos/use-langchain-with-ai-proxy.md
+++ b/app/_how-tos/use-langchain-with-ai-proxy.md
@@ -9,6 +9,7 @@ description: Connect your LangChain integrations with {{site.base_gateway}} with
 
 products:
     - gateway
+    - ai-gateway
 
 works_on:
     - on-prem
@@ -21,7 +22,7 @@ plugins:
   - ai-proxy
   - key-auth
 
-entities: 
+entities:
   - service
   - route
   - plugin
@@ -29,6 +30,7 @@ entities:
 tags:
     - ai
     - openai
+    - ai-gateway
 
 tldr:
     q: How can use my LangChain integrations with AI Gateway?
@@ -85,8 +87,8 @@ variables:
 To secure the access to your Route, create a Consumer and set up an authentication plugin.
 
 {:.info}
-> Note that LangChain expects authentication as an `Authorization` header with a value starting with `Bearer`. 
-You can use plugins like [OAuth 2.0 Authentication](/plugins/oauth2/) or [OpenID Connect](/plugins/openid-connect/) to generate Bearer tokens. 
+> Note that LangChain expects authentication as an `Authorization` header with a value starting with `Bearer`.
+You can use plugins like [OAuth 2.0 Authentication](/plugins/oauth2/) or [OpenID Connect](/plugins/openid-connect/) to generate Bearer tokens.
 In this example, for testing purposes, we'll recreate this pattern using the [Key Authentication](/plugins/key-auth/) plugin.
 
 {% entity_examples %}
@@ -146,7 +148,7 @@ print(f"$ ChainAnswer:> {response.content}")' > app.py
 {: data-deployment-topology="on-prem" }
 
 ```sh
-echo 'from langchain_openai import ChatOpenAI 
+echo 'from langchain_openai import ChatOpenAI
 import os
 
 kong_url = os.environ['KONNECT_PROXY_URL']

--- a/app/_kong_plugins/ai-proxy-advanced/examples/bedrock-chat-route.yaml
+++ b/app/_kong_plugins/ai-proxy-advanced/examples/bedrock-chat-route.yaml
@@ -18,8 +18,9 @@ config:
         provider: bedrock
         name: meta.llama3-70b-instruct-v1:0
         options:
-          aws_region: us-east-1
-        
+          bedrock:
+            aws_region: us-east-1
+
 variables:
   key:
     value: $AWS_ACCESS_KEY_ID

--- a/app/_kong_plugins/ai-proxy/examples/bedrock-chat-route.yaml
+++ b/app/_kong_plugins/ai-proxy/examples/bedrock-chat-route.yaml
@@ -17,8 +17,9 @@ config:
     provider: bedrock
     name: meta.llama3-70b-instruct-v1:0
     options:
-      aws_region: us-east-1
-      
+      bedrock:
+        aws_region: us-east-1
+
 variables:
   key:
     value: $AWS_ACCESS_KEY_ID


### PR DESCRIPTION
## Description

Fixes incorrect sample config for Bedrock in ai-proxy and ai-proxy advanced plugin. Added `ai-gateway` tag to the LangChain ho-to doc.

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
