### PR TITLE
Fix: Event Gateway example

### DIFF
--- a/app/_includes/knep/konnect-create-cp.md
+++ b/app/_includes/knep/konnect-create-cp.md
@@ -10,7 +10,7 @@ capture: KONNECT_CONTROL_PLANE_ID
 body:
     name: {% if include.name %}{{ include.name }}{% else %}My KNEP Control Plane{% endif %}
     cluster_type: "CLUSTER_TYPE_KAFKA_NATIVE_EVENT_PROXY"
-jq: "-r .id"
+jq: ".id"
 {% endkonnect_api_request %}
 
 <!--vale on-->


### PR DESCRIPTION
Issue reported on Slack: https://kongstrong.slack.com/archives/C089Z3BMC9Z/p1748454653692639?thread_ts=1748370876.490149&cid=C089Z3BMC9Z

Removing a duplicate `-r` that's getting treated as a string. The generated example already adds a `-r`: 