### PR TITLE
fix: Konnect DP creation with env var

### DIFF
--- a/app/_how-tos/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity.md
+++ b/app/_how-tos/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity.md
@@ -39,6 +39,10 @@ prereqs:
     - name: AWS_ACCESS_KEY_ID
     - name: AWS_SECRET_ACCESS_KEY
     - name: AWS_SESSION_TOKEN
+  konnect:
+    - name: AWS_ACCESS_KEY_ID
+    - name: AWS_SECRET_ACCESS_KEY
+    - name: AWS_SESSION_TOKEN
   cloud:
     aws:
       secret: true

--- a/app/_how-tos/configure-azure-key-vaults-as-a-vault-backend-with-vault-entity.md
+++ b/app/_how-tos/configure-azure-key-vaults-as-a-vault-backend-with-vault-entity.md
@@ -28,6 +28,7 @@ tags:
   - azure
 search_aliases:
   - key vault
+  - Azure
 
 tldr:
     q: How can I access Azure Key Vaults secrets in {{site.base_gateway}}?
@@ -42,6 +43,8 @@ faqs:
     a: You can only reference secrets. Azure Key Vaults keys and certificates are not supported.
 prereqs:
   gateway:
+    - name: AZURE_CLIENT_SECRET
+  konnect:
     - name: AZURE_CLIENT_SECRET
   cloud:
     azure:

--- a/app/_how-tos/configure-google-cloud-secret-as-a-vault-backend.md
+++ b/app/_how-tos/configure-google-cloud-secret-as-a-vault-backend.md
@@ -43,6 +43,9 @@ prereqs:
   gateway:
     - name: GCP_SERVICE_ACCOUNT
     - name: KONG_LUA_SSL_TRUSTED_CERTIFICATE
+  konnect:
+    - name: GCP_SERVICE_ACCOUNT
+    - name: KONG_LUA_SSL_TRUSTED_CERTIFICATE
   cloud:
     gcp:
       secret: true

--- a/app/_how-tos/rotate-secrets-in-google-cloud-secret.md
+++ b/app/_how-tos/rotate-secrets-in-google-cloud-secret.md
@@ -55,6 +55,8 @@ prereqs:
         - example-route
   gateway:
     - name: GCP_SERVICE_ACCOUNT
+  konnect:
+    - name: GCP_SERVICE_ACCOUNT
   inline:
     - title: Google Cloud Secret Manager
       position: before
@@ -85,7 +87,7 @@ prereqs:
           Set the environment variables needed to authenticate to Google Cloud:
           ```sh
           export GCP_SERVICE_ACCOUNT=$(cat /path/to/file/service-account.json)
-          export MISTRAL_API_KEY="Bearer <Mistral-API-key>"
+          export MISTRAL_API_KEY="Bearer YOUR-MISTRAL-API-KEY"
           ```
 
           Note that the `GCP_SERVICE_ACCOUNT` variables **must** be passed when creating your data plane container.

--- a/app/_how-tos/set-up-dynatrace-with-otel.md
+++ b/app/_how-tos/set-up-dynatrace-with-otel.md
@@ -46,24 +46,18 @@ prereqs:
   gateway:
     - name: KONG_TRACING_INSTRUMENTATIONS
     - name: KONG_TRACING_SAMPLING_RATE
+  konnect:
+    - name: KONG_TRACING_INSTRUMENTATIONS
+    - name: KONG_TRACING_SAMPLING_RATE
   inline:
   - title: Tracing environment variables
     position: before
     content: |
       Set the following Dynatrace tracing variables before you configure the Data Plane:
-      {: data-deployment-topology="on-prem" }
       ```sh
       export KONG_TRACING_INSTRUMENTATIONS=all
       export KONG_TRACING_SAMPLING_RATE=1.0
       ```
