### PR TITLE
Fix edit link for indices

### DIFF
--- a/app/_plugins/generators/indices.rb
+++ b/app/_plugins/generators/indices.rb
@@ -28,6 +28,10 @@ module Jekyll
       page.data['layout'] = 'indices'
       page.data['toc_depth'] = 3
       page.data['toc_skip_page_title'] = true
+
+      # Needed for edit link and site regeneration
+      page.instance_variable_set(:@relative_path, "_indices/#{filename.gsub('.html', '.yaml')}")
+
       grouped_pages = config_to_grouped_pages(site, index)
       page.content = render(index, grouped_pages, site)
       page


### PR DESCRIPTION
## Description

Pages need to have relative_path set not only for site re-generation but for the edit link too.

## Preview Links

[ai gateway index](https://deploy-preview-1483--kongdeveloper.netlify.app/index/ai-gateway/)

## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
