### PR TITLE
Fix event hooks schema name

### DIFF
--- a/app/_gateway_entities/event-hook.md
+++ b/app/_gateway_entities/event-hook.md
@@ -27,7 +27,7 @@ tools:
     - admin-api
 schema:
     api: gateway/admin-ee
-    path: /schemas/Event-Hooks
+    path: /schemas/Event-hooks
 
 api_specs:
     - gateway/admin-ee


### PR DESCRIPTION
## Description

Schema is currently not displaying: https://developer.konghq.com/gateway/entities/event-hook/
The schema path is `Event-hooks`, not `Event-Hooks`.

## Preview Links
https://deploy-preview-2223--kongdeveloper.netlify.app/gateway/entities/event-hook/
