### PR TITLE
Ai gateway tiers

### DIFF
--- a/.github/styles/frontmatter/Keys.txt
+++ b/.github/styles/frontmatter/Keys.txt
@@ -39,3 +39,4 @@ extended_description
 skip_proxy_ip
 gateway_custom_env
 gateway_env
+ai_gateway_enterprise

--- a/app/_assets/stylesheets/index.css
+++ b/app/_assets/stylesheets/index.css
@@ -390,7 +390,7 @@
   }
 
   blockquote {
-    &.success, &.warning, &.danger, &.info, &.neutral, &.decorative {
+    &.success, &.warning, &.danger, &.info, &.neutral, &.decorative, &.ai {
       @apply rounded-md p-4 gap-2 border-l-[3px] text-primary flex flex-col pl-10 relative text-sm;
 
       &:not(.no-icon)::before {
@@ -447,6 +447,14 @@
 
       &:not(.no-icon)::before {
         @apply bg-semantic-purple-primary;
+      }
+    }
+
+    &.ai {
+      @apply bg-semantic-teal-secondary border-semantic-teal-primary;
+
+      &:not(.no-icon)::before {
+        @apply bg-semantic-teal-primary;
       }
     }
   }

--- a/app/_kong_plugins/ai-azure-content-safety/index.md
+++ b/app/_kong_plugins/ai-azure-content-safety/index.md
@@ -2,6 +2,8 @@
 title: 'AI Azure Content Safety'
 name: 'AI Azure Content Safety'
 
+ai_gateway_enterprise: true
+
 content_type: plugin
 
 publisher: kong-inc

--- a/app/_kong_plugins/ai-proxy-advanced/index.md
+++ b/app/_kong_plugins/ai-proxy-advanced/index.md
@@ -2,6 +2,8 @@
 title: 'AI Proxy Advanced'
 name: 'AI Proxy Advanced'
 
+ai_gateway_enterprise: true
+
 content_type: plugin
 
 publisher: kong-inc

--- a/app/_kong_plugins/ai-rag-injector/index.md
+++ b/app/_kong_plugins/ai-rag-injector/index.md
@@ -2,6 +2,8 @@
 title: 'AI RAG Injector'
 name: 'AI RAG Injector'
 
+ai_gateway_enterprise: true
+
 content_type: plugin
 
 publisher: kong-inc

--- a/app/_kong_plugins/ai-rate-limiting-advanced/index.md
+++ b/app/_kong_plugins/ai-rate-limiting-advanced/index.md
@@ -4,6 +4,8 @@ title: AI Rate Limiting Advanced
 name: AI Rate Limiting Advanced
 publisher: kong-inc
 
+ai_gateway_enterprise: true
+
 products:
     - gateway
 

--- a/app/_kong_plugins/ai-sanitizer/index.md
+++ b/app/_kong_plugins/ai-sanitizer/index.md
@@ -4,6 +4,8 @@ name: 'AI Sanitizer'
 
 content_type: plugin
 
+ai_gateway_enterprise: true
+
 publisher: kong-inc
 description: Protect sensitive information in client request bodies before they reach upstream services
 

--- a/app/_kong_plugins/ai-semantic-cache/index.md
+++ b/app/_kong_plugins/ai-semantic-cache/index.md
@@ -4,6 +4,8 @@ name: 'AI Semantic Cache'
 
 content_type: plugin
 
+ai_gateway_enterprise: true
+
 publisher: kong-inc
 description: 'Enhance performance for AI providers by caching LLM responses semantically'
 

--- a/app/_kong_plugins/ai-semantic-prompt-guard/index.md
+++ b/app/_kong_plugins/ai-semantic-prompt-guard/index.md
@@ -4,6 +4,8 @@ name: 'AI Semantic Prompt Guard'
 
 content_type: plugin
 
+ai_gateway_enterprise: true
+
 publisher: kong-inc
 description: 'Semantically and intelligently create allow and deny lists of topics that can be requested across every LLM.'
 

--- a/app/_layouts/plugins/with_aside.html
+++ b/app/_layouts/plugins/with_aside.html
@@ -23,6 +23,13 @@ tier_inline: true
       </span>
     </blockquote>
   {% endif %}
+  {% if page.ai_gateway_enterprise %}
+  <blockquote class="ai w-full -my-4">
+    <span>
+      <strong>AI Gateway Enterprise:</strong> This plugin is only available as part of our AI Gateway Enterprise offering.
+    </span>
+  </blockquote>
+  {% endif %}
 {% endif %}
 
 {{ content }}


### PR DESCRIPTION
Fixes #1338 

Request from AI Gateway team + sales. Adding a banner that labels AI Gateway Enterprise plugins.

Originally I tried adding a badge as well, but it really looked like overkill - and since we don't use badges for Enterprise, it really stood out as out of place.