### PR TITLE
Local perf improvements

### DIFF
--- a/app/_includes/breadcrumbs.html
+++ b/app/_includes/breadcrumbs.html
@@ -1,8 +1,8 @@
-{% if page.breadcrumbs %}
+{% if include.breadcrumbs %}
 <div class="flex gap-1 justify-start text-xs items-center xl:basis-3/4">
   <a class="text-terciary" href="/">Home</a>
   <span>/</span>
-  {% for breadcrumb in page.breadcrumbs %}
+  {% for breadcrumb in include.breadcrumbs %}
     <a class="text-terciary" href="{{ breadcrumb.url }}">{{ breadcrumb.title | liquify }}</a>
     {% unless forloop.last %}<span>/</span>{% endunless %}
   {% endfor %}

--- a/app/_includes/breadcrumbs_and_links.html
+++ b/app/_includes/breadcrumbs_and_links.html
@@ -1,11 +1,11 @@
-{% if page.breadcrumbs or page.edit_and_issue_links != false %}
+{% if include.breadcrumbs or include.edit_and_issue_links != false %}
 <div class="flex w-full justify-between pt-12 md:gap-16">
-    {% include breadcrumbs.html %}
+    {% include_cached breadcrumbs.html breadcrumbs=include.breadcrumbs %}
 
 
-    {% if page.layout == 'plugins/example' or page.layout == 'landing_page' %}{% assign no_aside = true %}{% endif %}
+    {% if include.layout == 'plugins/example' or include.layout == 'landing_page' %}{% assign no_aside = true %}{% endif %}
     <div class="flex gap-3 text-xs xl:basis-1/4 items-center {% if no_aside == true %}justify-end{% endif %}">
-        {% include edit_and_issue_links.html edit_link=page.edit_link %}
+        {% include_cached edit_and_issue_links.html edit_link=include.edit_link %}
     </div>
   </div>
 {% endif %}

--- a/app/_includes/get_help.html
+++ b/app/_includes/get_help.html
@@ -6,9 +6,9 @@
                 <span>Something wrong?</span>
                 <div class="flex gap-2">
                     <a class="text-brand no-icon" href="{{ site.repos.developer }}/issues/">Report an Issue</a>
-                    {% if page.edit_link %}
+                    {% if include.edit_link %}
                         <span class="text-secondary">|</span>
-                        <a class="text-brand no-icon" href="{{ page.edit_link }}">Edit this Page</a>
+                        <a class="text-brand no-icon" href="{{ include.edit_link }}">Edit this Page</a>
                     {% endif %}
                 </div>
             </div>

--- a/app/_layouts/api/spec.html
+++ b/app/_layouts/api/spec.html
@@ -4,7 +4,7 @@ api_spec: true
 ---
 
 <div class="flex flex-col gap-3 py-12 w-full mx-auto">
-  {% include breadcrumbs.html %}
+  {% include breadcrumbs.html breadcrumbs=page.breadcrumbs %}
 
   <div id="api-spec"></div>
 

--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -122,18 +122,18 @@
     {% endif %}
 
     <div class="min-h-full flex flex-col">
-      {% include header.html api_spec=layout.api_spec %}
+      {% include_cached header.html api_spec=layout.api_spec %}
 
     <div class="flex flex-col gap-3 px-5 md:px-8 2xl:mx-auto flex-1 w-full {% if layout.api_spec == true %} 2xl:px-16 {% else %} max-w-screen-2xl  2xl:px-[156px] {% endif %}">
       {% unless layout.api_spec == true %}
-        {% include breadcrumbs_and_links.html %}
+        {% include_cached breadcrumbs_and_links.html breadcrumbs=page.breadcrumbs edit_and_issue_links=page.edit_and_issue_links layout=page.layout edit_link=page.edit_link %}
       {% endunless%}
 
       {{ content }}
     </div>
 
     {% if page.get_help != false %}
-      {% include get_help.html %}
+      {% include_cached get_help.html edit_link=page.edit_link %}
     {% endif %}
 
     {% include_cached footer.html %}

--- a/app/_plugins/generators/explorer.rb
+++ b/app/_plugins/generators/explorer.rb
@@ -6,6 +6,7 @@ module Jekyll
     priority :lowest
     def generate(site)
       return if Jekyll.env == 'production'
