### PR TITLE
Correct link to Manage Insomnia

### DIFF
--- a/app/_landing_pages/insomnia.yaml
+++ b/app/_landing_pages/insomnia.yaml
@@ -102,7 +102,7 @@ rows:
             icon:  /assets/icons/profile.svg
             cta:
               text: Learn more
-              url: /manage-insomnia/
+              url: /insomnia/manage-insomnia/
       - blocks:
         - type: card
           config:

--- a/app/_landing_pages/insomnia.yaml
+++ b/app/_landing_pages/insomnia.yaml
@@ -102,7 +102,7 @@ rows:
             icon:  /assets/icons/profile.svg
             cta:
               text: Learn more
-              url: /inso-cli/
+              url: /manage-insomnia/
       - blocks:
         - type: card
           config:


### PR DESCRIPTION
## Description

The Manage Insomnia link was linking to the inso-cli page instead.
