### PR TITLE
fix: Add guidance for managing Kong Gateway with AWS CDK

### DIFF
--- a/app/_how-tos/kic-install.md
+++ b/app/_how-tos/kic-install.md
@@ -48,6 +48,9 @@ faqs:
       Because Kubernetes resources are the source of truth for configuring {{ site.base_gateway }} in Kubernetes, the KIC instance configuration in {{site.konnect_short_name}} is marked as read-only. This prevents configuration drift in {{ site.base_gateway }} caused by changes made outside the Ingress or Kubernetes Gateway API.
 
       For example, if a Route is created via the Kubernetes Gateway API and then modified in {{site.base_gateway}}, those changes wouldn't be reflected in the CRD and would conflict with the desired state defined in the CRD.
+  - q: I'm using AWS CDK, can I manage Kong resources with CDK instead of {{ site.kic_product_name }}?
+    a: |
+      Currently, you can't manage Kong resources via AWS CDK. We recommend managing Kong configurations by [deploying decK](/deck/) or custom automation (for example, Lambda functions) through CDK that interact with the [Admin API](/admin-api/). 
 ---
 
 {: data-deployment-topology="konnect" }

--- a/app/_landing_pages/kubernetes-ingress-controller.yaml
+++ b/app/_landing_pages/kubernetes-ingress-controller.yaml
@@ -175,3 +175,15 @@ rows:
         config:
           entity: vault
           additional_url: "?tab=kic#set-up-a-vault"
+  
+  - header:
+      type: h2
+      text: "Frequently asked questions"
+    columns:
+      - blocks:
+          - type: faqs
+            config:
+              - q: I'm using AWS CDK, can I manage Kong resources with CDK instead of {{ site.kic_product_name }}?
+                a: |
+                  Currently, you can't manage Kong resources via AWS CDK. 
+                  We recommend managing Kong configurations by [deploying decK](/deck/) or custom automation (for example, Lambda functions) through CDK that interact with the [Admin API](/admin-api/).


### PR DESCRIPTION
## Description

Fixes #2162

## Preview Links
- https://deploy-preview-2414--kongdeveloper.netlify.app/kubernetes-ingress-controller/
- https://deploy-preview-2414--kongdeveloper.netlify.app/kubernetes-ingress-controller/install/#faqs

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
