### PR TITLE
Pass args: ["--no-sandbox", "--disable-setuid-sandbox"] to puppeteer so

### DIFF
--- a/tools/automated-tests/instructions/extractor.js
+++ b/tools/automated-tests/instructions/extractor.js
@@ -185,8 +185,9 @@ export async function extractInstructionsFromURL(uri, config, browser) {
 }
 
 export async function generateInstructionFiles(urlsToTest, config) {
-  const browser = await puppeteer.launch({});
-
+  const browser = await puppeteer.launch({
+    args: ["--no-sandbox", "--disable-setuid-sandbox"],
+  });
   try {
     await browser
       .defaultBrowserContext()


### PR DESCRIPTION
that it works in github actions

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
