### PR TITLE
Potential fix for code scanning alert no. 20: Incomplete regular expression for hostnames

### DIFF
--- a/tools/broken-link-checker/lib/check-url-list.js
+++ b/tools/broken-link-checker/lib/check-url-list.js
@@ -43,7 +43,7 @@ export default function (urls, opts) {
             if (
               opts.skipEditLink &&
               result.url.resolved.match(
-                /.*github.com\/Kong\/developer.konghq.com\/edit\/.*/
+                /.*github\.com\/Kong\/developer\.konghq\.com\/edit\/.*/
               )
             ) {
               return;


### PR DESCRIPTION
Potential fix for [https://github.com/Kong/developer.konghq.com/security/code-scanning/20](https://github.com/Kong/developer.konghq.com/security/code-scanning/20)

To fix the problem, we need to escape the dots in `developer.konghq.com` so that they match literal periods rather than any character. This is done by replacing each `.` with `\.` in the regular expression. The fix should be applied only to the regular expression on line 46 in `tools/broken-link-checker/lib/check-url-list.js`. No additional imports or methods are required, as this is a simple regex correction.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
