### PR TITLE
fix: Fix incorrect config sample for RAG injector

### DIFF
--- a/app/_kong_plugins/ai-rag-injector/examples/openai-redis.yaml
+++ b/app/_kong_plugins/ai-rag-injector/examples/openai-redis.yaml
@@ -19,8 +19,8 @@ variables:
 
 config:
   inject_template: |
-    Only use the following information surrounded by <CONTEXT></CONTEXT> and your existing knowledge to provide the best possible answer to the user.
-    <CONTEXT><RAG RESPONSE></CONTEXT>
+    Only use the following information surrounded by <RAG></RAG>to and your existing knowledge to provide the best possible answer to the user.
+    <RAG><CONTEXT></RAG>
     User's question: <PROMPT>
   embeddings:
     auth:
@@ -44,4 +44,3 @@ tools:
   - kic
   - terraform
 
-  


### PR DESCRIPTION
## Description

Fixes incorrect config sample for the RAG injector plugin.

## Preview Links

https://deploy-preview-1501--kongdeveloper.netlify.app/plugins/ai-rag-injector/examples/openai-redis/

## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
