### PR TITLE
Third-party tools note

### DIFF
--- a/app/gateway/third-party-support.md
+++ b/app/gateway/third-party-support.md
@@ -48,8 +48,8 @@ Other supported third-party tools:
 
 {:.info}
 > **Note:** Kong only tests compatibility against these tools and dependencies.
-> Kong **does not** maintain or own any of the third party tools listed here.
-> Likewise, Kong does not maintain or own any of the supported AI providers and identity providers.
+> Kong **does not** maintain, own, or provide user support for any of the third-party tools listed here,
+> or for any AI providers and identity providers.
 
 ## Third-party tools
 

--- a/app/gateway/third-party-support.md
+++ b/app/gateway/third-party-support.md
@@ -46,6 +46,11 @@ Other supported third-party tools:
 * For identity providers supported by the OpenID Connect plugin, see the [OIDC plugin's documentation](/plugins/openid-connect/#supported-identity-providers).
 * For supported AI providers, see the [AI Gateway providers documentation](/ai-gateway/ai-providers/).
 
+{:.info}
+> **Note:** Kong only tests compatibility against these tools and dependencies.
+> Kong **does not** maintain or own any of the third party tools listed here.
+> Likewise, Kong does not maintain or own any of the supported AI providers and identity providers.
+
 ## Third-party tools
 
 Kong supports the following third-party tools for each given {{site.base_gateway}} release version.


### PR DESCRIPTION
## Description

Adding a note about support vs maintenance for 3rd party tools for Gateway.
This stems from a concern that someone had about a user assuming that Kong will maintain these tools for them:

> Is there a way to call out that the [third-party supportability](https://developer.konghq.com/gateway/third-party-support/) mentioned here does not mean that Kong will work on upgrading/maintaining the third party tools in a customer's deployment stack?

Reviewers: does this note cover the issue for you?

## Preview Links

https://deploy-preview-2252--kongdeveloper.netlify.app/gateway/third-party-support/
