### PR TITLE
Fix: Route strip_path description

### DIFF
--- a/app/_gateway_entities/route.md
+++ b/app/_gateway_entities/route.md
@@ -185,7 +185,7 @@ The Route entity allows you to configure proxy behavior on a per route basis by 
 In most cases:
 * `strip_path` should be `true` (default)
 * `preserve_host` should be `false` (default)
-* `*path_handling` should be set to `v0`
+* `path_handling` should be set to `v0`
 
 <!--vale off-->
 


### PR DESCRIPTION
## Description

Fixes #1992

## Preview Links
gateway/entities/route/#route-behavior

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
