### PR TITLE
Migrate org switcher info

### DIFF
--- a/app/konnect-platform/account.md
+++ b/app/konnect-platform/account.md
@@ -20,6 +20,7 @@ search_aliases:
   - billing
   - pricing
   - deactivate
+  - org switcher
 
 related_resources:
   - text: "{{site.base_gateway}} version support policy"
@@ -91,3 +92,37 @@ For any license questions, contact your sales representative.
 ## Geographic region management
 
 When you create a {{site.konnect_short_name}} account, you select a [geographic region](/konnect-platform/geos/) for your instance. Geos are distinct deployments of {{site.konnect_short_name}} with objects, such as services and consumers, that are geo-specific. Only authentication is shared between {{site.konnect_short_name}} geos.
+
+## Org switcher
+
+The org switcher allows a user with multiple {{site.konnect_short_name}} accounts to switch between their organizations. 
+You can navigate to the org switcher by clicking on **Your Org Name** > **View Organizations** in the {{site.konnect_short_name}} side menu.
+
+### Email matching
+
+The org switcher uses the email of the logged in user to locate all organizations where this email is attached to a {{site.konnect_short_name}} account. 
+
+To gain access to more organizations, you can:
+* Create a new organization: Newly created organizations will automatically show up in the org switcher.
+* Be invited to an organization: Organizations that the user is invited to will automatically show up in the org switcher.
+
+{:.warning}
+> **Note**: If you don't choose to "Link Accounts" when logging into {{site.konnect_short_name}} for the very first time on different social credentials, it's possible to end up with more than one org switcher identity. To avoid issues, we recommend linking accounts when using multiple social identities.
+> <br><br>
+> Organizations will only be associated with one primary account. It's **not** currently possible to re-link accounts.
+
+### Switch organizations
+
+Users can switch organizations while logged in by clicking on the **Org Name** > **View Organizations**, then selecting an org from the list.
+
+If the organization is configured to be single-sign-on (SSO) only, then the user will be directed to the configured identity provider to re-authenticate into {{site.konnect_short_name}}.
+
+{:.info}
+> **Note**: You can't be logged in to more than one {{site.konnect_short_name}} organization at the same time. 
+You must return to the org switcher to switch to another organization.
+
+### Delete organizations from org switcher
+
+To remove organizations from the org switcher, you can log in to that organization and navigate to 
+[**My Account**](https://cloud.konghq.com/global/account) > **Delete Account**. 
+This will delete the {{site.konnect_short_name}} account in that organization and remove the org from org switcher.


### PR DESCRIPTION
## Description

Missing info reported on slack. 
This was yet another page we didn't migrate because it doesn't need to exist on its own, but now there's no information about this feature anywhere on the site, which makes it look like it doesn't exist.

Merge redirect PR after this one: https://github.com/Kong/docs.konghq.com/pull/8872

## Preview Links
https://deploy-preview-1957--kongdeveloper.netlify.app/konnect-platform/account/#org-switcher

## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [x] Add new pages to the product documentation index (if applicable).
