### PR TITLE
fix: Add "Next steps" to tools, install pages and getting started guide

### DIFF
--- a/app/_how-tos/docker-compose.md
+++ b/app/_how-tos/docker-compose.md
@@ -42,6 +42,11 @@ faqs:
     a: |
       Yes, you can run a {{site.base_gateway}} Docker container in read-only mode by setting `database` to `off` and passing a configuration file when starting the container.
       See [Running {{site.base_gateway}} in read-only mode using Docker Compose](/gateway/install/docker-read-only/) for more information.
+next_steps:
+  - text: Rate limit a Gateway Service
+    url: /how-to/add-rate-limiting-to-a-service-with-kong-gateway/
+  - text: Enable key authentication on a Gateway Service
+    url: /how-to/authenticate-consumers-with-key-auth-enc/
 ---
 
 ## Set up the Docker Compose file

--- a/app/_how-tos/docker-compose.md
+++ b/app/_how-tos/docker-compose.md
@@ -42,11 +42,6 @@ faqs:
     a: |
       Yes, you can run a {{site.base_gateway}} Docker container in read-only mode by setting `database` to `off` and passing a configuration file when starting the container.
       See [Running {{site.base_gateway}} in read-only mode using Docker Compose](/gateway/install/docker-read-only/) for more information.
-next_steps:
-  - text: Rate limit a Gateway Service
-    url: /how-to/add-rate-limiting-to-a-service-with-kong-gateway/
-  - text: Enable key authentication on a Gateway Service
-    url: /how-to/authenticate-consumers-with-key-auth-enc/
 ---
 
 ## Set up the Docker Compose file

--- a/app/_how-tos/gateway-install-helm-konnect.md
+++ b/app/_how-tos/gateway-install-helm-konnect.md
@@ -25,7 +25,11 @@ prereqs:
   skip_product: true
 
 topology_switcher: page
-
+next_steps:
+  - text: Rate limit a Gateway Service
+    url: /how-to/add-rate-limiting-to-a-service-with-kong-gateway/
+  - text: Enable key authentication on a Gateway Service
+    url: /how-to/authenticate-consumers-with-key-auth-enc/
 ---
 
 ## Konnect setup

--- a/app/_how-tos/gateway-install-helm-onprem-manager.md
+++ b/app/_how-tos/gateway-install-helm-onprem-manager.md
@@ -36,6 +36,11 @@ faqs:
     a: Ensure that `env.admin_gui_api_url` is set correctly in `values-cp.yaml`.
 
 automated_tests: false
+next_steps:
+  - text: Rate limit a Gateway Service
+    url: /how-to/add-rate-limiting-to-a-service-with-kong-gateway/
+  - text: Enable key authentication on a Gateway Service
+    url: /how-to/authenticate-consumers-with-key-auth-enc/
 ---
 
 Kong Manager is the graphical user interface (GUI) for {{ site.base_gateway }}. It uses the Kong Admin API under the hood to administer and control {{ site.base_gateway }}.

--- a/app/_how-tos/get-started-with-gateway.md
+++ b/app/_how-tos/get-started-with-gateway.md
@@ -66,7 +66,15 @@ cleanup:
 
 min_version:
     gateway: '3.4'
-
+next_steps:
+  - text: See all {{site.base_gateway}} tutorials
+    url: /how-to/?products=gateway
+  - text: Learn about {{site.base_gateway}} entities
+    url: /gateway/entities/
+  - text: Learn about how {{site.base_gateway}} is configured
+    url: /gateway/configuration/
+  - text: See all {{site.base_gateway}} plugins
+    url: /plugins/
 automated_tests: false
 ---
 

--- a/app/_how-tos/install-gateway-read-only.md
+++ b/app/_how-tos/install-gateway-read-only.md
@@ -37,7 +37,9 @@ cleanup:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/docker
       icon_url: /assets/icons/gateway.svg
-
+next_steps:
+  - text: Learn about DB-less mode
+    url: /gateway/db-less-mode/
 ---
 
 ## Create a `kong.yml` configuration file

--- a/app/_how-tos/operator-get-started-hybrid-create-route.md
+++ b/app/_how-tos/operator-get-started-hybrid-create-route.md
@@ -31,7 +31,7 @@ tldr:
 next_steps:
   - text: Learn about Custom resource definitions (CRDs)
     url: /operator/reference/custom-resources/
