### PR TITLE
Update CORS limitations section in documentation

### DIFF
--- a/app/_kong_plugins/cors/index.md
+++ b/app/_kong_plugins/cors/index.md
@@ -45,6 +45,8 @@ The CORS plugin lets you add Cross-Origin Resource Sharing (CORS) to a Service o
 
 ## CORS limitations
 
-When the client is a browser, the preflight OPTIONS requests defined by the [CORS specification](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) have strict rules about which headers can be set. Certain headers, including Host, are classified as forbidden headers, meaning the browser always controls their value and they cannot be customised in code, e.g. in JavaScript. As a result, a browser cannot send a custom Host header during a preflight request.
+When the client is a browser, the preflight OPTIONS requests defined by the [CORS specification](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) have strict rules about which headers can be set. 
+Certain headers, including Host, are classified as forbidden headers, meaning the browser always controls their value and they can't be customized in code (for example, in JavaScript). 
+As a result, a browser can't send a custom Host header during a preflight request.
 
 This limitation is important when using the CORS plugin with Routes in Kong. If a Route is configured to match only on the hosts field, the preflight request may not carry the expected Host header, and Kong may fail to match the Route. As a result, the CORS plugin cannot reliably process these requests. To ensure correct behaviour, the plugin should be used with routes that match on paths (and optionally methods), which the preflight request will include and Kong can use for matching.

--- a/app/_kong_plugins/cors/index.md
+++ b/app/_kong_plugins/cors/index.md
@@ -49,4 +49,6 @@ When the client is a browser, the preflight OPTIONS requests defined by the [COR
 Certain headers, including Host, are classified as forbidden headers, meaning the browser always controls their value and they can't be customized in code (for example, in JavaScript). 
 As a result, a browser can't send a custom Host header during a preflight request.
 
-This limitation is important when using the CORS plugin with Routes in Kong. If a Route is configured to match only on the hosts field, the preflight request may not carry the expected Host header, and Kong may fail to match the Route. As a result, the CORS plugin cannot reliably process these requests. To ensure correct behaviour, the plugin should be used with routes that match on paths (and optionally methods), which the preflight request will include and Kong can use for matching.
+This limitation is important when using the CORS plugin with Routes in {{site.base_gateway}}. If a Route is configured to match only on the `hosts` field, the preflight request may not carry the expected Host header, and {{site.base_gateway}} may fail to match the Route. This means that the plugin can't reliably process these requests.
+
+To ensure correct behavior, use the CORS plugin only with Routes that match on paths or methods. The preflight request includes both paths and methods, so {{site.base_gateway}} can use these fields for matching.

--- a/app/_kong_plugins/cors/index.md
+++ b/app/_kong_plugins/cors/index.md
@@ -45,10 +45,6 @@ The CORS plugin lets you add Cross-Origin Resource Sharing (CORS) to a Service o
 
 ## CORS limitations
 
-If the client is a browser, there is a known issue with this plugin caused by a
-limitation of the [CORS specification](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) that prevents specifying a custom
-`Host` header in a preflight `OPTIONS` request.
+When the client is a browser, the preflight OPTIONS requests defined by the [CORS specification](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) have strict rules about which headers can be set. Certain headers, including Host, are classified as forbidden headers, meaning the browser always controls their value and they cannot be customised in code, e.g. in JavaScript. As a result, a browser cannot send a custom Host header during a preflight request.
 
-Because of this limitation, this plugin only works for Routes that have been
-configured with a `paths` setting. The CORS plugin does not work for Routes that
-are being resolved using a custom DNS (the `hosts` property).
+This limitation is important when using the CORS plugin with Routes in Kong. If a Route is configured to match only on the hosts field, the preflight request may not carry the expected Host header, and Kong may fail to match the Route. As a result, the CORS plugin cannot reliably process these requests. To ensure correct behaviour, the plugin should be used with routes that match on paths (and optionally methods), which the preflight request will include and Kong can use for matching.


### PR DESCRIPTION
Clarified CORS limitations regarding preflight OPTIONS requests and Host header handling in the plugin documentation.

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
