### PR TITLE
[fix] Add missing conflict for `consumer` entities in Konnect control plane groups.

### DIFF
--- a/app/gateway-manager/control-plane-groups.md
+++ b/app/gateway-manager/control-plane-groups.md
@@ -295,6 +295,9 @@ rows:
   - conflict: ACL group names across Control Plane Group members
     description: ACL group names are shared across members.
     action: Remove or rename duplicate ACL groups if isolation is needed.
+  - conflict: Consumers across Control Plane Group members
+    description: Consumer names are shared across members.
+    action: Remove or rename duplicates if isolation is needed.
   - conflict: Consumer groups across Control Plane Group members
     description: Consumer group names are shared across members.
     action: Remove or rename duplicates if isolation is needed.


### PR DESCRIPTION
## Description

Added a missing conflict for `consumer` entities. The table showed other entity conflict types (control plane group names, consumer groups, credentials, etc.) but not one for just consumers.

Fixes support case #00059261.
