### PR TITLE
Fix: Konnect Gateway compatibility table

### DIFF
--- a/app/_data/support/gateway.yml
+++ b/app/_data/support/gateway.yml
@@ -2,7 +2,7 @@
   konnect: true
   beginning: "3.11.0.0"
   release_date: "2025-07-03"
-  eol: "2028-03-31"
+  eol: "2026-09-30"
 - release: "3.10"
   lts: true
   konnect: true

--- a/app/_data/support/gateway.yml
+++ b/app/_data/support/gateway.yml
@@ -1,3 +1,8 @@
+- release: "3.11"
+  konnect: true
+  beginning: "3.11.0.0"
+  release_date: "2025-07-03"
+  eol: "2028-03-31"
 - release: "3.10"
   lts: true
   konnect: true

--- a/app/_data/support/gateway.yml
+++ b/app/_data/support/gateway.yml
@@ -2,7 +2,7 @@
   konnect: true
   beginning: "3.11.0.0"
   release_date: "2025-07-03"
-  eol: "2026-09-30"
+  eol: "2026-07-03"
 - release: "3.10"
   lts: true
   konnect: true


### PR DESCRIPTION
3.11 not appearing in compat table