### PR TITLE
Feat: GCP VPC peering on DCGWs

### DIFF
--- a/app/_how-tos/aws-vpc-peering.md
+++ b/app/_how-tos/aws-vpc-peering.md
@@ -11,7 +11,7 @@ works_on:
   - konnect
 automated_tests: false
 tldr:
-  q: How do I set up a VPC peering connection with my Dedicated Cloud Gateway using the API?
+  q: How do I set up an AWS VPC peering connection with my Dedicated Cloud Gateway using the API?
   a: Use the {{site.konnect_short_name}} API to initiate peering, then accept the request in AWS and update your route table.
 related_resources:
   - text: Dedicated Cloud Gateways

--- a/app/_how-tos/gcp-vpc-peering.md
+++ b/app/_how-tos/gcp-vpc-peering.md
@@ -1,0 +1,131 @@
+---
+title: Set up a GCP VPC peering connection
+description: 'Use the {{site.konnect_short_name}} Cloud Gateways API or the Konnect UI to create a VPC peering connection with your GCP VPC.'
+content_type: how_to
+permalink: /dedicated-cloud-gateways/gcp-vpc-peering/
+breadcrumbs:
+  - /dedicated-cloud-gateways/
+products:
+  - gateway
+works_on:
+  - konnect
+automated_tests: false
+tldr:
+  q: How do I set up a Google Cloud VPC peering connection with my Dedicated Cloud Gateway?
+  a: Use {{site.konnect_short_name}} to initiate peering, then create a GCP VPC peering resource to accept connections from {{site.konnect_short_name}}.
+related_resources:
+  - text: Dedicated Cloud Gateways
+    url: /dedicated-cloud-gateways/
+  - text: Google Cloud VPC Peering Documentation
+    url: https://cloud.google.com/vpc/docs/vpc-peering
+  - text: Private hosted zones
+    url: /dedicated-cloud-gateways/private-hosted-zones/
+prereqs:
+  skip_product: true
+  inline:
+    - title: "Dedicated Cloud Gateway"
+      include_content: prereqs/dedicated-cloud-gateways
+
+    - title: "GCP credentials and VPC"
+      content: |
+        Set up a GCP account with the following permissions:
+        * `compute.networks.addPeering`
+        * `compute.networks.updatePeering`
+        * `compute.networks.removePeering`
+        * `compute.networks.listPeeringRoutes`
+---
+
+## Initiate the VPC peering connection
+
+{% navtabs "configure-gcp-konnect" %}
+{% navtab "Cloud Gateways API" %}
+
+Export the following values as environment variables, setting your own custom values:
+```sh
+$GCP_VPC_PEERING_NAME='gcp vpc peering'
+$GCP_PROJECT_ID='my-gcp-vpc-project'
+$GCP_VPC_NAME='my-gcp-vpc-name'
+```
+Where:
+* **VPC Peering Name**: A unique name to identify this VPC peering connection.
+* **Project ID**: ID of your GCP project that contains the VPC you want to peer with Kong.
+* **VPC Name**: Name of your VPC network in GCP for the peering connection.
+
+Next, send the following request to the Cloud Gateways API:
+
+<!--vale off-->
+{% konnect_api_request %}
+url: /v2/cloud-gateways/networks/$KONNECT_NETWORK_ID/transit-gateways
+status_code: 201
+region: global
+method: POST
+headers:
+  - 'Accept: application/json'
+  - 'Content-Type: application/json'
+body:
+  name: $GCP_VPC_PEERING_NAME
+  transit_gateway_attachment_config:
+    kind: gcp-vpc-peering-attachment
+    peer_project_id: $GCP_PROJECT_ID
+    peer_vpc_name: $GCP_VPC_NAME
+{% endkonnect_api_request %}
+<!--vale on-->
+
+{% endnavtab %}
+{% navtab "Konnect UI" %}
+
+1. Navigate to **Gateway Manager**, select your Dedicated Cloud Gateway, then open **Networks** from the side menu.
+1. Choose a network, open its action menu, and select **Configure Private Networking**.
+1. Add a new VPC peering connection by filling out all of the required fields:
+  * **VPC Peering Name**: A unique name to identify this VPC peering connection.
+  * **Project ID**: ID of your GCP project that contains the VPC you want to peer with Kong.
+  * **VPC Name**: Name of your VPC network in GCP for the peering connection.
+1. Click **Next**.
+
+{% endnavtab %}
+{% endnavtabs %}
+
+## Create a VPC peering resource in GCP
+
+{% navtabs "configure-gcp-konnect" %}
+{% navtab "Cloud Gateways API" %}
+
+Run the following command in the GCP console, replacing any placeholders with values specific to your Dedicated Cloud Gateway instance:
+
+```sh
+gcloud compute networks peerings create $GCP_VPC_PEERING_NAME \
+  --network=$GCP_VPC_NAME \
+  --peer-project=? \
+  --peer-network=? \
+  --stack-type=IPV4_ONLY \
+  --import-custom-routes \
+  --export-custom-routes \
+  --import-subnet-routes-with-public-ip \
+  --export-subnet-routes-with-public-ip \
+  --project=$GCP_PROJECT_ID
+```
+{% endnavtab %}
+{% navtab "Konnect UI" %}
+
+Copy the generated command and run it in the GCP console.
+
+{% endnavtab %}
+{% endnavtabs %}
+
+{:.info}
+> Make sure that your VPC ranges don't conflict with the Cloud Gateway Network VPC range.
+
+The peering connection status will initially show as `Initializing` and should change to `Ready` once peering is successfully established on both GCP and Kong. 
+
+## Validation
+
+To validate that everything was configured correctly, issue a `GET` request to the [`/transit-gateways`](/api/konnect/control-planes/#/operations/list-transit-gateways) endpoint to retrieve VPC peering information:
+
+<!--vale off-->
+{% konnect_api_request %}
+url: /v2/cloud-gateways/networks/$KONNECT_NETWORK_ID/transit-gateways
+status_code: 200
+region: global
+method: GET
+{% endkonnect_api_request %}
+<!--vale on-->

--- a/app/_how-tos/gcp-vpc-peering.md
+++ b/app/_how-tos/gcp-vpc-peering.md
@@ -74,7 +74,7 @@ body:
 {% endnavtab %}
 {% navtab "Konnect UI" %}
 
-1. Navigate to **Gateway Manager**, select your Dedicated Cloud Gateway, then open **Networks** from the side menu.
+1. From your Dedicated Cloud Gateway, open **Networks** from the side menu.
 1. Choose a network, open its action menu, and select **Configure Private Networking**.
 1. Add a new VPC peering connection by filling out all of the required fields:
   * **VPC Peering Name**: A unique name to identify this VPC peering connection.

--- a/app/_how-tos/gcp-vpc-peering.md
+++ b/app/_how-tos/gcp-vpc-peering.md
@@ -90,13 +90,55 @@ body:
 {% navtabs "configure-gcp-konnect" %}
 {% navtab "Cloud Gateways API" %}
 
-Run the following command in the GCP console, replacing any placeholders with values specific to your Dedicated Cloud Gateway instance:
+In {{site.konnect_short_name}}, you need to retrieve two pieces of data: the provider account ID and the VPC ID.
+
+First, make a GET request to `/provider-accounts`:
+
+<!--vale off-->
+{% konnect_api_request %}
+url: /v2/cloud-gateways/provider-accounts
+status_code: 201
+region: global
+method: GET
+headers:
+  - 'Accept: application/json'
+  - 'Content-Type: application/json'
+{% endkonnect_api_request %}
+<!--vale on-->
+
+Save the `provider_account_id` from the output:
+
+```
+export PROVIDER_ACCOUNT_ID='your-provider-account-id'
+```
+
+Next, make a GET request to the `networks` endpoint:
+
+<!--vale off-->
+{% konnect_api_request %}
+url: /v2/cloud-gateways/networks
+status_code: 201
+region: global
+method: GET
+headers:
+  - 'Accept: application/json'
+  - 'Content-Type: application/json'
+{% endkonnect_api_request %}
+<!--vale on-->
+
+Save the `provider_metadata.vpc_id` from the output:
+
+```
+export PROVIDER_VPC_ID='your-provider-vpc-id'
+```
+
+Run the following command in the GCP console:
 
 ```sh
 gcloud compute networks peerings create $GCP_VPC_PEERING_NAME \
   --network=$GCP_VPC_NAME \
-  --peer-project=? \
-  --peer-network=? \
+  --peer-project=$PROVIDER_ACCOUNT_ID \
+  --peer-network=$PROVIDER_VPC_ID \
   --stack-type=IPV4_ONLY \
   --import-custom-routes \
   --export-custom-routes \
@@ -107,7 +149,23 @@ gcloud compute networks peerings create $GCP_VPC_PEERING_NAME \
 {% endnavtab %}
 {% navtab "Konnect UI" %}
 
-Copy the generated command and run it in the GCP console.
+{{site.konnect_short_name}} generates a command with all of your required values filled in.
+Copy the generated command and run it in the GCP console. 
+
+The command will look something like this:
+
+```sh
+gcloud compute networks peerings create $GCP_VPC_PEERING_NAME \
+  --network=$GCP_VPC_NAME \
+  --peer-project=$PROVIDER_ACCOUNT_ID \
+  --peer-network=$PROVIDER_VPC_ID \
+  --stack-type=IPV4_ONLY \
+  --import-custom-routes \
+  --export-custom-routes \
+  --import-subnet-routes-with-public-ip \
+  --export-subnet-routes-with-public-ip \
+  --project=$GCP_PROJECT_ID
+```
 
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/_how-tos/gcp-vpc-peering.md
+++ b/app/_how-tos/gcp-vpc-peering.md
@@ -1,6 +1,6 @@
 ---
 title: Set up a GCP VPC peering connection
-description: 'Use the {{site.konnect_short_name}} Cloud Gateways API or the Konnect UI to create a VPC peering connection with your GCP VPC.'
+description: 'Use the {{site.konnect_short_name}} Cloud Gateways API or the  {{site.konnect_short_name}} UI to create a VPC peering connection with your GCP VPC.'
 content_type: how_to
 permalink: /dedicated-cloud-gateways/gcp-vpc-peering/
 breadcrumbs:
@@ -28,7 +28,7 @@ prereqs:
 
     - title: "GCP credentials and VPC"
       content: |
-        Set up a GCP account with the following permissions:
+        Set up a GCP account with the [Compute Network Admin role](https://cloud.google.com/iam/docs/understanding-roles#compute.networkAdmin) (`roles/compute.networkAdmin`) or the following [custom permissions](https://cloud.google.com/iam/docs/custom-roles-permissions-support):
         * `compute.networks.addPeering`
         * `compute.networks.updatePeering`
         * `compute.networks.removePeering`
@@ -42,9 +42,9 @@ prereqs:
 
 Export the following values as environment variables, setting your own custom values:
 ```sh
-$GCP_VPC_PEERING_NAME='gcp vpc peering'
-$GCP_PROJECT_ID='my-gcp-vpc-project'
-$GCP_VPC_NAME='my-gcp-vpc-name'
+export GCP_VPC_PEERING_NAME='gcp vpc peering'
+export GCP_PROJECT_ID='my-gcp-vpc-project'
+export GCP_VPC_NAME='my-gcp-vpc-name'
 ```
 Where:
 * **VPC Peering Name**: A unique name to identify this VPC peering connection.
@@ -74,7 +74,7 @@ body:
 {% endnavtab %}
 {% navtab "Konnect UI" %}
 
-1. From your Dedicated Cloud Gateway, open **Networks** from the side menu.
+1. From your Dedicated Cloud Gateway, open **Networks**.
 1. Choose a network, open its action menu, and select **Configure Private Networking**.
 1. Add a new VPC peering connection by filling out all of the required fields:
   * **VPC Peering Name**: A unique name to identify this VPC peering connection.
@@ -92,7 +92,7 @@ body:
 
 In {{site.konnect_short_name}}, you need to retrieve two pieces of data: the provider account ID and the VPC ID.
 
-First, make a GET request to the {{site.konnect_short_name}} Cloud Gateways API at `/provider-accounts`:
+First, make a GET request to the {{site.konnect_short_name}} Cloud Gateways API using the `/provider-accounts` endpoint:
 
 <!--vale off-->
 {% konnect_api_request %}
@@ -132,7 +132,7 @@ Save the `provider_metadata.vpc_id` from the output:
 export PROVIDER_VPC_ID='your-provider-vpc-id'
 ```
 
-Switch to GCP and run the following command in the GCP console:
+In the GCP console, run the following command:
 
 ```sh
 gcloud compute networks peerings create $GCP_VPC_PEERING_NAME \
@@ -149,7 +149,7 @@ gcloud compute networks peerings create $GCP_VPC_PEERING_NAME \
 {% endnavtab %}
 {% navtab "Konnect UI" %}
 
-{{site.konnect_short_name}} generates a command with all of your required values filled in.
+{{site.konnect_short_name}} generates a command with all of the required values populated.
 Copy the generated command and run it in the GCP console. 
 
 The command will look something like this:

--- a/app/_how-tos/gcp-vpc-peering.md
+++ b/app/_how-tos/gcp-vpc-peering.md
@@ -92,7 +92,7 @@ body:
 
 In {{site.konnect_short_name}}, you need to retrieve two pieces of data: the provider account ID and the VPC ID.
 
-First, make a GET request to `/provider-accounts`:
+First, make a GET request to the {{site.konnect_short_name}} Cloud Gateways API at `/provider-accounts`:
 
 <!--vale off-->
 {% konnect_api_request %}
@@ -112,7 +112,7 @@ Save the `provider_account_id` from the output:
 export PROVIDER_ACCOUNT_ID='your-provider-account-id'
 ```
 
-Next, make a GET request to the `networks` endpoint:
+Next, make a GET request to the `/networks` endpoint:
 
 <!--vale off-->
 {% konnect_api_request %}
@@ -132,7 +132,7 @@ Save the `provider_metadata.vpc_id` from the output:
 export PROVIDER_VPC_ID='your-provider-vpc-id'
 ```
 
-Run the following command in the GCP console:
+Switch to GCP and run the following command in the GCP console:
 
 ```sh
 gcloud compute networks peerings create $GCP_VPC_PEERING_NAME \

--- a/app/_includes/prereqs/dedicated-cloud-gateways.md
+++ b/app/_includes/prereqs/dedicated-cloud-gateways.md
@@ -9,7 +9,6 @@ If you don't have a Konnect account, you can get started quickly with our [onboa
 2. Set these values as environment variables:
     ```sh
     export KONNECT_TOKEN='YOUR KONNECT TOKEN'
-    export KONNECT_CONTROL_PLANE_URL=https://us.api.konghq.com
     export KONNECT_NETWORK_ID='KONNECT NETWORK ID'
     ```
 

--- a/app/_landing_pages/dedicated-cloud-gateways.yaml
+++ b/app/_landing_pages/dedicated-cloud-gateways.yaml
@@ -110,7 +110,17 @@ rows:
       - blocks:
           - type: card
             config:
-              title: VPC Peering
+              title: GCP VPC peering
+              description: |
+                {{site.konnect_short_name}} can leverage Google Cloud VPC network peering to create virtual networks, ingest data from your GCP services, and expose them to the internet via {{site.konnect_short_name}}.
+              icon: /assets/icons/google-cloud.svg
+              cta:
+                text: Set up GCP VPC peering
+                url: /dedicated-cloud-gateways/gcp-vpc-peering/
+      - blocks:
+          - type: card
+            config:
+              title: AWS VPC Peering
               description: |
                 Set up an AWS VPC peering connection using the API
               icon: /assets/icons/aws.svg

--- a/app/dedicated-cloud-gateways/reference.md
+++ b/app/dedicated-cloud-gateways/reference.md
@@ -242,9 +242,11 @@ body:
 ### AWS Transit Gateway
 If you are using Dedicated Cloud Gateways and your upstream services are hosted in AWS, AWS Transit Gateway is the preferred method for most users. For more information and a guide on how to attach your Dedicated Cloud Gateway, see the [Transit Gateways](/dedicated-cloud-gateways/transit-gateways/) documentation.
 
-
 ### Azure VNet Peering
 If you are using Dedicated Cloud Gateways and your upstream services are hosted in Azure, VNet Peering is the preferred method for most users. For more information and a guide on how to attach your Dedicated Cloud Gateway, see the [Azure Peering](/dedicated-cloud-gateways/azure-peering/) documentation.
+
+### GCP VPC Peering
+If you are using Dedicated Cloud Gateways and your upstream services are hosted in GCP, VPC Network Peering is the preferred method for most users. For more information and a guide on how to attach your Dedicated Cloud Gateway, see the [GCP VPC Peering](/dedicated-cloud-gateways/gcp-vpc-peering/) documentation.
 
 ## Custom plugins
 


### PR DESCRIPTION
## Description

Fixes #2172 
Fixes #2171 
Fixes #2170 (there are no beta labels to remove, so just closing this)

Outstanding questions:
* If you use the API to create a vpc connection on the Konnect side, where do you find the values for `peer-project` and `peer-network`?
  
  Referring to the flags here:
    ```
    gcloud compute networks peerings create $GCP_VPC_PEERING_NAME \
      --network=$GCP_VPC_NAME \
      --peer-project=? \
      --peer-network=? \
      --stack-type=IPV4_ONLY \
      --import-custom-routes \
      --export-custom-routes \
      --import-subnet-routes-with-public-ip \
      --export-subnet-routes-with-public-ip \
      --project=$GCP_PROJECT_ID
    ```
* The note "Make sure that your VPC ranges don't conflict with the Cloud Gateway Network VPC range." - is this the CIDR range? If not, what does it refer to?

## Preview Links

https://deploy-preview-2312--kongdeveloper.netlify.app/dedicated-cloud-gateways/gcp-vpc-peering/