### PR TITLE
Add support for min_version in references

### DIFF
--- a/app/_includes/info_box/reference.html
+++ b/app/_includes/info_box/reference.html
@@ -19,6 +19,10 @@
 </div>
 {% endif %}
 
+{% if page.min_version %}
+{% include info_box/sections/min_version.html min_version=page.min_version %}
+{% endif %}
+
 {% if page.works_on %}
 {% include_cached info_box/sections/works_on.html works_on=page.works_on %}
 {% endif %}

--- a/app/operator/konnect/control-plane-watch-namespaces.md
+++ b/app/operator/konnect/control-plane-watch-namespaces.md
@@ -15,6 +15,9 @@ breadcrumbs:
 related_resources:
   - text: "Create a Control Plane with KGO"
     url: /operator/konnect/crd/control-planes/hybrid/
+
+min_version:
+  operator: '3.5'
 ---
 
 By default, {{ site.kgo_product_name }}'s `ControlPlane` watches all namespaces.


### PR DESCRIPTION
## Description

Add minimum version to reference page info boxes

## Preview Links

[/operator/konnect/control-plane-watch-namespaces/](https://deploy-preview-2280--kongdeveloper.netlify.app/operator/konnect/control-plane-watch-namespaces/)
