### PR TITLE
fix(mesh-manager): Improve links on landing/index pages from feedback

### DIFF
--- a/app/_data/kuma_to_mesh/config.yaml
+++ b/app/_data/kuma_to_mesh/config.yaml
@@ -800,4 +800,16 @@ pages:
         url: /mesh/access-audit/
     tags:
       - security
+  -
+    path: app/_src/quickstart/kubernetes-demo.md
+    title: 'Deploy Kong Mesh on Kubernetes'
+    description: 'Start learning how {{site.mesh_product_name}} works by running and securing a simple demo application that consists of two services.'
+    url: '/mesh/kubernetes/'
+    related_resources:
+      - text: Get started with Red Hat OpenShift
+        url: /mesh/openshift-quickstart/
+      - text: Deploy Kong Mesh on Universal
+        url: /mesh/universal/
+    tags:
+      - get-started
 

--- a/app/_indices/mesh.yaml
+++ b/app/_indices/mesh.yaml
@@ -25,7 +25,7 @@ sections:
       - path: /mesh/ubi-images/
       - path: /mesh/deploy-with-terraform-konnect/
       - path: /mesh/import-konnect-deployment-to-terraform/
-      - title: Mesh Manager
+      - title: Mesh Manager with Konnect
         description: Manage service meshes and Control Planes in Konnect.
         url: /mesh-manager/
 

--- a/app/_landing_pages/mesh-manager.yaml
+++ b/app/_landing_pages/mesh-manager.yaml
@@ -27,9 +27,13 @@ rows:
                     using the {{site.konnect_short_name}} platform.
 
                     **Key benefits of Mesh Manager:**
-                    - **Kong-managed Global Control Plane**: Kong handles the management of your Global Control Plane.
-                    - **Centralized view**: See all your Services, Control Planes, and Data Plane Proxies in one place.
-                    - **Multi-zone support**: Deploy across Kubernetes, Universal environments, and multiple clouds.
+                    - **Kong-managed Global control plane**: Kong handles the management of your Global control plane.
+                    - **Centralized view**: See all your Services, control planes, and data plane proxies in one place.
+                    - **Multi-zone support**: Deploy across Kubernetes, Universal environments, and multiple clouds. 
+          - type: button
+            config:
+              text: "Create a service mesh in {{site.konnect_short_name}}"
+              url: https://cloud.konghq.com/mesh-manager/create-control-plane
       - blocks:
           - type: image
             config:
@@ -47,9 +51,9 @@ rows:
                   text: |
                     Mesh Manager follows a hierarchical control plane model to manage service mesh deployments across zones.
 
-                    - **Global Control Plane**: Stores configuration and policies for all meshes.
-                    - **Zone Control Planes**: Manage mesh networking and service traffic in their respective zones.
-                    - **Services**: Connect to the zone Control Plane for inbound and outbound traffic control.
+                    - **Global control plane**: Stores configuration and policies for all meshes.
+                    - **Zone control planes**: Manage mesh networking and service traffic in their respective zones.
+                    - **Services**: Connect to the zone control plane for inbound and outbound traffic control.
 
       - blocks:
           - type: mermaid
@@ -57,10 +61,10 @@ rows:
               diagram: |
                 graph TD
                   subgraph Konnect
-                      CP1[Global Control Plane]
+                      CP1[Global control plane]
                   end
-                  subgraph Kong Mesh US Control Plane
-                      CP2[Control Plane]
+                  subgraph Kong Mesh US control plane
+                      CP2[control plane]
                   end
 
                   S1[Service A]
@@ -78,12 +82,56 @@ rows:
       - blocks:
           - type: card
             config:
-              title: Create a service mesh
+              title: Configure a Mesh global control plane with the Kubernetes demo app
               description: |
-                Set up Kong Mesh in {{site.konnect_short_name}}
+                Set up a global control plane in {{site.konnect_short_name}}, add a zone, and deploy the Kubernetes demo app to test your {{site.mesh_product_name}} mesh.
+              icon: /assets/icons/graduation.svg
+              cta:
+                url: /mesh-manager/service-mesh/
+      - blocks:
+          - type: card
+            config:
+              title: Deploy Kong Mesh using Terraform and Konnect
+              description: |
+                Learn how to provision a Global control plane, Mesh, and Kubernetes zone for {{site.mesh_product_name}} using Terraform and {{site.konnect_short_name}}.
+              icon: /assets/icons/terraform.svg
+              cta:
+                url: /mesh/deploy-with-terraform-konnect/
+      - blocks:
+          - type: card
+            config:
+              title: Import an existing Konnect Kong Mesh deployment into Terraform
+              description: |
+                Learn how to import an existing {{site.konnect_short_name}} {{site.mesh_product_name}} deployment into Terraform.
+              icon: /assets/icons/download.svg
+              cta:
+                url: /mesh/import-konnect-deployment-to-terraform/
+  - column_count: 3
+    columns:
+      - blocks:
+          - type: card
+            config:
+              title: Migrate a self-managed zone control plane
+              description: |
+                Move your existing {{site.mesh_product_name}} zone control planes from a self-managed global control plane to a managed global control plane in {{site.konnect_short_name}}.
+              icon: /assets/icons/migrate.svg
+              cta:
+                url: /mesh-manager/migrate-zone/
+      - blocks:
+          - type: card
+            config:
+              title: Federate a zone control plane
+              description: |
+                Migrate a single-zone {{site.mesh_product_name}} control plane to {{site.konnect_short_name}} and enable multi-zone service mesh federation.
               icon: /assets/icons/mesh.svg
               cta:
-                url: https://cloud.konghq.com/mesh-manager/create-control-plane
+                url: /mesh-manager/federate-zone/
+  
+
+  - header:
+      type: h2
+      text: "Learn more"
+    columns:
       - blocks:
           - type: card
             config:

--- a/app/assets/icons/migrate.svg
+++ b/app/assets/icons/migrate.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="none">
+<g fill="#000000">
+<path d="M9.22 3.72a.75.75 0 011.06 0l3.5 3.5a.75.75 0 010 1.06l-3.5 3.5a.75.75 0 11-1.06-1.06l2.97-2.97-2.97-2.97a.75.75 0 010-1.06z"/>
+<path d="M5.22 3.72a.75.75 0 011.06 0l3.5 3.5a.75.75 0 010 1.06l-3.5 3.5a.75.75 0 01-1.06-1.06L7.44 8.5H2A.75.75 0 012 7h5.44L5.22 4.78a.75.75 0 010-1.06z"/>
+</g>
+</svg>

--- a/app/index.html
+++ b/app/index.html
@@ -110,7 +110,7 @@ edit_and_issue_links: false
                 </div>
                 <div class="flex flex-col w-full text-primary text-sm">
                     <a class="flex justify-between py-3 border-b border-primary/5  hover:bg-hover-component/100 hover:px-6 hover:-mx-6 hover:no-underline" href="/mesh-manager/">Overview <span class="text-terciary">&rarr;</span></a>
-                    <a class="flex justify-between py-3  hover:bg-hover-component/100 hover:px-6 hover:-mx-6 hover:no-underline" href="/index/mesh/">All documentation<span class="text-terciary">&rarr;</span></a>
+                    <a class="flex justify-between py-3  hover:bg-hover-component/100 hover:px-6 hover:-mx-6 hover:no-underline" href="/search/?tags=mesh-manager">All documentation<span class="text-terciary">&rarr;</span></a>
                 </div>
             </div>
             <div class="card flex-col gap-5 p-6 pb-4">

--- a/app/mesh-manager/federate-zone.md
+++ b/app/mesh-manager/federate-zone.md
@@ -9,6 +9,9 @@ products:
   - mesh
 works_on:
   - konnect
+tags:
+  - mesh-manager
+  - service-mesh
 ---
 
 If you already have a zone Control Plane that's not connected to any global Control Plane, you can federate it to {{site.konnect_short_name}} using [Mesh Manager](/mesh-manager/).

--- a/app/mesh-manager/migrate-zone.md
+++ b/app/mesh-manager/migrate-zone.md
@@ -7,6 +7,9 @@ breadcrumbs:
   - /mesh-manager/
 products:
   - mesh
+tags:
+  - mesh-manager
+  - service-mesh
 ---
 
 If you already have zone Control Planes in {{site.mesh_product_name}}, you can migrate them to {{site.konnect_short_name}} using [Mesh Manager](/mesh-manager/).

--- a/app/mesh-manager/service-mesh.md
+++ b/app/mesh-manager/service-mesh.md
@@ -9,6 +9,9 @@ products:
   - mesh
 works_on:
   - konnect
+tags:
+  - mesh-manager
+  - service-mesh
 ---
 
 Using Mesh Manager, you can create global Control Planes to manage your {{site.mesh_product_name}} meshes. This guide explains how to configure a global Control Plane and then install the Kubernetes demo app to test out the {{site.mesh_product_name}} interface in {{site.konnect_short_name}}.

--- a/app/mesh-manager/service-mesh.md
+++ b/app/mesh-manager/service-mesh.md
@@ -64,8 +64,6 @@ To see these services:
 1. Open **Mesh Manager**, select `example-cp`, and click **Meshes**.
 1. Click **Default**, then go to the **Services** tab.
 
-For more, see [Explore {{site.mesh_product_name}} with the Kubernetes demo app](/mesh/kubernetes/).
-
 ## Configure `kumactl` to connect to the global Control Plane
 
 {:.info}

--- a/app/mesh/deploy-kong-mesh-using-terraform-and-konnect.md
+++ b/app/mesh/deploy-kong-mesh-using-terraform-and-konnect.md
@@ -16,6 +16,7 @@ tags:
   - universal-mode
   - kubernetes
   - zones
+  - mesh-manager
 permalink: /mesh/deploy-with-terraform-konnect/
 related_resources:
   - text: "Terraform provider (GA)"

--- a/app/mesh/import-existing-konnect-kong-mesh-deployment-to-terraform.md
+++ b/app/mesh/import-existing-konnect-kong-mesh-deployment-to-terraform.md
@@ -14,6 +14,7 @@ tags:
   - terraform
   - automation
   - import
+  - mesh-manager
 permalink: /mesh/import-konnect-deployment-to-terraform/
 related_resources:
   - text: "Deploy {{site.mesh_product_name}} using Terraform and {{site.konnect_short_name}}"


### PR DESCRIPTION
## Description

Fixes #1980 

## Preview Links
- https://deploy-preview-2549--kongdeveloper.netlify.app/#:~:text=%E2%86%92-,Mesh%20Manager,-Create%2C%20manage%2C%20and (check link for All documentation on the Mesh manager tile)
- https://deploy-preview-2549--kongdeveloper.netlify.app/mesh-manager/#get-started (added more links for get started tiles)
- https://deploy-preview-2549--kongdeveloper.netlify.app/index/mesh/#install-configure (changed name here so it's clearer that this is with Konnect)
- https://deploy-preview-2549--kongdeveloper.netlify.app/mesh/kubernetes/ (If I did it correctly, this page should now be fixed as it was added to the submodule file, was previously missing)

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
