### PR TITLE
fix: mem_cache_size link in Resource Guidelines

### DIFF
--- a/app/gateway/resource-sizing-guidelines.md
+++ b/app/gateway/resource-sizing-guidelines.md
@@ -240,7 +240,7 @@ of traffic flowing through the cluster.
 
 ### In-memory caching
 
-We recommend defining the largest [`mem_cache_size`](/gateway/configuration/#mem_cache_size) possible
+We recommend defining the largest [`mem_cache_size`](/gateway/configuration/#mem-cache-size) possible
 while still providing adequate resources to the operating system and any other
 processes running adjacent to {{site.base_gateway}}. This configuration allows
 {{site.base_gateway}} to take maximum advantage of the in-memory cache, and


### PR DESCRIPTION
## Description

Fixes https://kongstrong.slack.com/archives/CDSTDSG9J/p1753967389568559

## Preview Links
https://deploy-preview-2405--kongdeveloper.netlify.app/gateway/resource-sizing-guidelines/#in-memory-caching

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
