### PR TITLE
chore(plugins): Add min versions to all plugins that don't have them

### DIFF
--- a/app/_kong_plugins/acl/index.md
+++ b/app/_kong_plugins/acl/index.md
@@ -40,6 +40,9 @@ categories:
 
 search_aliases:
   - access control list
+
+min_version:
+  gateway: '1.0'
 ---
 
 The ACL (access control list) plugin allows you to restrict [Consumer](/gateway/entities/consumer/) access to a [Gateway Service](/gateway/entities/service/) or [Route](/gateway/entities/route/). You do this by configuring **either** an allow list or a deny list with certain Consumers or [Consumer Groups](/gateway/entities/consumer-group/).

--- a/app/_kong_plugins/acme/index.md
+++ b/app/_kong_plugins/acme/index.md
@@ -48,6 +48,9 @@ search_aliases:
 notes: | 
    <b>Serverless Gateways</b>: This plugin is not supported in serverless gateways because the 
    TLS handshake does not occur at the Kong layer in this setup. 
+
+min_version:
+  gateway: '2.0'
 ---
 
 The ACME plugin allows {{site.base_gateway}} to apply SSL certificates from Let's Encrypt or any other ACMEv2 service and serve them dynamically for TLS requests.

--- a/app/_kong_plugins/amberflo/index.md
+++ b/app/_kong_plugins/amberflo/index.md
@@ -39,6 +39,9 @@ icon: amberflo.png
 search_aliases:
   - amberflo.io
   - kong-plugin-amberflow
+
+min_version:
+  gateway: '3.0'
 ---
 
 

--- a/app/_kong_plugins/appsentinels/index.md
+++ b/app/_kong_plugins/appsentinels/index.md
@@ -29,6 +29,8 @@ support_url: https://appsentinels.ai/
 
 icon: appsentinels.png
 
+min_version:
+  gateway: '2.8'
 ---
 
 The AppSentinels API Security Platform is purpose-built for keeping the security needs of next-generation applications in mind.

--- a/app/_kong_plugins/aws-lambda/index.md
+++ b/app/_kong_plugins/aws-lambda/index.md
@@ -41,6 +41,9 @@ search_aliases:
 notes: |
   <b>Dedicated Cloud Gateways</b>: If you use the IAM assumeRole functionality with this plugin, 
   it must be configured differently than for hybrid deployments in Konnect.