-      {: data-deployment-topology="on-prem" }
-      When you create the Data Plane in {{site.konnect_short_name}}, add the following {{site.base_gateway}} configuration variables for Dynatrace tracing:
-      {: data-deployment-topology="konnect" }
-      ```sh
-      -e "KONG_TRACING_INSTRUMENTATIONS=all" \
-      -e "KONG_TRACING_SAMPLING_RATE=1.0" \
-      ```
-      {: data-deployment-topology="konnect" }
   - title: Dynatrace
     content: |
       This tutorial requires you to have a [Dynatrace](https://www.dynatrace.com/) SaaS account.
@@ -73,8 +67,8 @@ prereqs:
 
       Export those values as environment variables:
       ```sh
-      export DECK_DYNATRACE_ENVIRONMENT_ID=<environment-id-here>
-      export DECK_DYNATRACE_API_TOKEN=<token-here>
+      export DECK_DYNATRACE_ENVIRONMENT_ID='ENVIRONMENT-ID-HERE'
+      export DECK_DYNATRACE_API_TOKEN='TOKEN-HERE'
       ```
     icon_url: /assets/icons/third-party/dynatrace.png
 

--- a/app/_how-tos/set-up-jaeger-with-otel.md
+++ b/app/_how-tos/set-up-jaeger-with-otel.md
@@ -40,24 +40,18 @@ prereqs:
   gateway:
     - name: KONG_TRACING_INSTRUMENTATIONS
     - name: KONG_TRACING_SAMPLING_RATE
+  konnect:
+    - name: KONG_TRACING_INSTRUMENTATIONS
+    - name: KONG_TRACING_SAMPLING_RATE
   inline:
   - title: Tracing environment variables
     position: before
     content: |
       Set the following Jaeger tracing variables before you configure the Data Plane:
-      {: data-deployment-topology="on-prem" }
       ```sh
       export KONG_TRACING_INSTRUMENTATIONS=all
       export KONG_TRACING_SAMPLING_RATE=1.0
       ```
-      {: data-deployment-topology="on-prem" }
-      When you create the Data Plane in {{site.konnect_short_name}}, add the following {{site.base_gateway}} configuration variables for Jaeger tracing:
-      {: data-deployment-topology="konnect" }
-      ```sh
-      -e "KONG_TRACING_INSTRUMENTATIONS=all" \
-      -e "KONG_TRACING_SAMPLING_RATE=1.0" \
-      ```
-      {: data-deployment-topology="konnect" }
   - title: Jaeger
     content: |
       This tutorial requires you to install [Jaeger](https://www.jaegertracing.io/docs/2.5/getting-started/).

--- a/app/_includes/components/prereqs.html
+++ b/app/_includes/components/prereqs.html
@@ -63,7 +63,8 @@
       {% if page.products contains 'gateway' or page.products contains 'ai-gateway' %}
         {% if page.works_on contains 'konnect' %}
         <div class="flex flex-col gap-1.5 border-b border-primary/5 accordion-item last:border-b-0" data-deployment-topology="konnect" data-test-setup="konnect">
-          {% include prereqs/products/konnect.md tier=include.tier %}
+          {% assign variables=prereqs['konnect'] %}
+          {% include prereqs/products/konnect.md tier=include.tier env_variables=variables %}
         </div>
         {% endif %}
         <div class="flex flex-col gap-1.5 border-b border-primary/5 accordion-item last:border-b-0" data-deployment-topology="on-prem" data-test-setup='{ "gateway": "{{page.min_version.gateway}}" }'>

--- a/app/_includes/prereqs/products/konnect.md
+++ b/app/_includes/prereqs/products/konnect.md
@@ -15,7 +15,7 @@ This is a Konnect tutorial and requires a Konnect personal access token.
 1. Run the [quickstart script](https://get.konghq.com/quickstart) to automatically provision a Control Plane and Data Plane, and configure your environment:
 
     ```bash
-    curl -Ls https://get.konghq.com/quickstart | bash -s -- -k $KONNECT_TOKEN --deck-output
+    curl -Ls https://get.konghq.com/quickstart | bash -s -- -k $KONNECT_TOKEN {% for variable in include.env_variables %} -e {{variable.name}}{% if variable.value %}={{variable.value}}{% endif %}{% endfor %} --deck-output
     ```
 
     This sets up a Konnect Control Plane named `quickstart`, provisions a local Data Plane, and prints out the following environment variable exports:


### PR DESCRIPTION
## Description

When we added the new DP creation method for Konnect, it broke how tos that required you to pass in en var to the data plane (or at least users could no longer copy/paste down the page). This adds support for passing the env var in when the DP is created for Konnect.

**Important for reviewers:** I retested all of these how tos with Konnect, except Azure since it's not published due to authentication problems. GCP env var are in 1Pass as well as the Mistral API key and Dynatrace. 

## Preview Links
- https://deploy-preview-1731--kongdeveloper.netlify.app/how-to/rotate-secrets-in-google-cloud-secret/
- https://deploy-preview-1731--kongdeveloper.netlify.app/how-to/configure-google-cloud-secret-as-a-vault-backend/
- https://deploy-preview-1731--kongdeveloper.netlify.app/how-to/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity/
- https://deploy-preview-1731--kongdeveloper.netlify.app/how-to/set-up-dynatrace-with-otel/
- https://deploy-preview-1731--kongdeveloper.netlify.app/how-to/set-up-jaeger-with-otel/


## Checklist 

- [x] Every page is page one.
- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
- [ ] Add new pages to the product documentation index (if applicable)
