### PR TITLE
fix(gateway): Clearer description for partials

### DIFF
--- a/app/_gateway_entities/partial.md
+++ b/app/_gateway_entities/partial.md
@@ -43,10 +43,14 @@ min_version:
 ---
 
 ## What is a Partial?
-Some entities in {{site.base_gateway}} share common configuration settings that often need to be repeated. For example, multiple [plugins](/gateway/entities/plugin/) that connect to Redis may require the same connection settings. Without Partials, you would need to replicate this configuration across all plugins. If the settings change, you would need to update each plugin individually.
 
-Partials address this issue by allowing you to extract shared configurations into reusable entities that can be linked to multiple plugins. To ensure validation and consistency, Partials have defined types. 
+Partials allow you to reuse shared Redis configurations across plugins.
 
+Some [plugins](/gateway/entities/plugin/) in {{site.base_gateway}} share common Redis configuration settings that often need to be repeated. 
+Partials allow you to extract those shared configurations into reusable entities that can be linked to multiple plugins.
+Without Partials, you would need to replicate this configuration across all plugins. If the settings change, you would need to update each plugin individually.
+
+To ensure validation and consistency, Partials have defined types.
 {{site.base_gateway}} supports the following types of Partials, `redis-ce` and `redis-ee`. `redis-ce` has a shorter and simpler configuration, whereas `redis-ee` provides options for configuring Redis Sentinel or Redis Cluster connections. Each plugin that supports Partials only supports one of these types.
 
 {:.info}


### PR DESCRIPTION
## Description

User was confused about Partials, as it wasn't immediately clear that partials are applicable to plugins only. This clarifies that. 

https://github.com/Kong/developer.konghq.com/pull/2836 will help address the confusion as well; it will cover the doc from types onward (which is why I didn't adjust any of that part of the description).

## Preview Links

https://deploy-preview-2898--kongdeveloper.netlify.app/gateway/entities/partial/
