### PR TITLE
OIDC diagram and example improvements

### DIFF
--- a/app/_includes/plugins/oidc/diagrams/auth-code.md
+++ b/app/_includes/plugins/oidc/diagrams/auth-code.md
@@ -1,0 +1,50 @@
+<!--vale off-->
+{% mermaid %}
+sequenceDiagram
+    autonumber
+    participant client as Client <br>(e.g. mobile app)
+    participant kong as API Gateway <br>(Kong)
+    participant idp as IdP <br>(e.g. Keycloak)
+    participant httpbin as Upstream <br>(upstream service,<br> e.g. httpbin)
+    activate client
+    activate kong
+    client->>kong: HTTP request
+    kong->>client: Redirect mobile app to IDP 
+    deactivate kong
+    activate idp
+    client->>idp: Request access and authentication<br>with client parameter
+    Note left of idp: /auth<br>response_type=code,<br>scope=openid
+    idp->>client: Login (ask for consent)
+    client->>idp: /auth with user credentials (grant consent)
+    idp->>client: Return authorization code and redirect
+    Note left of idp: short-lived authcode
+    activate kong
+    client->>kong: HTTP redirect with authorization code
+    deactivate client
+    kong->>kong: Verify authorization code flow
+    kong->>idp: Request ID token, access token, and refresh token
+    Note left of idp: /token<br>client_id:client_secret<br>authcode
+    idp->>idp: Authenticate client (Kong)<br>and validate authcode
+    idp->>kong: Returns tokens
+    Note left of idp: ID token, access token, and refresh token
+    deactivate idp
+    kong->>kong: Validate tokens
+    Note right of kong: Cryptographic<br>signature validation,<br>expiry check<br>(OIDC Standard JWT validation)
+    activate client
+    kong->>client: Redirect with session cookie<br>having session ID (SID)
+    Note left of kong: sid: cryptorandom bytes <br>(128 bits)<br>& HMAC protected
+    client->>kong: Authenticated request with session cookie
+    deactivate client
+    kong->>kong: Verify session cookie
+    Note right of kong: Retrieve encrypted tokens<br>from session store (redis)
+    activate httpbin
+    kong->>httpbin: Backend service request with tokens
+    Note right of idp: Access token and ID token
+    httpbin->>kong: Backend service response
+    deactivate httpbin
+    activate client
+    kong->>client: HTTP response
+    deactivate kong
+    deactivate client
+{% endmermaid %}
+<!--vale on-->

--- a/app/_includes/plugins/oidc/diagrams/client-credentials.md
+++ b/app/_includes/plugins/oidc/diagrams/client-credentials.md
@@ -1,0 +1,31 @@
+<!--vale off-->
+{% mermaid %}
+sequenceDiagram
+    autonumber
+    participant client as Client <br>(e.g. mobile app)
+    participant kong as API Gateway <br>(Kong)
+    participant idp as IdP <br>(e.g. Keycloak)
+    participant httpbin as Upstream <br>(upstream service,<br> e.g. httpbin)
+    activate client
+    activate kong
+    client->>kong: Service with<br>basic authentication
+    deactivate client
+    kong->>kong: load basic<br>authentication credentials
+    activate idp
+    kong->>idp: IdP/token<br>with client credentials
+    deactivate kong
+    idp->>idp: authenticate client
+    activate kong
+    idp->>kong: return tokens
+    deactivate idp
+    kong->>kong: verify tokens
+    activate httpbin
+    kong->>httpbin: request with access token
+    httpbin->>kong: response
+    deactivate httpbin
+    activate client
+    kong->>client: response
+    deactivate kong
+    deactivate client
+{% endmermaid %}
+<!--vale on-->