-  - text: Create a Kong Ingress Controller Control Plane
+  - text: Create a {{site.kic_product_name}} Control Plane
     url: /operator/konnect/crd/control-planes/kubernetes/
 ---
 

--- a/app/_how-tos/operator-get-started-hybrid-create-route.md
+++ b/app/_how-tos/operator-get-started-hybrid-create-route.md
@@ -28,7 +28,11 @@ works_on:
 tldr:
   q: How can I create a Route with {{ site.operator_product_name }}?
   a: Create a `KongService` object , then create a `KongRoute` and associate it to the `KongService`.
-
+next_steps:
+  - text: Learn about Custom resource definitions (CRDs)
+    url: /operator/reference/custom-resources/
+  - text: Create a Kong Ingress Controller Control Plane
+    url: /operator/konnect/crd/control-planes/kubernetes/
 ---
 
 {:data-deployment-topology='konnect'}

--- a/app/_how-tos/operator-get-started-kic-create-route.md
+++ b/app/_how-tos/operator-get-started-kic-create-route.md
@@ -34,7 +34,7 @@ prereqs:
 next_steps:
   - text: Proxying HTTP Traffic
     url: /kubernetes-ingress-controller/routing/http/
-  - text: Rate limiting with Kong Ingress Controller
+  - text: Rate limiting with {{site.kic_product_name}}
     url: /kubernetes-ingress-controller/rate-limiting/
 ---
 

--- a/app/_how-tos/operator-get-started-kic-create-route.md
+++ b/app/_how-tos/operator-get-started-kic-create-route.md
@@ -31,6 +31,11 @@ tldr:
 
 prereqs:
   skip_product: true
+next_steps:
+  - text: Proxying HTTP Traffic
+    url: /kubernetes-ingress-controller/routing/http/
+  - text: Rate limiting with Kong Ingress Controller
+    url: /kubernetes-ingress-controller/rate-limiting/
 ---
 
 {% assign gatewayApiVersion = "v1" %}

--- a/app/_how-tos/operator-konnect-getstarted-key-auth.md
+++ b/app/_how-tos/operator-konnect-getstarted-key-auth.md
@@ -30,7 +30,9 @@ works_on:
   - konnect
 
 entities: []
-
+next_steps:
+  - text: See the Custom resource definitions (CRDs) reference
+    url: /operator/reference/custom-resources/
 ---
 
 

--- a/app/_landing_pages/admin-api.yaml
+++ b/app/_landing_pages/admin-api.yaml
@@ -78,6 +78,31 @@ rows:
             align: end
 
   - header:
+      type: h2
+      text: "Next Steps"
+      sub_text: Use one of the following tutorials to get started.              
+    column_count: 3
+    columns:
+      - blocks:
+        - type: card
+          config:
+            icon: /assets/icons/gateway.svg
+            title: Install self-managed {{ site.base_gateway }}
+            description: |
+              {{ site.base_gateway }} is a low-demand, high-performing API gateway. 
+              You can set up {{ site.base_gateway }} with {{site.konnect_short_name}}, or install it on various self-managed systems.
+            cta:
+              url: /gateway/install/
+      - blocks:
+        - type: card
+          config:
+            icon: /assets/icons/gateway.svg
+            title: Get started with {{ site.base_gateway }}
+            description: |
+              This tutorial will help you get started with {{ site.base_gateway }} by setting up either a {{site.konnect_short_name}} hybrid deployment or self-managed local installation and walking through some common API management tasks.
+            cta:
+              url: /gateway/get-started/
+  - header:
       text: "Frequently asked questions"
       type: h2
     columns:

--- a/app/_landing_pages/konnect-api.yaml
+++ b/app/_landing_pages/konnect-api.yaml
@@ -309,3 +309,15 @@ rows:
                     ]
                   }
                   ```
+  
+  - header:
+      type: h2
+      text: How-to guides
+    columns:
+      - blocks:
+          - type: how_to_list
+            config:
+              tools:
+                - konnect-api
+              quantity: 5
+              allow_empty: true

--- a/app/_landing_pages/operator/install.yaml
+++ b/app/_landing_pages/operator/install.yaml
@@ -38,6 +38,7 @@ rows:
   - header:
       type: h2
       text: "Next Steps"
+      sub_text: After installing KGO, use one of the following tutorials to get started.              
     columns:
       - blocks:
         - type: card

--- a/app/_landing_pages/terraform.yaml
+++ b/app/_landing_pages/terraform.yaml
@@ -265,3 +265,14 @@ rows:
               control_plane_id = konnect_gateway_control_plane.tfdemo.id
             }
             ```
