### PR TITLE
fix(gateway): change command name in ping.md to `deck gateway ping`

### DIFF
--- a/app/deck/gateway/ping.md
+++ b/app/deck/gateway/ping.md
@@ -21,9 +21,9 @@ related_resources:
     url: /deck/gateway/
 ---
 
-The `deck file ping` command checks that decK can contact the Admin API. This could be either the {{site.konnect_short_name}} API, or an on-prem installation.
+The `deck gateway ping` command checks that decK can contact the Admin API. This could be either the {{site.konnect_short_name}} API, or an on-prem installation.
 
-`deck file ping` validates both network connectivity and authentication details.
+`deck gateway ping` validates both network connectivity and authentication details.
 
 ## On-prem example
 


### PR DESCRIPTION
## Description

The incorrectly documented command `deck file ping` has been corrected to the proper `deck gateway ping`.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
