### PR TITLE
Don't render edit link on plugin reference pages

### DIFF
--- a/app/_plugins/generators/data/edit_link/base.rb
+++ b/app/_plugins/generators/data/edit_link/base.rb
@@ -19,6 +19,7 @@ module Jekyll
 
         def edit_link
           return if @page.data['content_type'] == 'policy'
+          return if @page.data['plugin?'] && @page.data['reference?']
 
           if @page.data['source_url']
             @page.data['source_url'].gsub('/tree/', '/edit/')


### PR DESCRIPTION
## Description

Fixes https://github.com/Kong/developer.konghq.com/issues/2242

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
