### PR TITLE
Organize OIDC examples

### DIFF
--- a/.github/styles/base/Dictionary.txt
+++ b/.github/styles/base/Dictionary.txt
@@ -212,6 +212,7 @@ event_hook
 eventhooks
 eventTime
 failover
+fapi
 Fargate
 Fargate
 favicon

--- a/.github/styles/frontmatter/Keys.txt
+++ b/.github/styles/frontmatter/Keys.txt
@@ -44,3 +44,4 @@ ai_gateway_enterprise
 topology_switcher
 discovery_default
 examples_groups
+basic_examples

--- a/app/_kong_plugins/openid-connect/examples/acl-auth.yaml
+++ b/app/_kong_plugins/openid-connect/examples/acl-auth.yaml
@@ -49,3 +49,5 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+group: authentication

--- a/app/_kong_plugins/openid-connect/examples/amazon-cognito.yaml
+++ b/app/_kong_plugins/openid-connect/examples/amazon-cognito.yaml
@@ -35,3 +35,5 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+group: providers

--- a/app/_kong_plugins/openid-connect/examples/auth0.yaml
+++ b/app/_kong_plugins/openid-connect/examples/auth0.yaml
@@ -38,3 +38,5 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+group: authentication

--- a/app/_kong_plugins/openid-connect/examples/authorization-code.yaml
+++ b/app/_kong_plugins/openid-connect/examples/authorization-code.yaml
@@ -50,3 +50,5 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+group: authentication

--- a/app/_kong_plugins/openid-connect/examples/azure-ad.yaml
+++ b/app/_kong_plugins/openid-connect/examples/azure-ad.yaml
@@ -73,3 +73,5 @@ tools:
 
 search_aliases:
   - Microsoft Entra ID
+
+group: providers

--- a/app/_kong_plugins/openid-connect/examples/cert-bound-access-tokens.yaml
+++ b/app/_kong_plugins/openid-connect/examples/cert-bound-access-tokens.yaml
@@ -38,3 +38,5 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+group: fapi

--- a/app/_kong_plugins/openid-connect/examples/claims-based-auth.yaml
+++ b/app/_kong_plugins/openid-connect/examples/claims-based-auth.yaml
@@ -51,3 +51,5 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+group: authorization

--- a/app/_kong_plugins/openid-connect/examples/client-credentials.yaml
+++ b/app/_kong_plugins/openid-connect/examples/client-credentials.yaml
@@ -48,3 +48,5 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+group: authentication

--- a/app/_kong_plugins/openid-connect/examples/consumer-auth.yaml
+++ b/app/_kong_plugins/openid-connect/examples/consumer-auth.yaml
@@ -52,3 +52,5 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+group: authorization

--- a/app/_kong_plugins/openid-connect/examples/curity.yaml
+++ b/app/_kong_plugins/openid-connect/examples/curity.yaml
@@ -56,3 +56,5 @@ tools:
 
 search_aliases:
   - curity identity server
+
+group: providers

--- a/app/_kong_plugins/openid-connect/examples/dpop.yaml
+++ b/app/_kong_plugins/openid-connect/examples/dpop.yaml
@@ -38,3 +38,5 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+group: fapi

--- a/app/_kong_plugins/openid-connect/examples/google.yaml
+++ b/app/_kong_plugins/openid-connect/examples/google.yaml
@@ -45,3 +45,5 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+group: providers

--- a/app/_kong_plugins/openid-connect/examples/headers.yaml
+++ b/app/_kong_plugins/openid-connect/examples/headers.yaml
@@ -59,3 +59,5 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+group: other

--- a/app/_kong_plugins/openid-connect/examples/introspection-auth.yaml
+++ b/app/_kong_plugins/openid-connect/examples/introspection-auth.yaml
@@ -48,3 +48,5 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+group: authentication

--- a/app/_kong_plugins/openid-connect/examples/jwt-access-token.yaml
+++ b/app/_kong_plugins/openid-connect/examples/jwt-access-token.yaml
@@ -49,3 +49,5 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+group: authentication

