### PR TITLE
fix: schema tables rendering

### DIFF
--- a/app/custom-plugins/schema.lua.md
+++ b/app/custom-plugins/schema.lua.md
@@ -77,7 +77,7 @@ columns:
     key: type
   - title: Description
     key: description
-columns:
+rows:
   - name: "`name`"
     type: "`string`"
     description: |
@@ -101,7 +101,7 @@ columns:
     key: type
   - title: Description
     key: description
-columns:
+rows:
   - name: "`id`"
     type: "`string`"
     description: Auto-generated plugin ID.
@@ -155,7 +155,7 @@ return {
       config = {
         type = "record",
         fields = {
-          -- Describe your plugin's configuration's schema here.        
+          -- Describe your plugin's configuration's schema here.
         },
       },
     },
@@ -275,7 +275,7 @@ rows:
   - rule: "`contains`"
     description: Checks that the input array contains the given value.
   - rule: "`is_regex`"
-    description: Checks that the input string is a valid regex pattern.  
+    description: Checks that the input string is a valid regex pattern.
   - rule: "`custom_validator`"
     description: A custom validation function written in Lua.
 {% endtable %}
@@ -414,7 +414,7 @@ return {
                       65534
                     },
                   },
-                },  
+                },
               },
             },
           },


### PR DESCRIPTION
## Description

Fixes incorrect rendering of schema tables:

<img width="1063" height="316" alt="Screenshot 2025-08-06 at 14 11 33" src="https://github.com/user-attachments/assets/bc23da7f-fbef-476c-a4e8-05d65af02ac5" />


## Preview Links

https://deploy-preview-2480--kongdeveloper.netlify.app/custom-plugins/schema.lua/#schema-lua-specification

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
