### PR TITLE
fix: sample bedrock guardrail request

### DIFF
--- a/app/_includes/plugins/ai-proxy/formats.md
+++ b/app/_includes/plugins/ai-proxy/formats.md
@@ -65,15 +65,11 @@ The Kong AI Proxy accepts the following inputs formats, standardized across all 
             "content": "What is the theory of relativity?"
         }
     ],
-    "extra_body":
-        {
-            "guardrailConfig":
-                {
-                    "guardrailIdentifier":"<guardrail_identifier>",
-                    "guardrailVersion":"1",
-                    "trace":"enabled"
-                }
-        }
+      "guardrailConfig": {
+              "guardrailIdentifier":"<guardrail_identifier>",
+              "guardrailVersion":"1",
+              "trace":"enabled"
+          }
 }
 ```
 


### PR DESCRIPTION
## Description

Deletes incorrect `extra_body` param from the Bedrock Guardrail sample request.

## Preview Links


## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
- [x] Add new pages to the product documentation index (if applicable)
