### PR TITLE
fix: KO latest version to 2.0.2

### DIFF
--- a/app/_data/products/operator.yml
+++ b/app/_data/products/operator.yml
@@ -1,7 +1,7 @@
 name: Kong Gateway Operator
 
 releases:
-  - release: "2.0"
+  - release: "2.0.2"
     releaseDate: "2025-09-22"
     endOfLifeDate: "2026-09-22"
     latest: true


### PR DESCRIPTION
## Description

This PR fixes the version listed during helm installation of kong-operator pointing to the latest minor version without forcing the patch release version

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
