### PR TITLE
Feat(Mesh): Restrict permissions to selected namespaces on Kubernetes

### DIFF
--- a/app/_data/kuma_to_mesh/config.yaml
+++ b/app/_data/kuma_to_mesh/config.yaml
@@ -27,16 +27,7 @@ pages:
         url: '/mesh/policies-introduction/'
     min_version:
       mesh: '2.9'
-  -
-    path: app/_src/guides/restrict-permissions-to-selected-namespaces-on-kubernetes.md
-    title: 'Restrict permissions to selected namespaces on Kubernetes'
-    description: 'This guide explains how to limit Kuma to specific namespaces, giving you greater control over security and resource management.'
-    url: /mesh/restrict-permissions-to-selected-namespaces-on-kubernetes/
-    related_resources: 
-      - text: Manage control plane permissions on Kubernetes
-        url: '/mesh/manage-control-plane-permissions-on-kubernetes/'
-    min_version:
-      mesh: '2.11'
+      
   -
     path: app/_src/production/secure-deployment/manage-control-plane-permissions-on-kubernetes.md
     title: 'Manage Control Plane permissions on Kubernetes'

--- a/app/_how-tos/restrict-permissions-to-selected-namespaces-on-kubernetes.md
+++ b/app/_how-tos/restrict-permissions-to-selected-namespaces-on-kubernetes.md
@@ -1,0 +1,236 @@
+---
+title: Restrict {{site.mesh_product_name}} permissions to selected namespaces on Kubernetes
+description: "This guide explains how to limit {{site.mesh_product_name}} to specific namespaces, giving you greater control over security and resource management."
+content_type: how_to
+permalink: /mesh/restrict-permissions-to-selected-namespaces-on-kubernetes/
+bread-crumbs: 
+  - /mesh/
+related_resources: 
+  - text: Manage control plane permissions on Kubernetes
+    url: /mesh/manage-control-plane-permissions-on-kubernetes/
+min_version:
+    mesh: '2.11'
+products:
+  - mesh
+
+works_on:
+  - on-prem
+
+tldr:
+  q: How can I configure {{site.mesh_product_name}} to only manage specific namespaces?
+  a: Create a namespace, then set `kuma.namespaceAllowList` to the name of the namespace to use when installing {{site.mesh_product_name}}.
+
+prereqs:
+  inline:
+    - title: Helm
+      include_content: prereqs/helm
+    - title: A running Kubernetes cluster
+      content: |
+        This guide requires a running Kubernetes cluster. If you already have a Kubernetes cluster running, you can skip this step. 
+        It can be a cluster running locally, like Docker, or in a public cloud like AWS EKS, GCP GKE, etc.
+
+        For example, if you are using [minikube](https://minikube.sigs.k8s.io/docs/):
+        ```sh
+        minikube start -p mesh-zone
+        ```
+
+cleanup:
+  inline:
+    - title: Clean up Mesh
+      include_content: cleanup/products/mesh
+      icon_url: /assets/icons/gateway.svg
+---
+
+
+## Install {{site.mesh_product_name}} which manages a single namespace
+
+By default, {{site.mesh_product_name}} deployed on Kubernetes has permissions to observe and react to events from resources across the entire cluster. While this behavior simplifies initial setup and testing, it might be too permissive for production environments. Limiting {{site.mesh_product_name}}'s access to only necessary namespaces helps enhance security and prevents potential impact on unrelated applications.
+
+Run the following commands to create a first namespace and install an instance of {{site.mesh_product_name}} restricted to that namespace.
+
+1. Create and label the namespace:
+   ```bash
+   kubectl create namespace first-namespace
+   kubectl label namespace first-namespace kuma.io/sidecar-injection=enabled
+   ```
+
+1. Install {{site.mesh_product_name}}:
+   ```bash
+   helm upgrade \
+     --install \
+     --create-namespace \
+     --namespace {{ site.mesh_namespace }} \
+     --set "{{ site.set_flag_values_prefix }}namespaceAllowList={first-namespace}" \
+     {{ site.mesh_helm_install_name }} {{ site.mesh_helm_repo }}
+   ```
+
+1. Deploy a test workload:
+   ```bash
+   kubectl run nginx --image=nginx --port=80 --namespace first-namespace
+   ```
+
+## Verify that the first namespace is working
+
+1. Check that the control plane is managing the workload:
+   ```bash
+   kubectl get dataplanes --namespace first-namespace
+   ```
+
+   Expected output:
+   ```
+   NAME    KUMA.IO/SERVICE             KUMA.IO/SERVICE
+   nginx   nginx_first-namespace_svc
+   ```
+   {:.no-copy-code}
+
+1. Check that the pod has the sidecar injected:
+
+   ```bash
+   kubectl get pods --namespace first-namespace
+   ```
+
+   Expected output:
+   ```
+   NAME    READY   STATUS    RESTARTS   AGE
+   nginx   2/2     Running   0          2m5s
+   ```
+   {:.no-copy-code}
+
+1. Verify the required RoleBinding:
+
+   ```bash
+   kubectl get rolebindings --namespace first-namespace
+   ```
+
+   Expected output:
+   ```
+   NAME                                ROLE                                            AGE
+   kong-mesh-control-plane-workloads   ClusterRole/kong-mesh-control-plane-workloads   3m46s
+   ```
+   {:.no-copy-code}
+
+This confirms that:
+
+* A `Dataplane` was created
+* The pod includes the `kuma-sidecar`
+* A `RoleBinding` named `{{ kuma-control-plane-workloads }}` grants elevated access to the control plane
+
+## Create a second namespace in which {{site.mesh_product_name}} doesn't run
+
+1. Create and label the namespace:
+   ```bash
+   kubectl create namespace second-namespace
+   kubectl label namespace second-namespace kuma.io/sidecar-injection=enabled
+   ```
+
+1. Deploy the same test workload in the second namespace:
+   ```bash
+   kubectl run nginx --image=nginx --port=80 --namespace second-namespace
+   ```
+
+## Verify the second namespace is not working
+
+Check that the control plane is **not** managing resources in `second-namespace`.
+
+1. Check the data planes in the second namespace:
+   ```bash
+   kubectl get dataplanes --namespace second-namespace
+   ```
+
+   Expected output:
+   ```
+   No resources found in second-namespace namespace.
+   ```
+   {:.no-copy-code}
+
+1. Check the pods: 
+   ```bash
+   kubectl get pods --namespace second-namespace
+   ```
+
+   Expected output:
+   ```
+   NAME    READY   STATUS    RESTARTS   AGE
+   nginx   1/1     Running   0          42s
+   ```
+   {:.no-copy-code}
+
+   This indicates the pod is running without the `kuma-sidecar`.
+
+1. Check the role bindings:
+   ```bash
+   kubectl get rolebindings --namespace second-namespace
+   ```
+
+   Expected output:
+   ```
+   No resources found in second-namespace namespace.
+   ```
+   {:.no-copy-code}
+
+This confirms that:
+* The control plane does not have permission to manage this namespace
+* The pod was started without sidecar injection
+* No `RoleBinding` was created to grant control plane access
+
+## Update {{site.mesh_product_name}} to also manage the second namespace
+
+1. Update {{site.mesh_product_name}} to include `second-namespace`:
+   ```bash
+   helm upgrade \
+     --install \
+     --create-namespace \
+     --namespace {{ site.mesh_namespace }} \
+     --set "{{ site.set_flag_values_prefix }}namespaceAllowList={first-namespace,second-namespace}" \
+     {{ site.mesh_helm_install_name }} {{ site.mesh_helm_repo }}
+   ```
+
+1. Delete the old pod and recreate it to trigger sidecar injection:
+   ```bash
+   kubectl delete pod --namespace second-namespace --all
+   kubectl run nginx --image=nginx --port=80 --namespace second-namespace
+   ```
+
+## Verify the second namespace is now working
+
+1. Check that the control plane is now managing the workload in `second-namespace`:
+   ```bash
+   kubectl get dataplanes --namespace second-namespace
+   ```
+
+   Expected output:
+   ```
+   NAME    KUMA.IO/SERVICE              KUMA.IO/SERVICE
+   nginx   nginx_second-namespace_svc   
+   ```
+   {:.no-copy-code}
+
+1. Verify that the pod now includes a sidecar:
+   ```bash
+   kubectl get pods --namespace second-namespace
+   ```
+
+   Expected output:
+   ```
+   NAME    READY   STATUS    RESTARTS   AGE
+   nginx   2/2     Running   0          30s
+   ```
+   {:.no-copy-code}
+
+1. Check that the required `RoleBinding` has been created:
+   ```bash
+   kubectl get rolebindings --namespace second-namespace
+   ```
+
+   Expected output:
+   ```
+   NAME                                ROLE                                            AGE
+   kong-mesh-control-plane-workloads   ClusterRole/kong-mesh-control-plane-workloads   30s
+   ```
+   {:.no-copy-code}
+
+This confirms that:
+
+* The control plane has the correct permissions in `second-namespace`
+* The pod was injected with the `kuma-sidecar`
+* The namespace is now fully integrated with the mesh

--- a/app/_how-tos/restrict-permissions-to-selected-namespaces-on-kubernetes.md
+++ b/app/_how-tos/restrict-permissions-to-selected-namespaces-on-kubernetes.md
@@ -13,8 +13,6 @@ min_version:
 products:
   - mesh
 
-works_on:
-  - on-prem
 
 tldr:
   q: How can I configure {{site.mesh_product_name}} to only manage specific namespaces?
@@ -114,9 +112,9 @@ Run the following commands to create a first namespace and install an instance o
 
 This confirms that:
 
-* A `Dataplane` was created
-* The pod includes the `kuma-sidecar`
-* A `RoleBinding` named `{{ kuma-control-plane-workloads }}` grants elevated access to the control plane
+* A `Dataplane` was created.
+* The pod includes the `kuma-sidecar`.
+* A `RoleBinding` named `kong-mesh-control-plane-workloads` grants elevated access to the control plane.
 
 ## Create a second namespace in which {{site.mesh_product_name}} doesn't run
 
@@ -172,9 +170,9 @@ Check that the control plane is **not** managing resources in `second-namespace`
    {:.no-copy-code}
 
 This confirms that:
-* The control plane does not have permission to manage this namespace
-* The pod was started without sidecar injection
-* No `RoleBinding` was created to grant control plane access
+* The control plane does not have permission to manage this namespace.
+* The pod was started without sidecar injection.
+* No `RoleBinding` was created to grant control plane access.
 
 ## Update {{site.mesh_product_name}} to also manage the second namespace
 

--- a/app/_how-tos/restrict-permissions-to-selected-namespaces-on-kubernetes.md
+++ b/app/_how-tos/restrict-permissions-to-selected-namespaces-on-kubernetes.md
@@ -85,6 +85,9 @@ Run the following commands to create a first namespace and install an instance o
 
 1. Check that the pod has the sidecar injected:
 
+   {:.info}
+   > You may need to wait a few minutes for the pods to initialize.
+
    ```bash
    kubectl get pods --namespace first-namespace
    ```
@@ -206,6 +209,10 @@ This confirms that:
    {:.no-copy-code}
 
 1. Verify that the pod now includes a sidecar:
+
+   {:.info}
+   > You may need to wait a few minutes for the pods to initialize.
+
    ```bash
    kubectl get pods --namespace second-namespace
    ```


### PR DESCRIPTION
## Description

Fixes #1768 

## Note for reviewers

I'm not sure if this can apply to Konnect too, there's no mention of it in the original doc so I made it on-prem only for now.

## Preview Links

https://deploy-preview-2820--kongdeveloper.netlify.app/mesh/restrict-permissions-to-selected-namespaces-on-kubernetes/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
