### PR TITLE
fix: Add why use deck section

### DIFF
--- a/app/_landing_pages/deck.yaml
+++ b/app/_landing_pages/deck.yaml
@@ -14,23 +14,40 @@ rows:
       text: "decK"
       sub_text: Kong's command line tool for API Lifecycle Automation
 
-  - header:
-      type: h2
-      text: What is decK?
-    columns:
+  - columns:
     - blocks:
-        - type: text
-          config: |
-            decK is a command line tool that facilitates API Lifecycle Automation (APIOps) 
-            by offering a comprehensive toolkit of commands designed to orchestrate and automate the 
-            entire process of API delivery. 
-            APIOps involves leveraging automation frameworks to streamline and enforce best practices 
-            throughout the API lifecycle. 
-            This enables developers and operations teams to manage APIs from development through deployment, 
-            ensuring consistency, reliability, and speed in API integrations.
+        - type: structured_text
+          config:
+            header:
+              text: "What is decK?"
+            blocks:
+              - type: text
+                text: |
+                  decK is a command line tool that facilitates API Lifecycle Automation (APIOps)
+                  by offering a comprehensive toolkit of commands designed to orchestrate and automate the
+                  entire process of API delivery.
+                  APIOps involves leveraging automation frameworks to streamline and enforce best practices
+                  throughout the API lifecycle.
+                  This enables developers and operations teams to manage APIs from development through deployment,
+                  ensuring consistency, reliability, and speed in API integrations.
 
