### PR TITLE
Align table text to top of cell

### DIFF
--- a/app/_includes/components/table.html
+++ b/app/_includes/components/table.html
@@ -14,7 +14,7 @@
         <tr>
             {% for column in include.columns %}
                 {% assign v = row[column.key] %}
-                <td{% if v == true or v == false %}{% endif %}>
+                <td{% if v == true or v == false %}{% endif %} style="vertical-align: top">
                 {% if v == true %}
                     {% include icon_true.html %}
                 {% elsif v == false %}


### PR DESCRIPTION
## Description

Fixes this alignment issue, where any table with mismatched cell content length makes it difficult to read the adjoining cells + looks misaligned.

For example:
https://developer.konghq.com/gateway/breaking-changes/#known-issues-in-3-6-0-0
https://deploy-preview-2290--kongdeveloper.netlify.app/gateway/breaking-changes/#known-issues-in-3-6-0-0

Before:
<img width="932" height="745" alt="Screenshot 2025-07-22 at 3 11 35 PM" src="https://github.com/user-attachments/assets/e663ff9c-f921-4192-a80b-7e569f13806d" />

After:
<img width="902" height="747" alt="Screenshot 2025-07-22 at 3 11 59 PM" src="https://github.com/user-attachments/assets/04c5164f-08cf-4e2d-a593-6db81dc9acb3" />
