### PR TITLE
Revert changes to X-Proxy-Kong-Latency

### DIFF
--- a/app/gateway/traffic-control/proxying.md
+++ b/app/gateway/traffic-control/proxying.md
@@ -193,7 +193,7 @@ rows:
   - header: "`Via: kong/x.x.x`"
     description: "`x.x.x` is the {{site.base_gateway}} version in use."
   - header: "`X-Kong-Proxy-Latency: <latency>`"
-    description: "`latency` is the time, in milliseconds, between {{site.base_gateway}} receiving the request from the client and sending the request to your upstream service. {% if_version gte:3.11.x %} In {{site.base_gateway}} 3.11 or later, This value represents the pure Kong internal processing time, excluding external factors such as upstream latency and third-party I/O latencies (e.g., Redis, DNS, HTTP calls, socket calls). {% endif_version %}"
+    description: "`latency` is the time, in milliseconds, between {{site.base_gateway}} receiving the request from the client and sending the request to your upstream service."
   - header: "`X-Kong-Upstream-Latency: <latency>`"
     description: "`latency` is the time, in milliseconds, that {{site.base_gateway}} was waiting for the first byte of the upstream service response."
 {% endtable %}


### PR DESCRIPTION
## Description

Partial revert of doc changes made in https://github.com/Kong/developer.konghq.com/pull/1821
The changes to the X-Kong-Proxy-Latency header were reversed in https://github.com/Kong/kong-ee/pull/13007


## Preview Links


## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [x] Add new pages to the product documentation index (if applicable).
