### PR TITLE
3 12 rc6 perf results

### DIFF
--- a/app/gateway/performance/benchmarks.md
+++ b/app/gateway/performance/benchmarks.md
@@ -86,44 +86,44 @@ columns:
 rows:
   - test: Kong proxy with no plugins
     entities: 1 Route, 0 Consumers
-    rps: 128241.75
-    p99: 6.19
+    rps: 129920.5
+    p99: 6.35
     p95: 3.55
   - test: Kong proxy with no plugins
     entities: 100 Routes, 0 Consumers
-    rps: 125337.15
-    p99: 6.85
-    p95: 3.73
+    rps: 124692.9
+    p99: 6.49
+    p95: 3.78
   - test: Rate limit and no auth
     entities: 1 Route, 0 Consumers
-    rps: 109471.47
-    p99: 8.22
-    p95: 4.12
+    rps: 111872.7
+    p99: 8.09
+    p95: 4.03
   - test: Rate limit and no auth
     entities: 100 Routes, 0 Consumers
-    rps: 106861.64
-    p99: 8.23
-    p95: 4.13
+    rps: 106551.5
+    p99: 8.29
+    p95: 4.17
   - test: Rate limit and key auth
     entities: 1 Route, 1 Consumer
-    rps: 92017.84
-    p99: 9.85
-    p95: 5.26
+    rps: 96570.3
+    p99: 9.71
+    p95: 4.80
   - test: Rate limit and key auth
     entities: 100 Routes, 100 Consumers
-    rps: 88461.17
-    p99: 9.99
-    p95: 5.50
+    rps: 90593.5
+    p99: 9.80
+    p95: 5.08
   - test: Rate limit and basic auth
     entities: 1 Route, 1 Consumer
-    rps: 88795.48
-    p99: 9.79
-    p95: 5.41
+    rps: 91341.7
+    p99: 9.86
+    p95: 5.40
   - test: Rate limit and basic auth
     entities: 100 Routes, 100 Consumers
-    rps: 84938.83
-    p99: 10.48
-    p95: 5.87
+    rps: 86474.5
+    p99: 10.09
+    p95: 5.46
 {% endtable %}
 
 {% endnavtab %}


### PR DESCRIPTION
## Description

Update public benchmar perf tests for `3.12.0.0-rc.6`

The raw results could be found [here](https://docs.google.com/spreadsheets/d/1knu87tczpuTQ4a5si3WSkOoFHWf0pS8vqNpC44-Oxmw/edit?gid=565649791#gid=565649791)

Preview: https://deploy-preview-2964--kongdeveloper.netlify.app/gateway/performance/benchmarks/