### PR TITLE
FIx oidc tests

### DIFF
--- a/app/_how-tos/configure-oidc-with-acl-auth.md
+++ b/app/_how-tos/configure-oidc-with-acl-auth.md
@@ -67,8 +67,6 @@ cleanup:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg
-
-automated_tests: false
 ---
 
 ## Enable the OpenID Connect plugin

--- a/app/_how-tos/configure-oidc-with-claims-based-auth.md
+++ b/app/_how-tos/configure-oidc-with-claims-based-auth.md
@@ -98,8 +98,6 @@ cleanup:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg
-
-automated_tests: false
 ---
 
 ## Enable the OpenID Connect plugin with claims-based authorization

--- a/app/_how-tos/configure-oidc-with-client-credentials.md
+++ b/app/_how-tos/configure-oidc-with-client-credentials.md
@@ -73,8 +73,6 @@ cleanup:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg
-
-automated_tests: false
 ---
 
 ## Enable the OpenID Connect plugin with the client credentials grant

--- a/app/_how-tos/configure-oidc-with-consumers.md
+++ b/app/_how-tos/configure-oidc-with-consumers.md
@@ -77,8 +77,6 @@ cleanup:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg
-
-automated_tests: false
 ---
 
 ## Enable the OpenID Connect plugin

--- a/app/_how-tos/configure-oidc-with-introspection.md
+++ b/app/_how-tos/configure-oidc-with-introspection.md
@@ -66,8 +66,6 @@ cleanup:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg
-
-automated_tests: false
 ---
 
 ## Enable the OpenID Connect plugin with introspection

--- a/app/_how-tos/configure-oidc-with-jwt-auth.md
+++ b/app/_how-tos/configure-oidc-with-jwt-auth.md
@@ -67,8 +67,6 @@ cleanup:
 
 search_aliases:
   - oidc
-
-automated_tests: false
 ---
 
 ## Enable the OpenID Connect plugin with JWT authentication

--- a/app/_how-tos/configure-oidc-with-refresh-token.md
+++ b/app/_how-tos/configure-oidc-with-refresh-token.md
@@ -66,8 +66,6 @@ cleanup:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg
-
-automated_tests: false
 ---
 
 ## Enable the OpenID Connect plugin with refresh tokens

--- a/app/_how-tos/configure-oidc-with-session-auth.md
+++ b/app/_how-tos/configure-oidc-with-session-auth.md
@@ -70,8 +70,6 @@ cleanup:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg
-
-automated_tests: false
 ---
 
 ## Enable the OpenID Connect plugin with session auth

--- a/app/_how-tos/configure-oidc-with-user-info-auth.md
+++ b/app/_how-tos/configure-oidc-with-user-info-auth.md
@@ -65,8 +65,6 @@ cleanup:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg
-
-automated_tests: false
 ---
 
 ## Enable the OpenID Connect plugin with user info auth

--- a/tools/automated-tests/config/tests.yaml
+++ b/tools/automated-tests/config/tests.yaml
@@ -4,7 +4,7 @@ baseUrl: http://localhost:8888
 
 before:
   commands:
-    - docker run -d --name automated-tests-keycloak -p 127.0.0.1:8080:8080 -e KC_DB_USERNAME=keycloak -e KC_DB_PASSWORD=password -e KC_DB_DATABASE=keycloak -v $REALM_PATH:/opt/keycloak/data/import quay.io/keycloak/keycloak  start-dev --import-realm
+    - docker run -d --add-host=host.docker.internal:host-gateway --name automated-tests-keycloak -p 127.0.0.1:8080:8080 -e KC_DB_USERNAME=keycloak -e KC_DB_PASSWORD=password -e KC_DB_DATABASE=keycloak -v $REALM_PATH:/opt/keycloak/data/import quay.io/keycloak/keycloak  start-dev --import-realm
 
 after:
   commands:


### PR DESCRIPTION
## Description

Fixes #2148 

Enable automated tests on oidc how-tos and run keycloakwith --add-host=host.docker.internal:host-gateway

In linux host.docker.internal doesn't work out of the box, so processes
in different containers couldn't communicate.
This flag fixes that.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
