### PR TITLE
Add KGO Konnect reference docs

### DIFF
--- a/app/_indices/operator.yaml
+++ b/app/_indices/operator.yaml
@@ -58,7 +58,9 @@ groups:
           - path: /operator/konnect/get-started/**/*
       - title: Key Concepts
         items:
-          - path: /operator/konnect/concepts/labelling/
+          - path: /operator/konnect/reconciliation-loop/
+          - path: /operator/konnect/labelling/
+          - path: /operator/konnect/kongpluginbinding/
       - title: "Konnect CRDs: Control Planes"
         items:
           - path: /operator/konnect/crd/control-planes/**/*
@@ -71,11 +73,7 @@ groups:
       - title: Troubleshooting
         items:
           - path: /operator/konnect/troubleshooting/status/
-          - path: /operator/konnect/faq/
       - title: Reference
         items:
           - path: /operator/konnect/reference/crds/
-          - path: /operator/konnect/reference/crds/konnectextension/
-          - path: /operator/konnect/reference/crds/kongpluginbinding/
-          - path: /operator/konnect/reference/configuration/
-          - path: /operator/konnect/faq/
+          - path: /operator/konnect/reference/faq/

--- a/app/operator/konnect/kongpluginbinding.md
+++ b/app/operator/konnect/kongpluginbinding.md
@@ -1,0 +1,18 @@
+---
+title: "Understanding KongPluginBinding"
+description: "What is KongPluginBinding, and how does it interact with the konghq.com/plugins annotation?"
+content_type: reference
+layout: reference
+products:
+  - operator
+breadcrumbs:
+  - /operator/
+  - index: operator
+    group: Konnect
+  - index: operator
+    group: Konnect
+    section: Key Concepts
+
+---
+
+@TODO

--- a/app/operator/konnect/labelling.md
+++ b/app/operator/konnect/labelling.md
@@ -18,7 +18,7 @@ breadcrumbs:
 Tags and labels are a way to organize and categorize your resources. This doc explains how to annotate your {{site.konnect_short_name}} entities managed by {{site.kgo_product_name}} with tags and labels depending on particular entity's support for those.
 
 ## Labeling
-Labels are key-value pairs you can attach to certain objects. Currently, the only {{site.konnect_short_name}} entity that supports labels is [`KonnectGatewayControlPlane`](/operator/konnect/gatewaycontrolplane).
+Labels are key-value pairs you can attach to certain objects. Currently, the only {{site.konnect_short_name}} entity that supports labels is [`KonnectGatewayControlPlane`](/operator/konnect/crd/control-planes/hybrid/).
 You can add labels to the `KonnectGatewayControlPlane` object by specifying the `labels` field in the `spec` section.
 
 ```yaml

--- a/app/operator/konnect/labelling.md
+++ b/app/operator/konnect/labelling.md
@@ -1,0 +1,80 @@
+---
+title: "Labelling and Tagging resources"
+description: "How do I add additional metadata to entities managed by {{ site.operator_product_name }}?"
+content_type: reference
+layout: reference
+products:
+  - operator
+breadcrumbs:
+  - /operator/
+  - index: operator
+    group: Konnect
+  - index: operator
+    group: Konnect
+    section: Key Concepts
+
+---
+
+Tags and labels are a way to organize and categorize your resources. In this guide, you'll learn how to annotate your Konnect entities managed by {{site.kgo_product_name}} with tags and labels (depending on particular entity's support for those).
+
+## Labeling
+
+Labels are key-value pairs that you can attach to objects. As of now, the only Konnect entity that supports labeling is the [KonnectGatewayControlPlane](/operator/konnect/gatewaycontrolplane). You can add labels to the `KonnectGatewayControlPlane` object by specifying the `labels` field in the `spec` section.
+
+```yaml
+echo '
+kind: KonnectGatewayControlPlane
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: gateway-control-plane
+  namespace: default
+spec:
+  labels: # Arbitrary key-value pairs
+    environment: production
+    team: devops
+  name: gateway-control-plane
+  konnect:
+    authRef:
+      name: konnect-api-auth # Reference to the KonnectAPIAuthConfiguration object
+  ' | kubectl apply -f -
+```
+
+{% validation kubernetes-resource %}
+kind: KonnectGatewayControlPlane
+name: gateway-control-plane
+{% endvalidation %}
+
+At this point, labels should be visible in the Gateway Manager UI.
+
+## Tagging
+
+Tags are values that you can attach to objects. All the {{site.konnect_product_name}} entities that can be attached to a `KonnectGatewayControlPlane` object support tagging. You can add tags to those entities by specifying the `tags` field in their `spec` section.
+
+For example, to add tags to a `KongService` object, you can apply the following YAML manifest:
+
+```yaml
+echo '
+kind: KongService
+apiVersion: configuration.konghq.com/v1alpha1
+metadata:
+  name: service
+  namespace: default
+spec:
+  tags: # Arbitrary list of strings
+    - production
+    - devops
+  name: service
+  host: example.com
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: gateway-control-plane # Reference to the KonnectGatewayControlPlane object
+  ' | kubectl apply -f -
+```
+
+{% validation kubernetes-resource %}
+kind: KongService
+name: service
+{% endvalidation %}
+
+At this point, tags should be visible in the Gateway Manager UI.

--- a/app/operator/konnect/labelling.md
+++ b/app/operator/konnect/labelling.md
@@ -15,11 +15,11 @@ breadcrumbs:
 
 ---
 
-Tags and labels are a way to organize and categorize your resources. In this guide, you'll learn how to annotate your Konnect entities managed by {{site.kgo_product_name}} with tags and labels (depending on particular entity's support for those).
+Tags and labels are a way to organize and categorize your resources. This doc explains how to annotate your {{site.konnect_short_name}} entities managed by {{site.kgo_product_name}} with tags and labels depending on particular entity's support for those.
 
 ## Labeling
-
-Labels are key-value pairs that you can attach to objects. As of now, the only Konnect entity that supports labeling is the [KonnectGatewayControlPlane](/operator/konnect/gatewaycontrolplane). You can add labels to the `KonnectGatewayControlPlane` object by specifying the `labels` field in the `spec` section.
+Labels are key-value pairs you can attach to certain objects. Currently, the only {{site.konnect_short_name}} entity that supports labels is [`KonnectGatewayControlPlane`](/operator/konnect/gatewaycontrolplane).
+You can add labels to the `KonnectGatewayControlPlane` object by specifying the `labels` field in the `spec` section.
 
 ```yaml
 echo '
