### PR TITLE
Fix: Add caution info to Insomnia docs 

### DIFF
--- a/app/insomnia/accounts.md
+++ b/app/insomnia/accounts.md
@@ -85,6 +85,9 @@ faqs:
       Some banks may show multiple charge attempts due to currency differences. 
       However, our payment provider (Stripe) only processes a single charge per billing cycle. 
       If you have concerns, please contact us through the [support page](https://insomnia.rest/support).
+      Do not include sensitive data in any requests, responses, or logs you share with support unless you send it through a secure channel.
+
+
   - q: Why am I not getting my Insomnia login code email?
     a: |
       If sender verification callout is enabled on your mail server, it may be blocking Insomnia emails. To avoid this issue, we recommend disabling sender verification for your mail server.

--- a/app/insomnia/allowlist.md
+++ b/app/insomnia/allowlist.md
@@ -68,7 +68,7 @@ rows:
 {% endtable %}
 
 
-Allowlisting these domains ensures uninterrupted access to all functionalities of Insomnia, including updates, documentation, and necessary backend services. Should you experience issues post-allowlisting, we recommend seeking assistance from your IT support or reaching out to Insomnia's customer service at `<support@insomnia.rest> ` or 
+Allowlisting these domains ensures uninterrupted access to all functionalities of Insomnia, including updates, documentation, and necessary backend services. Should you experience issues post-allowlisting, we recommend seeking assistance from your IT support or reaching out to Insomnia's customer service at `support@insomnia.rest` or 
  the [Kong support website](https://support.konghq.com/support/s/).
 Do not include sensitive data in any requests, responses, or logs you share with support unless you send it through a secure channel.
 

--- a/app/insomnia/allowlist.md
+++ b/app/insomnia/allowlist.md
@@ -20,7 +20,7 @@ related_resources:
 faqs:
   - q: I'm experiencing issues after allowlisting Insomnia domains. Who can I reach out to for help?
     a: |
-        Reach out to your IT support or reach out to Insomnia’s customer service at support@insomnia.rest or [https://support.konghq.com/support/s/](https://support.konghq.com/support/s/).
+        Reach out to your IT support or reach out to Insomnia’s customer service at support@insomnia.rest or [https://support.konghq.com/support/s/](https://support.konghq.com/support/s/). Do not include sensitive data in any requests, responses, or logs you share with support unless you send it through a secure channel.
 
 ---
 
@@ -70,6 +70,7 @@ rows:
 
 Allowlisting these domains ensures uninterrupted access to all functionalities of Insomnia, including updates, documentation, and necessary backend services. Should you experience issues post-allowlisting, we recommend seeking assistance from your IT support or reaching out to Insomnia's customer service at `<support@insomnia.rest> ` or 
  the [Kong support website](https://support.konghq.com/support/s/).
+Do not include sensitive data in any requests, responses, or logs you share with support unless you send it through a secure channel.
 
 ## Proxy
 


### PR DESCRIPTION
## Description

Out of [some security/compliance work](https://konghq.atlassian.net/browse/INS-974), we realized there's no warning to make sure that clients should redact any sensitive data before sending us logs or anything else. We're putting this warning in a few spots, training support, etc... but can we make sure that anywhere in the docs we mention reaching out to support that we call out to not include any sensitive data in any requests/responses/logs unless shared securely?

Fixes https://github.com/Kong/developer.konghq.com/issues/2318


## Preview Links


## Checklist 


