### PR TITLE
Fix: URL mistake in Gitlab URL

### DIFF
--- a/app/service-catalog/integrations/gitlab.md
+++ b/app/service-catalog/integrations/gitlab.md
@@ -40,7 +40,7 @@ For each linked project, the UI can show a **Project Summary** with simple data 
 {% navtab "Self-Managed" %}
 To use the GitLab integration in a self-hosted environment:
 
-1. [Create a group-owned application](https://docs.gitlab.com/integration/oauth_provider/) in your GitLab instance. This is required to enable OAuth access for your organization.
+1. [Create a group-owned application](https://docs.gitlab.com/integrations/oauth_provider/) in your GitLab instance. This is required to enable OAuth access for your organization.
    * Set the redirect URI in GitLab to `https://cloud.konghq.com/$KONNECT_REGION/service-catalog/integration/gitlab`
    * Make sure the application has the `api` scope.
 1. In the {{site.konnect_short_name}} UI, navigate to the [GitLab integration](https://cloud.konghq.com/service-catalog/integrations/gitlab/configuration)


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
- [ ] Add new pages to the product documentation index (if applicable)
