### PR TITLE
Add konnect-platform as product for konnect-api

### DIFF
--- a/app/_landing_pages/konnect-api.yaml
+++ b/app/_landing_pages/konnect-api.yaml
@@ -7,6 +7,7 @@ metadata:
     - dev-portal
     - mesh
     - advanced-analytics
+    - konnect-platform
   tools: 
     - konnect-api
   works_on:


### PR DESCRIPTION
Small edit from Slack report: https://kongstrong.slack.com/archives/CDSTDSG9J/p1750790797074599?thread_ts=1750714733.115429&cid=CDSTDSG9J

User expected to see this page marked as Konnect Platform and didn't click on it because they thought it wasn't what they were looking for.