### PR TITLE
Fix: (Konnect): Add Next Steps link and Validation pointer to Secret Type content

### DIFF
--- a/app/_how-tos/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity.md
+++ b/app/_how-tos/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity.md
@@ -108,4 +108,4 @@ value: 'secret'
 
 If the vault was configured correctly, this command should return the value of the secret. Then, you can use `{vault://aws-vault/my-aws-secret/token}` to reference the secret in any referenceable field.
 
-For more information about what secret types we support, go to [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret). 
+For more information about supported secret types, see [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret). 

--- a/app/_how-tos/configure-cyberark-as-a-vault-backend.md
+++ b/app/_how-tos/configure-cyberark-as-a-vault-backend.md
@@ -128,4 +128,4 @@ This assumes your secret was stored in `BotApp/secretVar` in Conjur.
 
 If the Vault was configured correctly, this command should return the value of the secret. You can use `{vault://my-conjur/BotApp%2FsecretVar}` to reference the secret in any referenceable field.
 
-For more information about what secret types we support, go to [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret). 
+For more information about supported secret types, see [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret). 

--- a/app/_how-tos/configure-google-cloud-secret-as-a-vault-backend.md
+++ b/app/_how-tos/configure-google-cloud-secret-as-a-vault-backend.md
@@ -116,5 +116,5 @@ value: 'secret'
 
 If the vault was configured correctly, this command should return the value of the secret. You can use `{vault://gcp-sm-vault/test-secret}` to reference the secret in any referenceable field.
 
-For more information about what secret types we support, go to [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret). 
+For more information about supported secret types, see [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret). 
     

--- a/app/_how-tos/configure-hashicorp-vault-as-a-vault-backend.md
+++ b/app/_how-tos/configure-hashicorp-vault-as-a-vault-backend.md
@@ -158,4 +158,4 @@ value: 'ACME Inc.'
 
 If the vault was configured correctly, this command should return the value of the secret. You can use `{vault://hashicorp-vault/customer/acme/name}` to reference the secret in any referenceable field.
 
-For more information about what secret types we support, go to [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret). 
+For more information about supported secret types, see [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret).  

--- a/app/_how-tos/configure-hashicorp-vault-with-cert-auth.md
+++ b/app/_how-tos/configure-hashicorp-vault-with-cert-auth.md
@@ -351,4 +351,4 @@ value: 'x-kong:test'
 
 If the vault was configured correctly, this command should return the value of the secret. You can use `{vault://hashicorp-vault/headers/request/header}` to reference the secret in any referenceable field.
 
-For more information about what secret types we support, go to [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret). 
+For more information about supported secret types, see [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret). 

--- a/app/_how-tos/configure-the-konnect-config-store.md
+++ b/app/_how-tos/configure-the-konnect-config-store.md
@@ -161,4 +161,4 @@ method: GET
 
 If your secret was successfully stored in {{site.konnect_short_name}}, the endpoint should return a `201` status code and your `secret-key` key in the output.
 
-You can now reference your {{site.konnect_short_name}} secret in configurations as `{vault://mysecretvault/secret-key}`. For more information about secret types, go to [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret). 
+You can now reference your {{site.konnect_short_name}} secret in configurations as `{vault://mysecretvault/secret-key}`. For more information about supported secret types, see [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret). 

--- a/app/_how-tos/kic-vault-aws.md
+++ b/app/_how-tos/kic-vault-aws.md
@@ -88,4 +88,4 @@ command: kubectl exec -n kong -it deployment/kong-gateway -c proxy --
 
 If the vault was configured correctly, this command should return the value of the secret. You can use `{vault://aws-vault/my-aws-secret/token}` to reference the secret in any referenceable field.
 
-For more information about what secret types we support, go to [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret). 
+For more information about supported secret types, see [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret). 

--- a/app/_how-tos/kic-vault-gcp.md
+++ b/app/_how-tos/kic-vault-gcp.md
@@ -89,4 +89,4 @@ command: kubectl exec -n kong -it deployment/kong-gateway -c proxy --
 
 If the vault was configured correctly, this command should return the value of the secret. You can use `{vault://gcp-vault/test-secret}` to reference the secret in any referenceable field.
 
-For more information about what secret types we support, go to [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret). 
+For more information about supported secret types, see [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret). 

--- a/app/_how-tos/kic-vault-hashicorp.md
+++ b/app/_how-tos/kic-vault-hashicorp.md
@@ -103,4 +103,4 @@ command: kubectl exec -n kong -it deployment/kong-gateway -c proxy --
 
 If the vault was configured correctly, this command should return the value of the secret. You can use `{vault://hashicorp-vault/customer/acme/name}` to reference the secret in any referenceable field.
 
-For more information about what secret types we support, go to [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret). 
+For more information about supported secret types, see [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret). 


### PR DESCRIPTION
## Description

> From:
> DoD:
> 
> Add a link to what can be referenced as a secret as a link in the validate step as well as a Next step link in all Vault how tos https://developer.konghq.com/gateway/entities/vault/#what-can-be-stored-as-a-secret
> https://developer.konghq.com/how-to/configure-the-konnect-config-store/
> https://developer.konghq.com/how-to/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity/
> https://developer.konghq.com/how-to/configure-google-cloud-secret-as-a-vault-backend/
> https://developer.konghq.com/how-to/configure-hashicorp-vault-as-a-vault-backend/
> https://developer.konghq.com/how-to/configure-cyberark-as-a-vault-backend/
> https://developer.konghq.com/kubernetes-ingress-controller/vault/aws/
> https://developer.konghq.com/kubernetes-ingress-controller/vault/gcp/
> https://developer.konghq.com/how-to/configure-hashicorp-vault-with-cert-auth/
> https://developer.konghq.com/kubernetes-ingress-controller/vault/hashicorp/
> Request: https://kongstrong.slack.com/archives/C08QWBZP8B0/p1754909668426979
> Size: S

Fixes #2540 

## Preview Links

1. https://deploy-preview-2966--kongdeveloper.netlify.app/how-to/configure-the-konnect-config-store/
2. https://deploy-preview-2966--kongdeveloper.netlify.app/how-to/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity/
3. https://deploy-preview-2966--kongdeveloper.netlify.app/how-to/configure-google-cloud-secret-as-a-vault-backend/
4. https://deploy-preview-2966--kongdeveloper.netlify.app/how-to/configure-hashicorp-vault-as-a-vault-backend/
5. https://deploy-preview-2966--kongdeveloper.netlify.app/how-to/configure-cyberark-as-a-vault-backend/
6. https://deploy-preview-2966--kongdeveloper.netlify.app/kubernetes-ingress-controller/vault/aws/
7. https://deploy-preview-2966--kongdeveloper.netlify.app/kubernetes-ingress-controller/vault/gcp/
8. https://deploy-preview-2966--kongdeveloper.netlify.app/how-to/configure-hashicorp-vault-with-cert-auth/
9. https://deploy-preview-2966--kongdeveloper.netlify.app/kubernetes-ingress-controller/vault/hashicorp/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
