### PR TITLE
Gateway kubernetes install

### DIFF
--- a/app/_assets/javascripts/how_to.js
+++ b/app/_assets/javascripts/how_to.js
@@ -80,11 +80,13 @@ class HowTo {
   }
 
   toggleTopology(topology) {
-    this.prerequisites
-      .querySelectorAll("[data-deployment-topology]")
-      .forEach((item) => {
-        this.toggleItem(item, topology);
-      });
+    if (this.prerequisites) {
+      this.prerequisites
+        .querySelectorAll("[data-deployment-topology]")
+        .forEach((item) => {
+          this.toggleItem(item, topology);
+        });
+    }
 
     document
       .querySelectorAll(
@@ -103,7 +105,10 @@ class HowTo {
     }
 
     const event = new Event("accordion:update", { bubbles: true });
-    this.prerequisites.dispatchEvent(event);
+
+    if (this.prerequisites) {
+      this.prerequisites.dispatchEvent(event);
+    }
 
     if (this.cleanup) {
       this.cleanup.dispatchEvent(event);

--- a/app/_assets/stylesheets/index.css
+++ b/app/_assets/stylesheets/index.css
@@ -882,3 +882,8 @@
 .select-popover.popover .popover-container {
   @apply border-none py-0 !important;
 }
+
+/* How-to lists */
+ol:has(code) {
+  @apply flex flex-col gap-4;
+}

--- a/app/_data/schemas/frontmatter/how_to.json
+++ b/app/_data/schemas/frontmatter/how_to.json
@@ -7,6 +7,7 @@
   ],
   "properties": {
     "tldr": {
+      "nullable": true,
       "type": "object",
       "properties": {
         "q": {

--- a/app/_data/series.yml
+++ b/app/_data/series.yml
@@ -13,3 +13,7 @@ operator-get-started-hybrid:
 operator-get-started-kic:
   title: Deploy {{ site.kic_product_name }} with {{ site.operator_product_name }}
   url: /operator/dataplanes/get-started/kic/install/
+gateway-k8s-on-prem-install:
+  title: Install {{ site.base_gateway }} on-prem on Kubernetes
+  breadcrumb_title: On-Prem Kubernetes
+  url: /gateway/install/kubernetes/on-prem/

--- a/app/_how-tos/gateway-install-helm-konnect.md
+++ b/app/_how-tos/gateway-install-helm-konnect.md
@@ -12,6 +12,7 @@ products:
 
 works_on:
   - konnect
+  - on-prem
 
 entities: []
 

--- a/app/_how-tos/gateway-install-helm-konnect.md
+++ b/app/_how-tos/gateway-install-helm-konnect.md
@@ -41,6 +41,8 @@ helm repo update
 
 ## Create certificates
 
+Create a certificate and key:
+
 ```bash
 openssl req -new -x509 -nodes -newkey ec:<(openssl ecparam -name secp384r1) -keyout ./tls.key -out ./tls.crt -days 1095 -subj "/CN=kong_clustering"
 ```
@@ -143,6 +145,8 @@ manager:
  enabled: false
 ' > values-dp.yaml
 ```
+
+Deploy the Data Plane using the `values-dp.yaml`:
 
 ```bash
 helm install kong kong/kong --values ./values-dp.yaml -n kong --create-namespace

--- a/app/_how-tos/gateway-install-helm-onprem-admin-api.md
+++ b/app/_how-tos/gateway-install-helm-onprem-admin-api.md
@@ -1,0 +1,35 @@
+---
+title: Configure the Admin API with {{ site.base_gateway }} on Kubernetes
+short_title: Configure the Admin API
+description: Expose the {{ site.base_gateway }} Admin API through an Ingress Controller
+content_type: how_to
+permalink: /gateway/install/kubernetes/on-prem/admin/
+breadcrumbs:
+  - /gateway/
+  - /gateway/install/
+
+series:
+  id: gateway-k8s-on-prem-install
+  position: 2
+
+products:
+  - gateway
+
+works_on:
+  - on-prem
+
+entities: []
+
+tldr: null
+
+prereqs:
+  skip_product: true
+
+automated_tests: false
+---
+
+{{ site.base_gateway }} is now running on Kubernetes. The Admin API is a `NodePort` service, which means it's not publicly available. The proxy service is a `LoadBalancer` which provides a public address.
+
+To make the admin API accessible without using `kubectl port-forward`, you can create an internal load balancer on your chosen cloud. This is required to use [Kong Manager]({{ page.navigation.next.url }}) to view or edit your configuration.
+
+{% include k8s/helm-ingress-setup.md service="admin" release="cp" type="private" %}

--- a/app/_how-tos/gateway-install-helm-onprem-manager.md
+++ b/app/_how-tos/gateway-install-helm-onprem-manager.md
@@ -1,0 +1,75 @@
+---
+title: Enable Kong Manager with {{ site.base_gateway }} on Kubernetes
+short_title: Enable Kong Manager
+description: View your {{ site.base_gateway }} configuration in a UI using Kong Manager
+content_type: how_to
+permalink: /gateway/install/kubernetes/on-prem/manager/
+breadcrumbs:
+  - /gateway/
+  - /gateway/install/
+
+series:
+  id: gateway-k8s-on-prem-install
+  position: 3
+
+products:
+  - gateway
+
+works_on:
+  - on-prem
+
+entities: []
+
+tldr: null
+
+prereqs:
+  skip_product: true
+
+faqs:
+  - q: I can't log in to Kong Manager
+    a: Check that `env.password` was set in `values-cp.yaml` before installing Kong. {{ site.base_gateway }} generates a random admin password if this is not set. This password can not be recovered and you must reinstall Kong to set a new admin password.
+
+  - q: What are my login credentials?
+    a: The Kong super admin username is `kong_admin`, and the password is the value set in `env.password` in `values-cp.yaml`.
+
+  - q: Kong Manager shows a white screen
+    a: Ensure that `env.admin_gui_api_url` is set correctly in `values-cp.yaml`.
+
+automated_tests: false
+---
+
+Kong Manager is the graphical user interface (GUI) for {{ site.base_gateway }}. It uses the Kong Admin API under the hood to administer and control {{ site.base_gateway }}.
+
+{:.important}
+> Kong's Admin API must be accessible over HTTP from your local machine to use Kong Manager
+
+## Installation
+
+Kong Manager is served from the same node as the Admin API. To enable Kong Manager, make the following changes to your `values-cp.yaml` file.
+
+1. Set `admin_gui_url`, `admin_gui_api_url` and `admin_gui_session_conf` under the `env` key.
+
+   ```yaml
+   env:
+     admin_gui_url: http://manager.example.com
+     admin_gui_api_url: http://admin.example.com
+     # Change the secret and set cookie_secure to true if using a HTTPS endpoint
+     admin_gui_session_conf: '{"secret":"secret","storage":"kong","cookie_secure":false}'
+   ```
+
+1. Replace `example.com` in the configuration with your domain.
+
+1. Enable Kong Manager authentication under the `enterprise` key.
+
+   ```yaml
+   enterprise:
+     rbac:
+       enabled: true
+       admin_gui_auth: basic-auth
+   ```
+
+{% include k8s/helm-ingress-setup.md service="manager" release="cp" type="private" skip_ingress_controller_install=true %}
+
+## Testing
+
+Visit the URL in `env.admin_gui_url` in a web browser to see the Kong Manager log in page. The default username is `kong_admin`, and the password is the value you set in `env.password` when installing the {{ site.base_gateway }} control plane in the previous step.

--- a/app/_how-tos/gateway-install-helm-onprem-manager.md
+++ b/app/_how-tos/gateway-install-helm-onprem-manager.md
@@ -26,13 +26,13 @@ prereqs:
   skip_product: true
 
 faqs:
-  - q: I can't log in to Kong Manager
+  - q: I can't log in to Kong Manager.
     a: Check that `env.password` was set in `values-cp.yaml` before installing Kong. {{ site.base_gateway }} generates a random admin password if this is not set. This password can not be recovered and you must reinstall Kong to set a new admin password.
 
   - q: What are my login credentials?
     a: The Kong super admin username is `kong_admin`, and the password is the value set in `env.password` in `values-cp.yaml`.
 
-  - q: Kong Manager shows a white screen
+  - q: Kong Manager shows a white screen.
     a: Ensure that `env.admin_gui_api_url` is set correctly in `values-cp.yaml`.
 
 automated_tests: false
@@ -40,26 +40,26 @@ automated_tests: false
 
 Kong Manager is the graphical user interface (GUI) for {{ site.base_gateway }}. It uses the Kong Admin API under the hood to administer and control {{ site.base_gateway }}.
 
-{:.important}
+{:.warning}
 > Kong's Admin API must be accessible over HTTP from your local machine to use Kong Manager
 
 ## Installation
 
 Kong Manager is served from the same node as the Admin API. To enable Kong Manager, make the following changes to your `values-cp.yaml` file.
 
-1. Set `admin_gui_url`, `admin_gui_api_url` and `admin_gui_session_conf` under the `env` key.
+1. Set `admin_gui_url`, `admin_gui_api_url` and `admin_gui_session_conf` under the `env` key:
 
    ```yaml
    env:
      admin_gui_url: http://manager.example.com
      admin_gui_api_url: http://admin.example.com
-     # Change the secret and set cookie_secure to true if using a HTTPS endpoint
+     # Change the secret and set cookie_secure to true if using an HTTPS endpoint
      admin_gui_session_conf: '{"secret":"secret","storage":"kong","cookie_secure":false}'
    ```
 
 1. Replace `example.com` in the configuration with your domain.
 
-1. Enable Kong Manager authentication under the `enterprise` key.
+1. Enable Kong Manager authentication under the `enterprise` key:
 
    ```yaml
    enterprise:

--- a/app/_how-tos/gateway-install-helm-onprem.md
+++ b/app/_how-tos/gateway-install-helm-onprem.md
@@ -17,10 +17,7 @@ works_on:
 
 entities: []
 
-tldr:
-  q: Question
-  a: |
-    Answer
+tldr: null
 
 prereqs:
   skip_product: true

--- a/app/_how-tos/gateway-install-helm-onprem.md
+++ b/app/_how-tos/gateway-install-helm-onprem.md
@@ -245,13 +245,13 @@ manager:
 
 {{ values_file | indent }}
 
-1. Run `helm install` to create the release.
+1. Run `helm install` to create the release:
 
    ```bash
    helm install kong-dp kong/kong -n kong --values ./values-dp.yaml
    ```
 
-1. Run `kubectl get pods -n kong`. Ensure that the data plane is running as expected.
+1. Run `kubectl get pods -n kong` to ensure that the Data Plane is running as expected:
 
    ```
    NAME                                 READY   STATUS
@@ -263,33 +263,33 @@ manager:
 
 {{ site.base_gateway }} is now running. To send some test traffic, try the following:
 
-1. Fetch the `LoadBalancer` address for the `kong-dp` service and store it in the `PROXY_IP` environment variable
+1. Fetch the `LoadBalancer` address for the `kong-dp` service and store it in the `PROXY_IP` environment variable:
 
    ```bash
    PROXY_IP=$(kubectl get service --namespace kong kong-dp-kong-proxy \
      -o jsonpath='{range .status.loadBalancer.ingress[0]}{@.ip}{@.hostname}{end}')
    ```
 
-1. Make a HTTP request to your `$PROXY_IP`. This will return a `HTTP 404` served by {{ site.base_gateway }}
+1. Make an HTTP request to your `$PROXY_IP`. This will return a `HTTP 404` served by {{ site.base_gateway }}:
 
    ```bash
    curl $PROXY_IP/mock/anything
    ```
 
-1. In another terminal, run `kubectl port-forward` to set up port forwarding and access the admin API.
+1. In another terminal, run `kubectl port-forward` to set up port forwarding and access the Admin API:
 
    ```bash
    kubectl port-forward -n kong service/kong-cp-kong-admin 8001
    ```
 
-1. Create a mock service and route
+1. Create a mock Service and Route:
 
    ```bash
    curl localhost:8001/services -d name=mock -d url="https://httpbin.konghq.com"
    curl localhost:8001/services/mock/routes -d "paths=/mock"
    ```
 
-1. Make a HTTP request to your `$PROXY_IP` again. This time {{ site.base_gateway }} will route the request to httpbin.
+1. Make an HTTP request to your `$PROXY_IP` again. This time {{ site.base_gateway }} will route the request to httpbin:
 
    ```bash
    curl $PROXY_IP/mock/anything

--- a/app/_how-tos/gateway-install-helm-onprem.md
+++ b/app/_how-tos/gateway-install-helm-onprem.md
@@ -1,12 +1,16 @@
 ---
 title: Install {{ site.base_gateway }} on-prem with Helm
-published: false
-description: TODO
+short_title: Install {{ site.base_gateway }}
+description: Deploy {{ site.base_gateway }} on Kubernetes in Hybrid mode
 content_type: how_to
 permalink: /gateway/install/kubernetes/on-prem/
 breadcrumbs:
   - /gateway/
   - /gateway/install/
+
+series:
+  id: gateway-k8s-on-prem-install
+  position: 1
 
 products:
   - gateway
@@ -24,165 +28,269 @@ prereqs:
 
 topology_switcher: page
 
+automated_tests: false
 ---
 
+These instructions configure {{ site.base_gateway }} to use separate control plane and data plane deployments. This is the recommended production installation method.
+
 ## Helm Setup
+
+Kong provides a Helm chart for deploying {{ site.base_gateway }}. Add the `charts.konghq.com` repository and run `helm repo update` to ensure that you have the latest version of the chart.
 
 ```bash
 helm repo add kong https://charts.konghq.com
 helm repo update
 ```
 
-## Create Certificates
+## Create a {{ site.ee_product_name }} License
 
-```bash
-openssl req -new -x509 -nodes -newkey ec:<(openssl ecparam -name secp384r1) -keyout ./tls.key -out ./tls.crt -days 1095 -subj "/CN=kong_clustering"
-```
-
-Create a Secret containing the certificate:
+First, create the `kong` namespace:
 
 ```bash
 kubectl create namespace kong
-kubectl create secret tls kong-cluster-cert --cert=./tls.crt --key=./tls.key -n kong
 ```
 
+Next, create a {{site.ee_product_name}} license secret.
 
-## Create a License
+{:.warning}
+> Ensure you are in the directory that contains a `license.json` file before running this command.
 
-Create a license
+```bash
+kubectl create secret generic kong-enterprise-license --from-file=license=license.json -n kong
+```
+
+## Create clustering certificates
+
+{{ site.base_gateway }} uses mTLS to secure the control plane/data plane communication when running in hybrid mode.
+
+1. Generate a TLS certificate using OpenSSL.
+
+   ```bash
+   openssl req -new -x509 -nodes -newkey ec:<(openssl ecparam -name secp384r1) \
+     -keyout ./tls.key -out ./tls.crt -days 1095 -subj "/CN=kong_clustering"
+   ```
+
+1. Create a Kubernetes secret containing the certificate.
+
+   ```
+   kubectl create secret tls kong-cluster-cert --cert=./tls.crt --key=./tls.key -n kong
+   ```
 
 ## Create a Control Plane
 
-TODO
+The control plane contains all {{ site.base_gateway }} configurations. The configuration is stored in a PostgreSQL database.
+
+1. Create a `values-cp.yaml` file.
+
+{% capture values_file %}
 
 ```yaml
-echo '
-# Do not use Kong Ingress Controller
+# Do not use {{ site.kic_product_name }}
 ingressController:
- enabled: false
-  
+  enabled: false
+
 image:
- repository: kong/kong-gateway
- tag: "{{ site.data.gateway_latest.release }}"
-  
+  repository: kong/kong-gateway
+  tag: "{{ site.data.gateway_latest.release }}"
+
 # Mount the secret created earlier
 secretVolumes:
- - kong-cluster-cert
-  
+  - kong-cluster-cert
+
 env:
- # This is a control_plane node
- role: control_plane
- # These certificates are used for control plane / data plane communication
- cluster_cert: /etc/secrets/kong-cluster-cert/tls.crt
- cluster_cert_key: /etc/secrets/kong-cluster-cert/tls.key
-  
- # Database
- # CHANGE THESE VALUES
- database: postgres
- pg_database: kong
- pg_user: kong
- pg_password: demo123
- pg_host: kong-cp-postgresql.kong.svc.cluster.local
- pg_ssl: "on"
-  
- # Kong Manager password
- password: kong_admin_password
-  
+  # This is a control_plane node
+  role: control_plane
+  # These certificates are used for control plane / data plane communication
+  cluster_cert: /etc/secrets/kong-cluster-cert/tls.crt
+  cluster_cert_key: /etc/secrets/kong-cluster-cert/tls.key
+
+  # Database
+  # CHANGE THESE VALUES
+  database: postgres
+  pg_database: kong
+  pg_user: kong
+  pg_password: demo123
+  pg_host: kong-cp-postgresql.kong.svc.cluster.local
+  pg_ssl: "on"
+
+  # Kong Manager password
+  password: kong_admin_password
+
 # Enterprise functionality
 enterprise:
- enabled: true
- license_secret: kong-enterprise-license
-  
+  enabled: true
+  license_secret: kong-enterprise-license
+
 # The control plane serves the Admin API
 admin:
- enabled: true
- http:
-   enabled: true
-  
+  enabled: true
+  http:
+    enabled: true
+
 # Clustering endpoints are required in hybrid mode
 cluster:
- enabled: true
- tls:
-   enabled: true
-  
+  enabled: true
+  tls:
+    enabled: true
+
 clustertelemetry:
- enabled: true
- tls:
-   enabled: true
-  
-# Optional features
+  enabled: true
+  tls:
+    enabled: true
+
 manager:
- enabled: false
-  
+  enabled: false
+
 # These roles will be served by different Helm releases
 proxy:
- enabled: false
-' > values-cp.yaml
+  enabled: false
 ```
 
-(Optional) If you want to deploy a Postgres database within the cluster for testing purposes, add the following to the bottom of values-cp.yaml.
+{% endcapture %}
+
+{{ values_file | indent }}
+
+1. _(Optional)_ If you want to deploy a Postgres database within the cluster for testing purposes, add the following to the bottom of `values-cp.yaml`.
+
+   ```yaml
+   # This is for testing purposes only
+   # DO NOT DO THIS IN PRODUCTION
+   # Your cluster needs a way to create PersistentVolumeClaims
+   # if this option is enabled
+   postgresql:
+     enabled: true
+     auth:
+       password: demo123
+   ```
+
+1. Update the database connection values in `values-cp.yaml`.
+
+   - `env.pg_database`: The database name to use
+   - `env.pg_user`: Your database username
+   - `env.pg_password`: Your database password
+   - `env.pg_host`: The hostname of your Postgres database
+   - `env.pg_ssl`: Use SSL to connect to the database
+
+1. Set your Kong Manager super admin password in `values-cp.yaml`.
+
+   - `env.password`: The Kong Manager super admin password
+
+1. Run `helm install` to create the release.
+
+   ```bash
+   helm install kong-cp kong/kong -n kong --values ./values-cp.yaml
+   ```
+
+1. Run `kubectl get pods -n kong`. Ensure that the control plane is running as expected.
+
+   ```
+   NAME                                 READY   STATUS
+   kong-cp-kong-7bb77dfdf9-x28xf        1/1     Running
+   ```
+   {:.no-copy-code}
+
+## Create a Data Plane
+
+The {{ site.base_gateway }} data plane is responsible for processing incoming traffic. It receives the routing configuration from the control plane using the clustering endpoint.
+
+1. Create a `values-dp.yaml` file.
+
+{% capture values_file %}
 
 ```yaml
-echo '
-# This is for testing purposes only
-# DO NOT DO THIS IN PRODUCTION
-# Your cluster needs a way to create PersistentVolumeClaims
-# if this option is enabled
-postgresql:
-  enabled: true
-  auth:
-    password: demo123
-' >> values-cp.yaml
-```
-
-## Deploy a Data Plane
-
-This is common
-
-```yaml
-echo '
+# Do not use {{ site.kic_product_name }}
 ingressController:
- enabled: false
-  
+  enabled: false
+
 image:
- repository: kong/kong-gateway
- tag: "{{ site.data.gateway_latest.release }}"
-  
+  repository: kong/kong-gateway
+  tag: "{{ site.data.gateway_latest.release }}"
+
 # Mount the secret created earlier
 secretVolumes:
- - kong-cluster-cert
-  
+  - kong-cluster-cert
+
 env:
- # data_plane nodes do not have a database
- role: data_plane
- database: "off"
-  
- # Tell the data plane how to connect to the control plane
- cluster_control_plane: kong-cp-kong-cluster.kong.svc.cluster.local:8005
- cluster_telemetry_endpoint: kong-cp-kong-clustertelemetry.kong.svc.cluster.local:8006
-  
- # Configure control plane / data plane authentication
- lua_ssl_trusted_certificate: /etc/secrets/kong-cluster-cert/tls.crt
- cluster_cert: /etc/secrets/kong-cluster-cert/tls.crt
- cluster_cert_key: /etc/secrets/kong-cluster-cert/tls.key
-  
+  # data_plane nodes do not have a database
+  role: data_plane
+  database: "off"
+
+  # Tell the data plane how to connect to the control plane
+  cluster_control_plane: kong-cp-kong-cluster.kong.svc.cluster.local:8005
+  cluster_telemetry_endpoint: kong-cp-kong-clustertelemetry.kong.svc.cluster.local:8006
+
+  # Configure control plane / data plane authentication
+  lua_ssl_trusted_certificate: /etc/secrets/kong-cluster-cert/tls.crt
+  cluster_cert: /etc/secrets/kong-cluster-cert/tls.crt
+  cluster_cert_key: /etc/secrets/kong-cluster-cert/tls.key
+
 # Enterprise functionality
 enterprise:
- enabled: true
- license_secret: kong-enterprise-license
-  
+  enabled: true
+  license_secret: kong-enterprise-license
+
 # The data plane handles proxy traffic only
 proxy:
- enabled: true
-  
+  enabled: true
+
+# These roles are served by the kong-cp deployment
 admin:
- enabled: false
-  
+  enabled: false
+
 manager:
- enabled: false
-' > values-dp.yaml
+  enabled: false
 ```
 
-## Testing
+{% endcapture %}
 
-Foo bar. Use deck apply to sync some example config
+{{ values_file | indent }}
+
+1. Run `helm install` to create the release.
+
+   ```bash
+   helm install kong-dp kong/kong -n kong --values ./values-dp.yaml
+   ```
+
+1. Run `kubectl get pods -n kong`. Ensure that the data plane is running as expected.
+
+   ```
+   NAME                                 READY   STATUS
+   kong-dp-kong-5dbcd9f6b9-f2w49        1/1     Running
+   ```
+   {:.no-copy-code}
+
+## Test your deployment
+
+{{ site.base_gateway }} is now running. To send some test traffic, try the following:
+
+1. Fetch the `LoadBalancer` address for the `kong-dp` service and store it in the `PROXY_IP` environment variable
+
+   ```bash
+   PROXY_IP=$(kubectl get service --namespace kong kong-dp-kong-proxy \
+     -o jsonpath='{range .status.loadBalancer.ingress[0]}{@.ip}{@.hostname}{end}')
+   ```
+
+1. Make a HTTP request to your `$PROXY_IP`. This will return a `HTTP 404` served by {{ site.base_gateway }}
+
+   ```bash
+   curl $PROXY_IP/mock/anything
+   ```
+
+1. In another terminal, run `kubectl port-forward` to set up port forwarding and access the admin API.
+
+   ```bash
+   kubectl port-forward -n kong service/kong-cp-kong-admin 8001
+   ```
+
+1. Create a mock service and route
+
+   ```bash
+   curl localhost:8001/services -d name=mock -d url="https://httpbin.konghq.com"
+   curl localhost:8001/services/mock/routes -d "paths=/mock"
+   ```
+
+1. Make a HTTP request to your `$PROXY_IP` again. This time {{ site.base_gateway }} will route the request to httpbin.
+
+   ```bash
+   curl $PROXY_IP/mock/anything
+   ```

--- a/app/_includes/info_box/sections/series.html
+++ b/app/_includes/info_box/sections/series.html
@@ -2,8 +2,10 @@
     <div class="text-primary font-medium">In This Series</div>
     <ol class="flex flex-col gap-1.5">
         {% for item in page.series.items %}
+            {% assign title = item.title %}
+            {% if item.short_title %}{% assign title = item.short_title %}{% endif %}
             <li class="text-sm {% if page.series.position == item.series.position %}font-semibold text-primary{% else %} text-terciary{% endif %}">
-                <a href="{{ item.url }}">{{ item.title | liquify }}</a>
+                <a href="{{ item.url }}">{{ title | liquify }}</a>
             </li>
         {% endfor %}
     </ol>

--- a/app/_includes/k8s/cloud-ingress-controller-create-ingress.md
+++ b/app/_includes/k8s/cloud-ingress-controller-create-ingress.md
@@ -1,0 +1,22 @@
+{% capture content  %}
+{% navtabs ingress %}
+{% navtab "EKS" %}
+{% include k8s/cloud-ingress-controller-single-ingress.md provider="eks" service=include.service type=include.type %}
+{% endnavtab %}
+{% navtab "AKS" %}
+{% include k8s/cloud-ingress-controller-single-ingress.md provider="aks" service=include.service type=include.type %}
+{% endnavtab %}
+{% navtab "GKE" %}
+{% include k8s/cloud-ingress-controller-single-ingress.md provider="gke" service=include.service type=include.type %}
+{% endnavtab %}
+{% navtab "KIC" %}
+{% include k8s/cloud-ingress-controller-single-ingress.md provider="kic" service=include.service type=include.type %}
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{% if include.indent %}
+{{ content | indent }}
+{% else %}
+{{ content }}
+{% endif %}

--- a/app/_includes/k8s/cloud-ingress-controller-install-tabs.md
+++ b/app/_includes/k8s/cloud-ingress-controller-install-tabs.md
@@ -1,0 +1,22 @@
+{% capture content  %}
+{% navtabs ingress %}
+{% navtab "EKS" %}
+{% include k8s/cloud/eks/install.md service=include.service release=include.release %}
+{% endnavtab %}
+{% navtab "AKS" %}
+{% include k8s/cloud/aks/install.md service=include.service release=include.release %}
+{% endnavtab %}
+{% navtab "GKE" %}
+{% include k8s/cloud/gke/install.md service=include.service release=include.release %}
+{% endnavtab %}
+{% navtab "KIC" %}
+{% include k8s/cloud/kic/install.md service=include.service release=include.release %}
+{% endnavtab %}
+{% endnavtabs %}
+{% endcapture %}
+
+{% if include.indent %}
+{{ content | indent }}
+{% else %}
+{{ content }}
+{% endif %}

--- a/app/_includes/k8s/cloud-ingress-controller-single-ingress.md
+++ b/app/_includes/k8s/cloud-ingress-controller-single-ingress.md
@@ -1,0 +1,22 @@
+{% if include.type == "private" %}
+{% include k8s/cloud/{{include.provider}}/test-with-public-lb.md %}
+{% endif %}
+
+```yaml
+{{ include.service }}:
+  enabled: true
+  http:
+    enabled: true
+  tls:
+    enabled: false
+  {% if include.provider == "gke" -%}
+  annotations:
+    beta.cloud.google.com/backend-config: '{"default":"kong-hc"}'
+  {%- endif %}
+  ingress:
+    enabled: true
+    hostname: {{ include.service }}.example.com
+    path: /
+    pathType: Prefix
+{%- include k8s/cloud/{{include.provider}}/annotations.md type=include.type %}
+```

--- a/app/_includes/k8s/cloud/aks/annotations.md
+++ b/app/_includes/k8s/cloud/aks/annotations.md
@@ -1,0 +1,7 @@
+{%- assign private = "false" -%}
+{%- if include.type == "private" -%}
+ {%- assign private = "true" -%}
+{%- endif %}
+    ingressClassName: azure-application-gateway
+    annotations:
+      appgw.ingress.kubernetes.io/use-private-ip: "{{ private }}"

--- a/app/_includes/k8s/cloud/aks/install.md
+++ b/app/_includes/k8s/cloud/aks/install.md
@@ -1,0 +1,7 @@
+You need `application-gateway-kubernetes-ingress` [installed in your cluster](https://azure.github.io/application-gateway-kubernetes-ingress/setup/install/) to configure Ingress resources on AKS.
+
+After installing, check that your cluster is running the `ingress-appgw-deployment`.
+
+```bash
+kubectl get deployments.apps -n kube-system ingress-appgw-deployment
+```

--- a/app/_includes/k8s/cloud/aks/install.md
+++ b/app/_includes/k8s/cloud/aks/install.md
@@ -1,6 +1,6 @@
 You need `application-gateway-kubernetes-ingress` [installed in your cluster](https://azure.github.io/application-gateway-kubernetes-ingress/setup/install/) to configure Ingress resources on AKS.
 
-After installing, check that your cluster is running the `ingress-appgw-deployment`.
+After installing, check that your cluster is running the `ingress-appgw-deployment`:
 
 ```bash
 kubectl get deployments.apps -n kube-system ingress-appgw-deployment

--- a/app/_includes/k8s/cloud/aks/test-with-public-lb.md
+++ b/app/_includes/k8s/cloud/aks/test-with-public-lb.md
@@ -1,0 +1,4 @@
+{:.note}
+> If you are testing and do not have a VPN set up, you may change the
+> `appgw.ingress.kubernetes.io/use-private-ip` annotation to `false` to add a public IP address.
+> This is **not recommended for long running deployments**

--- a/app/_includes/k8s/cloud/aks/test-with-public-lb.md
+++ b/app/_includes/k8s/cloud/aks/test-with-public-lb.md
@@ -1,4 +1,4 @@
-{:.note}
-> If you are testing and do not have a VPN set up, you may change the
+{:.info}
+> If you are testing and don't have a VPN set up, you may change the
 > `appgw.ingress.kubernetes.io/use-private-ip` annotation to `false` to add a public IP address.
-> This is **not recommended for long running deployments**
+> This is **not recommended for long running deployments**.

--- a/app/_includes/k8s/cloud/eks/annotations.md
+++ b/app/_includes/k8s/cloud/eks/annotations.md
@@ -1,0 +1,14 @@
+{%- assign lb_name = "kong-alb-public" -%}
+{%- assign scheme = "internet-facing" -%}
+{%- if include.type == "private" -%}
+ {%- assign lb_name = "kong-alb-private" -%}
+ {%- assign scheme = "internal" -%}
+{%- endif %}
+    ingressClassName: alb
+    annotations:
+      alb.ingress.kubernetes.io/load-balancer-name: {{ lb_name }}
+      alb.ingress.kubernetes.io/group.name: demo.{{ lb_name }}
+      alb.ingress.kubernetes.io/target-type: instance
+      alb.ingress.kubernetes.io/scheme: {{ scheme }}
+      alb.ingress.kubernetes.io/healthcheck-path: /
+      alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'

--- a/app/_includes/k8s/cloud/eks/install.md
+++ b/app/_includes/k8s/cloud/eks/install.md
@@ -1,0 +1,7 @@
+You need the `aws-load-balancer-controller` [installed in your cluster](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/installation/) to configure Ingress resources on EKS.
+
+After installing, check that your cluster is running the  `aws-load-balancer-controller`.
+
+```bash
+kubectl get deployments.apps -n kube-system aws-load-balancer-controller
+```

--- a/app/_includes/k8s/cloud/eks/install.md
+++ b/app/_includes/k8s/cloud/eks/install.md
@@ -1,6 +1,6 @@
 You need the `aws-load-balancer-controller` [installed in your cluster](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/installation/) to configure Ingress resources on EKS.
 
-After installing, check that your cluster is running the  `aws-load-balancer-controller`.
+After installing, check that your cluster is running the  `aws-load-balancer-controller`:
 
 ```bash
 kubectl get deployments.apps -n kube-system aws-load-balancer-controller

--- a/app/_includes/k8s/cloud/eks/test-with-public-lb.md
+++ b/app/_includes/k8s/cloud/eks/test-with-public-lb.md
@@ -1,0 +1,4 @@
+{:.note}
+> If you are testing and do not have a VPN set up for your VPC, you may change the
+> `alb.ingress.kubernetes.io/scheme` annotation to `internet-facing` to add a public IP address.
+> This is **not recommended for long running deployments**

--- a/app/_includes/k8s/cloud/eks/test-with-public-lb.md
+++ b/app/_includes/k8s/cloud/eks/test-with-public-lb.md
@@ -1,4 +1,4 @@
-{:.note}
-> If you are testing and do not have a VPN set up for your VPC, you may change the
+{:.info}
+> If you are testing and don't have a VPN set up for your VPC, you may change the
 > `alb.ingress.kubernetes.io/scheme` annotation to `internet-facing` to add a public IP address.
-> This is **not recommended for long running deployments**
+> This is **not recommended for long running deployments**.

--- a/app/_includes/k8s/cloud/gke/annotations.md
+++ b/app/_includes/k8s/cloud/gke/annotations.md
@@ -1,0 +1,6 @@
+{%- assign ingress_class = "gce" -%}
+{%- if include.type == "private" -%}
+ {%- assign ingress_class = "gce-internal" -%}
+{%- endif %}
+    annotations:
+      kubernetes.io/ingress.class: {{ ingress_class }}

--- a/app/_includes/k8s/cloud/gke/install.md
+++ b/app/_includes/k8s/cloud/gke/install.md
@@ -1,0 +1,24 @@
+Clusters running GKE versions 1.18 and later automatically provision load balancers in response to `Ingress` resources being created.
+
+GKE requires a `BackendConfig` resource to be created for Kong deployments to be marked as healthy.
+
+1. Create a `BackendConfig` [resource](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#interpreted_hc) to configure health checks.
+
+    ```yaml
+    echo "apiVersion: cloud.google.com/v1
+    kind: BackendConfig
+    metadata:
+      name: kong-hc
+      namespace: kong
+    spec:
+      healthCheck:
+        checkIntervalSec: 15
+        port: 8100
+        type: HTTP
+        requestPath: /status" | kubectl apply -f -
+    ```
+
+2. This `BackendConfig` is attached to the `{{ include.service }}` service using the `annotations` key in `values-{{ include.release }}.yaml`
+
+{:.important}
+> GKE provisions one load balancer per `Ingress` definition. Following this guide will result in multiple load balancers being created.

--- a/app/_includes/k8s/cloud/gke/install.md
+++ b/app/_includes/k8s/cloud/gke/install.md
@@ -2,7 +2,7 @@ Clusters running GKE versions 1.18 and later automatically provision load balanc
 
 GKE requires a `BackendConfig` resource to be created for Kong deployments to be marked as healthy.
 
-1. Create a `BackendConfig` [resource](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#interpreted_hc) to configure health checks.
+1. Create a `BackendConfig` [resource](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress#interpreted_hc) to configure health checks:
 
     ```yaml
     echo "apiVersion: cloud.google.com/v1
@@ -18,7 +18,7 @@ GKE requires a `BackendConfig` resource to be created for Kong deployments to be
         requestPath: /status" | kubectl apply -f -
     ```
 
-2. This `BackendConfig` is attached to the `{{ include.service }}` service using the `annotations` key in `values-{{ include.release }}.yaml`
+2. This `BackendConfig` is attached to the `{{ include.service }}` service using the `annotations` key in `values-{{ include.release }}.yaml`.
 
-{:.important}
+{:.warning}
 > GKE provisions one load balancer per `Ingress` definition. Following this guide will result in multiple load balancers being created.

--- a/app/_includes/k8s/cloud/gke/test-with-public-lb.md
+++ b/app/_includes/k8s/cloud/gke/test-with-public-lb.md
@@ -1,0 +1,4 @@
+{:.note}
+> If you are testing and do not have a VPN set up, you may change the
+> `kubernetes.io/ingress.class` annotation to `gce` to add a public IP address.
+> This is **not recommended for long running deployments**

--- a/app/_includes/k8s/cloud/gke/test-with-public-lb.md
+++ b/app/_includes/k8s/cloud/gke/test-with-public-lb.md
@@ -1,4 +1,4 @@
-{:.note}
-> If you are testing and do not have a VPN set up, you may change the
+{:.info}
+> If you are testing and don't have a VPN set up, you may change the
 > `kubernetes.io/ingress.class` annotation to `gce` to add a public IP address.
-> This is **not recommended for long running deployments**
+> This is **not recommended for long running deployments**.

--- a/app/_includes/k8s/cloud/kic/annotations.md
+++ b/app/_includes/k8s/cloud/kic/annotations.md
@@ -1,0 +1,4 @@
+{% comment %}
+This comment is required for consistent whitespace formatting across includes. Do not remove.
+{% endcomment %}
+    ingressClassName: kong

--- a/app/_includes/k8s/cloud/kic/install.md
+++ b/app/_includes/k8s/cloud/kic/install.md
@@ -1,0 +1,11 @@
+Set `ingressController.enabled` to `true` in your `values-{{ include.release }}.yaml` file to enable {{ site.kic_product_name }}. When enabling the ingress controller, set `env.publish_service` to ensure that {{ site.kic_product_name }} populates the address field in the managed `Ingress` resources.
+
+You must also set `ingressController.env.kong_admin_token` to the value stored in `env.password` to enable communication between {{ site.kic_product_name }} and the {{ site.base_gateway }} Admin API.
+
+```yaml
+ingressController:
+  enabled: true
+  env:
+    publish_service: kong/kong-dp-kong-proxy
+    kong_admin_token: kong_admin_password
+```

--- a/app/_includes/k8s/cloud/kic/install.md
+++ b/app/_includes/k8s/cloud/kic/install.md
@@ -1,6 +1,6 @@
 Set `ingressController.enabled` to `true` in your `values-{{ include.release }}.yaml` file to enable {{ site.kic_product_name }}. When enabling the ingress controller, set `env.publish_service` to ensure that {{ site.kic_product_name }} populates the address field in the managed `Ingress` resources.
 
-You must also set `ingressController.env.kong_admin_token` to the value stored in `env.password` to enable communication between {{ site.kic_product_name }} and the {{ site.base_gateway }} Admin API.
+You must also set `ingressController.env.kong_admin_token` to the value stored in `env.password` to enable communication between {{ site.kic_product_name }} and the {{ site.base_gateway }} Admin API:
 
 ```yaml
 ingressController:

--- a/app/_includes/k8s/cloud/kic/test-with-public-lb.md
+++ b/app/_includes/k8s/cloud/kic/test-with-public-lb.md
@@ -1,0 +1,2 @@
+{:.note}
+> All endpoints proxied by {{ site.kic_product_name }} will be publicly accessible. Use an authentication plugin to secure your API

--- a/app/_includes/k8s/cloud/kic/test-with-public-lb.md
+++ b/app/_includes/k8s/cloud/kic/test-with-public-lb.md
@@ -1,2 +1,2 @@
-{:.note}
-> All endpoints proxied by {{ site.kic_product_name }} will be publicly accessible. Use an authentication plugin to secure your API
+{:.info}
+> All endpoints proxied by {{ site.kic_product_name }} will be publicly accessible. Use an authentication plugin to secure your API.

--- a/app/_includes/k8s/helm-ingress-setup.md
+++ b/app/_includes/k8s/helm-ingress-setup.md
@@ -1,0 +1,36 @@
+{% unless include.skip_ingress_controller_install %}
+## Configure your Ingress Controller
+
+To expose the Admin API, you need an Ingress Controller running in your cluster. Choose a provider and ensure that your Ingress controller is configured correctly:
+
+{% include k8s/cloud-ingress-controller-install-tabs.md indent=true service=include.service release=include.release %}
+
+{% endunless %}
+
+## Define Ingress annotations 
+
+Configure the `{{ include.service }}` section in `values-{{ include.release }}.yaml`. Replace `example.com` with your custom domain name.
+
+{% include k8s/cloud-ingress-controller-create-ingress.md indent=true service=include.service type=include.type %}
+
+{% unless include.skip_release %}
+
+## Helm upgrade
+
+Run `helm upgrade` to update the release.
+
+```bash
+helm upgrade kong-{{ include.release }} kong/kong -n kong --values ./values-{{ include.release }}.yaml
+```
+{% endunless %}
+
+{% unless include.skip_dns %}
+## Update DNS
+
+Fetch the `Ingress` IP address and update your DNS records to point at the Ingress address. You can configure DNS manually, or use a tool like [external-dns](https://github.com/kubernetes-sigs/external-dns) to automate DNS configuration.
+
+```bash
+kubectl get ingress -n kong kong-{{ include.release }}-kong-{{ include.service }} \
+  -o jsonpath='{.spec.rules[0].host}{": "}{range .status.loadBalancer.ingress[0]}{@.ip}{@.hostname}{end}'
+```
+{% endunless %}

--- a/app/_includes/sections/prev_next.html
+++ b/app/_includes/sections/prev_next.html
@@ -1,16 +1,20 @@
 {% unless page.navigation == empty %}
 <div class="flex gap-5 justify-between">
     {% if page.navigation.prev %}
+    {% assign title = page.navigation.prev.title %}
+    {% if page.navigation.prev.short_title %}{% assign title = page.navigation.prev.short_title %}{% endif %}
     <a href="{{ page.navigation.prev.url }}" class="flex flex-col gap-1 p-3 w-1/3 mr-auto rounded-md hover:bg-secondary  hover:no-underline">
         <span class="flex gap-1 px-1 text-xs text-secondary">&larr; Previous</span>
-        <span class="text-primary font-semibold">{{page.series.position | minus: 1}}. {{ page.navigation.prev.title | liquify }}</span>
+        <span class="text-primary font-semibold">{{page.series.position | minus: 1}}. {{ title | liquify }}</span>
     </a>
     {% endif %}
 
     {% if page.navigation.next %}
+    {% assign title = page.navigation.next.title %}
+    {% if page.navigation.next.short_title %}{% assign title = page.navigation.next.short_title %}{% endif %}
     <a href="{{ page.navigation.next.url }}" class="flex flex-col gap-1 p-3 w-1/3 ml-auto rounded-md items-end hover:bg-secondary  hover:no-underline">
         <span class="flex gap-1 px-1 text-xs text-secondary">Next &rarr;</span>
-        <span class="text-primary font-semibold">{{page.series.position | plus: 1}}. {{ page.navigation.next.title | liquify }}</span>
+        <span class="text-primary font-semibold">{{page.series.position | plus: 1}}. {{ title | liquify }}</span>
     </a>
     {% endif %}
 </div>

--- a/app/_layouts/how-to.html
+++ b/app/_layouts/how-to.html
@@ -1,7 +1,9 @@
 ---
 layout: with_aside
 ---
+{% if page.tldr %}
 {% include how-tos/tldr.html %}
+{% endif %}
 
 <div class="flex flex-col gap-8 accordion" data-all-expanded="true">
 {% include sections/prerequisites.html tier=page.tier tools=page.tools %}

--- a/app/_plugins/generators/data/breadcrumbs.rb
+++ b/app/_plugins/generators/data/breadcrumbs.rb
@@ -24,6 +24,7 @@ module Jekyll
 
           if entry.is_a?(Hash)
             next build_breadcrumbs_from_index_page(entry) unless entry['index'].nil?
+            next build_breadcrumbs_from_static(entry) unless entry['url'].nil?
 
             raise ArgumentError,
                   "On #{@page.relative_path}, the breadcrumb entry `#{entry}` is invalid. #{entry.to_json}"
@@ -47,6 +48,12 @@ module Jekyll
         title = breadcrumb.data['short_title'] if breadcrumb.data['short_title']
 
         { 'url' => normalized_url, 'title' => title }
+      end
+
+      def build_breadcrumbs_from_static(entry)
+        # We return it as-is for now, but we may process it in the future
+        # so I've added a method
+        entry
       end
 
       def build_breadcrumbs_from_index_page(entry)

--- a/app/_plugins/generators/data/series.rb
+++ b/app/_plugins/generators/data/series.rb
@@ -20,6 +20,7 @@ module Jekyll
           set_prerequisites!(page)
           set_next_prev!(page)
           set_cleanup!(page)
+          set_breadcrumbs!(page)
         end
 
         @site.documents.each do |page|
@@ -27,6 +28,7 @@ module Jekyll
           set_prerequisites!(page)
           set_next_prev!(page)
           set_cleanup!(page)
+          set_breadcrumbs!(page)
         end
       end
 
@@ -50,9 +52,9 @@ module Jekyll
 
         return unless previous_page
 
-        series_meta = @site.data['series'][page.data['series']['id']]
+        @series_meta = @site.data['series'][page.data['series']['id']]
 
-        unless series_meta
+        unless @series_meta
           raise "Could not read series meta from app/_data/series.yml with key #{page.data['series']['id']}"
         end
 
@@ -61,7 +63,7 @@ module Jekyll
           'position' => 'before',
           'title' => 'Series Prerequisites',
           'content' => <<~HEREDOC.strip
-            This page is part of the [**#{series_meta['title']}**](#{series_meta['url']}) series.
+            This page is part of the [**#{@series_meta['title']}**](#{@series_meta['url']}) series.
 
             Complete the previous page, [**#{previous_page.data['title']}**](#{previous_page.url}) before completing this page.
           HEREDOC
@@ -86,6 +88,16 @@ module Jekyll
         return unless page.data['series']
 
         page.data['cleanup'] = nil
+      end
+
+      def set_breadcrumbs!(page)
+        return unless page.data['series']
+        return unless @series_meta['breadcrumb_title']
+
+        page.data['breadcrumbs'] << {
+          'title' => @series_meta['breadcrumb_title'],
+          'url' => page.data['series']['items'].first.url
+        }
       end
 
       def add_series_item(id, page)


### PR DESCRIPTION
## Description

Adds on-prem Kubernetes install instructions that didn't make the migration deadline.

I also made a few small platform changes:

* Series can now define a `breadcrumb_title`. If set, it's automatically added as the last breadcrumb item
* `short_title` is used for the next/prev links on how-tos
* `tldr` can be null (they don't make sense in some series)  

## Preview Links

[/gateway/install/kubernetes/on-prem/](https://deploy-preview-1973--kongdeveloper.netlify.app/gateway/install/kubernetes/on-prem/) + the rest of the series.

I tested the KIC instructions, and am trusting that the cloud annotations haven't changed since the last time I tested.


## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [x] Add new pages to the product documentation index (if applicable).