### PR TITLE
fix(gateway): Mark known issue as fixed

### DIFF
--- a/app/gateway/breaking-changes.md
+++ b/app/gateway/breaking-changes.md
@@ -1,5 +1,5 @@
 ---
-title: "{{site.base_gateway}} breaking changes"
+title: "{{site.base_gateway}} breaking changes and known issues"
 content_type: reference
 layout: reference
 breadcrumbs:
@@ -107,7 +107,7 @@ rows:
       **Workaround**: 
       * Incremental config sync is `off` by default. If you haven't enabled incremental config sync, there is no action required.
       * If you are using stream proxying and incremental config sync, disable incremental sync by setting `incremental_sync=off`. 
-    status: Not fixed
+    status: Fixed in 3.11.0.3
   - issue: Brotli module missing from ARM64 {{site.base_gateway}} Docker images
     description: |
       The Brotli module is missing from all the following ARM64 {{site.base_gateway}} Docker images:


### PR DESCRIPTION
## Description

The incremental sync issue was fixed in 3.11.0.3: https://developer.konghq.com/gateway/changelog/#3-11-0-3-bugfix-clustering

Adding "and known issues" to the page title because this page doesn't come up in search when looking for known issues + just "breaking changes" is not an accurate descriptor.

## Preview Links

