### PR TITLE
Gateway 3.x known issue: Missing Brotli module

### DIFF
--- a/app/_data/changelogs/gateway.json
+++ b/app/_data/changelogs/gateway.json
@@ -723,6 +723,11 @@
         "message": "When running in incremental sync mode ([`incremental_sync=on`](/gateway/configuration/#incremental-sync)), Kong Gateway can't apply configuration deltas to the stream subsystem. \nThis issue affects versions 3.10.0.0 and above, where incremental sync is enabled alongside stream proxying ([`stream_listen`](/gateway/configuration/#stream-listen)).\nAs a workaround for this issue, set `incremental_sync=off` when using stream proxying.\n",
         "type": "known-issues",
         "scope": "Core"
+      },
+      {
+        "message": "The Brotli module is missing from all of the following ARM64 Kong Gateway Docker images:\n* RHEL 9\n* Debian 12\n* Amazon Linux 2\n* Amazon Linux 2023\n",
+        "type": "known-issues",
+        "scope": "Core"
       }
     ],
     "kong-manager-ee": [
@@ -1428,6 +1433,11 @@
         "message": "Added a feature to allow updating the `belong_workspace` field of an admin via the Admin API and Kong Manager.",
         "type": "feature",
         "scope": "Admin API"
+      },
+      {
+        "message": "The Brotli module is missing from all of the following ARM64 Kong Gateway Docker images:\n* RHEL 9\n* Debian 12\n* Amazon Linux 2\n* Amazon Linux 2023\n",
+        "type": "known-issues",
+        "scope": "Core"
       }
     ],
     "kong-manager-ee": [
@@ -2467,6 +2477,11 @@
         "message": "Returns a detailed error message when failed to cascade delete a workspace caused by admins associated.",
         "type": "bugfix",
         "scope": "Admin API"
+      },
+      {
+        "message": "The Brotli module is missing from all of the following ARM64 Kong Gateway Docker images:\n* RHEL 9\n* Debian 12\n* Amazon Linux 2\n* Amazon Linux 2023\n",
+        "type": "known-issues",
+        "scope": "Core"
       }
     ],
     "kong-manager-ee": [
@@ -3331,6 +3346,11 @@
       {
         "message": "When authenticating Kong Manager with IDPs (e.g., OIDC, LDAP), the source of an RBAC role will be stored in its `role_source` field, which enables the existing roles with a source of `idp` to be removed upon new logins after IDP role mapping has changed. This also allows users to change a role's source between `local` and `idp` via the Admin API manually.",
         "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "The Brotli module is missing from all of the following ARM64 Kong Gateway Docker images:\n* RHEL 9\n* Debian 12\n* Amazon Linux 2\n* Amazon Linux 2023\n",
+        "type": "known-issues",
         "scope": "Core"
       }
     ],
@@ -4253,6 +4273,11 @@
           "acme",
           "jwe-decrypt"
         ]
+      },
+      {
+        "message": "The Brotli module is missing from all the following ARM64 Kong Gateway Docker images:\n* RHEL 9\n* Debian 12\n* Amazon Linux 2\n* Amazon Linux 2023\n",
+        "type": "known-issues",
+        "scope": "Core"
       }
     ],
     "kong-manager-ee": [
@@ -15364,6 +15389,11 @@
           "ai-semantic-cache",
           "ai-semantic-prompt-guard"
         ]
