### PR TITLE
Header cert auth plugin fixes

### DIFF
--- a/api-specs/plugins/header-cert-auth/openapi.yaml
+++ b/api-specs/plugins/header-cert-auth/openapi.yaml
@@ -18,6 +18,7 @@ paths:
       tags: [Header Cert Auth]
       parameters:
         - name: ConsumerUsernameOrId
+          example: example-consumer
           in: path
           required: true
           schema:
@@ -35,10 +36,11 @@ paths:
                     items:
                       $ref: '#/components/schemas/HeaderCertAuthCredential'
     post:
-      summary: Create a Header Cert Auth credential for a consumer
+      summary: Create a Header Cert Auth credential for a Consumer
       tags: [Header Cert Auth]
       parameters:
         - name: ConsumerUsernameOrId
+          example: example-consumer
           in: path
           required: true
           schema:
@@ -48,7 +50,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/HeaderCertAuthCredentialRequest'
+              $ref: '#/components/schemas/HeaderCertAuthCredential'
       responses:
         '201':
           description: Credential created
@@ -63,11 +65,13 @@ paths:
       tags: [Header Cert Auth]
       parameters:
         - name: ConsumerUsernameOrId
+          example: example-consumer
           in: path
           required: true
           schema:
             type: string
         - name: HeaderCertAuthCredentials
+          example: 84175eaa-c795-483e-8a4a-3d57132003e8
           in: path
           required: true
           schema:
@@ -86,11 +90,13 @@ paths:
       tags: [Header Cert Auth]
       parameters:
         - name: ConsumerUsernameOrId
+          example: example-consumer
           in: path
           required: true
           schema:
             type: string
         - name: HeaderCertAuthCredentials
+          example: 84175eaa-c795-483e-8a4a-3d57132003e8
           in: path
           required: true
           schema:
@@ -100,7 +106,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/HeaderCertAuthCredentialRequest'
+              $ref: '#/components/schemas/HeaderCertAuthCredential'
       responses:
         '200':
           description: Credential replaced
@@ -109,11 +115,13 @@ paths:
       tags: [Header Cert Auth]
       parameters:
         - name: ConsumerUsernameOrId
+          example: example-consumer
           in: path
           required: true
           schema:
             type: string
         - name: HeaderCertAuthCredentials
+          example: 84175eaa-c795-483e-8a4a-3d57132003e8
           in: path
           required: true
           schema:
@@ -123,7 +131,7 @@ paths:
         content:
           application/json:
             schema:
-              type: object
+              $ref: '#/components/schemas/HeaderCertAuthCredential'
       responses:
         '200':
           description: Credential updated
@@ -132,11 +140,13 @@ paths:
       tags: [Header Cert Auth]
       parameters:
         - name: ConsumerUsernameOrId
+          example: example-consumer
           in: path
           required: true
           schema:
             type: string
         - name: HeaderCertAuthCredentials
+          example: 84175eaa-c795-483e-8a4a-3d57132003e8
           in: path
           required: true
           schema:
@@ -168,6 +178,7 @@ paths:
       tags: [Header Cert Auth]
       parameters:
         - name: HeaderCertAuthCredentials
+          example: 84175eaa-c795-483e-8a4a-3d57132003e8
           in: path
           required: true
           schema:
@@ -179,32 +190,74 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Consumer'
-
 components:
   schemas:
     HeaderCertAuthCredential:
       type: object
+      required: [subject_name]
       properties:
         id:
+          description: UUID of the Consumer mapping. Required if adding mapping using declarative configuration, otherwise generated automatically by Kong's Admin API."
           type: string
-        key:
+          example: 84175eaa-c795-483e-8a4a-3d57132003e8
+        subject_name:
+          description: "The Subject Alternative Name (SAN) or Common Name (CN) that should be mapped to `consumer` (in order of lookup)."
           type: string
+          example: CA_Subject_Name
         consumer:
           type: object
           properties:
             id:
               type: string
-    HeaderCertAuthCredentialRequest:
-      type: object
-      required: [key]
-      properties:
-        key:
-          type: string
+              example: a6f1f9db-737b-4a0b-8e87-21cda32fc857
+        ca_certificate:
+           description: |
+             The provided CA UUID or full CA Certificate has to be verifiable by the issuing certificate authority for the mapping to succeed. 
+             This is to help distinguish multiple certificates with the same subject name that are issued under different CAs.
+           type: object
+           properties:
+            id:
+              type: string
+              example: 50132e7d-a652-4a58-9f40-3722e9bd6afb
+        tags:
+          description: An optional set of strings associated with the credential for grouping and filtering.
+          items:
+              type: string
+          type: array
+        created_at:
+          description: Unix epoch when the resource was created.
+          nullable: true
+          type: integer
 
     Consumer:
       type: object
