### PR TITLE
docs: portal sso default domain examples [TDX-6380]

### DIFF
--- a/app/dev-portal/sso.md
+++ b/app/dev-portal/sso.md
@@ -81,8 +81,8 @@ The following is an example Dev Portal SSO configuration. For the example, we wi
 
 If you're using OIDC for SSO, you'd configure your settings like the following:
 - **Single Sign On URL (SSO URL)**: Also sometimes referred to as **Initiate login URI**, use to automatically initiate the SSO login flow.
-  - If using a custom domain: `https://www.example.com/login/sso`
-  - If not using a custom domain: `https://abc123456789.us.kongportals.com/login/sso`
+  - If you're using a custom domain: `https://www.example.com/login/sso`
+  - If you aren't using a custom domain: `https://abc123456789.us.kongportals.com/login/sso`
 - **Sign-in redirect URIs**:
   - `https://www.example.com/login`
   - `https://abc123456789.us.kongportals.com/login`
@@ -97,10 +97,10 @@ If you're using OIDC for SSO, you'd configure your settings like the following:
 
 If you're using SAML for SSO, you'd configure your settings like the following:
 - **Single Sign On URL (SSO URL)**: Also sometimes referred to as **Initiate login URI**, used to automatically initiate the SSO login flow.
-    - If using a custom domain: `https://www.example.com/api/v2/developer/authenticate/saml/acs`
-    - If not using a custom domain: `https://abc123456789.us.kongportals.com/api/v2/developer/authenticate/saml/acs`
+    - If you're using a custom domain: `https://www.example.com/api/v2/developer/authenticate/saml/acs`
+    - If you aren't using a custom domain: `https://abc123456789.us.kongportals.com/api/v2/developer/authenticate/saml/acs`
   - To automatically initiate the login flow when linking developers to the Dev Portal, use the dedicated path:
-    - If using a custom domain: `https://www.example.com/login/sso`
-    - If not using a custom domain: `https://abc123456789.us.kongportals.com/login/sso`
+    - If you're using a custom domain: `https://www.example.com/login/sso`
+    - If you aren't using a custom domain: `https://abc123456789.us.kongportals.com/login/sso`
 - **Other Requestable SSO URLs** (typically found in Advanced settings) for the Konnect Portal Editor:
   - `https://abc123456789.portal-preview.us.api.konghq.com/api/v2/developer/authenticate/saml/acs`

--- a/app/dev-portal/sso.md
+++ b/app/dev-portal/sso.md
@@ -80,21 +80,27 @@ The following is an example Dev Portal SSO configuration. For the example, we wi
 ### OIDC-specific settings
 
 If you're using OIDC for SSO, you'd configure your settings like the following:
-- **Single Sign On URL (SSO URL)**: `https://www.example.com/login/sso`
-  - Also sometimes referred to as **Initiate login URI**, use to automatically initiate the SSO login flow.
+- **Single Sign On URL (SSO URL)**: Also sometimes referred to as **Initiate login URI**, use to automatically initiate the SSO login flow.
+  - If using a custom domain: `https://www.example.com/login/sso`
+  - If not using a custom domain: `https://abc123456789.us.kongportals.com/login/sso`
 - **Sign-in redirect URIs**:
   - `https://www.example.com/login`
+  - `https://abc123456789.us.kongportals.com/login`
   - `https://abc123456789.portal-preview.us.api.konghq.com/login`
 
 - **Sign-out redirect URIs**:
   - `https://www.example.com/login`
+  - `https://abc123456789.us.kongportals.com/login`
   - `https://abc123456789.portal-preview.us.api.konghq.com/login`
 
 ### SAML-specific settings:
 
 If you're using SAML for SSO, you'd configure your settings like the following:
-- **Single Sign On URL (SSO URL)**: `https://www.example.com/api/v2/developer/authenticate/saml/acs`
-  - Also sometimes referred to as **Initiate login URI**, used to automatically initiate the SSO login flow.
-  - To automatically initiate the login flow when linking developers to the Dev Portal, use the dedicated path: `https://www.example.com/login/sso`
-- **Other Requestable SSO URLs** (typically found in Advanced settings):
+- **Single Sign On URL (SSO URL)**: Also sometimes referred to as **Initiate login URI**, used to automatically initiate the SSO login flow.
+    - If using a custom domain: `https://www.example.com/api/v2/developer/authenticate/saml/acs`
+    - If not using a custom domain: `https://abc123456789.us.kongportals.com/api/v2/developer/authenticate/saml/acs`
+  - To automatically initiate the login flow when linking developers to the Dev Portal, use the dedicated path:
+    - If using a custom domain: `https://www.example.com/login/sso`
+    - If not using a custom domain: `https://abc123456789.us.kongportals.com/login/sso`
+- **Other Requestable SSO URLs** (typically found in Advanced settings) for the Konnect Portal Editor:
   - `https://abc123456789.portal-preview.us.api.konghq.com/api/v2/developer/authenticate/saml/acs`


### PR DESCRIPTION
## Description

Document Portal SSO examples for both custom domains as well as the default domain. Customers were confused by not including default domain examples (e.g. when they are testing out changes in a staging portal)

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