+
+min_version:
+  gateway: '1.0'
 ---
 
 This plugin lets you invoke an [AWS Lambda](https://aws.amazon.com/lambda/) function from {{site.base_gateway}}. 

--- a/app/_kong_plugins/azure-functions/index.md
+++ b/app/_kong_plugins/azure-functions/index.md
@@ -41,6 +41,9 @@ tags:
 related_resources:
   - text: Use an Azure Function through {{site.base_gateway}}
     url: /how-to/use-an-azure-function-through-gateway/
+
+min_version:
+  gateway: '1.0'
 ---
 
 This plugin invokes [Azure Functions](https://azure.microsoft.com/en-us/services/functions/).

--- a/app/_kong_plugins/basic-auth/index.md
+++ b/app/_kong_plugins/basic-auth/index.md
@@ -47,6 +47,9 @@ faqs:
 related_resources:
   - text: Basic Auth how-to guides
     url: /how-to/?query=basic-auth
+
+min_version:
+  gateway: '1.0'
 ---
 
 The [Basic Authentication](https://datatracker.ietf.org/doc/html/rfc7617 ) plugin enforces username and password authentication for [Consumers](/gateway/entities/consumer/) when making a request to a [Gateway Service](/gateway/entities/service/) or [Route](/gateway/entities/route/). Consumers represent a developer or an application consuming the upstream service. 

--- a/app/_kong_plugins/bot-detection/index.md
+++ b/app/_kong_plugins/bot-detection/index.md
@@ -35,6 +35,8 @@ search_aliases:
 tags:
   - security
 
+min_version:
+  gateway: '1.0'
 ---
 
 Using the Bot Detection plugin, you can protect your a Gateway Service or a Route from bots. It automatically detects [common bots](https://github.com/Kong/kong/blob/master/kong/plugins/bot-detection/rules.lua) on every request from the associated Gateway Service or Route using regex.

--- a/app/_kong_plugins/canary/index.md
+++ b/app/_kong_plugins/canary/index.md
@@ -46,6 +46,9 @@ notes: |
   and shouldn't be used with the {{site.kic_product_name}}. Instead, use the 
   <a href="/kubernetes-ingress-controller/gateway-api/">Gateway API</a> 
   to manage canary deploys.
+
+min_version:
+  gateway: '1.0'
 ---
 
 The Canary Release plugin helps minimize risk when deploying a new software version by gradually rolling out changes to a limited group of users. 

--- a/app/_kong_plugins/correlation-id/index.md
+++ b/app/_kong_plugins/correlation-id/index.md
@@ -40,6 +40,9 @@ faqs:
   - q: Can I see my correlation IDs in my {{site.base_gateway}} logs?
     a: |
       Yes, if you edit your Nginx logging parameters you can see your correlation ID in the Nginx access log. For complete instructions, see [Add Correlation IDs to {{site.base_gateway}} logs](/how-to/add-correlation-ids-to-gateway-logs/).
+
+min_version:
+  gateway: '1.0'
 ---
 
 The Correlation ID plugin lets you correlate requests and responses using a unique ID transmitted as HTTP headers.

--- a/app/_kong_plugins/cors/index.md
+++ b/app/_kong_plugins/cors/index.md
@@ -35,6 +35,8 @@ icon: cors.png
 categories:
   - security
 
+min_version:
+  gateway: '1.0'
 ---
 
 The CORS plugin lets you add Cross-Origin Resource Sharing (CORS) to a Service or a Route. This allows you to automate the configuration of CORS rules, ensuring that your upstreams only accept and share resources with approved sources.

--- a/app/_kong_plugins/datadog/index.md
+++ b/app/_kong_plugins/datadog/index.md
@@ -26,6 +26,9 @@ icon: datadog.png
 
 categories:
   - analytics-monitoring
+
+min_version:
+  gateway: '1.0'
 ---
 
 This plugin lets you log metrics for a [Gateway Service](/gateway/entities/service/) or [Route](/gateway/entities/route/) to a local [Datadog agent](https://docs.datadoghq.com/agent/basic_agent_usage/).

--- a/app/_kong_plugins/datadome/index.md
+++ b/app/_kong_plugins/datadome/index.md
@@ -22,6 +22,9 @@ icon: datadome.png
 related_resources:
   - text: DataDome Kong documentation
     url: https://docs.datadome.co/docs/kong-plugin
+
+min_version:
+  gateway: '2.8'
 ---
 
 The Kong DataDome plugin relies on the DataDome Bot & Fraud Protection Platform to validate if any incoming API request is legitimate or coming from a bot.

--- a/app/_kong_plugins/degraphql/index.md
+++ b/app/_kong_plugins/degraphql/index.md
@@ -38,6 +38,9 @@ categories:
 related_resources:
   - text: Map URIs into GraphQL queries with DeGraphQL
     url: /how-to/map-uris-into-graphql-queries/
+
+min_version:
+  gateway: '1.3'
 ---
 
 The DeGraphQL plugin transforms GraphQL upstreams into traditional endpoints by mapping URIs into GraphQL queries.

--- a/app/_kong_plugins/exit-transformer/index.md
+++ b/app/_kong_plugins/exit-transformer/index.md
@@ -35,6 +35,9 @@ tags:
 
 search_aliases:
   - exit-transformer
+
+min_version:
+  gateway: '1.3'
 ---
 
 Transform and customize {{site.base_gateway}} response exit messages using Lua functions.

--- a/app/_kong_plugins/file-log/index.md
+++ b/app/_kong_plugins/file-log/index.md
@@ -38,6 +38,9 @@ notes: |
    <b>Dedicated Cloud Gateways</b>: This plugin is not supported in Dedicated or 
    Serverless Cloud Gateways because it depends on a local agent, and there are no 
    local nodes in Dedicated or Serverless Cloud Gateways.
+  
+min_version:
+  gateway: '1.0'
 ---
 
 Append request and response data in JSON format to a log file. You can also specify

--- a/app/_kong_plugins/forward-proxy/index.md
+++ b/app/_kong_plugins/forward-proxy/index.md
@@ -35,6 +35,9 @@ tags:
 
 search_aliases:
   - forward-proxy
+
+min_version:
+  gateway: '1.0'
 ---
 
 The Forward Proxy Advanced plugin allows {{site.base_gateway}} to connect to intermediary transparent HTTP proxies, instead of directly to the `upstream_url`, when forwarding requests upstream. 

--- a/app/_kong_plugins/graphql-proxy-cache-advanced/index.md
+++ b/app/_kong_plugins/graphql-proxy-cache-advanced/index.md
@@ -49,6 +49,9 @@ notes: |
   This plugin's API doesn't work in hybrid mode, as it targets data that only exists on data planes, 
   and data planes can't use Kong's Admin API. In Serverless gateways only the <code>memory</code> config 
   strategy is supported.
+
+min_version:
+  gateway: '1.3'
 ---
 
 The GrapQL Proxy Cache Advanced plugin provides a reverse GraphQL proxy cache implementation for {{site.base_gateway}}. 

--- a/app/_kong_plugins/graphql-rate-limiting-advanced/index.md
+++ b/app/_kong_plugins/graphql-rate-limiting-advanced/index.md
@@ -49,6 +49,9 @@ related_resources:
 notes: |
   In DB-less, hybrid mode, and Konnect, the <code>cluster</code> config strategy
   is not supported. Use <code>redis</code> instead.
+
+min_version:
+  gateway: '1.3'
 ---
 
 The GraphQL Rate Limiting Advanced plugin provides rate limiting for [GraphQL queries](https://graphql.org/learn/queries/).

--- a/app/_kong_plugins/grpc-gateway/index.md
+++ b/app/_kong_plugins/grpc-gateway/index.md
@@ -41,6 +41,9 @@ related_resources:
     url: /plugins/grpc-web/
   - text: Use the gRPC-Gateway plugin to proxy HTTP requests to a gRPC service
     url: /how-to/use-grpc-gateway/
+
+min_version:
+  gateway: '2.1'
 ---
 
 The gRPC-Gateway plugin allows you to send JSON requests to a [gRPC](https://grpc.io/) service. A

--- a/app/_kong_plugins/grpc-web/index.md
+++ b/app/_kong_plugins/grpc-web/index.md
@@ -40,6 +40,9 @@ related_resources:
     url: /plugins/grpc-gateway/
   - text: Use the gRPC-Web plugin to proxy HTTP requests to a gRPC service
     url: /how-to/use-grpc-web/
+
+min_version:
+  gateway: '2.1'
 ---
 
 The gRPC-Web plugins allows access to a [gRPC](https://grpc.io/) service via the [gRPC-Web protocol](https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-WEB.md#protocol-differences-vs-grpc-over-http2).

--- a/app/_kong_plugins/hmac-auth/index.md
+++ b/app/_kong_plugins/hmac-auth/index.md
@@ -40,6 +40,8 @@ related_resources:
   - text: ACL plugin
     url: /plugins/acl/
     
+min_version:
+  gateway: '1.0'
 ---
 
 This plugin adds HMAC Signature authentication to a Gateway Service or a Route

--- a/app/_kong_plugins/http-log/index.md
+++ b/app/_kong_plugins/http-log/index.md
@@ -47,6 +47,9 @@ faqs:
     a: The log is executed after {{site.base_gateway}} sends the last response byte to the client. 
   - q: Can the HTTP Log plugin expose latency metrics for individual phases of the request lifecycle (such as `rewrite`, `access`, `header_filter`, and `body_filter`)?
     a: The HTTP Log plugin doesn't provide latency metrics at this granular level. Instead, use [the Debugger {{site.konnect_short_name}}](/gateway/debugger/).
+
+min_version:
+  gateway: '1.0'
 ---
 
 The HTTP Log plugin lets you send request and response logs to an HTTP server.

--- a/app/_kong_plugins/imp-appsec-connector/index.md
+++ b/app/_kong_plugins/imp-appsec-connector/index.md
@@ -30,6 +30,9 @@ search_aliases:
 related_resources:
   - text: Imperva documentation
     url: https://docs.imperva.com/
+
+min_version:
+  gateway: '3.0'
 ---
 
 The Imperva API Security plugin connects {{site.base_gateway}} with the Imperva API Security service, providing continuous discovery and monitoring of APIs exposed by {{site.base_gateway}}.

--- a/app/_kong_plugins/inigo/index.md
+++ b/app/_kong_plugins/inigo/index.md
@@ -35,6 +35,9 @@ related_resources:
     url: https://app.inigo.io
   - text: Inigo documentation
     url: https://docs.inigo.io
+
+min_version:
+  gateway: '3.0'
 ---
 
 Inigo offers complete visibility, control, and security for your production GraphQL APIs, enabling you to confidently adopt and scale GraphQL with the Inigo Kong plugin. 

--- a/app/_kong_plugins/ip-restriction/index.md
+++ b/app/_kong_plugins/ip-restriction/index.md
@@ -39,6 +39,9 @@ search_aliases:
 related_resources:
   - text: Restrict access to {{site.base_gateway}} resources by allowing specific IPs
     url: /how-to/restrict-access-to-resources-by-allowing-ips/
+
+min_version:
+  gateway: '1.0'
 ---
 
 The IP Restriction plugin restricts access to a Gateway Service or a Route by either allowing or denying IP addresses. This can help block malicious activity, such as spam or access to certain websites. Single IPs, multiple IPs, or ranges in [Classless Inter-Domain Routing (CIDR) notation](https://datatracker.ietf.org/doc/html/rfc4632) like 10.10.10.0/24 can be used. The plugin supports IPv4 and IPv6 addresses.

--- a/app/_kong_plugins/jwt-signer/index.md
+++ b/app/_kong_plugins/jwt-signer/index.md
@@ -31,6 +31,9 @@ tags:
 search_aliases:
   - json web tokens
   - jwt-signer
+
+min_version:
+  gateway: '1.0'
 ---
 
 The {{site.base_gateway}} JWT Signer plugin allows you to verify, sign, or re-sign

--- a/app/_kong_plugins/jwt/index.md
+++ b/app/_kong_plugins/jwt/index.md
@@ -32,6 +32,9 @@ categories:
 
 search_aliases:
   - json web tokens
+
+min_version:
+  gateway: '1.0'
 ---
 
 The JWT plugin lets you verify requests containing HS256 or RS256 signed JSON Web Tokens, as specified in [RFC 7519](https://tools.ietf.org/html/rfc7519).

--- a/app/_kong_plugins/kafka-log/index.md
+++ b/app/_kong_plugins/kafka-log/index.md
@@ -38,6 +38,9 @@ search_aliases:
   - kafka-log
   - events
   - event-gateway
+
+min_version:
+  gateway: '1.3'
 ---
 
 Publish request and response logs to an [Apache Kafka](https://kafka.apache.org/) topic. This plugin does not support message compression.

--- a/app/_kong_plugins/kafka-upstream/index.md
+++ b/app/_kong_plugins/kafka-upstream/index.md
@@ -39,6 +39,8 @@ search_aliases:
   - events
   - event gateway
 
+min_version:
+  gateway: '1.3'
 ---
 
 This plugin converts requests into [Apache Kafka](https://kafka.apache.org/) messages and publishes them to a specified Kafka topic.  

--- a/app/_kong_plugins/key-auth-enc/index.md
+++ b/app/_kong_plugins/key-auth-enc/index.md
@@ -48,6 +48,9 @@ notes: |
   Use the regular [Key Auth](/plugins/key-auth/) plugin instead.
   - The time-to-live (ttl) does not work in hybrid mode. This setting
   determines the length of time a credential remains valid.
+
+min_version:
+  gateway: '1.0'
 ---
 
 The Key Authentication Encrypted plugin adds encrypted API key authentication to a [Gateway Service](/gateway/entities/service/) or [Route](/gateway/entities/route/).  

--- a/app/_kong_plugins/key-auth/index.md
+++ b/app/_kong_plugins/key-auth/index.md
@@ -43,6 +43,9 @@ related_resources:
 notes: |
   The time-to-live (ttl) does not work in Konnect or hybrid mode. This setting
   determines the length of time a credential remains valid.
+
+min_version:
+  gateway: '1.0'
 ---
 
 The Key Authentication plugin lets you add API key authentication to a [Gateway Service](/gateway/entities/service/) or a [Route](/gateway/entities/route/).

--- a/app/_kong_plugins/kong-response-size-limiting/index.md
+++ b/app/_kong_plugins/kong-response-size-limiting/index.md
@@ -25,6 +25,9 @@ support_url: https://github.com/Optum/kong-response-size-limiting/issues
 source_code_url: https://github.com/Optum/kong-response-size-limiting/
 
 license_type: Apache-2.0
+
+min_version:
+  gateway: '1.0'
 ---
 
 The Kong Response Size Limiting plugin blocks upstream responses with a body size that exceeds a specified limit in megabytes.

--- a/app/_kong_plugins/kong-service-virtualization/index.md
+++ b/app/_kong_plugins/kong-service-virtualization/index.md
@@ -25,6 +25,9 @@ icon: optum.png
 
 search_aliases:
   - optum
+
+min_version:
+  gateway: '1.0'
 ---
 
 The Kong Service Virtualization plugin enables mocking virtual API request and responses using {{site.base_gateway}}.

--- a/app/_kong_plugins/kong-spec-expose/index.md
+++ b/app/_kong_plugins/kong-spec-expose/index.md
@@ -25,6 +25,9 @@ icon: optum.png
 
 search_aliases:
     - optum
+
+min_version:
+  gateway: '1.0'
 ---
 
 The Kong Spec Expose plugin lets you expose an OpenAPI Spec (OAS), Swagger, or other specification of auth-protected upstream services fronted using {{site.base_gateway}}.

--- a/app/_kong_plugins/kong-splunk-log/index.md
+++ b/app/_kong_plugins/kong-splunk-log/index.md
@@ -25,6 +25,9 @@ icon: optum.png
 
 search_aliases:
   - optum
+
+min_version:
+  gateway: '3.0'
 ---
 
 The Kong Splunk Log plugin is a modified version of the [HTTP Log plugin](/plugins/http-log/) 

--- a/app/_kong_plugins/kong-upstream-jwt/index.md
+++ b/app/_kong_plugins/kong-upstream-jwt/index.md
@@ -25,6 +25,9 @@ icon: optum.png
 
 search_aliases:
   - optum
+
+min_version:
+  gateway: '3.0'
 ---
 
 The Kong Upstream JWT plugin adds a signed JWT into the HTTP Header `JWT` of requests proxied through {{site.base_gateway}}. 

--- a/app/_kong_plugins/ldap-auth-advanced/index.md
+++ b/app/_kong_plugins/ldap-auth-advanced/index.md
@@ -38,6 +38,9 @@ related_resources:
     url: /plugins/ldap-auth/
   - text: Kong Manager
     url: /gateway/kong-manager/
+
+min_version:
+  gateway: '1.0'
 ---
 
 {% include /plugins/ldap/description.md %}

--- a/app/_kong_plugins/ldap-auth/index.md
+++ b/app/_kong_plugins/ldap-auth/index.md
@@ -35,6 +35,9 @@ search_aliases:
 related_resources:
   - text: LDAP Authentication Advanced
     url: /plugins/ldap-auth-advanced/
+  
+min_version:
+  gateway: '1.0'
 ---
 
 {% include /plugins/ldap/description.md %}

--- a/app/_kong_plugins/loggly/index.md
+++ b/app/_kong_plugins/loggly/index.md
@@ -34,6 +34,9 @@ related_resources:
 
 categories:
   - logging
+
+min_version:
+  gateway: '1.0'
 ---
 
 Log request and response data over UDP to [Loggly](https://www.loggly.com).

--- a/app/_kong_plugins/mocking/index.md
+++ b/app/_kong_plugins/mocking/index.md
@@ -39,6 +39,8 @@ categories:
   - traffic-control
   - api-design
 
+min_version:
+  gateway: '2.4'
 ---
 
 The Mocking plugin allows you to provide mock endpoints to test APIs in development against your existing services. The Mocking plugin leverages standards based on the Open API Specification (OAS) for sending out mock responses to APIs. Mocking supports both Swagger 2.0 and OpenAPI 3.0.

--- a/app/_kong_plugins/moesif/index.md
+++ b/app/_kong_plugins/moesif/index.md
@@ -39,6 +39,9 @@ related_resources:
     url: https://www.moesif.com/docs/server-integration/kong-api-gateway/
   - text: Troubleshooting Kong with Moesif
     url: https://www.moesif.com/docs/server-integration/kong-api-gateway/#troubleshooting?language=kong-api-gateway&utm_medium=docs&utm_campaign=partners&utm_source=kong
+
+min_version:
+  gateway: '1.0'
 ---
 
 The Moesif plugin helps you understand [customer API usage](https://www.moesif.com/features/api-analytics?utm_medium=docs&utm_campaign=partners&utm_source=kong&language=kong-api-gateway) and monetize your APIs with [usage-based billing](https://www.moesif.com/solutions/metered-api-billing?utm_medium=docs&utm_campaign=partners&utm_source=kong&language=kong-api-gateway)

--- a/app/_kong_plugins/mtls-auth/index.md
+++ b/app/_kong_plugins/mtls-auth/index.md
@@ -42,6 +42,9 @@ tags:
 notes: | 
    <b>Serverless Gateways</b>: This plugin is not supported in serverless gateways because the 
    TLS handshake does not occur at the Kong layer in this setup. 
+
+min_version:
+  gateway: '1.0'
 ---
 
 The MTLS Auth plugin lets you add mutual TLS authentication based on a client-supplied or a server-supplied certificate, 

--- a/app/_kong_plugins/nonamesecurity/index.md
+++ b/app/_kong_plugins/nonamesecurity/index.md
@@ -26,6 +26,9 @@ search_aliases:
 related_resources:
   - text: Performance benchmark of {{site.base_gateway}} with Noname Security
     url: https://docs.nonamesecurity.com/docs/kong-performance-results
+
+min_version:
+  gateway: '1.0'
 ---
 
 The Noname Traffic Source plugin (also known as `nonamesecurity`) lets you tune

--- a/app/_kong_plugins/oauth2-introspection/index.md
+++ b/app/_kong_plugins/oauth2-introspection/index.md
@@ -44,6 +44,9 @@ related_resources:
     url: /plugins/oauth2/reference/
   - text: Configure the OAuth 2.0 Introspection plugin with Kong Identity
     url: /how-to/configure-kong-identity-oauth-introspection/
+
+min_version:
+  gateway: '1.0'
 ---
 
 You can validate access tokens sent by developers using a third-party OAuth 2.0

--- a/app/_kong_plugins/oauth2/index.md
+++ b/app/_kong_plugins/oauth2/index.md
@@ -41,6 +41,9 @@ notes: |
   This plugin can't be used in Konnect, hybrid, or DB-less modes. It needs to
   generate and delete tokens, and commit those changes to a database on the
   same node.
+
+min_version:
+  gateway: '1.0'
 ---
 
 Add an [OAuth 2.0](https://oauth.net/2/) authentication layer with one of the following grant flows:

--- a/app/_kong_plugins/opa/index.md
+++ b/app/_kong_plugins/opa/index.md
@@ -41,6 +41,10 @@ related_resources:
     url: /how-to/block-unauthorized-requests-with-opa/
   - text: How to Implement Secure Access Control with OPA and {{site.base_gateway}}
     url: https://konghq.com/blog/engineering/secure-access-control-with-opa-and-kong
+
+min_version:
+  gateway: '2.4'
+
 ---
 
 The OPA plugin allows you to forward requests to [Open Policy Agent](https://openpolicyagent.org/) and process the requests only if the authorization policy allows it. 

--- a/app/_kong_plugins/openid-connect/index.md
+++ b/app/_kong_plugins/openid-connect/index.md
@@ -102,6 +102,8 @@ faqs:
       If the IdP connected to the plugin enforces PKCE, it will be used during the authorization code flow. 
       If the IdP doesn't support or enforce PCKE, it won't be used.
  
+min_version:
+  gateway: '1.0'
 ---
 
 The OpenID Connect (OIDC) plugin lets you integrate {{site.base_gateway}} with an identity provider (IdP).

--- a/app/_kong_plugins/opentelemetry/index.md
+++ b/app/_kong_plugins/opentelemetry/index.md
@@ -15,7 +15,7 @@ works_on:
     - konnect
 
 min_version:
-    gateway: '3.1'
+    gateway: '3.0'
 
 topologies:
   on_prem:

--- a/app/_kong_plugins/post-function/index.md
+++ b/app/_kong_plugins/post-function/index.md
@@ -42,6 +42,9 @@ related_resources:
     url: /how-to/adjust-header-names-in-request/
   - text: Pre-Function plugin
     url: /plugins/pre-function/
+
+min_version:
+  gateway: '1.0'
 ---
 
 The Post-Function plugin (also known as Kong Functions, Post-Plugin) lets you dynamically run Lua code from {{site.base_gateway}} **after** other plugins in succession.

--- a/app/_kong_plugins/pre-function/index.md
+++ b/app/_kong_plugins/pre-function/index.md
@@ -46,6 +46,9 @@ related_resources:
     url: /plugins/post-function/
   - text: All serverless plugins
     url: /plugins/?category=serverless
+
+min_version:
+  gateway: '1.0'
 ---
 
 The Pre-Function plugin (also known as Kong Functions, Pre-Plugin) lets

--- a/app/_kong_plugins/prometheus/index.md
+++ b/app/_kong_plugins/prometheus/index.md
@@ -52,6 +52,9 @@ notes: |
    <b>Dedicated and Serverless Cloud Gateways</b>: This plugin is not supported in Dedicated or 
    Serverless Cloud Gateways because it depends on the Admin API and the Status API, which aren't 
    accessible in that setup.
+
+min_version:
+  gateway: '1.0'
 ---
 
 Expose metrics related to {{site.base_gateway}} and proxied upstream services in 

--- a/app/_kong_plugins/proxy-cache-advanced/index.md
+++ b/app/_kong_plugins/proxy-cache-advanced/index.md
@@ -58,6 +58,9 @@ faqs:
 
 notes: |
   In Serverless gateways only the <code>memory</code> config strategy is supported.
+
+min_version:
+  gateway: '1.0'
 ---
 
 The Proxy Cache Advanced plugin provides a reverse proxy cache implementation for {{site.base_gateway}}. 

--- a/app/_kong_plugins/proxy-cache/index.md
+++ b/app/_kong_plugins/proxy-cache/index.md
@@ -42,6 +42,9 @@ related_resources:
     url: /plugins/proxy-cache-advanced/
   - text: GraphQL Proxy Cache Advanced plugin
     url: /plugin/graphql-proxy-cache-advanced/
+
+min_version:
+  gateway: '1.2'
 ---
 
 The Proxy Cache plugin provides a reverse proxy cache implementation for {{site.base_gateway}}. 

--- a/app/_kong_plugins/rate-limiting-advanced/index.md
+++ b/app/_kong_plugins/rate-limiting-advanced/index.md
@@ -51,6 +51,9 @@ notes: |
   For DB-less mode, use one of <code>redis</code> or <code>local</code>;
   for Konnect and hybrid mode, use <code>redis</code>, or <code>local</code> for data
   planes only. In Serverless gateways only the <code>local</code> config strategy is supported.
+
+min_version:
+  gateway: '1.0'
 ---
 
 Rate limit how many HTTP requests can be made in a given time frame using multiple rate limits and window sizes, and applying sliding windows.

--- a/app/_kong_plugins/rate-limiting/index.md
+++ b/app/_kong_plugins/rate-limiting/index.md
@@ -60,6 +60,9 @@ notes: |
   For DB-less mode, use one of <code>redis</code> or <code>local</code>;
   for Konnect and hybrid mode, use <code>redis</code>, or <code>local</code> for data
   planes only. In Serverless gateways only the <code>local</code> config policy is supported.
+
+min_version:
+  gateway: '1.0'
 ---
 
 Rate limit how many HTTP requests can be made in a given period of seconds, minutes, hours, days, months, or years.

--- a/app/_kong_plugins/request-size-limiting/index.md
+++ b/app/_kong_plugins/request-size-limiting/index.md
@@ -35,6 +35,9 @@ search_aliases:
 
 tags:
   - traffic-control
+
+min_version:
+  gateway: '1.0'
 ---
 
 Block incoming requests where the body is greater than a specific size.

--- a/app/_kong_plugins/request-termination/index.md
+++ b/app/_kong_plugins/request-termination/index.md
@@ -37,6 +37,9 @@ search_aliases:
 related_resources:
   - text: Allow clients to choose their authentication methods and prevent unauthorized access
     url: /how-to/allow-multiple-authentication/
+
+min_version:
+  gateway: '1.0'
 ---
 
 This plugin terminates incoming requests with a specified status code and message.

--- a/app/_kong_plugins/request-transformer-advanced/index.md
+++ b/app/_kong_plugins/request-transformer-advanced/index.md
@@ -46,6 +46,9 @@ related_resources:
     url: /how-to/transform-a-client-request/
   - text: AI Request Transformer
     url: /plugins/ai-request-transformer/
+
+min_version:
+  gateway: '1.0'
 ---
 
 {% include plugins/request-response-transformer/request-transformer-description.md %}

--- a/app/_kong_plugins/request-transformer/index.md
+++ b/app/_kong_plugins/request-transformer/index.md
@@ -40,6 +40,9 @@ related_resources:
     url: /plugins/request-transformer-advanced/
   - text: AI Request Transformer
     url: /plugins/ai-request-transformer/
+
+min_version:
+  gateway: '1.2'
 ---
 
 {% include plugins/request-response-transformer/request-transformer-description.md %}

--- a/app/_kong_plugins/request-validator/index.md
+++ b/app/_kong_plugins/request-validator/index.md
@@ -40,6 +40,9 @@ tags:
 
 search_aliases:
   - request-validator
+
+min_version:
+  gateway: '1.0'
 ---
 
 The Request Validator plugin allows you to validate requests before they reach the upstream server. This plugin supports validating the schema of the body and the parameters of the request using either Kong's own schema validator (body only) or a JSON Schema Draft 4 compliant validator.

--- a/app/_kong_plugins/response-ratelimiting/index.md
+++ b/app/_kong_plugins/response-ratelimiting/index.md
@@ -46,6 +46,9 @@ notes: |
   For DB-less mode, use one of <code>redis</code> or <code>local</code>;
   for Konnect and hybrid mode, use <code>redis</code>, or <code>local</code> for data
   planes only. In Serverless gateways only the <code>local</code> config policy is supported.
+
+min_version:
+  gateway: '1.0'
 ---
 
 This plugin allows you to impose rate limits based on custom response headers returned by the upstream service.

--- a/app/_kong_plugins/response-transformer-advanced/index.md
+++ b/app/_kong_plugins/response-transformer-advanced/index.md
@@ -40,6 +40,9 @@ related_resources:
     url: /plugins/response-transformer/
   - text: All transformation plugins
     url: /plugins/?category=transformations
+
+min_version:
+  gateway: '1.0'
 ---
 
 {% include plugins/request-response-transformer/response-transformer-description.md %}

--- a/app/_kong_plugins/response-transformer/index.md
+++ b/app/_kong_plugins/response-transformer/index.md
@@ -40,6 +40,9 @@ related_resources:
     url: /plugins/response-transformer-advanced/
   - text: All transformation plugins
     url: /plugins/?category=transformations
+  
+min_version:
+  gateway: '1.0'
 ---
 
 {% include plugins/request-response-transformer/response-transformer-description.md %}

--- a/app/_kong_plugins/route-by-header/index.md
+++ b/app/_kong_plugins/route-by-header/index.md
@@ -39,6 +39,9 @@ search_aliases:
 related_resources:
   - text: Route requests to different Upstreams based on headers
     url: /how-to/route-requests-to-different-upstreams-based-on-headers/
+
+min_version:
+  gateway: '1.0'
 ---
 
 This plugin allows you to route a request to a specific [Upstream](/gateway/entities/upstream/) if it matches one of the

--- a/app/_kong_plugins/route-transformer-advanced/index.md
+++ b/app/_kong_plugins/route-transformer-advanced/index.md
@@ -34,6 +34,9 @@ tags:
 
 search_aliases:
   - route-transformer-advanced
+
+min_version:
+  gateway: '1.3'
 ---
 
 This plugin transforms routing on the fly in {{site.base_gateway}}, changing the host, port, or path of the request. 

--- a/app/_kong_plugins/salt-agent/index.md
+++ b/app/_kong_plugins/salt-agent/index.md
@@ -25,6 +25,9 @@ search_aliases:
 
 tags:
   - traffic-control
+
+min_version:
+  gateway: '1.0'
 ---
 
 The Salt Security Kong deployment is used to capture a mirror of application traffic and send it to the Salt Security Service for analysis.

--- a/app/_kong_plugins/session/index.md
+++ b/app/_kong_plugins/session/index.md
@@ -42,6 +42,9 @@ related_resources:
     url: /how-to/authenticate-consumers-with-session-and-key-auth/
   - text: "{{site.base_gateway}} authentication"
     url: /gateway/authentication/
+
+min_version:
+  gateway: '1.3'
 ---
 
 The Session plugin can be used to manage browser sessions for APIs proxied

--- a/app/_kong_plugins/statsd/index.md
+++ b/app/_kong_plugins/statsd/index.md
@@ -38,6 +38,9 @@ search_aliases:
 related_resources:
   - text: Collect {{site.base_gateway}} metrics with the StatsD plugin
     url: /how-to/collect-metrics-with-statsd/
+
+min_version:
+  gateway: '1.0'
 ---
 
 The StatsD plugin logs [metrics](#metrics) for a [Gateway Service](/gateway/entities/service/) or [Route](/gateway/entities/route/) to a StatsD server.

--- a/app/_kong_plugins/syslog/index.md
+++ b/app/_kong_plugins/syslog/index.md
@@ -44,6 +44,9 @@ notes: |
    <b>Dedicated and Serverless Cloud Gateways</b>: This plugin is not supported in Dedicated or 
    Serverless Cloud Gateways because it depends on a local agent, and there are no local nodes 
    in Dedicated or Serverless Cloud Gateways.
+
+min_version:
+  gateway: '1.0'
 ---
 
 Log request and response data to Syslog.

--- a/app/_kong_plugins/tcp-log/index.md
+++ b/app/_kong_plugins/tcp-log/index.md
@@ -35,6 +35,9 @@ search_aliases:
   - tcp-log
   - tcp
   - logging
+
+min_version:
+  gateway: '1.0'
 ---
 
 Log request and response data to a TCP server.

--- a/app/_kong_plugins/tls-handshake-modifier/index.md
+++ b/app/_kong_plugins/tls-handshake-modifier/index.md
@@ -15,7 +15,7 @@ works_on:
     - konnect
 
 min_version:
-    gateway: '3.1'
+    gateway: '3.0'
 
 topologies:
   on_prem:

--- a/app/_kong_plugins/tls-metadata-headers/index.md
+++ b/app/_kong_plugins/tls-metadata-headers/index.md
@@ -16,7 +16,7 @@ works_on:
     - konnect
 
 min_version:
-    gateway: '3.1'
+    gateway: '3.0'
 
 topologies:
   on_prem:

--- a/app/_kong_plugins/udp-log/index.md
+++ b/app/_kong_plugins/udp-log/index.md
@@ -36,6 +36,9 @@ search_aliases:
   - udp-log
   - udp
   - logging
+
+min_version:
+  gateway: '1.0'
 ---
 
 Log request and response data to a UDP server.

--- a/app/_kong_plugins/upstream-timeout/index.md
+++ b/app/_kong_plugins/upstream-timeout/index.md
@@ -37,6 +37,9 @@ search_aliases:
 related_resources:
   - text: Gateway Service timeout settings
     url: /gateway/entities/service/#schema-service-connect-timeout
+
+min_version:
+  gateway: '1.0'
 ---
 
 The Upstream Timeout plugin allows you to configure specific timeouts for the connection between {{site.base_gateway}} and an upstream service.

--- a/app/_kong_plugins/vault-auth/index.md
+++ b/app/_kong_plugins/vault-auth/index.md
@@ -39,6 +39,9 @@ related_resources:
     url: /gateway/authentication/
   - text: Configure HashiCorp Vault as a vault backend
     url: /how-to/configure-hashicorp-vault-as-a-vault-backend/
+
+min_version:
+  gateway: '1.0'
 ---
 
 Add authentication to a Gateway Service or Route with an access token and a secret token. 

--- a/app/_kong_plugins/websocket-size-limit/index.md
+++ b/app/_kong_plugins/websocket-size-limit/index.md
@@ -15,7 +15,7 @@ works_on:
     - konnect
 
 min_version:
-    gateway: '3.1'
+    gateway: '3.0'
 
 topologies:
   on_prem:

--- a/app/_kong_plugins/websocket-validator/index.md
+++ b/app/_kong_plugins/websocket-validator/index.md
@@ -16,7 +16,7 @@ works_on:
     - konnect
 
 min_version:
-    gateway: '3.1'
+    gateway: '3.0'
 
 topologies:
   on_prem:

--- a/app/_kong_plugins/zipkin/index.md
+++ b/app/_kong_plugins/zipkin/index.md
@@ -43,6 +43,9 @@ related_resources:
     url: /plugins/opentelemetry/
   - text: "{{site.base_gateway}} monitoring and metrics"
     url: /gateway/monitoring/
+
+min_version:
+  gateway: '1.0'
 ---
 
 When enabled, the Zipkin plugin traces requests in a way that's compatible with [zipkin](https://zipkin.io/).


### PR DESCRIPTION
## Description

Fixes #2169 

Based on changelogs and repo history.
If a plugin was introduced before 1.0, I set the version to 1.0, as the first GA gateway version. It's difficult to find exact info for anything before that.

## Preview Links

