### PR TITLE
Fix links to kong.conf sections and update references

### DIFF
--- a/app/_includes/components/kong_conf.html
+++ b/app/_includes/components/kong_conf.html
@@ -1,5 +1,5 @@
 {% for section in config.sections %}
-<h2 id="{{ section.title | slugify }}">{{section.title}}</h2>
+<h2 id="{{ section.title | slugify }}-section" data-skip-process-heading-id="true">{{section.title}}</h2>
 
 {% if section.description != empty %}
 <div class="flex flex-col text-secondary content kong-conf-section-description">

--- a/app/_includes/indices.html
+++ b/app/_includes/indices.html
@@ -3,7 +3,7 @@
 <div class="grid grid-cols-1 gap-10">
   {% if group.title or group.description  %}
   <div>
-  {% if group.title %}<h2 id="{{ group.title | slugify }}">{{ group.title | liquify }}</h2>{% endif %}
+  {% if group.title %}<h2 id="{{ group.title | slugify }}" data-skip-process-heading-id="true">{{ group.title | liquify }}</h2>{% endif %}
 
   {% if group.description %}
   <p class="text-base text-terciary mt-2">{{ group.description | liquify }}</p>
@@ -14,7 +14,7 @@
   {% for section in group.sections %}{% unless section.hidden %}
     <div class="flex flex-col gap-5 heading-section card p-6 rounded-lg shadow-primary">
       {% if section.title %}
-      <h3 id="{% if group.title %}{{ group.title | slugify }}--{% endif %}{{ section.title | slugify }}" class="always-link mb-2">{{ section.title | liquify }}</h3>
+      <h3 id="{% if group.title %}{{ group.title | slugify }}--{% endif %}{{ section.title | slugify }}" class="always-link mb-2" data-skip-process-heading-id="true">{{ section.title | liquify }}</h3>
       {% endif %}
 
       <div class="content">

--- a/app/_includes/upgrade/lts-changes.md
+++ b/app/_includes/upgrade/lts-changes.md
@@ -555,7 +555,7 @@ rows:
     description: |
       The default PostgreSQL SSL version has been bumped to TLS 1.2. In `kong.conf`:
       <br><br>
-      * The default [`pg_ssl_version`](/gateway/configuration/#datastore)
+      * The default [`pg_ssl_version`](/gateway/configuration/#datastore-section)
       is now `tlsv1_2`.
       * Constrained the valid values of this configuration option to only accept the following: `tlsv1_1`, `tlsv1_2`, `tlsv1_3` or `any`.
       <br><br>

--- a/app/_plugins/hooks/post_process_html.rb
+++ b/app/_plugins/hooks/post_process_html.rb
@@ -30,7 +30,7 @@ class AddLinksToHeadings # rubocop:disable Style/Documentation
       old_id = heading['id']
 
       # Index pages have specific heading IDs to account for groups
-      unless @page_or_doc.url.include?("/index/")
+      unless heading.attr('data-skip-process-heading-id') && heading.attr('data-skip-process-heading-id') == 'true'
         heading['id'] = Jekyll::Utils.slugify(text)
       end
 

--- a/app/gateway/plugins/datakit.md
+++ b/app/gateway/plugins/datakit.md
@@ -59,7 +59,7 @@ It allows you to create an API workflow, which can include:
 {:.warning}
 > The Datakit plugin is not available in {{site.base_gateway}} packages by default. 
 Before you can configure the plugin, enable it in one of the following ways:
-> * **Package install:** Set `wasm=on` in [`kong.conf`](/gateway/configuration/#wasm) before starting {{site.base_gateway}}
+> * **Package install:** Set `wasm=on` in [`kong.conf`](/gateway/configuration/#wasm-section) before starting {{site.base_gateway}}
 > * **Docker:** Set `export WASM=on` in the environment
 > * **Kubernetes:** Set `WASM=on` using the [Custom Plugin](/kubernetes-ingress-controller/custom-plugins/) instructions
 

--- a/app/gateway/traditional-mode.md
+++ b/app/gateway/traditional-mode.md
@@ -110,7 +110,7 @@ greatly reduces the load on the main database instance since read-only
 queries are no longer sent to it.
 
 To learn more about how to configure this feature, refer to the
-[Datastore section](/gateway/configuration/#datastore)
+[Datastore section](/gateway/configuration/#datastore-section)
 of the {{site.base_gateway}} configuration reference.
 
 ## What information is cached?

--- a/tools/track-docs-changes/config/missing_dev_site_url.yml
+++ b/tools/track-docs-changes/config/missing_dev_site_url.yml
@@ -436,10 +436,10 @@
   dev_site_url: '/how-to/configure-datastore/'
   status: migrated
 - docs_url: "/gateway/latest/production/networking/configure-postgres-tls/"
-  dev_site_url: '/gateway/configuration/#datastore'
+  dev_site_url: '/gateway/configuration/#datastore-section'
   status: "?"
 - docs_url: "/gateway/latest/production/networking/troubleshoot-postgres-tls/"
-  dev_site_url: '/gateway/configuration/#datastore'
+  dev_site_url: '/gateway/configuration/#datastore-section'
   status: "?"
 - docs_url: "/gateway/latest/production/environment-variables/"
   dev_site_url: '/gateway/manage-kong-conf/#environment-variables'


### PR DESCRIPTION
## Description

Fix links to kong.conf sections and update references
Skip processing a heading's id attribute based on
data-skip-process-heading-id=true.
Update the indices to use it too, since they were an exception too.

Added `-section` to the kong.conf section headings, `vaults` was both a section and a param causing the original issue because both ended up having the same id.
I also updated all the links

## Preview Links


## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
