### PR TITLE
chore(gateway): Update GPG and RSA keys for 3.12

### DIFF
--- a/app/_data/products/gateway.yml
+++ b/app/_data/products/gateway.yml
@@ -1391,6 +1391,9 @@ release_dates:
 
 public_keys:
   # e.g.: https://cloudsmith.io/~kong/repos/internal-gateway-37/pub-keys/
+  "312":
+    rsa_key: CF99E3B118DABBFB
+    gpg_key: 875433A518B93006
   "311":
     rsa_key: D0099E9501A25DF6
     gpg_key: CF9CDA9D288571F9


### PR DESCRIPTION
## Description

Release checklist item.

Keys are from https://cloudsmith.io/~kong/repos/gateway-312/pub-keys/.

## Preview Links
