### PR TITLE
Kong Manager RBAC docs

### DIFF
--- a/app/_gateway_entities/admin.md
+++ b/app/_gateway_entities/admin.md
@@ -5,7 +5,7 @@ entities:
   - admin
 
 description: |
-  Admins can manage {{site.base_gateway}} entities inside Workspaces, including Users and their Roles.
+  Admins can manage {{site.base_gateway}} entities inside Workspaces, including users and their roles.
 
 
 related_resources:
@@ -28,18 +28,23 @@ schema:
   api: gateway/admin-ee
   path: /schemas/Admin
 faqs:
-  - q: What happens when an Admin doesn't have a Role assigned?
-    a: If an Admin is in a Workspace without a Role, they can’t see or interact with anything. Admins can manage entities inside Workspaces, including Users and their Roles.
+  - q: What happens when an admin doesn't have a role assigned?
+    a: If an admin is in a Workspace without a role, they can’t see or interact with anything. Admins can manage entities inside Workspaces, including users and their roles.
+  - q: What is a super admin?
+    a: A super admin is a role that has the ability to assign and modify RBAC roles and permissions. A generic admin without this role can't manage RBAC.
+  - q: How can I invite and manage admins in Kong Manager?
+    a: If you want to manage admins from the Kong Manager UI, go to Teams > Admins. From here, you can invite new admins, manage existing admins, and find invitation links for invited admins.
+  - q: Can admins manage multiple Workspaces?
+    a: No, each admin is specific to one Workspace.
 
 works_on:
   - on-prem
-  - konnect
 
 tags:
   - rbac
 ---
 
-## What is an Admin?
+## What is an admin?
 Admins in {{site.base_gateway}} are [RBAC](/gateway/entities/rbac/) entities used to used to manage all administrators for a specific [Workspace](/gateway/entities/workspace/). 
 Admins can be managed using the Admin API or Kong Manager and are used in the following operations:
 
