### PR TITLE
Migrate declarative config doc

### DIFF
--- a/app/gateway/db-less-mode.md
+++ b/app/gateway/db-less-mode.md
@@ -29,6 +29,8 @@ related_resources:
     url: /gateway/hybrid-mode/
   - text: Traditional mode
     url: /gateway/traditional-mode/
+  - text: "CLI reference: kong config"
+    url: /gateway/cli/reference/#kong-config
 ---
 
 {{site.base_gateway}} can be run without a database using only in-memory storage for entities. 
@@ -107,10 +109,21 @@ curl -i -X GET http://localhost:8001
 
 This will return the entire {{site.base_gateway}} configuration. Verify that `database` is set to `off` in the response body.
 
+## Generate a declarative configuration file
+
+To get started using declarative configuration, you need a JSON or YAML file containing {{site.base_gateway}} entity definitions.
+
+The following command generates a file named `kong.yml` in the current directory containing configuration examples:
+
+```
+kong config init
+```
+
 ## Load the declarative configuration file
 
-There are two ways to load a declarative configuration file into {{site.base_gateway}}: using
-`kong.conf` or the using the [`/config` Admin API endpoint](/api/gateway/admin-ee/#/operations/post-config).
+There are two ways to load a declarative configuration file into {{site.base_gateway}}: 
+* At start-up, using `kong.conf`
+* At runtime, using the [`/config` Admin API endpoint](/api/gateway/admin-ee/#/operations/post-config)
 
 You can use the following `kong.conf` parameters to load the declarative config file:
 

--- a/tools/track-docs-changes/config/sources.yml
+++ b/tools/track-docs-changes/config/sources.yml
@@ -1165,6 +1165,7 @@ app/gateway/upgrade/backup-and-restore.md:
   - app/_src/gateway/upgrade/backup-and-restore.md
 app/gateway/db-less-mode.md:
   - app/_src/gateway/production/deployment-topologies/db-less-and-declarative-config.md
+  - app/_src/gateway/admin-api/declarative-configuration.md
 app/gateway/upgrade/blue-green.md:
   - app/_src/gateway/upgrade/blue-green.md
 app/gateway/upgrade/index.md:


### PR DESCRIPTION
## Description

Fixes #1510 

No need to update the redirects file on docs, the source page already links to the right place.

## Preview Links

https://deploy-preview-1645--kongdeveloper.netlify.app/gateway/db-less-mode/#generate-a-declarative-configuration-file

## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
- [x] Add new pages to the product documentation index (if applicable)
