### PR TITLE
fix: add variable to kong gateway guick start version number

### DIFF
--- a/app/_includes/how-tos/steps/ping-gateway.md
+++ b/app/_includes/how-tos/steps/ping-gateway.md
@@ -10,7 +10,7 @@ If everything is running, then you should get the following response:
 
 ```sh
 Successfully connected to Kong!
-Kong version: 3.9.0.0
+Kong version: {{site.data.gateway_latest.ee-version}}
 ```
 {: data-deployment-topology="on-prem" .no-copy-code}
 


### PR DESCRIPTION
## Description
Added a release variable to always show the most up to date version
Fixes #issue

## Preview Links
1. Check that kong gateway... http://localhost:8888/gateway/get-started/#check-that-kong-gateway-is-running

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
