### PR TITLE
Insomnia changelog link

### DIFF
--- a/app/_landing_pages/insomnia.yaml
+++ b/app/_landing_pages/insomnia.yaml
@@ -270,3 +270,15 @@ rows:
                 - insomnia
               quantity: 5
               allow_empty: true
+
+
+  - header:
+      text: "Frequently asked questions"
+      type: h2
+    columns:
+      - blocks:
+        - type: faqs
+          config:
+            - q: Where can I find the Insomnia changelog?
+              a: Insomnia release notes are published at [https://insomnia.rest/changelog](https://insomnia.rest/changelog).
+            


### PR DESCRIPTION
## Description

Adding an FAQ that links to the Insomnia changelog. Doing it this way instead of as a tile so that it comes up search better.

Issue reported on Slack.

## Preview Links

https://deploy-preview-2265--kongdeveloper.netlify.app/insomnia/#where-can-i-find-the-insomnia-changelog
