### PR TITLE
Fix: use public docker image for KNEP

### DIFF
--- a/app/_data/products/event-gateway.yml
+++ b/app/_data/products/event-gateway.yml
@@ -1,6 +1,7 @@
 name: Event Gateway
 
 releases:
-  - release: "0.0"
+  - release: "0.1"
+    version: "0.1.0-beta"
     name: "v0"
     latest: true

--- a/app/_includes/knep/docker-compose-start.md
+++ b/app/_includes/knep/docker-compose-start.md
@@ -50,7 +50,7 @@ services:
       retries: 5
 
   knep:
-    image: kong/kong-native-event-proxy:latest
+    image: kong/kong-native-event-proxy:{{ site.data.event-gateway_latest.version }}
     container_name: knep
     depends_on:
       - broker

--- a/app/_includes/knep/docker-compose-start.md
+++ b/app/_includes/knep/docker-compose-start.md
@@ -50,7 +50,7 @@ services:
       retries: 5
 
   knep:
-    image: kong/kong-native-event-proxy-dev:main
+    image: kong/kong-native-event-proxy:latest
     container_name: knep
     depends_on:
       - broker


### PR DESCRIPTION
Issue reported on Slack.

Variable is currently not working because jekyll doesn't seem to be parsing `event-gateway` correctly in 
`{{ site.data.event-gateway_latest.version }}`. 

These options work:
* `{{ site.data.products.event-gateway.releases[0].version }}`: super long and not sustainable, as the latest version won't be first in the array when we add the next one.
* Renaming `event-gateway.yaml` to `knep.yaml`: then `{{ site.data.knep_latest.version }}` works with no problem - but that's fairly invasive. Is that the only way to get the variable to work?
cc @fabianrbz 