### PR TITLE
Remove ignored_placeholder_paths from broken links

### DIFF
--- a/tools/broken-link-checker/config/ignored_placeholder_paths.json
+++ b/tools/broken-link-checker/config/ignored_placeholder_paths.json
@@ -1,5 +1,1 @@
-[
-    "/tools/",
-    "/api-ops/",
-    "/terraform/"
-]
+[]


### PR DESCRIPTION
## Description

Remove placeholder_paths, they were set in the early stages of the project to preven the broken links check from failing.

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
