### PR TITLE
Vale rule for legacy admonitions and American english

### DIFF
--- a/.github/styles/base/Admonition.yml
+++ b/.github/styles/base/Admonition.yml
@@ -1,0 +1,6 @@
+extends: existence
+message: "'%s' is a legacy admonition. Use ':.info', ':.danger', or ':.warning' instead."
+level: error
+ignorecase: false
+raw:
+  - '{:\.(note|warning|important)}'

--- a/.github/styles/base/Admonition.yml
+++ b/.github/styles/base/Admonition.yml
@@ -3,4 +3,4 @@ message: "'%s' is a legacy admonition. Use ':.info', ':.danger', or ':.warning' 
 level: error
 ignorecase: false
 raw:
-  - '{:\.(note|warning|important)}'
+  - '{:\.(note|important)}'

--- a/.github/styles/base/Terms.yml
+++ b/.github/styles/base/Terms.yml
@@ -18,5 +18,5 @@ swap:
   timezone: time zone
   utilize: use
   whitelist: allowlist
-  'a HTTPRoute': 'an HTTPRoute'
+  'a HTTP': 'an HTTP'
   

--- a/.github/styles/base/Terms.yml
+++ b/.github/styles/base/Terms.yml
@@ -18,3 +18,5 @@ swap:
   timezone: time zone
   utilize: use
   whitelist: allowlist
+  'a HTTPRoute': 'an HTTPRoute'
+  

--- a/.github/styles/docs/Admonition.yml
+++ b/.github/styles/docs/Admonition.yml
@@ -1,0 +1,6 @@
+extends: existence
+message: "Avoid using '%s'; replace attribute blocks with semantic shortcodes or components."
+level: warning
+ignorecase: false
+raw:
+  - '{:\.(note|warning|important)}'

--- a/.github/styles/docs/Admonition.yml
+++ b/.github/styles/docs/Admonition.yml
@@ -1,6 +1,0 @@
-extends: existence
-message: "Avoid using '%s'; replace attribute blocks with semantic shortcodes or components."
-level: warning
-ignorecase: false
-raw:
-  - '{:\.(note|warning|important)}'

