### PR TITLE
fix(service-catalog): Add required Datadog scopes

### DIFF
--- a/app/_how-tos/install-and-map-datadog-resources.md
+++ b/app/_how-tos/install-and-map-datadog-resources.md
@@ -28,7 +28,7 @@ prereqs:
       content: |
         You'll need [Datadog API and application keys](https://docs.datadoghq.com/account_management/api-app-keys/) and must select your Datadog region to authenticate the integration. Your Datadog region must be in a format similar to `US_5`.
 
-        Your Datadog instance API key must either have no scopes or the following scopes:
+        Your Datadog instance application key must either have no scopes or the following [scopes](https://docs.datadoghq.com/api/latest/scopes/):
         * `monitors_read`
         * `dashboards_read`
         * `create_webhooks`

--- a/app/service-catalog/integrations/datadog.md
+++ b/app/service-catalog/integrations/datadog.md
@@ -36,7 +36,7 @@ For a complete tutorial using the {{site.konnect_short_name}} API, see [Import a
 
 ## Prerequisites
 
-Your Datadog instance API key must either have no scopes or the following scopes:
+Your Datadog instance application key must either have no scopes or the following [scopes](https://docs.datadoghq.com/api/latest/scopes/):
 * `monitors_read`
 * `dashboards_read`
 * `create_webhooks`


### PR DESCRIPTION
## Description

Fixes https://kongstrong.slack.com/archives/C068AHKGSPQ/p1754941492336349

## Preview Links
- https://deploy-preview-2585--kongdeveloper.netlify.app/service-catalog/integrations/datadog/#prerequisites
- https://deploy-preview-2585--kongdeveloper.netlify.app/how-to/install-and-map-datadog-resources/#datadog-api-access

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
