### PR TITLE
fix: h1 LCP in homepage

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -9,7 +9,9 @@ edit_and_issue_links: false
     <div class="flex justify-between gap-[60px]">
         <div class="flex flex-col gap-8 py-24">
             <div class="flex flex-col gap-2">
-                <h1 class="font-extrabold text-[40px] leading-[60px]">Kong Developer</h1>
+                <h1 class="font-extrabold text-[40px] leading-[60px] [contain:layout:style]">
+                Kong Developer
+                </h1>
                 <span class="leading-7">Discover Kong’s tools, APIs, and tutorials to help you build, secure, and scale your services.</span>
             </div>
             <div id="homepage-search-input" class="flex gap-2 bg-secondary rounded-md border border-brand-saturated/40 py-2 px-4 items-center lg:w-3/5 cursor-pointer">


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
