### PR TITLE
Fix plugin examples so that they rendere correctly when the dropdowns

### DIFF
--- a/app/_includes/components/plugin_config_example.html
+++ b/app/_includes/components/plugin_config_example.html
@@ -2,7 +2,7 @@
 {% assign targets = plugin_config_example.targets %}
 {% assign formats = plugin_config_example.formats %}
 
-<div class="flex flex-col gap-4 heading-section entity-example">
+<div class="flex flex-col gap-4 heading-section entity-example" id="{{ plugin_config_example.id }}">
   <div class="flex flex-col sm:flex-row gap-4 sm:items-center sm:justify-between">
     <h2 id="set-up-the-plugin">Set up the plugin</h2>
     <div class="flex w-full sm:w-fit sm:justify-end">
@@ -32,7 +32,7 @@
     </div>
   </div>
 
-  <div id="{{ plugin_config_example.id }}" class="entity-example content">
+  <div class="content">
 
     {% if targets.size > 0 %}
     {% for entity_example in plugin_config_example.entity_examples %}


### PR DESCRIPTION
change

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
- [ ] Add new pages to the product documentation index (if applicable)
