### PR TITLE
feat(service-catalog): Terraform support for integrations and services

### DIFF
--- a/app/_indices/service-catalog.yaml
+++ b/app/_indices/service-catalog.yaml
@@ -5,6 +5,7 @@ sections:
       - path: /service-catalog/
       - path: /service-catalog/scorecards/
       - path: /service-catalog/integrations/
+      - path: /service-catalog/services/
   - title: Integrations
     items:
       - path: /service-catalog/integrations/**/*

--- a/app/_landing_pages/service-catalog.yaml
+++ b/app/_landing_pages/service-catalog.yaml
@@ -45,7 +45,7 @@ rows:
                 Connect external tools like GitHub, PagerDuty, and CI/CD pipelines to map services, dependencies, and metadata.
               icon: /assets/icons/plug.svg
               cta:
-                text: Learn more
+                text: See all integrations
                 url: /service-catalog/integrations/
       - blocks:
           - type: card
@@ -55,7 +55,7 @@ rows:
                 Monitor compliance, security, and best practices across services using automated scorecards.
               icon: /assets/icons/data-object.svg
               cta:
-                text: Learn more
+                text: Learn about scorecards
                 url: /service-catalog/scorecards/
       - blocks:
           - type: card
@@ -65,7 +65,7 @@ rows:
                 Map resources to a Service Catalog service.
               icon: /assets/icons/linked-services.svg
               cta:
-                text: Learn more
+                text: Learn about Service Catalog services
                 url: /service-catalog/services/
   - header:
       type: h2

--- a/app/_landing_pages/service-catalog.yaml
+++ b/app/_landing_pages/service-catalog.yaml
@@ -45,7 +45,7 @@ rows:
                 Connect external tools like GitHub, PagerDuty, and CI/CD pipelines to map services, dependencies, and metadata.
               icon: /assets/icons/plug.svg
               cta:
-                text: View integrations
+                text: Learn more
                 url: /service-catalog/integrations/
       - blocks:
           - type: card
@@ -55,8 +55,18 @@ rows:
                 Monitor compliance, security, and best practices across services using automated scorecards.
               icon: /assets/icons/data-object.svg
               cta:
-                text: View scorecards
+                text: Learn more
                 url: /service-catalog/scorecards/
+      - blocks:
+          - type: card
+            config:
+              title: Service Catalog services
+              description: |
+                Map integration resources to a service.
+              icon: /assets/icons/linked-services.svg
+              cta:
+                text: Learn more
+                url: /service-catalog/services/
   - header:
       type: h2
       text: "Frequently asked questions"

--- a/app/_landing_pages/service-catalog.yaml
+++ b/app/_landing_pages/service-catalog.yaml
@@ -62,7 +62,7 @@ rows:
             config:
               title: Service Catalog services
               description: |
-                Map resources to a service.
+                Map resources to a Service Catalog service.
               icon: /assets/icons/linked-services.svg
               cta:
                 text: Learn more

--- a/app/_landing_pages/service-catalog.yaml
+++ b/app/_landing_pages/service-catalog.yaml
@@ -62,7 +62,7 @@ rows:
             config:
               title: Service Catalog services
               description: |
-                Map integration resources to a service.
+                Map resources to a service.
               icon: /assets/icons/linked-services.svg
               cta:
                 text: Learn more

