### PR TITLE
feat(gateway/kafka-consume): add docs on disallowing scope to Service

### DIFF
--- a/app/_kong_plugins/kafka-consume/index.md
+++ b/app/_kong_plugins/kafka-consume/index.md
@@ -93,26 +93,19 @@ This mode provides parity with HTTP-based consumption, including support for:
 
 {% include_cached /plugins/confluent-kafka-consume/schema-registry.md name=page.name slug=page.slug workflow='consumer' %}
 
-## Migration Considerations for Kong 3.12 {% new_in 3.12 %}
+## Migration considerations for {{site.base_gateway}} 3.12 {% new_in 3.12 %}
 
-**Important:**
-The `kafka-consume` plugin **no longer supports scoping to a Service**.
+{:.warning}
+> The `kafka-consume` plugin **no longer supports scoping to a Service**.
 
-- **Fresh installations**
-  If you try to scope this plugin to a Service on a fresh {{site.base_gateway}} instance, a *schema violation* error will be returned.
+### Fresh installations
 
-- **Upgrading existing configurations**
+If you try to scope this plugin to a Service on a fresh {{site.base_gateway}} instance, a schema violation error will be returned.
 
-  **Traditional mode**
-  - During startup, Kong will log an *error-level* message if a `kafka-consume` plugin scoped to a Service is detected.
-  - Kong will still start successfully, but the plugin configuration **must be updated after startup**.
-  - Until the configuration is updated, requests to the previous plugin URL will continue to be forwarded to the upstream Service, and responses will be returned to the downstream client as before.
+### Upgrading existing configurations
 
-  **DB-less mode**
-  - If the declarative configuration file contains a `kafka-consume` plugin scoped to a Service, Kong will **fail to start**.
-  - In this case, you must **update the declarative configuration** before restarting Kong.
+In traditional mode, {{site.base_gateway}} will log an error-level message at startup if a `kafka-consume` plugin scoped to a Service is detected. The plugin configuration must be updated after startup. Until the configuration is updated, requests to the previous plugin URL will continue to be forwarded to the upstream Service, and responses will be returned to the downstream client as before.
 
-  **Hybrid mode**
-  - If such a plugin exists in PostgreSQL, upgrading and restarting the **Control Plane (CP)** will succeed.
-  - However, before updating the **Data Plane (DP)**, you must update the plugin configuration.
-  - Otherwise, once the DP is upgraded and restarted, it will fail to sync the configuration due to validation errors.
+In DB-less mode, if the declarative configuration file contains a `kafka-consume` plugin scoped to a Service, {{site.base_gateway}} will fail to start. In this case, you must update the declarative configuration before restarting {{site.base_gateway}}.
+
+In hybrid mode, if a `kafka-consume` plugin scoped to a Service exists in PostgreSQL, upgrading and restarting the control plane will succeed. However, before updating the data plane, you must update the plugin configuration. Otherwise, once the data plane is upgraded and restarted, it will fail to sync the configuration due to validation errors.

--- a/app/_kong_plugins/kafka-consume/index.md
+++ b/app/_kong_plugins/kafka-consume/index.md
@@ -92,3 +92,27 @@ This mode provides parity with HTTP-based consumption, including support for:
 ## Schema registry support {% new_in 3.11 %}
 
 {% include_cached /plugins/confluent-kafka-consume/schema-registry.md name=page.name slug=page.slug workflow='consumer' %}
+
+## Migration Considerations for Kong 3.12 {% new_in 3.12 %}
+
+**Important:**
+The `kafka-consume` plugin **no longer supports scoping to a Service**.
+
+- **Fresh installations**
+  If you try to scope this plugin to a Service on a fresh {{site.base_gateway}} instance, a *schema violation* error will be returned.
+
+- **Upgrading existing configurations**
+
+  **Traditional mode**
+  - During startup, Kong will log an *error-level* message if a `kafka-consume` plugin scoped to a Service is detected.
+  - Kong will still start successfully, but the plugin configuration **must be updated after startup**.
+  - Until the configuration is updated, requests to the previous plugin URL will continue to be forwarded to the upstream Service, and responses will be returned to the downstream client as before.
+
+  **DB-less mode**
+  - If the declarative configuration file contains a `kafka-consume` plugin scoped to a Service, Kong will **fail to start**.
+  - In this case, you must **update the declarative configuration** before restarting Kong.
+
+  **Hybrid mode**
+  - If such a plugin exists in PostgreSQL, upgrading and restarting the **Control Plane (CP)** will succeed.
+  - However, before updating the **Data Plane (DP)**, you must update the plugin configuration.
+  - Otherwise, once the DP is upgraded and restarted, it will fail to sync the configuration due to validation errors.


### PR DESCRIPTION
## Description

KAG-6924

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
