### PR TITLE
Add API Errors page

### DIFF
--- a/app/_includes/components/table.html
+++ b/app/_includes/components/table.html
@@ -11,7 +11,7 @@
     </thead>
     <tbody>
         {% for row in include.rows %}
-        <tr>
+        <tr{% if row.id %} id="{{ row.id }}"{% endif %}>
             {% for column in include.columns %}
                 {% assign v = row[column.key] %}
                 <td{% if v == true or v == false %}{% endif %} style="vertical-align: top">

--- a/app/_plugins/blocks/table.rb
+++ b/app/_plugins/blocks/table.rb
@@ -13,6 +13,15 @@ module Jekyll
 
       config = YAML.load(contents)
 
+      # Convert code errors to use 'id'
+      config['rows'] = config['rows'].map do |row|
+        if row['code']
+          row['id'] = row['code'] unless row['id']
+          row['code'] = "`#{row['code']}`"
+        end
+        row
+      end
+
       context.stack do
         context['include'] =
           { 'columns' => config['columns'], 'rows' => config['rows'] }

--- a/app/_plugins/generators/data/title/api_page.rb
+++ b/app/_plugins/generators/data/title/api_page.rb
@@ -24,6 +24,8 @@ module Jekyll
         end
 
         def title
+          return page_title if @page.url == '/api/errors/'
+
           case @page.data['content_type']
           when 'api'
             page_title

--- a/app/api/errors.md
+++ b/app/api/errors.md
@@ -1,0 +1,54 @@
+---
+title: "Konnect API Errors"
+content_type: reference
+layout: reference
+
+products:
+  - konnect
+
+tags:
+  - api
+
+breadcrumbs:
+  - /api/
+description: "Documentation on common API errors when working with Kong products"
+
+related_resources:
+  - text: API specifications
+    url: /api/
+
+works_on:
+  - on-prem
+  - konnect
+---
+
+<!--vale off-->
+{% table %}
+columns:
+  - title: Error Code
+    key: code
+  - title: Description
+    key: description
+  - title: Resolution
+    key: resolution
+rows:
+  - code: bad-request
+    description: Your API request did not match the expected schema
+    resolution: "Check the [request schema](/api/) for the API that you're calling"
+  - code: unauthorized
+    description: "The `Authorization` header is missing from your request, or an invalcode token has been provided"
+    resolution: "Ensure that your have specified a `Authorization: Bearer TOKEN_HERE` header in your request"
+  - code: forbidden
+    description: "You do not have permission to call the specified API"
+    resolution: "Reach out to your organization administrator to request elevated permissions"
+  - code: not-found
+    description: The endpoint that you have requested does not exist, or belongs to a different organization
+    resolution: "Check your request URL and try again"
+  - code: conflict
+    description: The resource could not be created due to an existing resource on the remote server
+    resolution: "Change your API request to contain unique details"
+  - code: internal
+    description: There has been a server error. This requires intervention from the Kong team to fix.
+    resolution: "Check the [Kong Status Page](https://kong.statuspage.io/) for any updates"
+{% endtable %}
+<!--vale on-->


### PR DESCRIPTION
## Description

Adds a page for kongapi.info to redirect to

## Preview Links

/api/errors/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
