### PR TITLE
Fix (Insomnia) Clarify invitation expiry time

### DIFF
--- a/app/insomnia/organizations.md
+++ b/app/insomnia/organizations.md
@@ -42,7 +42,7 @@ Organization owners and admins can invite new users to an organization:
 
 By default, new users are added with the **Member** role.
 
-{:.warning} # Invitation links expire after 30 days. If an invite expires before the user accepts it, the pre-authorised license seat is released and becomes available for reuse.
+{:.warning} #Invitation links expire after 30 days. If an invite expires before the user accepts it, the pre-authorised license seat is released and becomes available for reuse.
 
 ## Transfer an organization
 

--- a/app/insomnia/organizations.md
+++ b/app/insomnia/organizations.md
@@ -42,7 +42,9 @@ Organization owners and admins can invite new users to an organization:
 
 By default, new users are added with the **Member** role.
 
-{:.warning} #Invitation links expire after 30 days. If an invite expires before the user accepts it, the pre-authorised license seat is released and becomes available for reuse.
+{:.warning} 
+
+> Invitation links expire after 30 days. If an invite expires before the user accepts it, the pre-authorised license seat is released and becomes available for reuse.
 
 ## Transfer an organization
 

--- a/app/insomnia/organizations.md
+++ b/app/insomnia/organizations.md
@@ -43,7 +43,6 @@ Organization owners and admins can invite new users to an organization:
 By default, new users are added with the **Member** role.
 
 {:.warning} 
-
 > Invitation links expire after 30 days. If an invite expires before the user accepts it, the pre-authorised license seat is released and becomes available for reuse.
 
 ## Transfer an organization

--- a/app/insomnia/organizations.md
+++ b/app/insomnia/organizations.md
@@ -40,7 +40,9 @@ Organization owners and admins can invite new users to an organization:
 1. Enter the email addresses of the users to invite and click **Invite**.
 1. Enter your passphrase and click **Invite**.
 
-By default, new users are added with the **Member** role. 
+By default, new users are added with the **Member** role.
+
+{:.warning} # Invitation links expire after 30 days. If an invite expires before the user accepts it, the pre-authorised license seat is released and becomes available for reuse.
 
 ## Transfer an organization
 


### PR DESCRIPTION
### Description

> From:
> Definition of done
> Update the [organization](https://developer.konghq.com/insomnia/organizations/#invite-users-to-your-organization) docs to indicate that invites expire after 30 days
> 
> Information
> https://kongstrong.slack.com/archives/C095TCU8TDX/p1756388045741799
> 
> Size
> S

Fixes #2723 

## Preview Links

- Organizations> https://deploy-preview-2770--kongdeveloper.netlify.app/insomnia/organizations/#invite-users-to-your-organization

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
