### PR TITLE
Make breadcrumbs sticky on api pages

### DIFF
--- a/app/_assets/javascripts/apps/APISpec.vue
+++ b/app/_assets/javascripts/apps/APISpec.vue
@@ -30,7 +30,7 @@
     <KSkeleton v-if="loading" type="spinner" class="mx-auto items-center justify-center min-h-52 flex"/>
 
     <div v-if="!loading" class="flex gap-10 w-full">
-      <aside class="sticky top-16 left-0 flex-col gap-3 flex-shrink-0 w-64 hidden md:flex h-screen">
+      <aside class="sticky top-24 left-0 flex-col gap-3 flex-shrink-0 w-64 hidden md:flex h-screen">
         <KSelect
           :items="versions"
           @selected="onVersionSelect"

--- a/app/_includes/breadcrumbs.html
+++ b/app/_includes/breadcrumbs.html
@@ -1,5 +1,5 @@
 {% if include.breadcrumbs %}
-<div class="flex gap-1 justify-start text-xs items-center xl:basis-3/4">
+<div class="flex gap-1 justify-start text-xs items-center xl:basis-3/4 {% if include.sticky %} md:sticky md:top-20 {% endif %}">
   <a class="text-terciary" href="/">Home</a>
   <span>/</span>
   {% for breadcrumb in include.breadcrumbs %}

--- a/app/_layouts/api/spec.html
+++ b/app/_layouts/api/spec.html
@@ -4,7 +4,7 @@ api_spec: true
 ---
 
 <div class="flex flex-col gap-3 py-12 w-full mx-auto">
-  {% include breadcrumbs.html breadcrumbs=page.breadcrumbs %}
+  {% include breadcrumbs.html breadcrumbs=page.breadcrumbs sticky=true %}
 
   <div id="api-spec"></div>
 


### PR DESCRIPTION
## Description

Fixes https://github.com/Kong/developer.konghq.com/issues/1583

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
- [ ] Add new pages to the product documentation index (if applicable)
