### PR TITLE
fix(missing-redirects): treat every source url as a regexp and check

### DIFF
--- a/tools/missing-redirects/index.js
+++ b/tools/missing-redirects/index.js
@@ -18,6 +18,8 @@ const lines = diffOutput.trim().split("\n").filter(Boolean);
 const redirects = fs
   .readFileSync("../../app/_redirects", "utf8")
   .split("\n")
+  .filter((line) => line && !line.startsWith("#"))
+  .map((line) => line.split(/\s+/)[0])
   .filter(Boolean);
 
 const collectionPermalinks = (function () {
@@ -96,9 +98,7 @@ function fileToUrl(file) {
       .replace("app/_event_gateway_policies/", "/event-gateway/policies/")
       .replace(ext, "/");
   } else if (file.startsWith("app/_api")) {
-    return file
-      .replace("app/_api/", "/api/")
-      .replace(`_index${ext}`, "");
+    return file.replace("app/_api/", "/api/").replace(`_index${ext}`, "");
   }
 
   const pathWithoutExtension = file.replace(ext, "/").replace("app", "");
@@ -125,6 +125,14 @@ function ignoreFile(file) {
   ].some((folder) => file.startsWith(folder));
 }
 
+function patternToRegex(pattern) {
+  let regex = pattern
+    .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*")
+    .replace(/:([A-Za-z0-9_]+)/g, "[^/]+");
+  return new RegExp(`^${regex}$`);
+}
+
 (async function () {
   let missingRedirects = [];
 
@@ -138,7 +146,7 @@ function ignoreFile(file) {
       }
 
       const oldUrl = fileToUrl(filePath);
-      if (oldUrl && !redirects.some((r) => new RegExp("^" + oldUrl + "(?:\\*|:splat)?\\s").test(r))) {
+      if (oldUrl && !redirects.some((r) => patternToRegex(r).test(oldUrl))) {
         missingRedirects.push({ path: filePath, url: oldUrl, status });
       }
     }


### PR DESCRIPTION
against them

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
