### PR TITLE
fix: Add more obvious v2 Portal TF migration link, add PII FAQ to audit log page

### DIFF
--- a/app/dev-portal/v2-migration.md
+++ b/app/dev-portal/v2-migration.md
@@ -40,8 +40,11 @@ Dev Portal v3 provides additional features such as a streamlined [API creation a
 To migrate from Dev Portal classic (v2) to the new Dev Portal (v3), do the following:
 
 1. For Kong-hosted classic Dev Portals, do the following:
-   1. [Create a new v3 Dev Portal in {{site.konnect_short_name}}](https://cloud.konghq.com/portals/create)
-   1. [Republish your API catalog](/how-to/automate-api-catalog/) either via the UI or the v3 API
+   1. [Create a new v3 Dev Portal in {{site.konnect_short_name}}](https://cloud.konghq.com/portals/create). 
+      
+      {:.warning}
+      > If you're using Terraform to manage your v2 Dev Portal, make sure you've migrated your `konnect_portal` Terraform resource to `konnect_portal_classic` by following the [Migrate your classic Dev Portal (v2) Terraform resource](/dev-portal/migrate-classic-dev-portal-resource-with-terraform/) guide. 
+   1. [Republish your API catalog](/how-to/automate-api-catalog/) either via the UI or the v3 API.
    
 1. If you are using an [IdP for developer credentials](/dev-portal/team-mapping/), update your IdP with the new Dev Portal domain for the redirect URIs. This will maintain developer logins.
 1. If you are using {{site.konnect_short_name}} developer logins, like basic auth, developers will need to register at the new v3 Dev Portal and regenerate their API credentials.

--- a/app/konnect-platform/audit-logs.md
+++ b/app/konnect-platform/audit-logs.md
@@ -45,6 +45,8 @@ faqs:
       1. Get an audit log from {{site.konnect_short_name}} and remove the `sig` value. Make sure to save the signature, you'll need it in the next step.
       1. Decode the Base64-encoded signature and private key.
       1. Use your preferred tool (for example, [OpenSSL](https://www.openssl.org/)) to verify the ED25519 signature by using the signature-less audit log entry together with the decoded signature and public key.
+  - q: Do {{site.konnect_short_name}} audit logs collect personally identifiable information?
+    a: No, {{site.konnect_short_name}} audit logs don't collect any PII. See the [audit log examples](#log-formats) for the information that they do collect.
 ---
 
 {:.success}


### PR DESCRIPTION
## Description

Fixes feedback from Jason and https://kongstrong.slack.com/archives/C04RXLGNB6K/p1755768362048199

## Preview Links
- /dev-portal/v2-migration/#migrate-manually
- /konnect-platform/audit-logs/#faqs

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
