### PR TITLE
fix: only render the supported prereqs based on `works-on`

### DIFF
--- a/app/_includes/components/prereqs.html
+++ b/app/_includes/components/prereqs.html
@@ -72,10 +72,12 @@
           {% include prereqs/products/konnect.md tier=include.tier env_variables=variables ports=ports %}
         </div>
         {% endif %}
+        {% if page.works_on contains 'on-prem' %}
         <div class="flex flex-col gap-1.5 border-b border-primary/5 accordion-item last:border-b-0" data-deployment-topology="on-prem">
           {% assign variables=prereqs['gateway'] %}
           {% include prereqs/products/gateway.md rbac=page.rbac env_variables=variables %}
         </div>
+        {% endif %}
       {% endif %}
 
       {% if page.products contains 'kic'  %}
@@ -87,12 +89,16 @@
       {% for product in prereqs.products %}
         {% assign product_include = 'prereqs/products/' | append: product | append: '.md' %}
         {% if page.works_on %}
+         {% if page.works_on contains 'konnect' %}
           <div class="flex flex-col gap-1.5 border-b border-primary/5 accordion-item last:border-b-0" data-deployment-topology="konnect" data-test-setup="konnect">
             {% include {{ product_include }} prereqs=prereqs topology="konnect" %}
           </div>
-          <div class="flex flex-col gap-1.5 border-b border-primary/5 accordion-item last:border-b-0" data-deployment-topology="on-prem" data-test-setup='{ "gateway": "{{page.min_version.gateway}}" }'>
-            {% include {{ product_include }} prereqs=prereqs topology="on-prem" %}
-          </div>
+          {% endif %}
+           {% if page.works_on contains 'on-prem' %}
+            <div class="flex flex-col gap-1.5 border-b border-primary/5 accordion-item last:border-b-0" data-deployment-topology="on-prem" data-test-setup='{ "gateway": "{{page.min_version.gateway}}" }'>
+              {% include {{ product_include }} prereqs=prereqs topology="on-prem" %}
+            </div>
+          {% endif %}
         {% else %}
           <div class="flex flex-col gap-1.5 border-b border-primary/5 accordion-item last:border-b-0">
             {% include {{ product_include }} prereqs=prereqs %}


### PR DESCRIPTION
## Description

This used to work in the past even when both cases were wrongly rendered because the deployment topology toggle used to be a dropdown so there was always an option selected.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
