### PR TITLE
fix typo

### DIFF
--- a/app/_kong_plugins/ai-prompt-template/index.md
+++ b/app/_kong_plugins/ai-prompt-template/index.md
@@ -74,7 +74,7 @@ When activated, the template restricts LLM usage to the predefined templates. Th
 When calling a template, replace the content of `messages` (`llm/v1/chat`) or `prompt` (`llm/v1/completions`) with a template reference, using the following format:
 ```json
 {
-  "message": "{template://sample-template}",
+  "messages": "{template://sample-template}",
   "properties": {
     "thing": "gravity"
   }


### PR DESCRIPTION
## Description

Issue reported on Slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1750700673513629

Checked old site, the example used `messages`: https://old-docs-preview--kongdocs.netlify.app/hub/kong-inc/ai-prompt-template/how-to/#examples

@tomek-labuk can you please double-check?

## Preview Links


## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [x] Add new pages to the product documentation index (if applicable).
