### PR TITLE
fix:Add missing note about LLM cost metric

### DIFF
--- a/app/ai-gateway/monitor-ai-llm-metrics.md
+++ b/app/ai-gateway/monitor-ai-llm-metrics.md
@@ -42,12 +42,12 @@ You can aggregate the LLM provider responses to count the number of tokens used 
 If you have defined input and output costs in the models, you can also calculate cost aggregation.
 The metrics details also expose whether the requests have been cached by {{site.base_gateway}}, saving the cost of contacting the LLM providers, which improves performance.
 
-Kong AI Gateway exposes metrics related to Kong and proxied upstream services in 
-[Prometheus](https://prometheus.io/docs/introduction/overview/) 
+Kong AI Gateway exposes metrics related to Kong and proxied upstream services in
+[Prometheus](https://prometheus.io/docs/introduction/overview/)
 exposition format, which can be scraped by a Prometheus server.
 
-The metrics are available on both the [Admin API](/api/gateway/admin-ee/) and the 
-[Status API](/api/gateway/status/)  at the `http://{host}:{port}/metrics` endpoint. 
+The metrics are available on both the [Admin API](/api/gateway/admin-ee/) and the
+[Status API](/api/gateway/status/)  at the `http://{host}:{port}/metrics` endpoint.
 Note that the URL to those APIs is specific to your
 installation. See [Accessing the metrics](#accessing-the-metrics) for more information.
 
@@ -114,7 +114,9 @@ ai_llm_provider_latency{ai_provider="provider1",ai_model="model1",cache_status="
 
 {:.info}
 > **Note:** If you don't use any cache plugins, then `cache_status`, `vector_db`,
-`embeddings_provider`, and `embeddings_model` values will be empty. 
+`embeddings_provider`, and `embeddings_model` values will be empty.
+>
+> To expose the `ai_llm_cost_total` metric, you must define `model.options.input_cost` `model.options.output_cost` parameters. See [AI Proxy](/plugins/ai-proxy/reference/) and [AI Proxy Advanced](/plugins/ai-proxy-advanced/reference/) configuration reference for more details.
 
 ## Accessing the metrics
 

--- a/app/ai-gateway/monitor-ai-llm-metrics.md
+++ b/app/ai-gateway/monitor-ai-llm-metrics.md
@@ -116,7 +116,7 @@ ai_llm_provider_latency{ai_provider="provider1",ai_model="model1",cache_status="
 > **Note:** If you don't use any cache plugins, then `cache_status`, `vector_db`,
 `embeddings_provider`, and `embeddings_model` values will be empty.
 >
-> To expose the `ai_llm_cost_total` metric, you must define `model.options.input_cost` `model.options.output_cost` parameters. See [AI Proxy](/plugins/ai-proxy/reference/) and [AI Proxy Advanced](/plugins/ai-proxy-advanced/reference/) configuration reference for more details.
+> To expose the `ai_llm_cost_total` metric, you must define `model.options.input_cost` `model.options.output_cost` parameters. See [AI Proxy](/plugins/ai-proxy/reference/#schema--config-model-options-input-cost) and [AI Proxy Advanced](/plugins/ai-proxy-advanced/reference/#schema--config-targets-model-options-input-cost) configuration reference for more details.
 
 ## Accessing the metrics
 

--- a/app/ai-gateway/monitor-ai-llm-metrics.md
+++ b/app/ai-gateway/monitor-ai-llm-metrics.md
@@ -116,7 +116,7 @@ ai_llm_provider_latency{ai_provider="provider1",ai_model="model1",cache_status="
 > **Note:** If you don't use any cache plugins, then `cache_status`, `vector_db`,
 `embeddings_provider`, and `embeddings_model` values will be empty.
 >
-> To expose the `ai_llm_cost_total` metric, you must define `model.options.input_cost` `model.options.output_cost` parameters. See [AI Proxy](/plugins/ai-proxy/reference/#schema--config-model-options-input-cost) and [AI Proxy Advanced](/plugins/ai-proxy-advanced/reference/#schema--config-targets-model-options-input-cost) configuration reference for more details.
+> To expose the `ai_llm_cost_total` metric, you must define the `model.options.input_cost` `model.options.output_cost` parameters. See the [AI Proxy](/plugins/ai-proxy/reference/#schema--config-model-options-input-cost) and [AI Proxy Advanced](/plugins/ai-proxy-advanced/reference/#schema--config-targets-model-options-input-cost) configuration references for more details.
 
 ## Accessing the metrics
 


### PR DESCRIPTION
## Description

Adds missing note about exposing LLM cost metric.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
