### PR TITLE
[Fix] Added limitations of Active Tracing to certain Gateway types

### DIFF
--- a/app/konnect-platform/active-tracing.md
+++ b/app/konnect-platform/active-tracing.md
@@ -70,7 +70,7 @@ Active tracing requires the following Data Plane version and environment variabl
 - Konnect Dedicated Cloud Gateways
 - Konnect Serverless Gateways
 > <br><br>
-> {{site.kic_product_name}} and {{site.event_gateway}} Gateways are not compatible with active tracing at this time.
+> Active tracing is not supported on {{site.kic_product_name}} and {{site.event_gateway}} Gateways at this time.
 
 ### Start a trace session
 

--- a/app/konnect-platform/active-tracing.md
+++ b/app/konnect-platform/active-tracing.md
@@ -63,13 +63,14 @@ Active tracing requires the following Data Plane version and environment variabl
   - `KONG_CLUSTER_RPC=on`
   - `KONG_ACTIVE_TRACING=on`
 
-    {:.info}
-    > **Note:**
-    > Active tracing is currently limited to
-    - Konnect Self-Managed Hybrid Gateways
-    - Konnect Dedicated Cloud Gateways
-    - Konnect Serverless Gateways
-    {{site.kic_product_name}} and Native Event Proxy Gateways are not supported at this time.
+{:.info}
+> **Note:**
+> Active tracing is currently limited to:
+- Konnect Self-Managed Hybrid Gateways
+- Konnect Dedicated Cloud Gateways
+- Konnect Serverless Gateways
+> <br><br>
+> {{site.kic_product_name}} and {{site.event_gateway}} Gateways are not supported at this time.
 
 ### Start a trace session
 

--- a/app/konnect-platform/active-tracing.md
+++ b/app/konnect-platform/active-tracing.md
@@ -63,6 +63,14 @@ Active tracing requires the following Data Plane version and environment variabl
   - `KONG_CLUSTER_RPC=on`
   - `KONG_ACTIVE_TRACING=on`
 
+> **Note:** Active tracing is currently limited to:
+>
+> - Konnect Self-Managed Hybrid Gateways
+> - Konnect Dedicated Cloud Gateways
+> - Konnect Serverless Gateways
+>
+> Kong Ingress Controller environments and Native Event Proxy Gateways are not supported at this time.
+
 ### Start a trace session
 
 1. Navigate to **Gateway Manager**.

--- a/app/konnect-platform/active-tracing.md
+++ b/app/konnect-platform/active-tracing.md
@@ -70,7 +70,7 @@ Active tracing requires the following Data Plane version and environment variabl
 - Konnect Dedicated Cloud Gateways
 - Konnect Serverless Gateways
 > <br><br>
-> {{site.kic_product_name}} and {{site.event_gateway}} Gateways are not supported at this time.
+> {{site.kic_product_name}} and {{site.event_gateway}} Gateways are not compatible with active tracing at this time.
 
 ### Start a trace session
 

--- a/app/konnect-platform/active-tracing.md
+++ b/app/konnect-platform/active-tracing.md
@@ -63,13 +63,13 @@ Active tracing requires the following Data Plane version and environment variabl
   - `KONG_CLUSTER_RPC=on`
   - `KONG_ACTIVE_TRACING=on`
 
-> **Note:** Active tracing is currently limited to:
->
-> - Konnect Self-Managed Hybrid Gateways
-> - Konnect Dedicated Cloud Gateways
-> - Konnect Serverless Gateways
->
-> Kong Ingress Controller environments and Native Event Proxy Gateways are not supported at this time.
+    {:.info}
+    > **Note:**
+    > Active tracing is currently limited to
+    - Konnect Self-Managed Hybrid Gateways
+    - Konnect Dedicated Cloud Gateways
+    - Konnect Serverless Gateways
+    Kong Ingress Controller environments and Native Event Proxy Gateways are not supported at this time.
 
 ### Start a trace session
 

--- a/app/konnect-platform/active-tracing.md
+++ b/app/konnect-platform/active-tracing.md
@@ -69,7 +69,7 @@ Active tracing requires the following Data Plane version and environment variabl
     - Konnect Self-Managed Hybrid Gateways
     - Konnect Dedicated Cloud Gateways
     - Konnect Serverless Gateways
-    Kong Ingress Controller environments and Native Event Proxy Gateways are not supported at this time.
+    {{site.kic_product_name}} and Native Event Proxy Gateways are not supported at this time.
 
 ### Start a trace session
 


### PR DESCRIPTION
## Description

Added notes around supporting Self-Managed, Dedicated, and Serverless Gateways only at the moment to avoid confusing customers who expect this to be available no matter what type of Gateway they deploy.

Relates to support case #00058009 and relevant [Slack thread](https://kongstrong.slack.com/archives/CDSTDSG9J/p1747930618868659).

## Preview Links