### PR TITLE
Deck usage and versions

### DIFF
--- a/.github/workflows/sync-deck.yml
+++ b/.github/workflows/sync-deck.yml
@@ -1,0 +1,36 @@
+name: Sync Deck
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+  repository_dispatch:
+    types: [PLUGINS_UPDATED]
+
+permissions:
+  contents: read
+
+jobs:
+  deck-versions:
+    name: Fetch Deck Versions
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@6c439dc8bdf85cadbbce9ed30d1c7b959517bc49 # v2.12.2
+        with:
+          egress-policy: audit
+      - uses: Kong/setup-deck@v1
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Fetch OAS Data
+        run: |
+          cd tools/deck-versions
+          npm ci
+          node extract-help.js
+          node fetch-versions.js
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7
+        with:
+          title: Sync Deck Releases
+          commit-message: Sync Deck Releases
+          labels: skip-changelog,review:general
+          token: ${{ secrets.PAT }}

--- a/app/_data/tools/deck.yml
+++ b/app/_data/tools/deck.yml
@@ -1,8 +1,19 @@
-name: decK
+name: deck
 
 releases:
-  - release: "1.48"
-    version: "1.48.0"
   - release: "1.49"
     version: "1.49.1"
     latest: true
+    released: 2025-06-30
+  - release: "1.48"
+    version: "1.48.0"
+    released: 2025-06-04
+  - release: "1.47"
+    version: "1.47.1"
+    released: 2025-05-12
+  - release: "1.46"
+    version: "1.46.3"
+    released: 2025-04-10
+  - release: "1.45"
+    version: "1.45.0"
+    released: 2025-02-26

--- a/app/_includes/deck/help/file/add-plugins.md
+++ b/app/_includes/deck/help/file/add-plugins.md
@@ -1,0 +1,25 @@
+```bash
+Usage:
+  deck file add-plugins [flags] [...plugin-files]
+
+Examples:
+# adds a plugin to all services in a deck file, except if it is already present
+cat kong.yml | deck file add-plugins --selector='services[*]' \
+               --config='{"name":"my-plugin","config":{"my-property":"value"}}'
+
+# same, but now overwriting plugins if they already exist and reading from files
+cat kong.yml | deck file add-plugins --overwrite plugin1.json plugin2.yml
+
+Flags:
+      --config stringArray     JSON snippet containing the plugin configuration to add. Repeat to add
+                               multiple plugins.
+      --format string          Output format: json or yaml (default "yaml")
+  -h, --help                   help for add-plugins
+  -o, --output-file string     Output file to write to. Use - to write to stdout. (default "-")
+      --overwrite              Specify this flag to overwrite plugins by the same name if they already
+                               exist in an array. The default behavior is to skip existing plugins.
+      --selector stringArray   JSON path expression to select plugin-owning objects to add plugins to.
+                               Defaults to the top-level (selector '$'). Repeat for multiple selectors.
+  -s, --state string           decK file to process. Use - to read from stdin. (default "-")
+
+```

--- a/app/_includes/deck/help/file/add-tags.md
+++ b/app/_includes/deck/help/file/add-tags.md
@@ -1,0 +1,17 @@
+```bash
+Usage:
+  deck file add-tags [flags] tag [...tag]
+
+Examples:
+# adds tags 'tag1' and 'tag2' to all services in file 'kong.yml'
+cat kong.yml | deck file add-tags --selector='services[*]' tag1 tag2
+
+Flags:
+      --format string          Output format: json or yaml (default "yaml")
+  -h, --help                   help for add-tags
+  -o, --output-file string     Output file to write to. Use - to write to stdout. (default "-")
+      --selector stringArray   JSON path expression to select objects to add tags to.
+                               Defaults to all Kong entities. Repeat for multiple selectors.
+  -s, --state string           decK file to process. Use - to read from stdin. (default "-")
+
+```

--- a/app/_includes/deck/help/file/convert.md
+++ b/app/_includes/deck/help/file/convert.md
@@ -1,0 +1,14 @@
+```bash
+Usage:
+  deck file convert [flags]
+
+Flags:
+      --format string   output file format: json or yaml. (default "yaml")
+      --from string     format of the source file, allowed formats: [kong-gateway kong-gateway-2.x]
+  -h, --help            help for convert
+      --input-file -    configuration file to be converted. Use - to read from stdin. (default "-")
+  -o, --output-file -   file to write configuration to after conversion. Use - to write to stdout. (default "-")
+      --to string       desired format of the output, allowed formats: [konnect kong-gateway-3.x]
+      --yes yes         assume yes to prompts and run non-interactively.
+
+```

--- a/app/_includes/deck/help/file/kong2kic.md
+++ b/app/_includes/deck/help/file/kong2kic.md
@@ -1,0 +1,15 @@
+```bash
+Usage:
+  deck file kong2kic [flags]
+
+Flags:
+      --class-name string    Value to use for "kubernetes.io/ingress.class" ObjectMeta.Annotations and for
+                             		"parentRefs.name" in the case of HTTPRoute. (default "kong")
+  -f, --format string        Output file format: json or yaml. (default "yaml")
+  -h, --help                 help for kong2kic
+      --ingress              Use Kubernetes Ingress API manifests instead of Gateway API manifests.
+      --kic-version string   Generate manifests for KIC v3 or v2. Possible values are 2 or 3. (default "3")
+  -o, --output-file string   Output file to write. Use - to write to stdout. (default "-")
+  -s, --state string         decK file to process. Use - to read from stdin. (default "-")
+
+```

