### PR TITLE
Fix(Plugins): Explicitly say that exit-transformer doesn't work with other upstreams

### DIFF
--- a/app/_kong_plugins/exit-transformer/index.md
+++ b/app/_kong_plugins/exit-transformer/index.md
@@ -42,7 +42,9 @@ min_version:
 
 Transform and customize {{site.base_gateway}} response exit messages using Lua functions.
 The plugin's capabilities range from changing messages, status codes, and headers,
-to completely transforming the structure of {{site.base_gateway}} responses. Responses originating from upstream services can't be intercepted or transformed by this plugin.
+to completely transforming the structure of {{site.base_gateway}} responses. 
+
+Responses originating from upstream services can't be intercepted or transformed by this plugin.
 
 
 {:.info}


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
