### PR TITLE
If version plugin pages

### DIFF
--- a/app/_plugins/generators/plugins/pages/overview.rb
+++ b/app/_plugins/generators/plugins/pages/overview.rb
@@ -21,7 +21,11 @@ module Jekyll
         end
 
         def data
-          super.merge('overview?' => true, 'search_aliases' => @plugin.metadata['search_aliases'])
+          super.merge(
+            'overview?' => true,
+            'search_aliases' => @plugin.metadata['search_aliases'],
+            'release' => @plugin.latest_release_in_range
+          )
         end
 
         private

--- a/app/_plugins/generators/plugins/plugin.rb
+++ b/app/_plugins/generators/plugins/plugin.rb
@@ -133,7 +133,7 @@ module Jekyll
       end
 
       def max_version
-        @max_version ||= metadata.fetch('maxs_version', {})
+        @max_version ||= metadata.fetch('max_version', {})
       end
     end
   end

--- a/app/_plugins/tags/if_version.rb
+++ b/app/_plugins/tags/if_version.rb
@@ -87,6 +87,7 @@ module Jekyll
           return false unless versions.any? { |v| v == current_version }
         end
         if params.key? :gte
+          return true if ENV['RENDER_IF_VERSION_UNRELEASED'] && ENV['JEKYLL_ENV'] != 'production'
           # If there's a greater than or equal to check, fail if it's lower
           version = to_version(params[:gte])
           return false unless current_version >= version


### PR DESCRIPTION
## Description

Setting `RENDER_IF_VERSION_UNRELEASED=true` when running the docs makes `if_version` to 
render the content if the version hasn't been released (locally and preview-apps only)


## Preview Links


## Checklist 

- [ ] Every page is page one.
- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Updated [sources.yaml](https://github.com/Kong/developer.konghq.com/blob/main/tools/track-docs-changes/config/sources.yml). For more info, review [track docs changes](https://github.com/Kong/developer.konghq.com/tree/main/tools/track-docs-changes)
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). 
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter
- [ ] Add new pages to the product documentation index (if applicable)
