### PR TITLE
feat: use a toggle switch for the deployment topology

### DIFF
--- a/app/_assets/entrypoints/application.js
+++ b/app/_assets/entrypoints/application.js
@@ -12,6 +12,7 @@ import Dropdowns from "@/javascripts/components/dropdown";
 import EntityExample from "@/javascripts/components/entity_example";
 import Tabs from "@/javascripts/components/tabs";
 import TopNav from "@/javascripts/components/top_nav";
+import ToggleSwitchManager from "@/javascripts/components/switch";
 import "@/javascripts/anchor_links";
 import "@/javascripts/accordion";
 import "@/javascripts/how_to";
@@ -29,6 +30,7 @@ document.addEventListener("DOMContentLoaded", function () {
   new EntityExample();
   new Tabs();
   new Dropdowns();
+  new ToggleSwitchManager();
 });
 
 if (import.meta.env.PROD) {

--- a/app/_assets/javascripts/components/switch.js
+++ b/app/_assets/javascripts/components/switch.js
@@ -143,6 +143,15 @@ export default class ToggleSwitchManager {
       if (this.type === "page") {
         this.switchPageTopology(selectedValue);
       }
+
+      if (this.getParamValue() && this.getParamValue() !== selectedValue) {
+        const url = new URL(window.location);
+
+        url.searchParams.set("deployment", selectedValue);
+
+        // Don't reload the page
+        window.history.pushState({}, "", url);
+      }
       this.switches.forEach((instance) => {
         instance.updateState(selectedValue);
       });

--- a/app/_assets/javascripts/components/switch.js
+++ b/app/_assets/javascripts/components/switch.js
@@ -1,0 +1,145 @@
+class ToggleSwitch {
+  constructor(elem) {
+    this.elem = elem;
+    this.inputs = this.elem.querySelectorAll(".switch__input");
+    this.onPrem = this.elem.querySelector('label[for*="on-prem"]');
+    this.konnect = this.elem.querySelector('label[for*="konnect"]');
+    this.addEventListeners();
+  }
+
+  addEventListeners() {
+    this.inputs.forEach((radio) => {
+      radio.addEventListener("change", this.onToggleChange.bind(this));
+    });
+  }
+
+  onToggleChange(event) {
+    const selectedValue = event.target.value;
+    const changeEvent = new CustomEvent("switch-state-change", {
+      detail: { selectedValue },
+    });
+
+    document.dispatchEvent(changeEvent);
+  }
+
+  updateState(selectedValue) {
+    this.inputs.forEach((radio) => {
+      radio.checked = radio.value === selectedValue;
+    });
+  }
+}
+
+export default class ToggleSwitchManager {
+  constructor() {
+    this.deploymentToplogyKey = "deployment-topology-switch";
+    this.type = "toggle";
+    this.values = ["konnect", "on-prem"];
+    this.switches = [];
+    this.initialValue = "konnect";
+
+    document.querySelectorAll(".switch").forEach((elem) => {
+      this.switches.push(new ToggleSwitch(elem));
+    });
+
+    this.topologySwitcherOption = document.querySelector(
+      "[data-topology-switcher]"
+    );
+
+    this.addEventListeners();
+    this.init();
+  }
+
+  init() {
+    if (this.switches.length > 0) {
+      this.setType();
+      this.setInitialValue();
+    }
+  }
+
+  setInitialValue() {
+    if (this.getStoredValue()) {
+      this.initialValue = this.getStoredValue();
+    }
+    if (this.getParamValue()) {
+      this.initialValue = this.getParamValue();
+    }
+    if (this.getURLValue()) {
+      this.initialValue = this.getURLValue();
+    }
+
+    const initialEvent = new CustomEvent("switch-state-change", {
+      detail: { selectedValue: this.initialValue },
+    });
+    document.dispatchEvent(initialEvent);
+  }
+
+  setType() {
+    if (this.topologySwitcherOption) {
+      this.type = this.topologySwitcherOption.dataset.topologySwitcher;
+    }
+  }
+
+  getURLValue() {
+    if (this.type === "page") {
+      if (this.values.includes(this.lastURLSegment())) {
+        return this.lastURLSegment();
+      }
+    }
+  }
+
+  lastURLSegment() {
+    const segments = window.location.pathname.split("/");
+    if (!segments[segments.length - 1]) {
+      segments.pop();
+    }
+    return segments[segments.length - 1];
+  }
+
+  switchPageTopology(value) {
+    if (this.lastURLSegment() !== value) {
+      const url = new URL(window.location.href);
+      const segments = url.pathname.split("/");
+      if (!segments[segments.length - 1]) {
+        segments.pop();
+      }
+      segments[segments.length - 1] = value;
+      url.pathname = segments.join("/");
+      window.location.href = url.toString();
+    }
+  }
+
+  getStoredValue() {
+    try {
+      if (localStorage.getItem(this.deploymentToplogyKey) !== null) {
+        const storedValue = localStorage.getItem(this.deploymentToplogyKey);
+        if (storedValue && this.values.some((v) => v === storedValue)) {
+          return storedValue;
+        }
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  getParamValue() {
+    const urlParams = new URLSearchParams(window.location.search);
+    const deployment = urlParams.get("deployment");
+    if (this.values.includes(deployment)) {
+      return deployment;
+    }
+  }
+
+  addEventListeners() {
+    document.addEventListener("switch-state-change", (event) => {
+      const { selectedValue } = event.detail;
+      localStorage.setItem(this.deploymentToplogyKey, selectedValue);
+
+      if (this.type === "page") {
+        this.switchPageTopology(selectedValue);
+      }
+      this.switches.forEach((instance) => {
+        instance.updateState(selectedValue);
+      });
+    });
+  }
+}

--- a/app/_assets/javascripts/components/switch.js
+++ b/app/_assets/javascripts/components/switch.js
@@ -2,8 +2,7 @@ class ToggleSwitch {
   constructor(elem) {
     this.elem = elem;
     this.inputs = this.elem.querySelectorAll(".switch__input");
-    this.onPrem = this.elem.querySelector('label[for*="on-prem"]');
-    this.konnect = this.elem.querySelector('label[for*="konnect"]');
+    this.slider = this.elem.querySelector(".switch__slider");
     this.addEventListeners();
   }
 
@@ -11,6 +10,7 @@ class ToggleSwitch {
     this.inputs.forEach((radio) => {
       radio.addEventListener("change", this.onToggleChange.bind(this));
     });
+    this.slider.addEventListener("click", this.onSliderClick.bind(this));
   }
 
   onToggleChange(event) {
@@ -20,6 +20,12 @@ class ToggleSwitch {
     });
 
     document.dispatchEvent(changeEvent);
+  }
+
+  onSliderClick() {
+    const newValue = Array.from(this.inputs).find((radio) => !radio.checked);
+    newValue.checked = true;
+    newValue.dispatchEvent(new Event("change", { bubbles: true }));
   }
 
   updateState(selectedValue) {

--- a/app/_assets/javascripts/how_to.js
+++ b/app/_assets/javascripts/how_to.js
@@ -1,82 +1,22 @@
 class HowTo {
   constructor() {
-    this.deploymentTopologySwitch = Array.from(
-      document.querySelectorAll(".deployment-topology-switch")
-    ).find(
-      (e) => !!(e.offsetWidth || e.offsetHeight || e.getClientRects().length)
-    );
     this.prerequisites = document.querySelector(".prerequisites");
     this.cleanup = document.querySelector(".cleanup");
-    this.deploymentToplogyKey = "deployment-topology-switch";
 
-   
-    this.switchType = "toggle";
-    this.topologySwitcherOption = document.querySelector("[data-topology-switcher]")
-    if (this.topologySwitcherOption){
-      this.switchType = this.topologySwitcherOption.dataset.topologySwitcher;
-    }
-
-    this.init();
     this.addEventListeners();
+    this.init();
   }
 
   addEventListeners() {
-    if (this.deploymentTopologySwitch) {
-      this.deploymentTopologySwitch.addEventListener(
-        "change",
-        this.onChange.bind(this)
-      );
-    }
+    document.addEventListener("switch-state-change", this.onChange.bind(this));
   }
 
   init() {
-    if (this.deploymentTopologySwitch) {
-      try {
-        if (localStorage.getItem(this.deploymentToplogyKey) !== null) {
-          const storedOption = localStorage.getItem(this.deploymentToplogyKey);
-          if (
-            storedOption &&
-            [...this.deploymentTopologySwitch.options].some(
-              (opt) => opt.value === storedOption
-            )
-          ) {
-            this.deploymentTopologySwitch.value = storedOption;
-          }
-        }
-      } catch (error) {
-        console.log(error);
-      }
-
-      const urlParams = new URLSearchParams(window.location.search);
-      const deployment = urlParams.get("deployment");
-      if (deployment) {
-        this.deploymentTopologySwitch.value = deployment;
-      }
-
-      this.toggleTopology(this.deploymentTopologySwitch.value);
-    } else {
-      this.updateTOC();
-    }
+    this.updateTOC();
   }
 
   onChange(event) {
-    localStorage.setItem(this.deploymentToplogyKey, event.target.value);
-    if (this.switchType == "page") {
-      this.switchPageTopology(event.target.value);
-    } else {
-      this.toggleTopology(event.target.value, true);
-    }
-  }
-
-  switchPageTopology(topology){
-    const url = new URL(window.location.href);
-    const segments = url.pathname.split('/');
-    if (!segments[segments.length - 1]){
-      segments.pop();
-    }
-    segments[segments.length - 1] = topology;
-    url.pathname = segments.join('/');
-    window.location.href = url.toString();
+    this.toggleTopology(event.detail.selectedValue);
   }
 
   toggleTopology(topology) {

--- a/app/_assets/stylesheets/index.css
+++ b/app/_assets/stylesheets/index.css
@@ -786,8 +786,47 @@
       @apply hover:border-white text-white hover:text-white;
     }
   }
-}
 
+  .switch {
+    @apply flex items-center;
+  }
+
+  .switch__option-label {
+    @apply cursor-pointer text-sm text-terciary;
+  }
+
+  .switch__options {
+    @apply flex items-center gap-2;
+  }
+
+  .switch__wrapper {
+    @apply relative inline-block w-7 h-4;
+
+    input {
+      @apply h-0 w-0 opacity-0;
+    }
+  }
+
+  .switch__slider {
+    @apply absolute cursor-pointer top-0 left-0 right-0 bottom-0 bg-brand rounded-full;
+  }
+
+  .switch__slider:before {
+    @apply absolute content-[''] h-3 w-3 left-0.5 top-0.5 bg-white rounded-full transition-transform duration-300;
+  }
+
+  input:checked + .switch__slider:before {
+    @apply translate-x-[12px];
+  }
+
+  input:focus ~ .switch__slider {
+    @apply outline outline-2;
+
+    @supports (-webkit-appearance: none) {
+      outline-color: -webkit-focus-ring-color;
+    }
+  }
+}
 
 #ask-ai-button {
   @apply button button--secondary w-full lg:w-fit justify-center !py-[7px] !px-3 !font-normal  !text-secondary border-b border-primary/5 gap-1 bg-secondary;

--- a/app/_includes/how-tos/controls.html
+++ b/app/_includes/how-tos/controls.html
@@ -5,7 +5,7 @@
     <div class="switch__options">
         <label for="{{id}}-konnect" class="switch__option-label">konnect</label>
         <div class="switch__wrapper">
-            <input type="radio" id="{{id}}-konnect" name="{{id}}-deployment-type" value="konnect" class="switch__input" checked>
+            <input type="radio" id="{{id}}-konnect" name="{{id}}-deployment-type" value="konnect" class="switch__input">
             <input type="radio" id="{{id}}-on-prem" name="{{id}}-deployment-type" value="on-prem" class="switch__input">
 
             <span class="switch__slider"></span>

--- a/app/_includes/how-tos/controls.html
+++ b/app/_includes/how-tos/controls.html
@@ -1,10 +1,15 @@
-<div class="bg-secondary rounded-md flex justify-between py-2 px-4 gap-2 w-full shadow-primary items-center">
-<label class="text-primary flex gap-2 w-full items-center">
-    Deployment Platform:
-    <select class="bg-secondary grow deployment-topology-switch">
-        {% for option in include.works_on %}
-        <option value="{{ option }}" {% if option == 'konnect' %}selected{% endif %}>{{ option }}</option>
-        {% endfor %}
-    </select>
-</label>
+{% assign id = "deployment-topology-switch" %}
+{% if include.mobile %}{% assign id = id | append: '-mobile' %}{% endif %}
+
+<div class="switch">
+    <div class="switch__options">
+        <label for="{{id}}-konnect" class="switch__option-label">konnect</label>
+        <div class="switch__wrapper">
+            <input type="radio" id="{{id}}-konnect" name="{{id}}-deployment-type" value="konnect" class="switch__input" checked>
+            <input type="radio" id="{{id}}-on-prem" name="{{id}}-deployment-type" value="on-prem" class="switch__input">
+
+            <span class="switch__slider"></span>
+        </div>
+        <label for="{{id}}-on-prem" class="switch__option-label">on-prem</label>
+    </div>
 </div>

--- a/app/_includes/info_box/concept.html
+++ b/app/_includes/info_box/concept.html
@@ -1,9 +1,9 @@
-{% if page.all_docs_indices and page.all_docs_indices != empty  %}
-{% include_cached info_box/sections/all_docs_indices.html all_docs_indices=page.all_docs_indices %}
-{% endif %}
-
 {% if page.works_on %}
 {% include info_box/sections/works_on.html works_on=page.works_on %}
+{% endif %}
+
+{% if page.all_docs_indices and page.all_docs_indices != empty  %}
+{% include_cached info_box/sections/all_docs_indices.html all_docs_indices=page.all_docs_indices %}
 {% endif %}
 
 {% if page.series %}

--- a/app/_includes/info_box/sections/controls.html
+++ b/app/_includes/info_box/sections/controls.html
@@ -1,0 +1,12 @@
+{% if page.works_on %}
+{% assign incompatibilities = include.works_on | works_on_incompatibilities %}
+
+{% if incompatibilities.size == 0  %}
+<div class="flex flex-col gap-2  w-full">
+  <div class="text-primary font-medium">Deployment Platform</div>
+  <div class="flex gap-1.5">
+    {% include how-tos/controls.html works_on=page.works_on mobile=include.mobile  %}
+  </div>
+</div>
+{% endif %}
+{% endif %}

--- a/app/_includes/layouts/aside.html
+++ b/app/_includes/layouts/aside.html
@@ -2,14 +2,13 @@
     {% include releases_dropdown.html releases_dropdown=page.releases_dropdown release=page.release mobile=include.mobile %}
 {% endif %}
 
-{% ifhascontent controls %}
-    <div class="flex flex-col text-xs">
-        {% contentblock controls no-convert %}
-    </div>
-{% endifhascontent %}
-
 {% ifhascontent info_box %}
 <div class="flex flex-col rounded-md p-5 gap-5 bg-secondary shadow-primary w-full">
+{% comment %}XXX: Unfortunately, this needs to be here because contentblock caches the content.{% endcomment %}
+{% if page.content_type == 'how_to' %}
+    {% include_cached info_box/sections/controls.html works_on=page.works_on mobile=include.mobile %}
+{% endif %}
+
 {% contentblock info_box %}
 </div>
 {% endifhascontent %}

--- a/app/_layouts/how-to.html
+++ b/app/_layouts/how-to.html
@@ -30,9 +30,3 @@ layout: with_aside
 {% contentfor info_box %}
 {% include info_box/concept.html %}
 {% endcontentfor %}
-
-{% if page.works_on %}
-{% contentfor controls %}
-{% include how-tos/controls.html works_on=page.works_on %}
-{% endcontentfor %}
-{% endif %}


### PR DESCRIPTION
## Description

Fixes #1880 

Works in the same way as the dropdown, i.e. sets the value in the following order (each option overwrites the previous value):
* user preference stored.
* "?deployment" param in the url.
* if the page has data-topology-switcher="page" updates the url depending on the value of the switch.

## Preview Links

* [gateway get-started](https://deploy-preview-2871--kongdeveloper.netlify.app/gateway/get-started/)
* [data-topology-switcher example](https://deploy-preview-2871--kongdeveloper.netlify.app//gateway/install/kubernetes/konnect/)

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
