### PR TITLE
feat(gateway): Confluent Consume plugin - schema registry oauth2

### DIFF
--- a/app/_includes/plugins/confluent-kafka-consume/schema-registry.md
+++ b/app/_includes/plugins/confluent-kafka-consume/schema-registry.md
@@ -85,8 +85,11 @@ autonumber
 
 To configure Schema Registry with the {{include.name}} plugin, use the [`config.schema_registry`](./reference/#schema--config-schema-registry) parameter in your plugin configuration. 
 
-See the [schema registry configuration example](./examples/schema-registry/) for sample configuration values.
-
+For sample configuration values, see:
+* [Schema registry configuration example](./examples/schema-registry/)
+{% if include.slug == 'confluent-consume' %}
+* [Schema registry with OAuth2 configuration example](./examples/schema-registry-oauth2/) {% new_in 3.12 %}
+{% endif %}
 
 
 

--- a/app/_kong_plugins/confluent-consume/examples/schema-registry-oauth2.yaml
+++ b/app/_kong_plugins/confluent-consume/examples/schema-registry-oauth2.yaml
@@ -1,0 +1,67 @@
+description: 'Configure the Confluent Consume plugin to use the Confluent Schema Registry for message deserialization and secure it with OAuth 2.0 token authentication.'
+
+title: 'Confluent Schema Registry with OAuth2'
+
+weight: 900
+
+requirements: 
+  - "[Create a Kafka cluster in Confluent Cloud](https://docs.confluent.io/cloud/current/get-started/index.html#step-1-create-a-ak-cluster-in-ccloud)"
+  - "[Create a Kafka topic in the cluster](https://docs.confluent.io/cloud/current/get-started/index.html#step-2-create-a-ak-topic)"
+  - "Create an API key and secret in the cluster"
+  - "[Configure a Schema Registry](https://docs.confluent.io/platform/current/schema-registry/index.html)"
+  - "Set up an identity provider (IdP) that supports OAuth 2.0 client credentials grant, such as Keycloak or Okta"
+
+variables:
+  host:
+    description: The bootstrap server host.
+    value: $BOOTSTRAP_SERVER_HOST
+  key:
+    description: The API key to use for authentication.
+    value: $API_KEY
+  secret:
+    description: The API secret to use for authentication.
+    value: $API_SECRET
+  topic:
+    description: The name of the Kafka topic to consume from.
+    value: $KAFKA_TOPIC
+  registry_url:
+    description: "The URL of your Confluent Schema Registry instance. For example, `http://schema-registry:8081`."
+    value: $REGISTRY_URL
+  client_id:
+    description: The client ID that the plugin uses when it calls authenticated endpoints of the IdP.
+    value: $CLIENT_ID
+  client_secret:
+    description: 'The client secret from the IdP.'
+    value: $CLIENT_SECRET
+
+
+config:
+  bootstrap_servers:
+  - host: ${host}
+    port: 9092
+  topics:
+  - name: ${topic}
+  mode: http-get
+  cluster_api_key: ${key}
+  cluster_api_secret: ${secret}
+  schema_registry:
+    confluent:
+      url: ${registry_url}
+      authentication:
+        mode: oauth2
+        oauth2:
+          token_endpoint: https://example.com/oauth2/token
+          client_id: ${client_id}
+          client_secret: ${client_secret}
+        oauth2_client:
+          auth_method: client_secret_post
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform
+
+min_version:
+  gateway: '3.12'


### PR DESCRIPTION
## Description

Fixes #2860 

Linked issue says Kafka also, but this only applies to the Confluent Consume plugin, as it connects to the Confluent Schema Registry.

@windmgc @cshuaimin could I please get a docs review from one of you? Should be a quick review, it's just adding a config example.

## Preview Links

https://deploy-preview-2918--kongdeveloper.netlify.app/plugins/confluent-consume/#configure-schema-registry
https://deploy-preview-2918--kongdeveloper.netlify.app/plugins/confluent-consume/examples/schema-registry-oauth2/