### PR TITLE
fix(missing-redirects): api specs checks and take into account splats

### DIFF
--- a/tools/missing-redirects/index.js
+++ b/tools/missing-redirects/index.js
@@ -95,6 +95,10 @@ function fileToUrl(file) {
     return file
       .replace("app/_event_gateway_policies/", "/event-gateway/policies/")
       .replace(ext, "/");
+  } else if (file.startsWith("app/_api")) {
+    return file
+      .replace("app/_api/", "/api/")
+      .replace(`_index${ext}`, "");
   }
 
   const pathWithoutExtension = file.replace(ext, "/").replace("app", "");
@@ -134,7 +138,7 @@ function ignoreFile(file) {
       }
 
       const oldUrl = fileToUrl(filePath);
-      if (oldUrl && !redirects.some((r) => r.startsWith(oldUrl + " "))) {
+      if (oldUrl && !redirects.some((r) => new RegExp("^" + oldUrl + "(?:\\*|:splat)?\\s").test(r))) {
         missingRedirects.push({ path: filePath, url: oldUrl, status });
       }
     }


### PR DESCRIPTION
and * when checking for urls

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