--- a/app/_includes/deck/help/file/kong2tf.md
+++ b/app/_includes/deck/help/file/kong2tf.md
@@ -1,0 +1,12 @@
+```bash
+Usage:
+  deck file kong2tf [flags]
+
+Flags:
+  -g, --generate-imports-for-control-plane-id deck gateway dump --with-id   Generate terraform import statements for the control plane ID.Typically used after deck gateway dump --with-id to obtain the IDs of all entities.
+  -h, --help                                                                help for kong2tf
+      --ignore-credential-changes                                           Enable flag to add a 'lifecycle' block to each consumer credential, that ignores any changes from local to remote state.
+  -o, --output-file string                                                  Output file to write. Use - to write to stdout. (default "-")
+  -s, --state string                                                        decK file to process. Use - to read from stdin. (default "-")
+
+```

--- a/app/_includes/deck/help/file/lint.md
+++ b/app/_includes/deck/help/file/lint.md
@@ -1,0 +1,14 @@
+```bash
+Usage:
+  deck file lint [flags] ruleset-file
+
+Flags:
+  -D, --display-only-failures   only output results equal to or greater than --fail-severity
+  -F, --fail-severity string    results of this level or above will trigger a failure exit code
+                                [choices: "error", "warn", "info", "hint"] (default "error")
+      --format string           output format [choices: "plain", "json", "yaml"] (default "plain")
+  -h, --help                    help for lint
+  -o, --output-file string      Output file to write to. Use - to write to stdout. (default "-")
+  -s, --state string            decK file to process. Use - to read from stdin. (default "-")
+
+```

--- a/app/_includes/deck/help/file/list-tags.md
+++ b/app/_includes/deck/help/file/list-tags.md
@@ -1,0 +1,17 @@
+```bash
+Usage:
+  deck file list-tags [flags]
+
+Examples:
+# list all tags used on services
+cat kong.yml | deck file list-tags --selector='services[*]'
+
+Flags:
+      --format string          Output format: json, yaml, or PLAIN (default "PLAIN")
+  -h, --help                   help for list-tags
+  -o, --output-file string     Output file to write to. Use - to write to stdout. (default "-")
+      --selector stringArray   JSON path expression to select objects to scan for tags.
+                               Defaults to all Kong entities. Repeat for multiple selectors.
+  -s, --state string           decK file to process. Use - to read from stdin. (default "-")
+
+```

--- a/app/_includes/deck/help/file/merge.md
+++ b/app/_includes/deck/help/file/merge.md
@@ -1,0 +1,14 @@
+```bash
+Usage:
+  deck file merge [flags] filename [...filename]
+
+Examples:
+# Merge 3 files
+deck file merge -o merged.yaml file1.yaml file2.yaml file3.yaml
+
+Flags:
+      --format string        output format: yaml or json (default "yaml")
+  -h, --help                 help for merge
+  -o, --output-file string   Output file to write to. Use - to write to stdout. (default "-")
+
+```

--- a/app/_includes/deck/help/file/namespace.md
+++ b/app/_includes/deck/help/file/namespace.md
@@ -1,0 +1,53 @@
+```bash
+Usage:
+  deck file namespace [flags]
+
+Examples:
+# Apply namespace to a deckfile, path and host:
+deck file namespace --path-prefix=/kong --host=konghq.com --state=deckfile.yaml
+
+# Apply namespace to a deckfile, and write to a new file
+# Example file 'kong.yaml':
+routes:
+- paths:
+  - ~/tracks/system$
+  strip_path: true
+- paths:
+  - ~/list$
+  strip_path: false
+
+# Apply namespace to the deckfile, and write to stdout:
+cat kong.yaml | deck file namespace --path-prefix=/kong
+
+# Output:
+routes:
+- paths:
+  - ~/kong/tracks/system$
+  strip_path: true
+  hosts:
+  - konghq.com
+- paths:
+  - ~/kong/list$
+  strip_path: false
+  hosts:
+  - konghq.com
+  plugins:
+  - name: pre-function
+    config:
+      access:
+      - "local ns='/kong' -- this strips the '/kong' namespace from the path\nlocal <more code here>"
+
+
+
+Flags:
+      --allow-empty-selectors   Do not error out if the selectors return empty
+  -c, --clear-hosts             Clear existing hosts.
+      --format string           Output format: yaml or json. (default "yaml")
+  -h, --help                    help for namespace
+      --host stringArray        Hostname to add for host-based namespacing. Repeat for multiple hosts.
+  -o, --output-file string      Output file to write. Use - to write to stdout. (default "-")
+  -p, --path-prefix string      The path based namespace to apply.
+      --selector stringArray    json-pointer identifying element to patch. Repeat for multiple selectors. Defaults to selecting all routes.
+  -s, --state string            decK file to process. Use - to read from stdin. (default "-")
+
+```

--- a/app/_includes/deck/help/file/openapi2kong.md
+++ b/app/_includes/deck/help/file/openapi2kong.md
@@ -1,0 +1,25 @@
+```bash
+Usage:
+  deck file openapi2kong [flags]
+
+Examples:
+# Convert an OAS file, adding 2 tags, with inso compatibility enabled
+cat service_oas.yml | deck file openapi2kong --inso-compatible --select-tag=serviceA,teamB
+
+Flags:
+      --format string            output format: yaml or json (default "yaml")
+      --generate-security        generate OpenIDConnect plugins from the security directives
+  -h, --help                     help for openapi2kong
+      --ignore-security-errors   ignore errors for unsupported security schemes
+  -i, --inso-compatible          This flag will enable Inso compatibility. The generated entity names will be
+                                 the same, and no 'id' fields will be generated.
+      --no-id                    Setting this flag will skip UUID generation for entities (no 'id' fields
+                                 will be added, implicit if '--inso-compatible' is set).
+  -o, --output-file string       Output file to write. Use - to write to stdout. (default "-")
+      --select-tag strings       Select tags to apply to all entities. If omitted, uses the "x-kong-tags"
+                                 directive from the file.
+  -s, --spec string              OpenAPI spec file to process. Use - to read from stdin. (default "-")
+      --uuid-base string         The unique base-string for uuid-v5 generation of entity IDs. If omitted,
+                                 uses the root-level "x-kong-name" directive, or falls back to 'info.title'.)
+
+```

