### PR TITLE
feat(deck): FAQ for using --ignore-circular-refs with openapi2kong

### DIFF
--- a/app/deck/file/openapi2kong.md
+++ b/app/deck/file/openapi2kong.md
@@ -35,7 +35,7 @@ faqs:
 
       With decK, you have two options:
         * Resolve the circular references
-        * Pass the `--ignore-circular-refs` flag to the command to ignore circular references and continue converting the file:
+        * {% new_in 1.51.0 %} Pass the `--ignore-circular-refs` flag to the command to ignore circular references and continue converting the file:
           
           ```sh
           deck file openapi2kong -s /tmp/openapi.yaml --ignore-circular-refs

--- a/app/deck/file/openapi2kong.md
+++ b/app/deck/file/openapi2kong.md
@@ -27,6 +27,21 @@ related_resources:
 tags:
   - openapi
   - declarative-config
+
+faqs:
+  - q: When running `deck file openapi2kong`, I get the error `infinite circular reference detected`. How do I resolve it?
+    a: |
+      The solution depends on your use case. In some situations, [circular references](https://pb33f.io/libopenapi/circular-references/) may be valid for a particular API spec design. 
+
+      With decK, you have two options:
+        * Resolve the circular references
+        * Pass the `--ignore-circular-refs` flag to the command to ignore circular references and continue converting the file:
+          
+          ```sh
+          deck file openapi2kong -s /tmp/openapi.yaml --ignore-circular-refs
+          ```
+        Use this option with caution.
+
 ---
 
 The `openapi2kong` command converts an OpenAPI specification to Kong's declarative configuration format.


### PR DESCRIPTION
## Description

Fixes #2729 

New feature that went out with decK 1.51. See https://kongstrong.slack.com/archives/C045Y8G7VDW/p1756370528628289 for context.

## Preview Links

https://deploy-preview-2735--kongdeveloper.netlify.app/deck/file/openapi2kong/#when-running-deck-file-openapi2kong-i-get-the-error-infinite-circular-reference-detected-how-do-i-resolve-it
