### PR TITLE
feat(konnect): Rename: Notification hub gateway manager naming update

### DIFF
--- a/app/konnect-platform/notification-hub.md
+++ b/app/konnect-platform/notification-hub.md
@@ -28,7 +28,7 @@ You can manage your notification configurations through the [bell icon next to y
 
 The Notification Hub generates notifications for the following areas:
 * **Organization**: Configurable notifications about org access and audit logs.
-* **Gateway Manager**: Entity notification configurations. You can have up to three regional notification configurations per entity.
+* **API Gateway**: Entity notification configurations. You can have up to three regional notification configurations per entity.
 * **Billing**: Org billing notifications. These notifications are sent to organization admins, and they are mandatory - you can't opt out of billing notifications.
 
 

--- a/app/konnect-platform/notification-hub.md
+++ b/app/konnect-platform/notification-hub.md
@@ -27,9 +27,10 @@ Notification delivery is scoped to users with [access to the relevant entity](/k
 You can manage your notification configurations through the [bell icon next to your user menu](https://cloud.konghq.com/global/notifications/) in the {{site.konnect_short_name}} UI, or the [Notification Hub API](/api/konnect/notification-hub/). 
 
 The Notification Hub generates notifications for the following areas:
-* **Organization**: Configurable notifications about org access and audit logs.
+
+* **Dev Portal**: Developer and application registrations requests.
 * **API Gateway**: Entity notification configurations. You can have up to three regional notification configurations per entity.
-* **Billing**: Org billing notifications. These notifications are sent to organization admins, and they are mandatory - you can't opt out of billing notifications.
+* **Organization**: Configurable notifications about org access and audit logs.
 
 
 

--- a/app/konnect-platform/notification-hub.md
+++ b/app/konnect-platform/notification-hub.md
@@ -31,6 +31,7 @@ The Notification Hub generates notifications for the following areas:
 * **Dev Portal**: Developer and application registrations requests.
 * **API Gateway**: Entity notification configurations. You can have up to three regional notification configurations per entity.
 * **Organization**: Configurable notifications about org access and audit logs.
+* **Billing**: Org billing notifications. These notifications are sent to organization admins, and they are mandatory - you can't opt out of billing notifications.
 
 
 

--- a/app/konnect-platform/notification-hub.md
+++ b/app/konnect-platform/notification-hub.md
@@ -28,7 +28,7 @@ You can manage your notification configurations through the [bell icon next to y
 
 The Notification Hub generates notifications for the following areas:
 
-* **Dev Portal**: Developer and application registrations requests.
+* **Dev Portal**: Developer and application registration requests.
 * **API Gateway**: Entity notification configurations. You can have up to three regional notification configurations per entity.
 * **Organization**: Configurable notifications about org access and audit logs.
 * **Billing**: Org billing notifications. These notifications are sent to organization admins, and they are mandatory - you can't opt out of billing notifications.


### PR DESCRIPTION
## Description

Fixes #2865 

This PR is part of a series.
https://github.com/Kong/developer.konghq.com/pull/2974
https://github.com/Kong/developer.konghq.com/pull/2975
https://github.com/Kong/developer.konghq.com/pull/2976
https://github.com/Kong/developer.konghq.com/pull/2977
https://github.com/Kong/developer.konghq.com/pull/2978

In this change, we have:
* Notification hub setting rename
* Add missing dev portal section

Note that this PR is separate from other rename changes, as Notification Hub work is dependent on a different team and is likely to have a different timeline.

## Preview

https://deploy-preview-2978--kongdeveloper.netlify.app/konnect-platform/notification-hub/