### PR TITLE
Fix: LTS guide typo

### DIFF
--- a/app/_includes/upgrade/lts-changes-34-310.md
+++ b/app/_includes/upgrade/lts-changes-34-310.md
@@ -185,7 +185,7 @@ rows:
     description: |
       Changed the encoding of spaces in query arguments from `+` to `%20` in the `kong.service.request.clear_query_arg` PDK module.
       While the `+` character represents the correct encoding of space in query strings, Kong uses `%20` in many other APIs, which is inherited from Nginx/OpenResty.
-    action:
+    action: |
       No
           
 {% endtable %}


### PR DESCRIPTION
## Description

The text should say "No", but it's displaying an X image:
<img width="727" height="156" alt="Screenshot 2025-08-27 at 1 17 26 PM" src="https://github.com/user-attachments/assets/7e918dac-12ba-4d5b-896b-ed29a30caf47" />


## Preview Links