--- a/app/_includes/plugins/oidc/diagrams/dpop.md
+++ b/app/_includes/plugins/oidc/diagrams/dpop.md
@@ -1,0 +1,30 @@
+<!--vale off-->
+{% mermaid %}
+sequenceDiagram
+    autonumber
+    participant client as Client <br>(e.g. mobile app)
+    participant kong as API Gateway <br>({{site.base_gateway}})
+    participant upstream as Upstream <br>(backend service,<br> e.g. httpbin)
+    participant idp as Authentication Server <br>(e.g. Keycloak)
+    activate client
+    client->>client: generate key pair
+    client->>idp: POST /oauth2/token<br>DPoP:$PROOF
+    deactivate client
+    activate idp
+    idp-->>client: DPoP bound access token ($AT)
+    activate client
+    deactivate idp
+    client->>kong: GET https://example.com/resource<br>Authorization: DPoP $AT<br>DPoP: $PROOF
+    activate kong
+    deactivate client
+    kong->>kong: validate $AT and $PROOF
+    kong->>upstream: proxied request <br> GET https://example.com/resource<br>Authorization: Bearer $AT
+    deactivate kong
+    activate upstream
+    upstream-->>kong: upstream response
+    deactivate upstream
+    activate kong
+    kong-->>client: response
+    deactivate kong
+{% endmermaid %}
+<!--vale on-->

--- a/app/_includes/plugins/oidc/diagrams/introspection.md
+++ b/app/_includes/plugins/oidc/diagrams/introspection.md
@@ -1,0 +1,31 @@
+<!--vale off-->
+{% mermaid %}
+sequenceDiagram
+    autonumber
+    participant client as Client <br>(e.g. mobile app)
+    participant kong as API Gateway <br>(Kong)
+    participant idp as IdP <br>(e.g. Keycloak)
+    participant httpbin as Upstream <br>(upstream service,<br> e.g. httpbin)
+    activate client
+    activate kong
+    client->>kong: Service with access token
+    deactivate client
+    kong->>kong: load access token
+    activate idp
+    kong->>idp: IdP/introspect with <br/>client credentials and access token
+    deactivate kong
+    idp->>idp: authenticate client <br/>and introspect access token
+    activate kong
+    idp->>kong: return introspection response
+    deactivate idp
+    kong->>kong: verify introspection response
+    activate httpbin
+    kong->>httpbin: request with <br/>access token
+    httpbin->>kong: response
+    deactivate httpbin
+    activate client
+    kong->>client: response
+    deactivate kong
+    deactivate client
+{% endmermaid %}
+<!--vale on-->

--- a/app/_includes/plugins/oidc/diagrams/jwt-access-token.md
+++ b/app/_includes/plugins/oidc/diagrams/jwt-access-token.md
@@ -1,0 +1,24 @@
+<!--vale off-->
+{% mermaid %}
+sequenceDiagram
+    autonumber
+    participant client as Client <br>(e.g. mobile app)
+    participant kong as API Gateway <br>(Kong)
+    participant httpbin as Upstream <br>(upstream service,<br> e.g. httpbin)
+    activate client
+    activate kong
+    client->>kong: Service with<br>access token
+    deactivate client
+    kong->>kong: load access token
+    kong->>kong: verify signature
+    kong->>kong: verify claims
+    activate httpbin
+    kong->>httpbin: request with<br>access token
+    httpbin->>kong: response
+    deactivate httpbin
+    activate client
+    kong->>client: response
+    deactivate kong
+    deactivate client
+{% endmermaid %}
+<!--vale on-->

--- a/app/_includes/plugins/oidc/diagrams/kong-oauth2.md
+++ b/app/_includes/plugins/oidc/diagrams/kong-oauth2.md
@@ -1,0 +1,23 @@
+<!--vale off-->
+{% mermaid %}
+sequenceDiagram
+    autonumber
+    participant client as Client <br>(e.g. mobile app)
+    participant kong as API Gateway <br>(Kong)
+    participant httpbin as Upstream <br>(upstream service,<br> e.g. httpbin)
+    activate client
+    activate kong
+    client->>kong: Service with<br>access token
+    deactivate client
+    kong->>kong: load access token
+    kong->>kong: verify kong<br>oauth token
+    activate httpbin
+    kong->>httpbin: request with<br>access token
+    httpbin->>kong: response
+    deactivate httpbin
+    activate client
+    kong->>client: response
+    deactivate kong
+    deactivate client
+{% endmermaid %}
+<!--vale on-->

