### PR TITLE
Update: Mark CombinedServicesFromDifferentHTTPRoutes as GA

### DIFF
--- a/app/kubernetes-ingress-controller/reference/feature-gates.md
+++ b/app/kubernetes-ingress-controller/reference/feature-gates.md
@@ -100,7 +100,7 @@ rows:
     until: TBD
   - feature: CombinedServicesFromDifferentHTTPRoutes
     default: '`false`'
-    stage: Alpha
+    stage: GA
     since: 3.4.0
     until: TBD
 {% endtable %}


### PR DESCRIPTION
## Description

Porting over changes from https://github.com/Kong/docs.konghq.com/pull/8858. No KIC release necessary.