--- a/app/_includes/deck/help/file/patch.md
+++ b/app/_includes/deck/help/file/patch.md
@@ -1,0 +1,17 @@
+```bash
+Usage:
+  deck file patch [flags] [...patch-files]
+
+Examples:
+# update the read-timeout on all services
+cat kong.yml | deck file patch --selector="$..services[*]" --value="read_timeout:10000"
+
+Flags:
+      --format string          Output format: yaml or json. (default "yaml")
+  -h, --help                   help for patch
+  -o, --output-file string     Output file to write. Use - to write to stdout. (default "-")
+      --selector stringArray   json-pointer identifying element to patch. Repeat for multiple selectors.)
+  -s, --state string           decK file to process. Use - to read from stdin. (default "-")
+      --value stringArray      A value to set in the selected entry in <key:value> format. Can be specified multiple times.
+
+```

--- a/app/_includes/deck/help/file/remove-tags.md
+++ b/app/_includes/deck/help/file/remove-tags.md
@@ -1,0 +1,23 @@
+```bash
+Usage:
+  deck file remove-tags [flags] tag [...tag]
+
+Examples:
+# clear tags 'tag1' and 'tag2' from all services in file 'kong.yml'
+cat kong.yml | deck file remove-tags --selector='services[*]' tag1 tag2
+
+# clear all tags except 'tag1' and 'tag2' from the file 'kong.yml'
+cat kong.yml | deck file remove-tags --keep-only tag1 tag2
+
+Flags:
+      --format string          Output format: json or yaml (default "yaml")
+  -h, --help                   help for remove-tags
+      --keep-empty-array       Keep empty tag arrays in output.
+      --keep-only              Setting this flag will remove all tags except the ones listed.
+                               If none are listed, all tags will be removed.
+  -o, --output-file string     Output file to write. Use - to write to stdout. (default "-")
+      --selector stringArray   JSON path expression to select objects to remove tags from.
+                               Defaults to all Kong entities. Repeat for multiple selectors.
+  -s, --state string           decK file to process. Use - to read from stdin. (default "-")
+
+```

--- a/app/_includes/deck/help/file/render.md
+++ b/app/_includes/deck/help/file/render.md
@@ -1,0 +1,12 @@
+```bash
+Usage:
+  deck file render [flags]
+
+Flags:
+      --format string       output file format: json or yaml. (default "yaml")
+  -h, --help                help for render
+  -o, --output-file -       file to which to write Kong's configuration.Use - to write to stdout. (default "-")
+      --populate-env-vars   Populate 'DECK_' environment variables in the output file. The default behavior
+                            is to mock environment variable values.
+
+```

--- a/app/_includes/deck/help/file/validate.md
+++ b/app/_includes/deck/help/file/validate.md
@@ -1,0 +1,14 @@
+```bash
+Usage:
+  deck file validate [flags] [kong-state-files...]
+
+Flags:
+  -h, --help                           help for validate
+      --konnect-compatibility          validate that the state file(s) are ready to be deployed to Konnect
+      --online-entities-list strings   indicate the list of entities that should be validated online validation.
+      --parallelism int                Maximum number of concurrent requests to Kong. (default 10)
+      --rbac-resources-only            indicate that the state file(s) contains RBAC resources only (Kong Enterprise only).
+  -w, --workspace string               validate configuration of a specific workspace (Kong Enterprise only).
+                                       This takes precedence over _workspace fields in state files.
+
+```

--- a/app/_includes/deck/help/gateway/apply.md
+++ b/app/_includes/deck/help/gateway/apply.md
@@ -1,0 +1,16 @@
+```bash
+Usage:
+  deck gateway apply [flags] [kong-state-files...]
+
+Flags:
+      --db-update-propagation-delay db_update_propagation   artificial delay (in seconds) that is injected between insert operations 
+                                                            for related entities (usually for Cassandra deployments).
+                                                            See db_update_propagation in kong.conf.
+  -h, --help                                                help for apply
+      --json-output                                         generate command execution report in a JSON format
+      --parallelism int                                     Maximum number of concurrent operations. (default 10)
+      --silence-events                                      disable printing events to stdout
+  -w, --workspace string                                    Apply configuration to a specific workspace (Kong Enterprise only).
+                                                            This takes precedence over _workspace fields in state files.
+
+```

--- a/app/_includes/deck/help/gateway/diff.md
+++ b/app/_includes/deck/help/gateway/diff.md
@@ -1,0 +1,31 @@
+```bash
+Usage:
+  deck gateway diff [flags] [kong-state-files...]
+
+Flags:
+      --consumer-group-policy-overrides       allow deck to diff consumer-group policy overrides.
+                                              This allows policy overrides to work with Kong GW versions >= 3.4
+                                              Warning: do not mix with consumer-group scoped plugins
+  -h, --help                                  help for diff
+      --json-output                           generate command execution report in a JSON format
+      --no-mask-deck-env-vars-value           do not mask DECK_ environment variable values at diff output.
+      --non-zero-exit-code                    return exit code 2 if there is a diff present,
+                                              exit code 0 if no diff is found,
+                                              and exit code 1 if an error occurs.
+      --parallelism int                       Maximum number of concurrent operations. (default 10)
+      --rbac-resources-only                   sync only the RBAC resources (Kong Enterprise only).
+      --select-tag strings                    only entities matching tags specified via this flag are diffed.
+                                              When this setting has multiple tag values, entities must match each of them.
+      --silence-events                        disable printing events to stdout
+      --skip-ca-certificates                  do not diff CA certificates.
+      --skip-consumers                        do not diff consumers or any plugins associated with consumers
+      --skip-consumers-with-consumer-groups   do not show the association between consumer and consumer-group.
+                                              If set to true, deck skips listing consumers with consumer-groups,
+                                              thus gaining some performance with large configs.
+                                              Usage of this flag without apt select-tags and default-lookup-tags can be problematic.
+                                              This flag is not valid with Konnect.
+  -w, --workspace string                      Diff configuration with a specific workspace (Kong Enterprise only).
+                                              This takes precedence over _workspace fields in state files.
+      --yes yes                               assume yes to prompts and run non-interactively.
+
+```

