### PR TITLE
Fix the mismatched version numbers in the description of breaking-changes.md

### DIFF
--- a/app/gateway/breaking-changes.md
+++ b/app/gateway/breaking-changes.md
@@ -151,7 +151,7 @@ Review the [changelog](/gateway/changelog/#3900) for all the changes in this rel
 
 ### 3.9.0.0
 
-Breaking changes in the 3.10.0.0 release.
+Breaking changes in the 3.9.0.0 release.
 
 #### Node ID deprecation in `kong.conf`
 
@@ -183,7 +183,7 @@ Review the [changelog](/gateway/changelog/#3800) for all the changes in this rel
 
 ### 3.8.0.0
 
-Breaking changes in the 3.10.0.0 release.
+Breaking changes in the 3.8.0.0 release.
 
 #### `kong.logrotate` configuration file no longer overwritten during upgrade
 
@@ -239,7 +239,7 @@ Review the [changelog](/gateway/changelog/#3700) for all the changes in this rel
 
 ### 3.7.0.0
 
-Breaking changes in the 3.10.0.0 release.
+Breaking changes in the 3.7.0.0 release.
 
 #### Configuration
 
@@ -278,7 +278,7 @@ Review the [changelog](/gateway/changelog/#3600) for all the changes in this rel
 
 ### 3.6.1.0
 
-Breaking changes in the 3.10.0.0 release.
+Breaking changes in the 3.6.1.0 release.
 
 #### TLS changes
 
@@ -286,7 +286,7 @@ TLSv1.1 and lower is now disabled by default in OpenSSL 3.x.
 
 ### 3.6.0.0
 
-Breaking changes in the 3.10.0.0 release.
+Breaking changes in the 3.6.0.0 release.
 
 #### General
 


### PR DESCRIPTION
Some release version descriptions are mismatched

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
