### PR TITLE
fix(ai-gateway): add missing variables to GCP Model Armor example

### DIFF
--- a/app/_kong_plugins/ai-gcp-model-armor/examples/configure-gcp-model-armor.yaml
+++ b/app/_kong_plugins/ai-gcp-model-armor/examples/configure-gcp-model-armor.yaml
@@ -7,11 +7,20 @@ variables:
   gcp_service_account_json:
     description: GCP service account credentials in JSON format
     value: $GCP_SERVICE_ACCOUNT_JSON
+  project_id:
+    description: GCP project identifier
+    value: $GCP_PROJECT_ID
+  location_id:
+    description: GCP location identifier
+    value: $GCP_LOCATION_ID
+  template_id:
+    description: Guardrail template identifier
+    value: $GCP_TEMPLATE_ID
 
 config:
-  project_id: "your-gcp-project-id"
-  location_id: "us-central1"
-  template_id: "my-guardrail-template"
+  project_id: ${project_id}
+  location_id: ${location_id}
+  template_id: ${template_id}
   guarding_mode: "BOTH"
   gcp_use_service_account: true
   gcp_service_account_json: ${gcp_service_account_json}
@@ -21,6 +30,7 @@ config:
   timeout: 15000
   response_buffer_size: 4096
   text_source: "last_message"
+
 
 tools:
   - deck


### PR DESCRIPTION
## Description

Adds missing variables to the GCP Model Armor sample.

## Preview Links

https://deploy-preview-3070--kongdeveloper.netlify.app/plugins/ai-gcp-model-armor/examples/configure-gcp-model-armor/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
