### PR TITLE
Reuse manual cert mapping info across plugins

### DIFF
--- a/app/_includes/plugins/manual-consumer-mapping.md
+++ b/app/_includes/plugins/manual-consumer-mapping.md
@@ -1,0 +1,91 @@
+Sometimes, you might not want to use automatic Consumer lookup, or you have certificates
+that contain a field value not directly associated with Consumer objects. In those
+situations, you can manually assign one or more subject names to the [Consumer entity](/gateway/entities/consumer/) for
+identifying the correct Consumer.
+
+{:.info}
+> **Note**: Subject names refer to the certificate's Subject Alternative Names (SAN) or
+Common Name (CN). CN is only used if the SAN extension does not exist.
+
+{% if include.slug == "mtls-auth" %}
+You can create a Consumer mapping with either of the following:
+  * The [`/consumers/{consumer}/mtls-auth` Admin API endpoint](/plugins/mtls-auth/api/)
+  * [decK](/gateway/entities/consumer/#set-up-a-consumer) by specifying `mtls_auth_credentials` in the configuration like the following:
+
+    ```yaml
+    consumers:
+    - custom_id: my-consumer
+      username: example-consumer
+      mtls_auth_credentials:
+      - id: bda09448-3b10-4da7-a83b-2a8ba6021f0c
+        subject_name: test@example.com
+    ```
+{% elsif include.slug == "header-cert-auth" %}
+You can create a Consumer mapping with either of the following:
+  * The [`/consumers/{consumer}/header-cert-auth` Admin API endpoint](/plugins/header-cert-auth/api/)
+  * [decK](/gateway/entities/consumer/#set-up-a-consumer) by specifying `header_cert_auth_credentials` in the configuration like the following:
+
+    ```yaml
+    consumers:
+    - custom_id: my-consumer
+      username: example-consumer
+      header_cert_auth_credentials:
+      - id: bda09448-3b10-4da7-a83b-2a8ba6021f0c
+        subject_name: test@example.com
+    ```
+{% endif %}
+
+The following table describes how Consumer mapping parameters work for the {{include.name}} plugin:
+
+{% table %}
+columns:
+  - title: Form Parameter
+    key: parameter
+  - title: Default
+    key: default
+  - title: Description
+    key: description
+rows:
+  - parameter: "`id`<br>*required for declarative config*"
+    default: none
+    description: "UUID of the Consumer mapping. Required if adding mapping using declarative configuration, otherwise generated automatically by {{site.base_gateway}}'s Admin API."
+  - parameter: "`subject_name`<br>*required*"
+    default: none
+    description: "The Subject Alternative Name (SAN) or Common Name (CN) that should be mapped to `consumer` (in order of lookup)."
+  - parameter: "`ca_certificate`<br>*optional*"
+    default: none
+    description: |
+      * **If using the Admin API:** UUID of the Certificate Authority (CA). 
+      * **If using declarative configuration:** Full PEM-encoded CA certificate.
+      <br><br>
+      The provided CA UUID or full CA Certificate has to be verifiable by the issuing certificate authority for the mapping to succeed. 
+      This is to help distinguish multiple certificates with the same subject name that are issued under different CAs. 
+      <br><br>
+      If empty, the subject name matches certificates issued by any CA under the corresponding `config.ca_certificates`."
+{% endtable %}
+
+### Matching behaviors
+
+After a client certificate has been verified as valid, the Consumer object is determined in the following order, unless [`config.skip_consumer_lookup`](./reference/#schema--config-skip-consumer-lookup) is set to `true`:
+
+1. Manual mappings with `subject_name` matching the certificate's SAN or CN (in that order) and `ca_certificate = {issuing authority of the client certificate}`.
+2. Manual mappings with `subject_name` matching the certificate's SAN or CN (in that order) and `ca_certificate = NULL`.
+3. If [`config.consumer_by`](./reference/#schema--config-consumer-by) is not null, Consumer with `username` and/or `id` matching the certificate's SAN or CN (in that order).
+4. The [`config.anonymous`](./reference/#schema--config-anonymous) Consumer (if set).
+
+{:.info}
+> **Note**: Matching stops as soon as the first successful match is found.
+
+### Upstream headers
+
+{% include_cached /plugins/upstream-headers.md %}
+
+When [`config.skip_consumer_lookup`](./reference/#schema--config-skip-consumer-lookup) is set to `true`, Consumer lookup is skipped and instead of appending aforementioned headers, the plugin appends the following two headers:
+
+* `X-Client-Cert-Dn`: The distinguished name of the client certificate
+* `X-Client-Cert-San`: The SAN of the client certificate
+
+Once `config.skip_consumer_lookup` is applied, any client with a valid certificate can access the Service/API.
+To restrict usage to only some of the authenticated users, also add the [ACL plugin](/plugins/acl/) and create
+allowed or denied groups of users using the same
+certificate property being set in [`config.authenticated_group_by`](./reference/#schema--config-authenticated-group-by).

--- a/app/_kong_plugins/header-cert-auth/index.md
+++ b/app/_kong_plugins/header-cert-auth/index.md
@@ -124,77 +124,13 @@ x-client-cert: -----BEGIN%20CERTIFICATE-----%0AMIIDbDCCAdSgAwIBAgIUa...-----END%
 
 ## Manual mappings between Certificate and Consumer objects
 
-Sometimes, you might not want to use automatic Consumer lookup, or you have certificates
-that contain a field value not directly associated with Consumer objects. In those
-situations, you can manually assign one or more subject names to the [Consumer entity](/gateway/entities/consumer/) for
-identifying the correct Consumer.
-
-{:.info}
-> **Note**: Subject names refer to the certificate's Subject Alternative Names (SAN) or
-Common Name (CN). CN is only used if the SAN extension does not exist.
-
-You can create a Consumer mapping with either of the following:
-  * The [`/consumers/{consumer}/header-cert-auth` Admin API endpoint](/api/gateway/admin-ee/#/operations/create-plugin-for-consumer)
-  * [decK](/gateway/entities/consumer/#set-up-a-consumer) by specifying `header_cert_auth_credentials` in the configuration like the following:
-
-    ```yaml
-    consumers:
-    - custom_id: my-consumer
-      username: {consumer}
-      header_cert_auth_credentials:
-      - id: bda09448-3b10-4da7-a83b-2a8ba6021f0c
-        subject_name: test@example.com
-    ```
-
-The following table describes how Consumer mapping parameters work for the Header Cert Auth plugin:
-
-{% table %}
-columns:
-  - title: Form Parameter
-    key: parameter
-  - title: Default
-    key: default
-  - title: Description
-    key: description
-rows:
-  - parameter: "`id`<br>*required for declarative config*"
-    default: none
-    description: "UUID of the Consumer mapping. Required if adding mapping using declarative configuration, otherwise generated automatically by {{site.base_gateway}}'s Admin API."
-  - parameter: "`subject_name`<br>*required*"
-    default: none
-    description: "The Subject Alternative Name (SAN) or Common Name (CN) that should be mapped to `consumer` (in order of lookup)."
-  - parameter: "`ca_certificate`<br>*optional*"
-    default: none
-    description: "**If using the Admin API:** UUID of the Certificate Authority (CA). <br><br> **If using declarative configuration:** Full PEM-encoded CA certificate. <br><br>The provided CA UUID or full CA Certificate has to be verifiable by the issuing certificate authority for the mapping to succeed. This is to help distinguish multiple certificates with the same subject name that are issued under different CAs. <br><br>If empty, the subject name matches certificates issued by any CA under the corresponding `config.ca_certificates`."
-{% endtable %}
-
-### Matching behaviors
-
-After a client certificate has been verified as valid, the Consumer object is determined in the following order, unless [`config.skip_consumer_lookup`](./reference/#schema--config-skip-consumer-lookup) is set to `true`:
-
-1. Manual mappings with `subject_name` matching the certificate's SAN or CN (in that order) and `ca_certificate = {issuing authority of the client certificate}`
-2. Manual mappings with `subject_name` matching the certificate's SAN or CN (in that order) and `ca_certificate = NULL`
-3. If [`config.consumer_by`](./reference/#schema--config.consumer_by) is not null, Consumer with `username` and/or `id` matching the certificate's SAN or CN (in that order)
-4. The [`config.anonymous`](./reference/#schema--config-anonymous) Consumer (if set)
-
-{:.info}
-> **Note**: Matching stops as soon as the first successful match is found.
-
-### Upstream headers
-{% include_cached /plugins/upstream-headers.md %}
-
-When `config.skip_consumer_lookup` is set to `true`, Consumer lookup is skipped and instead of appending aforementioned headers, the plugin appends the following two headers:
-
-* `X-Client-Cert-Dn`: The distinguished name of the client certificate
-* `X-Client-Cert-San`: The SAN of the client certificate
-
-Once `config.skip_consumer_lookup` is applied, any client with a valid certificate can access the Service/API.
-To restrict usage to only some of the authenticated users, also add the [ACL plugin](/plugins/acl/) and create
-allowed or denied groups of users using the same
-certificate property being set in `config.authenticated_group_by`.
+{% include_cached plugins/manual-consumer-mapping.md name=page.name slug=page.slug %}
 
 ## Troubleshooting authentication failure
 
-When authentication fails, the client doesn't have access to any details that explain the failure. The security reason for this omission is to prevent malicious reconnaissance. Instead, the details are recorded inside [{{site.base_gateway}}'s error logs](/gateway/logs/) under the `[header-cert-auth]` filter.
+When authentication fails, the client doesn't have access to any details that explain the failure. 
+The security reason for this omission is to prevent malicious reconnaissance. 
+
+Instead, the details are recorded inside [{{site.base_gateway}}'s error logs](/gateway/logs/) under the `[header-cert-auth]` filter.
 
 

--- a/app/_kong_plugins/mtls-auth/index.md
+++ b/app/_kong_plugins/mtls-auth/index.md
@@ -109,9 +109,13 @@ During the mTLS handshake:
 * If the client includes a known SNI in the `ClientHello`, the corresponding CA DN list is sent in the `CertificateRequest`.
 * If the client does not send an SNI or sends an unknown one, {{site.base_gateway}} only sends the CA DN list associated with `*`—and only if a client certificate is being requested.
 
+## Manual mappings between Certificate and Consumer objects
 
-### Troubleshooting
+{% include_cached plugins/manual-consumer-mapping.md name=page.name slug=page.slug %}
 
-When authentication fails, the client does not receive any details about the failure. This is intentional for security reasons—to prevent information leaks that could aid malicious users.
+## Troubleshooting authentication failure
 
-Failure details are logged internally in {{site.base_gateway}} error logs under the `[mtls-auth]` filter.
+When authentication fails, the client doesn't have access to any details that explain the failure. 
+The security reason for this omission is to prevent malicious reconnaissance. 
+
+Instead, the details are recorded inside [{{site.base_gateway}}'s error logs](/gateway/logs/) under the `[mtls-auth]` filter.


### PR DESCRIPTION
## Description

We have this info documented in the Header Cert Auth plugin, but not in the mTLS Auth plugin. The docs is exactly the same for both:
* [Header Cert Auth](https://old-docs-preview--kongdocs.netlify.app/hub/kong-inc/header-cert-auth/how-to/manual-mapping-cert-consumers/)
* [mTLS Auth](https://old-docs-preview--kongdocs.netlify.app/hub/kong-inc/mtls-auth/how-to/manual-mapping-cert-consumers/)

Issue reported on Slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1751401614190219

## Preview Links

## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [x] Add new pages to the product documentation index (if applicable).
