### PR TITLE
Fix gateway changelog's anchor links

### DIFF
--- a/app/_plugins/hooks/post_process_html.rb
+++ b/app/_plugins/hooks/post_process_html.rb
@@ -11,6 +11,9 @@ class AddLinksToHeadings # rubocop:disable Style/Documentation
     doc = Nokogiri::HTML(@page_or_doc.output)
     changes = false
 
+    h2_id = nil
+    h3_id = nil
+
     doc.css('h2, h3, h4, h5, h6').each do |heading|
       should_always_link = heading['class']&.split&.include?('always-link')
 
@@ -32,6 +35,18 @@ class AddLinksToHeadings # rubocop:disable Style/Documentation
       # Index pages have specific heading IDs to account for groups
       unless heading.attr('data-skip-process-heading-id') && heading.attr('data-skip-process-heading-id') == 'true'
         heading['id'] = Jekyll::Utils.slugify(text)
+      end
+
+      if @page_or_doc.url == '/gateway/changelog/'
+        if heading.name == 'h2'
+          h2_id = heading['id']
+          h3_id = nil
+        elsif heading.name == 'h3'
+          h3_id = heading['id']
+        end
+        # Fix for gateway's changelog anchor links
+        # All releases have the same entries
+        heading['id'] = [h2_id, h3_id, heading['id']].compact.uniq.join('-')
       end
 
       # special case, it has links in the headings


### PR DESCRIPTION
## Description

All the releases have the same sections, prepend the release number before them.

Fixes https://github.com/Kong/developer.konghq.com/issues/1525

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