+  - header:
+      type: h2
+      text: How-to guides
+    columns:
+      - blocks:
+          - type: how_to_list
+            config:
+              tools:
+                - terraform
+              quantity: 5
+              allow_empty: true

--- a/app/_layouts/how-to.html
+++ b/app/_layouts/how-to.html
@@ -19,12 +19,12 @@ layout: with_aside
 {% include sections/faq.html %}
 {% endif %}
 
-{% if page.next_steps %}
-{% include sections/next_steps.html %}
-{% endif %}
-
 {% if page.navigation %}
 {% include sections/prev_next.html %}
+{% endif %}
+
+{% if page.next_steps %}
+{% include sections/next_steps.html %}
 {% endif %}
 
 {% contentfor info_box %}

--- a/app/gateway/install.md
+++ b/app/gateway/install.md
@@ -39,8 +39,13 @@ faqs:
 
 no_wrap: true
 versioned: true
+next_steps:
+  - text: Get started with {{site.base_gateway}}
+    url: /gateway/get-started/
 ---
 
 {% include install/gateway.html %}
 
 {% include sections/faq.html %}
+
+{% include sections/next_steps.html %}

--- a/app/kubernetes-ingress-controller/deployment-topologies/gateway-discovery.md
+++ b/app/kubernetes-ingress-controller/deployment-topologies/gateway-discovery.md
@@ -27,7 +27,7 @@ related_resources:
   - text: Architecture
     url: /kubernetes-ingress-controller/architecture/
 next_steps:
-  - text: Get started with Kong Ingress Controller
+  - text: Get started with {{site.kic_product_name}}
     url: /kubernetes-ingress-controller/install/
 ---
 

--- a/app/kubernetes-ingress-controller/deployment-topologies/gateway-discovery.md
+++ b/app/kubernetes-ingress-controller/deployment-topologies/gateway-discovery.md
@@ -26,6 +26,9 @@ related_resources:
     url: /kubernetes-ingress-controller/deployment-topologies/sidecar/
   - text: Architecture
     url: /kubernetes-ingress-controller/architecture/
+next_steps:
+  - text: Get started with Kong Ingress Controller
+    url: /kubernetes-ingress-controller/install/
 ---
 
 Gateway Discovery is a deployment topology in which {{ site.kic_product_name }} and {{ site.base_gateway }} are separate deployments in the Kubernetes cluster. {{ site.kic_product_name }} uses Kubernetes service discovery to discover the {{ site.base_gateway }} Pods.


### PR DESCRIPTION
## Description

Fixes #1874

## Preview Links
- https://deploy-preview-2408--kongdeveloper.netlify.app/gateway/install/docker/
- https://deploy-preview-2408--kongdeveloper.netlify.app/gateway/install/kubernetes/konnect/
- https://deploy-preview-2408--kongdeveloper.netlify.app/gateway/install/kubernetes/on-prem/manager/
- https://deploy-preview-2408--kongdeveloper.netlify.app/gateway/get-started/
- https://deploy-preview-2408--kongdeveloper.netlify.app/gateway/install/docker-read-only/
- https://deploy-preview-2408--kongdeveloper.netlify.app/operator/dataplanes/get-started/hybrid/create-route/
- https://deploy-preview-2408--kongdeveloper.netlify.app/operator/dataplanes/get-started/kic/create-route/
- https://deploy-preview-2408--kongdeveloper.netlify.app/operator/konnect/get-started/key-authentication/
- https://deploy-preview-2408--kongdeveloper.netlify.app/admin-api/
- https://deploy-preview-2408--kongdeveloper.netlify.app/konnect-api/
- https://deploy-preview-2408--kongdeveloper.netlify.app/operator/install/
- https://deploy-preview-2408--kongdeveloper.netlify.app/terraform/
- https://deploy-preview-2408--kongdeveloper.netlify.app/gateway/install/
- https://deploy-preview-2408--kongdeveloper.netlify.app/kubernetes-ingress-controller/deployment-topologies/gateway-discovery/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
