### PR TITLE
Fix: EOL June 2026 for Amazon Linux 2 for LTS releases.

### DIFF
--- a/app/_data/products/gateway.yml
+++ b/app/_data/products/gateway.yml
@@ -31,7 +31,7 @@ releases:
             graviton: true
           docker: true
           docker_support:
-          eol: June 2025
+          eol: June 2026
       - amazonlinux2023:
           package: true
           package_support:
@@ -729,6 +729,7 @@ releases:
             arm: true
             graviton: true
           docker: true
+          eol: June 2026
       - amazonlinux2023:
           package: true
           package_support:


### PR DESCRIPTION
## Description

Extended the EOL of Amazon Linux 2 on Kong Gateway 3.4 and 3.10 LTS releases to June 2026.

Related: https://old-docs-preview--kongdocs.netlify.app/gateway/latest/support-policy/#sunset-support