+      description: The Consumer object represents a consumer - or a user - of a Service. You can either rely on Kong as the primary datastore, or you can map the consumer list with your database to keep consistency between Kong and your existing primary datastore.
+      example:
+          id: 8a388226-80e8-4027-a486-25e4f7db5d21
+          username: example-consumer
       properties:
+        created_at:
+          description: Unix epoch when the resource was created.
+          nullable: true
+          type: integer
+        custom_id:
+          description: Field for storing an existing unique ID for the Consumer - useful for mapping Kong with users in your existing database. You must send either this field or `username` with the request.
+          nullable: true
+          type: string
         id:
+          nullable: true
           type: string
+        tags:
+          description: An optional set of strings associated with the Consumer for grouping and filtering.
+          items:
+              type: string
+          type: array
+        updated_at:
+          description: Unix epoch when the resource was last updated.
+          nullable: true
+          type: integer
         username:
+          description: The unique username of the Consumer. You must send either this field or `custom_id` with the request.
+          nullable: true
           type: string
+      type: object

--- a/api-specs/plugins/header-cert-auth/openapi.yaml
+++ b/api-specs/plugins/header-cert-auth/openapi.yaml
@@ -12,17 +12,12 @@ servers:
     description: Kong Admin API
 
 paths:
-  /consumers/{ConsumerUsernameOrId}/header-cert-auth:
+  /consumers/{consumerUsernameOrId}/header-cert-auth:
     get:
       summary: List Header Cert Auth credentials for a consumer
       tags: [Header Cert Auth]
       parameters:
-        - name: ConsumerUsernameOrId
-          example: example-consumer
-          in: path
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/consumerUsernameOrId'
       responses:
         '200':
           description: List of credentials
@@ -39,12 +34,7 @@ paths:
       summary: Create a Header Cert Auth credential for a Consumer
       tags: [Header Cert Auth]
       parameters:
-        - name: ConsumerUsernameOrId
-          example: example-consumer
-          in: path
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/consumerUsernameOrId'
       requestBody:
         required: true
         content:
@@ -59,23 +49,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/HeaderCertAuthCredential'
 
-  /consumers/{ConsumerUsernameOrId}/header-cert-auth/{HeaderCertAuthCredentials}:
+  /consumers/{consumerUsernameOrId}/header-cert-auth/{headerCertAuthCredentials}:
     get:
       summary: Retrieve a Header Cert Auth credential
       tags: [Header Cert Auth]
       parameters:
-        - name: ConsumerUsernameOrId
-          example: example-consumer
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: HeaderCertAuthCredentials
-          example: 84175eaa-c795-483e-8a4a-3d57132003e8
-          in: path
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/consumerUsernameOrId'
+        - $ref: '#/components/parameters/headerCertAuthCredentials'
       responses:
         '200':
           description: Credential found
@@ -89,18 +69,8 @@ paths:
       summary: Replace a Header Cert Auth credential
       tags: [Header Cert Auth]
       parameters:
-        - name: ConsumerUsernameOrId
-          example: example-consumer
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: HeaderCertAuthCredentials
-          example: 84175eaa-c795-483e-8a4a-3d57132003e8
-          in: path
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/consumerUsernameOrId'
+        - $ref: '#/components/parameters/headerCertAuthCredentials'
       requestBody:
         required: true
         content:
@@ -114,18 +84,8 @@ paths:
       summary: Update a Header Cert Auth credential
       tags: [Header Cert Auth]
       parameters:
-        - name: ConsumerUsernameOrId
-          example: example-consumer
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: HeaderCertAuthCredentials
-          example: 84175eaa-c795-483e-8a4a-3d57132003e8
-          in: path
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/consumerUsernameOrId'
+        - $ref: '#/components/parameters/headerCertAuthCredentials'
       requestBody:
         required: true
         content:
@@ -139,18 +99,8 @@ paths:
       summary: Delete a Header Cert Auth credential
       tags: [Header Cert Auth]
       parameters:
-        - name: ConsumerUsernameOrId
-          example: example-consumer
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: HeaderCertAuthCredentials
-          example: 84175eaa-c795-483e-8a4a-3d57132003e8
-          in: path
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/consumerUsernameOrId'
+        - $ref: '#/components/parameters/headerCertAuthCredentials'
       responses:
         '204':
           description: Credential deleted
@@ -172,17 +122,13 @@ paths:
                     items:
                       $ref: '#/components/schemas/HeaderCertAuthCredential'
 
-  /header-cert-auths/{HeaderCertAuthCredentials}/consumer:
+  /header-cert-auths/{headerCertAuthCredentials}/consumer:
     get:
       summary: Get the consumer associated with a Header Cert Auth credential
       tags: [Header Cert Auth]
       parameters:
