### PR TITLE
chore(gateway): EOL for Gateway 3.8

### DIFF
--- a/app/_data/products/gateway.yml
+++ b/app/_data/products/gateway.yml
@@ -382,7 +382,8 @@ releases:
   - release: "3.8"
     ee-version: "3.8.1.2"
     ce-version: "3.8.1"
-    eol: 2025-09-30
+    eol: 2025-09-11
+    sunset: true
     distributions:
       - amazonlinux2:
           package: true

--- a/app/_data/support/gateway.yml
+++ b/app/_data/support/gateway.yml
@@ -20,7 +20,7 @@
 - release: "3.8"
   konnect: true
   beginning: "3.8.0.0"
-  release_date: "2024-11-04"
+  release_date: "2024-09-11"
   eol: "2025-09-11"
   sunset: "2026-09-11"
 - release: "3.7"

--- a/app/_data/support/gateway.yml
+++ b/app/_data/support/gateway.yml
@@ -21,8 +21,8 @@
   konnect: true
   beginning: "3.8.0.0"
   release_date: "2024-11-04"
-  eol: "2025-09-30"
-  sunset: "2026-09-30"
+  eol: "2025-09-11"
+  sunset: "2026-09-11"
 - release: "3.7"
   konnect: true
   beginning: "3.7.0.0"

--- a/app/gateway/third-party-support.md
+++ b/app/gateway/third-party-support.md
@@ -62,11 +62,13 @@ These tools are managed services and Kong provides compatibility with the curren
 {% assign releases = site.data.products.gateway.releases | reverse | where: "label", empty %}
 {% navtabs "gateway-version" %}
 {% for release in releases %}
+{% unless release.sunset == true %}
 {% assign tab_name = release.release %}
 {% if release.lts %}{% assign tab_name = tab_name | append: ' LTS' %}{% endif %}
 {% navtab {{ tab_name }} %}
   {% include_cached support/gateway-third-party.html release=release %}
 {% endnavtab %}
+{% endunless %}
 {% endfor %}
 {% endnavtabs %}
 

--- a/docs/version-eol-or-sunset.md
+++ b/docs/version-eol-or-sunset.md
@@ -1,0 +1,27 @@
+# Managing version End-of-Life (EOL) and End of Sunset support
+
+Instructions for managing docs for EOL and EOS product versions.
+
+## Kong Gateway
+
+Kong Gateway versions have three stages:
+* Supported
+* Reached end of life (EOL) and entered sunset support
+* Reached end of sunset support (EOS)
+
+### Moving an EOL version into sunset support
+
+1. In `app/_data/support/gateway.yml`, ensure that the EOL and sunset dates are correct. 
+
+    * For regular releases, the EOL should be exactly a year after the first minor release (e.g. 3.8.0.0); the sunset date should be exactly two years after.
+    For example, if 3.8.0.0 came out on 2024-09-11, the EOL is 2025-09-11, and sunset is 2026-09-11.
+    * For LTS releases, the EOL should be exactly three years after the first minor release; the sunset date should be exactly four years after.
+    For example, if 3.10.0.0 LTS came out on 2025-03-31, the EOL is 2028-03-31, and sunset is 2029-03-31.
+
+1. In `/app/_data/products/gateway.yml`, find the release and set `sunset: true`. Check the dates and ensure they align to the previous step.
+
+### Moving a sunset version into EOS
+
+When a version moves into end of sunset support, it is completely removed from the doc.
+
+More details TBA when we actually have to do this.

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -7,12 +7,12 @@ skip:
   indices: true # skip indices
   mesh_policy: true # skip mesh policies generation, except for overviews
   explorer: true # skip explorer
-  # auto_generated: true # skip auto_generated references, i.e. app/_referneces
+  auto_generated: true # skip auto_generated references, i.e. app/_referneces
   mesh: true # skip kuma to mesh generation
 
 # exclude app/_references
 # even though we set skip.auto_generated: true and the collection has output:false
 # Jekyll still reads, parses and renders the collection. It doesn't write the pages
 # to disc though, but the first part is very time consuming.
-# exclude:
-#   - _references
+exclude:
+  - _references

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -7,12 +7,12 @@ skip:
   indices: true # skip indices
   mesh_policy: true # skip mesh policies generation, except for overviews
   explorer: true # skip explorer
-  auto_generated: true # skip auto_generated references, i.e. app/_referneces
+  # auto_generated: true # skip auto_generated references, i.e. app/_referneces
   mesh: true # skip kuma to mesh generation
 
 # exclude app/_references
 # even though we set skip.auto_generated: true and the collection has output:false
 # Jekyll still reads, parses and renders the collection. It doesn't write the pages
 # to disc though, but the first part is very time consuming.
-exclude:
-  - _references
+# exclude:
+#   - _references


### PR DESCRIPTION
## Description

Fixes #2041

Gateway 3.8 moved into sunset support on Sept 11. Adjusting the doc to reflect this.
* Fixing the third-party support tables to only display supported versions
* Adding a short internal doc so that anyone can make this update

## Preview Links

https://deploy-preview-2935--kongdeveloper.netlify.app/gateway/version-support-policy/#supported-versions
https://deploy-preview-2935--kongdeveloper.netlify.app/gateway/version-support-policy/#older-versions
https://deploy-preview-2935--kongdeveloper.netlify.app/gateway/third-party-support/