### PR TITLE
fix: Numbered steps on how to

### DIFF
--- a/app/_how-tos/visualize-ai-gateway-metrics-with-kibana.md
+++ b/app/_how-tos/visualize-ai-gateway-metrics-with-kibana.md
@@ -67,7 +67,7 @@ related_resources:
     url: /how-to/use-langchain-with-ai-proxy/
 ---
 
-## 1. Clone the sample repository
+## Clone the sample repository
 
 Kong provides a sample stack using Elasticsearch, Logstash, and Kibana to visualize AI Gateway metrics.
 
@@ -89,14 +89,14 @@ git clone https://github.com/KongHQ-CX/kong-ai-gateway-observability
 cd kong-ai-gateway-observability
 ```
 
-## 2. Start the stack
+## Start the stack
 
 Use the following command to start the sample stack:
 ```sh
 docker compose up
 ```
 
-## 3. Send requests
+## Send requests
 
 Once the stack is running, open a new terminal and send some requests to the `/gpt4o` endpoint with the Consumer's API key to generate metrics. For example:
 {% validation request-check %}
@@ -115,7 +115,7 @@ body:
           content: "What is 1+1?"
 {% endvalidation %}
 
-## 4. Visualize the metrics
+## Visualize the metrics
 
 Go to the following URL to visualize your metrics in Kibana:
 ```


### PR DESCRIPTION
## Description

Just happened to notice this one as it's the first how to in the Gateway list, but I searched for `## 1.` to make sure there were no other how tos with manual numbering.

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
