### PR TITLE
Fix(dev-portal): Added info about KAA plugin

### DIFF
--- a/app/_how-tos/automate-api-catalog-with-terraform.md
+++ b/app/_how-tos/automate-api-catalog-with-terraform.md
@@ -100,14 +100,9 @@ faqs:
       * With [Dev Portal app registration](/dev-portal/self-service/): If non-current versions have Route configurations that allow requests to specify the version in some way, each version must document how to modify the request to access the given version (for example, using a header). 
       * Without Dev Portal app registration: If the version can be accessed separately from other versions of the same API, each version must document how to modify the request to access the given version.
 
-  - q: What adds {{site.konnect_short_name}} Application Auth (KAA) to a service?
-    a: After the Terraform plan creates a link between the API and a Konnect Gateway Service, the Service includes the Konnect Application Auth (KAA) plugin. The plugin ID is konnect-application-auth. Data planes must run Kong Gateway 3.6 or later.
-
-  - q: Can I manage {{site.konnect_short_name}} Application Auth (KAA) in Terraform or Gateway Manager?
-    a: No. Understand KAA as a managed plugin. Terraform defines the API-to-Service link. Dev Portal controls KAA behavior. Gateway Manager does not expose KAA settings.
-  
-  - q: What do developers do after I link the API?
-    a: Developers open Dev Portal, create applications, and generate credentials or API keys. They then call the API through the linked Service.
+  - q: How does {{site.konnect_short_name}} manage authentication and authorization on Gateway Services that are linked to my APIs?
+    a: |
+      When a Gateway Service is linked to an API, {{site.konnect_short_name}} automatically adds the [{{site.konnect_short_name}} Application Auth (KAA) plugin](/dev-portal/apis/#allow-developers-to-consume-your-api) to your Service. The KAA plugin applies authentication and authorization to the Service. This is a {{site.konnect_short_name}}-managed plugin that you can't directly modify, you can only modify it by configuring JSON in the advanced configuration for your [application auth strategy](/dev-portal/auth-strategies/). 
 next_steps:
   - text: Apply an authentication strategy to your APIs
     url: /dev-portal/auth-strategies/

--- a/app/_how-tos/automate-api-catalog-with-terraform.md
+++ b/app/_how-tos/automate-api-catalog-with-terraform.md
@@ -99,6 +99,15 @@ faqs:
       There are two exceptions when the underlying implementation should match the selected version:
       * With [Dev Portal app registration](/dev-portal/self-service/): If non-current versions have Route configurations that allow requests to specify the version in some way, each version must document how to modify the request to access the given version (for example, using a header). 
       * Without Dev Portal app registration: If the version can be accessed separately from other versions of the same API, each version must document how to modify the request to access the given version.
+
+  - q: What adds {{site.konnect_short_name}} Application Auth (KAA) to a service?
+    a: After the Terraform plan creates a link between the API and a Konnect Gateway Service, the Service includes the Konnect Application Auth (KAA) plugin. The plugin ID is konnect-application-auth. Data planes must run Kong Gateway 3.6 or later.
+
+  - q: Can I manage {{site.konnect_short_name}} Application Auth (KAA) in Terraform or Gateway Manager?
+    a: No. Understand KAA as a managed plugin. Terraform defines the API-to-Service link. Dev Portal controls KAA behavior. Gateway Manager does not expose KAA settings.
+  
+  - q: What do developers do after I link the API?
+    a: Developers open Dev Portal, create applications, and generate credentials or API keys. They then call the API through the linked Service.
 next_steps:
   - text: Apply an authentication strategy to your APIs
     url: /dev-portal/auth-strategies/

--- a/app/_how-tos/automate-api-catalog.md
+++ b/app/_how-tos/automate-api-catalog.md
@@ -58,17 +58,9 @@ faqs:
       There are two exceptions when the underlying implementation should match the selected version:
       * With [Dev Portal app registration](/dev-portal/self-service/): If non-current versions have Route configurations that allow requests to specify the version in some way, each version must document how to modify the request to access the given version (for example, using a header). 
       * Without Dev Portal app registration: If the version can be accessed separately from other versions of the same API, each version must document how to modify the request to access the given version.
-  - q: What happens to the Service after I link the API?
-    a: |
-      After you link the API to a {{site.konnect_short_name}} Gateway Service, {{site.konnect_short_name}} updates that Service’s configuration. It enables Konnect Application Auth (KAA) on the linked Service and binds it to the Application Authentication strategy that you set for the API (Key Auth, OpenID Connect, or Dynamic Client Registration). 
-      KAA is configured in Dev Portal; not Gateway Manager. 
-      If you select a strategy before any Service is linked, {{site.konnect_short_name}} records that choice and applies it automatically when you link a Service. If you later unlink the Service, the same strategy applies to the next Service you link to that API. The plugin ID is `konnect-application-auth`.
-  - q: Can I remove {{site.konnect_short_name}} Application Auth (KAA) from a Service?
-    a: No. If you remove the API-to-Service association, the Service no longer follows the API’s application-auth strategy. Test requests to confirm the current behavior.
-  - q: How does {{site.konnect_short_name}} Application Auth (KAA) work with the steps on this page?
-    a: |
-      Our guide uses Konnect endpoints to create the API, attach a spec or a document, associate the API with a Service, and publish it. After you associate the API with the Service, the Service includes KAA and Dev Portal controls the strategy.
-      For example, when you create an API, add a spec or a document, then associate the API with a Gateway Service by calling `/v3/apis/{apiId}/implementations`. That association is the point after which the Service includes KAA. You then publish the API to the Dev Portal.
+     - q: How does {{site.konnect_short_name}} manage authentication and authorization on Gateway Services that are linked to my APIs?
+	    a: |
+	      When a Gateway Service is linked to an API, {{site.konnect_short_name}} automatically adds the [{{site.konnect_short_name}} Application Auth (KAA) plugin](/dev-portal/apis/#allow-developers-to-consume-your-api) to your Service. The KAA plugin applies authentication and authorization to the Service. This is a {{site.konnect_short_name}}-managed plugin that you can't directly modify, you can only modify it by configuring JSON in the advanced configuration for your [application auth strategy](/dev-portal/auth-strategies/). 
 next_steps:
   - text: Apply an authentication strategy to your APIs
     url: /dev-portal/auth-strategies/

--- a/app/_how-tos/automate-api-catalog.md
+++ b/app/_how-tos/automate-api-catalog.md
@@ -58,9 +58,9 @@ faqs:
       There are two exceptions when the underlying implementation should match the selected version:
       * With [Dev Portal app registration](/dev-portal/self-service/): If non-current versions have Route configurations that allow requests to specify the version in some way, each version must document how to modify the request to access the given version (for example, using a header). 
       * Without Dev Portal app registration: If the version can be accessed separately from other versions of the same API, each version must document how to modify the request to access the given version.
-     - q: How does {{site.konnect_short_name}} manage authentication and authorization on Gateway Services that are linked to my APIs?
-	    a: |
-	      When a Gateway Service is linked to an API, {{site.konnect_short_name}} automatically adds the [{{site.konnect_short_name}} Application Auth (KAA) plugin](/dev-portal/apis/#allow-developers-to-consume-your-api) to your Service. The KAA plugin applies authentication and authorization to the Service. This is a {{site.konnect_short_name}}-managed plugin that you can't directly modify, you can only modify it by configuring JSON in the advanced configuration for your [application auth strategy](/dev-portal/auth-strategies/). 
+  - q: How does {{site.konnect_short_name}} manage authentication and authorization on Gateway Services that are linked to my APIs?
+    a: |
+	    When a Gateway Service is linked to an API, {{site.konnect_short_name}} automatically adds the [{{site.konnect_short_name}} Application Auth (KAA) plugin](/dev-portal/apis/#allow-developers-to-consume-your-api) to your Service. The KAA plugin applies authentication and authorization to the Service. This is a {{site.konnect_short_name}}-managed plugin that you can't directly modify, you can only modify it by configuring JSON in the advanced configuration for your [application auth strategy](/dev-portal/auth-strategies/). 
 next_steps:
   - text: Apply an authentication strategy to your APIs
     url: /dev-portal/auth-strategies/

--- a/app/_how-tos/automate-api-catalog.md
+++ b/app/_how-tos/automate-api-catalog.md
@@ -60,7 +60,7 @@ faqs:
       * Without Dev Portal app registration: If the version can be accessed separately from other versions of the same API, each version must document how to modify the request to access the given version.
   - q: How does {{site.konnect_short_name}} manage authentication and authorization on Gateway Services that are linked to my APIs?
     a: |
-	    When a Gateway Service is linked to an API, {{site.konnect_short_name}} automatically adds the [{{site.konnect_short_name}} Application Auth (KAA) plugin](/dev-portal/apis/#allow-developers-to-consume-your-api) to your Service. The KAA plugin applies authentication and authorization to the Service. This is a {{site.konnect_short_name}}-managed plugin that you can't directly modify, you can only modify it by configuring JSON in the advanced configuration for your [application auth strategy](/dev-portal/auth-strategies/). 
+      When a Gateway Service is linked to an API, {{site.konnect_short_name}} automatically adds the [{{site.konnect_short_name}} Application Auth (KAA) plugin](/dev-portal/apis/#allow-developers-to-consume-your-api) to your Service. The KAA plugin applies authentication and authorization to the Service. This is a {{site.konnect_short_name}}-managed plugin that you can't directly modify, you can only modify it by configuring JSON in the advanced configuration for your [application auth strategy](/dev-portal/auth-strategies/). 
 next_steps:
   - text: Apply an authentication strategy to your APIs
     url: /dev-portal/auth-strategies/

--- a/app/_how-tos/automate-api-catalog.md
+++ b/app/_how-tos/automate-api-catalog.md
@@ -59,7 +59,10 @@ faqs:
       * With [Dev Portal app registration](/dev-portal/self-service/): If non-current versions have Route configurations that allow requests to specify the version in some way, each version must document how to modify the request to access the given version (for example, using a header). 
       * Without Dev Portal app registration: If the version can be accessed separately from other versions of the same API, each version must document how to modify the request to access the given version.
   - q: What happens to the Service after I link the API?
-    a: After you link the API to a {{site.konnect_short_name}} Gateway Service, the Service includes the {{site.konnect_short_name}} Application Auth (KAA) plugin. The plugin ID is `konnect-application-auth`.
+    a: |
+      After you link the API to a {{site.konnect_short_name}} Gateway Service, {{site.konnect_short_name}} updates that Service’s configuration. It enables Konnect Application Auth (KAA) on the linked Service and binds it to the Application Authentication strategy that you set for the API (Key Auth, OpenID Connect, or Dynamic Client Registration). 
+      KAA is configured in Dev Portal; not Gateway Manager. 
+      If you select a strategy before any Service is linked, {{site.konnect_short_name}} records that choice and applies it automatically when you link a Service. If you later unlink the Service, the same strategy applies to the next Service you link to that API. The plugin ID is `konnect-application-auth`.
   - q: Can I remove {{site.konnect_short_name}} Application Auth (KAA) from a Service?
     a: No. If you remove the API-to-Service association, the Service no longer follows the API’s application-auth strategy. Test requests to confirm the current behavior.
   - q: How does {{site.konnect_short_name}} Application Auth (KAA) work with the steps on this page?

--- a/app/_how-tos/automate-api-catalog.md
+++ b/app/_how-tos/automate-api-catalog.md
@@ -58,6 +58,14 @@ faqs:
       There are two exceptions when the underlying implementation should match the selected version:
       * With [Dev Portal app registration](/dev-portal/self-service/): If non-current versions have Route configurations that allow requests to specify the version in some way, each version must document how to modify the request to access the given version (for example, using a header). 
       * Without Dev Portal app registration: If the version can be accessed separately from other versions of the same API, each version must document how to modify the request to access the given version.
+  - q: What happens to the Service after I link the API?
+    a: After you link the API to a {{site.konnect_short_name}} Gateway Service, the Service includes the {{site.konnect_short_name}} Application Auth (KAA) plugin. The plugin ID is `konnect-application-auth`.
+  - q: Can I remove {{site.konnect_short_name}} Application Auth (KAA) from a Service?
+    a: No. If you remove the API-to-Service association, the Service no longer follows the API’s application-auth strategy. Test requests to confirm the current behavior.
+  - q: How does {{site.konnect_short_name}} Application Auth (KAA) work with the steps on this page?
+    a: |
+    Our guide uses Konnect endpoints to create the API, attach a spec or a document, associate the API with a Service, and publish it. After you associate the API with the Service, the Service includes KAA and Dev Portal controls the strategy.
+    For example, when you create an API, add a spec or a document, then associate the API with a Gateway Service by calling `/v3/apis/{apiId}/implementations`. That association is the point after which the Service includes KAA. You then publish the API to the Dev Portal.
 next_steps:
   - text: Apply an authentication strategy to your APIs
     url: /dev-portal/auth-strategies/

--- a/app/_how-tos/automate-api-catalog.md
+++ b/app/_how-tos/automate-api-catalog.md
@@ -64,8 +64,8 @@ faqs:
     a: No. If you remove the API-to-Service association, the Service no longer follows the API’s application-auth strategy. Test requests to confirm the current behavior.
   - q: How does {{site.konnect_short_name}} Application Auth (KAA) work with the steps on this page?
     a: |
-    Our guide uses Konnect endpoints to create the API, attach a spec or a document, associate the API with a Service, and publish it. After you associate the API with the Service, the Service includes KAA and Dev Portal controls the strategy.
-    For example, when you create an API, add a spec or a document, then associate the API with a Gateway Service by calling `/v3/apis/{apiId}/implementations`. That association is the point after which the Service includes KAA. You then publish the API to the Dev Portal.
+      Our guide uses Konnect endpoints to create the API, attach a spec or a document, associate the API with a Service, and publish it. After you associate the API with the Service, the Service includes KAA and Dev Portal controls the strategy.
+      For example, when you create an API, add a spec or a document, then associate the API with a Gateway Service by calling `/v3/apis/{apiId}/implementations`. That association is the point after which the Service includes KAA. You then publish the API to the Dev Portal.
 next_steps:
   - text: Apply an authentication strategy to your APIs
     url: /dev-portal/auth-strategies/

--- a/app/dev-portal/apis.md
+++ b/app/dev-portal/apis.md
@@ -255,9 +255,13 @@ Based on this data, you get the following generated URLs:
 
 You can link to a {{site.konnect_short_name}} [Gateway Service](/gateway/entities/service/) to allow developers to create applications and generate credentials or API keys. This is available to data planes running {{site.base_gateway}} 3.6 or later.
 
-This will install the {{site.konnect_short_name}} Application Auth (KAA) plugin on that Service. The KAA plugin can only be configured from the associated Dev Portal and its published APIs.
+When you link an API to a service, the link adds the {{site.konnect_short_name}} Application Auth (KAA) plugin on that service. The plugin ID is `konnect-application-auth`. You configure KAA only from Dev Portal. Gateway Manager does not expose KAA settings.
+
+The authentication strategy that you select for the API defines how clients authenticate. To change KAA behavior, open the API’s authentication strategy in Dev Portal and edit advanced JSON. Authorization relies on data in Dev Portal. A request succeeds only when the client application in Dev Portal has a registration for the Service.
 
 If you want the Gateway Service to restrict access to the API, [configure developer and application registration for your Dev Portal](/dev-portal/self-service/).
+
+After you link the API and set the strategy in Dev Portal, developers can create applications, obtain credentials or keys, and call the API through the service.
 
 To link your API to a Gateway Service, do one of the following:
 {% navtabs "link-service" %}

--- a/app/dev-portal/apis.md
+++ b/app/dev-portal/apis.md
@@ -255,9 +255,35 @@ Based on this data, you get the following generated URLs:
 
 You can link to a {{site.konnect_short_name}} [Gateway Service](/gateway/entities/service/) to allow developers to create applications and generate credentials or API keys. This is available to data planes running {{site.base_gateway}} 3.6 or later.
 
-When you link an API to a service, the link adds the {{site.konnect_short_name}} Application Auth (KAA) plugin on that service. The plugin ID is `konnect-application-auth`. You configure KAA only from Dev Portal.
+When you link a service with an API, {{site.konnect_short_name}} automatically adds the {{site.konnect_short_name}} Application Auth (KAA) plugin on that Service. The KAA plugin is responsible for applying authentication and authorization on the Service. The [authentication strategy](/dev-portal/auth-strategies/) that you select for the API defines how clients authenticate. While you can't directly modify the KAA plugin as it's managed by {{site.konnect_short_name}}, you can modify the plugin's behavior by adding JSON to the advanced configuration of your application auth strategy. 
 
-The authentication strategy that you select for the API defines how clients authenticate. To change KAA behavior, open the API’s authentication strategy in Dev Portal and edit the JSON. Authorization relies on data in Dev Portal. A request succeeds only when the client application in Dev Portal has a registration for the Service.
+The following diagram shows how the KAA plugin manages authorization and authentication on the linked Service:
+
+<!--vale off-->
+{% mermaid %}
+sequenceDiagram
+    actor Client
+    Client->> Kong:
+    Kong->>Konnect Application Auth: Send request
+    Konnect Application Auth->>Konnect Application Auth: Authenticate the request based on the auth strategy
+
+    rect rgb(191, 223, 255)
+    note right of Konnect Application Auth: OIDC Strategy.
+    Konnect Application Auth-->> OIDC Plugin: 
+    OIDC Plugin->> IdP: Sends credentials request
+    IdP ->> OIDC Plugin: return JWT token
+    OIDC Plugin-->>Konnect Application Auth:
+    end
+    rect rgb(191, 223, 255)
+    note right of Konnect Application Auth: Key Auth Strategy.
+    Konnect Application Auth->>Konnect Application Auth: Authenticate Api Key
+    end
+
+    Konnect Application Auth->>Konnect Application Auth: Authorize the request with the authenticated client
+    Konnect Application Auth->>Kong:
+    Kong->>Client:
+ {% endmermaid %}
+ <!--vale on-->
 
 If you want the Gateway Service to restrict access to the API, [configure developer and application registration for your Dev Portal](/dev-portal/self-service/).
 

--- a/app/dev-portal/apis.md
+++ b/app/dev-portal/apis.md
@@ -287,8 +287,6 @@ sequenceDiagram
 
 If you want the Gateway Service to restrict access to the API, [configure developer and application registration for your Dev Portal](/dev-portal/self-service/).
 
-After you link the API and set the strategy in Dev Portal, developers can create applications, obtain credentials or keys, and call the API through the service.
-
 To link your API to a Gateway Service, do one of the following:
 {% navtabs "link-service" %}
 {% navtab "{{site.konnect_short_name}} UI" %}

--- a/app/dev-portal/apis.md
+++ b/app/dev-portal/apis.md
@@ -18,6 +18,7 @@ api_specs:
 search_aliases:
   - postman
   - publish API specs
+  - konnect-application-auth
 description: | 
     An API is the interface that you publish to your end customer. Developers register applications for use with specific API.
 related_resources:

--- a/app/dev-portal/apis.md
+++ b/app/dev-portal/apis.md
@@ -255,9 +255,9 @@ Based on this data, you get the following generated URLs:
 
 You can link to a {{site.konnect_short_name}} [Gateway Service](/gateway/entities/service/) to allow developers to create applications and generate credentials or API keys. This is available to data planes running {{site.base_gateway}} 3.6 or later.
 
-When you link an API to a service, the link adds the {{site.konnect_short_name}} Application Auth (KAA) plugin on that service. The plugin ID is `konnect-application-auth`. You configure KAA only from Dev Portal. Gateway Manager does not expose KAA settings.
+When you link an API to a service, the link adds the {{site.konnect_short_name}} Application Auth (KAA) plugin on that service. The plugin ID is `konnect-application-auth`. You configure KAA only from Dev Portal.
 
-The authentication strategy that you select for the API defines how clients authenticate. To change KAA behavior, open the API’s authentication strategy in Dev Portal and edit advanced JSON. Authorization relies on data in Dev Portal. A request succeeds only when the client application in Dev Portal has a registration for the Service.
+The authentication strategy that you select for the API defines how clients authenticate. To change KAA behavior, open the API’s authentication strategy in Dev Portal and edit the JSON. Authorization relies on data in Dev Portal. A request succeeds only when the client application in Dev Portal has a registration for the Service.
 
 If you want the Gateway Service to restrict access to the API, [configure developer and application registration for your Dev Portal](/dev-portal/self-service/).
 


### PR DESCRIPTION
Origin ticket: https://github.com/Kong/developer.konghq.com/pull/2725#issue-3363654607

> Jobs to be done:
> 
> Why document a plugin that's entirely handled behind the scenes? "for KAA it's more about compliancy and security, to make customers understand that it's injected automatically by konnect to manage authZ."
> DoD:
> 
> Add information about how the KAA plugin is managed / injected in the configuration of the gateway when linking an api to the gateway service here https://developer.konghq.com/dev-portal/apis/#allow-developers-to-consume-your-api
> Add FAQ about it [here](https://developer.konghq.com/how-to/automate-api-catalog/) and [here](https://developer.konghq.com/how-to/automate-api-catalog-with-terraform/)
> Add a search alias for konnect-application-auth to https://developer.konghq.com/dev-portal/apis/#allow-developers-to-consume-your-api (people are searching for it)
> Request: https://kongstrong.slack.com/archives/C02D0BPQC85/p1754923326928189


## Description
- Added info about KAA plugin
- Added 6 FAQs across 2 articles
- Included search alias
Fixes #2538 

## Preview Links

- [ ] [How to automate your catalog with dev portal](https://deploy-preview-2725--kongdeveloper.netlify.app/how-to/automate-api-catalog/#faqs)
- [ ] [How to automate your catalog with Terraform](https://deploy-preview-2725--kongdeveloper.netlify.app/how-to/automate-api-catalog-with-terraform/#faqs)
- [ ] [Dev Portal](https://deploy-preview-2725--kongdeveloper.netlify.app/dev-portal/apis/#allow-developers-to-consume-your-api)
## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
