### PR TITLE
fix: Add Consumer Groups to dynamic plugin ordering limitations

### DIFF
--- a/app/_gateway_entities/plugin.md
+++ b/app/_gateway_entities/plugin.md
@@ -206,10 +206,10 @@ data:
 If using dynamic ordering, manually test all configurations, and handle this feature with care. 
 There are a number of considerations that can affect your environment:
 
-* **Consumer scoping**: If you have [Consumer-scoped plugins](#scoping-plugins) anywhere in your Workspace or Control Plane, you can't use dynamic plugin ordering.
+* **Consumer and Consumer Group scoping**: If you have [Consumer or Consumer Group-scoped plugins](#scoping-plugins) anywhere in your Workspace or Control Plane, you can't use dynamic plugin ordering. 
 
   Consumer mapping and dynamic plugin ordering both run in the `access` phase, but the order of the  plugins must be determined after Consumer mapping has happened.
-  {{site.base_gateway}} can't reliably change the order of the plugins in relation to mapped Consumers.
+  {{site.base_gateway}} can't reliably change the order of the plugins in relation to mapped Consumers or Consumer Groups.
 
 * **Cascading deletes**: Detecting if a plugin has a dependency to a deleted plugin isn't supported, so handle your configuration with care.
 


### PR DESCRIPTION
## Description

https://kongstrong.slack.com/archives/C03CTMSHP6C/p1752220957298099

## Preview Links
https://deploy-preview-2136--kongdeveloper.netlify.app/gateway/entities/plugin/#known-limitations-of-dynamic-plugin-ordering (see the first bullet point, I added Consumer Groups to it)

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
