### PR TITLE
Fix broken link

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -258,7 +258,7 @@ edit_and_issue_links: false
                     <p class="text-sm text-secondary">Comprehensive toolkit of commands for orchestrating and automating the entire process of API delivery</p>
                 </div>
                 <div class="flex flex-col w-full text-primary text-sm">
-                    <a class="flex justify-between py-3 border-b border-primary/5  hover:bg-hover-component/100 hover:px-6 hover:-mx-6 hover:no-underline" href="/decK/">Overview <span class="text-terciary">&rarr;</span></a>
+                    <a class="flex justify-between py-3 border-b border-primary/5  hover:bg-hover-component/100 hover:px-6 hover:-mx-6 hover:no-underline" href="/deck/">Overview <span class="text-terciary">&rarr;</span></a>
                     <a class="flex justify-between py-3  hover:bg-hover-component/100 hover:px-6 hover:-mx-6 hover:no-underline" href="/index/deck/">All documentation<span class="text-terciary">&rarr;</span></a>
                 </div>
             </div>


### PR DESCRIPTION
Fixing link from https://github.com/Kong/developer.konghq.com/actions/runs/14950464318/job/41999150800

The other broken link, `http://localhost:8888/gateway/install/kubernetes/`, should be gone by release time.