### PR TITLE
Don't skip generators if JEKYLL_ENV=test

### DIFF
--- a/.github/workflows/check-links-scheduled.yml
+++ b/.github/workflows/check-links-scheduled.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Run site
         run: |
-          npx netlify dev & npx wait-on http://localhost:8888
+          npx netlify dev --context test & npx wait-on http://localhost:8888
 
       - name: Run link checker
         run: |

--- a/app/_plugins/hooks/after_init.rb
+++ b/app/_plugins/hooks/after_init.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Jekyll::Hooks.register :site, :after_init do |site|
+  site.config['skip'] = {} if ENV['JEKYLL_ENV'] == 'test'
+end

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,6 +11,9 @@
   JEKYLL_ENV = "preview"
   BUNDLE_WITHOUT = "development"
 
+[context.test]
+  environment = { JEKYLL_ENV = "test" }
+
 [dev]
   autoLaunch = false
   targetPort = 4000


### PR DESCRIPTION
## Description

Fixes the scheduled broken link checker
Fixes #1543 

I ran the job on this branch:

https://github.com/Kong/developer.konghq.com/actions/runs/15156292480/job/42611824743


<img width="455" alt="Screenshot 2025-05-21 at 09 48 36" src="https://github.com/user-attachments/assets/8bacde07-6358-4593-be90-e17bc1d50cd2" />

## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
- [ ] Add new pages to the product documentation index (if applicable)
