### PR TITLE
chore: Note about site generation in docs README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ make run
 
 Once you see the `Server now ready on …` message, the docs site is available at [http://localhost:8888](http://localhost:8888).
 
+> Note: By default, some page generation is skipped for performance reasons. To generate the entire site locally, go to `jekyll-dev.yml` in the root of the repo and comment out the entire `skip` section.
+
 ## Contributing to the docs
 
 If you want to contribute to the Kong Developer docs, see the [Contributing guide](https://developer.konghq.com/contributing/).


### PR DESCRIPTION
## Description

User asked about running site locally; I noticed that they would have no way to know that the whole site wouldn't build by default without this info here.

## Preview Links

https://github.com/Kong/developer.konghq.com/tree/chore/readme-note?tab=readme-ov-file#developerkonghqcom