### PR TITLE
fix: Add missing product tags to ai how-tos

### DIFF
--- a/app/_how-tos/set-up-ai-proxy-with-anthropic.md
+++ b/app/_how-tos/set-up-ai-proxy-with-anthropic.md
@@ -10,8 +10,8 @@ related_resources:
 description: Configure the AI Proxy plugin to create a chat route using Anthropic.
 
 products:
-    # - ai-gateway
     - gateway
+    - ai-gateway
 
 works_on:
     - on-prem
@@ -23,7 +23,7 @@ min_version:
 plugins:
   - ai-proxy
 
-entities: 
+entities:
   - service
   - route
   - plugin
@@ -63,7 +63,7 @@ cleanup:
 
 ## Configure the plugin
 
-To set up AI Proxy with Anthropic, we need to specify the [model](https://docs.anthropic.com/en/docs/about-claude/models#model-names) and [Anthropic API version](https://docs.anthropic.com/en/api/versioning#version-history) to use. 
+To set up AI Proxy with Anthropic, we need to specify the [model](https://docs.anthropic.com/en/docs/about-claude/models#model-names) and [Anthropic API version](https://docs.anthropic.com/en/api/versioning#version-history) to use.
 
 In this example, we'll use the Claude 2.1 model and version 2023-06-01 of the API:
 

--- a/app/_how-tos/transform-a-client-request-with-ai.md
+++ b/app/_how-tos/transform-a-client-request-with-ai.md
@@ -9,6 +9,7 @@ description: Use the AI Request Transformer plugin with OpenAI to transform a cl
 
 products:
     - gateway
+    - ai-gateway
 
 works_on:
     - on-prem
@@ -20,7 +21,7 @@ min_version:
 plugins:
   - ai-request-transformer
 
-entities: 
+entities:
   - service
   - route
   - plugin

--- a/app/_how-tos/transform-a-response-with-ai.md
+++ b/app/_how-tos/transform-a-response-with-ai.md
@@ -9,6 +9,7 @@ description: Use the AI Response Transformer plugin with OpenAI to transform a r
 
 products:
     - gateway
+    - ai-gateway
 
 works_on:
     - on-prem
@@ -20,7 +21,7 @@ min_version:
 plugins:
   - ai-response-transformer
 
-entities: 
+entities:
   - service
   - route
   - plugin


### PR DESCRIPTION
## Description

Add missing `product` values in several ho-tos for AI gateway.

## Preview Links


## Checklist 

- [] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
- [ ] Add new pages to the product documentation index (if applicable)
