### PR TITLE
Fix (Gateway): Friction Log Get Started

### DIFF
--- a/app/_data/glossary.yml
+++ b/app/_data/glossary.yml
@@ -8,11 +8,6 @@ definitions:
     description: A functionality of a feature or release version is of high quality and can be used in a **non-production** environment.
     url: |
       [Stages of software availability](/stages-of-software-availability/#beta)
-  - term: Caching
-    description: |
-      A method of temporarily storing upstream responses so that the gateway can reuse them for identical requests. In Kong Gateway, caching reduces latency, lowers backend load, and increases throughput.
-    url: |
-      [Proxy Cache](/_kong_plugins/proxy-cache/index/)   
   - term: Consumer
     description: |
       A Consumer object represents the client of a Service. 

--- a/app/_data/glossary.yml
+++ b/app/_data/glossary.yml
@@ -8,6 +8,11 @@ definitions:
     description: A functionality of a feature or release version is of high quality and can be used in a **non-production** environment.
     url: |
       [Stages of software availability](/stages-of-software-availability/#beta)
+  - term: Caching
+    description: |
+      A method of temporarily storing upstream responses so that the gateway can reuse them for identical requests. In Kong Gateway, caching reduces latency, lowers backend load, and increases throughput.
+    url: |
+      [Proxy Cache](/_kong_plugins/proxy-cache/index/)   
   - term: Consumer
     description: |
       A Consumer object represents the client of a Service. 

--- a/app/_how-tos/get-started-with-gateway.md
+++ b/app/_how-tos/get-started-with-gateway.md
@@ -271,7 +271,7 @@ curl -s $KONNECT_PROXY_URL/mock/headers \
 
 ## Enable caching
 
-[Caching](/glossary/) is used to store and reuse upstream responses for faster replies and less backend load. The [Proxy Cache plugin](/plugins/proxy-cache/) accelerates performance by caching responses based on configurable response codes, content types, and request methods.
+Caching is used to store and reuse upstream responses for faster replies and less backend load. The [Proxy Cache plugin](/plugins/proxy-cache/) accelerates performance by caching responses based on configurable response codes, content types, and request methods.
 When caching is enabled, upstream services are not bogged down with repetitive requests,
 because {{site.base_gateway}} responds on their behalf with cached results.
 

--- a/app/_how-tos/get-started-with-gateway.md
+++ b/app/_how-tos/get-started-with-gateway.md
@@ -150,6 +150,7 @@ The [Key Authentication plugin](/plugins/key-auth/) lets you secure requests to 
 When activated, {{site.base_gateway}} generates and associates an API key with a [Consumer](/gateway/entities/consumer/). The client then presents this key as a secret in subsequent requests. Each request is approved or denied based on the validity of the key. The configuration uses the following logic:
 - The `key_names` field defines the request field the plugin checks for a key.
 - The plugin searches for this field in headers, query string parameters, and the request body.
+
 After setup, only requests that include a valid API key are accepted. To activate the Key Authentication plugin, copy and run the following command:
 
 {% entity_examples %}
@@ -270,7 +271,7 @@ curl -s $KONNECT_PROXY_URL/mock/headers \
 
 ## Enable caching
 
-Caching is used to store and reuse upstream responses for faster replies and less backend load. The [Proxy Cache plugin](/plugins/proxy-cache/) accelerates performance by caching responses based on configurable response codes, content types, and request methods.
+[Caching](/glossary/) is used to store and reuse upstream responses for faster replies and less backend load. The [Proxy Cache plugin](/plugins/proxy-cache/) accelerates performance by caching responses based on configurable response codes, content types, and request methods.
 When caching is enabled, upstream services are not bogged down with repetitive requests,
 because {{site.base_gateway}} responds on their behalf with cached results.
 

--- a/app/_how-tos/get-started-with-gateway.md
+++ b/app/_how-tos/get-started-with-gateway.md
@@ -145,10 +145,12 @@ As its name implies, API gateway authentication authenticates the flow of data t
 
 ### Enable Key Auth plugin
 
-For this example, we'll use the [Key Authentication plugin](/plugins/key-auth/). In key authentication, 
-{{site.base_gateway}} generates and associates an API key with a [Consumer](/gateway/entities/consumer/). 
-That key is the authentication secret presented by the client when making subsequent requests. 
-{{site.base_gateway}} approves or denies requests based on the validity of the presented key.
+The [Key Authentication plugin](/plugins/key-auth/) lets you secure requests to your services with API keys. Use this plugin when you want to verify that every request comes from a known client.
+
+When activated, {{site.base_gateway}} generates and associates an API key with a [Consumer](/gateway/entities/consumer/). The client then presents this key as a secret in subsequent requests. Each request is approved or denied based on the validity of the key. The configuration uses the following logic:
+- The `key_names` field defines the request field the plugin checks for a key.
+- The plugin searches for this field in headers, query string parameters, and the request body.
+After setup, only requests that include a valid API key are accepted. To activate the Key Authentication plugin, copy and run the following command:
 
 {% entity_examples %}
 entities:
@@ -158,10 +160,6 @@ entities:
         key_names:
           - apikey
 {% endentity_examples %}
-
-The `key_names` configuration field defines the name of the field that the
-plugin looks for to read the key when authenticating requests. 
-The plugin looks for the field in headers, query string parameters, and the request body.
 
 ### Create a Consumer
 
@@ -206,6 +204,7 @@ Now, let's send a request with the valid key in the `apikey` header:
 
 {% validation request-check %}
 url: /mock/anything
+display_headers: true
 headers:
   - 'apikey:top-secret-key'
 status_code: 200
@@ -271,9 +270,7 @@ curl -s $KONNECT_PROXY_URL/mock/headers \
 
 ## Enable caching
 
-One of the ways Kong delivers performance is through caching.
-The [Proxy Cache plugin](/plugins/proxy-cache/) accelerates performance by caching
-responses based on configurable response codes, content types, and request methods.
+Caching is used to store and reuse upstream responses for faster replies and less backend load. The [Proxy Cache plugin](/plugins/proxy-cache/) accelerates performance by caching responses based on configurable response codes, content types, and request methods.
 When caching is enabled, upstream services are not bogged down with repetitive requests,
 because {{site.base_gateway}} responds on their behalf with cached results.
 


### PR DESCRIPTION
## Description

From

> 
> Definition of done
> The [Validate the Gateway Service and Route by proxying a reques](https://developer.konghq.com/gateway/get-started/#validate-the-gateway-service-and-route-by-proxying-a-request) section says that the curl command will return a 200 and it currently doesn't. It just returns a valid response. This is a change to the codeblog config not the text. To do this, add the flag display_headers: true to the existing block:
> {% validation request-check %}
> url: /mock/anything
> headers:
>   - 'apikey:top-secret-key'
> status_code: 200
> {% endvalidation %}
> Restructure the [Enable Authentication](https://developer.konghq.com/gateway/get-started/#enable-authentication) section per the Friction log
> Make the Caching section start with "Caching" and a link to the proxy cache plugin
> Information
> This is from the friction log
> https://docs.google.com/document/d/1cnEA9Q5H_8JVouHHH_hdh1zebhik70XUQNs3lP5KxfM/edit?tab=t.0
> 
> Size
> S (Small). Example: fixing a broken link, updating wording in an FAQ or paragraph

Fixes #2862 

## Preview Links
https://deploy-preview-2984--kongdeveloper.netlify.app/gateway/get-started/#enable-authentication


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
