### PR TITLE
Updated custom linting instructions to match new Insomnia file structure

### DIFF
--- a/app/_how-tos/add-custom-linting-rules.md
+++ b/app/_how-tos/add-custom-linting-rules.md
@@ -18,7 +18,7 @@ related_resources:
 
 tldr: 
   q: How do I customize linting in Insomnia?
-  a: In your Git repository, add a `.spectral.yaml` file containing your custom ruleset at the same level as the `.insomnia` folder.
+  a: In your Git repository, add a `.spectral.yaml` file containing your custom ruleset at the same directory as the OAS file to lint.
 
 prereqs:
   inline:
@@ -38,7 +38,7 @@ faqs:
 
 ## Create add the file ruleset
 
-In the Git repository connected to your document, create a `.spectral.yaml` at the same level as the `.insomnia` folder.
+In the Git repository connected to your document, create a `.spectral.yaml` at the same directory as the OAS file to lint.
 
 ## Define the rules
 
@@ -60,7 +60,9 @@ rules:
 
 ## Synchronize the changes
 
-Commit and push the file on the repository, then pull the changes in Insomnia.
+Commit and push the file on the repository, then pull the changes in Insomnia.  
+> [!NOTE]  
+> This will place the `.spectral.yaml` file in the local working directory.  You will not see the file in the Insomnia UI but the linting rules will be applied to the associated OAS file.
 
 ## Validate
 


### PR DESCRIPTION
- Changed location of Spectral file from .insomnia folder to folder where OAS file lives
- Added note about not being able to see spectral file in UI

## Description
Simple change to how to page on adding custom linting rules in the Insomnia UI to match latest file structure.

## Preview Links
N/A

## Checklist 

- [ ] Tested how-to doc (https://developer.konghq.com/how-to/add-custom-linting-rules/). 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
