### PR TITLE
Fix Operator validation

### DIFF
--- a/app/_includes/how-tos/validations/custom-command/snippet.md
+++ b/app/_includes/how-tos/validations/custom-command/snippet.md
@@ -25,8 +25,8 @@ Check the return code of the command{% if expected.return_code == 0 %} to make s
 
 {% if expected.return_code %}
 ```bash
-if [[ ! $? -neq {{ expected.return_code }} ]]; then
-echo "Did not receive the expected return code"
+if [[ $? -ne {{ expected.return_code }} ]]; then
+  echo "Did not receive the expected return code"
 fi
 ```
 {% endif %}


### PR DESCRIPTION
```
if [[ ! $? -neq {{ expected.return_code }} ]]; then
echo "Did not receive the expected return code"
fi
```
-> 

```
if [[ $? -ne {{ expected.return_code }} ]]; then
  echo "Did not receive the expected return code"
fi
```

