### PR TITLE
Fix: republish 3.4.3.20 changelog

### DIFF
--- a/app/_data/changelogs/gateway.json
+++ b/app/_data/changelogs/gateway.json
@@ -14430,6 +14430,22 @@
       }
     ]
   },
+   "3.4.3.20": {
+    "kong": [],
+    "kong-ee": [
+      {
+        "message": "Bumped luarocks from 3.11.1 to 3.12.1. This fixes the error `main function has more than 65536 constants`, which was preventing rocks from being published or installed.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "**openid-connect**: Fixed an `500` error caused by receiving a JSON `null` from the request body when parsing bearer tokens or client IDs.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      }
+    ],
+    "kong-manager-ee": []
+  },
   "3.11.0.0": {
     "kong": [
       {

--- a/app/_data/products/gateway.yml
+++ b/app/_data/products/gateway.yml
@@ -18,7 +18,7 @@ deployment_topologies:
 
 releases:
   - release: "3.4"
-    ee-version: "3.4.3.19"
+    ee-version: "3.4.3.20"
     ce-version: "3.4.2"
     eol: 2026-08-31
     lts: true


### PR DESCRIPTION
## Description

The 3.4.3.20 gateway changelog got lost in the 3.11 rebase shuffle, so it needs to be republished.

## Preview Links

https://deploy-preview-2117--kongdeveloper.netlify.app/gateway/changelog/#3-4-3-20
## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [x] Add new pages to the product documentation index (if applicable).
