### PR TITLE
Add plugin name in source name format

### DIFF
--- a/app/_includes/plugins/table.html
+++ b/app/_includes/plugins/table.html
@@ -17,6 +17,7 @@
                     <td class="flex flex-col items-baseline">
                         <span class="block text-primary">
                             <a href="{{row.url}}">{{ row.title | liquify | markdown }}</a>
+                            <br>(<i>{{ row.slug }}</i>)
                         </span>
                     </td>
                     {% endif %}

--- a/app/_includes/plugins/table.html
+++ b/app/_includes/plugins/table.html
@@ -17,7 +17,7 @@
                     <td class="flex flex-col items-baseline">
                         <span class="block text-primary">
                             <a href="{{row.url}}">{{ row.title | liquify | markdown }}</a>
-                            <br>(<i>{{ row.slug }}</i>)
+                            <br>(<code>{{ row.slug }}</code>)
                         </span>
                     </td>
                     {% endif %}

--- a/app/_plugins/drops/plugins/tabular.rb
+++ b/app/_plugins/drops/plugins/tabular.rb
@@ -46,6 +46,10 @@ module Jekyll
           @url ||= @plugin.data['overview_url']
         end
 
+        def slug
+          @slug ||= @plugin.data['slug']
+        end
+
         def [](key)
           key = key.to_s
           if respond_to?(key)


### PR DESCRIPTION
## Description

Minor adjustment to the plugin compatibility table to also include the plugin name from code, eg "Key Authentication - Encrypted" gets `key-auth-enc`. Based on an AI bot answer where the bot was unable to tell the the Kafka Log plugin was present in this table because the question asked for `kafka-log` (that really should've worked, but for some reason it didn't).

## Preview Links

https://deploy-preview-2291--kongdeveloper.netlify.app/plugins/compatibility/