### PR TITLE
fix(script): mark oneTrust cookie consent script async

### DIFF
--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -43,7 +43,7 @@
 
     {% if jekyll.environment == "production" %}
     <!-- OneTrust Cookies Consent Notice start for konghq.com -->
-    <script src="https://cdn.cookielaw.org/consent/2c4de954-6bec-4e93-8086-64cb113f151a/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="2c4de954-6bec-4e93-8086-64cb113f151a" ></script>
+    <script src="https://cdn.cookielaw.org/consent/2c4de954-6bec-4e93-8086-64cb113f151a/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="2c4de954-6bec-4e93-8086-64cb113f151a" async></script>
     <script type="text/javascript">
     function OptanonWrapper() { }
     </script>
@@ -52,7 +52,7 @@
 
     {% if jekyll.environment == "preview" %}
     <!-- OneTrust Cookies Consent Notice start for konghq.com -->
-    <script src="https://cdn.cookielaw.org/consent/2c4de954-6bec-4e93-8086-64cb113f151a-test/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="2c4de954-6bec-4e93-8086-64cb113f151a-test" ></script>
+    <script src="https://cdn.cookielaw.org/consent/2c4de954-6bec-4e93-8086-64cb113f151a-test/otSDKStub.js"  type="text/javascript" charset="UTF-8" data-domain-script="2c4de954-6bec-4e93-8086-64cb113f151a-test" async></script>
     <script type="text/javascript">
     function OptanonWrapper() { }
     </script>


### PR DESCRIPTION
Scripts marked with async won’t block the rendering process, preventing the site from getting stuck on a blank screen when the network is not well.

JIRA: DOCU-3037
