### PR TITLE
Fix :reference to kong yaml file

### DIFF
--- a/app/_includes/components/entity_example/format/deck.md
+++ b/app/_includes/components/entity_example/format/deck.md
@@ -19,7 +19,7 @@
 {% when ca_certificate %}
   The following creates a new CA Certificate:
 {% when 'plugin' %}
-  Add this section to your declarative configuration file:
+  Add this section to your [`kong.yaml`](/deck/#how-does-deck-work) configuration file:
 {% else %}
 {% endcase %}
 {% endif %}


### PR DESCRIPTION
## Description

Fixes [#2152](https://github.com/Kong/developer.konghq.com/issues/2152)

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
