### PR TITLE
Fix automated tests instructions

### DIFF
--- a/app/_how-tos/deck-get-started.md
+++ b/app/_how-tos/deck-get-started.md
@@ -49,6 +49,8 @@ cleanup:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg
+
+automated_tests: false
 ---
 
 ## Create a Service

--- a/app/_how-tos/docker-compose.md
+++ b/app/_how-tos/docker-compose.md
@@ -42,6 +42,8 @@ faqs:
     a: |
       Yes, you can run a {{site.base_gateway}} Docker container in read-only mode by setting `database` to `off` and passing a configuration file when starting the container.
       See [Running {{site.base_gateway}} in read-only mode using Docker Compose](/gateway/install/docker-read-only/) for more information.
+
+automated_tests: false
 ---
 
 ## Set up the Docker Compose file

--- a/app/_how-tos/gateway-install-helm-konnect.md
+++ b/app/_how-tos/gateway-install-helm-konnect.md
@@ -30,6 +30,8 @@ next_steps:
     url: /how-to/add-rate-limiting-to-a-service-with-kong-gateway/
   - text: Enable key authentication on a Gateway Service
     url: /how-to/authenticate-consumers-with-key-auth-enc/
+
+automated_tests: false
 ---
 
 ## Konnect setup

--- a/app/_how-tos/govern-mcp-traffic.md
+++ b/app/_how-tos/govern-mcp-traffic.md
@@ -59,6 +59,8 @@ cleanup:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg
+
+automated_tests: false
 ---
 
 ## Reconfigure the AI Proxy Advanced plugin

--- a/app/_how-tos/install-gateway-read-only.md
+++ b/app/_how-tos/install-gateway-read-only.md
@@ -40,6 +40,8 @@ cleanup:
 next_steps:
   - text: Learn about DB-less mode
     url: /gateway/db-less-mode/
+
+automated_tests: false
 ---
 
 ## Create a `kong.yml` configuration file

--- a/app/_how-tos/observe-mcp-traffic.md
+++ b/app/_how-tos/observe-mcp-traffic.md
@@ -59,6 +59,9 @@ cleanup:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg
+
+
+automated_tests: false
 ---
 
 ## Reconfigure the AI Proxy Advanced plugin

--- a/app/_how-tos/outbound-dns-resolver.md
+++ b/app/_how-tos/outbound-dns-resolver.md
@@ -44,6 +44,7 @@ prereqs:
       export FORWARD_ZONES='example.internal.dev,example2.internal.dev'
       ```
 
+automated_tests: false
 ---
 
 

--- a/app/_how-tos/plugin-dev-add-plugin-configuration.md
+++ b/app/_how-tos/plugin-dev-add-plugin-configuration.md
@@ -37,6 +37,8 @@ related_resources:
     url: /custom-plugins/
   - text: Plugins
     url: /gateway/entities/plugins/
+
+automated_tests: false
 ---
 
 ## Add configuration fields to the schema 

--- a/app/_how-tos/plugin-dev-add-plugin-testing.md
+++ b/app/_how-tos/plugin-dev-add-plugin-testing.md
@@ -38,6 +38,8 @@ related_resources:
     url: /custom-plugins/
   - text: Plugins
     url: /gateway/entities/plugins/
+
+automated_tests: false
 ---
 
 ## Install Pongo

--- a/app/_how-tos/plugin-dev-deploy-plugins.md
+++ b/app/_how-tos/plugin-dev-deploy-plugins.md
@@ -37,6 +37,8 @@ related_resources:
     url: /custom-plugins/
   - text: Plugins
     url: /gateway/entities/plugins/
+
+automated_tests: false
 ---
 
 ## Create a Dockerfile

--- a/app/_how-tos/private-hosted-zones.md
+++ b/app/_how-tos/private-hosted-zones.md
@@ -49,6 +49,7 @@ prereqs:
       export AWS_VPC_ID='YOUR_VPC_ID'
       ```
 
+automated_tests: false
 ---
 
 

--- a/app/_how-tos/secure-mcp-traffic.md
+++ b/app/_how-tos/secure-mcp-traffic.md
@@ -82,6 +82,8 @@ cleanup:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg
+
+automated_tests: false
 ---
 
 ## Configure the AI Proxy Advanced plugin

--- a/tools/automated-tests/instructions-file.js
+++ b/tools/automated-tests/instructions-file.js
@@ -20,8 +20,16 @@ export async function testeableUrlsFromFiles(config, files) {
 
     if (isTesteable) {
       const skipHowTo =
-        content.includes("@todo") || frontmatter.automated_tests === false;
-      const howToUrl = `/how-to/${fileToUrl(file)}`;
+        content.includes("@todo") ||
+        frontmatter.automated_tests === false ||
+        frontmatter.published === false;
+
+      let howToUrl;
+      if (frontmatter.permalink) {
+        howToUrl = frontmatter.permalink;
+      } else {
+        howToUrl = `/how-to/${fileToUrl(file)}`;
+      }
 
       if (skipHowTo) {
         const relativeFilePath = file.replace("../../", "");


### PR DESCRIPTION
## Description

Fixes url generation when generating instruction files and update extraction to use the new toggle switch

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
