### PR TITLE
Fix(Prometheus): Update kong_control_plane_connected metric value

### DIFF
--- a/app/_kong_plugins/prometheus/index.md
+++ b/app/_kong_plugins/prometheus/index.md
@@ -175,7 +175,7 @@ Access-Control-Allow-Origin: *
 
 # HELP kong_control_plane_connected Kong connected to control plane, 0 is unconnected
 # TYPE kong_control_plane_connected gauge
-kong_control_plane_connected{instance="localhost:8100", job="kong"}	
+kong_control_plane_connected{instance="localhost:8100", job="kong"}	1
 # HELP kong_data_plane_cluster_cert_expiry_timestamp Unix timestamp of Data Plane's cluster_cert expiry time
 # TYPE kong_data_plane_cluster_cert_expiry_timestamp gauge
 kong_data_plane_cluster_cert_expiry_timestamp 2068058801


### PR DESCRIPTION
Missing value in the example. any Prometheus metric must have a value. `kong_control_plane_connected` can only be `0` or `1`. I suggest `1` since it means the dp is connected to the dp.

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
