### PR TITLE
fix(service-catalog): Remove inaccurate product link

### DIFF
--- a/app/service-catalog/scorecards.md
+++ b/app/service-catalog/scorecards.md
@@ -4,7 +4,6 @@ content_type: reference
 layout: reference
 
 products:
-    - gateway
     - service-catalog
 works_on:
   - konnect


### PR DESCRIPTION
## Description

The "all documentation" link is going to Gateway instead of Service Catalog. There shouldn't be any "gateway" entry here.

## Preview Links


