### PR TITLE
fix: bump plugin schema max expanded depth

### DIFF
--- a/app/_assets/javascripts/apps/PluginSchema.vue
+++ b/app/_assets/javascripts/apps/PluginSchema.vue
@@ -6,7 +6,7 @@
         :exampleVisible="false"
         :headerVisible="false"
         :enablePropertyLinks="true"
-        :maxExpandedDepth="4"
+        :maxExpandedDepth="10"
       />
     </div>
   </template>


### PR DESCRIPTION
## Description

Fixes https://github.com/Kong/developer.konghq.com/issues/2262

Bumped it up to 10 just in case, though if any plugin config goes that deep, that feels like a problem.

The issue was referring to https://developer.konghq.com/plugins/request-callout/reference/

## Preview Links

https://deploy-preview-2390--kongdeveloper.netlify.app/plugins/request-callout/reference/#schema--config-callouts-request-http-opts for example
