### PR TITLE
fix: Make AWS vault how to work on Konnect

### DIFF
--- a/app/_how-tos/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity.md
+++ b/app/_how-tos/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity.md
@@ -79,16 +79,6 @@ next_steps:
 
 Using decK, create a [Vault entity](/gateway/entities/vault/) with the required parameters for AWS:
 
-{% entity_example %}
-type: vault
-data:
-  name: aws
-  prefix: aws-vault
-  description: Storing secrets in AWS Secrets Manager
-  config:
-    region: us-east-1
-{% endentity_example %}
-
 {% entity_examples %}
 entities:
   vaults:

--- a/app/_how-tos/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity.md
+++ b/app/_how-tos/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity.md
@@ -13,6 +13,7 @@ products:
 
 works_on:
   - on-prem
+  - konnect
 
 min_version:
   gateway: '3.4'
@@ -76,7 +77,7 @@ next_steps:
 
 ## Configure the Vault entity
 
-Using decK, create a Vault entity with the required parameters for AWS:
+Using decK, create a [Vault entity](/gateway/entities/vault/) with the required parameters for AWS:
 
 {% entity_example %}
 type: vault
@@ -88,12 +89,23 @@ data:
     region: us-east-1
 {% endentity_example %}
 
+{% entity_examples %}
+entities:
+  vaults:
+    - name: aws
+      prefix: aws-vault
+      description: Storing secrets in AWS Secrets Manager
+      config:
+        region: us-east-1
+{% endentity_examples %}
+
 ## Validate
 
-To validate that the secret was stored correctly in AWS you can use the `kong vault get` command within the Data Plane container. If the Docker container is named `kong-quickstart-gateway`, you can use the following command:
+To validate that the secret was stored correctly in AWS you can use the `kong vault get` command within the Data Plane container. 
 
-```sh
-docker exec kong-quickstart-gateway kong vault get {vault://aws-vault/my-aws-secret/token}
-```
+{% validation vault-secret %}
+secret: '{vault://aws-vault/my-aws-secret/token}'
+value: 'secret'
+{% endvalidation %}
 
 If the vault was configured correctly, this command should return the value of the secret. Then, you can use `{vault://aws-vault/my-aws-secret/token}` to reference the secret in any referenceable field.


### PR DESCRIPTION
## Description
This was the last remaining Gateway Vault how to that didn't have Konnect instructions, so I added them.

Fixes #569

## Preview Links
https://deploy-preview-1450--kongdeveloper.netlify.app/how-to/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity/

## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
