### PR TITLE
ko: bump KonnectGatewayControlPlane to v1alpha2

### DIFF
--- a/app/_how-tos/create-transit-gateway-with-operator-and-aws.md
+++ b/app/_how-tos/create-transit-gateway-with-operator-and-aws.md
@@ -63,12 +63,13 @@ Use the following command to create a Control Plane:
 <!-- vale off -->
 {% konnect_crd %}
 kind: KonnectGatewayControlPlane
-apiVersion: konnect.konghq.com/v1alpha1
+apiVersion: konnect.konghq.com/{{ site.konnect_konnectgatewaycontrolplane_api_version }}
 metadata:
   name: gateway-control-plane
   namespace: kong
 spec:
-  name: gateway-control-plane
+  createControlPlaneRequest:
+    name: gateway-control-plane
   konnect:
     authRef:
       name: konnect-api-auth

--- a/app/_how-tos/create-transit-gateway-with-operator-and-aws.md
+++ b/app/_how-tos/create-transit-gateway-with-operator-and-aws.md
@@ -63,7 +63,7 @@ Use the following command to create a Control Plane:
 <!-- vale off -->
 {% konnect_crd %}
 kind: KonnectGatewayControlPlane
-apiVersion: konnect.konghq.com/{{ site.konnect_konnectgatewaycontrolplane_api_version }}
+apiVersion: konnect.konghq.com/{{ site.operator_konnectgatewaycontrolplane_api_version }}
 metadata:
   name: gateway-control-plane
   namespace: kong

--- a/app/_how-tos/operator-konnect-control-plane-group.md
+++ b/app/_how-tos/operator-konnect-control-plane-group.md
@@ -42,10 +42,12 @@ Create a Control Plane using the `KonnectGatewayControlPlane` object:
 <!-- vale off -->
 {% konnect_crd %}
 kind: KonnectGatewayControlPlane
+apiVersion: konnect.konghq.com/{{ site.konnect_konnectgatewaycontrolplane_api_version }}
 metadata:
   name: gateway-control-plane
 spec:
-  name: gateway-control-plane
+  createControlPlaneRequest:
+    name: gateway-control-plane
   konnect:
     authRef:
       name: konnect-api-auth
@@ -59,11 +61,13 @@ Create a new `KonnectGatewayControlPlane` object, add the `CLUSTER_TYPE_CONTROL_
 <!-- vale off -->
 {% konnect_crd %}
 kind: KonnectGatewayControlPlane
+apiVersion: konnect.konghq.com/{{ site.konnect_konnectgatewaycontrolplane_api_version }}
 metadata:
   name: control-plane-group
 spec:
-  name: control-plane-group
-  cluster_type: CLUSTER_TYPE_CONTROL_PLANE_GROUP
+  createControlPlaneRequest:
+    name: control-plane-group
+    clusterType: CLUSTER_TYPE_CONTROL_PLANE_GROUP
   members:
     - name: gateway-control-plane
   konnect:

--- a/app/_how-tos/operator-konnect-control-plane-group.md
+++ b/app/_how-tos/operator-konnect-control-plane-group.md
@@ -42,7 +42,7 @@ Create a Control Plane using the `KonnectGatewayControlPlane` object:
 <!-- vale off -->
 {% konnect_crd %}
 kind: KonnectGatewayControlPlane
-apiVersion: konnect.konghq.com/{{ site.konnect_konnectgatewaycontrolplane_api_version }}
+apiVersion: konnect.konghq.com/{{ site.operator_konnectgatewaycontrolplane_api_version }}
 metadata:
   name: gateway-control-plane
 spec:
@@ -61,7 +61,7 @@ Create a new `KonnectGatewayControlPlane` object, add the `CLUSTER_TYPE_CONTROL_
 <!-- vale off -->
 {% konnect_crd %}
 kind: KonnectGatewayControlPlane
-apiVersion: konnect.konghq.com/{{ site.konnect_konnectgatewaycontrolplane_api_version }}
+apiVersion: konnect.konghq.com/{{ site.operator_konnectgatewaycontrolplane_api_version }}
 metadata:
   name: control-plane-group
 spec:

--- a/app/_how-tos/operator-konnect-control-plane-kic.md
+++ b/app/_how-tos/operator-konnect-control-plane-kic.md
@@ -41,7 +41,7 @@ Create a Control Plane and add the cluster type `CLUSTER_TYPE_K8S_INGRESS_CONTRO
 <!-- vale off -->
 {% konnect_crd %}
 kind: KonnectGatewayControlPlane
-apiVersion: konnect.konghq.com/{{ site.konnect_konnectgatewaycontrolplane_api_version }}
+apiVersion: konnect.konghq.com/{{ site.operator_konnectgatewaycontrolplane_api_version }}
 metadata:
   name: gateway-control-plane
 spec:

--- a/app/_how-tos/operator-konnect-control-plane-kic.md
+++ b/app/_how-tos/operator-konnect-control-plane-kic.md
@@ -41,11 +41,13 @@ Create a Control Plane and add the cluster type `CLUSTER_TYPE_K8S_INGRESS_CONTRO
 <!-- vale off -->
 {% konnect_crd %}
 kind: KonnectGatewayControlPlane
+apiVersion: konnect.konghq.com/{{ site.konnect_konnectgatewaycontrolplane_api_version }}
 metadata:
   name: gateway-control-plane
 spec:
-  name: kic-control-plane
-  cluster_type: CLUSTER_TYPE_K8S_INGRESS_CONTROLLER
+  createControlPlaneRequest:
+    name: kic-control-plane
+    clusterType: CLUSTER_TYPE_K8S_INGRESS_CONTROLLER
   konnect:
     authRef:
       name: konnect-api-auth

