### PR TITLE
KIC plugin secrets

### DIFF
--- a/app/_indices/kubernetes-ingress-controller.yaml
+++ b/app/_indices/kubernetes-ingress-controller.yaml
@@ -88,6 +88,7 @@ sections:
       - path: /kubernetes-ingress-controller/reference/required-permissions/
       - path: /kubernetes-ingress-controller/reference/host-manipulation/
       - path: /kubernetes-ingress-controller/reference/path-manipulation/
+      - path: /kubernetes-ingress-controller/reference/secrets-in-plugins/
   - title: FAQs
     items:
       - path: /kubernetes-ingress-controller/faq/custom-nginx-conf/

--- a/app/kubernetes-ingress-controller/reference/secrets-in-plugins.md
+++ b/app/kubernetes-ingress-controller/reference/secrets-in-plugins.md
@@ -1,5 +1,5 @@
 ---
-title: "Using Kubernetes Secrets in Plugins"
+title: "Using Kubernetes Secrets in plugins"
 description: |
   Populate your KongPlugin configuration using Kubernetes Secrets
 
@@ -22,7 +22,7 @@ works_on:
 {{ site.kic_product_name }} allows you to configure {{ site.base_gateway }} plugins using the contents of a Kubernetes secret. {{ site.kic_product_name }} can read secrets in two ways:
 
 1. Read the complete plugin configuration from a secret
-1. Use `configPatches` to set a single field in a plugin configuration (requires {{ site.kic_product_name }} 3.1+)
+1. Use `configPatches` to set a single field in a plugin configuration (requires {{ site.kic_product_name }} 3.1 or later)
 
 {{ site.kic_product_name }} resolves the referenced secrets and sends a complete configuration to {{ site.base_gateway }}.
 
@@ -75,7 +75,7 @@ The `configPatches` field in the `KongPlugin` resource allows you to set a `path
 
 In the previous Redis rate-limiting example, only the `redis_password` field is sensitive. Instead of storing the whole configuration in a secret, use `configPatches` to patch a single key:
 
-Create a Kubernetes secret that contains a `password` field.
+Create a Kubernetes secret that contains a `password` field:
 
 ```bash
 echo "
@@ -88,7 +88,7 @@ stringData:
 type: Opaque" | kubectl apply -f -
 ```
 
-Define a new rate-limiting `KongPlugin` resource. The majority of the configuration is provided under the `config` key. The `redis_password` field is populated from the `password` field in the `rate-limit-redis` secret using `configPatches`.
+Define a new rate limiting `KongPlugin` resource. The majority of the configuration is provided under the `config` key. The `redis_password` field is populated from the `password` field in the `rate-limit-redis` secret using `configPatches`:
 
 ```bash
 echo "

