### PR TITLE
Render the plugin example's title in indices

### DIFF
--- a/app/_includes/indices.html
+++ b/app/_includes/indices.html
@@ -22,6 +22,7 @@
           {% for page in section.pages %}
             {% assign title = page.title %}
             {% if page.short_title %}{% assign title = page.short_title %}{% endif %}
+            {% if page.plugin? and page.example? %}{% assign title = page.example_title %}{% endif %}
             <li class="flex flex-col gap-1">
               <a class="text-brand-saturated !mb-0 text-base tracking-[-.01em]" href="{{ page.url }}">{{ title }}</a>
               <p class="text-xs text-terciary">


### PR DESCRIPTION
## Description

Render the plugin example's title in indices instead of the plugin's name

## Preview Links


## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
