### PR TITLE
Feat (Konnect) Kong identity consumer group support

### DIFF
--- a/app/konnect-platform/kong-identity.md
+++ b/app/konnect-platform/kong-identity.md
@@ -99,7 +99,7 @@ In the authorization code flow:
 5. The client exchanges this code at the `/oauth/token` endpoint for access tokens.
 6. The client uses the access token to call protected APIs.
 
-## Kong Comsumer Group plugin flow
+## Kong Consumer Group plugin flow
 In the consumer group plugin flow:
 1. In **{{site.konnect_short_name}} > API Gateway > Consumers**, the consumer is created. Each client that needs access is represented as a consumer.
 

--- a/app/konnect-platform/kong-identity.md
+++ b/app/konnect-platform/kong-identity.md
@@ -99,13 +99,14 @@ In the authorization code flow:
 5. The client exchanges this code at the `/oauth/token` endpoint for access tokens.
 6. The client uses the access token to call protected APIs.
 
-To enable plugin application at the [Consumer Group](/gateway_entities/consumer-group/) level, follow these steps:
-1. In **Konnect > API Gateway > Consumers**, create a consumer for each client.
+## Kong Comsumer Group plugin flow
+In the consumer group plugin flow:
+1. In **{{site.konnect_short_name}} > API Gateway > Consumers**, the consumer is created. Each client that needs access is represented as a consumer.
 
    {:.info}
-   > You don't need to migrate the client credential to a consumer credential. The OIDC plugin maps clients to consumers based on token claims.
-2. Create the required Consumer Groups and apply the plugin at the consumer group scope.
-3. Assign each consumer to the appropriate Consumer Group.
+   > If using OIDC, you don’t need to manually map credentials. The OIDC plugin automatically maps clients to consumers based on token claims.
+2. The required Consumer Groups are defined in {{site.konnect_short_name}}, and the desired plugin is applied at the consumer group scope.
+3. Each consumer is assigned to the appropriate consumer group. Once assigned, the plugin configuration at the group level automatically applies to the consumer.
 
 ## Dynamic claim templates
 

--- a/app/konnect-platform/kong-identity.md
+++ b/app/konnect-platform/kong-identity.md
@@ -101,12 +101,12 @@ In the authorization code flow:
 
 ## Kong Consumer Group plugin flow
 In the consumer group plugin flow:
-1. In **{{site.konnect_short_name}} > API Gateway > Consumers**, the consumer is created. Each client that needs access is represented as a consumer.
+1. In **{{site.konnect_short_name}} > API Gateway > Consumers**, the client creates the consumer. Each user that needs access is represented as a consumer.
 
    {:.info}
    > If using OIDC, you don’t need to manually map credentials. The OIDC plugin automatically maps clients to consumers based on token claims.
-2. The required Consumer Groups are defined in {{site.konnect_short_name}}, and the desired plugin is applied at the consumer group scope.
-3. Each consumer is assigned to the appropriate consumer group. Once assigned, the plugin configuration at the group level automatically applies to the consumer.
+2. The client defines the required Consumer Groups in {{site.konnect_short_name}}, and then applies the desired plugin at the consumer group scope.
+3. The client assigns Each consumer to the appropriate consumer group. Once assigned, the plugin configuration at the group level automatically applies to the consumer.
 
 ## Dynamic claim templates
 

--- a/app/konnect-platform/kong-identity.md
+++ b/app/konnect-platform/kong-identity.md
@@ -99,14 +99,14 @@ In the authorization code flow:
 5. The client exchanges this code at the `/oauth/token` endpoint for access tokens.
 6. The client uses the access token to call protected APIs.
 
-## Kong Consumer Group plugin flow
-In the consumer group plugin flow:
-1. In **{{site.konnect_short_name}} > API Gateway > Consumers**, the client creates the consumer. Each user that needs access is represented as a consumer.
+## Kong Consumer Group claim authorization flow
+When using plugins scoped to Consumer Groups:
+1. In **{{site.konnect_short_name}} > API Gateway > Consumers**, the client creates the Consumer. Each user that needs access is represented as a Consumer.
 
    {:.info}
-   > If using OIDC, you don’t need to manually map credentials. The OIDC plugin automatically maps clients to consumers based on token claims.
-2. The client defines the required Consumer Groups in {{site.konnect_short_name}}, and then applies the desired plugin at the consumer group scope.
-3. The client assigns each consumer to the appropriate consumer group. Once assigned, the plugin configuration at the group level automatically applies to the consumer.
+   > If using OIDC, you don’t need to manually map credentials. The OIDC plugin automatically maps clients to Consumers based on token claims.
+2. The client defines the required Consumer Groups in {{site.konnect_short_name}}, and then applies the desired plugin at the Consumer Group scope.
+3. The client assigns each Consumer to the appropriate Consumer Group. Once assigned, the plugin configuration at the group level automatically applies to the Consumer.
 
 ## Dynamic claim templates
 

--- a/app/konnect-platform/kong-identity.md
+++ b/app/konnect-platform/kong-identity.md
@@ -99,14 +99,13 @@ In the authorization code flow:
 5. The client exchanges this code at the `/oauth/token` endpoint for access tokens.
 6. The client uses the access token to call protected APIs.
 
-<!--
-For Consumer Group-scoped plugins:
-- Create a consumer per client in the respective control plane.
-- No need to migrate the client credential to a consumer credential.
-- The OIDC plugin maps clients to consumers using claims.
-- Create the required consumer groups and apply the plugin at the consumer group scope.
-- Add each consumer to the appropriate consumer group in the control plane.
--->
+To enable plugin application at the [Consumer Group](/gateway_entities/consumer-group/) level, follow these steps:
+1. In **Konnect > API Gateway > Consumers**, create a consumer for each client.
+
+   {:.info}
+   > You don't need to migrate the client credential to a consumer credential. The OIDC plugin maps clients to consumers based on token claims.
+2. Create the required Consumer Groups and apply the plugin at the consumer group scope.
+3. Assign each consumer to the appropriate Consumer Group.
 
 ## Dynamic claim templates
 

--- a/app/konnect-platform/kong-identity.md
+++ b/app/konnect-platform/kong-identity.md
@@ -106,7 +106,7 @@ In the consumer group plugin flow:
    {:.info}
    > If using OIDC, you don’t need to manually map credentials. The OIDC plugin automatically maps clients to consumers based on token claims.
 2. The client defines the required Consumer Groups in {{site.konnect_short_name}}, and then applies the desired plugin at the consumer group scope.
-3. The client assigns Each consumer to the appropriate consumer group. Once assigned, the plugin configuration at the group level automatically applies to the consumer.
+3. The client assigns each consumer to the appropriate consumer group. Once assigned, the plugin configuration at the group level automatically applies to the consumer.
 
 ## Dynamic claim templates
 


### PR DESCRIPTION
## Description

> Definition of done
> Uncomment and revise consumer group content on https://developer.konghq.com/kong-identity/
> The use case for this is it just allows users to apply plugins to clients as long as they map to consumer groups
> Information
> DRP: Smriti
> Aha: https://konghq.aha.io/epics/PLAT-E-33
> 
> Due date (optional)
> Sept, dependent on 3.12
> 
> Size
> small

Fixes #2597 

## Preview Links

- https://deploy-preview-2831--kongdeveloper.netlify.app/kong-identity/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
