### PR TITLE
Feat (konnect): Org admin owner definition

### DIFF
--- a/app/konnect-platform/account.md
+++ b/app/konnect-platform/account.md
@@ -69,6 +69,11 @@ faqs:
   - q: How do I manage and view billing and usage?
     a: |
       You can view service, Dev Portal, and API call usage from the [Billing and Usage](https://cloud.konghq.com/global/plan-and-usage/).
+  - q: What is the difference between an Organization Owner and an Organization Admin?
+    a: |
+      The Organization Owner is the single user tied to the organization itself, while Organization Admins are roles that multiple users can hold.
+      - An Organization Owner is a property of the organization that identifies a single user as the Owner. The Owner is automatically assigned when the organization is created and always has the Organization Admin role. Each organization can have only one Owner.
+      - An Organization Admin is a role that can be assigned to multiple users. Admins can manage users, teams, and roles, but they can't delete the organization. Only the Owner can delete an organization.
 ---
 
 {{site.konnect_short_name}} offers [two plans](https://konghq.com/pricing).

--- a/app/konnect-platform/teams-and-roles.md
+++ b/app/konnect-platform/teams-and-roles.md
@@ -89,7 +89,7 @@ rows:
   - team: Analytics Viewer
     description: Users can view the [Analytics](/advanced-analytics/) summary and report data.
   - team: Organization Admin
-    description: Users can fully manage all entities and configuration in the organization.
+    description: Users can fully manage all entities and configuration in the organization. Each organization has one Owner, that always has this role and is the only user who can delete the organization.
   - team: Organization Admin (Read Only)
     description: Users can view all entities and configuration in the organization.
   - team: Portal Admin

--- a/app/konnect-platform/teams-and-roles.md
+++ b/app/konnect-platform/teams-and-roles.md
@@ -89,7 +89,7 @@ rows:
   - team: Analytics Viewer
     description: Users can view the [Analytics](/advanced-analytics/) summary and report data.
   - team: Organization Admin
-    description: Users can fully manage all entities and configuration in the organization. Each organization has one Owner, that always has this role and is the only user who can delete the organization.
+    description: Users can fully manage all entities and configuration in the organization. In addition to users granted the Organization Admin role, each organization also has one Owner, who always has this role and is the only user who can delete the organization.
   - team: Organization Admin (Read Only)
     description: Users can view all entities and configuration in the organization.
   - team: Portal Admin


### PR DESCRIPTION
## Description

> From:
> 
> Jobs to be done (optional)
> User wants to know what the difference between an Organization Owner and an Organization Admin is in Konnect.
> 
> Definition of done
> Update https://developer.konghq.com/konnect-platform/account/ with an FAQ entry.
> 
> Information
> Reported in Kapa.
> 
> As far as I know, the differences are:
> 
> Org Admin is a role. Org Owner is an attribute of the org.
> An org owner automatically has the org admin role, and this role can't be removed.
> An org can only have one owner; it can have multiple org admins.
> Only an org owner can delete the org.
> Whoever creates the org is automatically an org owner.
> Might want to ask this question in #ask-konnect to check if there's anything I'm missing.
> 
> Size
> S

Fixes #2867

## Preview Links

- https://deploy-preview-2944--kongdeveloper.netlify.app/konnect-platform/teams-and-roles/#predefined-teams
- https://deploy-preview-2944--kongdeveloper.netlify.app/konnect-platform/account/#what-is-the-difference-between-an-organization-owner-and-an-organization-admin

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
