### PR TITLE
fix: change `MacOS` to `macOS` to standardize notation

### DIFF
--- a/.github/styles/base/Terms.yml
+++ b/.github/styles/base/Terms.yml
@@ -19,4 +19,5 @@ swap:
   utilize: use
   whitelist: allowlist
   'a HTTP': 'an HTTP'
+  MacOS : macOS
   

--- a/app/_how-tos/create-an-insomnia-plugin.md
+++ b/app/_how-tos/create-an-insomnia-plugin.md
@@ -18,7 +18,7 @@ tldr:
 ## Create the plugin directory
 
 In order for Insomnia to recognize your plugin as an Insomnia plugin, create a folder in the Insomnia plugins directory:
-* `~/Library/Application Support/Insomnia/plugins/` on MacOS
+* `~/Library/Application Support/Insomnia/plugins/` on macOS
 * `%APPDATA%\Insomnia\plugins\` on Windows
 * `$XDG_CONFIG_HOME/Insomnia/plugins/` or `~/.config/Insomnia/plugins/` on Linux
 

--- a/app/_how-tos/konnect-reference-platform.md
+++ b/app/_how-tos/konnect-reference-platform.md
@@ -44,7 +44,7 @@ prereqs:
         The [{{site.konnect_short_name}} Orchestrator](/konnect-reference-platform/orchestrator) (or `koctl`) is the 
         command line tool included in the {{site.konnect_short_name}} Reference Platform.
         
-        * On MacOS, install `koctl` using Homebrew
+        * On macOS, install `koctl` using Homebrew
 
           ```shell
           brew install kong/konnect-orchestrator/koctl

--- a/app/_includes/tools/deck/install/osx.md
+++ b/app/_includes/tools/deck/install/osx.md
@@ -1,4 +1,4 @@
-Kong provides a [Homebrew](https://brew.sh) tap for decK. To install decK on MacOS, run:
+Kong provides a [Homebrew](https://brew.sh) tap for decK. To install decK on macOS, run:
 
 ```bash
 brew install kong/deck/deck

--- a/app/_includes/tools/inso-cli/install/osx.md
+++ b/app/_includes/tools/inso-cli/install/osx.md
@@ -6,4 +6,4 @@
     ```bash
     inso --version
     ```
-You can also install it by downloading and extracting the [zip](https://updates.insomnia.rest/downloads/mac/latest?app=com.insomnia.inso&channel=stable) file for MacOS.
+You can also install it by downloading and extracting the [zip](https://updates.insomnia.rest/downloads/mac/latest?app=com.insomnia.inso&channel=stable) file for macOS.

--- a/app/_includes/tools/insomnia/install/osx.md
+++ b/app/_includes/tools/insomnia/install/osx.md
@@ -1,4 +1,4 @@
-Go to the [Insomnia downloads page](https://insomnia.rest/download) to download and run the installer for  MacOS, or use [Homebrew](https://brew.sh/):
+Go to the [Insomnia downloads page](https://insomnia.rest/download) to download and run the installer for  macOS, or use [Homebrew](https://brew.sh/):
 ```sh
 brew install --cask insomnia
 ```

--- a/app/_indices/deck.yaml
+++ b/app/_indices/deck.yaml
@@ -12,7 +12,7 @@ sections:
       - title: Install decK on Windows
         description: Install a binary package on Windows
         url: /deck/?tab=windows#install-deck
-      - title: Install decK on MacOS
+      - title: Install decK on macOS
         description: Use Homebrew to install decK
         url: /deck/?tab=macos#install-deck
       - title: Install decK on Linux

--- a/app/_landing_pages/deck.yaml
+++ b/app/_landing_pages/deck.yaml
@@ -51,7 +51,7 @@ rows:
         - type: tabs
           tab_group: install-on-os
           config:
-            - title: MacOS
+            - title: macOS
               include_content: tools/deck/install/osx
             - title: Windows
               include_content: tools/deck/install/windows

--- a/app/_landing_pages/inso-cli.yaml
+++ b/app/_landing_pages/inso-cli.yaml
@@ -28,7 +28,7 @@ rows:
         - type: tabs
           tab_group: install-on-os
           config:
-            - title: MacOS
+            - title: macOS
               include_content: tools/inso-cli/install/osx
             - title: Windows
               include_content: tools/inso-cli/install/windows

--- a/app/_landing_pages/insomnia.yaml
+++ b/app/_landing_pages/insomnia.yaml
@@ -37,7 +37,7 @@ rows:
         - type: tabs
           tab_group: install-on-os
           config:
-            - title: MacOS
+            - title: macOS
               include_content: tools/insomnia/install/osx
             - title: Windows
               include_content: tools/insomnia/install/windows

--- a/app/konnect-reference-platform/orchestrator.md
+++ b/app/konnect-reference-platform/orchestrator.md
@@ -60,7 +60,7 @@ the following functions are provided to support the reference platform features:
 
 ## How do I install `koctl`?
 
-MacOS users can install the orchestrator using Homebrew:
+macOS users can install the orchestrator using Homebrew:
 
 ```shell
 brew install kong/konnect-orchestrator/koctl


### PR DESCRIPTION
## Description

To standardize the notation, I changed `MacOS` to `macOS`.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
