### PR TITLE
Migrate brotli doc

### DIFF
--- a/app/gateway/performance/optimize.md
+++ b/app/gateway/performance/optimize.md
@@ -230,6 +230,27 @@ Disable access logs for high throughput benchmarking tests by setting the `proxy
 **Explanation:** Check {{site.base_gateway}}’s error log for internal errors. 
 Internal errors can highlight issues within {{site.base_gateway}} or a third-party system that {{site.base_gateway}} relies on to proxy traffic.
 
+## Enable Brotli compression to decrease payload size
+
+**Action**: Enable Brotli compression at a 4 or 5 compression level.
+
+Set the following parameters in `kong.conf` to enable Brotli compression:
+
+```
+nginx_proxy_brotli = "on"
+nginx_proxy_brotli_comp_level = 5
+nginx_proxy_brotli_types = "text/plain text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript text/x-js"
+```
+
+**Explanation**: [Brotli](https://github.com/google/brotli) is a compression algorithm for high-performance websites. 
+{{site.base_gateway}} supports the [`ngx_brotli`](https://github.com/google/ngx_brotli) module through its [Nginx directives injection mechanism](/gateway/nginx-directives/). 
+It's designed to be better at compression than other commonly used algorithms such as gzip and deflate.
+You can use it to speed up your applications, improve page speed, reduce data transmitted, and improve the overall performance of {{site.base_gateway}}.
+
+The `nginx_proxy_brotli*` parameters are [injected Nginx directives](/gateway/configuration/#nginx-injected-directives-section) that you can manage through `kong.conf`.
+We recommend setting a compression level (`nginx_proxy_brotli_comp_level`) of 4 or 5 as a balanced option, 
+as it still provides a smaller payload than the highest gzip compression level [without compromising processing time](https://paulcalvano.com/2018-07-25-brotli-compression-how-much-will-it-reduce-your-content/).
+
 ## Sample kong.conf for benchmarking
 
 The following `kong.conf` file examples contain all the recommended parameters from the previous sections:

--- a/tools/track-docs-changes/config/sources.yml
+++ b/tools/track-docs-changes/config/sources.yml
@@ -1118,6 +1118,7 @@ app/gateway/performance/establish-a-benchmark.md:
   - app/_src/gateway/production/performance/benchmark.md
 app/gateway/performance/optimize.md:
   - app/_src/gateway/production/performance/benchmark.md
+  - app/_src/gateway/production/performance/brotli.md
 app/ai-gateway/ai-audit-log-reference.md:
   - app/_src/gateway/production/logging/ai-analytics.md
 app/gateway/kong-manager/configuration.md:


### PR DESCRIPTION
## Description

Migrate https://docs.konghq.com/gateway/latest/production/performance/brotli/. Missed this page in the overall performance doc migration.

## Preview Links


## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
- [x] Add new pages to the product documentation index (if applicable)
