### PR TITLE
Don't swallow content before steps in how-tos

### DIFF
--- a/app/_plugins/hooks/sections/how-to.rb
+++ b/app/_plugins/hooks/sections/how-to.rb
@@ -20,7 +20,7 @@ module SectionWrapper
     end
 
     def build_wrapper(section_title = '', topology = '')
-      topology = "data-deployment-topology=\"#{topology}\"" if topology
+      topology = "data-deployment-topology=\"#{topology}\"" if !topology.nil? && !topology.empty?
       wrapper = if section_title != ''
                   <<-HTML
           <div #{topology} class="flex flex-col gap-4 border-b border-primary/5 pb-8 accordion-item">


### PR DESCRIPTION
## Description

The problem was that the code was setting data-deployment-topology even if the topology was empty.

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
