### PR TITLE
Align dropdowns to the title on plugin examples

### DIFF
--- a/app/_includes/components/plugin_config_example.html
+++ b/app/_includes/components/plugin_config_example.html
@@ -2,10 +2,12 @@
 {% assign targets = plugin_config_example.targets %}
 {% assign formats = plugin_config_example.formats %}
 
-<div id="{{ plugin_config_example.id }}" class="entity-example content">
-  <div class="flex justify-end">
-    <div class="flex gap-2 text-xs">
-      {% if targets.size > 0 %}
+<div class="flex flex-col gap-4 heading-section">
+  <div class="flex flex-col sm:flex-row gap-4 sm:items-center sm:justify-between">
+    <h2 id="set-up-the-plugin">Set up the plugin</h2>
+    <div class="flex w-full sm:w-fit sm:justify-end">
+      <div class="flex gap-2 text-xs">
+        {% if targets.size > 0 %}
         <div class="bg-secondary rounded-md flex justify-between py-2 px-4 w-full shadow-primary items-center">
           <label for="select-target-{{ plugin_config_example.id }}" class="sr-only">Select an entity</label>
           <select id="select-target-{{ plugin_config_example.id }}" class="select-target bg-secondary">
@@ -14,36 +16,40 @@
             {% endfor %}
           </select>
         </div>
-      {% endif %}
+        {% endif %}
 
-      {% if formats.size > 1 %}
-      <div class="bg-secondary rounded-md flex justify-between py-2 px-4 w-full shadow-primary items-center">
-        <label for="select-format-{{ plugin_config_example.id }}" class="sr-only">Select a format</label>
-        <select id="select-format-{{ plugin_config_example.id }}" class="select-format bg-secondary">
-          {% for format in formats %}
+        {% if formats.size > 1 %}
+        <div class="bg-secondary rounded-md flex justify-between py-2 px-4 w-full shadow-primary items-center">
+          <label for="select-format-{{ plugin_config_example.id }}" class="sr-only">Select a format</label>
+          <select id="select-format-{{ plugin_config_example.id }}" class="select-format bg-secondary">
+            {% for format in formats %}
             <option value="{{ format }}">{{ site.data.entity_examples.config.formats[format].label }}</option>
-          {% endfor %}
-        </select>
+            {% endfor %}
+          </select>
+        </div>
+        {% endif %}
       </div>
-      {% endif %}
     </div>
   </div>
 
-  {% if targets.size > 0 %}
+  <div id="{{ plugin_config_example.id }}" class="entity-example content">
+
+    {% if targets.size > 0 %}
     {% for entity_example in plugin_config_example.entity_examples %}
-     {% assign target = entity_example.target.key %}
+    {% assign target = entity_example.target.key %}
 
-     {% assign formatted_examples = entity_example.formatted_examples %}
-      <div tabindex="0" class="entity-example-target-panel hidden content" aria-labelledby="select-target-{{ entity_example.id }}" data-target="{{ target }}">
-
-        {% for formatted_example in formatted_examples %}
-          {% assign format = formatted_example.format %}
-          <div tabindex="0" class="entity-example-format-panel hidden content" aria-labelledby="select-format-{{ entity_example.id }}" data-format="{{ format }}">
-            {% capture markdown_template %}{% include {{ formatted_example.template_file }} presenter=formatted_example.presenter render_context=true %}{% endcapture %}
-            {{ markdown_template | markdownify }}
-          </div>
-        {% endfor %}
+    {% assign formatted_examples = entity_example.formatted_examples %}
+    <div tabindex="0" class="entity-example-target-panel hidden content" aria-labelledby="select-target-{{ entity_example.id }}" data-target="{{ target }}">
+      {% for formatted_example in formatted_examples %}
+      {% assign format = formatted_example.format %}
+      <div tabindex="0" class="entity-example-format-panel hidden content" aria-labelledby="select-format-{{ entity_example.id }}" data-format="{{ format }}">
+        {% capture markdown_template %}{% include {{ formatted_example.template_file }} presenter=formatted_example.presenter render_context=true %}{% endcapture %}
+        {{ markdown_template | markdownify }}
       </div>
+      {% endfor %}
+    </div>
     {% endfor %}
-  {% endif %}
+    {% endif %}
+  </div>
+
 </div>

--- a/app/_includes/plugins/example.md
+++ b/app/_includes/plugins/example.md
@@ -31,6 +31,4 @@
 
 {% endunless %}
 
-## Set up the plugin
-
 {% include components/plugin_config_example.html plugin_config_example=page.example %}

--- a/app/_plugins/hooks/sections/base.rb
+++ b/app/_plugins/hooks/sections/base.rb
@@ -32,6 +32,8 @@ module SectionWrapper
         doc.children.first.add_previous_sibling(content) if content && content.children.any?
 
         doc.css('h2').each do |h2|
+          next if h2.ancestors('.heading-section').any?
+
           title = h2.content
           slug = h2['id']
 
@@ -72,7 +74,7 @@ module SectionWrapper
     def move_sibling_content_into_wrapper(h2, wrapper)
       current_node = h2.next_element
 
-      while current_node && current_node.name != 'h2'
+      while current_node && current_node.name != 'h2' && !current_node.matches?('.heading-section')
         next_node = current_node.next_element
         wrapper.at_css('.content').add_child(current_node)
         current_node = next_node


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
- [ ] Add new pages to the product documentation index (if applicable)
