### PR TITLE
fix: add pages to broken links' ignored targets

### DIFF
--- a/tools/broken-link-checker/config/ignored_targets.json
+++ b/tools/broken-link-checker/config/ignored_targets.json
@@ -106,5 +106,7 @@
     "https://konghq.com/legal/privacy-policy",
     "https://www.gnu.org/*",
     "https://konghq.com/pricing",
-    "https://docs.splunk.com/*"
+    "https://docs.splunk.com/*",
+    "https://konghq.com/compliance",
+    "https://developer.hashicorp.com/*"
   ]


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
