### PR TITLE
docs(degraphql-plugin): improve degraphql plugin documentation

### DIFF
--- a/app/_kong_plugins/degraphql/index.md
+++ b/app/_kong_plugins/degraphql/index.md
@@ -88,8 +88,9 @@ For a complete tutorial, see [Map URIs into GraphQL queries with DeGraphQL](/how
 The following sections define some common patterns for DeGraphQL routes.
 
 {:.info}
-> Don’t include the GraphQL server path prefix in the `uri` configuration parameter (`/graphql` by default). 
+> - Don’t include the GraphQL server path prefix in the `uri` configuration parameter (`/graphql` by default). 
 Only include the custom portion of the path that you want to configure. For example: `uri: /my-path`, but not `uri: /graphql/my-path`.
+> - The content in the `query` field should follow [the GraphQL query syntax](https://graphql.org/learn/queries/).
 
 ### GraphQL query variables on URIs
 

--- a/app/_kong_plugins/degraphql/index.md
+++ b/app/_kong_plugins/degraphql/index.md
@@ -104,7 +104,7 @@ custom_entities:
     fields:
       service:
         name: "github"
-      uri: /me
+      uri: /:owner/:name
       query: |-
         query ($owner:String! $name:String!){
                         repository(owner:$owner, name:$name) {
@@ -135,7 +135,7 @@ custom_entities:
     fields:
       service:
         name: "github"
-      uri: /me
+      uri: /repo
       query: |-
         query ($owner:String! $name:String!){
                   repository(owner:$owner, name:$name) {


### PR DESCRIPTION
## Description

improve degraphql plugin document and fix the errors in the degraphql route examples

## Preview Links


## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
