### PR TITLE
Fix: Konnect API requests

### DIFF
--- a/app/_how-tos/automate-api-catalog.md
+++ b/app/_how-tos/automate-api-catalog.md
@@ -63,18 +63,17 @@ In this tutorial, you'll automate your API catalog by creating an API along with
 First, [create an API](/api/konnect/api-builder/v3/#/operations/create-api) using the `/v3/apis` endpoint:
 
 <!--vale off-->
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v3/apis
 status_code: 201
 method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     name: MyAPI
     attributes: {"env":["development"],"domains":["web","mobile"]}
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 
 Export the ID of your API from the response:
@@ -88,19 +87,18 @@ export API_ID='YOUR-API-ID'
 [Create and associate a spec and version](/api/konnect/api-builder/v3/#/operations/create-api-version) with your API using the `/v3/apis/{apiId}/versions` endpoint:
 
 <!--vale off-->
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v3/apis/$API_ID/versions
 status_code: 201
 method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     version: 1.0.0
     spec:
         content: '{"openapi":"3.0.3","info":{"title":"Example API","version":"1.0.0"},"paths":{"/example":{"get":{"summary":"Example endpoint","responses":{"200":{"description":"Successful response"}}}}}}'
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 
 {:.warning}
@@ -113,20 +111,19 @@ An [API document](/dev-portal/apis/#documentation) is Markdown documentation for
 [Create and associate an API document](/api/konnect/api-builder/v3/#/operations/create-api-document) using the `/v3/apis/{apiId}/documents` endpoint:
 
 <!--vale off-->
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v3/apis/$API_ID/documents
 status_code: 201
 method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     slug: api-document
     status: published
     title: API Document
     content: '# API Document Header'
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 
 ## Associate the API with a Gateway Service
@@ -138,15 +135,14 @@ Before you can associate the API with the Service, you need the Control Plane ID
 First, send a request to the `/v2/control-planes` endpoint to [get the ID of the `quickstart` Control Plane](/api/konnect/control-planes/v2/#/operations/list-control-planes):
 
 <!--vale off-->
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v2/control-planes?filter%5Bname%5D%5Bcontains%5D=quickstart
 status_code: 201
 method: GET
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 
 Export your Control Plane ID:
@@ -158,15 +154,14 @@ export CONTROL_PLANE_ID='YOUR-CONTROL-PLANE-ID'
 Next, [list Services](/api/konnect/control-planes-config/v2/#/operations/list-service) by using the `/v2/control-planes/{controlPlaneId}/core-entities/services` endpoint:
 
 <!--vale off-->
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v2/control-planes/$CONTROL_PLANE_ID/core-entities/services
 status_code: 201
 method: GET
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 
 Export the ID of the `example-service`:
@@ -178,19 +173,18 @@ export SERVICE_ID='YOUR-GATEWAY-SERVICE-ID'
 [Associate the API with a Service](/api/konnect/api-builder/v3/#/operations/create-api-implementation) using the `/v3/apis/{apiId}/implementations` endpoint:
 
 <!--vale off-->
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v3/apis/$API_ID/implementations
 status_code: 201
 method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     service:
         control_plane_id: $CONTROL_PLANE_ID
         id: $SERVICE_ID
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 
 ## Publish the API to Dev Portal
@@ -198,15 +192,14 @@ body:
 Now you can [publish the API](/api/konnect/api-builder/v3/#/operations/publish-api-to-portal) to your Dev Portal using the `/v3/apis/{apiId}/publications/{portalId}` endpoint:
 
 <!--vale off-->
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v3/apis/$API_ID/publications/$PORTAL_ID
 status_code: 201
 method: PUT
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 
 ## Validate

--- a/app/_how-tos/automate-api-catalog.md
+++ b/app/_how-tos/automate-api-catalog.md
@@ -67,9 +67,6 @@ First, [create an API](/api/konnect/api-builder/v3/#/operations/create-api) usin
 url: /v3/apis
 status_code: 201
 method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     name: MyAPI
     attributes: {"env":["development"],"domains":["web","mobile"]}
@@ -91,9 +88,6 @@ export API_ID='YOUR-API-ID'
 url: /v3/apis/$API_ID/versions
 status_code: 201
 method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     version: 1.0.0
     spec:
@@ -115,9 +109,6 @@ An [API document](/dev-portal/apis/#documentation) is Markdown documentation for
 url: /v3/apis/$API_ID/documents
 status_code: 201
 method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     slug: api-document
     status: published
@@ -139,9 +130,6 @@ First, send a request to the `/v2/control-planes` endpoint to [get the ID of the
 url: /v2/control-planes?filter%5Bname%5D%5Bcontains%5D=quickstart
 status_code: 201
 method: GET
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 {% endkonnect_api_request %}
 <!--vale on-->
 
@@ -158,9 +146,6 @@ Next, [list Services](/api/konnect/control-planes-config/v2/#/operations/list-se
 url: /v2/control-planes/$CONTROL_PLANE_ID/core-entities/services
 status_code: 201
 method: GET
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 {% endkonnect_api_request %}
 <!--vale on-->
 
@@ -177,9 +162,6 @@ export SERVICE_ID='YOUR-GATEWAY-SERVICE-ID'
 url: /v3/apis/$API_ID/implementations
 status_code: 201
 method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     service:
         control_plane_id: $CONTROL_PLANE_ID
@@ -196,9 +178,6 @@ Now you can [publish the API](/api/konnect/api-builder/v3/#/operations/publish-a
 url: /v3/apis/$API_ID/publications/$PORTAL_ID
 status_code: 201
 method: PUT
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 {% endkonnect_api_request %}
 <!--vale on-->
 

--- a/app/_how-tos/collect-audit-logs.md
+++ b/app/_how-tos/collect-audit-logs.md
@@ -57,9 +57,6 @@ Create a webhook by sending a `PATCH` request to the [`/audit-log-webhook`](/api
 url: /v2/audit-log-webhook
 status_code: 201
 method: PATCH
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     endpoint: $SIEM_ENDPOINT
     enabled: true
@@ -85,9 +82,6 @@ To validate that the webhook is configured correctly, send an API request using 
 url: /v2/control-planes
 status_code: 201
 method: GET
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 {% endkonnect_api_request %}
 <!--vale on-->
 

--- a/app/_how-tos/collect-audit-logs.md
+++ b/app/_how-tos/collect-audit-logs.md
@@ -53,20 +53,19 @@ Now that you have an external endpoint and authorization credentials, you can se
 Create a webhook by sending a `PATCH` request to the [`/audit-log-webhook`](/api/konnect/audit-logs/v2/#/operations/update-audit-log-webhook) endpoint with the connection details for your SIEM vendor:
 
 <!--vale off-->
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v2/audit-log-webhook
 status_code: 201
 method: PATCH
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     endpoint: $SIEM_ENDPOINT
     enabled: true
     authorization: "Bearer $SIEM_TOKEN"
     log_format: cef
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 
 Webhooks are triggered via an HTTPS request using the following retry rules:
@@ -82,15 +81,14 @@ A retry is performed on a connection error, server error (`500` HTTP status code
 To validate that the webhook is configured correctly, send an API request using the {{site.konnect_short_name}} API:
 
 <!--vale off-->
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v2/control-planes
 status_code: 201
 method: GET
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 
 This should trigger a log in SumoLogic. Sometimes it can take a minute to populate the logs.

--- a/app/_how-tos/collect-dev-portal-audit-logs.md
+++ b/app/_how-tos/collect-dev-portal-audit-logs.md
@@ -85,9 +85,6 @@ Create a webhook by sending a `PATCH` request to the [`/portals/{portalId}/audit
 url: /v3/portals/$PORTAL_ID/audit-log-webhook
 status_code: 201
 method: PATCH
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     audit_log_destination_id: $DESTINATION_ID
     enabled: true

--- a/app/_how-tos/collect-dev-portal-audit-logs.md
+++ b/app/_how-tos/collect-dev-portal-audit-logs.md
@@ -80,15 +80,19 @@ export DESTINATION_ID='YOUR DESTINATION ID'
 
 Create a webhook by sending a `PATCH` request to the [`/portals/{portalId}/audit-log-webhook`](/api/konnect/portal-management/v3/#/operations/update-portal-audit-log-webhook) endpoint with the audit log destination:
 
-```sh
-curl -i -X PATCH https://us.api.konghq.com/v3/portals/$PORTAL_ID/audit-log-webhook \
- --header "Content-Type: application/json" \
- --header "Authorization: Bearer $KONNECT_TOKEN" \
- --json '{
-     "audit_log_destination_id": "'$DESTINATION_ID'",
-     "enabled": true
- }'
-```
+<!--vale off-->
+{% konnect_api_request %}
+url: /v3/portals/$PORTAL_ID/audit-log-webhook
+status_code: 201
+method: PATCH
+headers:
+    - 'Accept: application/json'
+    - 'Content-Type: application/json'
+body:
+    audit_log_destination_id: $DESTINATION_ID
+    enabled: true
+{% endkonnect_api_request %}
+<!--vale on-->
 
 Webhooks are triggered via an HTTPS request using the following retry rules:
 

--- a/app/_how-tos/configure-the-konnect-config-store.md
+++ b/app/_how-tos/configure-the-konnect-config-store.md
@@ -67,9 +67,6 @@ Before you can configure a {{site.konnect_short_name}} Vault, you must first cre
 url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores
 status_code: 201
 method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     name: my-config-store
 {% endkonnect_api_request %}
@@ -111,9 +108,6 @@ Store your secret by sending a `POST` request to the `/secrets` endpoint:
 url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores/$DECK_CONFIG_STORE_ID/secrets/
 status_code: 201
 method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     key: secret-key
     value: my-secret-value
@@ -129,9 +123,6 @@ You can validate that your secret was stored correctly by sending a `GET` reques
 url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores/$DECK_CONFIG_STORE_ID/secrets/
 status_code: 201
 method: GET
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 {% endkonnect_api_request %}
 <!--vale on-->
 

--- a/app/_how-tos/configure-the-konnect-config-store.md
+++ b/app/_how-tos/configure-the-konnect-config-store.md
@@ -63,17 +63,16 @@ next_steps:
 Before you can configure a {{site.konnect_short_name}} Vault, you must first create a Config Store using the [Control Planes Configuration API](/api/konnect/control-planes-config/) by sending a `POST` request to the `/config-stores` endpoint:
 
 <!--vale off-->
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores
 status_code: 201
 method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     name: my-config-store
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 
 Export the Config Store ID in the response body as an environment variable so you can use it later:
@@ -108,18 +107,17 @@ By storing a secret in a {{site.konnect_short_name}} Vault, you can reference it
 Store your secret by sending a `POST` request to the `/secrets` endpoint:
 
 <!--vale off-->
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores/$DECK_CONFIG_STORE_ID/secrets/
 status_code: 201
 method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     key: secret-key
     value: my-secret-value
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 
 ## Validate
@@ -127,15 +125,14 @@ body:
 You can validate that your secret was stored correctly by sending a `GET` request to the `/secrets` endpoint:
 
 <!--vale off-->
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores/$DECK_CONFIG_STORE_ID/secrets/
 status_code: 201
 method: GET
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 
 If your secret was successfully stored in {{site.konnect_short_name}}, the endpoint should return a `201` status code and your `secret-key` key in the output.

--- a/app/_how-tos/create-centrally-managed-consumer.md
+++ b/app/_how-tos/create-centrally-managed-consumer.md
@@ -60,18 +60,17 @@ Centrally-managed Consumers are assigned to realms instead of Control Planes. Re
 Use the [`/realms` endpoint](/api/konnect/consumers/#/operations/create-realm) to create a realm and associate it with allowed Control Planes:
 
 <!--vale off-->
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v1/realms
 status_code: 201
 method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     name: prod
     allowed_control_planes: [$KONNECT_CONTROL_PLANE_ID]
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 
 Export the ID of the realm from the response:
@@ -85,17 +84,16 @@ export DECK_REALM_ID={realm-id}
 Use the [create a Consumer](/api/konnect/consumers/#/operations/create-consumer) endpoint to create a centrally-managed Consumer:
 
 <!--vale off-->
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v1/realms/$DECK_REALM_ID/consumers
 status_code: 201
 method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     username: Ariel
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 
 
@@ -109,17 +107,16 @@ export CONSUMER_ID={consumer-id}
 Centrally-managed Consumers require a key for authentication. Configure authentication keys for Consumers using the [create a key](/api/konnect/consumers/#/operations/create-consumer-key) endpoint:
 
 <!--vale off-->
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v1/realms/$DECK_REALM_ID/consumers/$CONSUMER_ID/keys
 status_code: 201
 method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     type: new
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->  
 
 Export the Consumer key from the `secret` field in the response:

--- a/app/_how-tos/create-centrally-managed-consumer.md
+++ b/app/_how-tos/create-centrally-managed-consumer.md
@@ -64,9 +64,6 @@ Use the [`/realms` endpoint](/api/konnect/consumers/#/operations/create-realm) t
 url: /v1/realms
 status_code: 201
 method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     name: prod
     allowed_control_planes: [$KONNECT_CONTROL_PLANE_ID]
@@ -88,9 +85,6 @@ Use the [create a Consumer](/api/konnect/consumers/#/operations/create-consumer)
 url: /v1/realms/$DECK_REALM_ID/consumers
 status_code: 201
 method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     username: Ariel
 {% endkonnect_api_request %}
@@ -111,9 +105,6 @@ Centrally-managed Consumers require a key for authentication. Configure authenti
 url: /v1/realms/$DECK_REALM_ID/consumers/$CONSUMER_ID/keys
 status_code: 201
 method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     type: new
 {% endkonnect_api_request %}

--- a/app/_how-tos/enable-oidc-auth-for-dev-portal.md
+++ b/app/_how-tos/enable-oidc-auth-for-dev-portal.md
@@ -149,14 +149,13 @@ Because we're using the `client_credentials` auth method, you must create a cust
 [Configure Okta OIDC application authentication](/api/konnect/application-auth-strategies/v2/#/operations/create-app-auth-strategy) using the `/v2/application-auth-strategies` endpoint:
 
 <!--vale off-->
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v2/application-auth-strategies
 status_code: 201
 method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     name: Okta OIDC
     display_name: Okta OIDC
@@ -170,7 +169,7 @@ body:
             - client_credentials
             scopes: 
             - api.access
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 
 Export the ID of the Okta OIDC auth strategy:
@@ -184,18 +183,17 @@ export AUTH_STRATEGY_ID='YOUR-AUTH-STRATEGY-ID'
 Now that the application auth strategy is configured, you can [apply it to an API](/api/konnect/api-builder/v3/#/operations/publish-api-to-portal) using the `/v3/apis/{apiId}/publications/{portalId}` endpoint:
 
 <!--vale off-->
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v3/apis/$API_ID/publications/$PORTAL_ID
 status_code: 201
 method: PUT
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     auth_strategy_ids: 
     - $AUTH_STRATEGY_ID
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 
 This request will also publish the API to the specified Dev Portal.

--- a/app/_how-tos/enable-oidc-auth-for-dev-portal.md
+++ b/app/_how-tos/enable-oidc-auth-for-dev-portal.md
@@ -153,9 +153,6 @@ Because we're using the `client_credentials` auth method, you must create a cust
 url: /v2/application-auth-strategies
 status_code: 201
 method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     name: Okta OIDC
     display_name: Okta OIDC
@@ -187,9 +184,6 @@ Now that the application auth strategy is configured, you can [apply it to an AP
 url: /v3/apis/$API_ID/publications/$PORTAL_ID
 status_code: 201
 method: PUT
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     auth_strategy_ids: 
     - $AUTH_STRATEGY_ID

--- a/app/_how-tos/store-a-mistral-api-key-as-a-secret-in-konnect-config-store.md
+++ b/app/_how-tos/store-a-mistral-api-key-as-a-secret-in-konnect-config-store.md
@@ -90,9 +90,6 @@ Before you can configure a {{site.konnect_short_name}} Vault, you must first cre
 url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores
 status_code: 201
 method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     name: my-config-store
 {% endkonnect_api_request %}
@@ -133,9 +130,6 @@ Store your Mistral key as a secret by sending a `POST` request to the `/secrets`
 url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores/$DECK_CONFIG_STORE_ID/secrets/
 status_code: 201
 method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     key: mistral-key
     value: Bearer $MISTRAL_API_KEY

--- a/app/_how-tos/store-a-mistral-api-key-as-a-secret-in-konnect-config-store.md
+++ b/app/_how-tos/store-a-mistral-api-key-as-a-secret-in-konnect-config-store.md
@@ -86,17 +86,16 @@ next_steps:
 Before you can configure a {{site.konnect_short_name}} Vault, you must first create a Config Store using the [Control Planes Configuration API](/api/konnect/control-planes-config/) by sending a `POST` request to the `/config-stores` endpoint:
 
 <!--vale off-->
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores
 status_code: 201
 method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     name: my-config-store
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 
 Export your Config Store ID as an environment variable so you can use it later:
@@ -130,18 +129,17 @@ In this tutorial, you'll be storing the Mistral API key you set previously and u
 Store your Mistral key as a secret by sending a `POST` request to the `/secrets` endpoint:
 
 <!--vale off-->
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores/$DECK_CONFIG_STORE_ID/secrets/
 status_code: 201
 method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     key: mistral-key
     value: Bearer $MISTRAL_API_KEY
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 
 ## Reference your stored Mistral API key

--- a/app/_includes/prereqs/api-catalog.md
+++ b/app/_includes/prereqs/api-catalog.md
@@ -3,14 +3,13 @@ For this tutorial, you’ll need a Dev Portal pre-configured. These settings are
 1. [Create a Dev Portal](/api/konnect/portal-management/v3/#/operations/create-portal):
    <!--vale off-->
 {% capture portal %}
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v3/portals
 status_code: 201
 method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     name: MyDevPortal
     authentication_enabled: false
@@ -18,7 +17,7 @@ body:
     auto_approve_developers: false
     default_api_visibility: public
     default_page_visibility: public
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 {% endcapture %}
 
 {{ portal | indent: 3 }}
@@ -31,14 +30,13 @@ body:
 1. [Create a page in your Dev Portal](/api/konnect/portal-management/v3/#/operations/create-portal-page) so published APIs will display:
 <!--vale off-->
 {% capture pages %}
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v3/portals/$PORTAL_ID/pages
 status_code: 201
 method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     title: My Page
     slug: /apis
@@ -53,7 +51,7 @@ body:
      persist-page-number: true
      cta-text: "View APIs"
      ---
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 {% endcapture %}
 
 {{ pages | indent: 3 }}

--- a/app/_includes/prereqs/api-catalog.md
+++ b/app/_includes/prereqs/api-catalog.md
@@ -7,9 +7,6 @@ For this tutorial, you’ll need a Dev Portal pre-configured. These settings are
 url: /v3/portals
 status_code: 201
 method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     name: MyDevPortal
     authentication_enabled: false
@@ -34,9 +31,6 @@ body:
 url: /v3/portals/$PORTAL_ID/pages
 status_code: 201
 method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     title: My Page
     slug: /apis

--- a/app/_includes/prereqs/dedicated-cloud-gateways.md
+++ b/app/_includes/prereqs/dedicated-cloud-gateways.md
@@ -30,9 +30,6 @@ Create a Control Plane for Dedicated Cloud Gateways:
     url: /v2/control-planes
     status_code: 201
     method: POST
-    headers:
-      - 'Authorization: Bearer $KONNECT_TOKEN'
-      - 'Content-Type: application/json'
     body:
       name: cloud-gateway-control-plane
       description: A test control plane for Dedicated Cloud Gateways.
@@ -72,9 +69,6 @@ Use the following endpoint to provision a Dedicated Cloud Gateway Data Plane:
     url: /v2/cloud-gateways/configurations
     status_code: 201
     method: PUT
-    headers:
-      - 'Authorization: Bearer $KONNECT_TOKEN'
-      - 'Content-Type: application/json'
     body:
       control_plane_id: $CONTROL_PLANE_ID
       version: "3.6"

--- a/app/_includes/prereqs/dedicated-cloud-gateways.md
+++ b/app/_includes/prereqs/dedicated-cloud-gateways.md
@@ -26,7 +26,7 @@ export KONNECT_CONTROL_PLANE_URL=https://us.api.konghq.com
 
 Create a Control Plane for Dedicated Cloud Gateways:
 
-    {% control_plane_request %}
+    {% konnect_api_request %}
     url: /v2/control-planes
     status_code: 201
     method: POST
@@ -42,7 +42,7 @@ Create a Control Plane for Dedicated Cloud Gateways:
         - host: example.com
           port: 443
           protocol: https
-    {% endcontrol_plane_request %}
+    {% endkonnect_api_request %}
 
 From the response body, export the `control_plane_id`:
 
@@ -68,7 +68,7 @@ export NETWORK_ID='YOUR_NETWORK_ID'
     
 Use the following endpoint to provision a Dedicated Cloud Gateway Data Plane:
 
-    {% control_plane_request %}
+    {% konnect_api_request %}
     url: /v2/cloud-gateways/configurations
     status_code: 201
     method: PUT
@@ -86,5 +86,5 @@ Use the following endpoint to provision a Dedicated Cloud Gateway Data Plane:
           autoscale:
             kind: autopilot
             base_rps: 100
-    {% endcontrol_plane_request %}
+    {% endkonnect_api_request %}
 -->

--- a/app/_includes/prereqs/dev-portal-configure.md
+++ b/app/_includes/prereqs/dev-portal-configure.md
@@ -7,9 +7,6 @@ For this tutorial, you’ll need a Dev Portal and some Dev Portal settings pre-c
 url: /v3/portals
 status_code: 201
 method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     name: MyDevPortal
     authentication_enabled: true
@@ -34,9 +31,6 @@ body:
 url: /v3/portals/$PORTAL_ID/pages
 status_code: 201
 method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     title: My Page
     slug: /

--- a/app/_includes/prereqs/dev-portal-configure.md
+++ b/app/_includes/prereqs/dev-portal-configure.md
@@ -3,14 +3,13 @@ For this tutorial, you’ll need a Dev Portal and some Dev Portal settings pre-c
 1. [Create a Dev Portal](/api/konnect/portal-management/v3/#/operations/create-portal):
    <!--vale off-->
 {% capture portal %}
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v3/portals
 status_code: 201
 method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     name: MyDevPortal
     authentication_enabled: true
@@ -18,7 +17,7 @@ body:
     auto_approve_developers: true
     default_api_visibility: public
     default_page_visibility: public
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 {% endcapture %}
 
 {{ portal | indent: 3 }}
@@ -31,14 +30,13 @@ body:
 1. [Create a page in your Dev Portal](/api/konnect/portal-management/v3/#/operations/create-portal-page) so published APIs will display:
 <!--vale off-->
 {% capture pages %}
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v3/portals/$PORTAL_ID/pages
 status_code: 201
 method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     title: My Page
     slug: /
@@ -53,7 +51,7 @@ body:
      persist-page-number: true
      cta-text: "View APIs"
      ---
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 {% endcapture %}
 
 {{ pages | indent: 3 }}

--- a/app/_includes/prereqs/publish-api.md
+++ b/app/_includes/prereqs/publish-api.md
@@ -3,18 +3,17 @@
 1. [Create an API](/api/konnect/api-builder/v3/#/operations/create-api) using the `/v3/apis` endpoint:
 <!--vale off-->
 {% capture create-api %}
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v3/apis
 status_code: 201
 method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     name: MyAPI
     attributes: {"env":["development"],"domains":["web","mobile"]}
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 Export the ID of your API from the response:
 ```sh
@@ -27,15 +26,14 @@ export API_ID='YOUR-API-ID'
 1. First, send a request to the `/v2/control-planes` endpoint to [get the ID of the `quickstart` Control Plane](/api/konnect/control-planes/v2/#/operations/list-control-planes):
 <!--vale off-->
 {% capture list-cp %}
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v2/control-planes?filter%5Bname%5D%5Bcontains%5D=quickstart
 status_code: 201
 method: GET
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 Export your Control Plane ID:
 ```sh
@@ -48,15 +46,14 @@ export CONTROL_PLANE_ID='YOUR-CONTROL-PLANE-ID'
 1. Next, [list Services](/api/konnect/control-planes-config/v2/#/operations/list-service) by using the `/v2/control-planes/{controlPlaneId}/core-entities/services` endpoint:
 <!--vale off-->
 {% capture list-services %}
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v2/control-planes/$CONTROL_PLANE_ID/core-entities/services
 status_code: 201
 method: GET
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 <!--vale on-->
 Export the ID of the `example-service`:
 ```sh
@@ -69,19 +66,18 @@ export SERVICE_ID='YOUR-GATEWAY-SERVICE-ID'
 1. [Associate the API with a Service](/api/konnect/api-builder/v3/#/operations/create-api-implementation) using the `/v3/apis/{apiId}/implementations` endpoint:
 <!--vale off-->
 {% capture associate-service %}
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v3/apis/$API_ID/implementations
 status_code: 201
 method: POST
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
 body:
     service:
         control_plane_id: $CONTROL_PLANE_ID
         id: $SERVICE_ID
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 {% endcapture %}
 
 {{ associate-service | indent: 3 }}
@@ -90,15 +86,14 @@ body:
 1. Now you can [publish the API](/api/konnect/api-builder/v3/#/operations/publish-api-to-portal) to your Dev Portal using the `/v3/apis/{apiId}/publications/{portalId}` endpoint:
 <!--vale off-->
 {% capture publish %}
-{% control_plane_request %}
+{% konnect_api_request %}
 url: /v3/apis/$API_ID/publications/$PORTAL_ID
 status_code: 201
 method: PUT
 headers:
     - 'Accept: application/json'
     - 'Content-Type: application/json'
-    - 'Authorization: Bearer $DECK_KONNECT_TOKEN'
-{% endcontrol_plane_request %}
+{% endkonnect_api_request %}
 {% endcapture %}
 
 {{ publish | indent: 3 }}

--- a/app/_includes/prereqs/publish-api.md
+++ b/app/_includes/prereqs/publish-api.md
@@ -7,9 +7,6 @@
 url: /v3/apis
 status_code: 201
 method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     name: MyAPI
     attributes: {"env":["development"],"domains":["web","mobile"]}
@@ -30,9 +27,6 @@ export API_ID='YOUR-API-ID'
 url: /v2/control-planes?filter%5Bname%5D%5Bcontains%5D=quickstart
 status_code: 201
 method: GET
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 {% endkonnect_api_request %}
 <!--vale on-->
 Export your Control Plane ID:
@@ -50,9 +44,6 @@ export CONTROL_PLANE_ID='YOUR-CONTROL-PLANE-ID'
 url: /v2/control-planes/$CONTROL_PLANE_ID/core-entities/services
 status_code: 201
 method: GET
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 {% endkonnect_api_request %}
 <!--vale on-->
 Export the ID of the `example-service`:
@@ -70,9 +61,6 @@ export SERVICE_ID='YOUR-GATEWAY-SERVICE-ID'
 url: /v3/apis/$API_ID/implementations
 status_code: 201
 method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     service:
         control_plane_id: $CONTROL_PLANE_ID
@@ -90,9 +78,6 @@ body:
 url: /v3/apis/$API_ID/publications/$PORTAL_ID
 status_code: 201
 method: PUT
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 {% endkonnect_api_request %}
 {% endcapture %}
 

--- a/app/contributing/index.md
+++ b/app/contributing/index.md
@@ -158,6 +158,76 @@ formats:
 {% endnavtab %}
 {% endnavtabs %}
 
+### Control plane requests
+
+Use this block when you are writing a how to for both {{site.base_gateway}} and {{site.konnect_short_name}} and you want to send a request via the control plane.
+
+{% navtabs "control plane request" %}
+{% navtab "Code example" %}
+<!--vale off-->
+```
+{% raw %}{% control_plane_request %}
+url: /keyring/generate
+method: POST
+headers:
+  - 'Accept: application/json'
+{% endcontrol_plane_request %}{% endraw %}
+```
+<!--vale on-->
+
+{% endnavtab %}
+{% navtab "Rendered output" %}
+<!--vale off-->
+{% control_plane_request %}
+url: /keyring/generate
+method: POST
+headers:
+  - 'Accept: application/json'
+{% endcontrol_plane_request %}
+<!--vale on-->
+{% endnavtab %}
+{% endnavtabs %}
+
+### {{site.konnect_short_name}} API requests
+
+Use this block when you are writing a how to for only {{site.konnect_short_name}} and you want to send a request via the {{site.konnect_short_name}} API.
+
+{% navtabs "API request" %}
+{% navtab "Code example" %}
+<!--vale off-->
+```
+{% raw %}{% konnect_api_request %}
+url: /v3/apis
+status_code: 201
+method: POST
+headers:
+    - 'Accept: application/json'
+    - 'Content-Type: application/json'
+body:
+    name: MyAPI
+    attributes: {"env":["development"],"domains":["web","mobile"]}
+{% endkonnect_api_request %}{% endraw %}
+```
+<!--vale on-->
+
+{% endnavtab %}
+{% navtab "Rendered output" %}
+<!--vale off-->
+{% konnect_api_request %}
+url: /v3/apis
+status_code: 201
+method: POST
+headers:
+    - 'Accept: application/json'
+    - 'Content-Type: application/json'
+body:
+    name: MyAPI
+    attributes: {"env":["development"],"domains":["web","mobile"]}
+{% endkonnect_api_request %}
+<!--vale on-->
+{% endnavtab %}
+{% endnavtabs %}
+
 ### Tables
 All tables should use the `table` block and be written in `yaml`. 
 

--- a/app/contributing/index.md
+++ b/app/contributing/index.md
@@ -200,9 +200,6 @@ Use this block when you are writing a how to for only {{site.konnect_short_name}
 url: /v3/apis
 status_code: 201
 method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     name: MyAPI
     attributes: {"env":["development"],"domains":["web","mobile"]}
@@ -217,9 +214,6 @@ body:
 url: /v3/apis
 status_code: 201
 method: POST
-headers:
-    - 'Accept: application/json'
-    - 'Content-Type: application/json'
 body:
     name: MyAPI
     attributes: {"env":["development"],"domains":["web","mobile"]}


### PR DESCRIPTION
## Description

Fixes https://kongstrong.slack.com/archives/C06TLRHG8KX/p1752491072844909

Changed the Konnect only how tos to use `konnect_api_request` instead of `control_plane_request`. 

**Note:** I did not test the how tos since functionally, all that changed was the control plane URL was hardcoded instead of an env var.

## Preview Links
- https://deploy-preview-2183--kongdeveloper.netlify.app/how-to/store-a-mistral-api-key-as-a-secret-in-konnect-config-store/
- https://deploy-preview-2183--kongdeveloper.netlify.app/how-to/enable-oidc-auth-for-dev-portal/
- https://deploy-preview-2183--kongdeveloper.netlify.app/how-to/create-centrally-managed-consumer/
- https://deploy-preview-2183--kongdeveloper.netlify.app/how-to/configure-the-konnect-config-store/
- https://deploy-preview-2183--kongdeveloper.netlify.app/how-to/collect-dev-portal-audit-logs/
- https://deploy-preview-2183--kongdeveloper.netlify.app/how-to/collect-audit-logs/
- https://deploy-preview-2183--kongdeveloper.netlify.app/how-to/automate-api-catalog/
- https://deploy-preview-2183--kongdeveloper.netlify.app/contributing/#control-plane-requests (added sections about both request type blocks and when to use each)

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
