### PR TITLE
Migrate CP namespace watch guide

### DIFF
--- a/.github/styles/base/Dictionary.txt
+++ b/.github/styles/base/Dictionary.txt
@@ -889,6 +889,7 @@ Wallarm
 Wallarm
 Wasm
 Wasm
+watchNamespaces
 WebAssembly
 WebAssembly
 webpages

--- a/app/operator/konnect/control-plane-watch-namespaces.md
+++ b/app/operator/konnect/control-plane-watch-namespaces.md
@@ -1,0 +1,70 @@
+---
+title: "Limiting namespaces watched by ControlPlane"
+description: "Learn how to limit the namespaces that `ControlPlane` watches."
+content_type: reference
+layout: reference
+products:
+  - operator
+breadcrumbs:
+  - /operator/
+  - index: operator
+    group: Konnect
+  - index: operator
+    group: Konnect
+    section: "Konnect CRDs: Control Planes"
+related_resources:
+  - text: "Create a Control Plane with KGO"
+    url: /operator/konnect/crd/control-planes/hybrid/
+---
+
+By default, {{ site.kgo_product_name }}'s `ControlPlane` watches all namespaces.
+This provides a convenient out-of-the-box experience but may not suit all production environments, especially those where multiple teams share the same cluster or in multitenant setups.
+
+To limit the namespaces watched by `ControlPlane`, you can set the `watchNamespaces` field in the `ControlPlane`'s `spec`.
+
+## ControlPlane's watchNamespaces field
+
+The `spec.watchNamespaces.type` field accepts three values to control this behavior:
+
+- `all` (default): Watches resources in all namespaces.
+- `own`: Watches resources only in the `ControlPlane`'s own namespace.
+- `list`: Watches resources in the `ControlPlane`'s own namespace and in the specified list of additional namespaces.
+  When using `list`, the `ControlPlane`'s own namespace is automatically added to the list of watched namespaces, because this behavior is required by {{ site.kic_product_name }}.  
+  By default, the publish service (the `Service` for the `DataPlane`, exposed by {{ site.base_gateway }}) is created in the same namespace as the `ControlPlane`.
+
+{:.info}
+> **Note:** Setting this field in `ControlPlane` will configure the `CONTROLLER_WATCH_NAMESPACE` environment variable in the managed {{ site.kic_product_name }}.
+> If you manually set the `CONTROLLER_WATCH_NAMESPACE` environment variable through `podTemplateSpec`, it will **override** this configuration.
+
+## Specify a list of namespaces to watch
+
+`all` and `own` types are self-explanatory and do not require any further changes
+or additional resources.
+
+The `list` type requires two additional steps:
+
+1. You must specify the namespaces to watch in the `spec.watchNamespaces.list` field.
+   ```yaml
+   spec:
+     watchNamespaces:
+       type: list
+        list:
+        - namespace-a
+        - namespace-b
+   ```
+1. You must create a `WatchNamespaceGrant` resource in each of the specified namespaces. This resource grants the `ControlPlane` permission to watch resources in the specified namespace. It can be defined as:
+   
+   ```yaml
+   apiVersion: gateway-operator.konghq.com/v1alpha1
+   kind: WatchNamespaceGrant
+   metadata:
+     name: watch-namespace-grant
+     namespace: namespace-a
+   spec:
+     from:
+     - group: gateway-operator.konghq.com
+       kind: ControlPlane
+       namespace: control-plane-namespace
+   ```
+
+For more information on the `WatchNamespaceGrant` CRD, see the [CRD reference](/operator/reference/custom-resources#watchnamespacegrant).

--- a/app/operator/konnect/control-plane-watch-namespaces.md
+++ b/app/operator/konnect/control-plane-watch-namespaces.md
@@ -1,6 +1,6 @@
 ---
 title: "Limiting namespaces watched by ControlPlane"
-description: "Learn how to limit the namespaces that `ControlPlane` watches."
+description: "Learn how to limit the namespaces that ControlPlane watches."
 content_type: reference
 layout: reference
 products:
@@ -36,14 +36,14 @@ The `spec.watchNamespaces.type` field accepts three values to control this behav
 > **Note:** Setting this field in `ControlPlane` will configure the `CONTROLLER_WATCH_NAMESPACE` environment variable in the managed {{ site.kic_product_name }}.
 > If you manually set the `CONTROLLER_WATCH_NAMESPACE` environment variable through `podTemplateSpec`, it will **override** this configuration.
 
+The `all` and `own` types don't require any further changes or additional resources. The `list` type requires further configuration.
+
 ## Specify a list of namespaces to watch
 
-`all` and `own` types are self-explanatory and do not require any further changes
-or additional resources.
 
 The `list` type requires two additional steps:
 
-1. You must specify the namespaces to watch in the `spec.watchNamespaces.list` field.
+1. Specify the namespaces to watch in the `spec.watchNamespaces.list` field.
    ```yaml
    spec:
      watchNamespaces:
@@ -52,7 +52,7 @@ The `list` type requires two additional steps:
         - namespace-a
         - namespace-b
    ```
-1. You must create a `WatchNamespaceGrant` resource in each of the specified namespaces. This resource grants the `ControlPlane` permission to watch resources in the specified namespace. It can be defined as:
+1. Create a `WatchNamespaceGrant` resource in each of the specified namespaces. This resource grants the `ControlPlane` permission to watch resources in the specified namespace. It can be defined as:
    
    ```yaml
    apiVersion: gateway-operator.konghq.com/v1alpha1
@@ -67,4 +67,4 @@ The `list` type requires two additional steps:
        namespace: control-plane-namespace
    ```
 
-For more information on the `WatchNamespaceGrant` CRD, see the [CRD reference](/operator/reference/custom-resources#watchnamespacegrant).
+For more information on the `WatchNamespaceGrant` CRD, see the [CRD reference](/operator/reference/custom-resources/#watchnamespacegrant).

--- a/app/operator/konnect/control-plane-watch-namespaces.md
+++ b/app/operator/konnect/control-plane-watch-namespaces.md
@@ -18,7 +18,7 @@ related_resources:
 ---
 
 By default, {{ site.kgo_product_name }}'s `ControlPlane` watches all namespaces.
-This provides a convenient out-of-the-box experience but may not suit all production environments, especially those where multiple teams share the same cluster or in multitenant setups.
+This provides a convenient out-of-the-box experience but may not suit all production environments, especially those where multiple teams share the same cluster or in multi-tenant setups.
 
 To limit the namespaces watched by `ControlPlane`, you can set the `watchNamespaces` field in the `ControlPlane`'s `spec`.
 

--- a/app/operator/reference/custom-resources.md
+++ b/app/operator/reference/custom-resources.md
@@ -1721,6 +1721,8 @@ Package v1alpha1 contains API Schema definitions for the operator v1alpha1 API g
 - [DataPlaneMetricsExtension](#dataplanemetricsextension)
 - [KongPluginInstallation](#kongplugininstallation)
 - [KonnectExtension](#konnectextension)
+- [WatchNamespaceGrant](#watchnamespacegrant)
+
 ### AIGateway
 
 
@@ -1827,7 +1829,20 @@ deployment spec gets customized to include the konnect-related configuration.
 | `spec` _[KonnectExtensionSpec](#konnectextensionspec)_ | Spec is the specification of the KonnectExtension resource. |
 | `status` _[KonnectExtensionStatus](#konnectextensionstatus)_ | Status is the status of the KonnectExtension resource. |
 
+### WatchNamespaceGrant
 
+
+WatchNamespaceGrant is a grant that allows a trusted namespace to watch
+resources in the namespace this grant exists in.
+
+Grant permission to watch a designated namespace.
+
+| Field | Description |
+| --- | --- |
+| `apiVersion` _string_ | `gateway-operator.konghq.com/v1alpha1`
+| `kind` _string_ | `WatchNamespaceGrant`
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `spec` _[WatchNamespaceGrantSpec](#watchnamespacegrantspec)_ | Spec is the desired state of the WatchNamespaceGrant. |
 
 ### Types
 
@@ -2246,6 +2261,31 @@ ServiceSelectorEntry holds the name of a service to match.
 
 _Appears in:_
 - [ServiceSelector](#serviceselector)
+
+#### WatchNamespaceGrantFrom
+
+WatchNamespaceGrantFrom describes trusted namespaces.
+
+| Field | Description |
+| --- | --- |
+| `group` _string_ | Group is the group of the referent. |
+| `kind` _string_ | Kind is the kind of the referent. |
+| `namespace` _string_ | Namespace is the namespace of the referent. |
+
+
+_Appears in:_
+- [WatchNamespaceGrantSpec](#watchnamespacegrantspec)
+
+#### WatchNamespaceGrantSpec
+
+WatchNamespaceGrantSpec defines the desired state of an WatchNamespaceGrant.
+
+| Field | Description |
+| --- | --- |
+| `from` _[WatchNamespaceGrantFrom](#watchnamespacegrantfrom) array_ | From describes the trusted namespaces and kinds that can reference the namespace this grant exists in. |
+
+_Appears in:_
+- [WatchNamespaceGrant](#watchnamespacegrant)
 
 
 ## gateway-operator.konghq.com/v1beta1


### PR DESCRIPTION
## Description

Fixes https://kongstrong.slack.com/archives/CDSTDSG9J/p1751618928264159

Original PR: https://github.com/Kong/docs.konghq.com/pull/8741

## Preview Links
- https://deploy-preview-2092--kongdeveloper.netlify.app/operator/konnect/control-plane-watch-namespaces/
- https://deploy-preview-2092--kongdeveloper.netlify.app/operator/reference/custom-resources/#watchnamespacegrant (manually added since we don't have this autogenerated yet)
- https://deploy-preview-2092--kongdeveloper.netlify.app/operator/reference/custom-resources/#watchnamespacegrantspec (manually added since we don't have this autogenerated yet)
- https://deploy-preview-2092--kongdeveloper.netlify.app/operator/reference/custom-resources/#watchnamespacegrantfrom (manually added since we don't have this autogenerated yet)


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