-        - name: HeaderCertAuthCredentials
-          example: 84175eaa-c795-483e-8a4a-3d57132003e8
-          in: path
-          required: true
-          schema:
-            type: string
+        - $ref: '#/components/parameters/consumerUsernameOrId'
+        - $ref: '#/components/parameters/headerCertAuthCredentials'
       responses:
         '200':
           description: Consumer associated with the credential
@@ -191,13 +137,32 @@ paths:
               schema:
                 $ref: '#/components/schemas/Consumer'
 components:
+  parameters:
+    consumerUsernameOrId:
+      name: consumerUsernameOrId
+      in: path
+      required: true
+      schema:
+        type: string
+      example: example-consumer
+      description: The username or ID of the consumer.
+
+    headerCertAuthCredentials:
+      name: headerCertAuthCredentials
+      in: path
+      required: true
+      schema:
+        type: string
+        format: uuid
+      example: 84175eaa-c795-483e-8a4a-3d57132003e8
+      description: UUID of the Header Cert Auth credential.
   schemas:
     HeaderCertAuthCredential:
       type: object
       required: [subject_name]
       properties:
         id:
-          description: UUID of the Consumer mapping. Required if adding mapping using declarative configuration, otherwise generated automatically by Kong's Admin API."
+          description: UUID of the Consumer mapping. Required if adding mapping using declarative configuration, otherwise generated automatically by Kong's Admin API.
           type: string
           example: 84175eaa-c795-483e-8a4a-3d57132003e8
         subject_name:
@@ -260,4 +225,3 @@ components:
           description: The unique username of the Consumer. You must send either this field or `custom_id` with the request.
           nullable: true
           type: string
-      type: object

--- a/app/_includes/plugins/manual-consumer-mapping.md
+++ b/app/_includes/plugins/manual-consumer-mapping.md
@@ -21,18 +21,7 @@ You can create a Consumer mapping with either of the following:
         subject_name: test@example.com
     ```
 {% elsif include.slug == "header-cert-auth" %}
-You can create a Consumer mapping with either of the following:
-  * The [`/consumers/{consumer}/header-cert-auth` Admin API endpoint](/plugins/header-cert-auth/api/)
-  * [decK](/gateway/entities/consumer/#set-up-a-consumer) by specifying `header_cert_auth_credentials` in the configuration like the following:
-
-    ```yaml
-    consumers:
-    - custom_id: my-consumer
-      username: example-consumer
-      header_cert_auth_credentials:
-      - id: bda09448-3b10-4da7-a83b-2a8ba6021f0c
-        subject_name: test@example.com
-    ```
+You can create a Consumer mapping using the [`/consumers/{consumer}/header-cert-auth` Admin API endpoint](/plugins/header-cert-auth/api/).
 {% endif %}
 
 The following table describes how Consumer mapping parameters work for the {{include.name}} plugin:

--- a/app/deck/reference/entities.md
+++ b/app/deck/reference/entities.md
@@ -20,9 +20,10 @@ related_resources:
     url: /gateway/entities/
 ---
 
-decK manages entity configuration for {{site.base_gateway}}, including all core proxy entities.
+decK can manage entity configuration for {{site.base_gateway}}, including all core proxy entities.
+It does not manage {{site.base_gateway}} configuration parameters in [`kong.conf`](/gateway/configuration/), or content and configuration for the Dev Portal.
 
-It does not manage {{site.base_gateway}} configuration parameters in `kong.conf`, or content and configuration for the Dev Portal.
+decK supports the following entities:
 
 {% feature_table %}
 item_title: Entity
@@ -81,3 +82,4 @@ However, decK can't delete workspaces, and it can't update multiple workspaces s
 See [Manage multiple workspaces](/deck/gateway/workspaces/) for more information.
 
 While decK can manage a majority of {{site.base_gateway}}'s configuration, we recommend [additional arrangements](/gateway/upgrade/backup-and-restore/) for deployment, backup, and restoring unmanaged entities for a more comprehensive approach.
+


### PR DESCRIPTION
## Description

Fixing issues with the Header Cert Auth plugin:
* decK doesn't support Header Cert Auth credentials, so we can't include decK examples for creating those. 
* The API spec (manually written) was incorrect, checked the credential schema and updated it accordingly 

Issue reported on Slack.

## Preview Links
https://deploy-preview-2227--kongdeveloper.netlify.app/plugins/header-cert-auth/#manual-mappings-between-certificate-and-consumer-objects
https://deploy-preview-2227--kongdeveloper.netlify.app/plugins/header-cert-auth/api/