-            decK is one of the many tools you can use to manage {{site.base_gateway}} and {{site.konnect_short_name}}. 
-            To learn about other tools, review our [tools page](/tools/).
+                  decK is one of the many tools you can use to manage {{site.base_gateway}} and {{site.konnect_short_name}}.
+                  To learn about other tools, review our [tools page](/tools/).
+    - blocks:
+        - type: structured_text
+          config:
+            header:
+              text: "Why use decK?"
+            blocks:
+              - type: text
+                text: |
+                  Choose decK if:
+
+                  - You want a simple CLI tool dedicated to managing Kong Gateway and Konnect configurations.
+                  - You need fast, scriptable automation for API lifecycle management and CI/CD integration.
+                  - You prefer managing Kong declaratively without adding extra infrastructure or tools.
+
+                  Or see [this section](/deck/#i-use-terraform-to-configure-kong-gateway-why-should-i-care-about-deck) to compare how decK differs from Terraform.
 
   - header:
       type: h2
@@ -61,9 +78,9 @@ rows:
         blocks:
         - type: text
           config:
-            decK is a tool that works with state files, which describe the configuration of {{site.base_gateway}}. These state files store {{site.base_gateway}}'s configuration in a clear, declarative format, 
+            decK is a tool that works with state files, which describe the configuration of {{site.base_gateway}}. These state files store {{site.base_gateway}}'s configuration in a clear, declarative format,
             allowing you to manage Services, Routes, Consumers, plugins, and other entities that define how requests are processed and routed through the Gateway.
-            decK communicates with {{site.base_gateway}} via the [Admin API](/api/gateway/admin-ee/). 
+            decK communicates with {{site.base_gateway}} via the [Admin API](/api/gateway/admin-ee/).
         - type: text
           config:
             decK is one of several [tools](/tools/) available for managing {{site.base_gateway}}.
@@ -149,7 +166,7 @@ rows:
                         - validate
                 - text: |
                     Sync Gateway configs to {{site.konnect_short_name}}
-                    
+
                     _Tip: You can add {{site.konnect_short_name}} flags to any decK command
                     to target a {{site.konnect_short_name}} Control Plane instead of a self-managed {{site.base_gateway}}._
 
@@ -204,7 +221,7 @@ rows:
                         - httpbin.yaml
                         - another-httpbin.yaml
                         - -o merged-kong.yaml
-                   
+
   - columns:
     - blocks:
        - type: text
@@ -218,7 +235,7 @@ rows:
           title: Get started
           description: Learn how to install decK and use it to configure {{ site.base_gateway }}.
           cta:
-            text: Get started 
+            text: Get started
             url: /deck/get-started/
             align: end
     - blocks:
@@ -227,7 +244,7 @@ rows:
           title: APIOps
           description: Learn how to manage {{ site.base_gateway }} configuration in a federated environment.
           cta:
-            text: Manage {{ site.base_gateway }} declaratively 
+            text: Manage {{ site.base_gateway }} declaratively
             url: /deck/apiops/
             align: end
     - blocks:
@@ -236,7 +253,7 @@ rows:
           title: Changelog
           description: Running list of release notes for decK.
           cta:
-            text: decK changelog 
+            text: decK changelog
             url: https://github.com/kong/deck/blob/main/CHANGELOG.md/
             align: end
 
@@ -263,43 +280,43 @@ rows:
             - q: |
                {{site.base_gateway}} already has built-in declarative configuration, do I still need decK?
               a: |
-                {{site.base_gateway}} has an official declarative configuration format. {{site.base_gateway}} can generate such a file with the `kong config db_export` command, 
+                {{site.base_gateway}} has an official declarative configuration format. {{site.base_gateway}} can generate such a file with the `kong config db_export` command,
                 which exports most of {{site.base_gateway}}'s database into a file.
 
-                You can use a file in this format to configure {{site.base_gateway}} when it is running in a DB-less or in-memory mode. 
+                You can use a file in this format to configure {{site.base_gateway}} when it is running in a DB-less or in-memory mode.
                 If you're using {{site.base_gateway}} in DB-less mode, you can't use decK for any sync, dump, or similar operations, as they require write access to the Admin API.
 
                 If you are using {{site.base_gateway}} alongside a database, you need decK because:
 
                 * {{site.base_gateway}}'s `kong config db_import` command isn't sufficient in the following situations:
-                  * The command is used to initialize a {{site.base_gateway}} database, 
-                  but we don't recommended using it if there are existing {{site.base_gateway}} nodes running, 
-                  as the cache in these nodes won't be invalidated when entities are changed or added. 
-                  In that case, you would need to manually restart all existing {{site.base_gateway}} nodes. 
+                  * The command is used to initialize a {{site.base_gateway}} database,
+                  but we don't recommended using it if there are existing {{site.base_gateway}} nodes running,
+                  as the cache in these nodes won't be invalidated when entities are changed or added.
+                  In that case, you would need to manually restart all existing {{site.base_gateway}} nodes.
                   decK performs all the changes via Kong's Admin API, meaning the changes are always propagated to all nodes.
-                  * The command can only add and update entities in the database. 
+                  * The command can only add and update entities in the database.
                     It won't remove the entities that are present in the database but aren't present in the configuration file.
                   * The command needs direct access to {{site.base_gateway}}'s database, which may not be possible in your production networking environment.
-                * decK can easily perform detect drifts in configuration. 
-                For example, it can verify if the configuration stored inside {{site.base_gateway}}'s database and the configuration inside the config file is the same. 
+                * decK can easily perform detect drifts in configuration.
+                For example, it can verify if the configuration stored inside {{site.base_gateway}}'s database and the configuration inside the config file is the same.
                 This feature is designed for integrating decK with a CI system or a cronjob which periodically checks for drifts and alerts a team if needed.
                 * `deck gateway dump` outputs a more human-readable configuration file compared to {{site.base_gateway}}'s `db_import`.
-                
+
                 However, decK has the following limitations which may affect your use case:
 
-                * If you have a very large installation, it can take some time for decK to sync up the configuration to {{site.base_gateway}}. 
-                This can be mitigated by adopting distributed configuration for your {{site.base_gateway}} installation and tweaking the `--parallelism` value. 
+                * If you have a very large installation, it can take some time for decK to sync up the configuration to {{site.base_gateway}}.
+                This can be mitigated by adopting distributed configuration for your {{site.base_gateway}} installation and tweaking the `--parallelism` value.
                 {{site.base_gateway}}`s `db_import` will usually be faster by orders of magnitude.
-                * decK can't export and re-import fields that are hashed in the database. 
-                This means that fields like the password of the `basic-auth` credential can't be correctly re-imported by decK. This 
+                * decK can't export and re-import fields that are hashed in the database.
+                This means that fields like the password of the `basic-auth` credential can't be correctly re-imported by decK. This
                 happens because {{site.base_gateway}}'s Admin API call to sync the configuration will rehash the already hashed password.
             - q: I'm a {{site.base_gateway}} user, can I use decK?
               a: |
                 decK is designed to be compatible with open-source and enterprise versions of {{site.base_gateway}}.
             - q: I'm a {{site.konnect_short_name}} user, can I use decK?
               a: |
-                Yes, decK is compatible with {{site.konnect_short_name}}. 
-                
+                Yes, decK is compatible with {{site.konnect_short_name}}.
+
                 {{site.konnect_short_name}} requires decK v1.40.0 or above. Versions below this will see inconsistent `deck gateway diff` and `sync` results.
             - q: I use Cassandra as a data store for {{site.base_gateway}}, can I use decK?
               a: |
@@ -362,6 +379,6 @@ rows:
             - text: decK on GitHub
               type: github
               url: https://github.com/Kong/deck
-            - text: decK changelog 
+            - text: decK changelog
               type: github
               url: https://github.com/kong/deck/blob/main/CHANGELOG.md


### PR DESCRIPTION
## Description

Fixes [#1884](https://github.com/Kong/developer.konghq.com/issues/1884)

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
