### PR TITLE
fix: path to hello-gateway.proto in how-to

### DIFF
--- a/app/_how-tos/use-grpc-gateway.md
+++ b/app/_how-tos/use-grpc-gateway.md
@@ -115,7 +115,7 @@ entities:
     - name: grpc-gateway
       route: http-route
       config:
-        proto: usr/local/kong/hello-gateway.proto
+        proto: /usr/local/kong/hello-gateway.proto
 {% endentity_examples %}
 
 ## Validate


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
