### PR TITLE
fix: correct the wrong description for 3.9 breaking changes

### DIFF
--- a/app/gateway/breaking-changes.md
+++ b/app/gateway/breaking-changes.md
@@ -121,7 +121,7 @@ The `node_id` parameter is planned to be removed in 4.x.
 
 This release adds support for the Hugging Face provider.
 
-To import the decK configuration files that are exported from 3.9 series to earlier versions, use the following script to transform it so that the configuration file can be compatible with the latest version:
+To import the decK configuration files that are exported from the 3.9.x series to earlier versions of {{site.base_gateway}}, use the following script to transform it so that the configuration file can be compatible with the latest version:
 
 ```
 yq -i '(


### PR DESCRIPTION
## Description

Correct the wrong description for 3.9 breaking changes

Before: `To import the decK configuration files that are exported from earlier versions`
After: `To import the decK configuration files that are exported from 3.9 series to earlier versions`


## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
