### PR TITLE
Release: Gateway OSS 3.9.1

### DIFF
--- a/app/_data/products/gateway.yml
+++ b/app/_data/products/gateway.yml
@@ -540,7 +540,7 @@ releases:
               - Confluent Cloud
   - release: "3.9"
     ee-version: "3.9.1.1"
-    ce-version: "3.9.0"
+    ce-version: "3.9.1"
     eol: Dec 2025
     distributions:
       - amazonlinux2:

--- a/app/_how-tos/kic-install.md
+++ b/app/_how-tos/kic-install.md
@@ -97,7 +97,7 @@ Content-Type: application/json; charset=utf-8
 Connection: keep-alive
 Content-Length: 48
 X-Kong-Response-Latency: 0
-Server: kong/3.9.0
+Server: kong/{{site.latest_gateway_oss_version}}
 
 {"message":"no Route matched with those values"}
 ```

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -159,4 +159,4 @@ mesh:
     - '\[.*\]\(https:\/\/github\.com\/[kK]ong\/kong-mesh.*\)'
 
 # Version vars
-latest_gateway_oss_version: "3.9"
+latest_gateway_oss_version: "3.9.1"


### PR DESCRIPTION
## Description

Bump gateway version for release that came out today: https://github.com/Kong/kong/releases/tag/3.9.1


