### PR TITLE
AWS VPC peering

### DIFF
--- a/app/_how-tos/vpc-peering.md
+++ b/app/_how-tos/vpc-peering.md
@@ -1,0 +1,91 @@
+---
+title: Set up an AWS VPC peering connection using the API
+description: 'Use the {{site.konnect_short_name}} Cloud Gateways API to create a VPC peering connection with your AWS VPC.'
+content_type: how_to
+permalink: /dedicated-cloud-gateways/aws-vpc-peering/
+breadcrumbs:
+  - /dedicated-cloud-gateways/
+products:
+  - gateway
+works_on:
+  - konnect
+tldr:
+  q: How do I set up a VPC peering connection with my Dedicated Cloud Gateway using the API?
+  a: Use the {{site.konnect_short_name}} API to initiate peering, then accept the request in AWS and update your route table.
+related_resources:
+  - text: Dedicated Cloud Gateways
+    url: /dedicated-cloud-gateways/
+  - text: AWS VPC Peering Documentation
+    url: https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html
+prereqs:
+  skip_product: true
+  inline:
+    - title: "Dedicated Cloud Gateway"
+      include_content: prereqs/dedicated-cloud-gateways
+
+    - title: "AWS credentials and VPC"
+      content: |
+        You'll need:
+
+        - An AWS account with permission to accept VPC peering requests and update route tables
+        - A target AWS VPC ID
+        - The AWS region of your VPC
+        - The VPC's CIDR block
+
+        Save these values:
+
+        ```sh
+        export AWS_ACCOUNT_ID='123456789012'
+        export AWS_VPC_ID='vpc-0f1e2d3c4b5a67890'
+        export AWS_REGION='us-east-2'
+        export AWS_VPC_CIDR='10.0.0.0/16'
+        ```
+
+---
+
+## Initiate the VPC peering connection
+
+Send the following request to the Cloud Gateways API:
+
+<!--vale off-->
+{% konnect_api_request %}
+url: /v2/cloud-gateways/networks/$NETWORK_ID/transit-gateways
+status_code: 201
+region: global
+method: POST
+headers:
+  - 'Accept: application/json'
+  - 'Content-Type: application/json'
+  - 'Authorization: Bearer $KONNECT_TOKEN'
+body:
+  name: us-east-2 vpc peering
+  cidr_blocks:
+    - $AWS_VPC_CIDR
+  transit_gateway_attachment_config:
+    kind: aws-vpc-peering-attachment
+    peer_account_id: $AWS_ACCOUNT_ID
+    peer_vpc_id: $AWS_VPC_ID
+    peer_vpc_region: $AWS_REGION
+{% endkonnect_api_request %}
+<!--vale on-->
+
+
+
+## Accept the peering request in AWS
+
+1. Go to the AWS Console → **VPC** → **Peering Connections**.
+2. Locate the pending request from {{site.konnect_short_name}}.
+3. Select the request and choose **Accept Request**.
+
+
+## Update your AWS route table
+
+1. In the AWS Console, go to **VPC** → **Route Tables**.
+2. Select the route table for your VPC's subnet.
+3. Add a new route:
+    - **Destination**: The CIDR block of the {{site.konnect_short_name}} network (provided in the peering details).
+    - **Target**: The accepted VPC peering connection.
+4. Save your changes.
+
+This ensures private traffic routing between your VPC and the Dedicated Cloud Gateway.
+

--- a/app/_includes/prereqs/dedicated-cloud-gateways.md
+++ b/app/_includes/prereqs/dedicated-cloud-gateways.md
@@ -1,0 +1,77 @@
+This is a Konnect tutorial that requires Dedicated Cloud Gateways access.
+
+If you don't have a Konnect account, you can get started quickly with our [onboarding wizard](https://konghq.com/products/kong-konnect/register?utm_medium=referral&utm_source=docs).
+
+You will also need a Personal Access Token: 
+Create a new personal access token by opening the [Konnect PAT page](https://cloud.konghq.com/global/account/tokens) and selecting **Generate Token**.
+
+Then save that token as an environment variable and your Control Plane URL as environment variables:
+
+```sh
+export KONNECT_TOKEN='YOUR KONNECT TOKEN'
+export KONNECT_CONTROL_PLANE_URL=https://global.api.konghq.com
+```
+
+Create a Control Plane for Dedicated Cloud Gateways:
+
+    {% control_plane_request %}
+    url: /v2/control-planes
+    status_code: 201
+    method: POST
+    headers:
+      - 'Authorization: Bearer $KONNECT_TOKEN'
+      - 'Content-Type: application/json'
+    body:
+      name: cloud-gateway-control-plane
+      description: A test control plane for Dedicated Cloud Gateways.
+      cluster_type: CLUSTER_TYPE_CONTROL_PLANE
+      cloud_gateway: true
+      proxy_urls:
+        - host: example.com
+          port: 443
+          protocol: https
+    {% endcontrol_plane_request %}
+
+From the response body, export the `control_plane_id`:
+
+```sh
+export CONTROL_PLANE_ID='3e812da0-7c34-4e79-9564-801fce356e5f'
+```
+
+Now, create a Dedicated Cloud Gateway network
+
+{% konnect_api_request %}
+url: /v2/cloud-gateways/networks
+region: global
+status_code: 201
+method: GET
+{% endkonnect_api_request %}
+
+Save the result as an environment variable:
+
+```sh
+export NETWORK_ID='YOUR_NETWORK_ID'
+```
+
+    
+Use the following endpoint to provision a Dedicated Cloud Gateway Data Plane:
+
+    {% control_plane_request %}
+    url: /v2/cloud-gateways/configurations
+    status_code: 201
+    method: PUT
+    headers:
+      - 'Authorization: Bearer $KONNECT_TOKEN'
+      - 'Content-Type: application/json'
+    body:
+      control_plane_id: $CONTROL_PLANE_ID
+      version: "3.6"
+      control_plane_geo: us
+      dataplane_groups:
+        - provider: aws
+          region: ap-northeast-1
+          cloud_gateway_network_id: $NETWORK_ID
+          autoscale:
+            kind: autopilot
+            base_rps: 100
+    {% endcontrol_plane_request %}

--- a/app/_plugins/drops/konnect_api_request.rb
+++ b/app/_plugins/drops/konnect_api_request.rb
@@ -26,7 +26,7 @@ module Jekyll
       end
 
       def url
-        "https://#{configuration['region']}.api.konghq.com#{@yaml['url']}"
+        "https://#{self['region']}.api.konghq.com#{@yaml['url']}"
       end
 
       def headers


### PR DESCRIPTION
## Description
Mirror the content in this docs.konghq.com PR: 
https://github.com/Kong/docs.konghq.com/pull/8707

Adds an include for DCGW getting started 

Fixes an issue with the `konnect_api_request` block that allows it to render regions. 

Fixes #issue
#1511 
## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
