### PR TITLE
fix: TL;DR in decK get started

### DIFF
--- a/app/_how-tos/deck-get-started.md
+++ b/app/_how-tos/deck-get-started.md
@@ -33,7 +33,10 @@ tags:
 
 tldr:
   q: How do I use decK?
-  a: Create a declarative configuration file named `kong.yaml` and run `deck gateway sync kong.yaml`
+  a: |
+    This page teaches you how to use decK to create a Gateway Service, Route, Plugins, and Consumers using a declarative configuration file (`kong.yaml`). It uses the `deck gateway apply` command to build the configuration up incrementally. 
+    
+    At any point, you can run `deck gateway dump` to see the entire configuration of {{site.base_gateway}} at once. 
 
 tools:
   - deck
@@ -47,8 +50,6 @@ cleanup:
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg
 ---
-
-This page teaches you how to use decK to create a Service, Route, Plugins, and Consumers. It uses the `deck gateway apply` command to build the configuration up incrementally. At any point, you can run `deck gateway dump` to see the entire configuration of {{ site.base_gateway }} at once.
 
 ## Create a Service
 


### PR DESCRIPTION
## Description
The decK get started had content before the h2 that wasn't being rendered, so I moved it to the TL;DR.

https://kongstrong.slack.com/archives/GN9V02K4N/p1747081825629909

## Preview Links


## Checklist 

- [x] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. (N/A: this change didn't impact any of the how to steps)
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
