### PR TITLE
JS PDK: multiple plugins

### DIFF
--- a/app/custom-plugins/go.md
+++ b/app/custom-plugins/go.md
@@ -176,6 +176,7 @@ pluginserver_other_one_socket = /usr/local/kong/other-one.socket
 pluginserver_other_one_start_cmd = /usr/local/bin/other-one
 pluginserver_other_one_query_cmd = /usr/local/bin/other-one -dump
 
+plugins = bundled,my-plugin,other-one
 ```
 
 The socket and start command settings coincide with
@@ -185,4 +186,5 @@ their defaults and can be omitted:
 pluginserver_names = my-plugin,other-one
 pluginserver_my_plugin_query_cmd = /usr/local/bin/my-plugin -dump
 pluginserver_other_one_query_cmd = /usr/local/bin/other-one -dump
+plugins = bundled,my-plugin,other-one
 ```

--- a/app/custom-plugins/javascript.md
+++ b/app/custom-plugins/javascript.md
@@ -225,14 +225,25 @@ npm install
 ````
 
 To load plugins using the `kong.conf` [configuration file](/gateway/configuration/), you have to map existing {{site.base_gateway}} properties to aspects of your plugin. 
-Here is an example of loading a plugin within `kong.conf`:
 
-````
-pluginserver_names = js
+Here is an example of loading two plugins within `kong.conf`:
 
-pluginserver_js_start_cmd = /usr/local/bin/kong-js-pluginserver -v --plugins-directory /usr/local/kong/js-plugins
-pluginserver_js_query_cmd = /usr/local/bin/kong-js-pluginserver --plugins-directory /usr/local/kong/js-plugins --dump-all-plugins
+```
+pluginserver_names = my-plugin,other-one
 
-pluginserver_js_socket = /usr/local/kong/js_pluginserver.sock
-````
+pluginserver_my_plugin_socket = /usr/local/kong/my-plugin_pluginserver.sock
+pluginserver_my_plugin_start_cmd = /usr/bin/kong-js-pluginserver --plugins-directory /usr/local/kong/js-plugins/my-plugin --sock-name my-plugin_pluginserver.sock
+pluginserver_my_plugin_query_cmd = /usr/bin/kong-js-pluginserver --plugins-directory /usr/local/kong/js-plugins/my-plugin --dump-all-plugins
 
+pluginserver_other_one_socket = /usr/local/kong/other-one_pluginserver.sock
+pluginserver_other_one_start_cmd = /usr/bin/kong-js-pluginserver --plugins-directory /usr/local/kong/js-plugins/other-one --sock-name other-one_pluginserver.sock
+pluginserver_other_one_query_cmd = /usr/bin/kong-js-pluginserver --plugins-directory /usr/local/kong/js-plugins/other-one --dump-all-plugins
+
+plugins = bundled,my-plugin,other-one
+```
+
+If you want to open verbose logging, pass the `-v` argument to the `start` command line:
+
+```
+pluginserver_my_plugin_start_cmd = /usr/bin/kong-js-pluginserver -v --plugins-directory /usr/local/kong/js-plugins/my-plugin --sock-name my-plugin_pluginserver.sock
+```

--- a/app/custom-plugins/python.md
+++ b/app/custom-plugins/python.md
@@ -164,12 +164,16 @@ Here are some examples of loading plugins within `kong.conf`:
 
 ```
 pluginserver_names = my-plugin,other-one
+
 pluginserver_my_plugin_socket = /usr/local/kong/my-plugin.socket
 pluginserver_my_plugin_start_cmd = /path/to/my-plugin.py
 pluginserver_my_plugin_query_cmd = /path/to/my-plugin.py --dump
+
 pluginserver_other_one_socket = /usr/local/kong/other-one.socket
 pluginserver_other_one_start_cmd = /path/to/other-one.py
 pluginserver_other_one_query_cmd = /path/to/other-one.py --dump
+
+plugins = bundled,my-plugin,other-one
 ```
 
 The socket and start command settings coincide with their defaults and can be omitted:
@@ -178,6 +182,7 @@ The socket and start command settings coincide with their defaults and can be om
 pluginserver_names = my-plugin,other-one
 pluginserver_my_plugin_query_cmd = /path/to/my-plugin --dump
 pluginserver_other_one_query_cmd = /path/to/other-one --dump
+plugins = bundled,my-plugin,other-one
 ```
 
 If you want to open verbose logging, pass the `-v` argument to the `start` command line:


### PR DESCRIPTION
## Description

Fixes #2303 

Updating th js-pdk plugin start instructions to match other pdks.

Similar to the other PDKs (Go, Python), the JS PDK also supports loading multiple plugins into Gateway.
Also adding the missing `plugins` config setting to the other PDKs.

## Preview Links

