### PR TITLE
fix: Add missing regional IP address hostnames link as an FAQ

### DIFF
--- a/app/konnect-platform/network.md
+++ b/app/konnect-platform/network.md
@@ -72,6 +72,8 @@ faqs:
 
       Each Data Plane node maintains a persistent connection with the Control Plane and sends a heartbeat every 30 seconds. 
       If the Control Plane doesn't respond, the Data Plane node attempts to reconnect after a 5–10 second delay.
+  - q: What IP addresses are associated with {{site.konnect_short_name}} regional hostnames?
+    a: Visit [https://ip-addresses.origin.konghq.com/ip-addresses.json](https://ip-addresses.origin.konghq.com/ip-addresses.json) for the list of IPs associated to regional hostnames. You can also subscribe to [https://ip-addresses.origin.konghq.com/rss](https://ip-addresses.origin.konghq.com/rss) for updates.
 
 ---
 


### PR DESCRIPTION
## Description

From Slack: https://kongstrong.slack.com/archives/C03ARNUTR1N/p1747753819477109

Realized this was missing from the dev site and it the docs site link was coming up a bit in Slack, so I've added it to the dev site.

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
- [ ] Add new pages to the product documentation index (if applicable)
