### PR TITLE
Fix: Debugger permissions

### DIFF
--- a/app/gateway/debugger.md
+++ b/app/gateway/debugger.md
@@ -17,7 +17,7 @@ faqs:
   - q: Will the {{site.konnect_short_name}} Debugger impact latency?
     a: Under normal conditions, the Debugger adds negligible latency. However, under heavy load, the Debugger may impact the throughput of data planes being traced.
   - q: How is data localization enforced in Debugger?
-    a: The entire infrastructure is regionally deployed. All logs, traces, and payload captures are stored within the local geographic region. To see a list of supported geos, visit: [Supported Geos](/konnect-platform/geos/#supported-geos)
+    a: "The entire infrastructure is regionally deployed. All logs, traces, and payload captures are stored within the local geographic region. To see a list of supported geos, visit: [Supported Geos](/konnect-platform/geos/#supported-geos)"
     
 tags:
   - tracing


### PR DESCRIPTION
Added the following changes: 
Permission needed for running debugger to be added Mention about data localization in debugger.
Attached reference docs for sampling rules configuration

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