@@ -44,7 +44,7 @@ kind: KonnectGatewayControlPlane
 name: gateway-control-plane
 {% endvalidation %}
 
-At this point, labels should be visible in the Gateway Manager UI.
+At this point, labels should be visible in the[ Gateway Manager](https://cloud.konghq.com/us/gateway-manager/) UI.
 
 ## Tagging
 
@@ -77,4 +77,4 @@ kind: KongService
 name: service
 {% endvalidation %}
 
-At this point, tags should be visible in the Gateway Manager UI.
+At this point, tags should be visible in the[ Gateway Manager](https://cloud.konghq.com/us/gateway-manager/) UI.

--- a/app/operator/konnect/labelling.md
+++ b/app/operator/konnect/labelling.md
@@ -44,7 +44,7 @@ kind: KonnectGatewayControlPlane
 name: gateway-control-plane
 {% endvalidation %}
 
-At this point, labels should be visible in the[ Gateway Manager](https://cloud.konghq.com/us/gateway-manager/) UI.
+At this point, labels should be visible in the [Gateway Manager](https://cloud.konghq.com/us/gateway-manager/) UI.
 
 ## Tagging
 
@@ -77,4 +77,4 @@ kind: KongService
 name: service
 {% endvalidation %}
 
-At this point, tags should be visible in the[ Gateway Manager](https://cloud.konghq.com/us/gateway-manager/) UI.
+At this point, tags should be visible in the [Gateway Manager](https://cloud.konghq.com/us/gateway-manager/) UI.

--- a/app/operator/konnect/reconciliation-loop.md
+++ b/app/operator/konnect/reconciliation-loop.md
@@ -16,73 +16,77 @@ breadcrumbs:
 faqs:
   - q: How often does the reconcile loop run?
     a: |
-      New resources are created immediately using the Konnect API.
+      New resources are created immediately using the {{ site.konnect_short_name }} API.
 
-      Existing resources are processed once per minute by default. This is customizable, but we recommend keeping the default value so that you do not hit the Konnect API rate limit.
+      Existing resources are processed once per minute by default. This is customizable, but we recommend keeping the default value so that you do not hit the {{ site.konnect_short_name }} API rate limit.
 
   - q: I deleted a resource in the UI, but it wasn’t recreated by the operator. Why?
-    a: Wait 60 seconds, then check the UI again. The reconcile loop only runs once per minute.
+    a: The reconciliation loop runs every 60 seconds. Wait one minute, then refresh the UI to see the resource restored.
+
 
 
 ---
 
-{{site.operator_product_name}} watches for changes in the Kubernetes cluster and synchronizes them against {{site.konnect_short_name}}.
+{{site.operator_product_name}} continuously watches your Kubernetes cluster and reconciles its state with {{site.konnect_short_name}}.
 
-The synchronization is performed in a loop, where the operator reconciles the state of the cluster with the state of {{site.konnect_short_name}}.
-
-Changes made in your Kubernetes cluster are synced with {{ site.konnect_short_name }} immediately. Any changes made outside of the cluster (using the UI, for example) will be overwritten within 60 seconds.
+This happens in a loop where the operator detects changes in the cluster and synchronizes them to {{site.konnect_short_name}}. Changes made in the Kubernetes cluster are propagated immediately. Changes made outside the cluster are overwritten within 60 seconds.
 
 ## How it works
 
-The algorithm is as follows:
+The reconciliation loop follows these steps:
 
-- When a Kubernetes resource is created:
+
+* On Kubernetes resource creation:
   - The operator checks if it has references and whether they are valid, if not it assigns a failure condition to the resource.
-  - If the resource has references and they are valid, the operator calls the Konnect API's create method.
+  - If the resource has references and they are valid, the operator calls the {{ site.konnect_short_name }} API's create method.
     - If the creation was unsuccessful, the operator assigns a failure condition to the resource.
-    - If the creation was successful, the operator assigns the resource's ID, OrgID, ServerURL and status conditions.
+    - If the creation was successful, the operator assigns the resource's `ID`, `OrgID`, `ServerURL` and status conditions.
   - The operator enqueues the resource for update after the configured sync period passes.
 
 - When a Kubernetes resource is updated:
   - The operator checks if the resource's spec, annotations or labels have changed.
   - If the spec, annotations or labels have changed:
-    - The operator calls the Konnect API's update method.
+    - The operator calls the {{ site.konnect_short_name }} API's update method.
       - If the update was unsuccessful, the operator assigns a failure condition to the resource.
       - If the update was successful, the operator waits for the configured sync period to pass.
   - If the spec, annotations or labels have not changed:
     - If sync period has not passed, the operator enqueues the resource for update.
-    - If sync period has passed, the operator calls the Konnect API's update method.
+    - If sync period has passed, the operator calls the {{ site.konnect_short_name }} API's update method.
       - If the update was unsuccessful, the operator assigns a failure condition to the resource.
       - If the update was successful, the operator enqueues the resource for update.
 
 - When a Kubernetes resource is deleted:
-  - The operator calls the Konnect API's delete method.
+  - The operator calls the {{ site.konnect_short_name }} API's delete method.
     - If the deletion was unsuccessful, the operator assigns a failure condition to the resource.
     - If the deletion was successful, the operator removes the resource from the cluster.
 
-Below diagram illustrates the algorithm:
+This diagram illustrates the flow:
 
 <!--vale off-->
 {% mermaid %}
 flowchart TB
 
-classDef decision fill:#d0e1fb
-classDef start fill:#545454,stroke:none,color:#fff
-
     k8sResourceCreated(Kubernetes resource created)
     k8sResourceUpdated(Kubernetes resource updated)
     rLoopStart[Operator reconciliation start]
     failure[Assign object's status conditions to indicate failure]
-    resourceSpecChanged{Resource spec, annotations or labels changed?}
+    resourceSpecChanged{Resource spec, 
+    annotations or 
+    labels changed?}
     waitForSync["Wait until sync period passes (default 1m)
     (Prevent API rate limiting)"]
     createSuccess[Assign object's ID, OrgID, ServerURL and status conditions]
-    hasReferences{If object has references, are they all valid?}
-    isAlreadyCreated{Object already created?}
+    hasReferences{If object has 
+    references, 
+    are they all valid?}
+    isAlreadyCreated{Object 
+    already created?}
     syncPeriodPassed[Sync period passed]
     updateKonnectEntity[Call Konnect API's update]
-    wasUpdateSuccessful{Was update successful?}
-    wasCreateSuccessful{Was create successful?}
+    wasUpdateSuccessful{Was update 
+    successful?}
+    wasCreateSuccessful{Was create 
+    successful?}
     callCreate[Call Konnect API's create]
 
     k8sResourceCreated --> rLoopStart
@@ -105,7 +109,5 @@ classDef start fill:#545454,stroke:none,color:#fff
     wasUpdateSuccessful -->|No| failure
     failure -->rLoopStart
 
-class hasReferences,wasCreateSuccessful,wasUpdateSuccessful decision
-class k8sResourceCreated,k8sResourceUpdated start
 {% endmermaid %}
 <!--vale on-->

--- a/app/operator/konnect/reconciliation-loop.md
+++ b/app/operator/konnect/reconciliation-loop.md
@@ -1,0 +1,111 @@
+---
+title: "Reconciliation loop"
+description: "How does the {{ site.operator_product_name }} reconciliation loop work?"
+content_type: reference
+layout: reference
+products:
+  - operator
+breadcrumbs:
+  - /operator/
+  - index: operator
+    group: Konnect
+  - index: operator
+    group: Konnect
+    section: Key Concepts
+
+faqs:
+  - q: How often does the reconcile loop run?
+    a: |
+      New resources are created immediately using the Konnect API.
+
+      Existing resources are processed once per minute by default. This is customizable, but we recommend keeping the default value so that you do not hit the Konnect API rate limit.
+
+  - q: I deleted a resource in the UI, but it wasn’t recreated by the operator. Why?
+    a: Wait 60 seconds, then check the UI again. The reconcile loop only runs once per minute.
+
+
+---
+
+{{site.operator_product_name}} watches for changes in the Kubernetes cluster and synchronizes them against {{site.konnect_short_name}}.
+
+The synchronization is performed in a loop, where the operator reconciles the state of the cluster with the state of {{site.konnect_short_name}}.
+
+Changes made in your Kubernetes cluster are synced with {{ site.konnect_short_name }} immediately. Any changes made outside of the cluster (using the UI, for example) will be overwritten within 60 seconds.
+
+## How it works
+
+The algorithm is as follows:
+
+- When a Kubernetes resource is created:
+  - The operator checks if it has references and whether they are valid, if not it assigns a failure condition to the resource.
+  - If the resource has references and they are valid, the operator calls the Konnect API's create method.
+    - If the creation was unsuccessful, the operator assigns a failure condition to the resource.
+    - If the creation was successful, the operator assigns the resource's ID, OrgID, ServerURL and status conditions.
+  - The operator enqueues the resource for update after the configured sync period passes.
+
+- When a Kubernetes resource is updated:
+  - The operator checks if the resource's spec, annotations or labels have changed.
+  - If the spec, annotations or labels have changed:
+    - The operator calls the Konnect API's update method.
+      - If the update was unsuccessful, the operator assigns a failure condition to the resource.
+      - If the update was successful, the operator waits for the configured sync period to pass.
+  - If the spec, annotations or labels have not changed:
+    - If sync period has not passed, the operator enqueues the resource for update.
+    - If sync period has passed, the operator calls the Konnect API's update method.
+      - If the update was unsuccessful, the operator assigns a failure condition to the resource.
+      - If the update was successful, the operator enqueues the resource for update.
+
+- When a Kubernetes resource is deleted:
+  - The operator calls the Konnect API's delete method.
+    - If the deletion was unsuccessful, the operator assigns a failure condition to the resource.
+    - If the deletion was successful, the operator removes the resource from the cluster.
+
+Below diagram illustrates the algorithm:
+
+<!--vale off-->
+{% mermaid %}
+flowchart TB
+
+classDef decision fill:#d0e1fb
+classDef start fill:#545454,stroke:none,color:#fff
+
+    k8sResourceCreated(Kubernetes resource created)
+    k8sResourceUpdated(Kubernetes resource updated)
+    rLoopStart[Operator reconciliation start]
+    failure[Assign object's status conditions to indicate failure]
+    resourceSpecChanged{Resource spec, annotations or labels changed?}
+    waitForSync["Wait until sync period passes (default 1m)
+    (Prevent API rate limiting)"]
+    createSuccess[Assign object's ID, OrgID, ServerURL and status conditions]
+    hasReferences{If object has references, are they all valid?}
+    isAlreadyCreated{Object already created?}
+    syncPeriodPassed[Sync period passed]
+    updateKonnectEntity[Call Konnect API's update]
+    wasUpdateSuccessful{Was update successful?}
+    wasCreateSuccessful{Was create successful?}
+    callCreate[Call Konnect API's create]
+
+    k8sResourceCreated --> rLoopStart
+    rLoopStart --> isAlreadyCreated
+    isAlreadyCreated -->|Yes| waitForSync
+    isAlreadyCreated -->|No| hasReferences
+    hasReferences -->|Yes| callCreate
+    hasReferences -->|No| failure
+    callCreate --> wasCreateSuccessful
+    wasCreateSuccessful -->|Yes| createSuccess
+    wasCreateSuccessful -->|No| failure
+    k8sResourceUpdated --> resourceSpecChanged
+    resourceSpecChanged -->|Yes| updateKonnectEntity
+    resourceSpecChanged -->|No| waitForSync
+    createSuccess --> waitForSync
+    waitForSync --> syncPeriodPassed
+    syncPeriodPassed --> updateKonnectEntity
+    updateKonnectEntity --> wasUpdateSuccessful
+    wasUpdateSuccessful -->|Yes| waitForSync
+    wasUpdateSuccessful -->|No| failure
+    failure -->rLoopStart
+
+class hasReferences,wasCreateSuccessful,wasUpdateSuccessful decision
+class k8sResourceCreated,k8sResourceUpdated start
+{% endmermaid %}
+<!--vale on-->

--- a/app/operator/konnect/reference/crds.md
+++ b/app/operator/konnect/reference/crds.md
@@ -1,0 +1,18 @@
+---
+title: "Custom Resource Definitions"
+description: "TODO"
+content_type: reference
+layout: reference
+products:
+  - operator
+breadcrumbs:
+  - /operator/
+  - index: operator
+    group: Konnect
+  - index: operator
+    group: Konnect
+    section: Reference
+
+---
+
+@TODO

--- a/app/operator/konnect/reference/faq.md
+++ b/app/operator/konnect/reference/faq.md
@@ -5,7 +5,7 @@ description: "Answers to common questions about managing {{site.konnect_short_na
 content_type: reference
 layout: reference
 search_aliases:
-  - KGO faq
+  - KGO FAQ
 products:
   - operator
 breadcrumbs:

--- a/app/operator/konnect/reference/faq.md
+++ b/app/operator/konnect/reference/faq.md
@@ -1,8 +1,11 @@
 ---
 title: "FAQ"
-description: "TODO"
+description: "Answers to common questions about managing {{site.konnect_short_name}} entities using the Operator."
+
 content_type: reference
 layout: reference
+search_aliases:
+  - KGO faq
 products:
   - operator
 breadcrumbs:
@@ -15,35 +18,37 @@ breadcrumbs:
 
 ---
 
-Managing {{ site.konnect_product_name }} entities with {{ site.kgo_product_name }} is a feature that is under active development. This document addresses commonly asked questions.
+Managing {{site.konnect_short_name}} entities with {{ site.operator_product_name }} is an actively developed feature. This page answers frequently asked questions.
 
-## I'm a {{ site.kic_product_name }} user, how much will I have to learn?
+## I'm a {{ site.kic_product_name }} user. How much do I need to learn?
 
-{{ site.kgo_product_name }} uses the same custom resources as {{ site.kic_product_name }}. A `KongConsumer` is the same no matter which product you're using.
+{{ site.operator_product_name }} uses the same custom resources as {{ site.kic_product_name }}. A `KongConsumer` is the same no matter which product you're using.
 
-By default, all `Kong*` custom resources will be reconciled by {{ site.kic_product_name }}. To make {{ site.kgo_product_name }} reconcile them with {{ site.konnect_short_name }}, you must provide a `spec.controlPlaneRef.type` of `konnectNamespacedRef`.
+By default, all `Kong*` custom resources will be reconciled by {{ site.kic_product_name }}. To make {{ site.operator_product_name }} reconcile them with {{ site.konnect_short_name }}, you must provide a `spec.controlPlaneRef.type` of `konnectNamespacedRef`.
 
-## Can I use HTTPRoute and Ingress definitions?
+## Can I use `HTTPRoute` and Ingress definitions?
 
-For the first release, we have chosen to keep a 1:1 mapping between custom resources and Konnect entities. This means that you should create `KongService` and `KongRoute` resources rather than `HTTPRoute` or `Ingress` resources.
+Not yet. The initial release uses a 1:1 mapping between custom resources and Konnect entities. Use `KongService` and `KongRoute` instead of `HTTPRoute` or `Ingress`.
+
 
 Support for standard Kubernetes resources is planned for the future.
 
 ## How often does the reconcile loop run?
 
-New resources are created immediately using the Konnect API.
+* New resources are created immediately via the {{site.konnect_short_name}} API.
+* Existing resources are reconciled every 60 seconds by default.
 
-Existing resources are processed once per minute by default. This is customizable, but we recommend keeping the default value so that you do not hit the {{ site.konnect_short_name }} API rate limit.
+This is customizable, but we recommend keeping the default value so that you do not hit the {{ site.konnect_short_name }} API rate limit.
 
-For more information, see [how it works](/gateway-operator/{{page.release}}/guides/konnect-entities/architecture/#how-it-works).
+For more information, see [how it works](/operator/konnect/reconciliation-loop/).
 
 ## I deleted a resource in the UI, but it wasn't recreated by the operator. Why?
 
-Wait 60 seconds, then check the UI again. The reconcile loop only runs once per minute.
+The reconciliation loop runs once per minute. Wait 60 seconds, then refresh the UI.
 
-## Can I use Secrets for consumer credentials like in {{ site.kic_product_name }}?
+## Can I use Secrets for Consumer credentials like in {{ site.kic_product_name }}?
 
-{{ site.kgo_product_name }} uses new `Credential` CRDs for managing [consumer credentials](/gateway-operator/{{page.release}}/guides/konnect-entities/consumer-and-consumergroup/#associate-the-consumer-with-credentials). We plan to support Kubernetes `Secret` resources in a future release. [#618](https://github.com/Kong/gateway-operator/issues/618).
+{{ site.operator_product_name }} uses new `Credential` CRDs for managing [consumer credentials](/operator/konnect/crd/gateway/consumer/). We plan to support Kubernetes `Secret` resources in a future release. [#618](https://github.com/Kong/gateway-operator/issues/618).
 
 ## Can I adopt existing {{ site.konnect_short_name }} entities?
 
@@ -51,4 +56,4 @@ Adopting existing entities is planned, but not yet available. Only resources cre
 
 ## How do I create a global plugin?
 
-It is not yet possible to create a global plugin. This is due to {{ site.konnect_short_name }} resources being namespaced in {{ site.kgo_product_name }}, while global plugins are cluster scoped. We are investigating options in [#440](https://github.com/Kong/gateway-operator/issues/440)
+It is not yet possible to create a global plugin. This is due to {{ site.konnect_short_name }} resources being namespaced in {{ site.operator_product_name }}, while global plugins are cluster scoped. We are investigating options in [#440](https://github.com/Kong/gateway-operator/issues/440)

--- a/app/operator/konnect/reference/faq.md
+++ b/app/operator/konnect/reference/faq.md
@@ -1,0 +1,54 @@
+---
+title: "FAQ"
+description: "TODO"
+content_type: reference
+layout: reference
+products:
+  - operator
+breadcrumbs:
+  - /operator/
+  - index: operator
+    group: Konnect
+  - index: operator
+    group: Konnect
+    section: Reference
+
+---
+
+Managing {{ site.konnect_product_name }} entities with {{ site.kgo_product_name }} is a feature that is under active development. This document addresses commonly asked questions.
+
+## I'm a {{ site.kic_product_name }} user, how much will I have to learn?
+
+{{ site.kgo_product_name }} uses the same custom resources as {{ site.kic_product_name }}. A `KongConsumer` is the same no matter which product you're using.
+
+By default, all `Kong*` custom resources will be reconciled by {{ site.kic_product_name }}. To make {{ site.kgo_product_name }} reconcile them with {{ site.konnect_short_name }}, you must provide a `spec.controlPlaneRef.type` of `konnectNamespacedRef`.
+
+## Can I use HTTPRoute and Ingress definitions?
+
+For the first release, we have chosen to keep a 1:1 mapping between custom resources and Konnect entities. This means that you should create `KongService` and `KongRoute` resources rather than `HTTPRoute` or `Ingress` resources.
+
+Support for standard Kubernetes resources is planned for the future.
+
+## How often does the reconcile loop run?
+
+New resources are created immediately using the Konnect API.
+
+Existing resources are processed once per minute by default. This is customizable, but we recommend keeping the default value so that you do not hit the {{ site.konnect_short_name }} API rate limit.
+
+For more information, see [how it works](/gateway-operator/{{page.release}}/guides/konnect-entities/architecture/#how-it-works).
+
+## I deleted a resource in the UI, but it wasn't recreated by the operator. Why?
+
+Wait 60 seconds, then check the UI again. The reconcile loop only runs once per minute.
+
+## Can I use Secrets for consumer credentials like in {{ site.kic_product_name }}?
+
+{{ site.kgo_product_name }} uses new `Credential` CRDs for managing [consumer credentials](/gateway-operator/{{page.release}}/guides/konnect-entities/consumer-and-consumergroup/#associate-the-consumer-with-credentials). We plan to support Kubernetes `Secret` resources in a future release. [#618](https://github.com/Kong/gateway-operator/issues/618).
+
+## Can I adopt existing {{ site.konnect_short_name }} entities?
+
+Adopting existing entities is planned, but not yet available. Only resources created by the operator can be managed using CRDs at this time. [#460](https://github.com/Kong/gateway-operator/issues/460)
+
+## How do I create a global plugin?
+
+It is not yet possible to create a global plugin. This is due to {{ site.konnect_short_name }} resources being namespaced in {{ site.kgo_product_name }}, while global plugins are cluster scoped. We are investigating options in [#440](https://github.com/Kong/gateway-operator/issues/440)

--- a/app/operator/konnect/troubleshooting/status.md
+++ b/app/operator/konnect/troubleshooting/status.md
@@ -3,6 +3,8 @@ title: "Status Fields"
 description: "How do I find out why my resources aren't being reconciled against {{ site.konnect_short_name }}?"
 content_type: reference
 layout: reference
+search_aliases:
+  - KGO status fields
 products:
   - operator
 breadcrumbs:
@@ -14,23 +16,23 @@ breadcrumbs:
 
 ## Status fields
 
-Each Kubernetes resource that is mapped to a Konnect entity has several fields that indicate its status in Konnect.
+Each Kubernetes resource that is mapped to a {{site.konnect_short_name}} entity has several fields that indicate its status in Konnect.
 
-### Konnect native objects
+### {{site.konnect_short_name}} native objects
 
-Objects that are native to {{site.konnect_short_name}} - they exist only in {{site.konnect_short_name}} - have the following `status` fields:
+Objects that are native to {{site.konnect_short_name}},they exist only in {{site.konnect_short_name}} - have the following `status` fields:
 
-- `id` is the unique identifier of the Konnect entity as assigned by {{site.konnect_product_name}} API. If it's unset (empty string), it means the {{site.konnect_product_name}} entity hasn't been created yet.
-- `serverURL` is the URL of the {{site.konnect_product_name}} server in which the entity exists.
-- `organizationID` is ID of {{site.konnect_product_name}} Org that this entity has been created in.
+- `id` is the unique identifier of the Konnect entity as assigned by {{site.konnect_short_name}} API. If it's unset (empty string), it means the {{site.konnect_short_name}} entity hasn't been created yet.
+- `serverURL` is the URL of the {{site.konnect_short_name}} server in which the entity exists.
+- `organizationID` is the ID of {{site.konnect_short_name}} Org that this entity has been created in.
 
-You can observe these fields by running:
+To inspect these fields:
 
 ```bash
 kubectl get <resource> <resource-name> -o yaml | yq '.status'
 ```
 
-You should see the following output:
+Example output:
 
 ```yaml
 conditions:
@@ -40,28 +42,27 @@ organizationID: 5ca26716-02f7-4430-9117-111111111111
 serverURL: https://us.api.konghq.com
 ```
 
-These objects are defined under `konnect.konghq.com` API group.
+These objects are defined under the `konnect.konghq.com` API group.
 
-### Objects configuring {{site.base_gateway}}
+### {{ site.base_gateway }} configuration objects
 
-Some objects can be used to configure {{site.base_gateway}} and are not native to {{site.konnect_short_name}}.  These are for example `KongConsumer`, `KongService`, `KongRoute` and `KongPlugin`. They are defined under `configuration.konghq.com` API group.
+Resources like `KongConsumer`, `KongService`, `KongRoute`, and `KongPlugin` configure {{ site.base_gateway }} and are **not** native to {{ site.konnect_short_name }}. These are defined under the `configuration.konghq.com` API group and may be used with other controllers, such as {{ site.kic_product_name }}.
 
-They can also be used in other contexts like for instance: be used for reconciliation with {{site.kic_product_name}}.
+When managed by {{ site.kgo_product_name }} for {{ site.konnect_short_name }}, Konnect-specific status fields appear under `.status.konnect`:
 
-These objects have their {{site.konnect_short_name}} status related fields nested under `konnect` field. These fields are:
+- `controlPlaneID`: The ID of the associated Konnect Control Plane.
+- `id`: The unique ID assigned by the {{ site.konnect_short_name }} API. If empty, the entity hasn't been created.
+- `serverURL`: The URL of the {{ site.konnect_short_name }} server where the entity resides.
+- `organizationID`: The Org ID under which the entity was created.
 
-- `controlPlaneID` is the ID of the Control Plane this entity is associated with.
-- `id` is the unique identifier of the Konnect entity as assigned by {{site.konnect_product_name}} API. If it's unset (empty string), it means the {{site.konnect_product_name}} entity hasn't been created yet.
-- `serverURL` is the URL of the {{site.konnect_product_name}} server in which the entity exists.
-- `organizationID` is ID of {{site.konnect_product_name}} Org that this entity has been created in.
+To inspect these fields:
 
-You can observe these fields by running:
 
 ```bash
 kubectl get <resource> <resource-name> -o yaml | yq '.status.konnect'
 ```
 
-You should see the following output:
+Example output:
 
 ```yaml
 controlPlaneID: 7dcf6756-b2e7-4067-a19b-111111111111

--- a/app/operator/konnect/troubleshooting/status.md
+++ b/app/operator/konnect/troubleshooting/status.md
@@ -1,0 +1,71 @@
+---
+title: "Status Fields"
+description: "How do I find out why my resources aren't being reconciled against {{ site.konnect_short_name }}?"
+content_type: reference
+layout: reference
+products:
+  - operator
+breadcrumbs:
+  - /operator/
+  - index: operator
+    group: Konnect
+
+---
+
+## Status fields
+
+Each Kubernetes resource that is mapped to a Konnect entity has several fields that indicate its status in Konnect.
+
+### Konnect native objects
+
+Objects that are native to {{site.konnect_short_name}} - they exist only in {{site.konnect_short_name}} - have the following `status` fields:
+
+- `id` is the unique identifier of the Konnect entity as assigned by {{site.konnect_product_name}} API. If it's unset (empty string), it means the {{site.konnect_product_name}} entity hasn't been created yet.
+- `serverURL` is the URL of the {{site.konnect_product_name}} server in which the entity exists.
+- `organizationID` is ID of {{site.konnect_product_name}} Org that this entity has been created in.
+
+You can observe these fields by running:
+
+```bash
+kubectl get <resource> <resource-name> -o yaml | yq '.status'
+```
+
+You should see the following output:
+
+```yaml
+conditions:
+  ...
+id: 7dcf6756-b2e7-4067-a19b-111111111111
+organizationID: 5ca26716-02f7-4430-9117-111111111111
+serverURL: https://us.api.konghq.com
+```
+
+These objects are defined under `konnect.konghq.com` API group.
+
+### Objects configuring {{site.base_gateway}}
+
+Some objects can be used to configure {{site.base_gateway}} and are not native to {{site.konnect_short_name}}.  These are for example `KongConsumer`, `KongService`, `KongRoute` and `KongPlugin`. They are defined under `configuration.konghq.com` API group.
+
+They can also be used in other contexts like for instance: be used for reconciliation with {{site.kic_product_name}}.
+
+These objects have their {{site.konnect_short_name}} status related fields nested under `konnect` field. These fields are:
+
+- `controlPlaneID` is the ID of the Control Plane this entity is associated with.
+- `id` is the unique identifier of the Konnect entity as assigned by {{site.konnect_product_name}} API. If it's unset (empty string), it means the {{site.konnect_product_name}} entity hasn't been created yet.
+- `serverURL` is the URL of the {{site.konnect_product_name}} server in which the entity exists.
+- `organizationID` is ID of {{site.konnect_product_name}} Org that this entity has been created in.
+
+You can observe these fields by running:
+
+```bash
+kubectl get <resource> <resource-name> -o yaml | yq '.status.konnect'
+```
+
+You should see the following output:
+
+```yaml
+controlPlaneID: 7dcf6756-b2e7-4067-a19b-111111111111
+id: 7dcf6756-b2e7-4067-a19b-111111111111
+organizationID: 5ca26716-02f7-4430-9117-111111111111
+serverURL: https://us.api.konghq.com
+```


### PR DESCRIPTION
## Description

I'll add preview links later today
https://deploy-preview-1385--kongdeveloper.netlify.app/operator/konnect/reconciliation-loop/
https://deploy-preview-1385--kongdeveloper.netlify.app/operator/konnect/labelling/
https://deploy-preview-1385--kongdeveloper.netlify.app/operator/konnect/reference/faq/
https://deploy-preview-1385--kongdeveloper.netlify.app/operator/konnect/troubleshooting/status/


These items have todo's

https://deploy-preview-1385--kongdeveloper.netlify.app/operator/konnect/kongpluginbinding/
https://deploy-preview-1385--kongdeveloper.netlify.app/operator/konnect/crd/cloud-gateways/configuration/


Fixes #issue

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
