### PR TITLE
fix: render cleanup instructions in last step of a series

### DIFF
--- a/app/_plugins/generators/data/series.rb
+++ b/app/_plugins/generators/data/series.rb
@@ -87,6 +87,9 @@ module Jekyll
       def set_cleanup!(page)
         return unless page.data['series']
 
+        # render cleanup step in last step of the series
+        return if page.data['series']['items'].size == page.data['series']['position']
+
         page.data['cleanup'] = nil
       end
 


### PR DESCRIPTION
## Description

Fixes #2674 

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
