### PR TITLE
fix: typo in konnect.yaml

### DIFF
--- a/app/_landing_pages/konnect.yaml
+++ b/app/_landing_pages/konnect.yaml
@@ -368,7 +368,7 @@ rows:
             config:
               title: "{{site.konnect_short_name}} account"
               description: |
-                Learn about the different {{site.konnect_short_name}} plasns and account management.
+                Learn about the different {{site.konnect_short_name}} plans and account management.
               cta:
                 text: View {{site.konnect_short_name}} account info
                 url: /konnect-platform/account/


### PR DESCRIPTION
## Description

spotted a typo.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
