### PR TITLE
OIDC FAQs and example for multiple IdP auth

### DIFF
--- a/app/_how-tos/configure-oidc-with-auth-code-flow.md
+++ b/app/_how-tos/configure-oidc-with-auth-code-flow.md
@@ -57,6 +57,15 @@ tldr:
   q: How do I use an authorization code to open a session with my identity provider, letting users log in through a browser?
   a: Using the OpenID Connect plugin, set up the [auth code flow](/plugins/openid-connect/#authorization-code-flow) to connect to an identity provider (IdP) through a browser, and use session authentication to store open sessions. You can do this by specifying `authorization_code` and `session` in the `config.auth_methods` plugin settings.
 
+faqs:
+  - q: How do I enable the Proof Key for Code Exchange (PKCE) extension to the authorization code flow in the OIDC plugin?
+    a: |
+      The OIDC plugin supports PKCE out of the box, so you don't need to configure anything. 
+      When [`config.auth_methods`](/plugins/openid-connect/reference/#schema--config-auth-methods) is set to `authorization_code`, the plugin sends the required `code_challenge` parameter automatically with the authorization code flow request. 
+      
+      If the IdP connected to the plugin enforces PKCE, it will be used during the authorization code flow. 
+      If the IdP doesn't support or enforce PCKE, it won't be used.
+ 
 cleanup:
   inline:
     - title: Clean up Konnect environment

--- a/app/_how-tos/configure-oidc-with-client-credentials.md
+++ b/app/_how-tos/configure-oidc-with-client-credentials.md
@@ -57,6 +57,14 @@ tldr:
   q: How do I use a client ID and client secret to authenticate directly with my identity provider?
   a: Using the OpenID Connect plugin, set up the [client credentials grant flow](/plugins/openid-connect/#client-credentials-grant-workflow) to connect to an identity provider (IdP) by passing a client ID and client secret in a header.
 
+faqs:
+  - q: Why does the OIDC plugin not use cached tokens with the client credentials grant, and instead connects to the IdP on every request?
+    a: |
+      Token caching doesn't work if both `client_credentials` and `password` are set as auth methods in the `config.auth_methods` parameter, and credentials are sent using the `Authorization: Basic` header. 
+      
+      In this scenario, either authentication method could match, but the plugin prioritises the password grant.
+      To resolve this caching issue, make sure you only have the `client_credentials` method enabled.
+
 cleanup:
   inline:
     - title: Clean up Konnect environment

--- a/app/_kong_plugins/openid-connect/examples/extra-jwks.yaml
+++ b/app/_kong_plugins/openid-connect/examples/extra-jwks.yaml
@@ -1,0 +1,55 @@
+title: Token validation for multiple IdPs
+description: |
+  Configure the OpenID Connect plugin to validate JWTs issued by multiple IdPs.
+extended_description: |
+  You can verify tokens issued by multiple IdP using the [`extra_jwks_uris`](/plugins/openid-connect/reference/#schema--config-extra-jwks-uris) configuration option, with the following considerations:
+
+  * Since the plugin only accepts a single issuer, any `iss` claim verification will fail for tokens that come from a different IdP than the one that was used in the issuer configuration option. Add all issuers as they appear in the `iss` claims of your tokens to the [`config.issuers_allowed`](/plugins/openid-connect/reference/#schema--config-issuers-allowed) setting.
+  * If you make any changes to the `extra_jwks_uris` value, you have to clear the second level DB cache for the change to become effective.
+  See [Delete a Discovery Cache Object](/plugins/openid-connect/api/#/operations/deleteDiscoveryCache).
+
+  This example shows how to configure two different `extra_jwks_uris` to support token validation for two different IdPs.
+
+weight: 698
+
+requirements:
+  - A configured identity provider (IdP)
+
+config:
+  issuer: ${issuer}
+  client_id:
+    - ${client-id}
+  client_secret:
+    - ${client-secret}
+  auth_methods:
+    - bearer
+  extra_jwks_uris:
+    - example-host1/auth/realms/other/protocol/openid-connect/certs
+    - example-host2/oauth2/some-id/v1/keys
+  issuers_allowed:
+    - issuer-url-for-example-host1
+    - issuer-url-for-example-host2
+  verify_signature: true
+  verify_claims: false
+
+variables:
+  issuer:
+    value: $ISSUER
+    description: |
+      The issuer authentication URL for your IdP. 
+      For example, if you're using Keycloak as your IdP, the issuer URL looks like this: `http://localhost:8080/realms/example-realm`
+  client-id:
+    value: $CLIENT_ID
+    description: The client ID that the plugin uses when it calls authenticated endpoints of the IdP.
+  client-secret:
+    value: $CLIENT_SECRET
+    description: The client secret needed to connect to your IdP.
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform
+
+group: other

--- a/app/_kong_plugins/openid-connect/index.md
+++ b/app/_kong_plugins/openid-connect/index.md
@@ -76,7 +76,7 @@ faqs:
   - q: Is it possible to avoid using a token from a cache that is almost expired?
     a: |
       Yes. You'll need to adjust the following settings:
-      * Access token lifetime, configured in the IdP
+      * Access token lifetime, configured in the IdP.
       * Max time-to-live for the OIDC plugin cache, configured using [`config.cache_ttl_max`](/plugins/openid-connect/reference/#schema--config-cache-ttl-max) and with [`config.cache_tokens`](/plugins/openid-connect/reference/#schema--config-cache-tokens) set to `true`.
 
       Set the max TTL on the Kong side based on the lifetime of the access token in the IdP. 


### PR DESCRIPTION
## Description

Fixes #1198 
Fixes #1073 

A bunch of OIDC doc improvements from Slack and support cases.
* Token validation for multiple IdPs: This was originally going to be an FAQ but made more sense as an example, so I did both.
* Added the auth code and client credentials FAQs to both the plugin index and the relevant how-to docs.
## Preview Links

https://deploy-preview-2112--kongdeveloper.netlify.app/plugins/openid-connect/#claims-based-authorization
https://deploy-preview-2112--kongdeveloper.netlify.app/plugins/openid-connect/#faqs
https://deploy-preview-2112--kongdeveloper.netlify.app/plugins/openid-connect/examples/extra-jwks/
https://deploy-preview-2112--kongdeveloper.netlify.app/how-to/configure-oidc-with-auth-code-flow/#faqs
https://deploy-preview-2112--kongdeveloper.netlify.app/how-to/configure-oidc-with-client-credentials/#faqs

## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [x] Add new pages to the product documentation index (if applicable).
