### PR TITLE
fix: KIC proxy TCP SNI route name

### DIFF
--- a/app/_how-tos/kic-proxy-tcp-sni.md
+++ b/app/_how-tos/kic-proxy-tcp-sni.md
@@ -23,7 +23,7 @@ entities: []
 
 tldr:
   q: How do I route TCP traffic with {{ site.kic_product_name }}?
-  a: Create a `TCPRoute` resource, which will then be converted in to a [{{ site.base_gateway }} Service](/gateway/entities/service/) and [Route](/gateway/entities/route/). TLS passthrough is _not_ supported using `TCPIngress`.
+  a: Create a `TLSRoute` resource, which will then be converted in to a [{{ site.base_gateway }} Service](/gateway/entities/service/) and [Route](/gateway/entities/route/). TLS passthrough is _not_ supported using `TCPIngress`.
 
 prereqs:
   kubernetes:


### PR DESCRIPTION
## Description

Fixes incorrect route name in the Proxy TCP traffic over TLS by SNI guide

## Preview Links

https://deploy-preview-1741--kongdeveloper.netlify.app/kubernetes-ingress-controller/routing/tcp-by-sni/

## Checklist 

- [x] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
- [ ] Add new pages to the product documentation index (if applicable)
