### PR TITLE
Render `all doc link` in h1 only

### DIFF
--- a/app/_includes/landing_pages/header.md
+++ b/app/_includes/landing_pages/header.md
@@ -27,7 +27,7 @@
 {{header}}
 <span class="{% if include.config.type == 'h1'%}text-xl{% else %}text-lg{% endif %} font-light">{{include.config.sub_text | liquify }}</span>
 
-{% if page.all_docs_indices and page.all_docs_indices != empty  %}
+{% if  include.config.type == 'h1' and page.all_docs_indices and page.all_docs_indices != empty  %}
 <div class="flex gap-2 items-center pt-2">
     {% for index in page.all_docs_indices %}
         <div class="flex gap-2 items-center w-fit badge bg-brand-saturated/40 py-1 px-2">


### PR DESCRIPTION
## Description

 Prevent the all doc link from being rendered in h2s, e.g. https://developer.konghq.com/operator/#konnect-crds

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
