### PR TITLE
Add missing redirect for knep get started

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -92,3 +92,8 @@
 ## Kubernetes
 
 /gateway/install/kubernetes/  /gateway/install/kubernetes/konnect/
+
+
+## Event gateway
+
+/knep/get-started/  /event-gateway/get-started/


### PR DESCRIPTION
## Description

The permalink was changed [here](https://github.com/Kong/developer.konghq.com/pull/1481/files#diff-2ae466d569c6e680e7448a3ed0815a4c8934deb80b55b69ff1d0a7bf019dd522R7) but we didn't add a redirect.
We'll need to a check for this.

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
- [ ] Add new pages to the product documentation index (if applicable)
