### PR TITLE
Fix (Insomnia) Clarify activation code for enterprise usage

### DIFF
--- a/app/insomnia/enterprise-account-management.md
+++ b/app/insomnia/enterprise-account-management.md
@@ -28,7 +28,7 @@ To upgrade your account to the Enterprise plan:
 1. Go to [Change subscription plan](https://app.insomnia.rest/app/subscription/update), select the Enterprise plan, and enter your activation code.
 
 {:.info}
-> Activation codes are single-use. The first user who enters the activation code activates the Enterprise plan for the account and then consequently becomes the Owner.
+> Activation codes are single-use. The first user who enters the activation code activates the Enterprise plan for the account and then consequently becomes the [Owner](/insomnia/terminology/#user-roles).
 
 ## Add domains
 

--- a/app/insomnia/enterprise-account-management.md
+++ b/app/insomnia/enterprise-account-management.md
@@ -28,7 +28,7 @@ To upgrade your account to the Enterprise plan:
 1. Go to [Change subscription plan](https://app.insomnia.rest/app/subscription/update), select the Enterprise plan, and enter your activation code.
 
 {:.info}
-> Activation codes are single-use. The first user who enters the activation code activates the Enterprise plan for the account and then consequently becomes the [Owner](insomnia/terminology/#user-roles).
+> Activation codes are single-use. The first user who enters the activation code activates the Enterprise plan for the account and then consequently becomes the Owner.
 
 ## Add domains
 

--- a/app/insomnia/enterprise-account-management.md
+++ b/app/insomnia/enterprise-account-management.md
@@ -27,6 +27,12 @@ To upgrade your account to the Enterprise plan:
 1. Contact the [sales team](https://insomnia.rest/pricing/contact) to get an activation code.
 1. Go to [Change subscription plan](https://app.insomnia.rest/app/subscription/update), select the Enterprise plan, and enter your activation code.
 
+{:.info}
+> Activation codes are single-use. The first user who enters the activation code activates the Enterprise plan for the account and then consequently becomes the [Owner](insomnia/terminology/#user-roles).
+
+## Activation and ownership
+Activation codes are single-use. The first user who enters the activation code activates the Enterprise plan for the account and becomes the Owner. Owners have full administrative control over the Enterprise account. They can invite additional Co-owners from Account settings → Enterprise controls → Co-owners to share those administrative privileges. For definitions of Owner and Co-owner, see Insomnia terminology.
+
 ## Add domains
 
 You can use domains in your Insomnia Enterprise account to manage users.

--- a/app/insomnia/enterprise-account-management.md
+++ b/app/insomnia/enterprise-account-management.md
@@ -28,7 +28,7 @@ To upgrade your account to the Enterprise plan:
 1. Go to [Change subscription plan](https://app.insomnia.rest/app/subscription/update), select the Enterprise plan, and enter your activation code.
 
 {:.info}
-> Activation codes are single-use. The first user who enters the activation code activates the Enterprise plan for the account and then consequently becomes the Owner.
+> Activation codes are single-use. The first user who enters the activation code activates the Enterprise plan for the account and then consequently becomes the [Owner](insomnia/terminology/#user-roles).
 
 ## Add domains
 

--- a/app/insomnia/enterprise-account-management.md
+++ b/app/insomnia/enterprise-account-management.md
@@ -28,10 +28,7 @@ To upgrade your account to the Enterprise plan:
 1. Go to [Change subscription plan](https://app.insomnia.rest/app/subscription/update), select the Enterprise plan, and enter your activation code.
 
 {:.info}
-> Activation codes are single-use. The first user who enters the activation code activates the Enterprise plan for the account and then consequently becomes the [Owner](insomnia/terminology/#user-roles).
-
-## Activation and ownership
-Activation codes are single-use. The first user who enters the activation code activates the Enterprise plan for the account and becomes the Owner. Owners have full administrative control over the Enterprise account. They can invite additional Co-owners from Account settings → Enterprise controls → Co-owners to share those administrative privileges. For definitions of Owner and Co-owner, see Insomnia terminology.
+> Activation codes are single-use. The first user who enters the activation code activates the Enterprise plan for the account and then consequently becomes the Owner.
 
 ## Add domains
 


### PR DESCRIPTION
## Description
From:

> Update the enterprise docs to clarify that:
> 
> The activation code can only be used once
> The user who uses the code becomes the owner of the enterprise instance
> The owner can then add other co-owners
> Information
> https://kongstrong.slack.com/archives/C044UFN49RT/p1756386827622849
> 
> Size
> S

Fixes #2726 

## Preview Links

- https://deploy-preview-2774--kongdeveloper.netlify.app/insomnia/enterprise-account-management/#enable-enterprise-membership

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