--- a/app/_includes/plugins/oidc/diagrams/password.md
+++ b/app/_includes/plugins/oidc/diagrams/password.md
@@ -1,0 +1,31 @@
+<!--vale off-->
+{% mermaid %}
+sequenceDiagram
+    autonumber
+    participant client as Client <br>(e.g. mobile app)
+    participant kong as API Gateway <br>(Kong)
+    participant idp as IdP <br>(e.g. Keycloak)
+    participant httpbin as Upstream <br>(upstream service,<br> e.g. httpbin)
+    activate client
+    activate kong
+    client->>kong: Service with<br>basic authentication
+    deactivate client
+    kong->>kong: load <br>basic authentication<br>credentials
+    activate idp
+    kong->>idp: IdP/token with<br>client credentials and<br>password grant
+    deactivate kong
+    idp->>idp: authenticate client and<br>verify password grant
+    activate kong
+    idp->>kong: return tokens
+    deactivate idp
+    kong->>kong: verify tokens
+    activate httpbin
+    kong->>httpbin: request with access token
+    httpbin->>kong: response
+    deactivate httpbin
+    activate client
+    kong->>client: response
+    deactivate kong
+    deactivate client
+{% endmermaid %}
+<!--vale on-->

--- a/app/_includes/plugins/oidc/diagrams/refresh-token.md
+++ b/app/_includes/plugins/oidc/diagrams/refresh-token.md
@@ -1,0 +1,31 @@
+<!--vale off-->
+{% mermaid %}
+sequenceDiagram
+    autonumber
+    participant client as Client <br>(e.g. mobile app)
+    participant kong as API Gateway <br>(Kong)
+    participant idp as IdP <br>(e.g. Keycloak)
+    participant httpbin as Upstream <br>(upstream service,<br> e.g. httpbin)
+    activate client
+    activate kong
+    client->>kong: Service with<br>refresh token
+    deactivate client
+    kong->>kong: load refresh token
+    activate idp
+    kong->>idp: IdP/token with<br>client credentials and<br>refresh token
+    deactivate kong
+    idp->>idp: authenticate client and<br>verify refresh token
+    activate kong
+    idp->>kong: return tokens
+    deactivate idp
+    kong->>kong: verify tokens
+    activate httpbin
+    kong->>httpbin: request with access token
+    httpbin->>kong: response
+    deactivate httpbin
+    activate client
+    kong->>client: response
+    deactivate kong
+    deactivate client
+{% endmermaid %}
+<!--vale on-->

--- a/app/_includes/plugins/oidc/diagrams/session.md
+++ b/app/_includes/plugins/oidc/diagrams/session.md
@@ -1,0 +1,23 @@
+<!--vale off-->
+{% mermaid %}
+sequenceDiagram
+    autonumber
+    participant client as Client <br>(e.g. mobile app)
+    participant kong as API Gateway <br>(Kong)
+    participant httpbin as Upstream <br>(upstream service,<br> e.g. httpbin)
+    activate client
+    activate kong
+    client->>kong: Service with<br>session cookie
+    deactivate client
+    kong->>kong: load session cookie
+    kong->>kong: verify session
+    activate httpbin
+    kong->>httpbin: request with<br>access token
+    httpbin->>kong: response
+    deactivate httpbin
+    activate client
+    kong->>client: response
+    deactivate kong
+    deactivate client
+{% endmermaid %}
+<!--vale on-->

--- a/app/_includes/plugins/oidc/diagrams/user-info.md
+++ b/app/_includes/plugins/oidc/diagrams/user-info.md
@@ -1,0 +1,31 @@
+<!--vale off-->
+{% mermaid %}
+sequenceDiagram
+    autonumber
+    participant client as Client <br>(e.g. mobile app)
+    participant kong as API Gateway <br>(Kong)
+    participant idp as IdP <br>(e.g. Keycloak)
+    participant httpbin as Upstream <br>(upstream service,<br> e.g. httpbin)
+    activate client
+    activate kong
+    client->>kong: Service with<br>access token
+    deactivate client
+    kong->>kong: load access token
+    activate idp
+    kong->>idp: IdP/userinfo<br>with client credentials<br>and access token
+    deactivate kong
+    idp->>idp: authenticate client and<br>verify token
+    activate kong
+    idp->>kong: return user info <br>response
+    deactivate idp
+    kong->>kong: verify response<br>status code (200)
+    activate httpbin
+    kong->>httpbin: request with access token
+    httpbin->>kong: response
+    deactivate httpbin
+    activate client
+    kong->>client: response
+    deactivate kong
+    deactivate client
+{% endmermaid %}
+<!--vale on-->