--- a/app/_includes/deck/help/gateway/dump.md
+++ b/app/_includes/deck/help/gateway/dump.md
@@ -1,0 +1,25 @@
+```bash
+Usage:
+  deck gateway dump [flags]
+
+Flags:
+      --all-workspaces                        dump configuration of all Workspaces (Kong Enterprise only).
+      --consumer-group-policy-overrides       allow deck to dump consumer-group policy overrides.
+                                              This allows policy overrides to work with Kong GW versions >= 3.4
+                                              Warning: do not mix with consumer-group scoped plugins
+      --format string                         output file format: json or yaml. (default "yaml")
+  -h, --help                                  help for dump
+  -o, --output-file -                         file to which to write Kong's configuration.Use - to write to stdout. (default "-")
+      --rbac-resources-only                   export only the RBAC resources (Kong Enterprise only).
+      --select-tag strings                    only entities matching tags specified with this flag are exported.
+                                              When this setting has multiple tag values, entities must match every tag.
+      --skip-ca-certificates                  do not dump CA certificates.
+      --skip-consumers                        skip exporting consumers, consumer-groups and any plugins associated with them.
+      --skip-consumers-with-consumer-groups   do not show the association between consumer and consumer-group.
+                                              If set to true, deck skips listing consumers with consumer-groups,
+                                              thus gaining some performance with large configs. This flag is not valid with Konnect.
+      --with-id                               write ID of all entities in the output
+  -w, --workspace string                      dump configuration of a specific Workspace(Kong Enterprise only).
+      --yes yes                               assume yes to prompts and run non-interactively.
+
+```

--- a/app/_includes/deck/help/gateway/ping.md
+++ b/app/_includes/deck/help/gateway/ping.md
@@ -1,0 +1,10 @@
+```bash
+Usage:
+  deck gateway ping [flags]
+
+Flags:
+  -h, --help               help for ping
+  -w, --workspace string   Ping configuration with a specific Workspace (Kong Enterprise only).
+                           Useful when RBAC permissions are scoped to a Workspace.
+
+```

--- a/app/_includes/deck/help/gateway/reset.md
+++ b/app/_includes/deck/help/gateway/reset.md
@@ -1,0 +1,18 @@
+```bash
+Usage:
+  deck gateway reset [flags]
+
+Flags:
+      --all-workspaces                reset configuration of all workspaces (Kong Enterprise only).
+  -f, --force                         Skip interactive confirmation prompt before reset.
+  -h, --help                          help for reset
+      --json-output                   generate command execution report in a JSON format
+      --no-mask-deck-env-vars-value   do not mask DECK_ environment variable values at diff output.
+      --rbac-resources-only           reset only the RBAC resources (Kong Enterprise only).
+      --select-tag strings            only entities matching tags specified via this flag are deleted.
+                                      When this setting has multiple tag values, entities must match every tag.
+      --skip-ca-certificates          do not reset CA certificates.
+      --skip-consumers                do not reset consumers, consumer-groups or any plugins associated with consumers.
+  -w, --workspace string              reset configuration of a specific workspace(Kong Enterprise only).
+
+```

--- a/app/_includes/deck/help/gateway/sync.md
+++ b/app/_includes/deck/help/gateway/sync.md
@@ -1,0 +1,32 @@
+```bash
+Usage:
+  deck gateway sync [flags] [kong-state-files...]
+
+Flags:
+      --consumer-group-policy-overrides                     allow deck to sync consumer-group policy overrides.
+                                                            This allows policy overrides to work with Kong GW versions >= 3.4
+                                                            Warning: do not mix with consumer-group scoped plugins
+      --db-update-propagation-delay db_update_propagation   artificial delay (in seconds) that is injected between insert operations 
+                                                            for related entities (usually for Cassandra deployments).
+                                                            See db_update_propagation in kong.conf.
+  -h, --help                                                help for sync
+      --json-output                                         generate command execution report in a JSON format
+      --no-mask-deck-env-vars-value                         do not mask DECK_ environment variable values at diff output.
+      --parallelism int                                     Maximum number of concurrent operations. (default 10)
+      --rbac-resources-only                                 diff only the RBAC resources (Kong Enterprise only).
+      --select-tag strings                                  only entities matching tags specified via this flag are synced.
+                                                            When this setting has multiple tag values, entities must match every tag.
+                                                            All entities in the state file will get the select-tags assigned if not present already.
+      --silence-events                                      disable printing events to stdout
+      --skip-ca-certificates                                do not sync CA certificates.
+      --skip-consumers                                      do not sync consumers, consumer-groups or any plugins associated with them.
+      --skip-consumers-with-consumer-groups                 do not show the association between consumer and consumer-group.
+                                                            If set to true, deck skips listing consumers with consumer-groups,
+                                                            thus gaining some performance with large configs.
+                                                            Usage of this flag without apt select-tags and default-lookup-tags can be problematic.
+                                                            This flag is not valid with Konnect.
+  -w, --workspace string                                    Sync configuration to a specific workspace (Kong Enterprise only).
+                                                            This takes precedence over _workspace fields in state files.
+      --yes yes                                             assume yes to prompts and run non-interactively.
+
+```