--- a/app/_kong_plugins/openid-connect/examples/kong-oauth-token.yaml
+++ b/app/_kong_plugins/openid-connect/examples/kong-oauth-token.yaml
@@ -49,3 +49,5 @@ tools:
   - deck
   - admin-api
   - kic
+
+group: authentication

--- a/app/_kong_plugins/openid-connect/examples/logout.yaml
+++ b/app/_kong_plugins/openid-connect/examples/logout.yaml
@@ -53,3 +53,5 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+group: other

--- a/app/_kong_plugins/openid-connect/examples/mtls-client-auth.yaml
+++ b/app/_kong_plugins/openid-connect/examples/mtls-client-auth.yaml
@@ -45,3 +45,5 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+group: client-auth

--- a/app/_kong_plugins/openid-connect/examples/okta.yaml
+++ b/app/_kong_plugins/openid-connect/examples/okta.yaml
@@ -63,3 +63,5 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+group: providers

--- a/app/_kong_plugins/openid-connect/examples/password.yaml
+++ b/app/_kong_plugins/openid-connect/examples/password.yaml
@@ -55,3 +55,5 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+group: authentication

--- a/app/_kong_plugins/openid-connect/examples/refresh-token.yaml
+++ b/app/_kong_plugins/openid-connect/examples/refresh-token.yaml
@@ -51,3 +51,5 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+group: authentication

--- a/app/_kong_plugins/openid-connect/examples/session-auth.yaml
+++ b/app/_kong_plugins/openid-connect/examples/session-auth.yaml
@@ -43,3 +43,5 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+group: authentication

--- a/app/_kong_plugins/openid-connect/examples/user-info-auth.yaml
+++ b/app/_kong_plugins/openid-connect/examples/user-info-auth.yaml
@@ -50,3 +50,5 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+group: authentication

--- a/app/_kong_plugins/openid-connect/index.md
+++ b/app/_kong_plugins/openid-connect/index.md
@@ -45,6 +45,23 @@ related_resources:
     url: /gateway/authentication/
   - text: OpenID Connect tutorials
     url: /how-to/?query=openid-connect
+
+examples_groups:
+  - slug: authentication
+    text: Authentication flows and grants
+  - slug: client-auth
+    text: Client authentication
+  - slug: authorization
+    text: Authorization
+  - slug: providers
+    text: Common provider configurations
+  - slug: fapi
+    text: Financial-grade API
+  - slug: other
+    text: Other examples
+
+basic_examples: false
+    
 ---
 
 The OpenID Connect (OIDC) plugin lets you integrate {{site.base_gateway}} with an identity provider (IdP).

--- a/app/_layouts/plugins/example.html
+++ b/app/_layouts/plugins/example.html
@@ -5,7 +5,7 @@ layout: plugins/without_aside
 <div class="flex gap-16 w-full flex-col md:flex-row">
   <nav class="hidden md:flex gap-8 basis-1/4">
     <div class="flex gap-3 flex-col">
-      {% if page.basic_examples %}
+      {% if page.basic_examples != empty %}
       <div class="text-sm text-brand font-semibold">Basic use cases</div>
       <ul class="tabcolumn">
         {% for example in page.basic_examples %}
@@ -29,7 +29,7 @@ layout: plugins/without_aside
   </nav>
   <div class="flex md:hidden bg-secondary rounded-md justify-between py-2 px-4 gap-2 w-full shadow-primary items-center">
     <select id="plugin-example-dropdown" class="bg-secondary grow max-w-full">
-      {% if page.basic_examples %}
+      {% if page.basic_examples != empty %}
         <optgroup label="Basic use cases">
           {% for example in page.basic_examples %}
             <option value="{{ example.url }}" {% if example == page.url %}selected{% endif %}>{{ example.title }}</option>


### PR DESCRIPTION
Use the new grouping functionality to organize the OIDC plugin examples.

https://deploy-preview-1579--kongdeveloper.netlify.app/plugins/openid-connect/examples/

@fabianrbz is there a way to disable the "basic use cases" section if all plugin examples are grouped in some way? 