@@ -51,17 +56,15 @@ Admins can be managed using the Admin API or Kong Manager and are used in the fo
 * [Viewing associated Workspaces](/api/gateway/admin-ee/#/operations/get-admins-name_or_id-workspaces)
 
 
-Admins can only interact with entities from within their Workspace. Depending on the Admin's specific Role, they can enforce RBAC Roles and Permissions across that Workspace, including creating and inviting other Admins. 
+Admins can only interact with entities from within their Workspace. Depending on the admin's specific role, they can enforce RBAC roles and permissions across that Workspace, including creating and inviting other admins. 
 
 ## Schema
 
 {% entity_schema %}
 
-## Invite an Admin
+## Invite an admin
 
-Inviting an Admin can only be done if you have [enabled RBAC](/gateway/entities/rbac/#enable-rbac). You can invite an Admin by issuing a `POST` request to [`/admins`](/api/gateway/admin-ee/#/operations/post-admins). 
-
-If you haven't configured email capabilities your Admin won't receive an invite link, but will still be created.
+Inviting an admin can only be done if you have [enabled RBAC](/gateway/entities/rbac/#enable-rbac). You can invite an admin by issuing a `POST` request to [`/admins`](/api/gateway/admin-ee/#/operations/post-admins). 
 
 {% entity_example %}
 type: admin
@@ -73,3 +76,9 @@ headers:
   admin-api:
     - "Kong-Admin-Token: $ADMIN_TOKEN"
 {% endentity_example %}
+
+If you haven't configured email capabilities your admin won't receive an invite link, but the link will still be created. 
+You can copy the generated invite link from the Kong Manager UI and provide it directly to your intended admin.
+
+By default, the invite link expires after 259,200 seconds (3 days). 
+You can customize this time frame by adjusting the [`admin_invitation_expiry`](/gateway/configuration/#admin-invitation-expiry) parameter in `kong.conf`.

--- a/app/_gateway_entities/rbac.md
+++ b/app/_gateway_entities/rbac.md
@@ -28,6 +28,8 @@ related_resources:
     url: /gateway/entities/admin/
   - text: Create a Super Admin
     url: /how-to/create-a-super-admin/
+  - text: Create an RBAC user with custom permissions
+    url: /how-to/configure-rbac-user-in-kong-gateway/
   - text: Reserved entity names
     url: /gateway/reserved-entity-names/
   - text: "{{site.konnect_short_name}} roles and teams"

--- a/app/_gateway_entities/rbac.md
+++ b/app/_gateway_entities/rbac.md
@@ -101,7 +101,7 @@ rows:
   - user: User
     purpose: |
       RBAC users without administrator permissions. 
-      They have access to manage Kong Gateway, but can’t adjust teams, groups, or user permissions.
+      They have access to manage {{site.base_gateway}}, but can’t adjust teams, groups, or user permissions.
     use: "Service accounts for {{site.base_gateway}}, used as part of an automated process"
     tools: |
       * Admin API

--- a/app/_how-tos/configure-rbac-user-in-kong-gateway.md
+++ b/app/_how-tos/configure-rbac-user-in-kong-gateway.md
@@ -1,0 +1,124 @@
+---
+title: Configure a {{site.base_gateway}} RBAC user
+content_type: how_to
+description: Learn how to create a {{site.base_gateway}} RBAC user and configure it with roles and permissions.
+products:
+    - gateway
+
+works_on:
+    - on-prem
+
+tags:
+  - authorization
+  - access-control
+  - rbac
+
+related_resources:
+  - text: Gateway RBAC
+    url: /gateway/entities/rbac/
+  - text: Gateway Groups
+    url: /gateway/entities/group/
+  - text: Gateway Admins
+    url: /gateway/entities/admin/
+  - text: Gateway Workspaces
+    url: /gateway/entities/workspace/
+
+tldr: 
+  q: How do I configure a {{site.base_gateway}} user with a role and permissions?
+  a: |
+     To configure an RBAC user in {{site.base_gateway}}, create the user with the `/rbac/users` endpoint of the Admin API, then assign roles and permissions to the new user.
+
+prereqs:
+  skip_product: true
+  inline:
+    - title: Start {{site.base_gateway}} with RBAC
+      include_content: prereqs/enable-rbac
+      icon_url: /assets/icons/gateway.svg
+---
+
+## Create an RBAC user
+
+An RBAC user has the ability to access the Kong Gateway Admin API.
+The permissions assigned to their role will define the types of actions they can perform with various Admin API objects.
+
+Create an [RBAC](/gateway/entities/rbac/) user by sending a `POST` request to the [`/rbac/users`](/api/gateway/admin-ee/#/operations/post-rbac-users) endpoint:
+
+<!-- vale off -->
+{% control_plane_request %}
+  url: /rbac/users
+  method: POST
+  body:
+      name: alex
+      user_token: alex-token
+  headers:
+      - 'Kong-Admin-Token:kong'
+{% endcontrol_plane_request %}
+<!-- vale on -->
+
+By omitting the Workspace in the request, the user gets added to the `default` Workspace.
+
+## Create a role
+
+Let's say that in our environment, we need a subset of users to access Gateway Services only. 
+Create a new role:
+
+{% control_plane_request %}
+url: /rbac/roles
+method: POST
+headers:
+  - 'Kong-Admin-Token:kong'
+body:
+  name: dev
+{% endcontrol_plane_request %}
+
+Then, assign endpoint permissions to the role, allowing access to the `/services/` endpoint:
+
+{% control_plane_request %}
+url: /rbac/roles/dev/endpoints
+method: POST
+headers:
+  - 'Kong-Admin-Token:kong'
+body:
+  endpoint: '/services/*'
+  workspace: default
+  actions: 
+    - '*'
+{% endcontrol_plane_request %}
+
+## Assign role to user
+
+Assign the `dev` role to the user you created earlier:
+
+{% control_plane_request %}
+url: /rbac/users/alex/roles
+
+method: POST
+headers:
+  - 'Kong-Admin-Token:kong'
+body:
+  roles:
+    - name: dev
+{% endcontrol_plane_request %}
+
+## Validate 
+
+You can validate that the user has correct permissions by trying to access entities with the user's access token.
+
+{% control_plane_request %}
+url: /routes
+headers:
+  - "Kong-Admin-Token:alex-token"
+display_headers: true
+{% endcontrol_plane_request %}
+
+If RBAC was enabled correctly, this request will return a `403 Forbidden` message.
+
+Passing the same request with the `user-token` will return a `200` and the list of Gateway Services:
+
+{% control_plane_request %}
+url: /services
+headers:
+  - "Kong-Admin-Token:alex-token"
+{% endcontrol_plane_request %}
+
+This time, the request succeeds and the us

--- a/app/_how-tos/configure-rbac-user-in-kong-gateway.md
+++ b/app/_how-tos/configure-rbac-user-in-kong-gateway.md
@@ -50,7 +50,7 @@ cleanup:
 
 ## Create an RBAC user
 
-An RBAC user has the ability to access the Kong Gateway Admin API.
+An RBAC user has the ability to access the {{site.base_gateway}} Admin API.
 The permissions assigned to their role will define the types of actions they can perform with various Admin API objects.
 
 Create an [RBAC](/gateway/entities/rbac/) user by sending a `POST` request to the [`/rbac/users`](/api/gateway/admin-ee/#/operations/post-rbac-users) endpoint:

--- a/app/_how-tos/create-a-super-admin.md
+++ b/app/_how-tos/create-a-super-admin.md
@@ -11,6 +11,8 @@ works_on:
 
 tags:
   - authorization
+  - access-control
+  - rbac
 
 tldr: 
   q: How do I create a {{site.base_gateway}} Super Admin using the Admin API?
@@ -35,6 +37,24 @@ prereqs:
 
 min_version:
     gateway: '3.4'
+
+cleanup:
+  inline:
+    - title: Destroy the {{site.base_gateway}} container
+      include_content: cleanup/products/gateway
+      icon_url: /assets/icons/gateway.svg
+
+related_resources:
+  - text: Gateway RBAC
+    url: /gateway/entities/rbac/
+  - text: Gateway Groups
+    url: /gateway/entities/group/
+  - text: Gateway Admins
+    url: /gateway/entities/admin/
+  - text: Gateway Workspaces
+    url: /gateway/entities/workspace/
+  - text: Create an RBAC user with custom permissions
+    url: /how-to/configure-rbac-user-in-kong-gateway/
 ---
 
 

--- a/app/_how-tos/enable-rbac-with-admin-api.md
+++ b/app/_how-tos/enable-rbac-with-admin-api.md
@@ -114,7 +114,7 @@ export KONG_ENFORCE_RBAC=on && kong reload
 
 After the Super Admin is created and RBAC is enabled, the `user_token` must be passed with Admin API requests otherwise the API will return a `401 Unauthorized` error.
 
-You can validate that RBAC is enabled by attempting to create a user like you did in the first step without passing the `user_token`:
+You can validate that RBAC is enabled by attempting to access the user list without a `user_token`:
 
 <!-- vale off -->
 

--- a/app/_includes/entities/permissions-table.md
+++ b/app/_includes/entities/permissions-table.md
@@ -1,14 +1,25 @@
-## Default {{site.base_gateway}} roles
+### Default {{site.base_gateway}} roles
 
 By default, when {{site.base_gateway}} is configured, the starting user is configured as a **Super Admin** in the `default` Workspace. Workspaces, by default, contain the following roles: 
 
-| Role      | Description |
-| ----------- | ----------- |
-| `admin` | Full access to all endpoints, across all Workspaces, except the RBAC Admin API  |
-| `super-admin`   | Full access to all endpoints, across all Workspaces, ability to assign and modify RBAC permissions.     |
-|`read-only`| Read access to all endpoints, across all Workspaces|
+<!--vale off-->
+{% table %}
+columns:
+  - title: Role
+    key: role
+  - title: Description
+    key: description
+rows:
+  - role: "`admin`"
+    description: Full access to all endpoints, across all Workspaces, except the RBAC Admin API.
+  - role: "`super-admin`"
+    description: Full access to all endpoints, across all Workspaces, including the ability to assign and modify RBAC permissions.
+  - role: "`read-only`"
+    description: Read access to all endpoints, across all Workspaces.
+{% endtable %}
+<!--vale on-->
 
-An **Admin** has full permissions to every endpoint in {{site.base_gateway}}, but they can't assign and modify RBAC permissions. An **Admin** can't modify their own permissions, or configure the permissions of the **Super Admin**.   
+An admin has full permissions to every endpoint in {{site.base_gateway}}, but they can't assign and modify RBAC permissions.
 
 {% mermaid %}
 
@@ -37,13 +48,29 @@ flowchart LR
     end
 
 {% endmermaid %}
-## Workspace roles
+### Workspace roles
 
 [Workspaces](/gateway/entities/workspace/) provide a way to logically segment configurations and entities with RBAC. Using RBAC, you can restrict access to groups of users and create roles within a Workspace so that users can manage each other. This is done using the [`workspaces/rbac/roles`](/api/gateway/admin-ee/#/operations/post-rbac-roles-workspace) endpoint.  
 
-| Role      | Description |
-| ----------- | ----------- |
-|`workspace-admin` | Full access to all endpoints in the Workspace, except the RBAC Admin API.| 
-|`Workspace-read-only` | Read access to all endpoints in the Workspace | 
+<!--vale off-->
+{% table %}
+columns:
+  - title: Role
+    key: role
+  - title: Description
+    key: description
+rows:
+  - role: "`workspace-admin`"
+    description: Full access to all endpoints in the Workspace, except the RBAC Admin API.
+  - role: "`workspace-super-admin`"
+    description: Full access to all endpoints in the Workspaces, including the ability to assign and modify RBAC.
+  - role: "`workspace-portal-admin`"
+    description: Full access to Dev Portal related endpoints in the Workspace.
+  - role: "`workspace-read-only`"
+    description: Read access to all endpoints in the Workspace.
+{% endtable %}
+<!--vale on-->
 
 A role assigned in the `default` Workspace has permissions across all subsequently created Workspaces unless the roles in the specific Workplace are explicitly assigned. When a Workspace has explicitly assigned roles, they take precedent over the `default` Workspace. 
+
+If RBAC roles and permissions are assigned from within a Workspace, they are specific to that Workspace. For example, if there are two Workspaces, Payments and Deliveries, an admin created in Payments doesn’t have access to any endpoints in Deliveries.

--- a/app/_includes/prereqs/enable-rbac.md
+++ b/app/_includes/prereqs/enable-rbac.md
@@ -19,5 +19,5 @@ This tutorial requires {{site.ee_product_name}}.
     ```bash
     Kong Gateway Ready
     ```
-    For more information about the values see the [Bootstrap RBAC](/how-to/enable-rbac-with-admin-api/) guide.
+    For more information about the values, see the [Bootstrap RBAC](/how-to/enable-rbac-with-admin-api/) guide.
     {:.no-copy-code}

--- a/tools/track-docs-changes/config/missing_dev_site_url.yml
+++ b/tools/track-docs-changes/config/missing_dev_site_url.yml
@@ -16,10 +16,10 @@
   dev_site_url: '/custom-plugins/'
   status: "?"
 - docs_url: "/gateway/latest/kong-manager/auth/rbac/add-role/"
-  dev_site_url: '/gateway/entities/rbac/'
+  dev_site_url: '/how-to/configure-rbac-user-in-kong-gateway/'
   status: post-ga
 - docs_url: "/gateway/latest/kong-manager/auth/rbac/add-user/"
-  dev_site_url: '/gateway/entities/rbac/'
+  dev_site_url: '/how-to/configure-rbac-user-in-kong-gateway/'
   status: post-ga
 - docs_url: "/gateway/3.4.x/kong-enterprise/dev-portal/customize/adding-javascript-assets/"
   dev_site_url: '/dev-portal/'
@@ -499,7 +499,7 @@
   dev_site_url: '/gateway/kong-manager/'
   status: post-ga
 - docs_url: "/gateway/latest/kong-manager/auth/rbac/enable/"
-  dev_site_url: '/gateway/kong-manager/'
+  dev_site_url: '/how-to/enable-rbac-with-admin-api/'
   status: post-ga
 - docs_url: "/gateway/latest/plugin-development/get-started/"
   dev_site_url: '/custom-plugins/get-started/set-up-plugin-project/'

--- a/tools/track-docs-changes/config/sources.yml
+++ b/tools/track-docs-changes/config/sources.yml
@@ -70,7 +70,6 @@ app/_gateway_entities/rbac.md:
   - app/_src/gateway/production/access-control/start-securely.md
   - app/_src/gateway/production/access-control/register-admin-api.md
   - app/_src/gateway/kong-manager/auth/rbac/index.md
-  - app/konnect/dev-portal/access-and-approval/manage-teams.md
 app/_gateway_entities/group.md:
   - app/_src/gateway/kong-manager/auth/ldap/service-directory-mapping.md
 
@@ -121,6 +120,7 @@ app/_gateway_entities/admin.md:
   - app/_src/gateway/production/access-control/start-securely.md
   - app/_src/gateway/production/access-control/register-admin-api.md
   - app/_src/gateway/production/access-control/enable-rbac.md
+  - app/_src/gateway/kong-manager/auth/rbac/add-admin.md
 
 app/_gateway_entities/partial.md:
   - app/_src/gateway/kong-enterprise/partials.md
@@ -164,7 +164,7 @@ app/_how-tos/enable-rbac-with-admin-api.md:
   - app/_src/gateway/production/access-control/start-securely.md
   - app/_src/gateway/production/access-control/register-admin-api.md
   - app/_src/gateway/kong-manager/auth/rbac.md
-  - app/konnect/dev-portal/access-and-approval/manage-teams.md
+  - app/_src/gateway/kong-manager/auth/rbac/enable.md
 app/_how-tos/store-secrets-in-konnect-config-store.md:
   - app/konnect/gateway-manager/configuration/config-store.md
 app/_how-tos/store-the-gateway-database-credentials-with-aws-secrets-manager.md:
@@ -267,6 +267,9 @@ app/_how-tos/get-started-with-datakit.md:
   - app/_src/gateway/kong-enterprise/datakit/get-started.md
 app/_how-tos/visualize-ai-gateway-metrics-with-kibana.md:
   - app/_src/gateway/ai-gateway/llm-library-integration-guides/langchain.md
+app/_how-tos/configure-rbac-user-in-kong-gateway.md:
+  - app/_src/gateway/kong-manager/auth/rbac/add-role.md
+  - app/_src/gateway/kong-manager/auth/rbac/add-user.md
 
 ## KIC
 app/_landing_pages/kubernetes-ingress-controller.yaml:
@@ -1471,6 +1474,7 @@ app/dev-portal/auth-strategies.md:
 app/dev-portal/access-and-approval.md:
   - app/dev-portal/access-and-approvals/teams.md
   - app/dev-portal/access-and-approvals/index.md
+  - app/konnect/dev-portal/access-and-approval/manage-teams.md
 app/dev-portal/developer-signup.md:
   - app/dev-portal/access-and-approvals/developers.md
 app/dev-portal/sso.md:


### PR DESCRIPTION
## Description

Fixes #1035 
Fixes #1037 
Fixes #1038 
Fixes #1036 

For the how-to: the last validation step still uses the admin API, even though it _could_ use decK. I thought that better illustrates the point that the API permissions are working, whereas using decK slightly abstracts that away.

~to do: sources.yaml and index page updates~ 

## Preview Links

https://deploy-preview-1563--kongdeveloper.netlify.app/how-to/configure-rbac-user-in-kong-gateway/
https://deploy-preview-1563--kongdeveloper.netlify.app/gateway/entities/rbac/
https://deploy-preview-1563--kongdeveloper.netlify.app/gateway/entities/admins/

## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
- [x] Add new pages to the product documentation index (if applicable)
