### PR TITLE
Re-generate pdk docs against  3.11 tag

### DIFF
--- a/app/_references/gateway/pdk/reference/3.11/kong.request.md
+++ b/app/_references/gateway/pdk/reference/3.11/kong.request.md
@@ -800,22 +800,3 @@ end
 ```
 
 
-
-## kong.request.get_id()
-
-Returns the unique request ID for the current request.
- The request ID is automatically generated for each request processed by Kong
- and can be used for tracking and debugging purposes.
- This ID remains the same throughout the entire request lifecycle.
-
-
-**Phases**
-
-* rewrite, access, header_filter, response, body_filter, log, admin_api
-
-**Returns**
-
-* `string`:  The unique request ID.
-
-
-


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
