### PR TITLE
Remove legacy tags

### DIFF
--- a/app/_how-tos/kic-external-service.md
+++ b/app/_how-tos/kic-external-service.md
@@ -59,7 +59,7 @@ spec:
 
 To route HTTP traffic, you need to create an `HTTPRoute` or an `Ingress` resource pointing at your Kubernetes `Service`.
 
-{% include /k8s/httproute.md release=page.release path='/httpbin' name='proxy-from-k8s-to-httpbin' service='proxy-to-httpbin' port='80' skip_host=true %}
+{% include_cached /k8s/httproute.md path='/httpbin' name='proxy-from-k8s-to-httpbin' service='proxy-to-httpbin' port='80' skip_host=true %}
 
 ## Validate your configuration
 

--- a/app/_how-tos/kic-get-started-services-routes.md
+++ b/app/_how-tos/kic-get-started-services-routes.md
@@ -85,7 +85,7 @@ kubectl apply -f {{ site.links.web }}/manifests/kic/echo-service.yaml -n kong
 
 To route traffic to the `echo` service, create an `HTTPRoute` or `Ingress` resource:
 
-{% include /k8s/httproute.md release=page.release path='/echo' name='echo' service='echo' port='1027' skip_host=true %}
+{% include_cached /k8s/httproute.md path='/echo' name='echo' service='echo' port='1027' skip_host=true %}
 
 ## Validate your configuration
 

--- a/app/_how-tos/kic-observability-prometheus-grafana.md
+++ b/app/_how-tos/kic-observability-prometheus-grafana.md
@@ -90,7 +90,7 @@ Deploy the Services and create routing resources:
 kubectl apply -f {{ site.links.web }}/manifests/kic/multiple-services.yaml -n kong
 ```
 
-{% include /k8s/httproute.md release=page.release name='sample-routes' path='/billing,/comments,/invoice' service='billing,comments,invoice' port='80,80,80' skip_host=true %}
+{% include_cached /k8s/httproute.md name='sample-routes' path='/billing,/comments,/invoice' service='billing,comments,invoice' port='80,80,80' skip_host=true %}
 
 ## Generate traffic
 

--- a/app/_how-tos/kic-plugin-authentication.md
+++ b/app/_how-tos/kic-plugin-authentication.md
@@ -173,7 +173,7 @@ data:
 
 To route HTTP traffic, you need to create an `HTTPRoute` or an `Ingress` resource pointing at your Kubernetes `Service`.
 
-{% include /k8s/httproute.md release=page.release path='/echo' name='echo' service='echo' port='1027' skip_host=true %}
+{% include_cached /k8s/httproute.md path='/echo' name='echo' service='echo' port='1027' skip_host=true %}
 
 ## Validate your configuration
 

--- a/app/_how-tos/kic-plugin-custom.md
+++ b/app/_how-tos/kic-plugin-custom.md
@@ -137,7 +137,7 @@ data:
 
 1. Create a Route to the `echo` service to test your custom plugin: 
 
-{% include /k8s/httproute.md release=page.release path='/echo' name='echo' service='echo' port='1027' skip_host=true indent=4 %}
+{% include_cached /k8s/httproute.md path='/echo' name='echo' service='echo' port='1027' skip_host=true indent=4 %}
 
 ## Validate your configuration
 

--- a/app/_how-tos/kic-plugin-degraphql.md
+++ b/app/_how-tos/kic-plugin-degraphql.md
@@ -142,7 +142,7 @@ curl -X POST -H "Content-Type:application/json" -H "X-Hasura-Role:admin" http://
 
 Our Hasura API will be exposed using the `/contacts` path. Create an `HTTPRoute` or `Ingress` resource pointing to the `hasura` Service that we can attach the `degraphql` plugin to:
 
-{% include /k8s/httproute.md release=page.release path='/contacts' name='demo-graphql' service='hasura' port='80' namespace='kong' skip_host=true %}
+{% include_cached /k8s/httproute.md path='/contacts' name='demo-graphql' service='hasura' port='80' namespace='kong' skip_host=true %}
 
 ## Configure the DeGraphQL plugin
 

--- a/app/_how-tos/kic-proxy-http.md
+++ b/app/_how-tos/kic-proxy-http.md
@@ -49,7 +49,7 @@ cleanup:
 
 To route HTTP traffic, you need to create an `HTTPRoute` or an `Ingress` resource pointing at your Kubernetes `Service`:
 
-{% include /k8s/httproute.md release=page.release path='/echo' name='echo' service='echo' port='1027' skip_host=true %}
+{% include_cached /k8s/httproute.md path='/echo' name='echo' service='echo' port='1027' skip_host=true %}
 
 ## Validate your configuration
 

--- a/app/_how-tos/kic-proxy-https.md
+++ b/app/_how-tos/kic-proxy-https.md
@@ -76,7 +76,7 @@ kubectl patch -n kong --type=json gateway kong -p='[
 
 To route HTTP traffic, you need to create an `HTTPRoute` or an `Ingress` resource pointing at your Kubernetes `Service`.
 
-{% include /k8s/httproute.md release=page.release path='/echo' name='echo' service='echo' port='1027' hostname='demo.example.com' section_name='https' %}
+{% include_cached /k8s/httproute.md path='/echo' name='echo' service='echo' port='1027' hostname='demo.example.com' section_name='https' %}
 
 ## Validate your configuration
 

--- a/app/_how-tos/kic-verify-upstream-tls.md
+++ b/app/_how-tos/kic-verify-upstream-tls.md
@@ -150,7 +150,7 @@ As part of the [prerequisites](#prerequisites), you deployed the `echo` Service 
 
 Now that the `echo` Service is serving an HTTPS endpoint, we need to expose it:
 
-{% include /k8s/httproute.md release=page.release path='/echo' name='echo' service='echo' port='443' host='kong.example' %}
+{% include_cached /k8s/httproute.md path='/echo' name='echo' service='echo' port='443' host='kong.example' %}
 
 Verify connectivity by making an HTTP request to proxy. The Service serves HTTPS but {{ site.base_gateway }} initiates the connection and proxies it as HTTP in this case, so the request should be made over HTTP. The `Host` header  has to match the hostname of the Service.
 

--- a/app/_includes/prereqs/kubernetes/keycloak.md
+++ b/app/_includes/prereqs/kubernetes/keycloak.md
@@ -14,7 +14,7 @@ kubectl apply -f https://raw.githubusercontent.com/keycloak/keycloak-quickstarts
 
 We'll use {{ site.base_gateway }} to expose Keycloak in our cluster on a custom domain:
 
-{% include /k8s/httproute.md release=page.release path='/' name='keycloak' service='keycloak' port='8080' hostname='keycloak.$PROXY_IP.nip.io' %}
+{% include_cached /k8s/httproute.md path='/' name='keycloak' service='keycloak' port='8080' hostname='keycloak.$PROXY_IP.nip.io' %}
 
 ### Register a client and user
 

--- a/app/_landing_pages/mesh.yaml
+++ b/app/_landing_pages/mesh.yaml
@@ -48,7 +48,7 @@ rows:
                 text: |
                   You can use the following script to run an instance of {{site.mesh_product_name}} in Universal mode:
                   
-                  1. Go to the [{{site.mesh_product_name}} packages](https://cloudsmith.io/~kong/repos/{{site.mesh_product_name_path}}-binaries-release/packages/?q=version%3A{{ page.version_data.version }}) page to download and extract the installation archive for your OS, or download and extract the latest release automatically (Linux or macOS):
+                  1. Go to the [{{site.mesh_product_name}} packages](https://cloudsmith.io/~kong/repos/{{site.mesh_product_name_path}}-binaries-release/packages/?q=version%3A{{site.data.mesh_latest.version}}) page to download and extract the installation archive for your OS, or download and extract the latest release automatically (Linux or macOS):
                      ```shell
                      curl -L {{site.links.web}}/mesh/installer.sh | VERSION={{site.data.mesh_latest.version}} sh -
                      ```

--- a/app/mesh/production-usage-values.md
+++ b/app/mesh/production-usage-values.md
@@ -69,7 +69,7 @@ Suggested `values.yaml` file:
 {% embed helm-values-prod/values.global-cp.yaml versioned %}
 ```
 
