### PR TITLE
fix(ai-gateway): Add instructions for Cursor for using MCP Konnect

### DIFF
--- a/app/_how-tos/get-started-with-mcp.md
+++ b/app/_how-tos/get-started-with-mcp.md
@@ -162,24 +162,10 @@ Now, add the following configuration to the file:
 > 1. Open Cursor desktop.
 > 2. Go to **Cursor Settings > Tools & Integrations**.
 > 3. Click **Add New MCP Server**.
-> 4. Paste the following configuration in the `mcp.json` file:
-> ```json
-> {
->   "mcpServers": {
->     "kong-konnect": {
->       "command": "node",
->       "args": ["/absolute/path/to/mcp-konnect/build/index.js"],
->       "env": {
->         "KONNECT_ACCESS_TOKEN": "YOUR_KONNECT_PAT",
->         "KONNECT_REGION": "us"
->       }
->     }
->   }
-> }
-> ```
+> 4. Paste the MCP server configuration from the code block above in the `mcp.json` file.
 > 5. Save the `mcp.json` file
 > 6. Go back to the **Cursor Settings > Tools & Integrations** tab.
-> 7. You should see **kong-konnect** in the MCP Tools with 10 tools available.
+> 7. You should see `kong-konnect` in the MCP Tools with 10 tools available.
 
 ## Restart Claude desktop
 

--- a/app/_how-tos/get-started-with-mcp.md
+++ b/app/_how-tos/get-started-with-mcp.md
@@ -155,6 +155,30 @@ Now, add the following configuration to the file:
 > * Make sure the `KONNECT_ACCESS_TOKEN` matches the one you set earlier.
 > * Replace the `KONNECT_REGION` value with your geographic region. You can see a list of all {{site.konnect_short_name}} regions in the [Geographic regions](/konnect-platform/geos/#control-planes) documentation.
 
+{:.success}
+> You can also use Kong {{site.konnect_short_name}} MCP with any other MCP client like Cursor. To do that:
+> 1. Open Cursor Desktop.
+> 2. Go to **Cursor Settings > Tools & Integrations**.
+> 3. Click **Add New MCP Server**.
+> 4. Paste the following configuration in the `mcp.json` file:
+> ```json
+> {
+>   "mcpServers": {
+>     "kong-konnect": {
+>       "command": "node",
+>       "args": ["/absolute/path/to/mcp-konnect/build/index.js"],
+>       "env": {
+>         "KONNECT_ACCESS_TOKEN": "YOUR_KONNECT_PAT",
+>         "KONNECT_REGION": "us"
+>       }
+>     }
+>   }
+> }
+> ```
+> 5. Save the `mcp.json` file
+> 6. Go back to the **Cursor Settings > Tools & Integrations** tab.
+> 7. You should see **kong-konnect** in the MCP Tools with 10 tools available.
+
 ## Restart Claude desktop
 
 After saving the `claude_desktop_config.json` file, restart Claude for Desktop. The Kong {{site.konnect_product_name}} tools will now be available for Claude to use in conversation.

--- a/app/_how-tos/get-started-with-mcp.md
+++ b/app/_how-tos/get-started-with-mcp.md
@@ -156,8 +156,10 @@ Now, add the following configuration to the file:
 > * Replace the `KONNECT_REGION` value with your geographic region. You can see a list of all {{site.konnect_short_name}} regions in the [Geographic regions](/konnect-platform/geos/#control-planes) documentation.
 
 {:.success}
+> **Use {{site.konnect_product_name}} MCP Server with Cursor**
+>
 > You can also use Kong {{site.konnect_short_name}} MCP with any other MCP client like Cursor. To do that:
-> 1. Open Cursor Desktop.
+> 1. Open Cursor desktop.
 > 2. Go to **Cursor Settings > Tools & Integrations**.
 > 3. Click **Add New MCP Server**.
 > 4. Paste the following configuration in the `mcp.json` file:


### PR DESCRIPTION
## Description

Fixes #2503

## Preview Links

http://localhost:8888/mcp/kong-mcp/get-started/#configure-claude-desktop

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