--- a/app/_includes/deck/help/gateway/validate.md
+++ b/app/_includes/deck/help/gateway/validate.md
@@ -1,0 +1,14 @@
+```bash
+Usage:
+  deck gateway validate [flags] [kong-state-files...]
+
+Flags:
+  -h, --help                           help for validate
+      --konnect-compatibility          validate that the state file(s) are ready to be deployed to Konnect
+      --online-entities-list strings   indicate the list of entities that should be validated online validation.
+      --parallelism int                Maximum number of concurrent requests to Kong. (default 10)
+      --rbac-resources-only            indicate that the state file(s) contains RBAC resources only (Kong Enterprise only).
+  -w, --workspace string               validate configuration of a specific workspace (Kong Enterprise only).
+                                       This takes precedence over _workspace fields in state files.
+
+```

--- a/app/deck/file/convert.md
+++ b/app/deck/file/convert.md
@@ -35,3 +35,7 @@ deck file convert --input-file kong2x.yaml --from kong-gateway-2.x --to kong-gat
 - `kong-gateway-2.x` to `kong-gateway-3.x`
   - Prefix any paths that look like a regular expression with a `~`
   - Generate default values for missing `namespace` fields in any Rate Limiting Advanced plugins
+
+## Command Usage
+
+{% include_cached deck/help/file/convert.md %}

--- a/app/deck/file/convert.md
+++ b/app/deck/file/convert.md
@@ -36,6 +36,6 @@ deck file convert --input-file kong2x.yaml --from kong-gateway-2.x --to kong-gat
   - Prefix any paths that look like a regular expression with a `~`
   - Generate default values for missing `namespace` fields in any Rate Limiting Advanced plugins
 
-## Command Usage
+## Command usage
 
 {% include_cached deck/help/file/convert.md %}

--- a/app/deck/file/kong2kic.md
+++ b/app/deck/file/kong2kic.md
@@ -738,6 +738,6 @@ metadata:
 {% endnavtab %}
 {% endnavtabs %}
 
-## Command Usage
+## Command usage
 
 {% include_cached deck/help/file/kong2kic.md %}

--- a/app/deck/file/kong2kic.md
+++ b/app/deck/file/kong2kic.md
@@ -737,3 +737,7 @@ metadata:
 
 {% endnavtab %}
 {% endnavtabs %}
+
+## Command Usage
+
+{% include_cached deck/help/file/kong2kic.md %}