-The values on this page may reference resources that need to be created in advance when certain features are enabled, read the file content carefully and prepare these resources according to the notes near the keywords `(action)`. If you decide to disable a feature that requires a pre-existing resource, remove or change those fields according to the full [Helm configuration reference](/mesh/{{ page.release }}/reference/kuma-cp/#helm-valuesyaml).
+The values on this page may reference resources that need to be created in advance when certain features are enabled, read the file content carefully and prepare these resources according to the notes near the keywords `(action)`. If you decide to disable a feature that requires a pre-existing resource, remove or change those fields according to the full [Helm configuration reference](/mesh/reference/kuma-cp/#helm-valuesyaml).
 
 {% endnavtab %}
 

--- a/app/mesh/provenance-verification-binaries.md
+++ b/app/mesh/provenance-verification-binaries.md
@@ -38,7 +38,7 @@ Because Kong uses GitHub Actions to build and release, Kong also uses GitHub's O
 
 * [`slsa-verifier`](https://github.com/slsa-framework/slsa-verifier?tab=readme-ov-file#installation) is installed.
 
-* [Download security assets](https://packages.konghq.com/public/kong-mesh-binaries-release/raw/names/security-assets/versions/{{page.version}}/security-assets.tar.gz) for the required version of {{site.mesh_product_name}} binaries
+* [Download security assets](https://packages.konghq.com/public/kong-mesh-binaries-release/raw/names/security-assets/versions/{{site.data.mesh_latest.version}}/security-assets.tar.gz) for the required version of {{site.mesh_product_name}} binaries
 
 * Extract the downloaded `security-assets.tar.gz` to access the provenance file `kong-mesh.intoto.jsonl`
 
@@ -46,7 +46,7 @@ Because Kong uses GitHub Actions to build and release, Kong also uses GitHub's O
    tar -xvzf security-assets.tar.gz
    ```
 
-* [Download compressed binaries](https://cloudsmith.io/~kong/repos/kong-mesh-binaries-release/packages/?q=name%3Akong-mesh-*+version%3A{{page.version}}) for the required version  of {{site.mesh_product_name}}
+* [Download compressed binaries](https://cloudsmith.io/~kong/repos/kong-mesh-binaries-release/packages/?q=name%3Akong-mesh-*+version%3A{{site.data.mesh_latest.version}}) for the required version of {{site.mesh_product_name}}
 
 * The GitHub owner is case-sensitive (`Kong/kong-mesh` vs `kong/kong-mesh`).
 


### PR DESCRIPTION
Fixes #1248 

Didn't remove tags in the following places:
* Mesh policy docs: we have automation to redirect those URLs, so nothing is broken.
* Inso CLI reference: same as above, and this doc is completely generated. Nothing is broken.

Note on the K8s example includes: `release=page.release` wasn't referencing anything that exists in the example include, so it shouldn't break anything.