+      return if site.config.dig('skip', 'explorer')
 
       jobs = [
         {

--- a/app/_plugins/generators/indices.rb
+++ b/app/_plugins/generators/indices.rb
@@ -5,6 +5,8 @@ module Jekyll
     priority :low
 
     def generate(site)
+      return if site.config.dig('skip', 'indices')
+
       site.data['indices'] = {}
       Dir.glob(File.join(site.source, '_indices/**/*.yaml')).each do |file|
         index = YAML.load_file(file)

--- a/app/_plugins/generators/mesh.rb
+++ b/app/_plugins/generators/mesh.rb
@@ -5,6 +5,8 @@ module Jekyll
     priority :high
 
     def generate(site)
+      return if site.config.dig('skip', 'mesh')
+
       site.data.dig('kuma_to_mesh', 'config').fetch('pages', []).each do |page_config|
         page = KumatoMesh::Page.new(site:, page_config:).to_jekyll_page
         KumatoMesh::Converter.new(page).process

--- a/app/_plugins/generators/mesh_policy/generator.rb
+++ b/app/_plugins/generators/mesh_policy/generator.rb
@@ -16,6 +16,8 @@ module Jekyll
       end
 
       def run
+        return if site.config.dig('skip', 'mesh_policy')
+
         Dir.glob(File.join(site.source, "#{POLICIES_FOLDER}/*/")).each do |folder|
           slug = folder.gsub("#{site.source}/#{POLICIES_FOLDER}/", '').chomp('/')
 

--- a/app/_plugins/generators/plugins/generator.rb
+++ b/app/_plugins/generators/plugins/generator.rb
@@ -25,6 +25,9 @@ module Jekyll
 
       def generate_pages(plugin)
         generate_overview_page(plugin)
+
+        return if site.config.dig('skip', 'plugins')
+
         generate_reference_page(plugin)
         generate_changelog_page(plugin)
         generate_example_pages(plugin)

--- a/app/_plugins/generators/references/auto_generated/generator.rb
+++ b/app/_plugins/generators/references/auto_generated/generator.rb
@@ -15,6 +15,8 @@ module Jekyll
         end
 
         def run
+          return if @site.config.dig('skip', 'auto_generated')
+
           generate_pages!
           generate_canonicals!
           set_release_info!

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -2,10 +2,10 @@ links:
   web: http://localhost:4000
 
 # skip generators to speed up dev builds, the name matches the generator's name
-# skip:
-#   plugins: true # skip plugins generation, except for overviews
-#   indices: true # skip indices
-#   mesh_policy: true # skip mesh policies generation, except for overviews
-#   explorer: true # skip explorer
-#   auto_generated: true # skip auto_generated references, i.e. app/_referneces
-#   mesh: true # skip kuma to mesh generation
+skip:
+  plugins: true # skip plugins generation, except for overviews
+  indices: true # skip indices
+  mesh_policy: true # skip mesh policies generation, except for overviews
+  explorer: true # skip explorer
+  auto_generated: true # skip auto_generated references, i.e. app/_referneces
+  mesh: true # skip kuma to mesh generation

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -1,2 +1,11 @@
 links:
   web: http://localhost:4000
+
+# skip generators to speed up dev builds, the name matches the generator's name
+# skip:
+#   plugins: true # skip plugins generation, except for overviews
+#   indices: true # skip indices
+#   mesh_policy: true # skip mesh policies generation, except for overviews
+#   explorer: true # skip explorer
+#   auto_generated: true # skip auto_generated references, i.e. app/_referneces
+#   mesh: true # skip kuma to mesh generation


### PR DESCRIPTION
## Description

Add support for skipping specific generators locally to speed up local builds.
Cold start is still an issue but edits are fast, there are still a lot of tweaks we can do like disabling api specs and how-tos but those require more work, I'll get to them eventually, but for now I wanted to unblock the team.

With the new changes:

https://github.com/user-attachments/assets/e26a3884-7e45-4fe8-b3a9-491521eb1635

Without the changes, same edit:

<img width="679" alt="Screenshot 2025-05-14 at 08 54 54" src="https://github.com/user-attachments/assets/c3f306a0-b175-4ff7-814f-c411f4a45237" />

### How it works
There's a new section in jekyll-dev.yml, you can uncomment the section and the generators you don't need.
```yaml
# skip generators to speed up dev builds, the name matches the generator's name
# skip:
#   plugins: true # skip plugins generation, except for overviews
#   indices: true # skip indices
#   mesh_policy: true # skip mesh policies generation, except for overviews
#   explorer: true # skip explorer
#   auto_generated: true # skip auto_generated references, i.e. app/_referneces
#   mesh: true # skip kuma to mesh generation
```

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
