### PR TITLE
fix: Add missing logging params to the compressor how to

### DIFF
--- a/app/_how-tos/compress-llm-prompts.md
+++ b/app/_how-tos/compress-llm-prompts.md
@@ -97,6 +97,9 @@ entities:
               options:
                 max_tokens: 512
                 temperature: 1.0
+            logging:
+              log_payloads: true
+              log_statistics: true
 variables:
   openai_api_key:
     value: $OPENAI_API_KEY
@@ -252,7 +255,7 @@ Before we send requests to our LLM, we need to set up the HTTP Logs plugin to ch
 entities:
   plugins:
     - name: http-log
-      service: example-route
+      service: example-service
       config:
         http_endpoint: http://host.docker.internal:9999/
         headers:


### PR DESCRIPTION
## Description

Fixes missing logging params/service name in the prompt compressor how-to.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
