### PR TITLE
Update status endpoint path in documentation

### DIFF
--- a/app/_kong_plugins/ai-prompt-compressor/index.md
+++ b/app/_kong_plugins/ai-prompt-compressor/index.md
@@ -136,7 +136,7 @@ The compressor service exposes both REST and JSON-RPC endpoints. You can use the
 
 * **POST `/llm/v1/compressPrompt`**: Compresses a prompt using either a compression ratio or a target token count. Supports selective compression via `<LLMLINGUA>` tags.
 
-* **GET `/llm/v1/status`**: Returns information about the currently loaded LLMLingua model and device settings (for example, CPU or GPU).
+* **GET `/status`**: Returns information about the currently loaded LLMLingua model and device settings (for example, CPU or GPU).
 
 * **POST `/`**: JSON-RPC endpoint that supports the `llm.v1.compressPrompt` method. Use this to invoke compression programmatically over JSON-RPC.
 


### PR DESCRIPTION
The defined path for the status endpoint, llm/v1/status, is incorrect and will return a 404

```bash
curl http://localhost:8080/llm/v1/status -i
```
```text
HTTP/1.1 404 NOT FOUND
```

The correct path should simply be `/status`

```bash
curl http://localhost:8080/status -i
```
```text
HTTP/1.1 200 OK
Server: gunicorn
Date: Wed, 17 Sep 2025 19:25:25 GMT
Connection: close
Content-Type: application/json
Content-Length: 102

{"status":"ok","model_name":"microsoft/llmlingua-2-xlm-roberta-large-meetingbank","device_map":"cpu"}
```

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
