### PR TITLE
Migrate plugin PDKs

### DIFF
--- a/app/_landing_pages/custom-plugins.yaml
+++ b/app/_landing_pages/custom-plugins.yaml
@@ -130,6 +130,8 @@ rows:
           description: |
             {{site.base_gateway}} supports the Go language with the Go PDK, a library that provides Go bindings for {{site.base_gateway}}
           ctas:
+            - text: Writing plugins in Go
+              url: /custom-plugins/go/
             - text: Kong Go PDK
               url: https://pkg.go.dev/github.com/Kong/go-pdk
             - text: Example plugins
@@ -142,6 +144,8 @@ rows:
           description: |
             {{site.base_gateway}} support for Python plugin development is provided by the `kong-python-pdk` library
           ctas:
+            - text: Writing plugins in Python
+              url: /custom-plugins/python/
             - text: Kong Python PDK
               url: https://github.com/Kong/kong-python-pdk
             - text: Example plugins
@@ -154,6 +158,8 @@ rows:
           description: |
             {{site.base_gateway}} support for the JavaScript language is provided by the JavaScript PDK
           ctas:
+            - text: Writing plugins in JavaScript
+              url: /custom-plugins/javascript/
             - text: Kong JavaScript PDK
               url: https://github.com/Kong/kong-js-pdk
             - text: Example plugins

--- a/app/_landing_pages/custom-plugins.yaml
+++ b/app/_landing_pages/custom-plugins.yaml
@@ -118,6 +118,8 @@ rows:
           description: |
             {{site.base_gateway}} provides a broad plugin development environment including an SDK, database abstractions, migrations
           ctas:
+            - text: Writing plugins in Lua
+              url: /custom-plugins/reference/
             - text: Kong Lua PDK
               url: "/gateway/pdk/reference/"
             - text: Plugin template

