### PR TITLE
fix: Konnect billing dashboard link

### DIFF
--- a/app/konnect-platform/account.md
+++ b/app/konnect-platform/account.md
@@ -12,6 +12,15 @@ products:
 works_on:
     - konnect
 
+tags:
+  - organization
+  - account-management
+
+search_aliases:
+  - billing
+  - pricing
+  - deactivate
+
 related_resources:
   - text: "{{site.base_gateway}} version support policy"
     url: /gateway/version-support-policy/

--- a/app/konnect-platform/account.md
+++ b/app/konnect-platform/account.md
@@ -58,7 +58,7 @@ faqs:
       * Unlock an email for use with another organization
   - q: How do I manage and view billing and usage?
     a: |
-      You can view service, Dev Portal, and API call usage from the [Billing and Usage](https://cloud.konghq.com/settings/billing-settings).
+      You can view service, Dev Portal, and API call usage from the [Billing and Usage](https://cloud.konghq.com/global/plan-and-usage/).
 ---
 
 {{site.konnect_short_name}} offers [two plans](https://konghq.com/pricing).


### PR DESCRIPTION
## Description

Fixed the link to the pricing page since it was currently a 404.

https://kongstrong.slack.com/archives/CDSTDSG9J/p1747126054849879

## Preview Links
https://deploy-preview-1475--kongdeveloper.netlify.app/konnect-platform/account/#how-do-i-manage-and-view-billing-and-usage

## Checklist 

- [x] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