--- a/app/_how-tos/operator-konnect-control-plane-mirror.md
+++ b/app/_how-tos/operator-konnect-control-plane-mirror.md
@@ -55,7 +55,7 @@ Create a `KonnectGatewayControlPlane` object and add the {{ site.konnect_short_n
 <!-- vale off -->
 {% konnect_crd %}
 kind: KonnectGatewayControlPlane
-apiVersion: konnect.konghq.com/{{ site.konnect_konnectgatewaycontrolplane_api_version }}
+apiVersion: konnect.konghq.com/{{ site.operator_konnectgatewaycontrolplane_api_version }}
 metadata:
   name: gateway-control-plane
 spec:

--- a/app/_how-tos/operator-konnect-control-plane-mirror.md
+++ b/app/_how-tos/operator-konnect-control-plane-mirror.md
@@ -55,6 +55,7 @@ Create a `KonnectGatewayControlPlane` object and add the {{ site.konnect_short_n
 <!-- vale off -->
 {% konnect_crd %}
 kind: KonnectGatewayControlPlane
+apiVersion: konnect.konghq.com/{{ site.konnect_konnectgatewaycontrolplane_api_version }}
 metadata:
   name: gateway-control-plane
 spec:

--- a/app/_how-tos/operator-konnect-control-plane.md
+++ b/app/_how-tos/operator-konnect-control-plane.md
@@ -41,7 +41,7 @@ Create a `KonnectGatewayControlPlane` object and add the {{ site.konnect_short_n
 <!-- vale off -->
 {% konnect_crd %}
 kind: KonnectGatewayControlPlane
-apiVersion: konnect.konghq.com/{{ site.konnect_konnectgatewaycontrolplane_api_version }}
+apiVersion: konnect.konghq.com/{{ site.operator_konnectgatewaycontrolplane_api_version }}
 metadata:
   name: gateway-control-plane
 spec:

--- a/app/_how-tos/operator-konnect-control-plane.md
+++ b/app/_how-tos/operator-konnect-control-plane.md
@@ -41,10 +41,12 @@ Create a `KonnectGatewayControlPlane` object and add the {{ site.konnect_short_n
 <!-- vale off -->
 {% konnect_crd %}
 kind: KonnectGatewayControlPlane
+apiVersion: konnect.konghq.com/{{ site.konnect_konnectgatewaycontrolplane_api_version }}
 metadata:
   name: gateway-control-plane
 spec:
-  name: gateway-control-plane
+  createControlPlaneRequest:
+    name: gateway-control-plane
   konnect:
     authRef:
       name: konnect-api-auth

--- a/app/_how-tos/operator-konnect-getstarted-controlplane.md
+++ b/app/_how-tos/operator-konnect-getstarted-controlplane.md
@@ -46,7 +46,7 @@ Apply the following configuration to define a Control Plane named `gateway-contr
 <!-- vale off -->
 {% konnect_crd %}
 kind: KonnectGatewayControlPlane
-apiVersion: konnect.konghq.com/{{ site.konnect_konnectgatewaycontrolplane_api_version }}
+apiVersion: konnect.konghq.com/{{ site.operator_konnectgatewaycontrolplane_api_version }}
 metadata:
   name: gateway-control-plane
 spec:

--- a/app/_how-tos/operator-konnect-getstarted-controlplane.md
+++ b/app/_how-tos/operator-konnect-getstarted-controlplane.md
@@ -46,11 +46,12 @@ Apply the following configuration to define a Control Plane named `gateway-contr
 <!-- vale off -->
 {% konnect_crd %}
 kind: KonnectGatewayControlPlane
-apiVersion: konnect.konghq.com/v1alpha1
+apiVersion: konnect.konghq.com/{{ site.konnect_konnectgatewaycontrolplane_api_version }}
 metadata:
   name: gateway-control-plane
 spec:
-  name: gateway-control-plane
+  createControlPlaneRequest:
+    name: gateway-control-plane
   konnect:
     authRef:
       name: konnect-api-auth

--- a/app/_includes/prereqs/operator/konnect_control_plane.md
+++ b/app/_includes/prereqs/operator/konnect_control_plane.md
@@ -5,11 +5,13 @@
 <!-- vale off -->
 {% konnect_crd %}
 kind: KonnectGatewayControlPlane
+apiVersion: konnect.konghq.com/{{ site.konnect_konnectgatewaycontrolplane_api_version }}
 metadata:
   name: gateway-control-plane
 spec:
-  name: gateway-control-plane{% if include.config.control_plane == 'kic' %}
-  cluster_type: CLUSTER_TYPE_K8S_INGRESS_CONTROLLER{% endif %}
+  createControlPlaneRequest:
+    name: gateway-control-plane{% if include.config.control_plane == 'kic' %}
+    clusterType: CLUSTER_TYPE_K8S_INGRESS_CONTROLLER{% endif %}
   konnect:
     authRef:
       name: konnect-api-auth

--- a/app/_includes/prereqs/operator/konnect_control_plane.md
+++ b/app/_includes/prereqs/operator/konnect_control_plane.md
@@ -5,7 +5,7 @@
 <!-- vale off -->
 {% konnect_crd %}
 kind: KonnectGatewayControlPlane
-apiVersion: konnect.konghq.com/{{ site.konnect_konnectgatewaycontrolplane_api_version }}
+apiVersion: konnect.konghq.com/{{ site.operator_konnectgatewaycontrolplane_api_version }}
 metadata:
   name: gateway-control-plane
 spec:

--- a/app/operator/konnect/labelling.md
+++ b/app/operator/konnect/labelling.md
@@ -24,7 +24,7 @@ You can add labels to the `KonnectGatewayControlPlane` object by specifying the 
 ```yaml
 echo '
 kind: KonnectGatewayControlPlane
-apiVersion: konnect.konghq.com/{{ site.konnect_konnectgatewaycontrolplane_api_version }}
+apiVersion: konnect.konghq.com/{{ site.operator_konnectgatewaycontrolplane_api_version }}
 metadata:
   name: gateway-control-plane
   namespace: default

--- a/app/operator/konnect/labelling.md
+++ b/app/operator/konnect/labelling.md
@@ -24,15 +24,16 @@ You can add labels to the `KonnectGatewayControlPlane` object by specifying the 
 ```yaml
 echo '
 kind: KonnectGatewayControlPlane
-apiVersion: konnect.konghq.com/v1alpha1
+apiVersion: konnect.konghq.com/{{ site.konnect_konnectgatewaycontrolplane_api_version }}
 metadata:
   name: gateway-control-plane
   namespace: default
 spec:
-  labels: # Arbitrary key-value pairs
-    environment: production
-    team: devops
-  name: gateway-control-plane
+  createControlPlaneRequest:
+    labels: # Arbitrary key-value pairs
+      environment: production
+      team: devops
+    name: gateway-control-plane
   konnect:
     authRef:
       name: konnect-api-auth # Reference to the KonnectAPIAuthConfiguration object

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -165,4 +165,4 @@ mesh:
 # Version vars
 latest_gateway_oss_version: "3.9.1"
 
-konnect_konnectgatewaycontrolplane_api_version: "v1alpha2"
+operator_konnectgatewaycontrolplane_api_version: "v1alpha2"

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -164,3 +164,5 @@ mesh:
 
 # Version vars
 latest_gateway_oss_version: "3.9.1"
+
+konnect_konnectgatewaycontrolplane_api_version: "v1alpha2"


### PR DESCRIPTION
## Description

Fixes https://github.com/Kong/kong-operator/issues/1945

## Preview Links

* https://deploy-preview-2641--kongdeveloper.netlify.app/operator/konnect/labelling/#labeling
* https://deploy-preview-2641--kongdeveloper.netlify.app/operator/konnect/crd/control-planes/hybrid/#create-a-konnectgatewaycontrolplane
* https://deploy-preview-2641--kongdeveloper.netlify.app/operator/dataplanes/get-started/hybrid/deploy-dataplane/


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
