### PR TITLE
Mark Keys/Key sets as supported in decK

### DIFF
--- a/app/_gateway_entities/key-set.md
+++ b/app/_gateway_entities/key-set.md
@@ -19,6 +19,7 @@ related_resources:
 
 
 tools:
+  - deck
   - admin-api
   - konnect-api
 

--- a/app/deck/reference/entities.md
+++ b/app/deck/reference/entities.md
@@ -51,7 +51,8 @@ features:
     managed: true
   - title: Vaults
     managed: true
-  - title: Keys and Key Sets
+  - title: |
+      Keys and Key Sets {% new_in 1.48 %}
     managed: true
   - title: Licenses
     managed: false

--- a/app/deck/reference/entities.md
+++ b/app/deck/reference/entities.md
@@ -52,7 +52,7 @@ features:
   - title: Vaults
     managed: true
   - title: Keys and Key Sets
-    managed: false
+    managed: true
   - title: Licenses
     managed: false
   - title: Workspaces <sup>1</sup>


### PR DESCRIPTION
## Description

Mark keys and key sets as supported by decK.
The Keys entity page already has decK as a tool option, so that doesn't need updating. 

I didn't put a decK version or new_in since we're avoiding mentioning versions in the decK docs.

## Preview Links


