### PR TITLE
fix(gateway/install): Non-existant OSS version in migration FAQ

### DIFF
--- a/app/gateway/install.md
+++ b/app/gateway/install.md
@@ -17,16 +17,19 @@ breadcrumbs:
     - /gateway/
 
 faqs:
-  - q: How do I migrate from {{site.base_gateway}} open source (OSS) to {{site.base_gateway}} Enterprise?
+  - q: How do I migrate from {{site.base_gateway}} open source (OSS) to {{site.ee_product_name}}?
     a: |
-        You can migrate to {{site.base_gateway}} Enterprise using the `kong migrations` CLI commands.
+        You can migrate to {{site.ee_product_name}} using the `kong migrations` CLI commands.
         
         {:.danger}
         > **Warning:** This action is irreversible, therefore we strongly recommend [backing up](/gateway/upgrade/backup-and-restore/) your production data before migrating from {{site.base_gateway}} OSS to {{site.ee_product_name}}.
         
-        You can only migrate to a {{site.ee_product_name}} version that supports the same OSS version. For example, if you want to migrate to {{site.ee_product_name}} 3.10, you must upgrade to {{site.base_gateway}} OSS 3.10 first.
+        You can only migrate to a {{site.ee_product_name}} version that supports the same OSS version. The latest version of {{site.base_gateway}} OSS is {{site.latest_gateway_oss_version}}.
 
-        1. Download the {{site.ee_product_name}} package and configure it to point to the same data store as your {{site.base_gateway}} OSS node. The migration command expects the data store to be up to date on any pending migration:
+        1. Download the {{site.ee_product_name}} package that matches your installed OSS version.
+        1. Configure it to point to the same data store as your {{site.base_gateway}} OSS node.
+           The migration command expects the data store to be up to date on any pending migration:
+
            ```sh
            kong migrations up [-c configuration_file]
            kong migrations -f finish [-c configuration_file]
@@ -36,6 +39,7 @@ faqs:
            > **Caution**: {% include_cached /gateway/migration-finish-warning.md %}
 
         1. Confirm that all of the entities are now available on your {{site.ee_product_name}} node.
+        1. (Optional) [Upgrade](/gateway/upgrade/) to your desired version of {{site.ee_product_name}}. 
 
 no_wrap: true
 versioned: true


### PR DESCRIPTION
## Description

Fixes an issue where were referring to an OSS Gateway version that doesn't exist. Now the FAQ tells users what the latest OSS version is and what they need to do to get to the latest Enterprise version

Issue reported on Slack.

## Preview Links