--- a/app/_kong_plugins/openid-connect/examples/acl-auth.yaml
+++ b/app/_kong_plugins/openid-connect/examples/acl-auth.yaml
@@ -50,4 +50,4 @@ tools:
   - kic
   - terraform
 
-group: authentication
+group: authorization

--- a/app/_kong_plugins/openid-connect/examples/authorization-code.yaml
+++ b/app/_kong_plugins/openid-connect/examples/authorization-code.yaml
@@ -5,6 +5,10 @@ description: |
 extended_description: |
   This example configures the OpenID Connect plugin with an authorization code flow.
 
+  Here's how the auth code flow works:
+
+  {% include_cached plugins/oidc/diagrams/auth-code.md %}
+
   For a full example that shows you how to set up the authorization code flow with Keycloak, 
   see [Configure OpenID Connect with the auth code flow](/how-to/configure-oidc-with-auth-code-flow/).
 

--- a/app/_kong_plugins/openid-connect/examples/client-credentials.yaml
+++ b/app/_kong_plugins/openid-connect/examples/client-credentials.yaml
@@ -3,6 +3,10 @@ description: |
   Configure the OpenID Connect plugin with the client credentials grant. 
 extended_description: |
   Configure the OpenID Connect plugin with the client credentials grant. 
+
+  Here's how the client credentials grant works:
+
+  {% include_cached plugins/oidc/diagrams/client-credentials.md %}
   
   In this example, the plugin will only accept client credentials sent in a header, 
   but you can also set the `client_credentials_param_type` parameter to `body`, `query`, or any combination of these values.