+      },
+      {
+        "message": "The Brotli module is missing from all of the following ARM64 Kong Gateway Docker images:\n* RHEL 9\n* Debian 12\n* Amazon Linux 2\n* Amazon Linux 2023\n",
+        "type": "known-issues",
+        "scope": "Core"
       }
     ],
     "kong-manager-ee": [

--- a/app/_data/changelogs/gateway.json
+++ b/app/_data/changelogs/gateway.json
@@ -5042,11 +5042,6 @@
         "message": "A bug originating from the underlying OpenResty platform affects connection pooling in certain circumstances. \nThis issue impacts transaction handling and negatively impacts performance, resulting in reduced request rates and increased latencies.\n Versions 3.10.0.0 and 3.10.0.1 are both affected. To resolve this regression, please upgrade to Kong Gateway 3.10.0.2 or later.\n",
         "type": "known-issues",
         "scope": "Core"
-      },
-      {
-        "message": "A bug originating from the underlying OpenResty platform affects connection pooling in certain circumstances. \nThis issue impacts transaction handling and negatively impacts performance, resulting in reduced request rates and increased latencies. \nVersions 3.10.0.0 and 3.10.0.1 are both affected. To resolve this regression, please upgrade to Kong Gateway 3.10.0.2 or later.\n",
-        "type": "known-issues",
-        "scope": "Core"
       }
     ],
     "kong-manager-ee": [

--- a/app/_data/changelogs/gateway.json
+++ b/app/_data/changelogs/gateway.json
@@ -715,17 +715,17 @@
         "scope": "Plugin"
       },
       {
-        "message": "A bug originating from the underlying OpenResty platform affects connection pooling in certain circumstances. \nThis issue impacts transaction handling and negatively impacts performance, resulting in reduced request rates and increased latencies.\n Versions 3.10.0.0 and 3.10.0.1 are both affected. To resolve this regression, please upgrade to Kong Gateway 3.10.0.2 or later.\n",
-        "type": "known-issues",
-        "scope": "Core"
-      },
-      {
         "message": "When running in incremental sync mode ([`incremental_sync=on`](/gateway/configuration/#incremental-sync)), Kong Gateway can't apply configuration deltas to the stream subsystem. \nThis issue affects versions 3.10.0.0 and above, where incremental sync is enabled alongside stream proxying ([`stream_listen`](/gateway/configuration/#stream-listen)).\nAs a workaround for this issue, set `incremental_sync=off` when using stream proxying.\n",
         "type": "known-issues",
         "scope": "Core"
       },
       {
         "message": "The Brotli module is missing from all of the following ARM64 Kong Gateway Docker images:\n* RHEL 9\n* Debian 12\n* Amazon Linux 2\n* Amazon Linux 2023\n",
+        "type": "known-issues",
+        "scope": "Core"
+      },
+      {
+        "message": "A bug originating from the underlying OpenResty platform affects connection pooling in certain circumstances. \nThis issue impacts transaction handling and negatively impacts performance, resulting in reduced request rates and increased latencies. \nVersions 3.10.0.0 and 3.10.0.1 are both affected. To resolve this regression, please upgrade to Kong Gateway 3.10.0.2 or later.\n",
         "type": "known-issues",
         "scope": "Core"
       }
@@ -5039,7 +5039,7 @@
         "scope": "Plugin"
       },
       {
-        "message": "A bug originating from the underlying OpenResty platform affects connection pooling in certain circumstances. \nThis issue impacts transaction handling and negatively impacts performance, resulting in reduced request rates and increased latencies.\n Versions 3.10.0.0 and 3.10.0.1 are both affected. To resolve this regression, please upgrade to Kong Gateway 3.10.0.2 or later.\n",
+        "message": "A bug originating from the underlying OpenResty platform affects connection pooling in certain circumstances. \nThis issue impacts transaction handling and negatively impacts performance, resulting in reduced request rates and increased latencies. \nVersions 3.10.0.0 and 3.10.0.1 are both affected. To resolve this regression, please upgrade to Kong Gateway 3.10.0.2 or later.\n",
         "type": "known-issues",
         "scope": "Core"
       }
