### PR TITLE
Feat(DCGW): Kong configuration environment variables

### DIFF
--- a/app/dedicated-cloud-gateways/reference.md
+++ b/app/dedicated-cloud-gateways/reference.md
@@ -321,6 +321,10 @@ The following table lists the environment variables that you can set while creat
 {% kong_config_table env %}
 config:
   - name: log_level
+    description: |
+      Log level of the data plane node.
+      
+      The logs are available in {{site.konnect_short_name}}, in the **Logs** tab of the data plane node.
   - name: request_debug_token
   - name: tracing_instrumentations
   - name: tracing_sampling_rate


### PR DESCRIPTION
## Description

Fixes #2685 

## Note for reviewers

- The `header_upstream` variable is the same as `headers_upstream` but with a different name, so I copied the description.

## Preview Links

https://deploy-preview-2957--kongdeveloper.netlify.app/dedicated-cloud-gateways/reference/#kong-gateway-configuration

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