--- a/app/_kong_plugins/openid-connect/examples/dpop.yaml
+++ b/app/_kong_plugins/openid-connect/examples/dpop.yaml
@@ -4,6 +4,10 @@ description: |
 extended_description: |
   Configure the OpenID Connect plugin for [Demonstrating Proof-of-Possession](/plugins/openid-connect/#demonstrating-proof-of-possession-dpop) by using the `proof_of_possession_dpop` configuration option. 
   
+  Here's how DPoP works:
+  
+  {% include_cached plugins/oidc/diagrams/dpop.md %}
+  
   This method binds the access token to a JSON Web Key (JWK) provided by the client.
 
 weight: 820

--- a/app/_kong_plugins/openid-connect/examples/introspection-auth.yaml
+++ b/app/_kong_plugins/openid-connect/examples/introspection-auth.yaml
@@ -4,6 +4,10 @@ description: |
 extended_description: |
   Configure the OpenID Connect plugin with introspection authentication.
 
+  Here's how introspection auth works:
+
+  {% include_cached plugins/oidc/diagrams/introspection.md %}
+
   In this example, the plugin will only accept a bearer token sent in a header, 
   but you can also set the `bearer_token_param_type` parameter to `body`, `query`, or any combination of these values.
   

--- a/app/_kong_plugins/openid-connect/examples/jwt-access-token.yaml
+++ b/app/_kong_plugins/openid-connect/examples/jwt-access-token.yaml
@@ -4,6 +4,10 @@ description: |
 extended_description: |
   Configure the OpenID Connect plugin with JWT access token authentication.
 
+  Here's how JWT access token auth works:
+
+  {% include_cached plugins/oidc/diagrams/jwt-access-token.md %}
+
   In this example, the plugin will only accept a bearer token sent in a query string, 
   but you can also set the `bearer_token_param_type` parameter to `body`, `header`, or any combination of these values.
   

--- a/app/_kong_plugins/openid-connect/examples/kong-oauth-token.yaml
+++ b/app/_kong_plugins/openid-connect/examples/kong-oauth-token.yaml
@@ -5,6 +5,10 @@ description: |
 extended_description: |
   Configure the OpenID Connect plugin to verify the tokens issued by [Kong OAuth 2.0](/plugins/oauth2/) plugin. 
 
+  Here's how Kong OAuth2 authentication works:
+
+  {% include_cached plugins/oidc/diagrams/kong-oauth2.md %}
+
   In this example, the OpenID Connect plugin will only accept a bearer token sent in a header, 
   but you can also set the `bearer_token_param_type` parameter to `body`, `query`, `cookie`, or any combination of these values.
 

--- a/app/_kong_plugins/openid-connect/examples/password.yaml
+++ b/app/_kong_plugins/openid-connect/examples/password.yaml
@@ -8,6 +8,10 @@ extended_description: |
   {:.info}
   > This is a legacy authentication grant, as it's less secure than other flows.
 
+  Here's how the password grant works:
+
+  {% include_cached plugins/oidc/diagrams/password.md %}
+
   In this example, the OpenID Connect plugin will only accept the password sent in a header, 
   but you can also set the [`config.bearer_token_param_type`](/plugins/openid-connect/reference/#schema--config-bearer-token-param-type) parameter to `body`, `query`, `cookie`, or any combination of these values.
 

--- a/app/_kong_plugins/openid-connect/examples/refresh-token.yaml
+++ b/app/_kong_plugins/openid-connect/examples/refresh-token.yaml
@@ -5,6 +5,10 @@ description: |
 extended_description: |
   Configure the OpenID Connect plugin to use the refresh token grant.
 
+  Here's how refresh token grant auth works:
+
+  {% include_cached plugins/oidc/diagrams/refresh-token.md %}
+
   In this example, the OpenID Connect plugin will only accept refresh tokens sent in a header, 
   but you can also set the `refresh_token_param_type` parameter to `body`, `query`, or any combination of these values.
 

--- a/app/_kong_plugins/openid-connect/examples/session-auth.yaml
+++ b/app/_kong_plugins/openid-connect/examples/session-auth.yaml
@@ -4,6 +4,23 @@ description: |
 extended_description: |
   Configure the OpenID Connect plugin to issue session cookies that can be used for further session authentication.
 
+  <blockquote class="info">
+  <details>
+  <summary>
+  <b>Expand this block to see a diagram illustrating how this flow works</b>
+  </summary>
+
+  {% capture session %}
+
+  {% include_cached plugins/oidc/diagrams/session.md %}
+
+  {% endcapture %}
+
+  {{ session | markdownify }}
+
+  </details>
+  </blockquote>
+
   For a complete example of retrieving, storing, and using session cookies for authentication with Keycloak, see the tutorial for [configuring OpenID Connect with session authentication](/how-to/configure-oidc-with-session-auth/).
   
   {% include_cached plugins/oidc/client-auth.md %}

--- a/app/_kong_plugins/openid-connect/examples/user-info-auth.yaml
+++ b/app/_kong_plugins/openid-connect/examples/user-info-auth.yaml
@@ -5,6 +5,10 @@ description: |
 extended_description: |
   Configure the OpenID Connect plugin to use user info authentication.
 
+  Here's how user info auth works:
+
+  {% include_cached plugins/oidc/diagrams/user-info.md %}
+
   In this example, the OpenID Connect plugin will only accept bearer tokens sent in a header, 
   but you can also set the `bearer_token_param_type` parameter to `body`, `query`, or any combination of these values.
 


### PR DESCRIPTION
## Description

Fixes #1949 

* Adding auth method diagrams to their respective examples - the diagrams aren't new, they're completely unchanged, just moved into their own files. No need to review them.
* Adding links from the OIDC overview page sections to their respective examples and how-tos
* Re-ordering the auth methods on the OIDC overview page to reflect their precedence order

Reviewers:
I'm testing two different methods of including the diagrams for the examples:
* Show the diagram completely
* Hide the diagram in a collapsed section

If we show them, people won't miss the diagrams. If we hide them, they don't have to scroll as much, and looking at the diagram is completely optional. This really depends on where they're coming from - if they were linked from the OIDC overview page, they already saw the diagram and this is a repeat. If they're coming from anywhere else (search, google, oidc landing page), then the diagram is potentially new and relevant. Which approach do you prefer?

## Preview Links


## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [x] Add new pages to the product documentation index (if applicable).