@@ -15356,17 +15356,12 @@
         "type": "bugfix"
       },
       {
-        "message": "Fixed an issue where sometimes the paginated sync incorrectly reports \"history lost\" and fails.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Fixed an issue where newly spawned workers used outdated router data because the `init` phase was skipped.",
-        "type": "bugfix",
+        "message": "The Brotli module is missing from all of the following ARM64 Kong Gateway Docker images:\n* RHEL 9\n* Debian 12\n* Amazon Linux 2\n* Amazon Linux 2023\n",
+        "type": "known-issues",
         "scope": "Core"
       },
       {
-        "message": "If any [AI Gateway plugin](/plugins/?category=ai) has been enabled in a self-managed Kong Gateway deployment for more than a week, upgrades from 3.10 versions to 3.11.0.0 will fail due to a license migration issue. This does not affect Konnect deployments.\n\nA fix will be provided in 3.11.0.1.\n\nSee [breaking changes in 3.11](/gateway/breaking-changes/#known-issues-in-3-11-0-0) for a temporary workaround.",
+        "message": "If any [AI Gateway plugin](/plugins/?category=ai) has been enabled in a self-managed Kong Gateway deployment for more than a week, upgrades from 3.10 versions to 3.11.0.0 will fail due to a license migration issue.\nThis does not affect Konnect deployments. A fix will be provided in 3.11.0.1.\n\nSee [breaking changes in 3.11](/gateway/breaking-changes/#known-issues-in-3-11-0-0) for a temporary workaround.\n",
         "type": "known-issues",
         "scope": "Plugin",
         "plugins": [
@@ -15384,11 +15379,6 @@
           "ai-semantic-cache",
           "ai-semantic-prompt-guard"
         ]
-      },
-      {
-        "message": "The Brotli module is missing from all of the following ARM64 Kong Gateway Docker images:\n* RHEL 9\n* Debian 12\n* Amazon Linux 2\n* Amazon Linux 2023\n",
-        "type": "known-issues",
-        "scope": "Core"
       }
     ],
     "kong-manager-ee": [

--- a/app/gateway/breaking-changes.md
+++ b/app/gateway/breaking-changes.md
@@ -108,6 +108,16 @@ rows:
       * Incremental config sync is `off` by default. If you haven't enabled incremental config sync, there is no action required.
       * If you are using stream proxying and incremental config sync, disable incremental sync by setting `incremental_sync=off`. 
     status: Not fixed
+  - issue: Brotli module missing from ARM64 Kong Gateway Docker images
+    description: |
+      The Brotli module is missing from all the following ARM64 Kong Gateway Docker images:
+      * RHEL 9
+      * Debian 12
+      * Amazon Linux 2
+      * Amazon Linux 2023
+
+      There is no workaround for this issue.
+    status: Not fixed
 {% endtable %}
 
 ## 3.10.x breaking changes
@@ -180,6 +190,16 @@ rows:
       * Incremental config sync is `off` by default. If you haven't enabled incremental config sync, there is no action required.
       * If you are using stream proxying and incremental config sync, disable incremental sync by setting `incremental_sync=off`. 
     status: Not fixed
+  - issue: Brotli module missing from ARM64 Kong Gateway Docker images
+    description: |
+      The Brotli module is missing from all the following ARM64 Kong Gateway Docker images:
+      * RHEL 9
+      * Debian 12
+      * Amazon Linux 2
+      * Amazon Linux 2023
+
+      There is no workaround for this issue.
+    status: Not fixed
 {% endtable %}
 
 ## 3.9.x breaking changes
@@ -213,6 +233,32 @@ yq -i '(
 ) |= "requestPrompt"
 ' config.yaml
 ```
+
+#### Known issues in 3.9.0.0
+
+The following is a list of known issues in 3.9.x that may be fixed in a future release.
+
+{% table %}
+columns:
+  - title: Known issue
+    key: issue
+  - title: Description
+    key: description
+  - title: Status
+    key: status
+rows:
+  - issue: Brotli module missing from ARM64 Kong Gateway Docker images
+    description: |
+      The Brotli module is missing from all the following ARM64 Kong Gateway Docker images:
+      * RHEL 9
+      * Debian 12
+      * Amazon Linux 2
+      * Amazon Linux 2023
+
+      There is no workaround for this issue.
+    status: Not fixed
+{% endtable %}
+
 
 ## 3.8.x breaking changes
 
@@ -269,6 +315,30 @@ These fields are converted automatically when you run `kong migrations up`. Also
 
 Forked custom plugins aren't automatically migrated. For more information about how to migrate custom plugins, see [Custom plugins that used shared Redis config](#custom-plugins-that-used-shared-redis-config).
 
+#### Known issues in 3.8.0.0
+
+The following is a list of known issues in 3.8.x that may be fixed in a future release.
+
+{% table %}
+columns:
+  - title: Known issue
+    key: issue
+  - title: Description
+    key: description
+  - title: Status
+    key: status
+rows:
+  - issue: Brotli module missing from ARM64 Kong Gateway Docker images
+    description: |
+      The Brotli module is missing from all the following ARM64 Kong Gateway Docker images:
+      * RHEL 9
+      * Debian 12
+      * Amazon Linux 2
+      * Amazon Linux 2023
+
+      There is no workaround for this issue.
+    status: Not fixed
+{% endtable %}
 
 ## 3.7.x breaking changes
 
@@ -308,6 +378,30 @@ entity when using the AppRole authentication method.
 [**AI Proxy**](/plugins/ai-proxy/) (`ai-proxy`): To support the new messages API of `Anthropic`, the upstream
 path of the `anthropic` setting for the `llm/v1/chat` Route type has changed from `/v1/complete` to `/v1/messages`.
 
+#### Known issues in 3.7.0.0
+
+The following is a list of known issues in 3.7.x that may be fixed in a future release.
+
+{% table %}
+columns:
+  - title: Known issue
+    key: issue
+  - title: Description
+    key: description
+  - title: Status
+    key: status
+rows:
+  - issue: Brotli module missing from ARM64 Kong Gateway Docker images
+    description: |
+      The Brotli module is missing from all the following ARM64 Kong Gateway Docker images:
+      * RHEL 9
+      * Debian 12
+      * Amazon Linux 2
+      * Amazon Linux 2023
+
+      There is no workaround for this issue.
+    status: Not fixed
+{% endtable %}
 
 ## 3.6.x breaking changes
 
@@ -428,6 +522,16 @@ rows:
       *Issue fixed in 3.6.1.1*:
       <br><br>
       Reverted the hard-coded limitation of the `ngx.read_body()` API in OpenResty upstreams’ new versions when downstream connections are in HTTP/2 or HTTP/3 stream modes.
+  - issue: Brotli module missing from ARM64 Kong Gateway Docker images
+    description: |
+      The Brotli module is missing from all the following ARM64 Kong Gateway Docker images:
+      * RHEL 9
+      * Debian 12
+      * Amazon Linux 2
+      * Amazon Linux 2023
+
+      There is no workaround for this issue.
+    status: Not fixed
 {% endtable %}
 
 ## 3.5.x breaking changes

--- a/app/gateway/breaking-changes.md
+++ b/app/gateway/breaking-changes.md
@@ -108,9 +108,9 @@ rows:
       * Incremental config sync is `off` by default. If you haven't enabled incremental config sync, there is no action required.
       * If you are using stream proxying and incremental config sync, disable incremental sync by setting `incremental_sync=off`. 
     status: Not fixed
-  - issue: Brotli module missing from ARM64 Kong Gateway Docker images
+  - issue: Brotli module missing from ARM64 {{site.base_gateway}} Docker images
     description: |
-      The Brotli module is missing from all the following ARM64 Kong Gateway Docker images:
+      The Brotli module is missing from all the following ARM64 {{site.base_gateway}} Docker images:
       * RHEL 9
       * Debian 12
       * Amazon Linux 2
@@ -190,9 +190,9 @@ rows:
       * Incremental config sync is `off` by default. If you haven't enabled incremental config sync, there is no action required.
       * If you are using stream proxying and incremental config sync, disable incremental sync by setting `incremental_sync=off`. 
     status: Not fixed
-  - issue: Brotli module missing from ARM64 Kong Gateway Docker images
+  - issue: Brotli module missing from ARM64 {{site.base_gateway}} Docker images
     description: |
-      The Brotli module is missing from all the following ARM64 Kong Gateway Docker images:
+      The Brotli module is missing from all the following ARM64 {{site.base_gateway}} Docker images:
       * RHEL 9
       * Debian 12
       * Amazon Linux 2
@@ -247,9 +247,9 @@ columns:
   - title: Status
     key: status
 rows:
-  - issue: Brotli module missing from ARM64 Kong Gateway Docker images
+  - issue: Brotli module missing from ARM64 {{site.base_gateway}} Docker images
     description: |
-      The Brotli module is missing from all the following ARM64 Kong Gateway Docker images:
+      The Brotli module is missing from all the following ARM64 {{site.base_gateway}} Docker images:
       * RHEL 9
       * Debian 12
       * Amazon Linux 2
@@ -328,9 +328,9 @@ columns:
   - title: Status
     key: status
 rows:
-  - issue: Brotli module missing from ARM64 Kong Gateway Docker images
+  - issue: Brotli module missing from ARM64 {{site.base_gateway}} Docker images
     description: |
-      The Brotli module is missing from all the following ARM64 Kong Gateway Docker images:
+      The Brotli module is missing from all the following ARM64 {{site.base_gateway}} Docker images:
       * RHEL 9
       * Debian 12
       * Amazon Linux 2
@@ -391,9 +391,9 @@ columns:
   - title: Status
     key: status
 rows:
-  - issue: Brotli module missing from ARM64 Kong Gateway Docker images
+  - issue: Brotli module missing from ARM64 {{site.base_gateway}} Docker images
     description: |
-      The Brotli module is missing from all the following ARM64 Kong Gateway Docker images:
+      The Brotli module is missing from all the following ARM64 {{site.base_gateway}} Docker images:
       * RHEL 9
       * Debian 12
       * Amazon Linux 2
@@ -522,9 +522,9 @@ rows:
       *Issue fixed in 3.6.1.1*:
       <br><br>
       Reverted the hard-coded limitation of the `ngx.read_body()` API in OpenResty upstreams’ new versions when downstream connections are in HTTP/2 or HTTP/3 stream modes.
-  - issue: Brotli module missing from ARM64 Kong Gateway Docker images
+  - issue: Brotli module missing from ARM64 {{site.base_gateway}} Docker images
     description: |
-      The Brotli module is missing from all the following ARM64 Kong Gateway Docker images:
+      The Brotli module is missing from all the following ARM64 {{site.base_gateway}} Docker images:
       * RHEL 9
       * Debian 12
       * Amazon Linux 2

--- a/tools/changelog-generator/missing_entries/3.10.0.0/amazonlinux-2-brotli.yml
+++ b/tools/changelog-generator/missing_entries/3.10.0.0/amazonlinux-2-brotli.yml
@@ -1,0 +1,8 @@
+message: |
+  The Brotli module is missing from all of the following ARM64 Kong Gateway Docker images:
+  * RHEL 9
+  * Debian 12
+  * Amazon Linux 2
+  * Amazon Linux 2023
+type: "known-issues"
+scope: "Core"

--- a/tools/changelog-generator/missing_entries/3.11.0.0/amazonlinux-2-brotli.yml
+++ b/tools/changelog-generator/missing_entries/3.11.0.0/amazonlinux-2-brotli.yml
@@ -1,0 +1,8 @@
+message: |
+  The Brotli module is missing from all of the following ARM64 Kong Gateway Docker images:
+  * RHEL 9
+  * Debian 12
+  * Amazon Linux 2
+  * Amazon Linux 2023
+type: "known-issues"
+scope: "Core"

--- a/tools/changelog-generator/missing_entries/3.6.0.0/amazonlinux-2-brotli.yml
+++ b/tools/changelog-generator/missing_entries/3.6.0.0/amazonlinux-2-brotli.yml
@@ -1,0 +1,8 @@
+message: |
+  The Brotli module is missing from all the following ARM64 Kong Gateway Docker images:
+  * RHEL 9
+  * Debian 12
+  * Amazon Linux 2
+  * Amazon Linux 2023
+type: "known-issues"
+scope: "Core"

--- a/tools/changelog-generator/missing_entries/3.7.0.0/amazonlinux-2-brotli.yml
+++ b/tools/changelog-generator/missing_entries/3.7.0.0/amazonlinux-2-brotli.yml
@@ -1,0 +1,8 @@
+message: |
+  The Brotli module is missing from all of the following ARM64 Kong Gateway Docker images:
+  * RHEL 9
+  * Debian 12
+  * Amazon Linux 2
+  * Amazon Linux 2023
+type: "known-issues"
+scope: "Core"

--- a/tools/changelog-generator/missing_entries/3.8.0.0/amazonlinux-2-brotli.yml
+++ b/tools/changelog-generator/missing_entries/3.8.0.0/amazonlinux-2-brotli.yml
@@ -1,0 +1,8 @@
+message: |
+  The Brotli module is missing from all of the following ARM64 Kong Gateway Docker images:
+  * RHEL 9
+  * Debian 12
+  * Amazon Linux 2
+  * Amazon Linux 2023
+type: "known-issues"
+scope: "Core"

--- a/tools/changelog-generator/missing_entries/3.9.0.0/amazonlinux-2-brotli.yml
+++ b/tools/changelog-generator/missing_entries/3.9.0.0/amazonlinux-2-brotli.yml
@@ -1,0 +1,8 @@
+message: |
+  The Brotli module is missing from all of the following ARM64 Kong Gateway Docker images:
+  * RHEL 9
+  * Debian 12
+  * Amazon Linux 2
+  * Amazon Linux 2023
+type: "known-issues"
+scope: "Core"


### PR DESCRIPTION
## Description

Related to https://konghq.atlassian.net/browse/FTI-6834.
While the linked ticket only mentions Amazon Linux 2, you can see which packages are missing the module here: https://github.com/Kong/kong-ee/pull/13409/files

There is no workaround, but they're planning on adding the module back in the next 3.8-3.11 patches.

Also reran the changelog generator to fix some duplicate entries, hopefully that's all fixed properly now.

## Preview Links

https://deploy-preview-2307--kongdeveloper.netlify.app/gateway/breaking-changes/
https://deploy-preview-2307--kongdeveloper.netlify.app/gateway/changelog/