### PR TITLE
Exclude app/_references in dev

### DIFF
--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -9,3 +9,10 @@ skip:
   explorer: true # skip explorer
   auto_generated: true # skip auto_generated references, i.e. app/_referneces
   mesh: true # skip kuma to mesh generation
+
+# exclude app/_references
+# even though we set skip.auto_generated: true and the collection has output:false
+# Jekyll still reads, parses and renders the collection. It doesn't write the pages
+# to disc though, but the first part is very time consuming.
+exclude:
+  - _references


### PR DESCRIPTION
## Description

It should speed up local build times

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
