### PR TITLE
fix(docs): Use consistent titles for support policies

### DIFF
--- a/app/deck/support.md
+++ b/app/deck/support.md
@@ -1,5 +1,5 @@
 ---
-title: decK version support
+title: decK version support policy
 
 description: The decK version support policy outlines the decK versioning scheme and version lifecycle.
 

--- a/app/gateway/version-support-policy.md
+++ b/app/gateway/version-support-policy.md
@@ -1,5 +1,5 @@
 ---
-title: "{{site.base_gateway}} version support"
+title: "{{site.base_gateway}} version support policy"
 content_type: policy
 layout: reference
 

--- a/app/konnect-platform/compatibility.md
+++ b/app/konnect-platform/compatibility.md
@@ -1,5 +1,5 @@
 ---
-title: "{{site.konnect_short_name}} compatibility"
+title: "{{site.konnect_short_name}} compatibility and support policy"
 description: 'Details which browsers, software, and versions {{site.konnect_short_name}} is compatible with.'
 content_type: policy
 layout: reference

--- a/app/kubernetes-ingress-controller/support.md
+++ b/app/kubernetes-ingress-controller/support.md
@@ -1,5 +1,5 @@
 ---
-title: "{{site.kic_product_name}} Support Policy"
+title: "{{site.kic_product_name}} version support policy"
 
 description: |
   The {{site.kic_product_name}} version support policy outlines the {{site.kic_product_name}} versioning scheme and version lifecycle, from release to sunset support.

--- a/app/operator/support-policy.md
+++ b/app/operator/support-policy.md
@@ -1,5 +1,5 @@
 ---
-title: "Support Policy"
+title: "{{site.operator_product_name}} version support policy"
 description: "Check if your version of {{ site.operator_product_name }} is supported"
 content_type: reference
 layout: reference


### PR DESCRIPTION
## Description

Making the version support policy titles consistent. Currently, you need to know the right combination of words to find the support policy you're looking for, and Kong Gateway doesn't even show up as one of the options if you omit the word "version":
<img width="815" height="711" alt="Screenshot 2025-08-15 at 2 38 29 PM" src="https://github.com/user-attachments/assets/31e21a04-471e-47ad-8fac-365669140d9b" />


## Preview Links


