### PR TITLE
Feat: CSRE-4868 Adding AWS Privatelink region ap-east-1 and us-east-1

### DIFF
--- a/app/gateway-manager/aws-private-link.md
+++ b/app/gateway-manager/aws-private-link.md
@@ -32,11 +32,13 @@ You can establish a private connection between {{site.konnect_short_name}} and y
 You can configure this instead of AWS Transit Gateways to secure your connection.
 
 PrivateLink support is currently available in the following AWS regions:
+* `us-east-1`
 * `us-east-2`
 * `us-west-2`
 * `eu-central-1`
 * `eu-west-1`
 * `eu-west-2`
+* `ap-east-1`
 * `ap-southeast-1`
 * `ap-southeast-2`
 


### PR DESCRIPTION
## Description

Fixes [CSRE-4868](https://konghq.atlassian.net/browse/CSRE-4868)

## Preview Links
https://deploy-preview-2582--kongdeveloper.netlify.app/gateway-manager/aws-private-link/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).


[CSRE-4868]: https://konghq.atlassian.net/browse/CSRE-4868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