### PR TITLE
Don't render KIC as a tool in the search/how-tos filter

### DIFF
--- a/app/_plugins/generators/site_data.rb
+++ b/app/_plugins/generators/site_data.rb
@@ -13,7 +13,7 @@ module Jekyll
       site.data['searchSources'] = site.data.dig('search', 'sources')
 
       products = site.data['products'].map do |p|
-        p[0].gsub("-","_")
+        p[0].gsub('-', '_')
       end
 
       products.each do |product|
@@ -43,7 +43,7 @@ module Jekyll
     def search_filters(site)
       {
         products: site.data.fetch('products').map { |k, v| { label: v['name'], value: k } },
-        tools: site.data.fetch('tools').map { |k, v| { label: v['name'], value: k } },
+        tools: site.data.fetch('tools').except('kic').map { |k, v| { label: v['name'], value: k } },
         works_on: site.data.dig('products', 'gateway', 'deployment_topologies').map do |t|
           { label: t['text'], value: t['slug'] }
         end

--- a/app/_plugins/generators/site_data.rb
+++ b/app/_plugins/generators/site_data.rb
@@ -43,7 +43,7 @@ module Jekyll
     def search_filters(site)
       {
         products: site.data.fetch('products').map { |k, v| { label: v['name'], value: k } },
-        tools: site.data.fetch('tools').except('kic').map { |k, v| { label: v['name'], value: k } },
+        tools: site.data.fetch('tools').except('kic', 'operator').map { |k, v| { label: v['name'], value: k } },
         works_on: site.data.dig('products', 'gateway', 'deployment_topologies').map do |t|
           { label: t['text'], value: t['slug'] }
         end


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
