### PR TITLE
Remove extra spacing in {% operator_podtemplatespec_example %}

### DIFF
--- a/app/_includes/components/operator_podtemplatespec_example.md
+++ b/app/_includes/components/operator_podtemplatespec_example.md
@@ -1,0 +1,17 @@
+{:.info}
+> The following example uses the `DataPlane` resource, but you can also configure your `GatewayConfiguration` resource as needed. For more information see the [PodTemplateSpec](/operator/dataplanes/reference/podtemplatespec/) page.
+
+```yaml
+{% if kubectl_apply %}echo '
+{% endif -%}
+apiVersion: gateway-operator.konghq.com/v1beta1
+kind: DataPlane
+metadata:
+  name: dataplane-example
+  namespace: kong
+spec:
+  deployment:
+    podTemplateSpec:
+{{spec | indent: 6}}{% if kubectl_apply %}
+' | kubectl apply -f -{% endif %}
+```

--- a/app/_plugins/blocks/operator_podtemplatespec_example.rb
+++ b/app/_plugins/blocks/operator_podtemplatespec_example.rb
@@ -11,36 +11,19 @@ module Jekyll
         raise "Unable to parse config in operator_podtemplatespec_example: \n#{spec}\n\n#{e}"
       end
 
-      dp = config['dataplane'].to_yaml.split("\n")[1..].join("\n")
+      return '' unless config['dataplane']
 
-      <<~TEXT
-        #{dataplane_example(dp, config['kubectl_apply']) if config['dataplane']}#{' '}
-      TEXT
+      context.stack do
+        context['kubectl_apply'] = config['kubectl_apply']
+        context['spec'] = Jekyll::Utils::HashToYAML.new(config['dataplane']).convert
+        Liquid::Template.parse(template).render(context)
+      end
     end
 
     private
 
-    def dataplane_example(spec, kubectl_apply) # rubocop:disable Metrics/MethodLength
-      return '' if spec.empty?
-
-      <<~TEXT
-        {:.info}
-        > The following example uses the `DataPlane` resource, but you can also configure your `GatewayConfiguration` resource as needed. For more information see the [PodTemplateSpec](/operator/dataplanes/reference/podtemplatespec/) page.
-
-        ```yaml
-        #{kubectl_apply && "echo '"}
-        apiVersion: gateway-operator.konghq.com/v1beta1
-        kind: DataPlane
-        metadata:
-          name: dataplane-example
-          namespace: kong
-        spec:
-          deployment:
-            podTemplateSpec:
-              #{spec.split("\n").map { |line| "      #{line}" }.join("\n").strip}
-        #{kubectl_apply && "' | kubectl apply -f -"}
-        ```
-      TEXT
+    def template
+      @template ||= File.read(File.expand_path('app/_includes/components/operator_podtemplatespec_example.md'))
     end
   end
 end

--- a/app/_plugins/blocks/operator_podtemplatespec_example.rb
+++ b/app/_plugins/blocks/operator_podtemplatespec_example.rb
@@ -15,7 +15,7 @@ module Jekyll
 
       context.stack do
         context['kubectl_apply'] = config['kubectl_apply']
-        context['spec'] = Jekyll::Utils::HashToYAML.new(config['dataplane']).convert
+        context['spec'] = Jekyll::Utils::HashToYAML.new(config['dataplane']).convert(indent_level: 0)
         Liquid::Template.parse(template).render(context)
       end
     end

--- a/app/_plugins/utils/hash_to_yaml.rb
+++ b/app/_plugins/utils/hash_to_yaml.rb
@@ -9,18 +9,18 @@ module Jekyll
         @hash = hash
       end
 
-      def convert
-        indent_yaml(YAML.dump(@hash).delete_prefix("---\n").chomp)
+      def convert(indent_level: 2)
+        indent_yaml(YAML.dump(@hash).delete_prefix("---\n").chomp, indent_level)
       end
 
-      def indent_yaml(yaml_string, indent_level = 2)
+      def indent_yaml(yaml_string, indent_level)
         indented_yaml = []
         yaml_string.lines.each do |line|
-          if line.match?(/^(\s*)-\s+/)
-            indented_yaml << ' ' * indent_level + line
-          else
-            indented_yaml << line.gsub(/^(\s+)/) { |spaces| ' ' * (spaces.length + indent_level) }
-          end
+          indented_yaml << if line.match?(/^(\s*)-\s+/)
+                             ' ' * indent_level + line
+                           else
+                             line.gsub(/^(\s+)/) { |spaces| ' ' * (spaces.length + indent_level) }
+                           end
         end
         indented_yaml.join
       end


### PR DESCRIPTION
## Description

Fixes https://github.com/Kong/developer.konghq.com/issues/1457
## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
