### PR TITLE
Custom plugins in konnect and external PDK links

### DIFF
--- a/app/_landing_pages/custom-plugins.yaml
+++ b/app/_landing_pages/custom-plugins.yaml
@@ -30,14 +30,13 @@ rows:
                     Plugins consist of modules interacting with the request/response objects or
                     streams via a PDK to implement arbitrary logic. With custom plugins, you can configure these modules to provide custom functionality to {{site.base_gateway}}.
 
-                    <!--* [Other language support](https://docs.konghq.com/gateway/latest/plugin-development/pluginserver/go/)-->
   - columns:
       - blocks:
           - type: card
             config:
               title: Get started with custom plugins
               description: |
-                Learn about custom plugin development by following a series of tutorials that walk you through all the steps to build a new custom plugin for {{site.base_gateway}}.
+                Learn about custom plugin development by following a series of tutorials that walk you through all the steps to build a new custom plugin for {{site.base_gateway}}
               icon: /assets/icons/KogoBlue.svg
               cta:
                 text: See tutorial
@@ -47,7 +46,7 @@ rows:
             config:
               title: Custom plugins reference
               description: |
-                Learn about how to develop custom plugins for {{site.base_gateway}}.
+                Learn about how to develop custom plugins for {{site.base_gateway}}
               icon: /assets/icons/plug.svg
               cta:
                 text: See reference
@@ -58,75 +57,107 @@ rows:
               title: Plugin Development Kit reference
               description: |
                 The Plugin Development Kit (PDK) is a set of Lua functions and variables
-                that can be used by plugins to implement their own logic.
+                that can be used by plugins to implement their own logic
               icon: /assets/icons/code.svg
               cta:
                 text: See reference
                 url: "/gateway/pdk/reference/"
+
+  - header:
+      type: h2
+      text: "Deploying custom plugins"
+    columns:
       - blocks:
           - type: card
             config:
               title: Custom plugin installation and distribution
               description: |
-                Learn about the different ways to deploy a custom plugin.
+                Learn about the different ways to deploy a custom plugin
               icon: /assets/icons/deployment.svg
               cta:
                 text: See reference
                 url: "/custom-plugins/installation-and-distribution/"
-  # - columns:
-  #    - blocks:
-  #        - type: structured_text
-  #          config:
-  #            header:
-  #              text: "Plugin Development Kits (PDKs)"
-  #            blocks:
-  #              - type: text
-  #                text:
-  #                  "PDKs are sets of functions that a plugin can use to facilitate interactions between plugins
-  #                  and the core (or other components) of Kong. Kong provides PDKs in the following languages:"
+      - blocks:
+          - type: card
+            config:
+              title: Custom plugins in Konnect hybrid mode
+              description: |
+                Learn how to deploy a custom plugin in {{site.konnect_short_name}} hybrid mode
+              icon: /assets/icons/serverless-gateway.svg
+              cta:
+                text: See reference
+                url: "/custom-plugins/konnect-hybrid-mode/"
+      - blocks:
+          - type: card
+            config:
+              title: Custom plugin streaming in Dedicated Cloud Gateways
+              description: |
+                Learn how to deploy a custom plugin on a Dedicated Cloud Gateway
+              icon: /assets/icons/dedicated-cloud-gateway.svg
+              cta:
+                text: See reference
+                url: "/dedicated-cloud-gateways/reference/#custom-plugins"
+          
+  - columns:
+     - blocks:
+         - type: structured_text
+           config:
+             header:
+               text: "Plugin Development Kits (PDKs)"
+             blocks:
+               - type: text
+                 text:
+                   "PDKs are sets of functions that a plugin can use to facilitate interactions between plugins
+                   and the core (or other components) of Kong. Kong provides PDKs in the following languages:"
 
-  # - columns:
-  #    - blocks:
-  #        - type: structured_text
-  #          config:
-  #            header:
-  #              text: "Lua"
-  #            blocks:
-  #              - type: text
-  #                text: "{{site.base_gateway}} provides a broad plugin development environment including an SDK, database abstractions, migrations"
-  #              - type: text
-  #                text: <a href="https://docs.konghq.com/gateway/latest/plugin-development/">Lua PDK &rarr;</a>
+  - columns:
+    - blocks:
+      - type: card
+        config:
+          title: Lua
+          description: |
+            {{site.base_gateway}} provides a broad plugin development environment including an SDK, database abstractions, migrations
+          ctas:
+            - text: Kong Lua PDK
+              url: "/gateway/pdk/reference/"
+            - text: Plugin template
+              url: https://github.com/Kong/kong-plugin
 
-  #    - blocks:
-  #        - type: structured_text
-  #          config:
-  #            header:
-  #              text: "Go"
-  #            blocks:
-  #              - type: text
-  #                text: "{{site.base_gateway}} supports the Go language with the Go PDK, a library that provides Go bindings for {{site.base_gateway}}"
-  #              - type: text
-  #                text: <a href="https://docs.konghq.com/gateway/latest/plugin-development/pluginserver/go/">Go PDK &rarr;</a>
-  #    - blocks:
-  #        - type: structured_text
-  #          config:
-  #            header:
-  #              text: "Python"
-  #            blocks:
-  #              - type: text
-  #                text: "{{site.base_gateway}} support for Python plugin development is provided by the [kong-python-pdk](https://github.com/Kong/kong-python-pdk) library."
-  #              - type: text
-  #                text: <a href="https://docs.konghq.com/gateway/latest/plugin-development/pluginserver/python/">Python PDK &rarr;</a>
-  #    - blocks:
-  #        - type: structured_text
-  #          config:
-  #            header:
-  #              text: "JavaScript"
-  #            blocks:
-  #              - type: text
-  #                text: "{{site.base_gateway}} support for the JavaScript language is provided by the [JavaScript PDK](https://github.com/Kong/kong-js-pdk)."
-  #              - type: text
-  #                text: <a href="https://docs.konghq.com/gateway/latest/plugin-development/pluginserver/javascript/">JavaScript PDK &rarr;</a>
+    - blocks:
+      - type: card
+        config:
+          title: Go
+          description: |
+            {{site.base_gateway}} supports the Go language with the Go PDK, a library that provides Go bindings for {{site.base_gateway}}
+          ctas:
+            - text: Kong Go PDK
+              url: https://pkg.go.dev/github.com/Kong/go-pdk
+            - text: Example plugins
+              url: https://github.com/Kong/go-pdk/tree/master/examples
+
+    - blocks:
+      - type: card
+        config:
+          title: Python
+          description: |
+            {{site.base_gateway}} support for Python plugin development is provided by the `kong-python-pdk` library
+          ctas:
+            - text: Kong Python PDK
+              url: https://github.com/Kong/kong-python-pdk
+            - text: Example plugins
+              url: https://github.com/Kong/kong-python-pdk/tree/master/examples
+
+    - blocks:
+      - type: card
+        config:
+          title: JavaScript
+          description: |
+            {{site.base_gateway}} support for the JavaScript language is provided by the JavaScript PDK
+          ctas:
+            - text: Kong JavaScript PDK
+              url: https://github.com/Kong/kong-js-pdk
+            - text: Example plugins
+              url: https://github.com/Kong/kong-js-pdk/tree/master/examples
 
   - columns:
       - blocks:

--- a/app/_landing_pages/custom-plugins.yaml
+++ b/app/_landing_pages/custom-plugins.yaml
@@ -83,7 +83,7 @@ rows:
               title: Custom plugins in Konnect hybrid mode
               description: |
                 Learn how to deploy a custom plugin in {{site.konnect_short_name}} hybrid mode
-              icon: /assets/icons/serverless-gateway.svg
+              icon: /assets/icons/KogoBlue.svg
               cta:
                 text: See reference
                 url: "/custom-plugins/konnect-hybrid-mode/"

--- a/app/custom-plugins/installation-and-distribution.md
+++ b/app/custom-plugins/installation-and-distribution.md
@@ -26,6 +26,10 @@ related_resources:
     url: /custom-plugins/
   - text: Custom plugins reference
     url: /custom-plugins/reference/
+  - text: Custom plugins in {{site.konnect_short_name}} hybrid mode
+    url: /custom-plugins/konnect-hybrid-mode/
+  - text: Custom plugins in Dedicated Cloud Gateways
+    url: /dedicated-cloud-gateways/reference/#custom-plugins
 ---
 
 Custom plugins for {{site.base_gateway}} consist of Lua source files that need to be in the file system of each of your {{site.base_gateway}} nodes. 
@@ -51,7 +55,7 @@ To package your plugin as a rock, run the following commands from within the plu
 
 2. Pack the installed rock:
    ```sh
-   luarocks pack {plugin-name} {version}
+   luarocks pack YOUR-PLUGIN-NAME PLUGIN-VERSION
    ```
    This creates a `.rock` file.
 
@@ -63,18 +67,29 @@ You can also include the `.rockspec` file if you do have LuaRocks on the target 
 
 The contents of this archive should look like this:
 ```
-tree {plugin-name}
-{plugin-name}
+tree your-plugin-name
+your-plugin-name
 ├── INSTALL.txt
 ├── README.md
 ├── kong
 │   └── plugins
-│       └── {plugin-name}
+│       └── your-plugin-name
 │           ├── handler.lua
 │           └── schema.lua
-└── {plugin-name}-{version}.rockspec
+└── name-version.rockspec
 ```
 {:.no-copy-code}
+
+## Upload plugin to a {{site.konnect_short_name}} Control Plane
+
+If you want to use a custom plugin in {{site.konnect_short_name}}, you have two options:
+
+* With Dedicated Cloud Gateways, you can [upload your entire plugin to {{site.konnect_short_name}}](/dedicated-cloud-gateways/reference/#custom-plugins).
+You only need to upload the plugin once, and {{site.konnect_short_name}} handles plugin distribution to all Data Planes in the same Control Plane.
+* In {{site.konnect_short_name}} Hybrid mode, you need to upload the plugin's `schema.lua` file to {{site.konnect_short_name}}, then manually install the plugin on each Data Plane.
+
+In either case, the plugin must meet specific requirements to be used in {{site.konnect_short_name}}. 
+Review [Custom plugins in {{site.konnect_short_name}}](/custom-plugins/konnect-hybrid-mode/) for more information.
 
 ## Install the plugin
 
@@ -89,7 +104,7 @@ The `.rock` file is a self contained package that can be installed locally or fr
 
 If the `luarocks` utility is installed in your system, you can install the rock in your LuaRocks tree:
 ```sh
-luarocks install {rock-filename}
+luarocks install YOUR-ROCK-FILENAME
 ```
 
 The filename can be a local name, or any of the supported methods, for example `http://myrepository.lan/rocks/my-plugin-0.1.0-1.all.rock`.
@@ -98,11 +113,11 @@ The filename can be a local name, or any of the supported methods, for example `
 
 If the `luarocks` utility is installed in your system, you can install the Lua sources in your LuaRocks tree:
 ```sh
-cd {plugin-name}
+cd YOUR-PLUGIN-NAME
 luarocks make
 ```
 
-This will install the Lua sources in `kong/plugins/{plugin-name}` in your system's LuaRocks tree, where all the {{site.base_gateway}} sources are already present.
+This will install the Lua sources in `kong/plugins/your-plugin-name` in your system's LuaRocks tree, where all the {{site.base_gateway}} sources are already present.
 
 ### Via a Dockerfile or docker run (install and load)
 
@@ -137,7 +152,7 @@ CMD ["kong", "docker-start"]
 
 You can also include the following in your `docker run` command:
 ```sh
--v "{custom_plugin_folder}:/tmp/custom_plugins/kong" 
+-v "./example-plugin-folder:/tmp/custom_plugins/kong" 
 -e "KONG_LUA_PACKAGE_PATH=/tmp/custom_plugins/?.lua;;"
 -e "KONG_PLUGINS=bundled,example-plugin"
 ```
@@ -150,13 +165,13 @@ You can do that with the [`lua_package_path`](/gateway/configuration/#lua-packag
 
 Those properties contain a semicolon-separated list of directories in which to search for Lua sources:
 ```
-lua_package_path = /{path-to-plugin-location}/?.lua;;
+lua_package_path = /path/?.lua;;
 ```
 
 In this example:
-* `/{path-to-plugin-location}` is the path to the directory containing the extracted archive. 
+* `/path/` is the path to the directory containing the extracted archive. 
   Replace it with the location of the `kong` directory from the archive.
-* `?` is a placeholder that will be replaced by `kong.plugins.{plugin-name}` when {{site.base_gateway}} tries to load your plugin. 
+* `?` is a placeholder that will be replaced by `kong.plugins.example-plugin-name` when {{site.base_gateway}} tries to load your plugin. 
   Do not change it.
 * `;;` a placeholder for the default Lua path. Do not change it.
 
@@ -169,7 +184,7 @@ lua_package_path = /usr/local/custom/?.lua;;
 
 If you want to install two or more custom plugins this way, you can set the variable to something like:
 ```
-lua_package_path = /path/to/plugin1/?.lua;/path/to/plugin2/?.lua;;
+lua_package_path = /plugin1/?.lua;/plugin2/?.lua;;
 ```
 
 In this example:
@@ -183,7 +198,7 @@ You can also set this property via its environment variable equivalent: `KONG_LU
 1. Add the custom plugin's name to the [`plugins`](/gateway/configuration/#plugins) list in your {{site.base_gateway}} configuration:
 
    ```
-   plugins = bundled,<plugin-name>
+   plugins = bundled,YOUR-PLUGIN-NAME
    ```
 
    If you are using two or more custom plugins, insert commas in between:
@@ -218,7 +233,7 @@ log_level = debug
 Then, you should see the following log for each plugin being loaded:
 
 ```
-[debug] Loading plugin {plugin-name}
+[debug] Loading plugin your-plugin-name
 ```
 {:.no-copy-code}
 

--- a/app/custom-plugins/konnect-hybrid-mode.md
+++ b/app/custom-plugins/konnect-hybrid-mode.md
@@ -184,12 +184,13 @@ For example, if your original plugin is named `delay`, you can name the new vers
 When you need to make plugin changes, we recommend updating the schema in {{site.konnect_short_name}} first, and then on the Data Plane nodes.
 
 This is especially important making a [breaking change to the schema](#what-does-a-non-breaking-change-to-a-plugin-schema-look-like), 
-as the the change will affect each Data Plane node as soon as the node receives its first payload. 
+as the change will affect each Data Plane node as soon as the node receives its first payload. 
 This will happen even if there are no changes in the Control Plane for existing or new plugins using the updated schema. 
 
 See the following table for a comparison of possible changes and upgrade paths, in the case of 
 a configuration parameter change in a custom plugin's schema:
 
+<!--vale off-->
 {% table %}
 columns:
   - title: Scenario
@@ -219,6 +220,7 @@ rows:
     opt_def: "CP/DP sync required"
     opt_non_def: "CP/DP sync required"
 {% endtable %}
+<!--vale on-->
 
 Based on your specific use case, you have to take one of the following paths:
 

--- a/app/custom-plugins/konnect-hybrid-mode.md
+++ b/app/custom-plugins/konnect-hybrid-mode.md
@@ -1,0 +1,279 @@
+---
+title: Custom plugins in {{site.konnect_short_name}} hybrid mode
+content_type: reference
+layout: reference
+
+breadcrumbs:
+  - /custom-plugins/
+
+products:
+    - gateway
+
+works_on:
+    - konnect
+    - on-prem
+
+description: Learn how to deploy a custom plugin in {{site.konnect_short_name}}.
+
+tags:
+  - custom-plugins
+  - gateway-manager
+
+min_version:
+  gateway: '3.4'
+
+related_resources:
+  - text: Custom plugins
+    url: /custom-plugins/
+  - text: Custom plugins reference
+    url: /custom-plugins/reference/
+  - text: Gateway Manager
+    url: /gateway-manager/
+
+faqs:
+  - q: What does a non-breaking change to a plugin schema look like?
+    a: |
+      A non-breaking change to a plugin schema fits the following criteria:
+        * No default values
+        * Parameter isn't marked as required
+
+      Adding a non-breaking schema change won't disrupt Data Plane payload validation. 
+      This means that even if new plugins are added or existing ones are updated, the Data Plane will 
+      stay in sync because null fields are gracefully handled and ignored.
+
+      Here's an example of a non-breaking change to a schema. This snippet adds a non-required 
+      `new_ttl` configuration parameter without a default value, and a response 
+      header that references an existing `typedef`:
+
+      ```lua
+      { 
+          new_ttl = {
+              type = "integer",
+              gt = 0,
+          }
+      },
+      { 
+          new_response_header = typedefs.header_name
+      },
+      ```
+
+      Similar to adding fields, when not-required fields are deleted, it doesn't break the Data Plane - even when a plugin is created or updated.
+  - q: How does the {{site.konnect_short_name}} platform read plugin configuration?
+    a: |
+      When a schema file is updated in {{site.konnect_short_name}}, the {{site.konnect_short_name}} 
+      platform doesn't trigger payload reconciliation automatically.
+
+      This means that if you **don't** make any configuration changes in the Control Plane, such as adding, 
+      modifying, or deleting a {{site.base_gateway}} entity, the Data Plane nodes won't receive a
+      payload update, and won't use the updated schema.
+
+      When pushing changes to the Control Plane, the payload reconciliation only affects 
+      Data Plane nodes if an instance of the plugin that uses the updated schema has its 
+      configuration changed.
+
+      Since plugin configurations are stored as JSON blobs, a schema change alone doesn't impact the 
+      plugin configuration. However, if an instance of this plugin is also updated, the new schema affects how 
+      any new plugin configuration is represented.
+
+      In summary:
+      * Uploading a custom plugin schema adds a new configurable object to the {{site.konnect_short_name}} Plugin Hub, 
+      both as a tile in the UI, and an API endpoint.
+      * Modifying the schema itself does not trigger payload updates to Data Plane nodes.
+      * The new tile or endpoint added by the schema lets you create plugin configurations.
+      If you create a plugin configuration in this way, it triggers a payload reconciliation with the Data Plane nodes.
+
+---
+
+You can add custom plugins to the Gateway Manager by uploading a Lua schema file to a Control Plane.
+
+Using that schema, Gateway Manager creates a plugin configuration object in {{site.konnect_short_name}},
+making the plugin available for configuration alongside all the Kong bundled plugins. 
+This means that {{site.konnect_short_name}} only sees a custom plugin's configuration options, and doesn't see any other plugin code.
+
+{:.info}
+> **Note**: For adding custom plugins to a Dedicated Cloud Gateway, see 
+[Custom plugins in Dedicated Cloud Gateways](/dedicated-cloud-gateways/reference/#custom-plugins).
+
+## Requirements
+
+To run in {{site.konnect_short_name}}, a custom plugin must meet the following requirements:
+
+**General requirements:**
+* Each custom plugin must have a unique name.
+* All plugin files must also be deployed to **each** {{site.base_gateway}} Data Plane node.
+
+**File structure requirements:**
+* The plugin must not contain an `api.lua` file, as Admin API extensions are not supported. 
+* The plugin must not contain the `dao.lua` or `migrations.lua` files, as custom data entities are not supported.
+
+**Code and language requirements:** 
+* The schema for your custom plugin must be written in Lua.
+* Custom validation functions must be written in Lua and be self-contained within the `schema.lua` file.
+* The `schema.lua` file must not contain any `require()` statements.
+* Plugins that require third-party libraries must reference them in the `handler.lua` file.
+
+{:.warning}
+> **Caution**: Carefully test the operation of any custom plugins before using them in production. 
+Kong is not responsible for the operation or support of any custom plugins, 
+including any performance impacts on your {{site.konnect_short_name}} or {{site.base_gateway}} deployments. 
+
+## Deploying a custom plugin
+
+To deploy a custom plugin in Hybrid mode, you need to separately deploy the plugin on the Control Plane and the Data Plane nodes.
+
+### Add a custom plugin to a Control Plane
+
+{{site.konnect_short_name}} only requires the custom plugin's `schema.lua` file. 
+Using that file, it creates a plugin entry in the plugin catalog for your Control Plane.
+
+Upload the `schema.lua` file for your plugin using the [`/plugin-schemas`](/api/konnect/control-planes-config/#/operations/create-plugin-schemas) endpoint:
+
+```sh
+curl -i -X POST \
+  https://us.api.konghq.com/v2/control-planes/CONTROL_PLANE_ID/core-entities/plugin-schemas \
+  --header 'Content-Type: application/json' \
+  --data "{\"lua_schema\": your escaped Lua schema}"
+```
+
+You can also use [jq](https://jqlang.org/) to pass your schema directly from the file instead of manually escaping it:
+```sh
+--data "{\"lua_schema\": $(jq -Rs './schema.lua')}"
+```
+
+Check that your schema was uploaded using the following request:
+
+```sh
+curl -i -X GET \
+  https://us.api.konghq.com/v2/control-planes/CONTROL_PLANE_ID/core-entities/plugin-schemas/your-plugin
+```
+
+If successful, the request returns an `HTTP 200` response with the schema for your plugin as a JSON object.
+
+### Upload files to Data Plane nodes
+
+After uploading a schema to {{site.konnect_short_name}}, upload the `schema.lua` and `handler.lua` for your plugin to **each** {{site.base_gateway}} Data Plane node.
+
+Follow the {{site.base_gateway}} [plugin deployment and installation instructions](/custom-plugins/installation-and-distribution/#install-the-plugin) 
+to get your plugin set up on each node.
+
+## Updating a custom plugin in {{site.konnect_short_name}} hybrid mode
+
+The workflow for updating an in-use custom plugin depends on whether you need to update the schema:
+
+* **No change to plugin schema:** Editing a custom plugin's logic **without** altering its schema won't 
+cause the Control Plane to go out of sync with its Data Planes. 
+
+  In this situation, you only need to make sure that each Data Plane node has the correct logic. 
+  The schema on the Control Plane doesn't need to be updated.
+
+* **Changes to plugin schema:** If there are changes required in the plugin schema, 
+you must update both the schema in {{site.konnect_short_name}} and the plugin code itself on each Data Plane node. 
+In this case, see the [custom plugin update paths](#custom-plugin-update-path) for possible scenarios and recommended paths.
+
+* **Deleting a plugin and its schema**: If you need to completely remove the plugin from your
+Control Plane, you must remove all existing plugin configurations of this entity, then remove 
+the schema from the Control Plane and all plugin files from the Data Plane nodes.
+
+There is no built-in versioning for custom plugins. 
+If you need to version a schema (that is, maintain two or more similar copies of a custom plugin), 
+upload it as a new custom plugin and add a version identifier to the name.
+For example, if your original plugin is named `delay`, you can name the new version `delay-v2`.
+
+### Custom plugin update paths
+
+When you need to make plugin changes, we recommend updating the schema in {{site.konnect_short_name}} first, and then on the Data Plane nodes.
+
+This is especially important making a [breaking change to the schema](#what-does-a-non-breaking-change-to-a-plugin-schema-look-like), 
+as the the change will affect each Data Plane node as soon as the node receives its first payload. 
+This will happen even if there are no changes in the Control Plane for existing or new plugins using the updated schema. 
+
+See the following table for a comparison of possible changes and upgrade paths, in the case of 
+a configuration parameter change in a custom plugin's schema:
+
+{% table %}
+columns:
+  - title: Scenario
+    key: scenario
+  - title: Change to required default
+    key: req_def
+  - title: Change to required non-default
+    key: req_non_def
+  - title: Change to optional default
+    key: opt_def
+  - title: Change to optional non-default
+    key: opt_non_def
+rows:
+  - scenario: Configuration parameter added to schema
+    req_def: Short
+    req_non_def: Long
+    opt_def: Short
+    opt_non_def: Short
+  - scenario: Configuration parameter removed from schema
+    req_def: Long
+    req_non_def: "CP/DP sync required"
+    opt_def: Long
+    opt_non_def: Long
+  - scenario: Configuration parameter's datatype changed
+    req_def: "CP/DP sync required"
+    req_non_def: "CP/DP sync required"
+    opt_def: "CP/DP sync required"
+    opt_non_def: "CP/DP sync required"
+{% endtable %}
+
+Based on your specific use case, you have to take one of the following paths:
+
+{% navtabs "paths" %}
+{% navtab "Short" %}
+
+1. Start a migration/maintenance window.
+1. Update the plugin schema in {{site.konnect_short_name}}.  
+1. Update the plugin schema on each Data Plane node.
+1. Stop the migration/maintenance window.
+
+{% endnavtab %}
+{% navtab "Long" %}
+
+1. Start a migration/maintenance window.
+1. Update the plugin schema in {{site.konnect_short_name}}.  
+1. Update the configuration for existing plugin instances.
+1. Update the plugin schema on each Data Plane node.
+1. Stop the migration/maintenance window.
+
+{% endnavtab %}
+{% navtab "CP/DP sync required" %}
+
+1. Start a migration/maintenance window.
+1. Update the plugin schema in {{site.konnect_short_name}}.  
+1. (Optional) Update the configuration for existing plugin instances.
+
+    Based on the nature of the schema updates, you might need this optional step 
+    after updating the schema in {{site.konnect_short_name}} to make sure that any
+    existing plugin entities are updated before the schemas are 
+    changed in the Data Plane nodes.
+
+1. Update the plugin schema on each Data Plane node.
+1. Stop the migration/maintenance window.
+
+{% endnavtab %}
+{% endnavtabs %}
+
+## Troubleshooting custom plugins in {{site.konnect_short_name}}
+
+Common issues that you might encounter when working with custom plugins in {{site.konnect_short_name}}.
+
+### Required field missing
+
+**Issue:** You may see the error `unable to update running config: bad config received from Control Plane` with `required field missing`:
+
+```sh
+[lua] data_plane.lua:244: [clustering] unable to update running config: bad config received from Control Plane in 'plugins':
+  - in entry 1 of 'plugins':
+    in 'config':
+      in 'ttl': required field missing, context: ngx.timer
+```
+{:.no-copy-code}
+
+This means that a required field was removed from the schema on the Control Plane, but the schema on the Data Plane wasn't updated.
+The Control Plane triggered a payload update and attempted to update the Data Plane, but ran into conflicts.
+
+**Solution:** Make sure the Data Plane has an up-to-date schema.

--- a/app/custom-plugins/konnect-hybrid-mode.md
+++ b/app/custom-plugins/konnect-hybrid-mode.md
@@ -147,7 +147,7 @@ curl -i -X GET \
   https://us.api.konghq.com/v2/control-planes/CONTROL_PLANE_ID/core-entities/plugin-schemas/your-plugin
 ```
 
-If successful, the request returns an `HTTP 200` response with the schema for your plugin as a JSON object.
+If it's successful, the request returns an `HTTP 200` response with the schema for your plugin as a JSON object.
 
 ### Upload files to Data Plane nodes
 

--- a/app/custom-plugins/reference.md
+++ b/app/custom-plugins/reference.md
@@ -44,7 +44,7 @@ related_resources:
 
 Kong allows you to develop and deploy custom plugins.
 
-Before building custom plugins, it's' important to understand how {{site.base_gateway}} 
+Before building custom plugins, it's important to understand how {{site.base_gateway}} 
 is built, how it integrates with Nginx, and how the high performance [Lua](https://www.lua.org/about.html) 
 language is used.
 
@@ -89,7 +89,7 @@ plugins = my-custom-plugin
 
 Now, {{site.base_gateway}} will try to load several Lua modules from the following namespace:
 ```
-kong.plugins.my-custom-plugin.<module_name>
+kong.plugins.my-custom-plugin.your_module_name
 ```
 {:.no-copy-code}
 

--- a/tools/track-docs-changes/config/sources.yml
+++ b/tools/track-docs-changes/config/sources.yml
@@ -1230,6 +1230,10 @@ app/custom-plugins/schema.lua.md:
   - app/_src/gateway/plugin-development/configuration.md
 app/custom-plugins/testing.md:
   - app/_src/gateway/plugin-development/tests.md
+app/custom-plugins/konnect-hybrid-mode.md:
+  - app/konnect/gateway-manager/plugins/add-custom-plugin.md
+  - app/konnect/gateway-manager/plugins/update-custom-plugin.md
+  - app/konnect/gateway-manager/plugins/index.md
 
 # policies
 app/gateway/vulnerabilities.md:
@@ -2264,6 +2268,9 @@ app/_landing_pages/advanced-analytics.yaml:
   - app/konnect/analytics/index.md
 app/_landing_pages/custom-plugins.yaml:
   - app/_src/gateway/kong-plugins/index.md
+  - app/_src/gateway/plugin-development/pluginserver/go.md
+  - app/_src/gateway/plugin-development/pluginserver/python.md
+  - app/_src/gateway/plugin-development/pluginserver/javascript.md
 app/_landing_pages/gateway/openid-connect.yaml:
   - app/_hub/kong-inc/openid-connect/overview/_index.md
 app/_landing_pages/konnect-api.yaml:


### PR DESCRIPTION
## Description

Fixes #1635 
Fixes #1631 

Future improvement: We might want a how-to uploading a custom plugin to konnect > adding it to a data plane > applying the plugin.

For the external PDKs, I only added links to the PDK docs/repos and to their plugin examples/templates. 

Should we/do we want to maintain full references for these PDKs on the dev site? For instance, should this page go to the dev site: https://docs.konghq.com/gateway/latest/plugin-development/pluginserver/go/ - or should it live in its own PDK doc?

## Preview Links

https://deploy-preview-1705--kongdeveloper.netlify.app/custom-plugins/
https://deploy-preview-1705--kongdeveloper.netlify.app/custom-plugins/konnect-hybrid-mode/

## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
- [x] Add new pages to the product documentation index (if applicable)
