### PR TITLE
fix: Redirects for broken links in API spec

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -1,3 +1,9 @@
+# API spec links (delete when fixed)
+/gateway/latest/plan-and-deploy/security/secrets-management/getting-started /gateway/entities/vault/
+/gateway/latest/plan-and-deploy/security/secrets-management/reference-format /gateway/entities/vault/#how-do-i-reference-secrets-stored-in-a-vault
+/gateway/:version/plan-and-deploy/security/secrets-management/getting-started /gateway/entities/vault/
+/gateway/:version/plan-and-deploy/security/secrets-management/reference-format /gateway/entities/vault/#how-do-i-reference-secrets-stored-in-a-vault
+
 ## How-to renames
 /how-to/collect-dev-portal-audit-logs-with-sumologic/ /how-to/collect-dev-portal-audit-logs/
 /how-to/collect-audit-logs-with-sumologic/ /how-to/collect-audit-logs/
@@ -113,3 +119,4 @@
 # Gateway LTS
 /archive/dev-portal/ https://gateway-lts--kongdocs.netlify.app/gateway/3.4.x/kong-enterprise/dev-portal/
 /archive/vitals/     https://gateway-lts--kongdocs.netlify.app/gateway/3.4.x/kong-enterprise/analytics/
+


### PR DESCRIPTION
## Description

Issue reported on slack. Interim fix - can't easily fix directly in source, as this spec is generated somewhere, still tracking that down.

## Preview Links


