### PR TITLE
fix schema validation example for knep

### DIFF
--- a/app/_event_gateway_policies/schema-validation.md
+++ b/app/_event_gateway_policies/schema-validation.md
@@ -68,7 +68,7 @@ produce_policies:
 Let's say you want to migrate topics that don't have schemas and eventually ensure that every topic has a schema.
 
 For example, assume that you have three topics without schemas: `topic-1`, `topic-2`, and `topic-3`.
-Start by setting `failure_action` to `mark`, so that each invalid record is enriched with `kong/sverr` header with value of a client ID.
+Start by setting `failure_action` to `mark`, so that each invalid record is enriched with a `kong/sverr` header, which provides a client ID value.
 
 Because we don't have policy overrides, we also need to exclude topics from the general rule. 
 
@@ -93,6 +93,7 @@ produce_policies:
 ```
 
 Now let's say that after some time, you migrated `topic-1`.
-You can inspect `kong_knep_kafka_schema_validation_failed_count{topic=topic-1}` metric to verify that clients do not produce invalid records.
-If there are still invalid records, consume them from the topic looking for `kong/sverr` header to identify a client that violates the schema.
+You can inspect the `kong_knep_kafka_schema_validation_failed_count{topic=topic-1}` metric to verify that clients don't produce invalid records.
+
+If there are still invalid records, consume them from the topic looking for the `kong/sverr` header to identify a client that violates the schema.
 If there are no invalid records, you can now remove `topic-1` from both expressions.

--- a/app/_event_gateway_policies/schema-validation.md
+++ b/app/_event_gateway_policies/schema-validation.md
@@ -68,7 +68,7 @@ produce_policies:
 Let's say you want to migrate topics that don't have schemas and eventually ensure that every topic has a schema.
 
 For example, assume that you have three topics without schemas: `topic-1`, `topic-2`, and `topic-3`.
-Start by setting `failure_action` to `log`, so that every time these topics are used, they'll generate a log entry but won't fail.
+Start by setting `failure_action` to `mark`, so that each invalid record is enriched with `kong/sverr` header with value of a client ID.
 
 Because we don't have policy overrides, we also need to exclude topics from the general rule. 
 
@@ -81,7 +81,7 @@ produce_policies:
           spec:
             record_value:
               schema_registry_name: my-registry
-              failure_action: log
+              failure_action: mark
   - match: "kafka.topic.name != \"topic-1\" && kafka.topic.name != \"topic-2\" && kafka.topic.name != \"topic-3\""
     policies:
       - policy:
@@ -92,5 +92,7 @@ produce_policies:
               failure_action: reject
 ```
 
-Now let's say that after some time, you migrated `topic-1`, and there are no logs that indicate validation failures. 
-You can now remove `topic-1` from both expressions.
+Now let's say that after some time, you migrated `topic-1`.
+You can inspect `kong_knep_kafka_schema_validation_failed_count{topic=topic-1}` metric to verify that clients do not produce invalid records.
+If there are still invalid records, consume them from the topic looking for `kong/sverr` header to identify a client that violates the schema.
+If there are no invalid records, you can now remove `topic-1` from both expressions.


### PR DESCRIPTION
## Description

Fixes invalid example of schema validation for KNEP.

## Preview Links

https://deploy-preview-2079--kongdeveloper.netlify.app/event-gateway/policies/schema-validation/


## Checklist 

- [X] Tested how-to docs. If not, note why here. 
- [X] All pages contain metadata.
- [X] Any new docs link to existing docs.
- [X] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [X] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [X] Every page has a `description` entry in frontmatter.
- [X] Add new pages to the product documentation index (if applicable).
