### PR TITLE
fix: AI load balancing docs

### DIFF
--- a/app/_kong_plugins/ai-proxy-advanced/examples/consistent-hashing.yaml
+++ b/app/_kong_plugins/ai-proxy-advanced/examples/consistent-hashing.yaml
@@ -44,3 +44,6 @@ tools:
   - konnect-api
   - kic
   - terraform
+
+
+group: load-balancing

--- a/app/_kong_plugins/ai-proxy-advanced/examples/semantic.yaml
+++ b/app/_kong_plugins/ai-proxy-advanced/examples/semantic.yaml
@@ -39,7 +39,7 @@ config:
     algorithm: semantic
   targets:
   - model:
-      name: gpt-35-turbo
+      name: gpt-3.5-turbo
       provider: openai
       options:
         max_tokens: 826

--- a/app/ai-gateway/load-balancing.md
+++ b/app/ai-gateway/load-balancing.md
@@ -149,7 +149,10 @@ flowchart LR
 
 #### Retry and fallback configuration
 
-The AI Gateway load balancer offers several configuration options to fine-tune request retries, timeouts, and failover behavior:
+The AI Gateway load balancer supports fine-grained control over failover behavior. Use [`failover_criteria`](/plugins/ai-proxy-advanced/reference/#schema--config-balancer-failover-criteria) to define when a request should retry on the next upstream target. By default, retries occur on `error` and `timeout`. An `error` means a failure occurred while connecting to the server, forwarding the request, or reading the response header. A `timeout` indicates that any of those stages exceeded the allowed time.
+
+You can add more criteria to adjust retry behavior as needed:
+
 
 <!--vale off-->
 {% table %}


### PR DESCRIPTION
## Description

This PR fixes incorrect values in load balancing documentation for AI Proxy Advanced plugin and adds a refined description of the `failover_criteria` in the main load balancing reference document.

## Preview Links


## Checklist 

- [x] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter
- [x] Add new pages to the product documentation index (if applicable)
