### PR TITLE
Fix (Kong AI): Incorrect answer referenceable vault values

### DIFF
--- a/app/_gateway_entities/vault.md
+++ b/app/_gateway_entities/vault.md
@@ -147,7 +147,7 @@ You can add secrets to Vaults in one of the following ways:
 
 ## What can be stored as a secret?
 
-The following plugin fields can be stored and referenced as secrets:
+You can store and reference the following as secrets in a Vault:
 
 * All [values](/gateway/manage-kong-conf/)<sup>1</sup> set in `kong.conf` are referenceable. For example:
   * Data store usernames and passwords, used with PostgreSQL and Redis

--- a/app/_gateway_entities/vault.md
+++ b/app/_gateway_entities/vault.md
@@ -147,9 +147,9 @@ You can add secrets to Vaults in one of the following ways:
 
 ## What can be stored as a secret?
 
-You can store and reference the following as secrets in a Vault:
+The following plugin fields can be stored and referenced as secrets:
 
-* All [`kong.conf` values](/gateway/manage-kong-conf/)<sup>1</sup>. For example:
+* All [values](/gateway/manage-kong-conf/)<sup>1</sup> set in `kong.conf` are referenceable. For example:
   * Data store usernames and passwords, used with PostgreSQL and Redis
   * Private X.509 certificates
 * Certificates and keys stored in the [Certificate {{site.base_gateway}} entity](/gateway/entities/certificate/)


### PR DESCRIPTION
## Description

> Jobs to be done (optional)
> When asked about whether admin_gui_auth_conf and admin_gui_session_conf are referenceable, the AI bot says no, but the correct answer is yes - all values set in kong.conf should be referenceable.
> 
> Definition of done
> Adjust the phrasing of https://developer.konghq.com/gateway/entities/vault/#what-can-be-stored-as-a-secret to say that "all values set in kong .conf are referenceable". For consistency and easy comparability, we should use the same language as the plugin fields section:
> 
> [Referenceable plugin fields](https://developer.konghq.com/gateway/entities/vault/#referenceable-plugin-fields)
> The following plugin fields can be stored and referenced as secrets:
> Information
> n/a
> 
> Due date (optional)
> n/a
> 
> Size
> XS

Fixes #2649

## Preview Links

- https://deploy-preview-2800--kongdeveloper.netlify.app/gateway/entities/vault/#what-can-be-stored-as-a-secret

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