--- a/app/service-catalog/integrations/datadog.md
+++ b/app/service-catalog/integrations/datadog.md
@@ -36,10 +36,49 @@ For a complete tutorial using the {{site.konnect_short_name}} API, see [Import a
 
 ## Authenticate the Datadog integration
 
+{% navtabs "datadog-integration" %}
+{% navtab "UI" %}
 1. From the **Service Catalog** in {{site.konnect_short_name}}, select **[Integrations](https://cloud.konghq.com/service-catalog/integrations)**. 
 1. Select **Add Datadog Instance**.
 1. Select your Datadog region and enter your [Datadog API and application keys](https://docs.datadoghq.com/account_management/api-app-keys/). 
 1. Select **Authorize**. 
+{% endnavtab %}
+{% navtab "Terraform" %}
+Use the [`konnect_integration_instance`](https://github.com/Kong/terraform-provider-konnect/blob/main/examples/resources/integration_instance.tf) and [`konnect_integration_instance_auth_credential`](https://github.com/Kong/terraform-provider-konnect/blob/main/examples/resources/integration_instance_auth_credential.tf) resources:
+```hcl
+echo '
+resource "konnect_integration_instance" "my_integrationinstance" {
+  name         = "datadog"
+  display_name = "Datadog"
+
+  integration_name = "datadog"
+  config = jsonencode({
+    datadog_region       = "'$DATADOG_REGION'"
+    datadog_webhook_name = "konnect-service-catalog"
+  })
+}
+
+resource "konnect_integration_instance_auth_credential" "my_integrationinstanceauthcredential" {
+  integration_instance_id = konnect_integration_instance.my_integrationinstance.id
+  multi_key_auth = {
+    config = {
+      "headers": [
+        {
+          "name": "DD-API-KEY",
+          "key": "'$DATADOG_API_KEY'"
+        },
+        {
+          "name": "DD-APPLICATION-KEY",
+          "key": "'$DATADOG_APPLICATION_KEY'"
+        }
+      ]
+    }
+  }
+}
+' >> main.tf
+```
+{% endnavtab %}
+{% endnavtabs %}
 
 ## Resources
 

--- a/app/service-catalog/integrations/swaggerhub.md
+++ b/app/service-catalog/integrations/swaggerhub.md
@@ -39,9 +39,42 @@ You need a [SwaggerHub API key](https://swagger.io/docs/specification/v3_0/authe
 
 ## Authenticate the SwaggerHub integration
 
+{% navtabs "swaggerhub-integration" %}
+{% navtab "UI" %}
 1. From the **Service Catalog** in {{site.konnect_short_name}}, select **[Integrations](https://cloud.konghq.com/service-catalog/integrations)**. 
 2. Select **Add SwaggerHub Instance**.
 3. Add your Swaggerhub API key and name the instance.
+{% endnavtab %}
+{% navtab "Terraform" %}
+Use the [`konnect_integration_instance`](https://github.com/Kong/terraform-provider-konnect/blob/main/examples/resources/integration_instance.tf) and [`konnect_integration_instance_auth_credential`](https://github.com/Kong/terraform-provider-konnect/blob/main/examples/resources/integration_instance_auth_credential.tf) resources:
+```hcl
+echo '
+resource "konnect_integration_instance" "my_integrationinstance" {
+  name             = "swaggerhub"
+  display_name     = "SwaggerHub"
+  integration_name = "swaggerhub"
+
+  config = jsonencode({})
+}
+
+resource "konnect_integration_instance_auth_credential" "my_integrationinstanceauthcredential" {
+  integration_instance_id = konnect_integration_instance.my_integrationinstance.id
+
+  multi_key_auth = {
+    config = {
+      headers = [
+        {
+          name = "authorization"
+          key  = "$SWAGGERHUB_API_KEY"
+        }
+      ]
+    }
+  }
+}
+' >> main.tf
+```
+{% endnavtab %}
+{% endnavtabs %}
 
 This will take you to SwaggerHub, where you can use your SwaggerHub API key to grant {{site.konnect_short_name}} access to your account.
 

--- a/app/service-catalog/integrations/traceable.md
+++ b/app/service-catalog/integrations/traceable.md
@@ -37,9 +37,42 @@ For a complete tutorial using the {{site.konnect_short_name}} API, see [Import a
 
 ## Authenticate the Traceable integration
 
+{% navtabs "traceable-integration" %}
+{% navtab "UI" %}
 1. From the **Service Catalog** in {{site.konnect_short_name}}, select **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
 2. Select **Add Traceable Instance**.
 3. Configure the instance, add authorization and name the instance. 
+{% endnavtab %}
+{% navtab "Terraform" %}
+Use the [`konnect_integration_instance`](https://github.com/Kong/terraform-provider-konnect/blob/main/examples/resources/integration_instance.tf) and [`konnect_integration_instance_auth_credential`](https://github.com/Kong/terraform-provider-konnect/blob/main/examples/resources/integration_instance_auth_credential.tf) resources:
+```hcl
+echo '
+resource "konnect_integration_instance" "my_integrationinstance" {
+  name         = "traceable"
+  display_name = "Traceable"
+
+  integration_name = "traceable"
+  config = jsonencode({
+    include_inactive = false
+  })
+}
+resource "konnect_integration_instance_auth_credential" "my_integrationinstanceauthcredential" {
+  integration_instance_id = konnect_integration_instance.my_integrationinstance.id
+  multi_key_auth = {
+    config = {
+      headers = [
+        {
+          name = "authorization"
+          key  = "$TRACEABLE_API_KEY"
+        }
+      ]
+    }
+  }
+}
+' >> main.tf
+```
+{% endnavtab %}
+{% endnavtabs %}
 
 ## Resources
 

--- a/app/service-catalog/scorecards.md
+++ b/app/service-catalog/scorecards.md
@@ -17,6 +17,8 @@ breadcrumbs:
 related_resources:
   - text: "Service Catalog"
     url: /service-catalog/
+  - text: Service Catalog services
+    url: /service-catalog/services/
   - text: Traceable integration
     url: /service-catalog/integrations/traceable/
   - text: GitHub integration

--- a/app/service-catalog/services.md
+++ b/app/service-catalog/services.md
@@ -1,0 +1,121 @@
+---
+title: "Service Catalog services"
+content_type: reference
+layout: reference
+
+products:
+    - gateway
+    - service-catalog
+works_on:
+  - konnect
+
+description: Learn about services in Service Catalog and how to configure them.
+
+breadcrumbs:
+  - /service-catalog/
+
+related_resources:
+  - text: "Service Catalog"
+    url: /service-catalog/
+  - text: Scorecards
+    url: /service-catalog/scorecards/
+  - text: Traceable integration
+    url: /service-catalog/integrations/traceable/
+  - text: GitHub integration
+    url: /service-catalog/integrations/github/
+  - text: GitLab integration
+    url: /service-catalog/integrations/gitlab/
+  - text: SwaggerHub integration
+    url: /service-catalog/integrations/swaggerhub/
+  - text: Datadog integration
+    url: /service-catalog/integrations/datadog/
+  - text: PagerDuty integration
+    url: /service-catalog/integrations/pagerduty/
+---
+
+A Service Catalog service can be thought of as a collection of one or more resources because you can associate resources from one or more integrations with them.
+
+A Service Catalog service represents the following:
+* A unit of software that is typically owned by a single team
+* Exposes one or more APIs 
+* May be dependent on other Service Catalog services (as either upstream or downstream)  
+
+Service Catalog services allow you to gain visibility into all resources in your organization, including what teams or people own them. 
+
+To create a Service Catalog service, do one of the following:
+
+{% navtabs "service" %}
+{% navtab "UI" %}
+In the {{site.konnect_short_name}} UI, click **Service Catalog** > **Services** in the sidebar. Click **New service** and configure the details about your service. Then, you can map a service to an integration's resource by clicking on the service and then select "Map resources" from the **Action** dropdown menu.
+{% endnavtab %}
+{% navtab "API" %}
+1. Create a service by sending a POST request to the [`/catalog-services` endpoint](/api/konnect/service-catalog/v1/#/operations/create-catalog-service):
+<!--vale off-->
+{% capture service %}
+{% konnect_api_request %}
+url: /v1/catalog-services
+method: POST
+status_code: 201
+region: us
+body:
+  name: billing
+  display_name: Billing Service
+{% endkonnect_api_request %}
+{% endcapture %}
+
+{{ service | indent: 3 }}
+<!--vale on-->
+
+1. Map an integration resource to the service by sending a POST request to the [`/resource-mappings` endpoint](/api/konnect/service-catalog/v1/#/operations/create-resource-mapping):
+<!--vale off-->
+{% capture resource %}
+{% konnect_api_request %}
+url: /v1/resource-mappings
+method: POST
+status_code: 201
+region: us
+body:
+  service: billing
+  resource: $INTEGRATION_RESOURCE_ID
+{% endkonnect_api_request %}
+{% endcapture %}
+
+{{ resource | indent: 3 }}
+<!--vale on-->
+{% endnavtab %}
+{% navtab "Terraform" %}
+Use the [`konnect_catalog_service`](https://github.com/Kong/terraform-provider-konnect/blob/main/examples/resources/catalog_service.tf) resource:
+```hcl
+echo '
+resource "konnect_catalog_service" "my_catalogservice" {
+  name         = "billing"
+  display_name = "Billing Service"
+  description  = "Billing Service for the app"
+  custom_fields = jsonencode({
+    "cost_center" : "eng",
+    "owner" : "Amal",
+    "product_manager" : "Ariel",
+    "dashboard" : {
+      "name" : "Example Dashboard",
+      "link" : "https://app.example.com/dashboard/123",
+    },
+    "git_repo" : {
+      "name" : "example-repo",
+      "link" : "https://github.com/example/repo",
+    },
+    "jira_project" : null,
+    "slack_channel" : {
+      "name" : "test-channel",
+      "link" : "https://example.slack.com/archives/C098WKDB020"
+    },
+  })
+
+  labels = {
+    key = "value"
+  }
+}
+' >> main.tf
+```
+{% endnavtab %}
+{% endnavtabs %}
+

--- a/app/service-catalog/services.md
+++ b/app/service-catalog/services.md
@@ -31,9 +31,9 @@ related_resources:
   - text: PagerDuty integration
     url: /service-catalog/integrations/pagerduty/
 faqs:
-  - q: What's the different between a Gateway Service and a Service Catalog service?
+  - q: What's the difference between a Gateway Service and a Service Catalog service?
     a: |
-      A [Gateway Service](/gateway/entities/service/) represent the upstream services in your system and is the business logic component of your system that's responsible for responding to requests. A Service Catalog service is a collection of one or more resources from Service Catalog integrations.
+      A [Gateway Service](/gateway/entities/service/) is a {{site.base_gateway}} entity that represents an upstream service in your system and is the business logic component that's responsible for responding to requests. A Service Catalog service is a collection of one or more resources from Service Catalog integrations.
 ---
 
 A Service Catalog service is a collection of one or more resources from integrations.

--- a/app/service-catalog/services.md
+++ b/app/service-catalog/services.md
@@ -33,7 +33,7 @@ related_resources:
     url: /service-catalog/integrations/pagerduty/
 ---
 
-A Service Catalog service can be thought of as a collection of one or more resources because you can associate resources from one or more integrations with them.
+A Service Catalog service is a collection of one or more resources from integrations.
 
 A Service Catalog service represents the following:
 * A unit of software that is typically owned by a single team
@@ -66,7 +66,7 @@ body:
 {{ service | indent: 3 }}
 <!--vale on-->
 
-1. Map an integration resource to the service by sending a POST request to the [`/resource-mappings` endpoint](/api/konnect/service-catalog/v1/#/operations/create-resource-mapping):
+1. Map a resource to the service by sending a POST request to the [`/resource-mappings` endpoint](/api/konnect/service-catalog/v1/#/operations/create-resource-mapping):
 <!--vale off-->
 {% capture resource %}
 {% konnect_api_request %}

--- a/app/service-catalog/services.md
+++ b/app/service-catalog/services.md
@@ -4,7 +4,6 @@ content_type: reference
 layout: reference
 
 products:
-    - gateway
     - service-catalog
 works_on:
   - konnect
@@ -46,10 +45,14 @@ To create a Service Catalog service, do one of the following:
 
 {% navtabs "service" %}
 {% navtab "UI" %}
-In the {{site.konnect_short_name}} UI, click **Service Catalog** > **Services** in the sidebar. Click **New service** and configure the details about your service. Then, you can map a service to an integration's resource by clicking on the service and then select "Map resources" from the **Action** dropdown menu.
+1. In the {{site.konnect_short_name}} UI, navigate to **Service Catalog** > **Services** in the sidebar. 
+1. Click **New service** and configure the details about your service. 
+1. Map the service to an integration: 
+   1. Click the service.
+   1.  Select "Map resources" from the **Action** dropdown menu.
 {% endnavtab %}
 {% navtab "API" %}
-1. Create a service by sending a POST request to the [`/catalog-services` endpoint](/api/konnect/service-catalog/v1/#/operations/create-catalog-service):
+1. Create a Service Catalog service by sending a POST request to the [`/catalog-services` endpoint](/api/konnect/service-catalog/v1/#/operations/create-catalog-service):
 <!--vale off-->
 {% capture service %}
 {% konnect_api_request %}

--- a/app/service-catalog/services.md
+++ b/app/service-catalog/services.md
@@ -30,6 +30,10 @@ related_resources:
     url: /service-catalog/integrations/datadog/
   - text: PagerDuty integration
     url: /service-catalog/integrations/pagerduty/
+faqs:
+  - q: What's the different between a Gateway Service and a Service Catalog service?
+    a: |
+      A [Gateway Service](/gateway/entities/service/) represent the upstream services in your system and is the business logic component of your system that's responsible for responding to requests. A Service Catalog service is a collection of one or more resources from Service Catalog integrations.
 ---
 
 A Service Catalog service is a collection of one or more resources from integrations.


### PR DESCRIPTION
## Description

Fixes #2482 

## Preview Links
- https://deploy-preview-2586--kongdeveloper.netlify.app/service-catalog/services/
- https://deploy-preview-2586--kongdeveloper.netlify.app/service-catalog/#explore-key-features
- https://deploy-preview-2586--kongdeveloper.netlify.app/service-catalog/integrations/traceable/
- https://deploy-preview-2586--kongdeveloper.netlify.app/service-catalog/integrations/swaggerhub/
- https://deploy-preview-2586--kongdeveloper.netlify.app/service-catalog/integrations/datadog/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
