### PR TITLE
Fix(gateway): Datakit docs adjustments

### DIFF
--- a/app/_kong_plugins/datakit/examples/authenticate-with-vault-secret.yaml
+++ b/app/_kong_plugins/datakit/examples/authenticate-with-vault-secret.yaml
@@ -21,7 +21,7 @@ requirements:
 config:
   resources:
     vault:
-      token: {vault://my-vault/my-token}
+      token: "{vault://my-vault/my-token}"
 
   nodes:
   - name: STATIC_INPUTS

--- a/app/_kong_plugins/datakit/index.md
+++ b/app/_kong_plugins/datakit/index.md
@@ -520,7 +520,7 @@ columns:
 rows:
   - nodetype: "`branch`"
     inputs: "user-defined"
-    outputs: "`then`, `else`"
+    outputs: none
     attributes: "`then`, `else`"
   - nodetype: "`cache`"
     inputs: "`key`, `ttl`, `data`"
@@ -651,13 +651,15 @@ nodes:
 
 Execute different nodes based on matching input conditions, such as a cache hit or miss.
 
-Input:
-* `name`: The name of a node, or a reference to a node field. For example, `NODE_NAME` or `NODE_NAME.FIELD`.
+#### Input
 
-Output:
-* `name`: The name of a node, or a reference to a node field. For example, `NODE_NAME` or `NODE_NAME.FIELD`.
+The input to a branch node represents a boolean condition to test and branch on:
+* If the input is `true`, the nodes named by the `then` array are executed.
+* If the input is `false`, the nodes named by the `else` array are executed.
+* If the input is a non-boolean value, an error is raised.
 
-Configuration attributes:
+#### Configuration attributes
+
 * `then`: Array of nodes to execute if the input condition is `true`.
 * `else`: Array of nodes to execute if the input condition is `false`.
 


### PR DESCRIPTION
## Description

* Vault node: Curly braces don't get rendered unless we have `""` around them, so example was incorrect.
* Branch node: adding more info about inputs; removing `then/else` from outputs, as we don't want to mention these in docs. See https://kongstrong.slack.com/archives/C08QKTB0LFK/p1758875160835109?thread_ts=1758757233.438679&cid=C08QKTB0LFK for context.

## Preview Links
https://deploy-preview-3055--kongdeveloper.netlify.app/plugins/datakit/#branch-node
https://deploy-preview-3055--kongdeveloper.netlify.app/plugins/datakit/examples/authenticate-with-vault-secret/

