### PR TITLE
Fix: Temporarily disable datakit guide test

### DIFF
--- a/app/_how-tos/get-started-with-datakit.md
+++ b/app/_how-tos/get-started-with-datakit.md
@@ -52,6 +52,8 @@ related_resources:
   - text: Datakit plugin
     url: /plugins/datakit/
 
+# temporary setting; will remove once the guide is reworked
+automated_tests: false 
 ---
 
 ## Enable Datakit


### PR DESCRIPTION
## Description

One of the APIs used in this guide is no longer functional. 
We could point to something else, but realistically this get started guide is being reworked for 3.12 anyway. Temporarily disabling the test while the guide is being updated so that it doesn't disrupt workflows.

## Preview Links
