### PR TITLE
Feat (Gateway): List of plugins that support partials

### DIFF
--- a/app/_gateway_entities/partial.md
+++ b/app/_gateway_entities/partial.md
@@ -110,7 +110,7 @@ rows:
   - Name: "[Rate Limiting](/plugins/rate-limiting/)"
     Redis: "Request counters"
     Partial: "`redis-ce`"
-    Benefit: "Apply the same Redis setup across multiple rate-limiting policies without duplication."
+    Benefit: "Apply the same Redis setup across multiple rate limiting policies without duplication."
   - Name: "[Rate Limiting Advanced](/plugins/rate-limiting-advanced/)"
     Redis: "Request counters (supports Sentinel/Cluster)"
     Partial: "`redis-ee`"


### PR DESCRIPTION
## Description

> Jobs to be done (optional)
> Users would like to know which plugins support partials.
> 
> Definition of done
> We don't maintain a list of plugins that support partials. It should be that any plugin that can use Redis, can also use partials. This info isn't in the [partials doc](https://developer.konghq.com/gateway/entities/partial/).
> 
> We can either:
> 
> Add a sentence about "plugins that connect to redis support partials"
> List out all plugins that can connect to redis
> Is there some way to let people know, from a plugin's page (eg Rate Limiting Advanced), that a particular plugin can use partials? Maybe we should have an include. If you were to look at https://developer.konghq.com/plugins/rate-limiting-advanced/, you'd never know that it's possible to reference redis config from elsewhere.
> 
> Information
> https://developer.konghq.com/gateway/entities/partial/ - all the info we need to extrapolate from is here, it's just not very clear.
> 
> Due date (optional)
> N/A
> 
> Size
> S
> 

Fixes #2652 

## Preview Links

- https://deploy-preview-2836--kongdeveloper.netlify.app/gateway/entities/partial/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
