### PR TITLE
feat(deck): deck file convert for LTS

### DIFF
--- a/app/_how-tos/convert-gateway-lts-2.8-3.4.md
+++ b/app/_how-tos/convert-gateway-lts-2.8-3.4.md
@@ -69,7 +69,7 @@ You can use `deck file convert` to automatically perform many of the changes tha
 See the [deck file convert](/deck/file/convert/) reference for a list of all the conversions that decK will perform.
 
 {:.info}
-> Note: Update your decK version to 1.47 or later before converting files.
+> **Note:** Update your decK version to 1.47 or later before converting files.
 
 ## Export configuration
 

--- a/app/_how-tos/convert-gateway-lts-2.8-3.4.md
+++ b/app/_how-tos/convert-gateway-lts-2.8-3.4.md
@@ -1,0 +1,134 @@
+---
+title: Convert Gateway entity configuration from 2.8 to 3.4
+content_type: how_to
+
+description: Use decK to upgrade from {{ site.base_gateway }} 2.8 LTS to 3.4 LTS
+
+permalink: /gateway/upgrade/convert-lts-28-34/
+
+products:
+    - gateway
+
+works_on:
+    - on-prem
+    - konnect
+
+min_version:
+  gateway: '3.4'
+
+tags:
+    - upgrade
+
+tldr:
+    q: How do I convert Gateway entity configuration from 2.8 to 3.4, as part of my upgrade process?
+    a: Run `deck file convert` and review the results.
+tools: []
+
+prereqs:
+  skip_product: true
+  inline:
+    - title: "{{site.base_gateway}} {% new_in 2.8 %}"
+      content: "You have {{site.base_gateway}} running on version 2.8."
+    - title: |
+        decK &nbsp; {% new_in 1.47 %}
+      content: |
+        decK is a CLI tool for managing {{site.base_gateway}} declaratively with state files.
+        To complete this tutorial, install [decK](/deck/) **version 1.47** or later.
+
+        This guide uses `deck gateway apply`, which directly applies entity configuration to your Gateway instance.
+        We recommend upgrading your decK installation to take advantage of this tool.
+
+        You can check your current decK version with `deck version`.
+
+related_resources:
+  - text: deck file convert
+    url: /deck/file/convert/
+  - text: Convert Gateway entity configuration from 3.4 to 3.10
+    url: /gateway/upgrade/convert-lts-34-310/
+  - text: Gateway LTS 2.8 to 3.4 upgrade
+    url: /gateway/upgrade/lts-upgrade-28-34/
+  - text: Gateway LTS 3.4 to 3.10 upgrade
+    url: /gateway/upgrade/lts-upgrade-34-310/
+
+faqs:
+  - q: I ran `deck file convert` but there are still errors or warnings, what do I do?
+    a: Manually validate the file, then make any necessary updates to your state file.
+  - q: Can I still apply configuration if there are warnings?
+    a: |
+      If you have validated the configuration and found no issues but are still getting a warning, the warning may be a false positive. 
+      You can still apply the configuration, but do so at your own risk.
+
+      If you run into false positives, [file an issue](https://github.com/Kong/deck/issues) to let us know.
+
+automated_tests: false
+---
+
+
+You can use `deck file convert` to automatically perform many of the changes that occurred between {{site.base_gateway}} 2.8 LTS and 3.4 LTS versions.
+
+See the [deck file convert](/deck/file/convert/) reference for a list of all the conversions that decK will perform.
+
+{:.info}
+> Note: Update your decK version to 1.47 or later before converting files.
+
+## Export configuration
+
+Use an existing backup file, or export the entity configuration an existing installation, for example 3.4:
+
+```sh
+deck gateway dump -o kong-2.8.yaml \
+    --konnect-token "$YOUR_KONNECT_PAT" \
+    --konnect-control-plane-name $YOUR_CP_NAME
+```
+{: data-deployment-topology="konnect" }
+
+```sh
+deck gateway dump -o kong-2.8.yaml --all-workspaces
+```
+{: data-deployment-topology="on-prem" }
+
+
+## Convert configuration
+
+Use `deck file convert` with version flags to convert the entity configuration:
+
+```sh
+deck file convert \
+    --from 2.8 \
+    --to 3.4 \
+    --input-file kong-2.8.yaml \
+    --output-file kong-3.4.yaml
+```
+
+## Review and validate
+
+1. Review the output of the command.
+   
+    `deck file convert` creates a new file and prints warnings and errors for any changes that can't be made automatically. 
+    These changes require some manual work, so adjust your configuration accordingly.
+
+1. Validate the converted file in a test environment.
+
+    Make sure to manually audit the generated file before applying the configuration in production. 
+    These changes may not be fully correct or exhaustive, so manual validation is strongly recommended.
+
+## Apply configuration
+
+Upload your new configuration to a {{site.konnect_short_name}} control plane:
+{: data-deployment-topology="konnect" }
+
+```sh
+deck gateway sync kong-3.4.yaml \
+    --konnect-token "$YOUR_KONNECT_PAT" \
+    --konnect-control-plane-name $YOUR_CP_NAME
+```
+{: data-deployment-topology="konnect" }
+
+Upload your new configuration to the new environment:
+{: data-deployment-topology="on-prem" }
+
+```sh
+deck gateway sync kong-3.4.yaml \
+    --workspace default
+```
+{: data-deployment-topology="on-prem" }

--- a/app/_how-tos/convert-gateway-lts-3.4-3.10.md
+++ b/app/_how-tos/convert-gateway-lts-3.4-3.10.md
@@ -69,7 +69,7 @@ You can use `deck file convert` to automatically perform many of the changes tha
 See the [deck file convert](/deck/file/convert/) reference for a list of all the conversions that decK will perform.
 
 {:.info}
-> Note: Update your decK version to 1.51 or later before converting files.
+> **Note:** Update your decK version to 1.51 or later before converting files.
 
 ## Export configuration
 

--- a/app/_how-tos/convert-gateway-lts-3.4-3.10.md
+++ b/app/_how-tos/convert-gateway-lts-3.4-3.10.md
@@ -1,0 +1,134 @@
+---
+title: Convert Gateway entity configuration from 3.4 to 3.10
+content_type: how_to
+
+description: Use decK to upgrade from {{ site.base_gateway }} 3.4 LTS to 3.10 LTS
+
+permalink: /gateway/upgrade/convert-lts-34-310/
+
+products:
+    - gateway
+
+works_on:
+    - on-prem
+    - konnect
+
+min_version:
+  gateway: '3.10'
+
+tags:
+    - upgrade
+
+tldr:
+    q: How do I convert Gateway entity configuration from 3.4 to 3.10, as part of my upgrade process?
+    a: Run `deck file convert` and review the results.
+tools: []
+
+prereqs:
+  skip_product: true
+  inline:
+    - title: "{{site.base_gateway}} {% new_in 3.4 %}"
+      content: "You have {{site.base_gateway}} running on version 3.4."
+    - title: |
+        decK &nbsp; {% new_in 1.51 %}
+      content: |
+        decK is a CLI tool for managing {{site.base_gateway}} declaratively with state files.
+        To complete this tutorial, install [decK](/deck/) **version 1.51** or later.
+
+        This guide uses `deck gateway apply`, which directly applies entity configuration to your Gateway instance.
+        We recommend upgrading your decK installation to take advantage of this tool.
+
+        You can check your current decK version with `deck version`.
+
+related_resources:
+  - text: deck file convert
+    url: /deck/file/convert/
+  - text: Convert Gateway entity configuration from 2.8 to 3.4
+    url: /deck/reference/3.0-upgrade/
+  - text: Gateway LTS 3.4 to 3.10 upgrade guide
+    url: /gateway/upgrade/lts-upgrade-28-34/
+  - text: Gateway LTS 3.10 to 3.10 upgrade guide
+    url: /gateway/upgrade/lts-upgrade-34-310/
+
+faqs:
+  - q: I ran `deck file convert` but there are still errors or warnings, what do I do?
+    a: Manually validate the file, then make any necessary updates to your state file.
+  - q: Can I still apply configuration if there are warnings?
+    a: |
+      If you have validated the configuration and found no issues but are still getting a warning, the warning may be a false positive. 
+      You can still apply the configuration, but do so at your own risk.
+
+      If you run into false positives, [file an issue](https://github.com/Kong/deck/issues) to let us know.
+
+automated_tests: false
+---
+
+
+You can use `deck file convert` to automatically perform many of the changes that occurred between {{site.base_gateway}} 3.4 LTS and 3.10 LTS versions.
+
+See the [deck file convert](/deck/file/convert/) reference for a list of all the conversions that decK will perform.
+
+{:.info}
+> Note: Update your decK version to 1.51 or later before converting files.
+
+## Export configuration
+
+Use an existing backup file, or export the entity configuration an existing installation, for example 3.10:
+
+```sh
+deck gateway dump -o kong-3.4.yaml \
+    --konnect-token "$YOUR_KONNECT_PAT" \
+    --konnect-control-plane-name $YOUR_CP_NAME
+```
+{: data-deployment-topology="konnect" }
+
+```sh
+deck gateway dump -o kong-3.4.yaml --all-workspaces
+```
+{: data-deployment-topology="on-prem" }
+
+
+## Convert configuration
+
+Use `deck file convert` with version flags to convert the entity configuration:
+
+```sh
+deck file convert \
+    --from 3.4 \
+    --to 3.10 \
+    --input-file kong-3.4.yaml \
+    --output-file kong-3.10.yaml
+```
+
+## Review and validate
+
+1. Review the output of the command.
+   
+    `deck file convert` creates a new file and prints warnings and errors for any changes that can't be made automatically. 
+    These changes require some manual work, so adjust your configuration accordingly.
+
+1. Validate the converted file in a test environment.
+
+    Make sure to manually audit the generated file before applying the configuration in production. 
+    These changes may not be fully correct or exhaustive, so manual validation is strongly recommended.
+
+## Apply configuration
+
+Upload your new configuration to a {{site.konnect_short_name}} control plane:
+{: data-deployment-topology="konnect" }
+
+```sh
+deck gateway sync kong-3.10.yaml \
+    --konnect-token "$YOUR_KONNECT_PAT" \
+    --konnect-control-plane-name $YOUR_CP_NAME
+```
+{: data-deployment-topology="konnect" }
+
+Upload your new configuration to the new environment:
+{: data-deployment-topology="on-prem" }
+
+```sh
+deck gateway sync kong-3.10.yaml \
+    --workspace default
+```
+{: data-deployment-topology="on-prem" }

--- a/app/_includes/upgrade/lts-upgrade.md
+++ b/app/_includes/upgrade/lts-upgrade.md
@@ -63,7 +63,6 @@ There are a number of steps you must complete before upgrading to {{site.base_ga
 1. Choose the right [strategy for upgrading](#preparation-choose-an-upgrade-strategy-based-on-deployment-mode) based on your deployment topology.
 1. Review the [{{site.base_gateway}} changes from {{ lts_version_from }} to {{ lts_version_to }}](#preparation-review-gateway-changes) for any breaking changes that may affect your deployments.
 1. Review any [modifications made to the `kong.conf` file](#kong-conf-changes) between the LTS releases.
-1. Export and convert your Gateway entities using `deck file convert`.
 1. Using your chosen strategy, test migration in a pre-production environment.
 
 ### Performing the upgrade
@@ -165,81 +164,6 @@ Traditional mode or control planes in hybrid mode:
 
 DB-less mode or data planes in hybrid mode:
 * [Rolling upgrade](/gateway/upgrade/rolling/)
-
-## Convert Gateway entity configuration
-
-You can use the [`deck file convert`](/deck/file/convert/) command to automatically perform many of the changes that occured between {{ lts_version_from }} and {{ lts_version_to }}.
-
-{% if include.lts_version_from == "3.4" %}
-{:.info}
-> decK version 1.51 or later is required.
-{% endif %}
-
-{% navtabs 'convert-entities' %}
-{% navtab "Konnect" %}
-
-1. Using the decK file you created during backup, convert the entity configuration into {{ lts_version_to }}:
-
-   ```sh
-   deck file convert \
-     --from {{ lts_version_from }} \
-     --to {{ lts_version_to }} \
-     --input-file kong-{{ lts_version_from }}.yaml \
-     --output-file kong-{{ lts_version_to }}.yaml
-   ```
-
-1. Review the output of the command.
-   
-    `deck file convert` creates a new file and prints warnings and errors for any changes that couldn't be made automatically. 
-    These changes require some manual work, so adjust your configuration accordingly.
-
-1. Validate the converted file in a test environment.
-
-    Make sure to manually audit the generated file before applying the configuration in production. 
-    These changes may not be fully correct or exhaustive, so manual validation is strongly recommended.
-
-1. Make any other changes that you noted from the [preparation stage](#preparation-review-gateway-changes) that may be specific to your implementation.
-
-1. Upload your new configuration to a {{site.konnect_short_name}} control plane:
-
-   ```sh
-   deck gateway sync kong-{{ lts_version_to }}.yaml \
-     --konnect-token "$YOUR_KONNECT_PAT" \
-     --konnect-control-plane-name $YOUR_CP_NAME
-   ```
-{% endnavtab %}
-{% navtab "Self-managed" %}
-
-1. Using the decK file you created during backup, convert the entity configuration into {{ lts_version_to }}:
-
-   ```sh
-   deck file convert \
-     --from {{ lts_version_from }} \
-     --to {{ lts_version_to }} \
-     --input-file kong-{{ lts_version_from }}.yaml \
-     --output-file kong-{{ lts_version_to }}.yaml
-   ```
-
-1. Review the output of the command.
-   
-    `deck file convert` creates a new file and prints warnings and errors for any changes that couldn't be made automatically. 
-    These changes require some manual work, so adjust your configuration accordingly.
-
-1. Validate the converted file in a test environment.
-
-    Make sure to manually audit the generated file before applying the configuration in production. 
-    These changes may not be fully correct or exhaustive, so manual validation is strongly recommended.
-
-1. Make any other changes that you noted from the [preparation stage](#preparation-review-gateway-changes) that may be specific to your implementation.
-
-1. Upload your new configuration to the new environment:
-
-   ```sh
-   deck gateway sync kong-{{ lts_version_to }}.yaml \
-     --workspace default
-   ```
-{% endnavtab %}
-{% endnavtabs %}
 
 ## Troubleshooting
 

--- a/app/_includes/upgrade/lts-upgrade.md
+++ b/app/_includes/upgrade/lts-upgrade.md
@@ -33,7 +33,7 @@ Read this document thoroughly to successfully complete the upgrade process, as i
   * [Kubernetes version and Helm prerequisites](/kubernetes-ingress-controller/support/)
   * [Hardware resources](/gateway/resource-sizing-guidelines/)
   * [Database and dependency versions](/gateway/third-party-support/)
-* If you're using decK, [upgrade it to the latest version](/deck/).
+* [decK installed and upgraded to the latest version](/deck/).
 
 {% if include.lts_version_from == "2.8" %}
 {:.info}
@@ -63,6 +63,7 @@ There are a number of steps you must complete before upgrading to {{site.base_ga
 1. Choose the right [strategy for upgrading](#preparation-choose-an-upgrade-strategy-based-on-deployment-mode) based on your deployment topology.
 1. Review the [{{site.base_gateway}} changes from {{ lts_version_from }} to {{ lts_version_to }}](#preparation-review-gateway-changes) for any breaking changes that may affect your deployments.
 1. Review any [modifications made to the `kong.conf` file](#kong-conf-changes) between the LTS releases.
+1. Export and convert your Gateway entities using `deck file convert`.
 1. Using your chosen strategy, test migration in a pre-production environment.
 
 ### Performing the upgrade
@@ -164,6 +165,81 @@ Traditional mode or control planes in hybrid mode:
 
 DB-less mode or data planes in hybrid mode:
 * [Rolling upgrade](/gateway/upgrade/rolling/)
+
+## Convert Gateway entity configuration
+
+You can use the [`deck file convert`](/deck/file/convert/) command to automatically perform many of the changes that occured between {{ lts_version_from }} and {{ lts_version_to }}.
+
+{% if include.lts_version_from == "3.4" %}
+{:.info}
+> decK version 1.51 or later is required.
+{% endif %}
+
+{% navtabs 'convert-entities' %}
+{% navtab "Konnect" %}
+
+1. Using the decK file you created during backup, convert the entity configuration into {{ lts_version_to }}:
+
+   ```sh
+   deck file convert \
+     --from {{ lts_version_from }} \
+     --to {{ lts_version_to }} \
+     --input-file kong-{{ lts_version_from }}.yaml \
+     --output-file kong-{{ lts_version_to }}.yaml
+   ```
+
+1. Review the output of the command.
+   
+    `deck file convert` creates a new file and prints warnings and errors for any changes that couldn't be made automatically. 
+    These changes require some manual work, so adjust your configuration accordingly.
+
+1. Validate the converted file in a test environment.
+
+    Make sure to manually audit the generated file before applying the configuration in production. 
+    These changes may not be fully correct or exhaustive, so manual validation is strongly recommended.
+
+1. Make any other changes that you noted from the [preparation stage](#preparation-review-gateway-changes) that may be specific to your implementation.
+
+1. Upload your new configuration to a {{site.konnect_short_name}} control plane:
+
+   ```sh
+   deck gateway sync kong-{{ lts_version_to }}.yaml \
+     --konnect-token "$YOUR_KONNECT_PAT" \
+     --konnect-control-plane-name $YOUR_CP_NAME
+   ```
+{% endnavtab %}
+{% navtab "Self-managed" %}
+
+1. Using the decK file you created during backup, convert the entity configuration into {{ lts_version_to }}:
+
+   ```sh
+   deck file convert \
+     --from {{ lts_version_from }} \
+     --to {{ lts_version_to }} \
+     --input-file kong-{{ lts_version_from }}.yaml \
+     --output-file kong-{{ lts_version_to }}.yaml
+   ```
+
+1. Review the output of the command.
+   
+    `deck file convert` creates a new file and prints warnings and errors for any changes that couldn't be made automatically. 
+    These changes require some manual work, so adjust your configuration accordingly.
+
+1. Validate the converted file in a test environment.
+
+    Make sure to manually audit the generated file before applying the configuration in production. 
+    These changes may not be fully correct or exhaustive, so manual validation is strongly recommended.
+
+1. Make any other changes that you noted from the [preparation stage](#preparation-review-gateway-changes) that may be specific to your implementation.
+
+1. Upload your new configuration to the new environment:
+
+   ```sh
+   deck gateway sync kong-{{ lts_version_to }}.yaml \
+     --workspace default
+   ```
+{% endnavtab %}
+{% endnavtabs %}
 
 ## Troubleshooting
 

--- a/app/deck/file/convert.md
+++ b/app/deck/file/convert.md
@@ -52,7 +52,8 @@ rows:
       - Prefix any paths that look like a regular expression with a `~`
       - Generate default values for missing `namespace` fields in any Rate Limiting Advanced plugins
       - Convert decK file `_format_version` from 1.1 to 3.0
-  - path: "`2.8` to `3.4`"
+  - path: |
+      `2.8` to `3.4` {% new_in 1.47.0 %}
     transforms: |
       - Prefix any paths that look like a regular expression with a `~`
       - Generate default values for missing `namespace` fields in any Rate Limiting Advanced plugins
@@ -64,7 +65,8 @@ rows:
         - Remove the deprecated `config.proxy_scheme` parameter
       - Pre-Function and Post-Function plugins: 
         - Convert `config.functions` to `config.access`
-  - path: "`3.4` to `3.10`"
+  - path: |
+      `3.4` to `3.10` {% new_in 1.51.0 %}
     transforms: |
       - Any plugins that use Redis configurations:
         - Transform `redis.cluster_addresses` into `redis.cluster_nodes`
@@ -78,6 +80,11 @@ rows:
 ## Converting between LTS versions
 
 You can use `deck file convert` to automatically perform many of the changes that occurred between adjacent LTS versions, such as 2.8 and 3.4, or 3.4 and 3.10.
+
+{:.info}
+> Note: Update your decK version before converting files:
+* 2.8 -> 3.4: deck 1.47.0 or later
+* 3.4 -> 3.10: decK 1.51.0 or later
 
 {% navtabs 'convert-entities' %}
 {% navtab "Konnect" %}

--- a/app/deck/file/convert.md
+++ b/app/deck/file/convert.md
@@ -19,7 +19,13 @@ breadcrumbs:
 related_resources:
   - text: decK gateway commands
     url: /deck/gateway/
-
+  - text: Upgrade to {{ site.base_gateway }} 3.x with decK
+    url: /deck/reference/3.0-upgrade/
+  - text: Gateway LTS 2.8 to 3.4 upgrade
+    url: /gateway/upgrade/lts-upgrade-28-34/
+  - text: Gateway LTS 3.4 to 3.10 upgrade
+    url: /gateway/upgrade/lts-upgrade-34-310/
+  
 tags:
   - declarative-config
 ---
@@ -32,9 +38,113 @@ deck file convert --input-file kong2x.yaml --from kong-gateway-2.x --to kong-gat
 
 ## Applied transformations
 
-- `kong-gateway-2.x` to `kong-gateway-3.x`
-  - Prefix any paths that look like a regular expression with a `~`
-  - Generate default values for missing `namespace` fields in any Rate Limiting Advanced plugins
+{% table %}
+columns:
+  - title: Conversion path
+    key: path
+  - title: Applied transformations
+    key: transforms
+rows:
+  - path: "`kong-gateway-2.x` to `kong-gateway-3.x`"
+    transforms: |
+      - Prefix any paths that look like a regular expression with a `~`
+      - Generate default values for missing `namespace` fields in any Rate Limiting Advanced plugins
+      - Convert decK file `_format_version` from 1.1 to 3.0
+  - path: "`2.8` to `3.4`"
+    transforms: |
+      - Prefix any paths that look like a regular expression with a `~`
+      - Generate default values for missing `namespace` fields in any Rate Limiting Advanced plugins
+      - Convert decK file `_format_version` from 1.1 to 3.0
+  - path: "`3.4` to `3.10`"
+    transforms: |
+      - Any plugins that use Redis configurations:
+        - Transform `redis.cluster_addresses` into `redis.cluster_nodes`
+        - Transform `redis.sentinel_addresses` into `redis.sentinel_nodes`
+      - AI plugins:
+        - Transform `model.options.upstream_path` into `model.options.upstream_url`
+      - AI Rate Limiting Advanced plugin:
+        - Transform `llm_providers.window_size` from a single value to a list
+{% endtable %}
+
+## Converting between LTS versions
+
+You can use `deck file convert` to automatically perform many of the changes that occured between adjacent LTS versions, such as 2.8 and 3.4, or 3.4 and 3.10.
+
+{% navtabs 'convert-entities' %}
+{% navtab "Konnect" %}
+
+1. Export the entity configuration an existing installation, for example 3.4:
+
+   ```sh
+   deck gateway dump -o kong-3.4.yaml \
+     --konnect-token "$YOUR_KONNECT_PAT" \
+     --konnect-control-plane-name $YOUR_CP_NAME
+   ```
+
+1. Convert the entity configuration:
+
+   ```sh
+   deck file convert \
+     --from 3.4 \
+     --to 3.10 \
+     --input-file kong-3.4.yaml \
+     --output-file kong-3.10.yaml
+   ```
+
+1. Review the output of the command.
+   
+    `deck file convert` creates a new file and prints warnings and errors for any changes that can't be made automatically. 
+    These changes require some manual work, so adjust your configuration accordingly.
+
+1. Validate the converted file in a test environment.
+
+    Make sure to manually audit the generated file before applying the configuration in production. 
+    These changes may not be fully correct or exhaustive, so manual validation is strongly recommended.
+
+1. Upload your new configuration to a {{site.konnect_short_name}} control plane:
+
+   ```sh
+   deck gateway sync kong-3.10.yaml \
+     --konnect-token "$YOUR_KONNECT_PAT" \
+     --konnect-control-plane-name $YOUR_CP_NAME
+   ```
+{% endnavtab %}
+{% navtab "Self-managed" %}
+
+1. Export the entity configuration an existing installation, for example 3.4:
+
+   ```sh
+   deck gateway dump -o kong-3.4.yaml --all-workspaces
+   ```
+
+1. Convert the entity configuration:
+
+   ```sh
+   deck file convert \
+     --from 3.4 \
+     --to 3.10 \
+     --input-file kong-3.4.yaml \
+     --output-file kong-3.10.yaml
+   ```
+
+1. Review the output of the command.
+   
+    `deck file convert` creates a new file and prints warnings and errors for any changes that can't be made automatically. 
+    These changes require some manual work, so adjust your configuration accordingly.
+
+1. Validate the converted file in a test environment.
+
+    Make sure to manually audit the generated file before applying the configuration in production. 
+    These changes may not be fully correct or exhaustive, so manual validation is strongly recommended.
+
+1. Upload your new configuration to the new environment:
+
+   ```sh
+   deck gateway sync kong-3.10.yaml \
+     --workspace default
+   ```
+{% endnavtab %}
+{% endnavtabs %}
 
 ## Command usage
 

--- a/app/deck/file/convert.md
+++ b/app/deck/file/convert.md
@@ -21,11 +21,10 @@ related_resources:
     url: /deck/gateway/
   - text: Upgrade to {{ site.base_gateway }} 3.x with decK
     url: /deck/reference/3.0-upgrade/
-  - text: Gateway LTS 2.8 to 3.4 upgrade
-    url: /gateway/upgrade/lts-upgrade-28-34/
-  - text: Gateway LTS 3.4 to 3.10 upgrade
-    url: /gateway/upgrade/lts-upgrade-34-310/
-  
+  - text: Convert Gateway entity config from 2.8 LTS to 3.4 LTS
+    url: /gateway/upgrade/convert-lts-28-34/
+  - text: Convert Gateway entity config from 3.4 LTS to 3.10 LTS
+    url: /gateway/upgrade/convert-lts-34-310/
 tags:
   - declarative-config
 ---
@@ -76,91 +75,6 @@ rows:
       - AI Rate Limiting Advanced plugin:
         - Transform `llm_providers.window_size` from a single value to a list
 {% endtable %}
-
-## Converting between LTS versions
-
-You can use `deck file convert` to automatically perform many of the changes that occurred between adjacent LTS versions, such as 2.8 and 3.4, or 3.4 and 3.10.
-
-{:.info}
-> Note: Update your decK version before converting files:
-* 2.8 -> 3.4: deck 1.47.0 or later
-* 3.4 -> 3.10: decK 1.51.0 or later
-
-{% navtabs 'convert-entities' %}
-{% navtab "Konnect" %}
-
-1. Use an existing backup file, or export the entity configuration an existing installation, for example 3.4:
-
-   ```sh
-   deck gateway dump -o kong-3.4.yaml \
-     --konnect-token "$YOUR_KONNECT_PAT" \
-     --konnect-control-plane-name $YOUR_CP_NAME
-   ```
-
-1. Convert the entity configuration:
-
-   ```sh
-   deck file convert \
-     --from 3.4 \
-     --to 3.10 \
-     --input-file kong-3.4.yaml \
-     --output-file kong-3.10.yaml
-   ```
-
-1. Review the output of the command.
-   
-    `deck file convert` creates a new file and prints warnings and errors for any changes that can't be made automatically. 
-    These changes require some manual work, so adjust your configuration accordingly.
-
-1. Validate the converted file in a test environment.
-
-    Make sure to manually audit the generated file before applying the configuration in production. 
-    These changes may not be fully correct or exhaustive, so manual validation is strongly recommended.
-
-1. Upload your new configuration to a {{site.konnect_short_name}} control plane:
-
-   ```sh
-   deck gateway sync kong-3.10.yaml \
-     --konnect-token "$YOUR_KONNECT_PAT" \
-     --konnect-control-plane-name $YOUR_CP_NAME
-   ```
-{% endnavtab %}
-{% navtab "Self-managed" %}
-
-1. Use an existing backup file, or export the entity configuration an existing installation, for example 3.4:
-
-   ```sh
-   deck gateway dump -o kong-3.4.yaml --all-workspaces
-   ```
-
-1. Convert the entity configuration:
-
-   ```sh
-   deck file convert \
-     --from 3.4 \
-     --to 3.10 \
-     --input-file kong-3.4.yaml \
-     --output-file kong-3.10.yaml
-   ```
-
-1. Review the output of the command.
-   
-    `deck file convert` creates a new file and prints warnings and errors for any changes that can't be made automatically. 
-    These changes require some manual work, so adjust your configuration accordingly.
-
-1. Validate the converted file in a test environment.
-
-    Make sure to manually audit the generated file before applying the configuration in production. 
-    These changes may not be fully correct or exhaustive, so manual validation is strongly recommended.
-
-1. Upload your new configuration to the new environment:
-
-   ```sh
-   deck gateway sync kong-3.10.yaml \
-     --workspace default
-   ```
-{% endnavtab %}
-{% endnavtabs %}
 
 ## Command usage
 

--- a/app/deck/file/convert.md
+++ b/app/deck/file/convert.md
@@ -38,6 +38,8 @@ deck file convert --input-file kong2x.yaml --from kong-gateway-2.x --to kong-gat
 
 ## Applied transformations
 
+The following table lists the transformations that `deck file convert` performs:
+
 {% table %}
 columns:
   - title: Conversion path
@@ -73,7 +75,7 @@ You can use `deck file convert` to automatically perform many of the changes tha
 {% navtabs 'convert-entities' %}
 {% navtab "Konnect" %}
 
-1. Export the entity configuration an existing installation, for example 3.4:
+1. Use an existing backup file, or export the entity configuration an existing installation, for example 3.4:
 
    ```sh
    deck gateway dump -o kong-3.4.yaml \
@@ -111,7 +113,7 @@ You can use `deck file convert` to automatically perform many of the changes tha
 {% endnavtab %}
 {% navtab "Self-managed" %}
 
-1. Export the entity configuration an existing installation, for example 3.4:
+1. Use an existing backup file, or export the entity configuration an existing installation, for example 3.4:
 
    ```sh
    deck gateway dump -o kong-3.4.yaml --all-workspaces

--- a/app/deck/file/convert.md
+++ b/app/deck/file/convert.md
@@ -57,6 +57,13 @@ rows:
       - Prefix any paths that look like a regular expression with a `~`
       - Generate default values for missing `namespace` fields in any Rate Limiting Advanced plugins
       - Convert decK file `_format_version` from 1.1 to 3.0
+      - ACL, Bot Detection, IP Restriction, and Canary plugins: 
+        - Convert `config.blacklist` to `config.deny`
+        - Convert `config.whitelist` to `config.allow`
+      - AWS Lambda plugin: 
+        - Remove the deprecated `config.proxy_scheme` parameter
+      - Pre-Function and Post-Function plugins: 
+        - Convert `config.functions` to `config.access`
   - path: "`3.4` to `3.10`"
     transforms: |
       - Any plugins that use Redis configurations:

--- a/app/deck/file/convert.md
+++ b/app/deck/file/convert.md
@@ -70,7 +70,7 @@ rows:
 
 ## Converting between LTS versions
 
-You can use `deck file convert` to automatically perform many of the changes that occured between adjacent LTS versions, such as 2.8 and 3.4, or 3.4 and 3.10.
+You can use `deck file convert` to automatically perform many of the changes that occurred between adjacent LTS versions, such as 2.8 and 3.4, or 3.4 and 3.10.
 
 {% navtabs 'convert-entities' %}
 {% navtab "Konnect" %}

--- a/app/deck/reference/3.0-upgrade.md
+++ b/app/deck/reference/3.0-upgrade.md
@@ -32,7 +32,7 @@ faqs:
       When you sync the file without updating regex paths, the incorrect values will be pushed to the database and {{site.base_gateway}} will Route traffic incorrectly.
 
       decK will issue a warning stating that an invalid regex pattern was detected and that it must be updated with a `~` to distinguish it from a standard prefix match.
-  - q: I ran decK convert but there are still errors or warnings, what do I do?
+  - q: I ran `deck file convert` but there are still errors or warnings, what do I do?
     a: Manually validate the file, then make any necessary updates to your state file.
   - q: Can I still apply configuration if there are warnings?
     a: |
@@ -59,10 +59,10 @@ Would need to be rewritten in the new 3.0 format:
 If you [migrated your {{site.base_gateway}} database](/gateway/upgrade/) from 2.8.x to 3.0, the `~` prefix is automatically added to the Route paths in the database.
 This causes configuration drift between the formats of the Routes that exist in the database and the Routes in your configuration file.
 
-Before using your state files to update the database, convert them into the 3.0 format using `deck convert`.
+Before using your state files to update the database, convert them into the 3.0 format using `deck file convert`.
 
 {:.warning}
-> **Important**: Don't use `deck sync` with {{site.base_gateway}} 3.x before converting paths into the 3.0 format.
+> **Important**: Don't use `deck gateway sync` with {{site.base_gateway}} 3.x before converting paths into the 3.0 format.
 > This will break all regex routing in 3.x.
 
 ## Convert declarative configuration files
@@ -70,7 +70,7 @@ Before using your state files to update the database, convert them into the 3.0 
 1. Run `deck-convert` against your 2.x state file to turn it into a 3.x file:
 
    ```sh
-   deck convert \
+   deck file convert \
    --from kong-gateway-2.x \
    --to kong-gateway-3.x \
    --input-file kong.yaml \
@@ -93,12 +93,12 @@ Before using your state files to update the database, convert them into the 3.0 
 
 When running decK commands against {{site.base_gateway}} 3.x, keep the following behavior in mind:
 
-### `deck dump`
+### `deck gateway dump`
 
 Explicitly sets the format version to 3.0.
-It assumes that the paths have been correctly transformed, either via Kong migrations, manually, or through a `deck convert`.
+It assumes that the paths have been correctly transformed, either via Kong migrations, manually, or through a `deck file convert`.
 
-### `deck diff`, `deck validate` (with `--online` flag only), or `deck sync`
+### `deck gateway diff`, `deck file validate` (with `--online` flag only), or `deck gateway sync`
 
 decK performs a check to ensure all regex Routes are correctly prefixed.
 The behavior of the command depends on the format version in the declarative configuration file:
@@ -107,7 +107,7 @@ The behavior of the command depends on the format version in the declarative con
 - `_format_version: 3.0` with _incorrectly_ prefixed routes: Prints a warning and goes ahead with the `diff`, `sync`, or `validate` operation as usual.
 - `_format_version: 3.0` with _correctly_ prefixed routes: Goes ahead with the `diff`, `sync`, or `validate` operation as usual.
 
-### `deck convert`
+### `deck file convert`
 
 Includes `--from` and `--to` flags for converting state files between major versions.
 Converts all relevant files in the present working directory:
@@ -118,11 +118,11 @@ Converts all relevant files in the present working directory:
 You can optionally provide `--input-file` and `--output-file` flags to limit conversion to
 a subset of files.
 
-## Using decK with {{site.konnect_short_name}} Data Plane nodes
+## Using decK with {{site.konnect_short_name}} data plane nodes
 
-{{site.konnect_short_name}} supports 3.x and 2.x Data Plane nodes, but the {{site.konnect_short_name}} Control Plane version is 3.x.
-Since decK can't tell if a Control Plane is intended for 2.x or 3.x Data Plane nodes, it will always dump configuration with `_format_version: 3.0`.
+{{site.konnect_short_name}} supports 3.x and 2.x data plane nodes, but the {{site.konnect_short_name}} control plane version is 3.x.
+Since decK can't tell if a control plane is intended for 2.x or 3.x data plane nodes, it will always dump configuration with `_format_version: 3.0`.
 
-To avoid compatibility errors, make sure that all Data Plane nodes in a single Control Plane are of the same major version (all 2.x or all 3.x).
+To avoid compatibility errors, make sure that all data plane nodes in a single control plane are of the same major version (all 2.x or all 3.x).
 
 For all `diff`, `sync`, or `validate` (with `--online` flag) operations against {{site.konnect_short_name}}, decK issues warnings when it detects incorrect regex path configurations.

--- a/app/deck/reference/3.0-upgrade.md
+++ b/app/deck/reference/3.0-upgrade.md
@@ -22,6 +22,8 @@ breadcrumbs:
 related_resources:
   - text: Upgrading {{site.base_gateway}}
     url: /gateway/upgrade/
+  - text: deck file convert
+    url: /deck/file/convert/
 
 faqs:
   - q: What happens if I set the format version to 3.0 but don't update regex paths?
@@ -91,26 +93,29 @@ Before using your state files to update the database, convert them into the 3.0 
 
 When running decK commands against {{site.base_gateway}} 3.x, keep the following behavior in mind:
 
-`deck dump`
-: Explicitly sets the format version to 3.0.
+### `deck dump`
+
+Explicitly sets the format version to 3.0.
 It assumes that the paths have been correctly transformed, either via Kong migrations, manually, or through a `deck convert`.
 
-`deck diff`, `deck validate` (with `--online` flag only), or `deck sync`
-: decK performs a check to ensure all regex Routes are correctly prefixed.
+### `deck diff`, `deck validate` (with `--online` flag only), or `deck sync`
+
+decK performs a check to ensure all regex Routes are correctly prefixed.
 The behavior of the command depends on the format version in the declarative configuration file:
 
 - `_format_version: 1.1` or earlier: Prints an error and stops the operation.
 - `_format_version: 3.0` with _incorrectly_ prefixed routes: Prints a warning and goes ahead with the `diff`, `sync`, or `validate` operation as usual.
 - `_format_version: 3.0` with _correctly_ prefixed routes: Goes ahead with the `diff`, `sync`, or `validate` operation as usual.
 
-`deck convert`
-: Includes `--from` and `--to` flags for converting state files between major versions.
+### `deck convert`
+
+Includes `--from` and `--to` flags for converting state files between major versions.
 Converts all relevant files in the present working directory:
 
 - Upgrades the `_format_version` setting to `3.0`
 - Adds the `~` prefix to all Route paths containing a regex pattern
 
-: You can optionally provide `--input-file` and `--output-file` flags to limit conversion to
+You can optionally provide `--input-file` and `--output-file` flags to limit conversion to
 a subset of files.
 
 ## Using decK with {{site.konnect_short_name}} Data Plane nodes

--- a/app/gateway/upgrade/blue-green.md
+++ b/app/gateway/upgrade/blue-green.md
@@ -139,14 +139,16 @@ point it at the existing database for cluster X.
     Provision the new cluster Y with the same-sized resource capacity as that of 
     the current cluster X.
 
-2. Migrate the database to the new version by running `kong migrations up`. 
+1. Migrate the database to the new version by running `kong migrations up`. 
 
     {{site.base_gateway}} will print a warning log entry that pending migrations exist. 
     This is expected.
 
-3. Start the new cluster Y.
+1. Start the new cluster Y.
 
-4. Perform staging tests against version Y to make sure it works for all use cases. 
+1. _(LTS upgrades or 2.x to 3.x upgrades only)_ Using the decK file created during backup, [convert](/deck/file/convert/#converting-between-lts-versions) your entity configuration and sync the converted file to your newly installed version.
+
+1. Perform staging tests against version Y to make sure it works for all use cases. 
 
     For example, does the Key Authentication plugin authenticate requests properly?
     

--- a/app/gateway/upgrade/blue-green.md
+++ b/app/gateway/upgrade/blue-green.md
@@ -146,7 +146,7 @@ point it at the existing database for cluster X.
 
 1. Start the new cluster Y.
 
-1. _(LTS upgrades or 2.x to 3.x upgrades only)_ Using the decK file created during backup, [convert](/deck/file/convert/#converting-between-lts-versions) your entity configuration and sync the converted file to your newly installed version.
+1. _(LTS upgrades or 2.x to 3.x upgrades only)_ Using the decK file created during backup, [convert](/deck/file/convert/) your entity configuration and sync the converted file to your newly installed version.
 
 1. Perform staging tests against version Y to make sure it works for all use cases. 
 

--- a/app/gateway/upgrade/dual-cluster.md
+++ b/app/gateway/upgrade/dual-cluster.md
@@ -144,7 +144,7 @@ to the new database.
 
 1. Start cluster Y.
 
-1. _(LTS upgrades or 2.x to 3.x upgrades only)_ Using the decK file created during backup, [convert](/deck/file/convert/#converting-between-lts-versions) your entity configuration and sync the converted file to your newly installed version.
+1. _(LTS upgrades or 2.x to 3.x upgrades only)_ Using the decK file created during backup, [convert](/deck/file/convert/) your entity configuration and sync the converted file to your newly installed version.
 
 1. Perform staging tests against version Y to make sure it works for all use cases. 
 

--- a/app/gateway/upgrade/dual-cluster.md
+++ b/app/gateway/upgrade/dual-cluster.md
@@ -135,16 +135,18 @@ You may have to consider customization of both `kong.conf` and {{site.base_gatew
     Provision the new cluster Y with the same-sized resource capacity as that of 
     the current cluster X.
 
-2. Install a new database of the same version.
+1. Install a new database of the same version.
 
-3. [Restore the backup data](/gateway/upgrade/backup-and-restore/#restore-gateway-entities)
+1. [Restore the backup data](/gateway/upgrade/backup-and-restore/#restore-gateway-entities)
 to the new database.
 
-4. Configure the new cluster Y to point to the new database.
+1. Configure the new cluster Y to point to the new database.
 
-5. Start cluster Y.
+1. Start cluster Y.
 
-6. Perform staging tests against version Y to make sure it works for all use cases. 
+1. _(LTS upgrades or 2.x to 3.x upgrades only)_ Using the decK file created during backup, [convert](/deck/file/convert/#converting-between-lts-versions) your entity configuration and sync the converted file to your newly installed version.
+
+1. Perform staging tests against version Y to make sure it works for all use cases. 
 
     For example, does the Key Authentication plugin authenticate requests properly?
     

--- a/app/gateway/upgrade/in-place.md
+++ b/app/gateway/upgrade/in-place.md
@@ -124,7 +124,7 @@ This will create a period of downtime until the upgrade completes.
 
 1. Start the new cluster Y.
 
-1. _(LTS upgrades or 2.x to 3.x upgrades only)_ Using the decK file created during backup, [convert](/deck/file/convert/#converting-between-lts-versions) your entity configuration and sync the converted file to your newly installed version.
+1. _(LTS upgrades or 2.x to 3.x upgrades only)_ Using the decK file created during backup, [convert](/deck/file/convert/) your entity configuration and sync the converted file to your newly installed version.
 
 Once this is done, actively monitor all proxy metrics. If you run into any issues, [roll back the upgrade](/gateway/upgrade/backup-and-restore/#restore-gateway-entities). 
 Prioritize the database-level restoration method over the application-level method.

--- a/app/gateway/upgrade/in-place.md
+++ b/app/gateway/upgrade/in-place.md
@@ -111,18 +111,20 @@ You may have to consider customization of both `kong.conf` and {{site.base_gatew
 1. Stop the {{site.base_gateway}} nodes of the old cluster X but keep the database running. 
 This will create a period of downtime until the upgrade completes.
 
-2. Install a new cluster running version Y as instructed in the 
+1. Install a new cluster running version Y as instructed in the 
     [{{site.base_gateway}} Installation Options](/gateway/install/) and 
     point it at the existing database for cluster X.
     
     Provision the new cluster Y with the same-sized resource capacity as that of 
     the current cluster X.
 
-3. Migrate the database to the new version by running `kong migrations up`. 
+1. Migrate the database to the new version by running `kong migrations up`. 
 
-4. When complete, run `kong migrations finish`.
+1. When complete, run `kong migrations finish`.
 
-5. Start the new cluster Y.
+1. Start the new cluster Y.
+
+1. _(LTS upgrades or 2.x to 3.x upgrades only)_ Using the decK file created during backup, [convert](/deck/file/convert/#converting-between-lts-versions) your entity configuration and sync the converted file to your newly installed version.
 
 Once this is done, actively monitor all proxy metrics. If you run into any issues, [roll back the upgrade](/gateway/upgrade/backup-and-restore/#restore-gateway-entities). 
 Prioritize the database-level restoration method over the application-level method.

--- a/app/gateway/upgrade/rolling.md
+++ b/app/gateway/upgrade/rolling.md
@@ -114,7 +114,7 @@ You may have to consider customization of both [`kong.conf`](/gateway/manage-kon
         Provision the new cluster Y with the same-sized resource capacity as that of 
         the current cluster X.
 
-    1. _(LTS upgrades or 2.x to 3.x upgrades only)_ Using the decK file created during backup, [convert](/deck/file/convert/#converting-between-lts-versions) your entity configuration and sync the converted file to your newly installed version.
+    1. _(LTS upgrades or 2.x to 3.x upgrades only)_ Using the decK file created during backup, [convert](/deck/file/convert/) your entity configuration and sync the converted file to your newly installed version.
 
     1. Perform staging tests against version Y to make sure it works for all use cases. 
     

--- a/app/gateway/upgrade/rolling.md
+++ b/app/gateway/upgrade/rolling.md
@@ -96,17 +96,17 @@ The exact execution of these steps will vary depending on your environment.
 1. Stop any {{site.base_gateway}} configuration updates (for example, [Admin API](/api/gateway/admin-ee/) calls to `:8001/config`). 
 This is critical to guarantee data consistency between cluster X and cluster Y.
 
-2. Back up data from the current cluster X by following the 
+1. Back up data from the current cluster X by following the 
 [declarative configuration backup instructions](/gateway/upgrade/backup-and-restore/#declarative-backup).
 
-3. Evaluate factors that may impact the upgrade, as described in [Upgrade considerations](/gateway/upgrade/).
+1. Evaluate factors that may impact the upgrade, as described in [Upgrade considerations](/gateway/upgrade/).
 You may have to consider customization of both [`kong.conf`](/gateway/manage-kong-conf/) and {{site.base_gateway}} configuration data.
 
-4. Evaluate any changes that have happened between releases:
+1. Evaluate any changes that have happened between releases:
     * [Breaking changes](/gateway/breaking-changes/)
     * [Full changelog](/gateway/changelog/)
 
-5.  Deploy a new {{site.base_gateway}} cluster of version Y:
+1.  Deploy a new {{site.base_gateway}} cluster of version Y:
     
     1. Install a new cluster running version Y as instructed in the 
     [{{site.base_gateway}} Installation Options](/gateway/install/).
@@ -114,7 +114,9 @@ You may have to consider customization of both [`kong.conf`](/gateway/manage-kon
         Provision the new cluster Y with the same-sized resource capacity as that of 
         the current cluster X.
 
-    2. Perform staging tests against version Y to make sure it works for all use cases. 
+    1. _(LTS upgrades or 2.x to 3.x upgrades only)_ Using the decK file created during backup, [convert](/deck/file/convert/#converting-between-lts-versions) your entity configuration and sync the converted file to your newly installed version.
+
+    1. Perform staging tests against version Y to make sure it works for all use cases. 
     
         For example, does the Key Authentication plugin authenticate requests properly?
 
@@ -125,17 +127,17 @@ You may have to consider customization of both [`kong.conf`](/gateway/manage-kon
         [breaking changes](/gateway/breaking-changes/)
         again to see if you missed anything.
 
-    3. Continuously install and launch more Y nodes.
+    1. Continuously install and launch more Y nodes.
 
-6. Divert traffic from old cluster X to new cluster Y.
+1. Divert traffic from old cluster X to new cluster Y.
     
     This is usually done gradually and incrementally, depending on the risk profile of the deployment. 
     Any load balancers that support traffic splitting will work here, such as DNS, Nginx, Kubernetes rollout mechanisms, and so on.
 
-7. If any issues arise, roll back by setting all traffic to cluster X, investigate the issues, 
+1. If any issues arise, roll back by setting all traffic to cluster X, investigate the issues, 
 and repeat the steps above.
 
-8. When there are no more issues, decommission the old cluster X to complete the upgrade. 
+1. When there are no more issues, decommission the old cluster X to complete the upgrade. 
 
 Write updates to {{site.base_gateway}} can now be performed, though we suggest you keep monitoring metrics for a while.
 


### PR DESCRIPTION
## Description

Fixes #2713 

Reviewers, I'd like your opinion here, as I'm struggling to decide how to structure this content.
Right now, it's like this:
* deck file convert is part of the individual upgrade reference docs (rolling upgrade, in-place upgrade, etc)
* ~the instructions to run it are all in the doc for `deck file convert`. Would this be better as a two how-tos, even if they're exactly the same for 2.8 -> 3.4 as for 3.4 -> 3.10?~ Reworked into how-tos.

## Preview Links
https://deploy-preview-2733--kongdeveloper.netlify.app/deck/file/convert/
https://deploy-preview-2733--kongdeveloper.netlify.app/gateway/upgrade/convert-lts-28-34/
https://deploy-preview-2733--kongdeveloper.netlify.app/gateway/upgrade/convert-lts-34-310/
https://deploy-preview-2733--kongdeveloper.netlify.app/deck/reference/3.0-upgrade/
Upgrade references, eg https://deploy-preview-2733--kongdeveloper.netlify.app/gateway/upgrade/dual-cluster/#deploy-a-new-kong-gateway-cluster-of-version-y
