### PR TITLE
fix(plugins): Add missing kafka & confluent plugin changelog entries

### DIFF
--- a/app/_data/changelogs/gateway.json
+++ b/app/_data/changelogs/gateway.json
@@ -17367,7 +17367,11 @@
       {
         "message": "**kafka-consume, confluent-consume**: Added `enforce_latest_offset_reset` flag to fix incorrect `latest` offset behavior. When `false` (default), maintains backwards compatibility where `latest` acts like `earliest`. When `true`, `latest` correctly starts from end of topic. Also fixed offset commit bug when no records are consumed, preventing feedback loop with true latest behavior.\n",
         "type": "bugfix",
-        "scope": "Plugin"
+        "scope": "Plugin",
+        "plugins": [
+          "kafka-consume",
+          "confluent-consume"
+        ]
       },
       {
         "message": "**ldap-auth-advanced**: Fixed group validation issue where LDAP group names containing asterisk (*) characters were incorrectly marked as invalid during Kong Manager RBAC authentication. Group names with asterisk characters (such as \"*Dev - EXAMPLE - TOP\") now properly validate and allow role mapping.\n",

--- a/app/_kong_plugins/confluent-consume/changelog.json
+++ b/app/_kong_plugins/confluent-consume/changelog.json
@@ -15,6 +15,11 @@
   ],
   "3.10.0.6": [
     {
+      "message": "Added `enforce_latest_offset_reset` flag to fix incorrect `latest` offset behavior. When `false` (default), maintains backwards compatibility where `latest` acts like `earliest`. When `true`, `latest` correctly starts from end of topic. Also fixed offset commit bug when no records are consumed, preventing feedback loop with true latest behavior.\n",
+      "type": "bugfix",
+      "scope": "Plugin"
+    },
+    {
       "message": "Fixed an issue where the plugin would fail to connect using mTLS.\n",
       "type": "bugfix",
       "scope": "Plugin"

--- a/app/_kong_plugins/kafka-consume/changelog.json
+++ b/app/_kong_plugins/kafka-consume/changelog.json
@@ -32,6 +32,11 @@
   ],
   "3.10.0.6": [
     {
+      "message": "Added `enforce_latest_offset_reset` flag to fix incorrect `latest` offset behavior. When `false` (default), maintains backwards compatibility where `latest` acts like `earliest`. When `true`, `latest` correctly starts from end of topic. Also fixed offset commit bug when no records are consumed, preventing feedback loop with true latest behavior.\n",
+      "type": "bugfix",
+      "scope": "Plugin"
+    },
+    {
       "message": "Fixed an issue where the plugin would fail to connect using mTLS.\n",
       "type": "bugfix",
       "scope": "Plugin"


### PR DESCRIPTION
## Description

Fixes https://konghq.atlassian.net/browse/DOCU-4217.

Symptom of inconsistently written changelogs.

## Preview Links
https://deploy-preview-3166--kongdeveloper.netlify.app/plugins/kafka-consume/changelog/
https://deploy-preview-3166--kongdeveloper.netlify.app/plugins/confluent-consume/changelog/
