### PR TITLE
OIDC plugin examples without client ID or secret

### DIFF
--- a/app/_kong_plugins/openid-connect/examples/cert-bound-access-tokens-no-client-info.yaml
+++ b/app/_kong_plugins/openid-connect/examples/cert-bound-access-tokens-no-client-info.yaml
@@ -1,0 +1,35 @@
+title: "Cert-bound access tokens without client secret or ID"
+description: |
+  Configure the OpenID Connect plugin wih TLS Handshake Modifier to use certificate-bound access tokens without a client secret or ID.
+extended_description: |
+  Configure the OpenID Connect plugin to use [certificate-bound access tokens](/plugins/openid-connect/#certificate-bound-access-tokens) without a client secret or ID.
+  Instead, you can use the [TLS Handshake Modifier plugin](/plugins/tls-handshake-modifier/) to request a client certificate and make it available to the OpenID Connect plugin.
+  
+  The OIDC plugin will validate and use the provided certificates to authenticate with your IdP and retrieve a bearer token.
+
+weight: 819
+
+requirements:
+  - "The [TLS Handshake Modifier plugin](/plugins/tls-handshake-modifier/) is configured to request client certificates from your IdP"
+  - An identity provider (IdP) configured with mTLS and X.509 client certificate authentication
+
+config:
+  issuer: ${issuer}
+  auth_methods:
+  - bearer
+  proof_of_possession_mtls: strict
+  proof_of_possession_auth_methods_validation: on
+
+variables:
+  issuer:
+    value: $ISSUER
+    description: The well-known issuer endpoint of your IdP, for example `http://keycloak.test:8080/realms/master`.
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform
+
+group: fapi

--- a/app/_kong_plugins/openid-connect/examples/extra-jwks.yaml
+++ b/app/_kong_plugins/openid-connect/examples/extra-jwks.yaml
@@ -17,10 +17,6 @@ requirements:
 
 config:
   issuer: ${issuer}
-  client_id:
-    - ${client-id}
-  client_secret:
-    - ${client-secret}
   auth_methods:
     - bearer
   extra_jwks_uris:
@@ -38,12 +34,6 @@ variables:
     description: |
       The issuer authentication URL for your IdP. 
       For example, if you're using Keycloak as your IdP, the issuer URL looks like this: `http://localhost:8080/realms/example-realm`
-  client-id:
-    value: $CLIENT_ID
-    description: The client ID that the plugin uses when it calls authenticated endpoints of the IdP.
-  client-secret:
-    value: $CLIENT_SECRET
-    description: The client secret needed to connect to your IdP.
 
 tools:
   - deck


### PR DESCRIPTION
## Description

Fixes #2247 

* fixing the  `extra_jwks_url` example to remove the extra auth info; it wasn't in the source KB: https://support.konghq.com/support/s/article/Does-the-openid-connect-plugin-support-multiple-IdPs
* Add cert-bound example that uses TLS handshake modifier, from https://tech.aufomm.com/use-oidc-to-secure-kong-manager-and-admins-group-mapping/

## Preview Links
https://deploy-preview-2342--kongdeveloper.netlify.app/plugins/openid-connect/examples/cert-bound-access-tokens-no-client-info/
https://deploy-preview-2342--kongdeveloper.netlify.app/plugins/openid-connect/examples/extra-jwks/
