### PR TITLE
fix: Add get started button to KIC landing page

### DIFF
--- a/app/_landing_pages/kubernetes-ingress-controller.yaml
+++ b/app/_landing_pages/kubernetes-ingress-controller.yaml
@@ -30,7 +30,7 @@ rows:
               KIC supports all [{{ site.base_gateway }} entities](/gateway/entities/), and can be deployed multiple times within a single cluster to provide [traffic splitting](/kubernetes-ingress-controller/split-traffic/).
           - type: button
             config:
-              text: Get Started with {{ site.kic_product_name }}
+              text: Get started with {{ site.kic_product_name }}
               url: "/kubernetes-ingress-controller/install/"
 
       - blocks:

--- a/app/_landing_pages/kubernetes-ingress-controller.yaml
+++ b/app/_landing_pages/kubernetes-ingress-controller.yaml
@@ -28,6 +28,10 @@ rows:
               {{ site.kic_product_name }} takes Kubernetes resources such as `Ingress` and `HTTPRoute` and converts them into a valid {{ site.base_gateway }} configuration. It enables you to configure all the [features](/gateway/#learn) of {{ site.base_gateway }} using Kubernetes CRDs.
 
               KIC supports all [{{ site.base_gateway }} entities](/gateway/entities/), and can be deployed multiple times within a single cluster to provide [traffic splitting](/kubernetes-ingress-controller/split-traffic/).
+          - type: button
+            config:
+              text: Get Started with {{ site.kic_product_name }}
+              url: "/kubernetes-ingress-controller/install/"
 
       - blocks:
           - type: mermaid


### PR DESCRIPTION
## Description

Fixes #1877

## Preview Links

https://deploy-preview-2393--kongdeveloper.netlify.app/kubernetes-ingress-controller/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