--- a/app/kubernetes-ingress-controller/reference/secrets-in-plugins.md
+++ b/app/kubernetes-ingress-controller/reference/secrets-in-plugins.md
@@ -1,0 +1,120 @@
+---
+title: "Using Kubernetes Secrets in Plugins"
+description: |
+  Populate your KongPlugin configuration using Kubernetes Secrets
+
+breadcrumbs:
+  - /kubernetes-ingress-controller/
+  - index: kubernetes-ingress-controller
+    section: Reference
+
+content_type: reference
+layout: reference
+
+products:
+  - kic
+
+works_on:
+  - on-prem
+  - konnect
+---
+
+{{ site.kic_product_name }} allows you to configure {{ site.base_gateway }} plugins using the contents of a Kubernetes secret. {{ site.kic_product_name }} can read secrets in two ways:
+
+1. Read the complete plugin configuration from a secret
+1. Use `configPatches` to set a single field in a plugin configuration (requires {{ site.kic_product_name }} 3.1+)
+
+{{ site.kic_product_name }} resolves the referenced secrets and sends a complete configuration to {{ site.base_gateway }}.
+
+{:.warning}
+> {{ site.kic_product_name }} resolves secrets _before_ sending the configuration to {{ site.base_gateway }}. Anyone with access to the {{ site.base_gateway }} pod can read the configuration, including secrets, from the admin API. To securely fetch secrets at runtime, use [{{ site.base_gateway }}'s Vault support](/gateway/entities/vault/).
+
+## Read a complete configuration
+
+The `configFrom` field in the `KongPlugin` resource allows you to set a `secretKeyRef` pointing to a Kubernetes secret.
+
+This `KongPlugin` definition points to a secret named `rate-limit-redis` that contains a complete configuration for the plugin:
+
+```bash
+echo "
+apiVersion: configuration.konghq.com/v1
+kind: KongPlugin
+metadata:
+ name: rate-limiting-example
+plugin: rate-limiting
+configFrom:
+  secretKeyRef:
+    name: rate-limit-redis
+    key: config
+" | kubectl apply -f -
+```
+
+The `rate-limit-redis` secret contains a complete configuration as a string:
+
+```yaml
+echo "
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rate-limit-redis
+stringData:
+  config: |
+    minute: 10
+    policy: redis
+    redis_host: redis-master
+    redis_password: PASSWORD
+type: Opaque
+" | kubectl apply -f -
+```
+
+## Single field using ConfigPatches {% new_in 3.1 %}
+
+{{ site.kic_product_name }} allows you to populate individual plugin configuration fields from a Kubernetes secret.
+
+The `configPatches` field in the `KongPlugin` resource allows you to set a `path` to a field in the `KongPlugin` and a `valueFrom` that points to a Kubernetes secret (and its field) that the configuration field value should be loaded from.
+
+In the previous Redis rate-limiting example, only the `redis_password` field is sensitive. Instead of storing the whole configuration in a secret, use `configPatches` to patch a single key:
+
+Create a Kubernetes secret that contains a `password` field.
+
+```bash
+echo "
+apiVersion: v1
+kind: Secret
+metadata:
+  name: rate-limit-redis
+stringData:
+  password: '\"PASSWORD\"' # The string fields require the value to be quoted in double quotation marks.
+type: Opaque" | kubectl apply -f -
+```
+
+Define a new rate-limiting `KongPlugin` resource. The majority of the configuration is provided under the `config` key. The `redis_password` field is populated from the `password` field in the `rate-limit-redis` secret using `configPatches`.
+
+```bash
+echo "
+apiVersion: configuration.konghq.com/v1
+kind: KongPlugin
+metadata:
+ name: rate-limiting-example
+plugin: rate-limiting
+config: # You can define the non-sensitive part of the config explicitly here.
+  minute: 10
+  policy: redis
+  redis_host: redis-master
+configPatches:
+  - path: /redis_password # This is the path to the field in the plugin's configuration this patch will populate.
+    valueFrom:
+      secretKeyRef:
+        name: rate-limit-redis # This is the name of the secret.
+        key: password          # This is the key in the secret.
+" | kubectl apply -f -
+```
+
+{{ site.kic_product_name }} resolves the referenced secret and builds the complete configuration for the plugin before sending it to {{ site.base_gateway }}. The complete configuration will look like this:
+
+```yaml
+minute: 10
+policy: redis
+redis_host: redis-master
+redis_password: PASSWORD
+```

--- a/tools/track-docs-changes/config/sources.yml
+++ b/tools/track-docs-changes/config/sources.yml
@@ -304,6 +304,8 @@ app/kubernetes-ingress-controller/reference/path-manipulation.md:
   - app/_src/kubernetes-ingress-controller/guides/requests/rewrite-host-and-paths.md
 app/kubernetes-ingress-controller/reference/host-manipulation.md:
   - app/_src/kubernetes-ingress-controller/guides/requests/rewrite-host-and-paths.md
+app/kubernetes-ingress-controller/reference/secrets-in-plugins.md:
+  - app/_src/kubernetes-ingress-controller/guides/security/plugin-secrets.md
 app/kubernetes-ingress-controller/admission-webhook.md:
   - app/_src/kubernetes-ingress-controller/concepts/admission-webhook.md
 app/_how-tos/kic-install.md:


### PR DESCRIPTION
## Description

Fixes #748 

## Preview Links

[/kubernetes-ingress-controller/reference/secrets-in-plugins/](https://deploy-preview-1311--kongdeveloper.netlify.app/kubernetes-ingress-controller/reference/secrets-in-plugins/)

## Checklist 

- [x] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
