### PR TITLE
fix(gateway): Add FAQ about installing via Helm without cluster permissions

### DIFF
--- a/app/_how-tos/gateway-install-helm-konnect.md
+++ b/app/_how-tos/gateway-install-helm-konnect.md
@@ -20,7 +20,18 @@ tldr:
   q: How do I install {{ site.base_gateway }} in Konnect with Helm?
   a: |
     Create a Control Plane in {{ site.konnect_short_name }}, populate a `values.yaml` file with the Control Plane details, and run `helm install kong kong/kong --values ./values.yaml -n kong --create-namespace`.
+faqs:
+  - q: Can I install {{ site.base_gateway }} via Helm without cluster permissions?
+    a: |
+      Yes. Using the `kong` chart, set `ingressController.rbac.enableClusterRoles` to false. 
 
+      {:.danger}
+      > **Warning:** Some resources require a ClusterRole for reconciliation because the controllers need to watch cluster scoped resources. Disabling ClusterRoles causes them fail, so you need to disable the controllers when setting it to `false`. These resources include:
+      > - All Gateway API resources
+      > - `IngressClass`
+      > - `KNative/Ingress` (KIC 2.x only)
+      > - `KongClusterPlugin`
+      > - `KongVault`, `KongLicense` (KIC 3.1 and above)
 prereqs:
   skip_product: true
 

--- a/app/_how-tos/gateway-install-helm-onprem.md
+++ b/app/_how-tos/gateway-install-helm-onprem.md
@@ -21,7 +21,18 @@ works_on:
 entities: []
 
 tldr: null
+faqs:
+  - q: Can I install {{ site.base_gateway }} via Helm without cluster permissions?
+    a: |
+      Yes. Using the `kong` chart, set `ingressController.rbac.enableClusterRoles` to false. 
 
+      {:.danger}
+      > **Warning:** Some resources require a ClusterRole for reconciliation because the controllers need to watch cluster scoped resources. Disabling ClusterRoles causes them fail, so you need to disable the controllers when setting it to `false`. These resources include:
+      > - All Gateway API resources
+      > - `IngressClass`
+      > - `KNative/Ingress` (KIC 2.x only)
+      > - `KongClusterPlugin`
+      > - `KongVault`, `KongLicense` (KIC 3.1 and above)
 prereqs:
   skip_product: true
 


### PR DESCRIPTION
## Description

Fixes #2672 

## Preview Links
Got the limitations from here: https://github.com/Kong/charts/blob/ea5eef28c5a601547061f048969fcb497ea17784/charts/kong/values.yaml#L657-L666

- /gateway/install/kubernetes/on-prem/#faqs
- /gateway/install/kubernetes/konnect/#faqs

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
