### PR TITLE
Fix: Event Gateway policies layout

### DIFF
--- a/app/_event_gateway_policies/decrypt.md
+++ b/app/_event_gateway_policies/decrypt.md
@@ -29,10 +29,6 @@ icon: /assets/icons/graph.svg
 This policy is used to decrypt messages that were previously encrypted using the referenced key. 
 Use this policy to enforce standards for decryption across {{site.event_gateway}} clients.
 
-## Schema
-
-{% entity_schema %}
-
 ## Example configuration
 
 Example configurations for the Decrypt policy.
@@ -86,3 +82,7 @@ policies:
        - type: keys
        - type: values
 ```
+
+## Schema
+
+{% entity_schema %}

--- a/app/_event_gateway_policies/encrypt.md
+++ b/app/_event_gateway_policies/encrypt.md
@@ -28,10 +28,6 @@ related_resources:
 
 This policy can be used to encrypt portions of Kafka records.
 
-## Schema
-
-{% entity_schema %}
-
 ## Example configuration
 
 Example configurations for the Encrypt policy.
@@ -87,3 +83,7 @@ policies:
        - type: values
          id: "static://user-chosen-id"
 ```
+
+## Schema
+
+{% entity_schema %}

--- a/app/_event_gateway_policies/modify-headers.md
+++ b/app/_event_gateway_policies/modify-headers.md
@@ -24,10 +24,6 @@ icon: /assets/icons/graph.svg
 
 This policy is used to set or remove record headers.
 
-## Schema
-
-{% entity_schema %}
-
 ## Example configuration
 
 Example configurations for the Modify Headers policy.
@@ -49,3 +45,7 @@ policies:
         - key: example-header2
           value: example
 ```
+
+## Schema
+
+{% entity_schema %}

--- a/app/_event_gateway_policies/schema-validation.md
+++ b/app/_event_gateway_policies/schema-validation.md
@@ -24,10 +24,6 @@ icon: /assets/icons/graph.svg
 
 This policy is used to validate records using a provided schema.
 
-## Schema
-
-{% entity_schema %}
-
 ## Example configuration
 
 Example configurations for the Schema Validation policy.
@@ -97,3 +93,7 @@ You can inspect the `kong_knep_kafka_schema_validation_failed_count{topic=topic-
 
 If there are still invalid records, consume them from the topic looking for the `kong/sverr` header to identify a client that violates the schema.
 If there are no invalid records, you can now remove `topic-1` from both expressions.
+
+## Schema
+
+{% entity_schema %}


### PR DESCRIPTION
## Description

Move schemas below examples. The current positioning puts the schemas out of context and makes examples easy to miss, plus the schema takes a second to load and makes the page jump.

## Preview Links

