### PR TITLE
Fix: Grammatical improvement on bullet-point for Payload prerequisites

### DIFF
--- a/app/gateway/debugger.md
+++ b/app/gateway/debugger.md
@@ -84,7 +84,7 @@ In critical scenarios, having access to payload details can help identify and pi
 
 ### Prerequisites
 * Your organization has opted-in to use debugger's payload capture feature and signed the Advanced Features Addendum
-* data plane nodes are deployed with new telemetry endpoints that support the payload capture feature
+* Data plane nodes are deployed with new telemetry endpoints that support the payload capture feature
 * Customer firewall rules updated to allow for the new telemetry endpoints
 
 {:.info}


### PR DESCRIPTION
## Description

Changed "data plane" to "Data plane" as it's the start of a bullet-point and so the first letter should be capitalized in this case. Very minor fix.