### PR TITLE
fix(gateway/entities): Fix broken links and missing links in Gateway entities

### DIFF
--- a/app/_gateway_entities/upstream.md
+++ b/app/_gateway_entities/upstream.md
@@ -12,6 +12,7 @@ tools:
     - kic
     - deck
     - terraform
+    - konnect-api
 
 description: An Upstream enables load balancing by providing a virtual hostname and collection of Targets (upstream service instances).
 

--- a/app/_includes/components/entity_example/format/admin-api.md
+++ b/app/_includes/components/entity_example/format/admin-api.md
@@ -1,21 +1,39 @@
 {% if include.render_context %}
 {% case include.presenter.entity_type %}
 {% when 'consumer' %}
-  To create a Consumer, call the [Admin API’s /consumers endpoint](/api/gateway/admin-ee/#/operations/create-consumer).
+  To create a Consumer, call the [Admin API’s `/consumers` endpoint](/api/gateway/admin-ee/#/operations/create-consumer).
 {% when 'consumer_group' %}
-  To create a Consumer Group, call the [Admin API’s /consumer_groups endpoint](/api/gateway/admin-ee/#/operations/post-consumer_groups).
+  To create a Consumer Group, call the [Admin API’s `/consumer_groups` endpoint](/api/gateway/admin-ee/#/operations/create-consumer_group).
 {% when 'route' %}
-  To create a Route, call the [Admin API’s /routes endpoint](/api/gateway/admin-ee/#/operations/create-route).
+  To create a Route, call the [Admin API’s `/routes` endpoint](/api/gateway/admin-ee/#/operations/create-route).
 {% when 'service' %}
-  To create a Gateway Service, call the [Admin API’s /services endpoint](/api/gateway/admin-ee/#/operations/create-service).
+  To create a Gateway Service, call the [Admin API’s `/services` endpoint](/api/gateway/admin-ee/#/operations/create-service).
 {% when 'target' %}
-  To create a Target, call the [Admin API’s /targets endpoint](/api/gateway/admin-ee/#/operations/create-target-with-upstream).
+  To create a Target, call the [Admin API’s `/targets` endpoint](/api/gateway/admin-ee/#/operations/create-target-with-upstream).
 {% when 'upstream' %}
-  To create a Upstream, call the [Admin API’s /upstreams endpoint](/api/gateway/admin-ee/#/operations/create-upstream).
+  To create a Upstream, call the [Admin API’s `/upstreams` endpoint](/api/gateway/admin-ee/#/operations/create-upstream).
 {% when 'workspace' %}
-  To create a Workspace, call the [Admin API’s /workspaces endpoint](/api/gateway/admin-ee/#/operations/create-workspace).
+  To create a Workspace, call the [Admin API’s `/workspaces` endpoint](/api/gateway/admin-ee/#/operations/create-workspace).
 {% when 'event_hook' %}
-  To create an Event Hook, call the [Admin API’s /event-hooks endpoint](/api/gateway/admin-ee/#/operations/post-event-hooks).
+  To create an Event Hook, call the [Admin API’s `/event-hooks` endpoint](/api/gateway/admin-ee/#/operations/create-event-hooks).
+{% when 'sni' %}
+  To create an SNI, call the [Admin API’s `/snis` endpoint](/api/gateway/admin-ee/#/operations/create-sni).
+{% when 'admin' %}
+  To create an Admin, call the [Admin API’s `/admins` endpoint](/api/gateway/admin-ee/#/operations/create-admin).
+{% when 'group' %}
+  To create a Group, call the [Admin API’s `/groups` endpoint](/api/gateway/admin-ee/#/operations/create-group).
+{% when 'ca_certificate' %}
+  To create a CA Certificate, call the [Admin API’s `/ca_certificates` endpoint](/api/gateway/admin-ee/#/operations/create-ca_certificate).
+{% when 'certificate' %}
+  To create a Certificate, call the [Admin API’s `/certificates` endpoint](/api/gateway/admin-ee/#/operations/create-certificate).
+{% when 'vault' %}
+  To create a Vault entity, call the [Admin API’s `/vaults` endpoint](/api/gateway/admin-ee/#/operations/create-vault).
+{% when 'partial' %}
+  To create a Partial, call the [Admin API’s `/partials` endpoint](/api/gateway/admin-ee/#/operations/create-partial).
+{% when 'key' %}
+  To create a Key, call the [Admin API’s `/keys` endpoint](/api/gateway/admin-ee/#/operations/create-key).
+{% when 'key-set' %}
+  To create a Key Set, call the [Admin API’s `/key-sets` endpoint](/api/gateway/admin-ee/#/operations/create-key-set).
 {% when 'plugin' %}
   Make the following request:
 {% else %}

--- a/app/_includes/components/entity_example/format/admin-api.md
+++ b/app/_includes/components/entity_example/format/admin-api.md
@@ -19,9 +19,9 @@
 {% when 'sni' %}
   To create an SNI, call the [Admin API’s `/snis` endpoint](/api/gateway/admin-ee/#/operations/create-sni).
 {% when 'admin' %}
-  To create an Admin, call the [Admin API’s `/admins` endpoint](/api/gateway/admin-ee/#/operations/create-admin).
+  To create an Admin, call the [Admin API’s `/admins` endpoint](/api/gateway/admin-ee/#/operations/create-admins).
 {% when 'group' %}
-  To create a Group, call the [Admin API’s `/groups` endpoint](/api/gateway/admin-ee/#/operations/create-group).
+  To create a Group, call the [Admin API’s `/groups` endpoint](/api/gateway/admin-ee/#/operations/post-groups).
 {% when 'ca_certificate' %}
   To create a CA Certificate, call the [Admin API’s `/ca_certificates` endpoint](/api/gateway/admin-ee/#/operations/create-ca_certificate).
 {% when 'certificate' %}

--- a/app/_includes/components/entity_example/format/konnect-api.md
+++ b/app/_includes/components/entity_example/format/konnect-api.md
@@ -1,18 +1,30 @@
 {% case include.presenter.entity_type %}
 {% when 'consumer' %}
-  To create a Consumer, call the Konnect [control plane config API’s /consumers endpoint](/api/konnect/control-planes-config/#/operations/create-consumer). 
+  To create a Consumer, call the Konnect [control plane config API’s `/consumers` endpoint](/api/konnect/control-planes-config/#/operations/create-consumer). 
 {% when 'consumer_group' %}
-  To create a Consumer Group, call the Konnect [control plane config API’s /consumer_groups endpoint](/api/konnect/control-planes-config/#/operations/create-consumer_group).
+  To create a Consumer Group, call the Konnect [control plane config API’s `/consumer_groups` endpoint](/api/konnect/control-planes-config/#/operations/create-consumer_group).
 {% when 'route' %}
-  To create a Route, call the Konnect [control plane config API's /routes endpoint](/api/konnect/control-planes-config/#/operations/create-route).
+  To create a Route, call the Konnect [control plane config API's `/routes` endpoint](/api/konnect/control-planes-config/#/operations/create-route).
 {% when 'service' %}
-  To create a Gateway Service, call the Konnect [control plane config API’s /services endpoint](/api/konnect/control-planes-config/#/operations/create-service).
+  To create a Gateway Service, call the Konnect [control plane config API’s `/services` endpoint](/api/konnect/control-planes-config/#/operations/create-service).
 {% when 'target' %}
-  To create a Target, call the Konnect [control plane config API’s /targets endpoint](/api/konnect/control-planes-config/#/operations/create-target-with-upstream). 
+  To create a Target, call the Konnect [control plane config API’s `/targets` endpoint](/api/konnect/control-planes-config/#/operations/create-target-with-upstream). 
 {% when 'upstream' %}
-  The following creates a new Upstream called **{{ include.presenter.data['name'] }}**:
-{% when workspace %}
-  To create a Workspace, call the [Admin API’s /workspaces endpoint](/api/gateway/admin-ee/#/operations/create-workspace).
+  To create an Upstream, call the Konnect [control plane config API’s `/upstreams` endpoint](/api/konnect/control-planes-config/#/operations/create-upstream). 
+{% when 'sni' %}
+  To create an SNI, call the Konnect [control plane config API’s `/snis` endpoint](/api/konnect/control-planes-config/#/operations/create-sni). 
+{% when 'ca_certificate' %}
+  To create a CA Certificate, call the Konnect [control plane config API’s `/ca-certificates` endpoint](/api/konnect/control-planes-config/#/operations/create-ca_certificate). 
+{% when 'certificate' %}
+  To create a Certificate, call the Konnect [control plane config API’s `/certificates` endpoint](/api/konnect/control-planes-config/#/operations/create-certificate). 
+{% when 'vault' %}
+  To create a Vault entity, call the Konnect [control plane config API’s `/vaults` endpoint](/api/konnect/control-planes-config/#/operations/create-vault). 
+{% when 'key' %}
+  To create a Key, call the Konnect [control plane config API’s `/keys` endpoint](/api/konnect/control-planes-config/#/operations/create-key). 
+{% when 'key-set' %}
+  To create a Key Set, call the Konnect [control plane config API’s `/key-sets` endpoint](/api/konnect/control-planes-config/#/operations/create-key-set). 
+{% when 'partial' %}
+  To create a Partial, call the Konnect [control plane config API’s `/partials` endpoint](/api/konnect/control-planes-config/#/operations/create-partial). 
 {% when 'plugin' %}
   Make the following request:
 {% else %}

--- a/app/_includes/components/entity_example/format/ui.md
+++ b/app/_includes/components/entity_example/format/ui.md
@@ -104,7 +104,7 @@ The following creates a new Certificate with basic configuration:
     {{ include.presenter.data['key'] }}
     ```
 {% when 'ca_certificate' %}
-The following creates a new Certificate with basic configuration:
+The following creates a new CA Certificate with basic configuration:
 
 1. In Kong Manager or Gateway Manager, go to **Certificates**.
 2. Click the **CA Certificates** tab.


### PR DESCRIPTION
## Description
Fixing broken and missing links that appear in Gateway entity examples.

Ran into issue when updating L1 menu docs. We have a lot of broken and inconsistently missing links in the entity examples. They don't get caught by the link checker because the API page doesn't 404, it just loads blank.

Also added `konnect-api` as a supported tool for Upstreams, it was missing.

## Preview Links

