### PR TITLE
Mirror cp docs

### DIFF
--- a/app/_how-tos/operator-konnect-control-plane-mirror.md
+++ b/app/_how-tos/operator-konnect-control-plane-mirror.md
@@ -1,0 +1,80 @@
+---
+title: Reference an existing Control Plane
+description: "Reference an existing Hybrid mode Control Plane in {{ site.konnect_short_name }}"
+content_type: how_to
+
+permalink: /operator/konnect/crd/control-planes/mirror/
+breadcrumbs:
+  - /operator/
+  - index: operator
+    group: Konnect
+  - index: operator
+    group: Konnect
+    section: "Konnect CRDs: Control Planes"
+
+products:
+  - operator
+
+works_on:
+  - konnect
+
+entities: []
+
+tags:
+  - konnect-crd
+ 
+tldr:
+  q: How do I reference an existing Hybrid mode Control Plane in {{ site.konnect_short_name }}?
+  a: |
+    Create a `KonnectGatewayControlPlane` object with `spec.source: Mirror` and add {{ site.konnect_short_name }} authentication.
+
+prereqs:
+  operator:
+    konnect:
+      auth: true
+  inline:
+    - title: "Set the {{ site.konnect_short_name }} Control Plane ID"
+      content: |
+        Set the `KONNECT_CONTROL_PLANE_ID` variable to the ID of the control plane that you want to reference:
+
+        ```bash
+        export KONNECT_CONTROL_PLANE_ID='YOUR CONTROL PLANE ID"
+        ```
+      icon_url: /assets/icons/self-hosted.svg
+
+next_steps:
+  - text: Create a Gateway Service
+    url: /operator/konnect/crd/gateway/service-and-route/
+
+---
+
+## Create a `KonnectGatewayControlPlane`
+
+Create a `KonnectGatewayControlPlane` object and add the {{ site.konnect_short_name }} authentication resource we created in the [prerequisites](#prerequisites).
+
+<!-- vale off -->
+{% konnect_crd %}
+kind: KonnectGatewayControlPlane
+metadata:
+  name: gateway-control-plane
+spec:
+  source: Mirror
+  mirror:
+    konnect:
+      id: $KONNECT_CONTROL_PLANE_ID
+  konnect:
+    authRef:
+      name: konnect-api-auth
+{% endkonnect_crd %}
+<!-- vale on -->
+
+## Validation
+
+<!-- vale off -->
+{% validation kubernetes-resource %}
+kind: KonnectGatewayControlPlane
+name: gateway-control-plane
+{% endvalidation %}
+<!-- vale on -->
+
+Now you can reference the `gateway-control-plane` resource from other CRDs as though it was created by {{ site.operator_product_name }}.

--- a/app/_how-tos/operator-konnect-getstarted-install.md
+++ b/app/_how-tos/operator-konnect-getstarted-install.md
@@ -20,7 +20,7 @@ tldr:
   a: |
     ```bash
     helm upgrade --install kgo kong/gateway-operator -n kong-system --create-namespace \
-      --set image.tag=1.5 \
+      --set image.tag={{ site.data.operator_latest.release }} \
       --set kubernetes-configuration-crds.enabled=true \
       --set env.ENABLE_CONTROLLER_KONNECT=true
     ```
@@ -64,7 +64,7 @@ Use Helm to install the {{site.operator_product_name}} with {{ site.konnect_shor
 
 ```sh
 helm upgrade --install kgo kong/gateway-operator -n kong-system --create-namespace \
-  --set image.tag=1.5 \
+  --set image.tag={{ site.data.operator_latest.release }} \
   --set kubernetes-configuration-crds.enabled=true \
   --set env.ENABLE_CONTROLLER_KONNECT=true
 ```

--- a/app/_includes/prereqs/products/operator.md
+++ b/app/_includes/prereqs/products/operator.md
@@ -22,7 +22,7 @@
 
    ```bash
    helm upgrade --install kgo kong/gateway-operator -n kong-system --create-namespace  \
-     --set image.tag=1.5 \
+     --set image.tag={{ site.data.operator_latest.release }} \
      --set kubernetes-configuration-crds.enabled=true \
      --set env.ENABLE_CONTROLLER_KONNECT=true{% if prereqs.operator.controllers %} \{% for controller in prereqs.operator.controllers %}
      --set env.ENABLE_CONTROLLER_{{ controller | upcase }}=true{% unless forloop.last %} \{% endunless %}{% endfor %}{% endif %}


### PR DESCRIPTION
## Description

Adds a page that was missed in the original migration

## Preview Links

https://deploy-preview-2249--kongdeveloper.netlify.app/operator/konnect/crd/control-planes/mirror/

## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [x] Add new pages to the product documentation index (if applicable).
