### PR TITLE
Fix: Incorrect license URL

### DIFF
--- a/app/_gateway_entities/license.md
+++ b/app/_gateway_entities/license.md
@@ -46,7 +46,7 @@ You receive a license file when you sign up for a {{site.ee_product_name}} subsc
 1. The contents of the environmental variable `KONG_LICENSE_DATA`.
 2. The default location `/etc/kong/license.json`.
 3. The contents of the file defined by the `KONG_LICENSE_PATH` environment variable.
-4. A License directly deployed with the [`/licenses` Admin API endpoint](/api/gateway/admin-ee/#/operations/post-licenses).
+4. A License directly deployed with the [`/licenses` Admin API endpoint](/api/gateway/admin-ee/#/operations/create-licenses).
 
 Each node independently checks for the license file when the {{site.base_gateway}} process starts. Network connectivity isn't required for license validation.
 


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
