### PR TITLE
fix: Dev Portal audit log reference

### DIFF
--- a/app/_indices/dev-portal.yaml
+++ b/app/_indices/dev-portal.yaml
@@ -6,6 +6,7 @@ sections:
       - path: /dev-portal/**/*
       - path: /dev-portal/analytics/
       - path: /dev-portal/breaking-changes/
+      - path: /konnect-platform/audit-logs/
     auto_exclude: true
   - title: API catalog
     items:

--- a/app/_landing_pages/dev-portal.yaml
+++ b/app/_landing_pages/dev-portal.yaml
@@ -189,6 +189,26 @@ rows:
                   In Dev Portal, you can view both analytics for developer applications as well as platform-wide analytics for all Dev Portals.
 
                   For more information, see [Dev Portal analytics](/dev-portal/analytics/).
+  - header:
+      type: h2
+      text: "References"
+  - columns:
+      - blocks:
+          - type: card
+            config:
+              title: Dev Portal audit logs
+              description: |
+                Learn about what events are logged in Dev Portal logs.
+              cta:
+                url: "/konnect-platform/audit-logs/"
+      - blocks:
+          - type: card
+            config:
+              title: Dev Portal v3 breaking changes
+              description: |
+                Review breaking changes from Dev Portal v3 beta to general release.
+              cta:
+                url: "/dev-portal/breaking-changes/"
   
   - header:
       text: "Frequently asked questions"

--- a/app/konnect-platform/audit-logs.md
+++ b/app/konnect-platform/audit-logs.md
@@ -1,11 +1,12 @@
 ---
-title: "{{site.konnect_short_name}} audit logs"
+title: "{{site.konnect_short_name}} and Dev Portal audit logs"
 content_type: reference
 layout: reference
 breadcrumbs: 
   - /konnect/
 products:
     - konnect-platform
+    - dev-portal
 works_on:
   - konnect
 
@@ -17,8 +18,9 @@ tags:
   - audit-logging
 search_aliases: 
   - auditing
+  - Dev Portal audit logs
 
-description: "Review logs for system events in {{site.konnect_short_name}}."
+description: "Review logs for system events in {{site.konnect_short_name}} and Dev Portal."
 related_resources:
   - text: "Collect {{site.konnect_short_name}} audit logs"
     url: /how-to/collect-audit-logs/
@@ -34,7 +36,7 @@ related_resources:
     url: /gateway/logs/
 
 faqs:
-  - q: How can I verify {{site.konnect_short_name}} audit log signatures
+  - q: How can I verify {{site.konnect_short_name}} audit log signatures?
     a: |
       {{site.konnect_short_name}} and Dev Portal use an [ED25519 signature](https://ed25519.cr.yp.to/) on the audit logs they produce. You can verify the signature in your audit logs to confirm that it's from {{site.konnect_short_name}} instead of a bad actor.
 
@@ -45,6 +47,10 @@ faqs:
       1. Use your preferred tool (for example, [OpenSSL](https://www.openssl.org/)) to verify the ED25519 signature by using the signature-less audit log entry together with the decoded signature and public key.
 ---
 
+{:.success}
+> **Get started:**
+>* [Collect audit logs for {{site.konnect_short_name}}](/how-to/collect-audit-logs/)
+>* [Collect audit logs for Dev Portal](/how-to/collect-dev-portal-audit-logs/)
 
 Audit logs can help you detect and respond to potential security incidents when they occur.
 
@@ -52,13 +58,11 @@ Audit logging provides the following benefits:
 * **Security**: System events can be used to show abnormalities to be investigated, forensic information related to breaches, or provide evidence for compliance and regulatory purposes.
 * **Compliance**: Regulators and auditors may require audit logs to confirm whether certain certification standards are met.
 * **Debugging**: Audit logs can help determine the root causes of efficiency or performance issues.
-* **Risk management**: Prevent issues or catch them early.
+* **Risk management**: Prevent issues or catch them early. 
 
-Learn how to collect audit logs:
-* [Collect audit logs for {{site.konnect_short_name}}](/how-to/collect-audit-logs/)
-* [Collect audit logs for Dev Portal](/how-to/collect-dev-portal-audit-logs/)
+You can collect audit logs for both the {{site.konnect_short_name}} org and [Dev Portal](/dev-portal/).
 
-## Configure audit logging
+## Audit log events
 
 {{site.konnect_short_name}} captures three types of events:
 
@@ -69,21 +73,32 @@ columns:
     key: event_type
   - title: Org audit logs
     key: org_audit_logs
+  - title: Dev Portal audit logs
+    key: dev_portal_audit_logs
 rows:
   - event_type: Authentication
     org_audit_logs: "This is triggered when a user attempts to log into the {{site.konnect_short_name}} web application or use the {{site.konnect_short_name}} API via a personal access token. Also triggered when a system account access token is used."
+    dev_portal_audit_logs: Triggered when a user logs in to the Dev Portal.
   - event_type: Authorization
     org_audit_logs: "Triggered when a permission check is made for a user or system account against a resource."
+    dev_portal_audit_logs: Not collected, use the org audit log.
   - event_type: Access logs
     org_audit_logs: "Triggered when a request is made to the {{site.konnect_short_name}} API."
+    dev_portal_audit_logs: Not collected, use the org audit log.
 {% endtable %}
 <!--vale on-->
 
 {{site.konnect_short_name}} retains audit logs for 7 days.
 
+{:.info}
+> Dev Portal audit logs don't collect authorization and access events by design. You can view Dev Portal entity creation, edits, and approved state changes from the {{site.konnect_short_name}} audit logs. 
+
 ## Audit log webhook status
 
-You can view the webhook status in the UI or via the API for the [{{site.konnect_short_name}} org audit logs](/api/konnect/audit-logs/#/operations/get-audit-log-webhook-status).
+You can view the webhook status in the UI or via [the API](/api/konnect/audit-logs/#/operations/get-audit-log-webhook-status) for the {{site.konnect_short_name}} org audit logs and Dev Portal audit logs:
+
+* To view the {{site.konnect_short_name}} org audit logs webhook status in the UI, navigate to **Organization > Audit Log Setup**, and click the **{{site.konnect_short_name}}** tab.
+* To view the Dev Portal audit log status in the UI, navigate to your Dev Portal, click **Settings**, and click the **Audit log** tab.
 
 The following table describes the webhook statuses:
 


### PR DESCRIPTION
## Description

Fixes #2034


## Preview Links
- https://deploy-preview-2368--kongdeveloper.netlify.app/konnect-platform/audit-logs/
- https://deploy-preview-2368--kongdeveloper.netlify.app/index/dev-portal/#overview
- https://deploy-preview-2368--kongdeveloper.netlify.app/dev-portal/#references

_Notes for reviewers:_
- I decided to leave Dev Portal audit log information on the same page as Konnect. They have overlap in a lot of areas as far as docs go, but also, to have a complete picture of Dev Portal, you need the Portal audit logs as well as Konnect org audit logs (see this [Slack](https://kongstrong.slack.com/archives/C02D0BPQC85/p1750284030482209) for details). I've tried to convey this, but maybe the wording needs adjusting.
- What do you think of the "Get Started" green note at the top? I figure this can help users who want a how to get to their how to easily, but let me know if you find it distracting.

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