--- a/app/custom-plugins/go.md
+++ b/app/custom-plugins/go.md
@@ -1,0 +1,185 @@
+---
+title: Writing plugins in Go
+content_type: reference
+layout: reference
+
+breadcrumbs:
+  - /custom-plugins/
+
+products:
+    - gateway
+
+works_on:
+    - on-prem
+
+description: Learn how to write plugins for {{site.base_gateway}} in Go.
+
+tags:
+  - custom-plugins
+
+min_version:
+  gateway: '3.4'
+
+related_resources:
+  - text: Custom plugins
+    url: /custom-plugins/
+  - text: Custom plugins reference
+    url: /custom-plugins/reference/
+  - text: Writing plugins in Javascript
+    url: /custom-plugins/javascript/
+  - text: Writing plugins in Python
+    url: /custom-plugins/python/
+  - text: Running plugins in containers
+    url: /custom-plugins/installation-and-distribution/#via-a-dockerfile-or-docker-run-install-and-load
+  - text: Go PDK repository
+    url: https://github.com/Kong/go-pdk
+---
+
+{{site.base_gateway}} supports the Go language with the [Go PDK](https://pkg.go.dev/github.com/Kong/go-pdk), a library that provides Go bindings for {{site.base_gateway}}.
+
+To write a {{site.base_gateway}} plugin in Go, you need to:
+
+1. Define a `structure` type to hold configuration.
+2. Write a `New()` function to create instances of your structure.
+3. Add methods to that structure to handle phases.
+4. Include the `go-pdk/server` sub-library.
+5. Add a `main()` function that calls `server.StartServer(New, Version, Priority)`.
+6. Compile as an executable with `go build`.
+
+See the [Go PDK repository](https://github.com/Kong/go-pdk/tree/master/examples) for examples of plugins built with Go.
+
+## Configuration
+
+Configuration reference for the Go PDK.
+
+<!--vale off-->
+### Struct
+<!--vale on-->
+
+The plugin you write needs a way to handle incoming configuration data from the data store or the Admin API.
+You can use a `struct` to create a schema of the incoming data.
+
+```go
+type MyConfig struct {
+    Path   string
+    Reopen bool
+}
+```
+Because this plugin will be processing configuration data, you are going to want to control encoding using the `encoding/json` package.
+Go fields that start with a capital letter can be exported, making them accessible outside of the current package, including by the `encoding/json` package.
+If you want the fields to have a different name in the data store, add tags to the fields in your `struct`.
+
+```go
+type MyConfig struct {
+    Path   string `json:"my_file_path"`
+    Reopen bool   `json:"reopen"`
+}
+```
+
+<!--vale off-->
+### New() constructor
+<!--vale on-->
+
+The plugin must define a function called `New`.
+This function should instantiate the `MyConfig` struct and return it as an `interface`.
+
+```go
+func New() interface{} {
+    return &MyConfig{}
+}
+```
+
+<!--vale off-->
+### main() function
+<!--vale on-->
+
+Each plugin is compiled as a standalone executable. 
+Include `github.com/Kong/go-pdk` in the imports list, and add a `main()` function:
+
+```go
+func main () {
+  server.StartServer(New, Version, Priority)
+}
+```
+
+Executables can be placed somewhere in your path (for example, `/usr/local/bin`). 
+For example, the `-h` flag shows a usage help message:
+
+```sh
+my-plugin -h
+```
+
+Output:
+```sh
+Usage of my-plugin:
+  -dump
+        Dump info about plugins
+  -help
+        Show usage info
+  -kong-prefix string
+        Kong prefix path (specified by the -p argument commonly used in the Kong CLI) (default "/usr/local/kong")
+```
+{:.no-copy-code}
+
+When you run the plugin without arguments, it creates a socket file within the `kong-prefix` and the executable name, appending `.socket`.
+For example, if the executable is `my-plugin`, the socket file would be `/usr/local/kong/my-plugin.socket`.
+
+### Phase handlers
+
+In {{site.base_gateway}} Lua plugins, you can implement custom logic to be executed at various [phases](/custom-plugins/handler.lua/) of the request processing lifecycle. 
+For example, to execute custom Go code during the access phase, create a function named `Access` with the following function signature:
+
+```go
+func (conf *MyConfig) Access (kong *pdk.PDK) {
+  ...
+}
+```
+
+You can implement custom logic during the following phases using the same function signature:
+
+* `certificate`
+* `rewrite`
+* `access`
+* `response`
+* `preread`
+* `log`
+
+The presence of the `Response` handler automatically enables the buffered proxy mode.
+
+### Version and priority
+
+You can define the version number and priority of execution by declaring the following constants within the plugin code:
+
+```go
+const Version = "1.0.0"
+const Priority = 1
+```
+
+{{site.base_gateway}} executes plugins from highest priority to lowest.
+
+## Example configuration
+
+To load plugins using the `kong.conf` [configuration file](/gateway/configuration/), you have to map existing {{site.base_gateway}} properties to aspects of your plugin.
+Here are two examples of loading plugins within `kong.conf`:
+
+```
+pluginserver_names = my-plugin,other-one
+
+pluginserver_my_plugin_socket = /usr/local/kong/my-plugin.socket
+pluginserver_my_plugin_start_cmd = /usr/local/bin/my-plugin
+pluginserver_my_plugin_query_cmd = /usr/local/bin/my-plugin -dump
+
+pluginserver_other_one_socket = /usr/local/kong/other-one.socket
+pluginserver_other_one_start_cmd = /usr/local/bin/other-one
+pluginserver_other_one_query_cmd = /usr/local/bin/other-one -dump
+
+```
+
+The socket and start command settings coincide with
+their defaults and can be omitted:
+
+```
+pluginserver_names = my-plugin,other-one
+pluginserver_my_plugin_query_cmd = /usr/local/bin/my-plugin -dump
+pluginserver_other_one_query_cmd = /usr/local/bin/other-one -dump
+```

--- a/app/custom-plugins/go.md
+++ b/app/custom-plugins/go.md
@@ -35,7 +35,10 @@ related_resources:
     url: https://github.com/Kong/go-pdk
 ---
 
-{{site.base_gateway}} supports the Go language with the [Go PDK](https://pkg.go.dev/github.com/Kong/go-pdk), a library that provides Go bindings for {{site.base_gateway}}.
+{{site.base_gateway}} supports Go plugin development through the [Go PDK](https://pkg.go.dev/github.com/Kong/go-pdk) library,
+which provides Go bindings for {{site.base_gateway}}.
+
+## Development
 
 To write a {{site.base_gateway}} plugin in Go, you need to:
 
@@ -157,7 +160,7 @@ const Priority = 1
 
 {{site.base_gateway}} executes plugins from highest priority to lowest.
 
-## Example configuration
+## Loading the plugin into {{site.base_gateway}}
 
 To load plugins using the `kong.conf` [configuration file](/gateway/configuration/), you have to map existing {{site.base_gateway}} properties to aspects of your plugin.
 Here are two examples of loading plugins within `kong.conf`:

--- a/app/custom-plugins/javascript.md
+++ b/app/custom-plugins/javascript.md
@@ -35,8 +35,8 @@ related_resources:
     url: https://github.com/Kong/kong-js-pdk
 ---
 
-{{site.base_gateway}} support for the JavaScript language is provided by the [JavaScript PDK](https://github.com/Kong/kong-js-pdk).
-The library provides a plugin server that provides a runtime for JavaScript bindings for {{site.base_gateway}}.
+{{site.base_gateway}} supports JavaScript plugin development through the [JavaScript PDK](https://github.com/Kong/kong-js-pdk).
+The `kong-js-pdk` library provides a plugin server that provides a runtime for JavaScript bindings for {{site.base_gateway}}.
 
 TypeScript is also supported in the following ways:
 
@@ -73,7 +73,11 @@ module.exports = {
 
 See the [JavaScript PDK repository](https://github.com/Kong/kong-js-pdk/tree/master/examples) for examples of plugins built with JavaScript.
 
-## Phase handlers
+## Configuration
+
+Configuration reference for the JavaScript PDK.
+
+### Phase handlers
 
 You can implement custom logic to be executed at various [phases](/custom-plugins/handler.lua/) in the request processing lifecycle. 
 For example, to execute custom JavaScript code in the access phase, define a function named `access`:
@@ -100,7 +104,7 @@ You can implement custom logic during the following phases using the same functi
 
 The presence of the `response` handler automatically enables the buffered proxy mode.
 
-## PDK functions
+### PDK functions
 
 Kong interacts with the PDK through network-based inter-rocess communication.
 Each function returns a [promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) instance. 
@@ -136,7 +140,7 @@ class KongPlugin {
 }
 ```
 
-## Plugin dependencies
+### Plugin dependencies
 
 When using the plugin server, plugins are allowed to have extra dependencies, as long as the
 directory that holds plugin source code also includes a `node_modules` directory.
@@ -169,7 +173,7 @@ Then, import `kong-pdk` in your TypeScript file:
 import kong from "kong-pdk/kong";
 ````
 
-### Testing
+#### Testing
 
 The JavaScript PDK provides a mock framework to test plugin code using [`jest`](https://jestjs.io/).
 
@@ -201,7 +205,7 @@ npm test
 
 See the [JavaScript PDK repo](https://github.com/Kong/kong-js-pdk/tree/master/examples) for examples of writing tests with `jest`.
 
-## Example configuration
+## Loading the plugin into {{site.base_gateway}}
 
 Prepare the system by installing the required dependencies. 
 

--- a/app/custom-plugins/javascript.md
+++ b/app/custom-plugins/javascript.md
@@ -1,0 +1,234 @@
+---
+title: Writing plugins in JavaScript
+content_type: reference
+layout: reference
+
+breadcrumbs:
+  - /custom-plugins/
+
+products:
+    - gateway
+
+works_on:
+    - on-prem
+
+description: Learn how to write plugins for {{site.base_gateway}} in JavaScript.
+
+tags:
+  - custom-plugins
+
+min_version:
+  gateway: '3.4'
+
+related_resources:
+  - text: Custom plugins
+    url: /custom-plugins/
+  - text: Custom plugins reference
+    url: /custom-plugins/reference/
+  - text: Writing plugins in Go
+    url: /custom-plugins/go/
+  - text: Writing plugins in Python
+    url: /custom-plugins/python/
+  - text: Running plugins in containers
+    url: /custom-plugins/installation-and-distribution/#via-a-dockerfile-or-docker-run-install-and-load
+  - text: JavaScript PDK repository
+    url: https://github.com/Kong/kong-js-pdk
+---
+
+{{site.base_gateway}} support for the JavaScript language is provided by the [JavaScript PDK](https://github.com/Kong/kong-js-pdk).
+The library provides a plugin server that provides a runtime for JavaScript bindings for {{site.base_gateway}}.
+
+TypeScript is also supported in the following ways:
+
+* The PDK includes type definitions for PDK functions that allow type checking when developing plugins in TypeScript.
+* Plugins written in TypeScript can be loaded directly to {{site.base_gateway}} and transpiled.
+
+## Installation
+
+You can install the [JavaScript PDK](https://github.com/Kong/kong-js-pdk) using `npm`. 
+To install the plugin server binary globally, run the following command:
+
+```sh
+npm install kong-pdk -g
+```
+
+## Development
+
+A valid JavaScript plugin implementation should export the following object:
+
+```javascript
+module.exports = {
+  Plugin: KongPlugin,
+  Schema: [
+    { message: { type: "string" } },
+  ],
+  Version: '0.1.0',
+  Priority: 0,
+}
+```
+
+* The `Plugin` attribute defines the class that implements this plugin.
+* The `Schema` defines the configuration schema of the plugin.
+* `Version` and `Priority` variables set to the version number and priority of execution.
+
+See the [JavaScript PDK repository](https://github.com/Kong/kong-js-pdk/tree/master/examples) for examples of plugins built with JavaScript.
+
+## Phase handlers
+
+You can implement custom logic to be executed at various [phases](/custom-plugins/handler.lua/) in the request processing lifecycle. 
+For example, to execute custom JavaScript code in the access phase, define a function named `access`:
+
+```javascript
+class KongPlugin {
+  constructor(config) {
+    this.config = config
+  }
+  async access(kong) {
+    // ...
+  }
+}
+```
+
+You can implement custom logic during the following phases using the same function signature:
+
+* `certificate`
+* `rewrite`
+* `access`
+* `response`
+* `preread`
+* `log`
+
+The presence of the `response` handler automatically enables the buffered proxy mode.
+
+## PDK functions
+
+Kong interacts with the PDK through network-based inter-rocess communication.
+Each function returns a [promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise) instance. 
+
+You can use `async` and `await` keywords in the phase handlers for better readability.
+For example:
+
+```javascript
+class KongPlugin {
+  constructor(config) {
+    this.config = config
+  }
+  async access(kong) {
+    let host = await kong.request.getHeader("host")
+    // do something to host
+  }
+}
+```
+
+Alternatively, use the `then` method to resolve a promise:
+
+```javascript
+class KongPlugin {
+  constructor(config) {
+    this.config = config
+  }
+  async access(kong) {
+    kong.request.getHeader("host")
+      .then((host) => {
+        // do something to host
+      })
+  }
+}
+```
+
+## Plugin dependencies
+
+When using the plugin server, plugins are allowed to have extra dependencies, as long as the
+directory that holds plugin source code also includes a `node_modules` directory.
+
+Assuming plugins are stored under `/usr/local/kong/js-plugins`, the extra dependencies are
+then defined in `/usr/local/kong/js-plugins/package.json`. 
+
+Developers also need to run `npm install` under `/usr/local/kong/js-plugins` to install those dependencies locally
+into `/usr/local/kong/js-plugins/node_modules`.
+
+The Node.js version and architecture that runs the plugin server and
+the one that runs `npm install` under plugins directory must match.
+
+When running TypeScript plugins, `kong-pdk` needs to be defined as a dependency in `package.json`:
+
+````json
+{
+  "name": "ts_hello",
+  "version": "0.1.0",
+  "description": "hello TS plugin from kong",
+  "main": "ts_hello.ts",
+  "dependencies": {
+    "kong-pdk": "^0.5.5"
+  }
+}
+````
+Then, import `kong-pdk` in your TypeScript file:
+
+````javascript
+import kong from "kong-pdk/kong";
+````
+
+### Testing
+
+The JavaScript PDK provides a mock framework to test plugin code using [`jest`](https://jestjs.io/).
+
+Install `jest` as a development dependency, then add  the `test` script in `package.json`:
+
+```sh
+npm install jest --save-dev
+```
+
+The `package.json` contains information like this:
+
+```json
+{
+    "scripts": {
+    "test": "jest"
+    },
+    "devDependencies": {
+    "jest": "^26.6.3",
+    "kong-pdk": "^0.3.2"
+    }
+}
+```
+
+Run the test through npm with:
+
+```sh
+npm test
+```
+
+See the [JavaScript PDK repo](https://github.com/Kong/kong-js-pdk/tree/master/examples) for examples of writing tests with `jest`.
+
+## Example configuration
+
+Prepare the system by installing the required dependencies. 
+
+For example, in Debian/Ubuntu based systems:
+
+````sh
+apt update
+apt install -y nodejs npm
+npm install -g kong-pdk
+````
+
+Copy the plugin code and the `package.json` file in `/usr/local/kong/js-plugins`, then run:
+
+````sh
+cd /usr/local/kong/js-plugins/ 
+npm install
+````
+
+To load plugins using the `kong.conf` [configuration file](/gateway/configuration/), you have to map existing {{site.base_gateway}} properties to aspects of your plugin. 
+Here is an example of loading a plugin within `kong.conf`:
+
+````
+pluginserver_names = js
+
+pluginserver_js_start_cmd = /usr/local/bin/kong-js-pluginserver -v --plugins-directory /usr/local/kong/js-plugins
+pluginserver_js_query_cmd = /usr/local/bin/kong-js-pluginserver --plugins-directory /usr/local/kong/js-plugins --dump-all-plugins
+
+pluginserver_js_socket = /usr/local/kong/js_pluginserver.sock
+````
+

--- a/app/custom-plugins/python.md
+++ b/app/custom-plugins/python.md
@@ -1,0 +1,183 @@
+---
+title: Writing plugins in Python
+content_type: reference
+layout: reference
+
+breadcrumbs:
+  - /custom-plugins/
+
+products:
+    - gateway
+
+works_on:
+    - on-prem
+
+description: Learn how to write plugins for {{site.base_gateway}} in Python.
+
+tags:
+  - custom-plugins
+
+min_version:
+  gateway: '3.4'
+
+related_resources:
+  - text: Custom plugins
+    url: /custom-plugins/
+  - text: Custom plugins reference
+    url: /custom-plugins/reference/
+  - text: Writing plugins in Javascript
+    url: /custom-plugins/javascript/
+  - text: Writing plugins in Go
+    url: /custom-plugins/go/
+  - text: Running plugins in containers
+    url: /custom-plugins/installation-and-distribution/#via-a-dockerfile-or-docker-run-install-and-load
+  - text: Python PDK repository
+    url: https://github.com/Kong/kong-python-pdk
+---
+
+{{site.base_gateway}} supports Python plugin development through the [kong-python-pdk](https://github.com/Kong/kong-python-pdk) library.
+The library provides a plugin server and Kong-specific functions to interface with {{site.base_gateway}}.
+
+## Installation
+
+To install the plugin server and PDK globally, use `pip`:
+
+```sh
+pip3 install kong-pdk
+```
+
+## Development
+
+A {{site.base_gateway}} Python plugin implementation has following attributes:
+
+```python
+Schema = (
+    { "message": { "type": "string" } },
+)
+version = '0.1.0'
+priority = 0
+class Plugin(object):
+  pass
+```
+
+* A class named `Plugin` defines the class that implements this plugin.
+* A dictionary called `Schema` that defines expected values and data types of the plugin.
+* The variables `version` and `priority` that define the version number and priority of execution respectively.
+
+See the [Python PDK repository](https://github.com/Kong/kong-python-pdk/tree/master/examples) for examples of plugins built with Python
+and an [API reference](https://kong.github.io/kong-python-pdk/py-modindex.html).
+
+## Phase handlers
+
+You can implement custom logic to be executed at various [phases](/custom-plugins/handler.lua/) of the request processing lifecycle. 
+For example, to execute custom code during the access phase, define a function named `access`:
+
+```python
+class Plugin(object):
+    def __init__(self, config):
+        self.config = config
+    def access(self, kong):
+      pass
+```
+
+You can implement custom logic during the following phases using the same function signature:
+
+* `certificate`
+* `rewrite`
+* `access`
+* `response`
+* `preread`
+* `log`
+
+The presence of the `response` handler automatically enables the buffered proxy mode.
+
+{:.info}
+> **Notes:** A positional argument is required in the definition of the phase handler method. 
+In this example, the positional argument is called `kong`. 
+The positional argument can be used as the PDK function's root object, 
+which means that you can call specific PDK functions by using this argument, like [`kong.log.info`](/gateway/pdk/reference/kong.log/) or 
+[`kong.request.get_header`](/gateway/pdk/reference/kong.request/).
+
+### Type hints
+
+Support for [type hints](https://www.python.org/dev/peps/pep-0484/) is available. 
+To use type hints and autocomplete in an IDE, add the `kong` parameter to the phase handler function:
+
+```python
+import kong_pdk.pdk.kong as kong
+class Plugin(object):
+    def __init__(self, config):
+        self.config = config
+    def access(self, kong: kong.kong):
+        host, err = kong.request.get_header("host")
+```
+
+{:.warning}
+> **Warning:** Classes and functions in the `kong_pdk.pdk.kong` module cannot be used directly because they're only used for type hints. 
+To call PDK functions,  use the `kong` object that is passed as the phase handler's parameter. 
+Keep in mind that if you want to call PDK functions outside of the phase handler, you also need to pass the `kong` object to your outer code.
+
+Here is an example of using the PDK functions outside of the `Plugin` class:
+
+```python
+import kong_pdk.pdk.kong as kong
+
+def example_access_phase(kong: kong.kong):
+    host_header, err = kong.request.get_header("host")
+    kong.log.info(host_header)
+
+class Plugin(object):
+    def __init__(self, config):
+        self.config = config
+    def access(self, kong: kong.kong):
+        example_access_phase(kong)
+```
+
+## Embedded server
+
+To use the embedded server, use the following code:
+
+```python
+if __name__ == "__main__":
+    from kong_pdk.cli import start_dedicated_server
+    start_dedicated_server("py-hello", Plugin, version, priority)
+```
+
+The first argument to `start_dedicated_server` defines the plugin name and must be unique.
+
+## Example configuration
+
+To load plugins using the `kong.conf` [configuration file](/gateway/configuration/), you have to map existing {{site.base_gateway}} properties to aspects of your plugin.
+Here are some examples of loading plugins within `kong.conf`:
+
+```
+pluginserver_names = my-plugin,other-one
+pluginserver_my_plugin_socket = /usr/local/kong/my-plugin.socket
+pluginserver_my_plugin_start_cmd = /path/to/my-plugin.py
+pluginserver_my_plugin_query_cmd = /path/to/my-plugin.py --dump
+pluginserver_other_one_socket = /usr/local/kong/other-one.socket
+pluginserver_other_one_start_cmd = /path/to/other-one.py
+pluginserver_other_one_query_cmd = /path/to/other-one.py -dump
+```
+
+The socket and start command settings coincide with their defaults and can be omitted:
+
+```
+pluginserver_names = my-plugin,other-one
+pluginserver_my_plugin_query_cmd = /path/to/my-plugin --dump
+pluginserver_other_one_query_cmd = /path/to/other-one --dump
+```
+
+If you want to open verbose logging, pass the `-v` argument to the `start` command line:
+
+```
+pluginserver_my_plugin_start_cmd = /path/to/my-plugin.py -v
+```
+
+## Concurrency model
+
+The Python plugin server and the embedded server support concurrency. 
+By default, the server starts in multi-threading mode.
+
+* If your workload is IO intensive, you can use the [Gevent](http://www.gevent.org/) model by passing the `-g` flag to `start_cmd` in `kong.conf`.
+* If your workload is CPU intensive, consider the multi-processing model by passing the `-m` flag to `start_cmd` in `kong.conf`.

--- a/app/custom-plugins/python.md
+++ b/app/custom-plugins/python.md
@@ -35,8 +35,8 @@ related_resources:
     url: https://github.com/Kong/kong-python-pdk
 ---
 
-{{site.base_gateway}} supports Python plugin development through the [kong-python-pdk](https://github.com/Kong/kong-python-pdk) library.
-The library provides a plugin server and Kong-specific functions to interface with {{site.base_gateway}}.
+{{site.base_gateway}} supports Python plugin development through the [Kong Python PDK](https://github.com/Kong/kong-python-pdk).
+The `kong-python-pdk` library provides a plugin server and Kong-specific functions to interface with {{site.base_gateway}}.
 
 ## Installation
 
@@ -67,7 +67,11 @@ class Plugin(object):
 See the [Python PDK repository](https://github.com/Kong/kong-python-pdk/tree/master/examples) for examples of plugins built with Python
 and an [API reference](https://kong.github.io/kong-python-pdk/py-modindex.html).
 
-## Phase handlers
+## Configuration
+
+Configuration reference for the Python PDK.
+
+### Phase handlers
 
 You can implement custom logic to be executed at various [phases](/custom-plugins/handler.lua/) of the request processing lifecycle. 
 For example, to execute custom code during the access phase, define a function named `access`:
@@ -133,7 +137,7 @@ class Plugin(object):
         example_access_phase(kong)
 ```
 
-## Embedded server
+### Embedded server
 
 To use the embedded server, use the following code:
 
@@ -145,7 +149,15 @@ if __name__ == "__main__":
 
 The first argument to `start_dedicated_server` defines the plugin name and must be unique.
 
-## Example configuration
+## Concurrency model
+
+The Python plugin server and the embedded server support concurrency. 
+By default, the server starts in multi-threading mode.
+
+* If your workload is IO intensive, you can use the [Gevent](http://www.gevent.org/) model by passing the `-g` flag to `start_cmd` in `kong.conf`.
+* If your workload is CPU intensive, consider the multi-processing model by passing the `-m` flag to `start_cmd` in `kong.conf`.
+
+## Loading the plugin into {{site.base_gateway}}
 
 To load plugins using the `kong.conf` [configuration file](/gateway/configuration/), you have to map existing {{site.base_gateway}} properties to aspects of your plugin.
 Here are some examples of loading plugins within `kong.conf`:
@@ -173,11 +185,3 @@ If you want to open verbose logging, pass the `-v` argument to the `start` comma
 ```
 pluginserver_my_plugin_start_cmd = /path/to/my-plugin.py -v
 ```
-
-## Concurrency model
-
-The Python plugin server and the embedded server support concurrency. 
-By default, the server starts in multi-threading mode.
-
-* If your workload is IO intensive, you can use the [Gevent](http://www.gevent.org/) model by passing the `-g` flag to `start_cmd` in `kong.conf`.
-* If your workload is CPU intensive, consider the multi-processing model by passing the `-m` flag to `start_cmd` in `kong.conf`.


### PR DESCRIPTION
## Description

We've had a couple of complaints that this content is missing, and people are depending on it - so it needs to be migrated.

## Preview Links


## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [x] Add new pages to the product documentation index (if applicable).
