### PR TITLE
fix(dev-portal): Update the API catalog TF how to to use service_reference

### DIFF
--- a/app/_how-tos/automate-api-catalog-with-terraform.md
+++ b/app/_how-tos/automate-api-catalog-with-terraform.md
@@ -193,9 +193,11 @@ echo '
 resource "konnect_api_implementation" "my_api_implementation" {
   provider = konnect-beta
   api_id = konnect_api.my_api.id
-  service = {
-    control_plane_id = konnect_gateway_control_plane.my_cp.id
-    id               = konnect_gateway_service.httpbin.id
+  service_reference = {
+    service = {
+      control_plane_id = konnect_gateway_control_plane.my_cp.id
+      id               = konnect_gateway_service.httpbin.id
+    }
   }
   depends_on = [
     konnect_api.my_api,


### PR DESCRIPTION
According to the konnect-beta Terraform provider version 0.8.0, the `service` is read-only attribute now. It needs to be nested into service_reference to link the API to a gateway service. See https://registry.terraform.io/providers/Kong/konnect-beta/latest/docs/resources/api_implementation

## Description

Fixes #issue

## Preview Links
https://deploy-preview-2610--kongdeveloper.netlify.app/how-to/automate-api-catalog-with-terraform/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
