### PR TITLE
Send category and name to segment

### DIFF
--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -59,11 +59,11 @@
 
     {% if jekyll.environment == "production" %}
     <!-- Segment start for konghq.com -->
-     {% if page.content_type %}{% assign category = "'" | append: page.content_type | append: "'" %}{% endif %}
+     {% assign category = "'" | append: page.content_type | append: "'" %}
     <script>
       !function(){var i="analytics",analytics=window[i]=window[i]||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","screen","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware","register"];analytics.factory=function(e){return function(){if(window[i].initialized)return window[i][e].apply(window[i],arguments);var n=Array.prototype.slice.call(arguments);if(["track","screen","alias","group","page","identify"].indexOf(e)>-1){var c=document.querySelector("link[rel='canonical']");n.push({__t:"bpc",c:c&&c.getAttribute("href")||void 0,p:location.pathname,u:location.href,s:location.search,t:document.title,r:document.referrer})}n.unshift(e);analytics.push(n);return analytics}};for(var n=0;n<analytics.methods.length;n++){var key=analytics.methods[n];analytics[key]=analytics.factory(key)}analytics.load=function(key,n){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.setAttribute("data-global-segment-analytics-key",i);t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var r=document.getElementsByTagName("script")[0];r.parentNode.insertBefore(t,r);analytics._loadOptions=n};analytics._writeKey="SMHOU8AoTR3Ekuuu4A9MkIOv6fmGfbkq";;analytics.SNIPPET_VERSION="5.2.0";
       analytics.load("SMHOU8AoTR3Ekuuu4A9MkIOv6fmGfbkq");
-      analytics.page({{category}});
+      analytics.page({{category}}, '{{page.title | liquify}}');
       }}();
     </script>
     <!-- Segment end for konghq.com -->


### PR DESCRIPTION
## Description

Pass category and name to segment to `analytics.page` so that the category is set correctly

From Segment docs:
Note: if you pass only one string to page it is assumed to be name. You must include a name to send a category

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
