### PR TITLE
fix: clarify plugin instances

### DIFF
--- a/app/_gateway_entities/plugin.md
+++ b/app/_gateway_entities/plugin.md
@@ -103,10 +103,11 @@ Every plugin supports a subset of these scopes.
 
 ### Plugin precedence
 
-A single plugin instance always runs _once_ per request. The
-configuration with which it runs depends on the entities it has been
-configured for.
-Plugins can be configured for various entities, combinations of entities, or even globally.
+A plugin can have multiple instances in the same configuration. 
+Different instances can be used to apply the plugin to various entities, combinations of entities, or even globally. 
+A single plugin instance always runs _once_ per request. 
+The configuration with which it runs depends on the entities it has been configured for.
+
 This is useful, for example, when you want to configure a plugin a certain way for most requests but make _authenticated requests_ behave slightly differently.
 
 Therefore, there is an order of precedence for running a plugin when it has been applied to different entities with different configurations. The number of entities configured to a specific plugin directly correlates to its priority. The more entities a plugin is configured for, the higher its order of precedence.

--- a/app/_gateway_entities/plugin.md
+++ b/app/_gateway_entities/plugin.md
@@ -105,6 +105,8 @@ Every plugin supports a subset of these scopes.
 
 A plugin can have multiple instances in the same configuration. 
 Different instances can be used to apply the plugin to various entities, combinations of entities, or even globally. 
+You can give each plugin instance a unique name to help identify it. The instance name itself doesn't affect processing - it acts like an internal label instead.
+
 A single plugin instance always runs _once_ per request. 
 The configuration with which it runs depends on the entities it has been configured for.
 


### PR DESCRIPTION
## Description

Fixes https://github.com/Kong/docs.konghq.com/issues/7988

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