--- a/app/deck/file/kong2tf.md
+++ b/app/deck/file/kong2tf.md
@@ -92,19 +92,17 @@ resource "konnect_gateway_custom_plugin" "demo_functionality_global" {
 The table below shows the most commonly used configuration options. For a complete list, run `deck file kong2kic --help`.
 
 <!--vale off-->
-
 {% table %}
 columns:
-
-- title: Flag
-  key: flag
-- title: Description
-  key: description
-  rows:
-- flag: "`--generate-imports-for-control-plane-id`"
-  description: "Generate Terraform import statements for the Control Plane ID."
-- flag: "`--ignore-credential-changes`"
-description: "Enable flag to add a `lifecycle` block to each consumer credential that ignores any changes from local to remote state."
+  - title: Flag
+    key: flag
+  - title: Description
+    key: description
+rows:
+  - flag: "`--generate-imports-for-control-plane-id`"
+    description: "Generate Terraform import statements for the Control Plane ID."
+  - flag: "`--ignore-credential-changes`"
+    description: "Enable flag to add a `lifecycle` block to each consumer credential that ignores any changes from local to remote state."
 {% endtable %}
 <!--vale on-->
 

--- a/app/deck/file/kong2tf.md
+++ b/app/deck/file/kong2tf.md
@@ -92,17 +92,19 @@ resource "konnect_gateway_custom_plugin" "demo_functionality_global" {
 The table below shows the most commonly used configuration options. For a complete list, run `deck file kong2kic --help`.
 
 <!--vale off-->
+
 {% table %}
 columns:
-  - title: Flag
-    key: flag
-  - title: Description
-    key: description
-rows:
-  - flag: "`--generate-imports-for-control-plane-id`"
-    description: "Generate Terraform import statements for the Control Plane ID."
-  - flag: "`--ignore-credential-changes`"
-    description: "Enable flag to add a `lifecycle` block to each consumer credential that ignores any changes from local to remote state."
+
+- title: Flag
+  key: flag
+- title: Description
+  key: description
+  rows:
+- flag: "`--generate-imports-for-control-plane-id`"
+  description: "Generate Terraform import statements for the Control Plane ID."
+- flag: "`--ignore-credential-changes`"
+description: "Enable flag to add a `lifecycle` block to each consumer credential that ignores any changes from local to remote state."
 {% endtable %}
 <!--vale on-->
 
@@ -862,3 +864,7 @@ resource "konnect_gateway_vault" "env" {
 
 {% endnavtab %}
 {% endnavtabs %}
+
+## Command Usage
+
+{% include_cached deck/help/file/kong2tf.md %}

--- a/app/deck/file/kong2tf.md
+++ b/app/deck/file/kong2tf.md
@@ -865,6 +865,6 @@ resource "konnect_gateway_vault" "env" {
 {% endnavtab %}
 {% endnavtabs %}
 
-## Command Usage
+## Command usage
 
 {% include_cached deck/help/file/kong2tf.md %}

--- a/app/deck/file/lint.md
+++ b/app/deck/file/lint.md
@@ -181,6 +181,6 @@ rules:
         match: "^https$"
 ```
 
-## Command Usage
+## Command usage
 
 {% include_cached deck/help/file/lint.md %}

--- a/app/deck/file/lint.md
+++ b/app/deck/file/lint.md
@@ -180,3 +180,7 @@ rules:
       functionOptions:
         match: "^https$"
 ```
+
+## Command Usage
+
+{% include_cached deck/help/file/lint.md %}

--- a/app/deck/file/manipulation/namespace.md
+++ b/app/deck/file/manipulation/namespace.md
@@ -67,3 +67,7 @@ If you need to ensure that the API only listens on the hostname provided, you ca
 ```bash
 deck file namespace --host service1.api.example.com --clear-hosts
 ```
+
+## Command usage
+
+{% include_cached deck/help/file/namespace.md %}

--- a/app/deck/file/manipulation/patch.md
+++ b/app/deck/file/manipulation/patch.md
@@ -76,3 +76,7 @@ patches:
 ```
 
 To apply the above file, run `deck file patch -s ./config.yaml patch1.yaml patch2.yaml`. Multiple patch files can be provided at once.
+
+## Command usage
+
+{% include_cached deck/help/file/patch.md %}

--- a/app/deck/file/manipulation/plugins.md
+++ b/app/deck/file/manipulation/plugins.md
@@ -69,3 +69,7 @@ patches:
 ```
 
 For more information, see the [deck file patch](/deck/file/manipulation/patch/) documentation.
+
+## Command usage
+
+{% include_cached deck/help/file/add-plugins.md %}

--- a/app/deck/file/manipulation/tags.md
+++ b/app/deck/file/manipulation/tags.md
@@ -48,6 +48,10 @@ To add tags to specific entities only, provide the `--selector` flag. The provid
 
 You can add multiple tags at once by providing them as additional arguments, for example: `team-one another-tag and-another`.
 
+### Command usage
+
+{% include_cached deck/help/file/add-tags.md %}
+
 ## remove-tags
 
 The opposite of `add-tags`, `remove-tags` allows you delete tags from your configuration file. It will remove the provided tag only by default:
@@ -70,6 +74,10 @@ deck file remove-tags -s ./config.yaml \
   --keep-only env-prod team-one
 ```
 
+### Command usage
+
+{% include_cached deck/help/file/remove-tags.md %}
+
 ## list-tags
 
 The `list-tags` command outputs all tags found in the file. Any tag that is applied to at least one entity is returned.
@@ -77,3 +85,7 @@ The `list-tags` command outputs all tags found in the file. Any tag that is appl
 ```bash
 deck file list-tags -s ./config.yaml
 ```
+
+### Command usage
+
+{% include_cached deck/help/file/list-tags.md %}

--- a/app/deck/file/merge.md
+++ b/app/deck/file/merge.md
@@ -45,6 +45,6 @@ The merge algorithm works in the following way:
 
 `deck file merge` does not perform any validations.
 
-## Command Usage
+## Command usage
 
 {% include_cached deck/help/file/merge.md %}

--- a/app/deck/file/merge.md
+++ b/app/deck/file/merge.md
@@ -38,9 +38,13 @@ deck file merge one.yaml two.yaml -o complete.yaml
 
 ## Merge algorithm
 
-The merge algorithm works in the following way: 
+The merge algorithm works in the following way:
 
 - Top level arrays are concatenated
 - Top level scalar values take the value from the last file passed as an argument
 
 `deck file merge` does not perform any validations.
+
+## Command Usage
+
+{% include_cached deck/help/file/merge.md %}

--- a/app/deck/file/openapi2kong.md
+++ b/app/deck/file/openapi2kong.md
@@ -163,3 +163,7 @@ rows:
         * `x-kong-security-[...] Plugin configurations`
 {% endtable %}
 <!--vale on-->
+
+## Command Usage
+
+{% include_cached deck/help/file/openapi2kong.md %}

--- a/app/deck/file/openapi2kong.md
+++ b/app/deck/file/openapi2kong.md
@@ -164,6 +164,6 @@ rows:
 {% endtable %}
 <!--vale on-->
 
-## Command Usage
+## Command usage
 
 {% include_cached deck/help/file/openapi2kong.md %}

--- a/app/deck/file/render.md
+++ b/app/deck/file/render.md
@@ -37,3 +37,7 @@ deck file render kong1.yml kong2.yml
 ```
 
 The `deck file render` command validates the configuration against a schema, and warns if any duplicate entities are detected.
+
+## Command Usage
+
+{% include_cached deck/help/file/render.md %}

--- a/app/deck/file/render.md
+++ b/app/deck/file/render.md
@@ -38,6 +38,6 @@ deck file render kong1.yml kong2.yml
 
 The `deck file render` command validates the configuration against a schema, and warns if any duplicate entities are detected.
 
-## Command Usage
+## Command usage
 
 {% include_cached deck/help/file/render.md %}

--- a/app/deck/file/validate.md
+++ b/app/deck/file/validate.md
@@ -52,6 +52,6 @@ Error: building state: route demo-route for plugin rate-limiting: entity not fou
 
 No communication takes places between decK and Kong during the execution of this command. This process is faster than online validation, but may catch fewer errors. For online validation, see [`deck gateway validate`](/deck/gateway/validate/).
 
-## Command Usage
+## Command usage
 
 {% include_cached deck/help/file/validate.md %}

--- a/app/deck/file/validate.md
+++ b/app/deck/file/validate.md
@@ -38,7 +38,6 @@ Error: 1 errors occurred:
 	validation error: object={"paths":["/demo"]}, err=services.0.routes.0: Must validate at least one schema (anyOf)
 	validation error: object={"paths":["/demo"]}, err=services.0.routes.0: name is required
 ```
-
 {:.no-copy-code}
 
 `deck file validate` also checks for foreign relationships and alerts in cases of broken relationships or missing links.
@@ -47,7 +46,6 @@ For example, you might see the following response:
 ```sh
 Error: building state: route demo-route for plugin rate-limiting: entity not found
 ```
-
 {:.no-copy-code}
 
 No communication takes places between decK and Kong during the execution of this command. This process is faster than online validation, but may catch fewer errors. For online validation, see [`deck gateway validate`](/deck/gateway/validate/).

--- a/app/deck/file/validate.md
+++ b/app/deck/file/validate.md
@@ -38,14 +38,20 @@ Error: 1 errors occurred:
 	validation error: object={"paths":["/demo"]}, err=services.0.routes.0: Must validate at least one schema (anyOf)
 	validation error: object={"paths":["/demo"]}, err=services.0.routes.0: name is required
 ```
+
 {:.no-copy-code}
 
-`deck file validate` also checks for foreign relationships and alerts in cases of broken relationships or missing links. 
+`deck file validate` also checks for foreign relationships and alerts in cases of broken relationships or missing links.
 For example, you might see the following response:
 
 ```sh
 Error: building state: route demo-route for plugin rate-limiting: entity not found
 ```
+
 {:.no-copy-code}
 
 No communication takes places between decK and Kong during the execution of this command. This process is faster than online validation, but may catch fewer errors. For online validation, see [`deck gateway validate`](/deck/gateway/validate/).
+
+## Command Usage
+
+{% include_cached deck/help/file/validate.md %}

--- a/app/deck/gateway/apply.md
+++ b/app/deck/gateway/apply.md
@@ -33,6 +33,6 @@ services:
 
 We recommend using [`deck gateway dump`](/deck/gateway/dump/) to back up the complete configuration to a file once you have finished iterating on your configuration. This file can then be used with [`deck gateway sync`](/deck/gateway/sync/).
 
-## Command Usage
+## Command usage
 
 {% include_cached deck/help/gateway/apply.md %}

--- a/app/deck/gateway/apply.md
+++ b/app/deck/gateway/apply.md
@@ -32,3 +32,7 @@ services:
 ```
 
 We recommend using [`deck gateway dump`](/deck/gateway/dump/) to back up the complete configuration to a file once you have finished iterating on your configuration. This file can then be used with [`deck gateway sync`](/deck/gateway/sync/).
+
+## Command Usage
+
+{% include_cached deck/help/gateway/apply.md %}

--- a/app/deck/gateway/diff.md
+++ b/app/deck/gateway/diff.md
@@ -71,3 +71,7 @@ Summary:
 {:.no-copy-code}
 
 If the live system has changed without a corresponding change to the state file, `deck gateway diff` will highlight the change and it can be reverted by running `deck gateway sync`.
+
+## Command Usage
+
+{% include_cached deck/help/gateway/diff.md %}

--- a/app/deck/gateway/diff.md
+++ b/app/deck/gateway/diff.md
@@ -72,6 +72,6 @@ Summary:
 
 If the live system has changed without a corresponding change to the state file, `deck gateway diff` will highlight the change and it can be reverted by running `deck gateway sync`.
 
-## Command Usage
+## Command usage
 
 {% include_cached deck/help/gateway/diff.md %}

--- a/app/deck/gateway/dump.md
+++ b/app/deck/gateway/dump.md
@@ -64,6 +64,6 @@ This creates multiple files in the current directory. Each file is named the sam
 deck gateway dump --all-workspaces
 ```
 
-## Command Usage
+## Command usage
 
 {% include_cached deck/help/gateway/dump.md %}

--- a/app/deck/gateway/dump.md
+++ b/app/deck/gateway/dump.md
@@ -63,3 +63,7 @@ This creates multiple files in the current directory. Each file is named the sam
 ```bash
 deck gateway dump --all-workspaces
 ```
+
+## Command Usage
+
+{% include_cached deck/help/gateway/dump.md %}

--- a/app/deck/gateway/ping.md
+++ b/app/deck/gateway/ping.md
@@ -39,3 +39,7 @@ deck gateway ping \
   --konnect-addr https://us.api.konghq.com \
   --konnect-control-plane-name default
 ```
+
+## Command Usage
+
+{% include_cached deck/help/gateway/ping.md %}

--- a/app/deck/gateway/ping.md
+++ b/app/deck/gateway/ping.md
@@ -40,6 +40,6 @@ deck gateway ping \
   --konnect-control-plane-name default
 ```
 
-## Command Usage
+## Command usage
 
 {% include_cached deck/help/gateway/ping.md %}

--- a/app/deck/gateway/reset.md
+++ b/app/deck/gateway/reset.md
@@ -27,3 +27,7 @@ The `deck gateway reset` command deletes all entities in the target control plan
 
 {:.danger}
 > **The reset command is destructive and cannot be undone.**
+
+## Command Usage
+
+{% include_cached deck/help/gateway/reset.md %}

--- a/app/deck/gateway/reset.md
+++ b/app/deck/gateway/reset.md
@@ -28,6 +28,6 @@ The `deck gateway reset` command deletes all entities in the target control plan
 {:.danger}
 > **The reset command is destructive and cannot be undone.**
 
-## Command Usage
+## Command usage
 
 {% include_cached deck/help/gateway/reset.md %}

--- a/app/deck/gateway/sync.md
+++ b/app/deck/gateway/sync.md
@@ -62,3 +62,7 @@ deck gateway sync services.yaml consumers.yaml
 # Sync a whole directory
 deck gateway sync directory/*.yaml
 ```
+
+## Command Usage
+
+{% include_cached deck/help/gateway/sync.md %}

--- a/app/deck/gateway/sync.md
+++ b/app/deck/gateway/sync.md
@@ -63,6 +63,6 @@ deck gateway sync services.yaml consumers.yaml
 deck gateway sync directory/*.yaml
 ```
 
-## Command Usage
+## Command usage
 
 {% include_cached deck/help/gateway/sync.md %}

--- a/app/deck/gateway/validate.md
+++ b/app/deck/gateway/validate.md
@@ -37,3 +37,7 @@ For example:
 ```bash
 deck gateway validate --online-entities-list Plugins kong.yaml
 ```
+
+## Command Usage
+
+{% include_cached deck/help/gateway/validate.md %}

--- a/app/deck/gateway/validate.md
+++ b/app/deck/gateway/validate.md
@@ -38,6 +38,6 @@ For example:
 deck gateway validate --online-entities-list Plugins kong.yaml
 ```
 
-## Command Usage
+## Command usage
 
 {% include_cached deck/help/gateway/validate.md %}

--- a/tools/deck-versions/README.md
+++ b/tools/deck-versions/README.md
@@ -1,0 +1,1 @@
+Run `node extract-help.js` to populate includes that contain the `--help` text from deck. It automatically detects commands and subcommands.

--- a/tools/deck-versions/extract-help.js
+++ b/tools/deck-versions/extract-help.js
@@ -1,0 +1,91 @@
+import { exec as execCb } from 'child_process';
+import { promisify } from 'util';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const execAsync = promisify(execCb);
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+(async () => {
+  try {
+    const { stdout } = await execAsync('deck --help');
+
+    const availableCommands = extractCommands(stdout);
+
+    for (const command of availableCommands) {
+      const { stdout } = await execAsync(`deck ${command} --help`);
+      const subCommands = extractCommands(stdout);
+      for (const subCommand of subCommands) {
+        const { stdout } = await execAsync(`deck ${command} ${subCommand} --help`);
+
+        const outputDir = path.resolve(__dirname, '../../app/_includes/deck/help', command);
+        if (!fs.existsSync(outputDir)) {
+          fs.mkdirSync(outputDir, { recursive: true });
+        }
+
+        const help = extractCommandSpecificHelp(stdout);
+        const content = "```bash\n" + help + "\n```";
+
+        const filePath = path.join(outputDir, `${subCommand}.md`);
+        fs.writeFileSync(filePath, content, 'utf8');
+        console.log(`Wrote help for 'deck ${command} ${subCommand}'`);
+      }
+    }
+
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+  }
+})();
+
+function extractCommandSpecificHelp(stdout) {
+  const help = [];
+  const lines = stdout.split('\n');
+
+  let isInFlags = false;
+  for (const line of lines) {
+    if (line.startsWith('Global Flags:')) {
+      break;
+    }
+
+    if (line.startsWith("Usage:")) {
+      isInFlags = true;
+    }
+
+    if (isInFlags) {
+      help.push(line);
+    }
+  }
+
+  return help.join("\n");
+}
+
+function extractCommands(stdout) {
+  const availableCommands = [];
+  const lines = stdout.split('\n');
+  let inCommandsSection = false;
+
+  for (const line of lines) {
+    if (line.startsWith('Available Commands:')) {
+      inCommandsSection = true;
+      continue;
+    }
+
+    if (inCommandsSection) {
+      if (line.trim() === '' || line.startsWith('Flags:')) {
+        break;
+      }
+
+      if (!line.includes('[deprecated]')) {
+        const command = line.trim().split(/\s+/)[0];
+        if (['help', 'completion', 'version'].includes(command)) {
+          continue;
+        }
+        availableCommands.push(command);
+      }
+    }
+  }
+
+  return availableCommands;
+}

--- a/tools/deck-versions/fetch-versions.js
+++ b/tools/deck-versions/fetch-versions.js
@@ -1,0 +1,53 @@
+import fetch from 'node-fetch';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+async function fetchDeckReleaseNames() {
+  const response = await fetch('https://api.github.com/repos/kong/deck/releases');
+  if (!response.ok) {
+    console.error('Failed to fetch releases:', response.statusText);
+    return;
+  }
+
+  const releases = await response.json();
+  const releaseNames = releases.slice(0, 10);
+
+
+  const deckDataPath = path.resolve(__dirname, '../../app/_data/tools/deck.yml');
+
+  const seenReleases = {};
+
+  const formattedReleases = releaseNames.map((r, index) => {
+    const version = r.name.replace(/^v/, '');
+    const [major, minor] = version.split('.');
+    const release = `${major}.${minor}`;
+    if (seenReleases[release]) {
+      return;
+    }
+
+    const releaseData = {
+      release,
+      version: version,
+      published_at: r.published_at.split("T")[0]
+    };
+    if (index == 0) {
+      releaseData.latest = true;
+    }
+    seenReleases[release] = true;
+    return releaseData;
+  }).filter(Boolean);
+
+  const yamlContent = `name: deck\n\nreleases:\n${formattedReleases
+    .map(r => `  - release: "${r.release}"\n    version: "${r.version}"\n${r.latest ? `    latest: true\n` : ''}    released: ${r.published_at}`)
+    .join('\n')}`;
+
+  fs.writeFileSync(deckDataPath, yamlContent, 'utf8');
+  console.log('Updated deck.yml successfully');
+
+}
+
+fetchDeckReleaseNames();

--- a/tools/deck-versions/package-lock.json
+++ b/tools/deck-versions/package-lock.json
@@ -1,0 +1,101 @@
+{
+  "name": "deck-versions",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "deck-versions",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "node-fetch": "^3.3.2"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "engines": {
+        "node": ">= 8"
+      }
+    }
+  }
+}

--- a/tools/deck-versions/package.json
+++ b/tools/deck-versions/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "deck-versions",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "scripts": {
+    "validate": "node index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "node-fetch": "^3.3.2"
+  }
+}


### PR DESCRIPTION
## Description

Adds a tool that populates the `deck` tool versions file automatically, and a GH Actions workflow that runs it daily. It also runs `--help` for each deck command and updates the include file for each command to keep the help output up to date

## Preview Links

[/deck/file/render/#command-usage](https://deploy-preview-2181--kongdeveloper.netlify.app/deck/file/render/#command-usage)