--- a/.vale.ini
+++ b/.vale.ini
@@ -16,7 +16,6 @@ WordTemplate = \s(?:%s)\s
 [*.md]
 BasedOnStyles = base,docs
 BlockIgnores = (\((http.*://|\.\/|\/).*?\)), \
-{\:.*?}, \
 (?s){% kgo_.*?%}.*?{% endkgo_.*?%}, \
 (?s) *{%\s*entity_examples?\s*%}.*?{%\s*endentity_examples?\s*%}, \
 (?:)(\s*type\: github\n), \

--- a/app/_how-tos/deck-get-started.md
+++ b/app/_how-tos/deck-get-started.md
@@ -76,7 +76,7 @@ entities:
         - "/"
 {% endentity_examples %}
 
-You can now make a HTTP request to your running {{ site.base_gateway }} instance and see it proxied to httpbin:
+You can now make an HTTP request to your running {{ site.base_gateway }} instance and see it proxied to httpbin:
 
 {% validation request-check %}
 url: '/anything'

--- a/app/_how-tos/kic-external-service.md
+++ b/app/_how-tos/kic-external-service.md
@@ -23,7 +23,7 @@ entities: []
 
 tldr:
   q: How do I route traffic outside of my Kubernetes cluster?
-  a: Configure an `ExternalName` service, then create a `HTTPRoute` to route traffic to the service.
+  a: Configure an `ExternalName` service, then create an `HTTPRoute` to route traffic to the service.
 
 prereqs:
   kubernetes:
@@ -57,7 +57,7 @@ spec:
 
 ## Create a HTTPRoute
 
-To route HTTP traffic, you need to create a `HTTPRoute` or an `Ingress` resource pointing at your Kubernetes `Service`.
+To route HTTP traffic, you need to create an `HTTPRoute` or an `Ingress` resource pointing at your Kubernetes `Service`.
 
 {% include /k8s/httproute.md release=page.release path='/httpbin' name='proxy-from-k8s-to-httpbin' service='proxy-to-httpbin' port='80' skip_host=true %}
 

--- a/app/_how-tos/kic-external-service.md
+++ b/app/_how-tos/kic-external-service.md
@@ -55,7 +55,7 @@ spec:
 ' | kubectl apply -f -
 ```
 
-## Create a HTTPRoute
+## Create an HTTPRoute
 
 To route HTTP traffic, you need to create an `HTTPRoute` or an `Ingress` resource pointing at your Kubernetes `Service`.
 

--- a/app/_how-tos/kic-get-started-rate-limiting.md
+++ b/app/_how-tos/kic-get-started-rate-limiting.md
@@ -1,7 +1,7 @@
 ---
 title: Rate Limiting
 description: |
-  Add rate limiting to a HTTPRoute or Ingress using the KongPlugin resource
+  Add rate limiting to an HTTPRoute or Ingress using the KongPlugin resource
 content_type: how_to
 
 permalink: /kubernetes-ingress-controller/get-started/rate-limiting/
@@ -15,7 +15,7 @@ series:
   position: 3
 
 tldr:
-  q: How to I rate limit a HTTPRoute or Ingress with {{ site.kic_product_name }}?
+  q: How to I rate limit an HTTPRoute or Ingress with {{ site.kic_product_name }}?
   a: |
     Create a `KongPlugin` resource containing a `rate-limiting` configuration. Set `config.minute` to the number of requests allowed per minute.
 

--- a/app/_how-tos/kic-get-started-services-routes.md
+++ b/app/_how-tos/kic-get-started-services-routes.md
@@ -1,7 +1,7 @@
 ---
 title: Services and Routes
 description: |
-  Use the a HTTPRoute or Ingress to configure a Service and a Route.
+  Use the an HTTPRoute or Ingress to configure a Service and a Route.
 content_type: how_to
 
 permalink: /kubernetes-ingress-controller/get-started/services-and-routes/
@@ -17,7 +17,7 @@ series:
 tldr:
   q: How do I create a Service and a Route with {{ site.kic_product_name }}?
   a: |
-    Create a HTTPRoute that points to a Kubernetes service in your cluster.
+    Create an HTTPRoute that points to a Kubernetes service in your cluster.
 
 products:
   - kic
@@ -81,7 +81,7 @@ Let's start by deploying an `echo` service which returns information about the K
 kubectl apply -f {{ site.links.web }}/manifests/kic/echo-service.yaml -n kong
 ```
 
-## Create a HTTPRoute / Ingress
+## Create an HTTPRoute / Ingress
 
 To route traffic to the `echo` service, create an `HTTPRoute` or `Ingress` resource:
 

--- a/app/_how-tos/kic-get-started-services-routes.md
+++ b/app/_how-tos/kic-get-started-services-routes.md
@@ -83,7 +83,7 @@ kubectl apply -f {{ site.links.web }}/manifests/kic/echo-service.yaml -n kong
 
 ## Create a HTTPRoute / Ingress
 
-To route traffic to the `echo` service, create a `HTTPRoute` or `Ingress` resource:
+To route traffic to the `echo` service, create an `HTTPRoute` or `Ingress` resource:
 
 {% include /k8s/httproute.md release=page.release path='/echo' name='echo' service='echo' port='1027' skip_host=true %}
 

--- a/app/_how-tos/kic-install.md
+++ b/app/_how-tos/kic-install.md
@@ -186,7 +186,7 @@ export PROXY_IP=$(kubectl get svc --namespace kong kong-gateway-proxy -o jsonpat
 curl -i $PROXY_IP
 ```
 
-You will receive a `HTTP 404` response as there are no routes configured:
+You will receive an `HTTP 404` response as there are no routes configured:
 
 ```
 HTTP/1.1 404 Not Found

--- a/app/_how-tos/kic-plugin-authentication.md
+++ b/app/_how-tos/kic-plugin-authentication.md
@@ -171,7 +171,7 @@ data:
 
 ## Create a HTTPRoute
 
-To route HTTP traffic, you need to create a `HTTPRoute` or an `Ingress` resource pointing at your Kubernetes `Service`.
+To route HTTP traffic, you need to create an `HTTPRoute` or an `Ingress` resource pointing at your Kubernetes `Service`.
 
 {% include /k8s/httproute.md release=page.release path='/echo' name='echo' service='echo' port='1027' skip_host=true %}
 

--- a/app/_how-tos/kic-plugin-authentication.md
+++ b/app/_how-tos/kic-plugin-authentication.md
@@ -169,7 +169,7 @@ data:
   consumer: anonymous
 {% endentity_example %}
 
-## Create a HTTPRoute
+## Create an HTTPRoute
 
 To route HTTP traffic, you need to create an `HTTPRoute` or an `Ingress` resource pointing at your Kubernetes `Service`.
 

--- a/app/_how-tos/kic-plugin-degraphql.md
+++ b/app/_how-tos/kic-plugin-degraphql.md
@@ -140,7 +140,7 @@ curl -X POST -H "Content-Type:application/json" -H "X-Hasura-Role:admin" http://
 
 ## Create a Route
 
-Our Hasura API will be exposed using the `/contacts` path. Create a `HTTPRoute` or `Ingress` resource pointing to the `hasura` Service that we can attach the `degraphql` plugin to:
+Our Hasura API will be exposed using the `/contacts` path. Create an `HTTPRoute` or `Ingress` resource pointing to the `hasura` Service that we can attach the `degraphql` plugin to:
 
 {% include /k8s/httproute.md release=page.release path='/contacts' name='demo-graphql' service='hasura' port='80' namespace='kong' skip_host=true %}
 

--- a/app/_how-tos/kic-plugin-oidc.md
+++ b/app/_how-tos/kic-plugin-oidc.md
@@ -83,7 +83,7 @@ data:
 
 Once the resource has been reconciled, you'll be able to call the `/echo` endpoint and {{ site.base_gateway }} will route the request to the `echo` Service.
 
-If you make a request without any authentication credentials, the request will fail with a `HTTP 302` and a redirect to the Keycloak login page:
+If you make a request without any authentication credentials, the request will fail with an `HTTP 302` and a redirect to the Keycloak login page:
 
 {% validation request-check %}
 url: /echo

--- a/app/_how-tos/kic-plugin-rate-limiting.md
+++ b/app/_how-tos/kic-plugin-rate-limiting.md
@@ -79,7 +79,7 @@ output:
   explanation: |
     The `RateLimit-Remaining` header indicates how many requests are remaining before the rate limit is enforced.  The first five responses return `HTTP/1.1 200 OK` which indicates that the request is allowed. The final request returns `HTTP/1.1 429 Too Many Requests` and the request is blocked.
 
-    If you receive a `HTTP 429` from the first request, wait 60 seconds for the rate limit timer to reset.
+    If you receive an `HTTP 429` from the first request, wait 60 seconds for the rate limit timer to reset.
 {% endvalidation %}
 
 ## Scale to multiple pods

--- a/app/_how-tos/kic-proxy-grpc-http.md
+++ b/app/_how-tos/kic-proxy-grpc-http.md
@@ -53,7 +53,7 @@ cleanup:
 
 All Gateway Services are assumed to be either HTTP or HTTPS by default. We need to update the Service to specify gRPC as the protocol by adding a `konghq.com/protocol` annotation.
 
-Annotate the `grpcbin` Service you installed in the [prerequisites](#prerequisites) with `grpc` to inform {{site.base_gateway}} that this service is a gRPC (with TLS) service and not a HTTP service:
+Annotate the `grpcbin` Service you installed in the [prerequisites](#prerequisites) with `grpc` to inform {{site.base_gateway}} that this service is a gRPC (with TLS) service and not an HTTP service:
 
 ```bash
 kubectl annotate service -n kong grpcbin 'konghq.com/protocol=grpc'

--- a/app/_how-tos/kic-proxy-grpc.md
+++ b/app/_how-tos/kic-proxy-grpc.md
@@ -54,7 +54,7 @@ cleanup:
 
 All services are assumed to be either HTTP or HTTPS by default. We need to update the service to specify gRPC over TLS as the protocol by adding a `konghq.com/protocol` annotation.
 
-The annotation `grpcs` informs {{site.base_gateway}} that this service is a gRPC (with TLS) service and not a HTTP service.
+The annotation `grpcs` informs {{site.base_gateway}} that this service is a gRPC (with TLS) service and not an HTTP service.
 
 ```bash
 kubectl annotate service -n kong grpcbin 'konghq.com/protocol=grpcs'

--- a/app/_how-tos/kic-proxy-https.md
+++ b/app/_how-tos/kic-proxy-https.md
@@ -72,7 +72,7 @@ kubectl patch -n kong --type=json gateway kong -p='[
 ]'
 ```
 
-## Create a HTTPRoute
+## Create an HTTPRoute
 
 To route HTTP traffic, you need to create an `HTTPRoute` or an `Ingress` resource pointing at your Kubernetes `Service`.
 

--- a/app/_how-tos/kic-proxy-https.md
+++ b/app/_how-tos/kic-proxy-https.md
@@ -20,7 +20,7 @@ entities: []
 
 tldr:
   q: How do I route HTTPS traffic with {{ site.kic_product_name }}?
-  a: Create a `HTTPRoute` or `Ingress` resource, which will then be converted into a [{{ site.base_gateway }} Service](/gateway/entities/service/) and [Route](/gateway/entities/route/). Specify a Kubernetes Secret containing a TLS certificate to terminate HTTPS requests using {{ site.base_gateway }}.
+  a: Create an `HTTPRoute` or `Ingress` resource, which will then be converted into a [{{ site.base_gateway }} Service](/gateway/entities/service/) and [Route](/gateway/entities/route/). Specify a Kubernetes Secret containing a TLS certificate to terminate HTTPS requests using {{ site.base_gateway }}.
 
 prereqs:
   kubernetes:
@@ -74,7 +74,7 @@ kubectl patch -n kong --type=json gateway kong -p='[
 
 ## Create a HTTPRoute
 
-To route HTTP traffic, you need to create a `HTTPRoute` or an `Ingress` resource pointing at your Kubernetes `Service`.
+To route HTTP traffic, you need to create an `HTTPRoute` or an `Ingress` resource pointing at your Kubernetes `Service`.
 
 {% include /k8s/httproute.md release=page.release path='/echo' name='echo' service='echo' port='1027' hostname='demo.example.com' section_name='https' %}
 

--- a/app/_how-tos/kic-proxy-rewriting-paths.md
+++ b/app/_how-tos/kic-proxy-rewriting-paths.md
@@ -80,7 +80,7 @@ Up to nine capture groups are supported using the `konghq.com/rewrite` annotatio
 
 ## Validate your configuration
 
-To validate that your rewrite is working, make a HTTP request to `/external-path/123`:
+To validate that your rewrite is working, make an HTTP request to `/external-path/123`:
 
 {% validation request-check %}
 url: /external-path/123

--- a/app/_how-tos/kic-proxy-weights.md
+++ b/app/_how-tos/kic-proxy-weights.md
@@ -43,7 +43,7 @@ Deploy the Services and create routing resources:
 kubectl apply -f {{ site.links.web }}/manifests/kic/echo-services.yaml -n kong
 ```
 
-## Create a HTTPRoute
+## Create an HTTPRoute
 
 To route HTTP traffic, create an `HTTPRoute` resource pointing at your Kubernetes `Service`:
 

--- a/app/_how-tos/kic-proxy-weights.md
+++ b/app/_how-tos/kic-proxy-weights.md
@@ -20,7 +20,7 @@ entities: []
 
 tldr:
   q: How do I route HTTP traffic with a custom weight per backend using {{ site.kic_product_name }}?
-  a: Create a `HTTPRoute` resource, and specify a `weight` property under `spec.rules[*].backendRefs[*].weight` to route traffic to specific backends.
+  a: Create an `HTTPRoute` resource, and specify a `weight` property under `spec.rules[*].backendRefs[*].weight` to route traffic to specific backends.
 
 prereqs:
   kubernetes:
@@ -45,7 +45,7 @@ kubectl apply -f {{ site.links.web }}/manifests/kic/echo-services.yaml -n kong
 
 ## Create a HTTPRoute
 
-To route HTTP traffic, create a `HTTPRoute` resource pointing at your Kubernetes `Service`:
+To route HTTP traffic, create an `HTTPRoute` resource pointing at your Kubernetes `Service`:
 
 ```bash
 echo 'apiVersion: gateway.networking.k8s.io/v1

--- a/app/_how-tos/kic-redirect-to-https.md
+++ b/app/_how-tos/kic-redirect-to-https.md
@@ -47,7 +47,7 @@ cleanup:
 
 {% assign demo_domain='example.com' %}
 
-## Create a HTTPRoute
+## Create an HTTPRoute
 
 To route HTTP traffic, you need to create an `HTTPRoute` or an `Ingress` resource pointing at your Kubernetes `Service`.
 
@@ -57,9 +57,9 @@ To route HTTP traffic, you need to create an `HTTPRoute` or an `Ingress` resourc
 
 {% include /k8s/add-tls.md namespace='kong' hostname=demo_domain cert_required=true %}
 
-## Configure a HTTPS redirect
+## Configure an HTTPS redirect
 
-{{site.base_gateway}} handles HTTPS redirects by automatically issuing redirects to requests whose characteristics match a HTTPS-only route except for the protocol. For example, with a {{site.base_gateway}} Route like the following:
+{{site.base_gateway}} handles HTTPS redirects by automatically issuing redirects to requests whose characteristics match an HTTPS-only route except for the protocol. For example, with a {{site.base_gateway}} Route like the following:
 
 ```json
 { "protocols": ["https"], "hosts": ["{{ demo_domain }}"],
@@ -114,7 +114,7 @@ kubectl annotate -n kong ingress echo konghq.com/https-redirect-status-code="301
 ## Validate your configuration
 
 With the redirect configuration in place, HTTP requests now receive a redirect rather than being proxied upstream:
-1. Send a HTTP request:
+1. Send an HTTP request:
     ```bash
     curl -ksvo /dev/null http://{{ demo_domain }}/echo --resolve {{ demo_domain }}:80:$PROXY_IP 2>&1 | grep -i http
     ```

--- a/app/_how-tos/kic-redirect-to-https.md
+++ b/app/_how-tos/kic-redirect-to-https.md
@@ -29,7 +29,7 @@ tags:
 
 tldr:
   q: How do I route traffic outside of my Kubernetes cluster?
-  a: Configure an `ExternalName` service, then create a `HTTPRoute` to route traffic to the service.
+  a: Configure an `ExternalName` service, then create an `HTTPRoute` to route traffic to the service.
 
 prereqs:
   kubernetes:
@@ -49,7 +49,7 @@ cleanup:
 
 ## Create a HTTPRoute
 
-To route HTTP traffic, you need to create a `HTTPRoute` or an `Ingress` resource pointing at your Kubernetes `Service`.
+To route HTTP traffic, you need to create an `HTTPRoute` or an `Ingress` resource pointing at your Kubernetes `Service`.
 
 {% include /k8s/httproute.md path='/echo' name='echo' service='echo' port='1027' skip_host=true %}
 

--- a/app/_how-tos/kic-service-healthchecks.md
+++ b/app/_how-tos/kic-service-healthchecks.md
@@ -168,7 +168,7 @@ konnect_url: $PROXY_IP
     Via: kong/{{ site.data.gateway_latest.release }}
     ```
 
-1. Make a request to `/status/200` and note that {{ site.base_gateway }} returns a `HTTP 503`:
+1. Make a request to `/status/200` and note that {{ site.base_gateway }} returns an `HTTP 503`:
 
 {% validation request-check %}
 url: /httpbin/status/200

--- a/app/_how-tos/operator-get-started-hybrid-create-route.md
+++ b/app/_how-tos/operator-get-started-hybrid-create-route.md
@@ -100,7 +100,7 @@ export PROXY_IP=$(kubectl get svc -n kong $NAME -o jsonpath='{range .status.load
 echo "Proxy IP: $PROXY_IP"
 ```
 
-{:.note}
+{:.info}
 > Note: If your cluster can't provision LoadBalancer type Services, then you might not receive an IP address.
 
 Test the routing rules by sending a request to the proxy IP address:

--- a/app/_how-tos/operator-get-started-kic-create-route.md
+++ b/app/_how-tos/operator-get-started-kic-create-route.md
@@ -81,7 +81,7 @@ prereqs:
     export PROXY_IP=$(kubectl get gateway kong -n kong -o jsonpath='{.status.addresses[0].value}')
     ```
 
-    {:.note}
+    {:.info}
     > Note: if your cluster can not provision LoadBalancer type Services then the IP you receive may only be routable from within the cluster.
 
 1. Make a call to the `$PROXY_IP` that you configured.

--- a/app/_how-tos/operator-konnect-getstarted-proxy-cache.md
+++ b/app/_how-tos/operator-konnect-getstarted-proxy-cache.md
@@ -79,7 +79,7 @@ grep: "(Status|< HTTP)"
 message: null
 output:
   explanation: |
-    The first request results in `X-Cache-Status: Miss`. This means that the request is sent to the upstream service. The next four responses return `X-Cache-Status: Hit` which indicates that the request was served from a cache. If you receive a `HTTP 429` from the first request, wait 60 seconds for the rate limit timer to reset.
+    The first request results in `X-Cache-Status: Miss`. This means that the request is sent to the upstream service. The next four responses return `X-Cache-Status: Hit` which indicates that the request was served from a cache. If you receive an `HTTP 429` from the first request, wait 60 seconds for the rate limit timer to reset.
   expected:
     - value:
       - "< HTTP/1.1 200 OK"

--- a/app/_how-tos/plugin-dev-add-plugin-testing.md
+++ b/app/_how-tos/plugin-dev-add-plugin-testing.md
@@ -140,7 +140,7 @@ using `curl` and filtering the response with `jq`:
 
 With the plugin installed, we can now configure [{{site.base_gateway}} entities](/gateway/entities/) to invoke and validate the plugin's behavior.
 
-For each of the following `POST` requests to the Admin API, you should receive a `HTTP/1.1 201 Created` response from {{site.base_gateway}} indicating the successful creation of the entity.
+For each of the following `POST` requests to the Admin API, you should receive an `HTTP/1.1 201 Created` response from {{site.base_gateway}} indicating the successful creation of the entity.
 
 1. Still within the {{site.base_gateway}} container's shell, [add a new Gateway Service](/api/gateway/admin-ee/#/operations/create-service):
 <!-- vale off -->

--- a/app/_how-tos/write-http-status-tests.md
+++ b/app/_how-tos/write-http-status-tests.md
@@ -45,7 +45,7 @@ cleanup:
 
 {% include /how-tos/steps/insomnia-test-suite.md %}
 
-## Create a HTTP status code test
+## Create an HTTP status code test
 
 We can create a test that checks a request against a certain status code. 
 

--- a/app/_includes/components/entity_example/format/snippets/kic/route.md
+++ b/app/_includes/components/entity_example/format/snippets/kic/route.md
@@ -1,6 +1,6 @@
 Routes are defined using native Kubernetes resources such as `Ingress` and `HTTPRoute`. This example uses HTTPRoute, but you can also use `Ingress` if needed. See the [{{site.kic_product_name}}](/kubernetes-ingress-controller/routing/http/) documentation for Ingress docs.
 
-To create a route in {{site.base_gateway}}, create a `HTTPRoute` resource that points to a service in your cluster:
+To create a route in {{site.base_gateway}}, create an `HTTPRoute` resource that points to a service in your cluster:
 
 ```yaml
 apiVersion: gateway.networking.k8s.io/v1

--- a/app/_includes/k8s/content/fallback-configuration/scenario-setup.md
+++ b/app/_includes/k8s/content/fallback-configuration/scenario-setup.md
@@ -93,7 +93,7 @@ At this point we can validate that our Routes are working as expected.
 
 ### Route A
 
-`route-a` is accessible without any authentication and will return a `HTTP 200`:
+`route-a` is accessible without any authentication and will return an `HTTP 200`:
 
 {% validation request-check %}
 url: /route-a

--- a/app/_includes/k8s/verify-upstream-tls-ca.md
+++ b/app/_includes/k8s/verify-upstream-tls-ca.md
@@ -18,7 +18,7 @@ kubectl annotate -n kong {{ source_type }} root-ca kubernetes.io/ingress.class=k
 {% if include.associate_with_service %}
 Now, associate the root CA certificate with the `Service` passing its name to `konghq.com/ca-certificates-{{ source_type }}s` annotation.
 
-{:.note}
+{:.info}
 > The `konghq.com/ca-certificates-{{ source_type }}s` annotation is a comma-separated list of `{{ kind }}`s holding CA certificates.
 > You can add multiple `{{ kind }}`s to the list.
 

--- a/app/_includes/plugins/confluent-kafka-consume/implementation-details.md
+++ b/app/_includes/plugins/confluent-kafka-consume/implementation-details.md
@@ -1,3 +1,3 @@
 The plugin supports two modes of operation:
-* `http-get`: Consume messages via HTTP GET requests (default)
+* `http-get`: Consume messages vian HTTP GET requests (default)
 * `server-sent-events`: Stream messages using [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events)

--- a/app/_includes/plugins/confluent-kafka-consume/implementation-details.md
+++ b/app/_includes/plugins/confluent-kafka-consume/implementation-details.md
@@ -1,3 +1,3 @@
 The plugin supports two modes of operation:
-* `http-get`: Consume messages vian HTTP GET requests (default)
+* `http-get`: Consume messages via an HTTP GET requests (default)
 * `server-sent-events`: Stream messages using [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events)

--- a/app/_kong_plugins/aws-lambda/index.md
+++ b/app/_kong_plugins/aws-lambda/index.md
@@ -72,7 +72,7 @@ precedence order:
 
 If you also specify the [`config.aws_assume_role_arn`](./reference/#schema--config-aws_assume_role_arn) parameter, the plugin will try to perform
 an additional [AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html)
-action. This requires the {{site.base_gateway}} process to make a HTTPS request to the AWS STS service API after
+action. This requires the {{site.base_gateway}} process to make an HTTPS request to the AWS STS service API after
 configuring the AWS access key/secret or fetching credentials automatically from EC2/ECS/EKS IAM roles.
 If it succeeds, the plugin will fetch temporary security credentials that give the plugin the access permission configured in the target assumed role. The plugin will then try to invoke the Lambda function based on the target assumed role.
 

--- a/app/_kong_plugins/aws-request-signing/index.md
+++ b/app/_kong_plugins/aws-request-signing/index.md
@@ -57,7 +57,7 @@ Add your token issuer to the **Identity Providers** in your AWS account so that 
 
 For more information on the required AWS setup, visit the [plugin repo](https://github.com/LEGO/kong-aws-request-signing#aws-setup-required).
 
-Once your AWS account is set up, you can use the plugin to communicate with your Lambdan HTTPS endpoint.
+Once your AWS account is set up, you can use the plugin to communicate with your Lambda HTTPS endpoint.
 
 ### Install
 

--- a/app/_kong_plugins/aws-request-signing/index.md
+++ b/app/_kong_plugins/aws-request-signing/index.md
@@ -57,7 +57,7 @@ Add your token issuer to the **Identity Providers** in your AWS account so that 
 
 For more information on the required AWS setup, visit the [plugin repo](https://github.com/LEGO/kong-aws-request-signing#aws-setup-required).
 
-Once your AWS account is set up, you can use the plugin to communicate with your Lambda HTTPS endpoint.
+Once your AWS account is set up, you can use the plugin to communicate with your Lambdan HTTPS endpoint.
 
 ### Install
 

--- a/app/_kong_plugins/opentelemetry/index.md
+++ b/app/_kong_plugins/opentelemetry/index.md
@@ -135,7 +135,7 @@ If no appropriate format is found, the plugin will fallback to the default forma
 
 ### OTLP exporter
 
-The OpenTelemetry plugin implements the [OTLP/HTTP](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#otlphttp) exporter, which uses Protobuf payloads encoded in binary format and is sent vian HTTP/1.1.
+The OpenTelemetry plugin implements the [OTLP/HTTP](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#otlphttp) exporter, which uses Protobuf payloads encoded in binary format and is sent via an HTTP/1.1.
 
 [`config.connect_timeout`](/plugins/opentelemetry/reference/#schema--config-connect-timeout), [`config.read_timeout`](/plugins/opentelemetry/reference/#schema--config-read-timeout), and [`config.send_timeout`](/plugins/opentelemetry/reference/#schema--config-send-timeout) are used to set the timeouts for the HTTP request.
 

--- a/app/_kong_plugins/opentelemetry/index.md
+++ b/app/_kong_plugins/opentelemetry/index.md
@@ -135,7 +135,7 @@ If no appropriate format is found, the plugin will fallback to the default forma
 
 ### OTLP exporter
 
-The OpenTelemetry plugin implements the [OTLP/HTTP](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#otlphttp) exporter, which uses Protobuf payloads encoded in binary format and is sent via HTTP/1.1.
+The OpenTelemetry plugin implements the [OTLP/HTTP](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/otlp.md#otlphttp) exporter, which uses Protobuf payloads encoded in binary format and is sent vian HTTP/1.1.
 
 [`config.connect_timeout`](/plugins/opentelemetry/reference/#schema--config-connect-timeout), [`config.read_timeout`](/plugins/opentelemetry/reference/#schema--config-read-timeout), and [`config.send_timeout`](/plugins/opentelemetry/reference/#schema--config-send-timeout) are used to set the timeouts for the HTTP request.
 

--- a/app/_kong_plugins/request-validator/index.md
+++ b/app/_kong_plugins/request-validator/index.md
@@ -48,7 +48,7 @@ If a validation fails, a `400 Bad Request` response is returned.
 
 ## Content-Type validation
 
-The request `Content-Type` header is validated against the plugin's [`config.allowed_content_types`](./reference/#schema--config-allowed-content-types) setting. If the `Content-Type` is not listed, the request will be rejected, and return a `HTTP/400` error: `{"message":"specified Content-Type is not allowed"}`.
+The request `Content-Type` header is validated against the plugin's [`config.allowed_content_types`](./reference/#schema--config-allowed-content-types) setting. If the `Content-Type` is not listed, the request will be rejected, and return an `HTTP/400` error: `{"message":"specified Content-Type is not allowed"}`.
 
 The parameter is strictly validated, which means a request with a parameter (for example, `application/json; charset=UTF-8`) is NOT considered valid for one without the same parameter (for example, `application/json`). The type, subtype, parameter names, and the value of the charset parameter are not case sensitive based on the RFC explanation.
 

--- a/app/_kong_plugins/response-ratelimiting/index.md
+++ b/app/_kong_plugins/response-ratelimiting/index.md
@@ -94,7 +94,7 @@ X-RateLimit-Remaining-Videos-Minute: 10
 ```
 
 If any of the configured limits configured is reached, the plugin
-returns a `HTTP/1.1 429` (Too Many Requests) status code and an empty response body.
+returns an `HTTP/1.1 429` (Too Many Requests) status code and an empty response body.
 
 ### Upstream headers
 

--- a/app/_kong_plugins/tls-metadata-headers/index.md
+++ b/app/_kong_plugins/tls-metadata-headers/index.md
@@ -5,7 +5,7 @@ name: 'TLS Metadata Headers'
 content_type: plugin
 
 publisher: kong-inc
-description: 'Proxies TLS client certificate metadata to upstream services vian HTTP headers'
+description: 'Proxies TLS client certificate metadata to upstream services via an HTTP headers'
 
 
 products:

--- a/app/_kong_plugins/tls-metadata-headers/index.md
+++ b/app/_kong_plugins/tls-metadata-headers/index.md
@@ -5,7 +5,7 @@ name: 'TLS Metadata Headers'
 content_type: plugin
 
 publisher: kong-inc
-description: 'Proxies TLS client certificate metadata to upstream services via HTTP headers'
+description: 'Proxies TLS client certificate metadata to upstream services vian HTTP headers'
 
 
 products:

--- a/app/_mesh_policies/meshglobalratelimit/index.md
+++ b/app/_mesh_policies/meshglobalratelimit/index.md
@@ -55,7 +55,7 @@ its data plane proxy will make a request to the ratelimit service to check if th
 checks if the counter for this service is below limits. If it is below limits, it updates the counter and allows the request to pass. If counters are above
 limits, deny response is returned. 
 
-{:.note}
+{:.info}
 > **Note**: Configuring global rate limit will increase your service response times because it needs additional requests to the ratelimit service and Redis.
 
 ### Ratelimit service configuration

--- a/app/assets/mesh/raw/CHANGELOG.md
+++ b/app/assets/mesh/raw/CHANGELOG.md
@@ -2748,7 +2748,7 @@ Based on [Kuma 2.5.0](https://github.com/kumahq/kuma/releases/tag/2.5.0)
 * feat(cni): k8s make namespace configurable [#6721](https://github.com/kumahq/kuma/pull/6721) @mmorel-35
 * feat(config): improve configurability [#6583](https://github.com/kumahq/kuma/pull/6583) @slonka
 * feat(docker/kumactl): make entrypoint consistent with kuma-cp and kuma-dp images [#6596](https://github.com/kumahq/kuma/pull/6596) @bartsmykla
-* feat(envoyadmin): support passing kds envoy operations vian HTTP proxy [#6915](https://github.com/kumahq/kuma/pull/6915) @jakubdyszkiewicz
+* feat(envoyadmin): support passing kds envoy operations via an HTTP proxy [#6915](https://github.com/kumahq/kuma/pull/6915) @jakubdyszkiewicz
 * feat(helm): Add logOutputPath support to chart [#6649](https://github.com/kumahq/kuma/pull/6649) @ashman1984
 * feat(helm): add possibility to extend secrets for cp in helm charts when reusing kuma charts [#6883](https://github.com/kumahq/kuma/pull/6883) @Automaat
 * feat(helm): enable NodePort customization [#6770](https://github.com/kumahq/kuma/pull/6770) @mmorel-35

--- a/app/assets/mesh/raw/CHANGELOG.md
+++ b/app/assets/mesh/raw/CHANGELOG.md
@@ -3647,7 +3647,7 @@ Stats and Clusters in the GUI:
 
 Extra `retryOn` options for Retry:
 
-* add extran HTTP retryOn options [#4744](https://github.com/kumahq/kuma/pull/4744) @johnharris85
+* add extra HTTP retryOn options [#4744](https://github.com/kumahq/kuma/pull/4744) @johnharris85
 
 Better support for TCP logging:
 

--- a/app/assets/mesh/raw/CHANGELOG.md
+++ b/app/assets/mesh/raw/CHANGELOG.md
@@ -2748,7 +2748,7 @@ Based on [Kuma 2.5.0](https://github.com/kumahq/kuma/releases/tag/2.5.0)
 * feat(cni): k8s make namespace configurable [#6721](https://github.com/kumahq/kuma/pull/6721) @mmorel-35
 * feat(config): improve configurability [#6583](https://github.com/kumahq/kuma/pull/6583) @slonka
 * feat(docker/kumactl): make entrypoint consistent with kuma-cp and kuma-dp images [#6596](https://github.com/kumahq/kuma/pull/6596) @bartsmykla
-* feat(envoyadmin): support passing kds envoy operations via http proxy [#6915](https://github.com/kumahq/kuma/pull/6915) @jakubdyszkiewicz
+* feat(envoyadmin): support passing kds envoy operations vian HTTP proxy [#6915](https://github.com/kumahq/kuma/pull/6915) @jakubdyszkiewicz
 * feat(helm): Add logOutputPath support to chart [#6649](https://github.com/kumahq/kuma/pull/6649) @ashman1984
 * feat(helm): add possibility to extend secrets for cp in helm charts when reusing kuma charts [#6883](https://github.com/kumahq/kuma/pull/6883) @Automaat
 * feat(helm): enable NodePort customization [#6770](https://github.com/kumahq/kuma/pull/6770) @mmorel-35
@@ -3647,7 +3647,7 @@ Stats and Clusters in the GUI:
 
 Extra `retryOn` options for Retry:
 
-* add extra http retryOn options [#4744](https://github.com/kumahq/kuma/pull/4744) @johnharris85
+* add extran HTTP retryOn options [#4744](https://github.com/kumahq/kuma/pull/4744) @johnharris85
 
 Better support for TCP logging:
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -6410,7 +6410,7 @@ Kong Gateway version.
 
   * [TLS Metadata Headers](/plugins/tls-metadata-headers/) (`tls-metadata-headers`)
 
-    Proxy TLS client certificate metadata to upstream services vian HTTP headers.
+    Proxy TLS client certificate metadata to upstream services via an HTTP headers.
 
   * [WebSocket Size Limit](/plugins/websocket-size-limit/) (`websocket-size-limit`)
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -1890,7 +1890,7 @@ the new `latencies.receive` metric, so if desired, the old value can be
 calculated as `latencies.kong + latencies.receive`.
   [#12795](https://github.com/Kong/kong/issues/12795)
 
-  {:.note}
+  {:.info}
   > **Note:** This also affects payloads from all logging plugins that use the log serializer:
   `file-log`, `tcp-log`, `udp-log`,`http-log`, `syslog`, and `loggly`.
 
@@ -6234,7 +6234,7 @@ This lets you run plugins such as `rate-limiting` before authentication plugins.
   To enable FIPS mode, set [`fips`](https://docs.konghq.com/gateway/3.0.x/reference/configuration/#fips) to `on`.
   FIPS mode is only supported in Ubuntu 20.04.
 
-  {:.note}
+  {:.info}
   > **Note**: The Kong Gateway FIPS package is not currently compatible with SSL
   > connections to PostgreSQL.
 

--- a/app/gateway/changelog.md
+++ b/app/gateway/changelog.md
@@ -6410,7 +6410,7 @@ Kong Gateway version.
 
   * [TLS Metadata Headers](/plugins/tls-metadata-headers/) (`tls-metadata-headers`)
 
-    Proxy TLS client certificate metadata to upstream services via HTTP headers.
+    Proxy TLS client certificate metadata to upstream services vian HTTP headers.
 
   * [WebSocket Size Limit](/plugins/websocket-size-limit/) (`websocket-size-limit`)
 

--- a/app/gateway/routing/expressions.md
+++ b/app/gateway/routing/expressions.md
@@ -480,7 +480,7 @@ rows:
     description: |
       Field value contains the constant value. This operator is used to check the existence of a string inside another string. 
       <br><br>
-      For example, `http.path contains \"foo\"` returns `true` if `foo` can be found anywhere inside `http.path`. This will match a `http.path` that looks like `/foo`, `/abc/foo`, or `/xfooy`, for example.
+      For example, `http.path contains \"foo\"` returns `true` if `foo` can be found anywhere inside `http.path`. This will match an `HTTP.path` that looks like `/foo`, `/abc/foo`, or `/xfooy`, for example.
   - operator: "`&&`"
     name: And
     description: "Returns `true` if **both** expressions on the left and right side evaluates to `true`."


### PR DESCRIPTION
## Description

Fixes #1259 
Fixes #1260 

Adds two vale rules one to catch instances of " A HTTP" and another to catch legacy admonitions. 

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
