### PR TITLE
Invalid OAS specs

### DIFF
--- a/app/dev-portal/apis.md
+++ b/app/dev-portal/apis.md
@@ -36,13 +36,13 @@ As an API Producer, you [publish an OpenAPI specification](/dev-portal/publishin
 
 All API specification files are validated during upload, although invalid specifications are permitted. If specifications are invalid, features like generated documentation and search may be degraded.
 
-### Validation methodology
+{{site.konnect_short_name}} looks for the following during spec validation:
 
 * Specs must be valid JSON or YAML.
-* Should be valid according to [OpenAPI 2.x or 3.x spec](https://spec.openapis.org/).
+* Spec should be valid according to [OpenAPI 2.x or 3.x specs](https://spec.openapis.org/).
     * OAS validation is performed using [Spectral](https://github.com/stoplightio/spectral).
     * To replicate validation in your own CI/CD pipeline, run `spectral lint [spec.yaml] .spectral.yaml`, where `.spectral.yaml` contains, `extends: ["spectral:oas"]`.
-* Invalid specs are permitted, and `validation_messages` will capture validation issues encountered.
+* Invalid specs are permitted, and `validation_messages` captures any validation issues.
 
 ## Documentation
 

--- a/app/dev-portal/apis.md
+++ b/app/dev-portal/apis.md
@@ -34,7 +34,15 @@ As an API Producer, you [publish an OpenAPI specification](/dev-portal/publishin
 
 ## Validation
 
-All API specification files are validated during upload. Specs much be valid JSON or YAML, and must be valid according to [OpenAPI 3.x spec](https://spec.openapis.org/). This ensures accurate generation of spec documentation.
+All API specification files are validated during upload, although invalid specifications are permitted. If specifications are invalid, features like generated documentation and search may be degraded.
+
+### Validation methodology
+
+* Specs must be valid JSON or YAML.
+* Should be valid according to [OpenAPI 2.x or 3.x spec](https://spec.openapis.org/).
+    * OAS validation is performed using [Spectral](https://github.com/stoplightio/spectral).
+    * To replicate validation in your own CI/CD pipeline, run `spectral lint [spec.yaml] .spectral.yaml`, where `.spectral.yaml` contains, `extends: ["spectral:oas"]`.
+* Invalid specs are permitted, and `validation_messages` will capture validation issues encountered.
 
 ## Documentation
 


### PR DESCRIPTION
## Description
Invalid OAS specs are now permitted. Validation methodology is explained to assist users in resolving validation errors locally. Additionally, `validation_messages` are persisted to aid users in resolution. The validation status and messages are surfaced in the UX, but as most users are automating the API catalog, there is a DX-focus in docs.

Fixes #issue
TDX-5484 

## Preview Links

## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
- [ ] Add new pages to the product documentation index (if applicable)
