### PR TITLE
Fix: paths to schemas

### DIFF
--- a/.github/styles/frontmatter/Dictionary.txt
+++ b/.github/styles/frontmatter/Dictionary.txt
@@ -28,3 +28,5 @@ act_as_plugin
 control_plane
 konnectextension
 kongplugininstallation
+CACertificate
+KeySet

--- a/app/_gateway_entities/ca-certificate.md
+++ b/app/_gateway_entities/ca-certificate.md
@@ -39,7 +39,7 @@ api_specs:
     - konnect/control-planes-config
 schema:
     api: gateway/admin-ee
-    path: /schemas/CA-Certificate
+    path: /schemas/CACertificate
 
 works_on:
   - on-prem

--- a/app/_gateway_entities/key-set.md
+++ b/app/_gateway_entities/key-set.md
@@ -29,7 +29,7 @@ api_specs:
 
 schema:
   api: gateway/admin-ee
-  path: /schemas/Key-set
+  path: /schemas/KeySet
 
 works_on:
   - on-prem


### PR DESCRIPTION
## Description

CA Certificates and Key Sets schema paths changed in the generated spec.

## Preview Links

https://deploy-preview-2123--kongdeveloper.netlify.app/gateway/entities/key-set/
https://deploy-preview-2123--kongdeveloper.netlify.app/gateway/entities/ca-certificate/
