### PR TITLE
chore(notificationhub): add public spec manually

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ node_modules
 
 tools/changelog-generator/tmp/*
 tools/automated-tests/.automated-tests
+
+.idea/*

--- a/api-specs/konnect/notification-hub/v1/openapi.yaml
+++ b/api-specs/konnect/notification-hub/v1/openapi.yaml
@@ -1,4 +1,3 @@
----
 openapi: 3.0.2
 info:
   title: Konnect Notification Hub
@@ -6,239 +5,255 @@ info:
   description: Notification Hub API for Konnect.
   contact:
     name: Kong
-    url: https://konghq.com
+    url: 'https://konghq.com'
 servers:
-- url: https://global.api.konghq.com/v1
-  description: Global Base URL
-security:
-- personalAccessToken: []
-tags:
-- name: Notifications
-  description: Operations related to notifications
+  - url: 'https://global.api.konghq.com/v1'
+    description: Global Base URL
 paths:
-  "/notifications/inbox":
+  /notifications/inbox:
     get:
-      summary: List available notifications.
-      description: List available notifications.
       operationId: list-notifications
+      summary: List available notifications
+      description: List available notifications.
       parameters:
-      - "$ref": "#/components/parameters/PageBefore"
-      - "$ref": "#/components/parameters/PageAfter"
-      - "$ref": "#/components/parameters/NotificationFilter"
+        - $ref: '#/components/parameters/PageBefore'
+        - $ref: '#/components/parameters/PageAfter'
+        - $ref: '#/components/parameters/NotificationFilter'
       responses:
         '200':
-          "$ref": "#/components/responses/NotificationListResponse"
+          $ref: '#/components/responses/NotificationListResponse'
         '400':
-          "$ref": "#/components/responses/BadRequest"
+          $ref: '#/components/responses/BadRequest'
         '401':
-          "$ref": "#/components/responses/Unauthorized"
+          $ref: '#/components/responses/Unauthorized'
         '403':
-          "$ref": "#/components/responses/Forbidden"
-        '404':
-          "$ref": "#/components/responses/NotFound"
+          $ref: '#/components/responses/Forbidden'
       tags:
-      - Notifications
-  "/notifications/inbox/{notificationId}":
+        - Notifications
+  '/notifications/inbox/{notificationId}':
     get:
-      summary: Get notification details.
-      description: Get notification details.
       operationId: get-notification-details
+      summary: Get notification details
+      description: Get notification details.
       parameters:
-      - "$ref": "#/components/parameters/notificationId"
+        - $ref: '#/components/parameters/notificationId'
       responses:
         '200':
-          "$ref": "#/components/responses/NotificationResponse"
+          $ref: '#/components/responses/NotificationResponse'
         '401':
-          "$ref": "#/components/responses/Unauthorized"
+          $ref: '#/components/responses/Unauthorized'
         '403':
-          "$ref": "#/components/responses/Forbidden"
+          $ref: '#/components/responses/Forbidden'
         '404':
-          "$ref": "#/components/responses/NotFound"
+          $ref: '#/components/responses/NotFound'
       tags:
-      - Notifications
+        - Notifications
     patch:
-      summary: Update notification.
-      description: Update notification.
       operationId: update-notification
+      summary: Update notification
+      description: Update notification.
       parameters:
-      - "$ref": "#/components/parameters/notificationId"
+        - $ref: '#/components/parameters/notificationId'
       requestBody:
-        "$ref": "#/components/requestBodies/NotificationUpdateRequest"
+        $ref: '#/components/requestBodies/NotificationUpdateRequest'
       responses:
         '200':
-          "$ref": "#/components/responses/NotificationResponse"
+          $ref: '#/components/responses/NotificationResponse'
         '400':
-          "$ref": "#/components/responses/BadRequest"
+          $ref: '#/components/responses/BadRequest'
         '401':
-          "$ref": "#/components/responses/Unauthorized"
+          $ref: '#/components/responses/Unauthorized'
         '403':
-          "$ref": "#/components/responses/Forbidden"
+          $ref: '#/components/responses/Forbidden'
         '404':
-          "$ref": "#/components/responses/NotFound"
+          $ref: '#/components/responses/NotFound'
       tags:
-      - Notifications
+        - Notifications
     delete:
-      summary: Delete notification.
-      description: Delete notification.
       operationId: delete-notification
+      summary: Delete notification
+      description: Delete notification.
       parameters:
-      - "$ref": "#/components/parameters/notificationId"
+        - $ref: '#/components/parameters/notificationId'
       responses:
         '204':
           description: No Content
         '401':
-          "$ref": "#/components/responses/Unauthorized"
+          $ref: '#/components/responses/Unauthorized'
         '403':
-          "$ref": "#/components/responses/Forbidden"
+          $ref: '#/components/responses/Forbidden'
         '404':
-          "$ref": "#/components/responses/NotFound"
+          $ref: '#/components/responses/NotFound'
       tags:
-      - Notifications
-  "/notifications/inbox/bulk":
+        - Notifications
+  /notifications/inbox/bulk:
     post:
-      summary: Mark a list of notifications to a status.
-      description: Mark a list of notifications to a status.
       operationId: bulk-notifications
+      summary: Mark a list of notifications to a status
+      description: Mark a list of notifications to a status.
       requestBody:
-        "$ref": "#/components/requestBodies/BulkRequest"
+        $ref: '#/components/requestBodies/BulkRequest'
       responses:
         '200':
           description: No Content
         '400':
-          "$ref": "#/components/responses/BadRequest"
+          $ref: '#/components/responses/BadRequest'
         '401':
-          "$ref": "#/components/responses/Unauthorized"
+          $ref: '#/components/responses/Unauthorized'
         '403':
-          "$ref": "#/components/responses/Forbidden"
+          $ref: '#/components/responses/Forbidden'
         '404':
-          "$ref": "#/components/responses/NotFound"
+          $ref: '#/components/responses/NotFound'
       tags:
-      - Notifications
-  "/notifications/configurations":
+        - Notifications
+  /notifications/configurations:
     get:
-      summary: List available user configurations.
-      description: List available user configurations.
       operationId: list-user-configurations
+      summary: List available user configurations
+      description: List available user configurations.
       parameters:
-      - "$ref": "#/components/parameters/ConfigurationFilter"
+        - $ref: '#/components/parameters/ConfigurationFilter'
       responses:
         '200':
-          "$ref": "#/components/responses/UserConfigurationListResponse"
+          $ref: '#/components/responses/UserConfigurationListResponse'
         '400':
-          "$ref": "#/components/responses/BadRequest"
+          $ref: '#/components/responses/BadRequest'
         '401':
-          "$ref": "#/components/responses/Unauthorized"
+          $ref: '#/components/responses/Unauthorized'
         '403':
-          "$ref": "#/components/responses/Forbidden"
-        '404':
-          "$ref": "#/components/responses/NotFound"
+          $ref: '#/components/responses/Forbidden'
       tags:
-      - Notifications
-  "/notifications/configurations/{eventId}/subscriptions":
+        - Notifications
+  '/notifications/configurations/{eventId}/subscriptions':
     get:
-      summary: List event subscriptions.
-      description: List event subscriptions.
       operationId: list-event-subscriptions
+      summary: List event subscriptions
+      description: List event subscriptions.
       parameters:
-      - "$ref": "#/components/parameters/eventId"
+        - $ref: '#/components/parameters/eventId'
       responses:
         '200':
-          "$ref": "#/components/responses/EventSubscriptionListResponse"
+          $ref: '#/components/responses/EventSubscriptionListResponse'
         '400':
-          "$ref": "#/components/responses/BadRequest"
+          $ref: '#/components/responses/BadRequest'
         '401':
-          "$ref": "#/components/responses/Unauthorized"
+          $ref: '#/components/responses/Unauthorized'
         '403':
-          "$ref": "#/components/responses/Forbidden"
-        '404':
-          "$ref": "#/components/responses/NotFound"
+          $ref: '#/components/responses/Forbidden'
       tags:
-      - Notifications
+        - Notifications
     post:
-      summary: Create a new subscription for an event.
-      description: Create a new subscription for an event.
       operationId: create-event-subscription
+      summary: Create a new subscription for an event
+      description: Create a new subscription for an event.
       parameters:
-      - "$ref": "#/components/parameters/eventId"
+        - $ref: '#/components/parameters/eventId'
       requestBody:
-        "$ref": "#/components/requestBodies/EventSubscriptionRequest"
+        $ref: '#/components/requestBodies/EventSubscriptionRequest'
       responses:
         '201':
-          "$ref": "#/components/responses/EventSubscriptionResponse"
+          $ref: '#/components/responses/EventSubscriptionResponse'
         '400':
-          "$ref": "#/components/responses/BadRequest"
+          $ref: '#/components/responses/BadRequest'
         '401':
-          "$ref": "#/components/responses/Unauthorized"
+          $ref: '#/components/responses/Unauthorized'
         '403':
-          "$ref": "#/components/responses/Forbidden"
+          $ref: '#/components/responses/Forbidden'
         '404':
-          "$ref": "#/components/responses/NotFound"
+          $ref: '#/components/responses/NotFound'
       tags:
-      - Notifications
-  "/notifications/configurations/{eventId}/subscriptions/{subscriptionId}":
+        - Notifications
+  '/notifications/configurations/{eventId}/subscriptions/{subscriptionId}':
     parameters:
-    - "$ref": "#/components/parameters/eventId"
-    - "$ref": "#/components/parameters/subscriptionId"
+      - $ref: '#/components/parameters/eventId'
+      - $ref: '#/components/parameters/subscriptionId'
     get:
-      summary: Get subscription for an event.
-      description: Get subscription for an event.
       operationId: get-event-subscription
+      summary: Get subscription for an event
+      description: Get subscription for an event.
       responses:
         '200':
-          "$ref": "#/components/responses/EventSubscriptionResponse"
+          $ref: '#/components/responses/EventSubscriptionResponse'
         '400':
-          "$ref": "#/components/responses/BadRequest"
+          $ref: '#/components/responses/BadRequest'
         '401':
-          "$ref": "#/components/responses/Unauthorized"
+          $ref: '#/components/responses/Unauthorized'
         '403':
-          "$ref": "#/components/responses/Forbidden"
+          $ref: '#/components/responses/Forbidden'
         '404':
-          "$ref": "#/components/responses/NotFound"
+          $ref: '#/components/responses/NotFound'
       tags:
-      - Notifications
+        - Notifications
     patch:
-      summary: Update subscription for an event.
-      description: Update subscription for an event.
       operationId: update-event-subscription
+      summary: Update subscription for an event
+      description: Update subscription for an event.
       requestBody:
-        "$ref": "#/components/requestBodies/EventSubscriptionRequest"
+        $ref: '#/components/requestBodies/EventSubscriptionRequest'
       responses:
         '200':
-          "$ref": "#/components/responses/EventSubscriptionResponse"
+          $ref: '#/components/responses/EventSubscriptionResponse'
         '400':
-          "$ref": "#/components/responses/BadRequest"
+          $ref: '#/components/responses/BadRequest'
         '401':
-          "$ref": "#/components/responses/Unauthorized"
+          $ref: '#/components/responses/Unauthorized'
         '403':
-          "$ref": "#/components/responses/Forbidden"
+          $ref: '#/components/responses/Forbidden'
         '404':
-          "$ref": "#/components/responses/NotFound"
+          $ref: '#/components/responses/NotFound'
       tags:
-      - Notifications
+        - Notifications
     delete:
-      summary: Delete subscription associated with event.
-      description: Delete subscription associated with event.
       operationId: delete-event-subscription
+      summary: Delete subscription associated with event
+      description: Delete subscription associated with event.
       responses:
         '204':
           description: No Content
         '401':
-          "$ref": "#/components/responses/Unauthorized"
+          $ref: '#/components/responses/Unauthorized'
         '403':
-          "$ref": "#/components/responses/Forbidden"
+          $ref: '#/components/responses/Forbidden'
         '404':
-          "$ref": "#/components/responses/NotFound"
+          $ref: '#/components/responses/NotFound'
       tags:
-      - Notifications
+        - Notifications
 components:
   parameters:
-    notificationId:
-      name: notificationId
-      in: path
-      required: true
-      description: ID of the notification.
+    ConfigurationFilter:
+      name: filter
+      description: Filters a collection of configurations.
+      required: false
+      in: query
+      schema:
+        $ref: '#/components/schemas/ConfigurationFilterParameters'
+      style: deepObject
+    NotificationFilter:
+      name: filter
+      description: Filters a collection of notifications.
+      required: false
+      in: query
+      schema:
+        $ref: '#/components/schemas/NotificationFilterParameters'
+      style: deepObject
+    PageAfter:
+      name: 'page[after]'
+      description: 'Request the next page of data, starting with the item after this parameter.'
+      required: false
+      in: query
+      allowEmptyValue: true
       schema:
         type: string
+        example: ewogICJpZCI6ICJoZWxsbyB3b3JsZCIKfQ
+    PageBefore:
+      name: 'page[before]'
+      description: 'Request the next page of data, starting with the item before this parameter.'
+      required: false
+      in: query
+      allowEmptyValue: true
+      schema:
+        type: string
+        example: ewogICJpZCI6ICJoZWxsbyB3b3JsZCIKfQ
     eventId:
       name: eventId
       in: path
@@ -247,6 +262,13 @@ components:
       schema:
         type: string
         example: invoice-ready
+    notificationId:
+      name: notificationId
+      in: path
+      required: true
+      description: ID of the notification.
+      schema:
+        type: string
     subscriptionId:
       name: subscriptionId
       in: path
@@ -254,305 +276,134 @@ components:
       description: Subscription ID of the user configuration.
       schema:
         type: string
-    NotificationFilter:
-      name: filter
-      description: Filters a collection of notifications.
-      required: false
-      in: query
-      schema:
-        "$ref": "#/components/schemas/NotificationFilterParameters"
-      style: deepObject
-    ConfigurationFilter:
-      name: filter
-      description: Filters a collection of configurations.
-      required: false
-      in: query
-      schema:
-        "$ref": "#/components/schemas/ConfigurationFilterParameters"
-      style: deepObject
-    PageBefore:
-      name: page[before]
-      description: Request the next page of data, starting with the item before this
-        parameter.
-      required: false
-      in: query
-      allowEmptyValue: true
-      schema:
-        type: string
-        example: ewogICJpZCI6ICJoZWxsbyB3b3JsZCIKfQ
-    PageAfter:
-      name: page[after]
-      description: Request the next page of data, starting with the item after this
-        parameter.
-      required: false
-      in: query
-      allowEmptyValue: true
-      schema:
-        type: string
-        example: ewogICJpZCI6ICJoZWxsbyB3b3JsZCIKfQ
-  requestBodies:
-    NotificationUpdateRequest:
-      description: Request body schema for updating notification status.
-      content:
-        application/json:
-          schema:
-            "$ref": "#/components/schemas/NotificationUpdatePayload"
-          examples:
-            Example Request Body:
-              "$ref": "#/components/examples/NotificationUpdatePayload"
-    EventSubscriptionRequest:
-      description: Request body schema for creating/updating event subscription.
-      content:
-        application/json:
-          schema:
-            "$ref": "#/components/schemas/EventSubscription"
-          examples:
-            Example Request Body:
-              "$ref": "#/components/examples/EventSubscriptionPayload"
-    BulkRequest:
-      description: Request body schema for bulk status update.
-      content:
-        application/json:
-          schema:
-            "$ref": "#/components/schemas/BulkPayload"
-          examples:
-            Example Request Body:
-              "$ref": "#/components/examples/BulkPayload"
-  responses:
-    NotificationResponse:
-      description: View a single notification.
-      content:
-        application/json:
-          schema:
-            "$ref": "#/components/schemas/Notification"
-          examples:
-            Notification:
-              "$ref": "#/components/examples/NotificationResponse"
-    NotificationListResponse:
-      description: A paginated list response for a collection of notifications
-      content:
-        application/json:
-          schema:
-            type: object
-            additionalProperties: false
-            required:
-            - data
-            - meta
-            properties:
-              data:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/Notification"
-              meta:
-                "$ref": "#/components/schemas/CursorMetaPage"
-          examples:
-            Notifications List:
-              "$ref": "#/components/examples/NotificationListResponse"
-    UserConfigurationListResponse:
-      description: A paginated list response for all notification events and user
-        subscriptions.
-      content:
-        application/json:
-          schema:
-            type: object
-            additionalProperties: false
-            required:
-            - data
-            properties:
-              data:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/UserConfiguration"
-          examples:
-            User Configurations List:
-              "$ref": "#/components/examples/UserConfigurationListResponse"
-    EventSubscriptionListResponse:
-      description: A paginated list response for all subscriptions associated with
-        an event.
-      content:
-        application/json:
-          schema:
-            type: object
-            additionalProperties: false
-            required:
-            - data
-            - meta
-            properties:
-              data:
-                type: array
-                items:
-                  "$ref": "#/components/schemas/EventSubscriptionResponse"
-              meta:
-                "$ref": "#/components/schemas/CursorMetaPage"
-          examples:
-            Event Subscriptions List:
-              "$ref": "#/components/examples/EventSubscriptionListResponse"
-    EventSubscriptionResponse:
-      description: Response containing specific subscription details associated with
-        an event.
-      content:
-        application/json:
-          schema:
-            "$ref": "#/components/schemas/EventSubscriptionResponse"
-          examples:
-            Event Subscription:
-              "$ref": "#/components/examples/EventSubscriptionResponse"
-    BadRequest:
-      description: Bad Request
-      content:
-        application/problem+json:
-          schema:
-            "$ref": "#/components/schemas/BadRequestError"
-    Unauthorized:
-      description: Unauthorized
-      content:
-        application/problem+json:
-          schema:
-            "$ref": "#/components/schemas/UnauthorizedError"
-          examples:
-            UnauthorizedExample:
-              "$ref": "#/components/examples/UnauthorizedExample"
-    Forbidden:
-      description: Forbidden
-      content:
-        application/problem+json:
-          schema:
-            "$ref": "#/components/schemas/ForbiddenError"
-          examples:
-            UnauthorizedExample:
-              "$ref": "#/components/examples/ForbiddenExample"
-    NotFound:
-      description: Not Found
-      content:
-        application/problem+json:
-          schema:
-            "$ref": "#/components/schemas/NotFoundError"
-          examples:
-            NotFoundExample:
-              "$ref": "#/components/examples/NotFoundExample"
   schemas:
     NotificationFilterParameters:
-      title: NotificationFilterParameters
       type: object
-      additionalProperties: false
       properties:
         title:
-          "$ref": "#/components/schemas/StringFieldFilter"
+          $ref: '#/components/schemas/LegacyStringFieldFilter'
         description:
-          "$ref": "#/components/schemas/StringFieldFilter"
+          $ref: '#/components/schemas/LegacyStringFieldFilter'
         namespace:
-          "$ref": "#/components/schemas/StringFieldFilter"
+          $ref: '#/components/schemas/LegacyStringFieldFilter'
         region:
-          "$ref": "#/components/schemas/StringFieldFilter"
+          $ref: '#/components/schemas/LegacyStringFieldFilter'
         status:
-          "$ref": "#/components/schemas/StringFieldFilter"
-    ConfigurationFilterParameters:
-      title: ConfigurationFilterParameters
-      type: object
+          $ref: '#/components/schemas/LegacyStringFieldFilter'
       additionalProperties: false
+      title: NotificationFilterParameters
+    ConfigurationFilterParameters:
+      type: object
       properties:
         event_title:
-          "$ref": "#/components/schemas/StringFieldFilter"
+          $ref: '#/components/schemas/LegacyStringFieldFilter'
         event_description:
-          "$ref": "#/components/schemas/StringFieldFilter"
+          $ref: '#/components/schemas/LegacyStringFieldFilter'
         event_namespace:
-          "$ref": "#/components/schemas/StringFieldFilter"
+          $ref: '#/components/schemas/LegacyStringFieldFilter'
         region:
-          "$ref": "#/components/schemas/StringFieldFilter"
-    Notification:
-      type: object
-      description: Properties of a notification.
+          $ref: '#/components/schemas/LegacyStringFieldFilter'
       additionalProperties: false
-      required:
-      - id
-      - title
-      - description
-      - status
-      - region
-      - namespace
-      - entity_id
-      - details
-      - created_at
-      - updated_at
+      title: ConfigurationFilterParameters
+    Notification:
+      description: Properties of a notification.
+      type: object
       properties:
         id:
-          "$ref": "#/components/schemas/UUID"
+          $ref: '#/components/schemas/UUID'
         title:
           type: string
         description:
           type: string
         status:
-          "$ref": "#/components/schemas/NotificationStatus"
+          $ref: '#/components/schemas/NotificationStatus'
         region:
-          "$ref": "#/components/schemas/NotificationRegion"
+          $ref: '#/components/schemas/NotificationRegion'
         namespace:
-          "$ref": "#/components/schemas/NotificationNamespace"
+          $ref: '#/components/schemas/NotificationNamespace'
         entity_id:
+          description: ID of the entity. Use '*' to represent all entities of this type.
           type: string
-          description: ID of the entity. Use '*' to represent all entities of this
-            type.
         details:
+          description: Metadata associated with the notification to build actionable links.
           type: object
-          description: Metadata associated with the notification to build actionable
-            links.
         created_at:
-          "$ref": "#/components/schemas/CreatedAt"
+          $ref: '#/components/schemas/CreatedAt'
         updated_at:
-          "$ref": "#/components/schemas/UpdatedAt"
+          $ref: '#/components/schemas/UpdatedAt'
+      additionalProperties: false
+      required:
+        - id
+        - title
+        - description
+        - status
+        - region
+        - namespace
+        - entity_id
+        - details
+        - created_at
+        - updated_at
     NotificationUpdatePayload:
       description: Status of the notification.
       type: object
-      required:
-      - status
       properties:
         status:
-          "$ref": "#/components/schemas/NotificationStatus"
-    NotificationStatus:
-      type: string
-      description: Status of the notification.
-      enum:
-      - READ
-      - UNREAD
-      - ARCHIVED
-    NotificationRegion:
-      type: string
-      description: Region associated to a notification.
-      enum:
-      - US
-      - EU
-      - AU
-      - "*"
-    NotificationChannel:
-      type: object
-      description: Channel subscription details for an event.
+          $ref: '#/components/schemas/NotificationStatus'
       required:
-      - type
-      - enabled
+        - status
+    NotificationStatus:
+      description: Status of the notification.
+      type: string
+      enum:
+        - READ
+        - UNREAD
+        - ARCHIVED
+    NotificationRegion:
+      description: Region associated to a notification.
+      type: string
+      enum:
+        - US
+        - EU
+        - AU
+        - ME
+        - IN
+        - '*'
+    NotificationChannel:
+      description: Channel subscription details for an event.
+      type: object
       properties:
         type:
-          "$ref": "#/components/schemas/NotificationChannelType"
+          $ref: '#/components/schemas/NotificationChannelType'
         enabled:
           type: boolean
+      required:
+        - type
+        - enabled
     NotificationChannelType:
       type: string
       enum:
-      - EMAIL
-      - IN_APP
+        - EMAIL
+        - IN_APP
     NotificationNamespace:
       type: string
       enum:
-      - plan-and-usage
-      - organization
+        - plan-and-usage
+        - organization
+        - dev-portal
+        - cloud-gateways
+        - gateway-manager
+    EntityTypes:
+      type: string
+      enum:
+        - billing-invoice
+        - access-token
+        - webhook
+        - dev-portal
+        - dataplane-group
+        - dataplane
     UserConfiguration:
       description: Properties of an event.
       type: object
-      required:
-      - event_id
-      - event_title
-      - event_description
-      - event_namespace
-      - event_subscription_count
-      - default_subscription
       properties:
         event_id:
           type: string
@@ -561,144 +412,173 @@ components:
         event_description:
           type: string
         event_namespace:
-          "$ref": "#/components/schemas/NotificationNamespace"
+          $ref: '#/components/schemas/NotificationNamespace'
         event_subscription_count:
           type: integer
           default: 0
         default_subscription:
           type: array
           items:
-            "$ref": "#/components/schemas/DefaultSubscription"
+            $ref: '#/components/schemas/DefaultSubscription'
+      required:
+        - event_id
+        - event_title
+        - event_description
+        - event_namespace
+        - event_subscription_count
+        - default_subscription
     DefaultSubscription:
       type: object
-      required:
-      - channel
-      - enabled
       properties:
         channel:
-          "$ref": "#/components/schemas/NotificationChannelType"
+          $ref: '#/components/schemas/NotificationChannelType'
         enabled:
           type: boolean
+      required:
+        - channel
+        - enabled
     EventSubscriptionResponse:
+      description: Properties associated with an event subscription.
+      type: object
       properties:
         id:
-          "$ref": "#/components/schemas/UUID"
+          $ref: '#/components/schemas/UUID'
+        entity_type:
+          $ref: '#/components/schemas/EntityTypes'
         created_at:
-          "$ref": "#/components/schemas/CreatedAt"
+          $ref: '#/components/schemas/CreatedAt'
         updated_at:
-          "$ref": "#/components/schemas/UpdatedAt"
+          $ref: '#/components/schemas/UpdatedAt'
         regions:
           type: array
           items:
-            "$ref": "#/components/schemas/NotificationRegion"
+            $ref: '#/components/schemas/NotificationRegion'
         entities:
           type: array
           items:
             type: string
-            description: ID of the entity. Use '*' to represent all entities of this
-              type.
+            description: ID of the entity. Use '*' to represent all entities of this type.
         channels:
           type: array
           items:
-            "$ref": "#/components/schemas/NotificationChannel"
+            $ref: '#/components/schemas/NotificationChannel'
         enabled:
-          type: boolean
           description: Enable/Disable complete subscription within an event.
-      description: Properties associated with an event subscription.
+          type: boolean
+        name:
+          description: User provided name of the subscription.
+          type: string
       required:
-      - id
-      - created_at
-      - updated_at
-      - regions
-      - entities
-      - channels
-      - enabled
-      type: object
+        - id
+        - entity_type
+        - created_at
+        - updated_at
+        - regions
+        - entities
+        - channels
+        - enabled
+        - name
     EventSubscription:
       description: Properties associated with an event subscription.
       type: object
-      required:
-      - regions
-      - entities
-      - channels
-      - enabled
       properties:
         regions:
           type: array
           items:
-            "$ref": "#/components/schemas/NotificationRegion"
+            $ref: '#/components/schemas/NotificationRegion'
         entities:
           type: array
           items:
             type: string
-            description: ID of the entity. Use '*' to represent all entities of this
-              type.
+            description: ID of the entity. Use '*' to represent all entities of this type.
         channels:
           type: array
           items:
-            "$ref": "#/components/schemas/NotificationChannel"
+            $ref: '#/components/schemas/NotificationChannel'
         enabled:
-          type: boolean
           description: Enable/Disable complete subscription within an event.
+          type: boolean
+        name:
+          description: User provided name of the subscription.
+          type: string
+      required:
+        - regions
+        - entities
+        - channels
+        - enabled
+        - name
     BulkPayload:
       description: Request body schema for bulk status update.
       type: object
-      required:
-      - ids
-      - status
       properties:
         ids:
           type: array
           items:
             type: string
-          minItems: 1
           maxItems: 100
+          minItems: 1
           uniqueItems: true
         status:
-          "$ref": "#/components/schemas/NotificationStatus"
+          $ref: '#/components/schemas/NotificationStatus'
+      required:
+        - ids
+        - status
     StringFieldEqualsFilter:
+      description: Filters on the given string field value by exact match.
+      oneOf:
+        - type: string
+        - type: object
+          title: StringFieldEqualsComparison
+          additionalProperties: false
+          properties:
+            eq:
+              type: string
+          required:
+            - eq
       title: StringFieldEqualsFilter
-      description: Filter a string value by exact match.
-      type: string
+      x-examples:
+        example-1: equals-some-value
+        example-2:
+          eq: some-value
     StringFieldContainsFilter:
+      description: Filters on the given string field value by fuzzy match.
       type: object
-      title: StringFieldContainsFilter
-      description: Filter a string value field by partial contains.
       properties:
         contains:
           type: string
+      additionalProperties: false
       required:
-      - contains
-    StringFieldFilter:
-      title: StringFieldFilter
+        - contains
+      title: StringFieldContainsFilter
+      x-examples:
+        example-1:
+          contains: some-value
+    LegacyStringFieldFilter:
       description: Filter a string value field either by exact match or partial contains.
       oneOf:
-      - "$ref": "#/components/schemas/StringFieldEqualsFilter"
-      - "$ref": "#/components/schemas/StringFieldContainsFilter"
+        - $ref: '#/components/schemas/StringFieldEqualsFilter'
+        - $ref: '#/components/schemas/StringFieldContainsFilter'
+      title: StringFieldFilter
     UUID:
+      description: Contains a unique identifier used for this resource.
       type: string
       format: uuid
       example: 5f9fd312-a987-4628-b4c5-bb4f4fddd5f7
-      description: Contains a unique identifier used for this resource.
       readOnly: true
     CreatedAt:
+      description: An ISO-8601 timestamp representation of entity creation date.
       type: string
       format: date-time
       example: '2022-11-04T20:10:06.927Z'
-      description: An ISO-8601 timestamp representation of entity creation date.
       readOnly: true
     UpdatedAt:
+      description: An ISO-8601 timestamp representation of entity update date.
       type: string
       format: date-time
       example: '2022-11-04T20:10:06.927Z'
-      description: An ISO-8601 timestamp representation of entity update date.
       readOnly: true
     CursorMetaPage:
       type: object
-      required:
-      - size
-      - next
-      - previous
       properties:
         first:
           description: URI to the first page
@@ -722,85 +602,88 @@ components:
           description: Requested page size
           type: number
           example: 10
-    BaseError:
-      type: object
-      title: Error
-      description: standard error
       required:
-      - status
-      - title
-      - instance
-      - detail
+        - size
+        - next
+        - previous
+    BaseError:
+      description: standard error
+      type: object
       properties:
         status:
-          type: integer
           description: |
             The HTTP status code of the error. Useful when passing the response
             body to child properties in a frontend UI. Must be returned as an integer.
+          type: integer
           readOnly: true
         title:
-          type: string
           description: |
             A short, human-readable summary of the problem. It should not
             change between occurences of a problem, except for localization.
             Should be provided as "Sentence case" for direct use in the UI.
+          type: string
           readOnly: true
         type:
-          type: string
           description: The error type.
+          type: string
           readOnly: true
         instance:
-          type: string
           description: |
             Used to return the correlation ID back to the user, in the format
             kong:trace:<correlation_id>. This helps us find the relevant logs
             when a customer reports an issue.
+          type: string
           readOnly: true
         detail:
-          type: string
           description: |
             A human readable explanation specific to this occurence of the problem.
             This field may contain request/entity data to help the user understand
             what went wrong. Enclose variable values in square brackets. Should be
             provided as "Sentence case" for direct use in the UI.
+          type: string
           readOnly: true
+      required:
+        - status
+        - title
+        - instance
+        - detail
+      title: Error
     InvalidRules:
       description: invalid parameters rules
       type: string
-      readOnly: true
-      nullable: true
       enum:
-      - required
-      - is_array
-      - is_base64
-      - is_boolean
-      - is_date_time
-      - is_integer
-      - is_null
-      - is_number
-      - is_object
-      - is_string
-      - is_uuid
-      - is_fqdn
-      - is_arn
-      - unknown_property
-      - missing_reference
-      - is_label
-      - matches_regex
-      - invalid
-      - is_supported_network_availability_zone_list
-      - is_supported_network_cidr_block
-      - is_supported_provider_region
+        - required
+        - is_array
+        - is_base64
+        - is_boolean
+        - is_date_time
+        - is_integer
+        - is_null
+        - is_number
+        - is_object
+        - is_string
+        - is_uuid
+        - is_fqdn
+        - is_arn
+        - unknown_property
+        - missing_reference
+        - is_label
+        - matches_regex
+        - invalid
+        - is_supported_network_availability_zone_list
+        - is_supported_network_cidr_block
+        - is_supported_provider_region
+      nullable: true
+      readOnly: true
     InvalidParameterStandard:
       type: object
-      additionalProperties: false
       properties:
         field:
           type: string
           example: name
           readOnly: true
         rule:
-          "$ref": "#/components/schemas/InvalidRules"
+          $ref: '#/components/schemas/InvalidRules'
         source:
           type: string
           example: body
@@ -808,12 +691,12 @@ components:
           type: string
           example: is a required field
           readOnly: true
+      additionalProperties: false
       required:
-      - field
-      - reason
+        - field
+        - reason
     InvalidParameterMinimumLength:
       type: object
-      additionalProperties: false
       properties:
         field:
           type: string
@@ -822,16 +705,16 @@ components:
         rule:
           description: invalid parameters rules
           type: string
-          readOnly: true
-          nullable: false
           enum:
-          - min_length
-          - min_digits
-          - min_lowercase
-          - min_uppercase
-          - min_symbols
-          - min_items
-          - min
+            - min_length
+            - min_digits
+            - min_lowercase
+            - min_uppercase
+            - min_symbols
+            - min_items
+            - min
+          nullable: false
+          readOnly: true
         minimum:
           type: integer
           example: 8
@@ -842,14 +725,14 @@ components:
           type: string
           example: must have at least 8 characters
           readOnly: true
+      additionalProperties: false
       required:
-      - field
-      - reason
-      - rule
-      - minimum
+        - field
+        - reason
+        - rule
+        - minimum
     InvalidParameterMaximumLength:
       type: object
-      additionalProperties: false
       properties:
         field:
           type: string
@@ -858,12 +741,12 @@ components:
         rule:
           description: invalid parameters rules
           type: string
-          readOnly: true
-          nullable: false
           enum:
-          - max_length
-          - max_items
-          - max
+            - max_length
+            - max_items
+            - max
+          nullable: false
+          readOnly: true
         maximum:
           type: integer
           example: 8
@@ -874,14 +757,14 @@ components:
           type: string
           example: must not have more than 8 characters
           readOnly: true
+      additionalProperties: false
       required:
-      - field
-      - reason
-      - rule
-      - maximum
+        - field
+        - reason
+        - rule
+        - maximum
     InvalidParameterChoiceItem:
       type: object
-      additionalProperties: false
       properties:
         field:
           type: string
@@ -890,32 +773,32 @@ components:
         rule:
           description: invalid parameters rules
           type: string
-          readOnly: true
-          nullable: false
           enum:
-          - enum
+            - enum
+          nullable: false
+          readOnly: true
         reason:
           type: string
           example: is a required field
           readOnly: true
         choices:
           type: array
-          uniqueItems: true
-          readOnly: true
-          nullable: false
-          minItems: 1
           items: {}
+          minItems: 1
+          nullable: false
+          readOnly: true
+          uniqueItems: true
         source:
           type: string
           example: body
+      additionalProperties: false
       required:
-      - field
-      - reason
-      - rule
-      - choices
+        - field
+        - reason
+        - rule
+        - choices
     InvalidParameterDependentItem:
       type: object
-      additionalProperties: false
       properties:
         field:
           type: string
@@ -924,95 +807,96 @@ components:
         rule:
           description: invalid parameters rules
           type: string
-          readOnly: true
-          nullable: true
           enum:
-          - dependent_fields
+            - dependent_fields
+          nullable: true
+          readOnly: true
         reason:
           type: string
           example: is a required field
           readOnly: true
         dependents:
           type: array
-          uniqueItems: true
-          nullable: true
           items: {}
+          nullable: true
           readOnly: true
+          uniqueItems: true
         source:
           type: string
           example: body
+      additionalProperties: false
       required:
-      - field
-      - rule
-      - reason
-      - dependents
+        - field
+        - rule
+        - reason
+        - dependents
     InvalidParameters:
-      type: array
-      nullable: false
-      uniqueItems: true
-      minItems: 1
       description: invalid parameters
+      type: array
       items:
         oneOf:
-        - "$ref": "#/components/schemas/InvalidParameterStandard"
-        - "$ref": "#/components/schemas/InvalidParameterMinimumLength"
-        - "$ref": "#/components/schemas/InvalidParameterMaximumLength"
-        - "$ref": "#/components/schemas/InvalidParameterChoiceItem"
-        - "$ref": "#/components/schemas/InvalidParameterDependentItem"
+          - $ref: '#/components/schemas/InvalidParameterStandard'
+          - $ref: '#/components/schemas/InvalidParameterMinimumLength'
+          - $ref: '#/components/schemas/InvalidParameterMaximumLength'
+          - $ref: '#/components/schemas/InvalidParameterChoiceItem'
+          - $ref: '#/components/schemas/InvalidParameterDependentItem'
+      minItems: 1
+      nullable: false
+      uniqueItems: true
     BadRequestError:
       allOf:
-      - "$ref": "#/components/schemas/BaseError"
-      - type: object
-        required:
-        - invalid_parameters
-        properties:
-          invalid_parameters:
-            "$ref": "#/components/schemas/InvalidParameters"
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          required:
+            - invalid_parameters
+          properties:
+            invalid_parameters:
+              $ref: '#/components/schemas/InvalidParameters'
     UnauthorizedError:
       allOf:
-      - "$ref": "#/components/schemas/BaseError"
-      - type: object
-        properties:
-          status:
-            example: 401
-          title:
-            example: Unauthorized
-          type:
-            example: https://httpstatuses.com/401
-          instance:
-            example: kong:trace:1234567890
-          detail:
-            example: Invalid credentials
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 401
+            title:
+              example: Unauthorized
+            type:
+              example: 'https://httpstatuses.com/401'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Invalid credentials
     ForbiddenError:
       allOf:
-      - "$ref": "#/components/schemas/BaseError"
-      - type: object
-        properties:
-          status:
-            example: 403
-          title:
-            example: Forbidden
-          type:
-            example: https://httpstatuses.com/403
-          instance:
-            example: kong:trace:1234567890
-          detail:
-            example: Forbidden
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 403
+            title:
+              example: Forbidden
+            type:
+              example: 'https://httpstatuses.com/403'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Forbidden
     NotFoundError:
       allOf:
-      - "$ref": "#/components/schemas/BaseError"
-      - type: object
-        properties:
-          status:
-            example: 404
-          title:
-            example: Not Found
-          type:
-            example: https://httpstatuses.com/404
-          instance:
-            example: kong:trace:1234567890
-          detail:
-            example: Not found
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 404
+            title:
+              example: Not Found
+            type:
+              example: 'https://httpstatuses.com/404'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Not found
   examples:
     NotificationUpdatePayload:
       value:
@@ -1031,101 +915,106 @@ components:
           entity_id: invoice-1
           entity_type: invoice
           regions:
-          - EU
+            - EU
         created_at: '2023-01-01T00:00:00.000Z'
         updated_at: '2023-01-01T00:00:00.000Z'
     NotificationListResponse:
       summary: List Notifications Response
       value:
         data:
-        - id: 93f8380e-7798-4566-99e3-2edf2b57d289
-          title: Unpaid invoice reminder
-          description: Reminder for an unpaid invoice.
-          status: UNREAD
-          region: US
-          namespace: plan-and-usage
-          entity_id: invoice-1
-          details:
+          - id: 93f8380e-7798-4566-99e3-2edf2b57d289
+            title: Unpaid invoice reminder
+            description: Reminder for an unpaid invoice.
+            status: UNREAD
+            region: US
+            namespace: plan-and-usage
             entity_id: invoice-1
-            entity_type: invoice
-          created_at: '2023-01-01T00:00:00.000Z'
-          updated_at: '2023-01-01T00:00:00.000Z'
-        - id: 93f8380e-7798-4566-99e3-2edf2b57d290
-          title: Unpaid invoice reminder
-          description: Reminder for an unpaid invoice.
-          status: UNREAD
-          region: EU
-          namespace: plan-and-usage
-          entity_id: invoice-2
-          details:
+            details:
+              entity_id: invoice-1
+              entity_type: invoice
+            created_at: '2023-01-01T00:00:00.000Z'
+            updated_at: '2023-01-01T00:00:00.000Z'
+          - id: 93f8380e-7798-4566-99e3-2edf2b57d290
+            title: Unpaid invoice reminder
+            description: Reminder for an unpaid invoice.
+            status: UNREAD
+            region: EU
+            namespace: plan-and-usage
             entity_id: invoice-2
-            entity_type: invoice
-          created_at: '2023-01-01T00:00:00.000Z'
-          updated_at: '2023-01-01T00:00:00.000Z'
+            details:
+              entity_id: invoice-2
+              entity_type: invoice
+            created_at: '2023-01-01T00:00:00.000Z'
+            updated_at: '2023-01-01T00:00:00.000Z'
         meta:
           next: ''
           previous: ''
           size: 10
     EventSubscriptionPayload:
       value:
+        name: Control Plane Global
         regions:
-        - US
-        - EU
+          - US
+          - EU
         entities:
-        - control-plane-1
-        - control-plane-2
+          - control-plane-1
+          - control-plane-2
         channels:
-        - type: IN_APP
-          enabled: true
-        - type: EMAIL
-          enabled: true
+          - type: IN_APP
+            enabled: true
+          - type: EMAIL
+            enabled: true
         enabled: true
         created_at: '2023-01-01T00:00:00.000Z'
         updated_at: '2023-01-01T00:00:00.000Z'
     UserConfigurationListResponse:
       value:
         data:
-        - event_id: billing.invoice.unpaid-reminder
-          event_title: Unpaid invoice reminder
-          event_description: Reminder for an unpaid invoice
-          event_namespace: plan-and-usage
-          event_subscription_count: 2
-          default_subscription:
-          - channel: IN_APP
-            enabled: true
-          - channel: EMAIL
-            enabled: true
+          - event_id: billing.invoice.unpaid-reminder
+            event_title: Unpaid invoice reminder
+            event_description: Reminder for an unpaid invoice
+            event_namespace: plan-and-usage
+            event_subscription_count: 2
+            default_subscription:
+              - channel: IN_APP
+                enabled: true
+              - channel: EMAIL
+                enabled: true
     EventSubscriptionListResponse:
       value:
         data:
-        - id: 93f8380e-7798-4566-99e3-2edf2b57d291
-          regions:
-          - US
-          - EU
-          entities:
-          - invoice-1
-          - invoice-2
-          channels:
-          - type: IN_APP
+          - id: 93f8380e-7798-4566-99e3-2edf2b57d291
+            name: Billing Invoice US and EU
+            regions:
+              - US
+              - EU
+            entities:
+              - invoice-1
+              - invoice-2
+            entity_type: billing-invoice
+            channels:
+              - type: IN_APP
+                enabled: true
+              - type: EMAIL
+                enabled: true
             enabled: true
-          - type: EMAIL
+            created_at: '2023-01-01T00:00:00.000Z'
+            updated_at: '2023-01-01T00:00:00.000Z'
+          - id: 93f8380e-7798-4566-99e3-2edf2b57d292
+            name: Billing Invoice Global
+            regions:
+              - '*'
+            entities:
+              - '*'
+            entity_type: billing-invoice
+            channels:
+              - type: IN_APP
+                enabled: true
+              - type: EMAIL
+                enabled: true
             enabled: true
-          enabled: true
-          created_at: '2023-01-01T00:00:00.000Z'
-          updated_at: '2023-01-01T00:00:00.000Z'
-        - id: 93f8380e-7798-4566-99e3-2edf2b57d292
-          regions:
-          - "*"
-          entities:
-          - "*"
-          channels:
-          - type: IN_APP
-            enabled: true
-          - type: EMAIL
-            enabled: true
-          enabled: true
-          created_at: '2023-01-01T00:00:00.000Z'
-          updated_at: '2023-01-01T00:00:00.000Z'
+            created_at: '2023-01-01T00:00:00.000Z'
+            updated_at: '2023-01-01T00:00:00.000Z'
         meta:
           next: ''
           previous: ''
@@ -1133,42 +1022,181 @@ components:
     EventSubscriptionResponse:
       value:
         id: 93f8380e-7798-4566-99e3-2edf2b57d292
+        name: Billing Invoice Global
         regions:
-        - "*"
+          - '*'
         entities:
-        - "*"
+          - '*'
+        entity_type: billing-invoice
         channels:
-        - type: IN_APP
-          enabled: true
-        - type: EMAIL
-          enabled: true
+          - type: IN_APP
+            enabled: true
+          - type: EMAIL
+            enabled: true
         enabled: true
         created_at: '2023-01-01T00:00:00.000Z'
         updated_at: '2023-01-01T00:00:00.000Z'
     BulkPayload:
       value:
         ids:
-        - 93f8380e-7798-4566-99e3-2edf2b57d289
-        - 93f8380e-7798-4566-99e3-2edf2b57d290
+          - 93f8380e-7798-4566-99e3-2edf2b57d289
+          - 93f8380e-7798-4566-99e3-2edf2b57d290
         status: READ
     UnauthorizedExample:
       value:
         status: 401
         title: Unauthorized
-        instance: kong:trace:8347343766220159418
+        instance: 'kong:trace:8347343766220159418'
         detail: Unauthorized
     ForbiddenExample:
       value:
         status: 403
         title: Forbidden
-        instance: kong:trace:2723154947768991354
+        instance: 'kong:trace:2723154947768991354'
         detail: You do not have permission to perform this action
     NotFoundExample:
       value:
         status: 404
         title: Not Found
-        instance: kong:trace:6816496025408232265
+        instance: 'kong:trace:6816496025408232265'
         detail: Not Found
+  requestBodies:
+    NotificationUpdateRequest:
+      description: Request body schema for updating notification status.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/NotificationUpdatePayload'
+          examples:
+            Example Request Body:
+              $ref: '#/components/examples/NotificationUpdatePayload'
+    EventSubscriptionRequest:
+      description: Request body schema for creating/updating event subscription.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/EventSubscription'
+          examples:
+            Example Request Body:
+              $ref: '#/components/examples/EventSubscriptionPayload'
+    BulkRequest:
+      description: Request body schema for bulk status update.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/BulkPayload'
+          examples:
+            Example Request Body:
+              $ref: '#/components/examples/BulkPayload'
+  responses:
+    NotificationResponse:
+      description: View a single notification.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Notification'
+          examples:
+            Notification:
+              $ref: '#/components/examples/NotificationResponse'
+    NotificationListResponse:
+      description: A paginated list response for a collection of notifications
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Notification'
+              meta:
+                $ref: '#/components/schemas/CursorMetaPage'
+            additionalProperties: false
+            required:
+              - data
+              - meta
+          examples:
+            Notifications List:
+              $ref: '#/components/examples/NotificationListResponse'
+    UserConfigurationListResponse:
+      description: A paginated list response for all notification events and user subscriptions.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserConfiguration'
+            additionalProperties: false
+            required:
+              - data
+          examples:
+            User Configurations List:
+              $ref: '#/components/examples/UserConfigurationListResponse'
+    EventSubscriptionListResponse:
+      description: A paginated list response for all subscriptions associated with an event.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              data:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EventSubscriptionResponse'
+              meta:
+                $ref: '#/components/schemas/CursorMetaPage'
+            additionalProperties: false
+            required:
+              - data
+              - meta
+          examples:
+            Event Subscriptions List:
+              $ref: '#/components/examples/EventSubscriptionListResponse'
+    EventSubscriptionResponse:
+      description: Response containing specific subscription details associated with an event.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/EventSubscriptionResponse'
+          examples:
+            Event Subscription:
+              $ref: '#/components/examples/EventSubscriptionResponse'
+    BadRequest:
+      description: Bad Request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BadRequestError'
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/UnauthorizedError'
+          examples:
+            UnauthorizedExample:
+              $ref: '#/components/examples/UnauthorizedExample'
+    Forbidden:
+      description: Forbidden
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ForbiddenError'
+          examples:
+            UnauthorizedExample:
+              $ref: '#/components/examples/ForbiddenExample'
+    NotFound:
+      description: Not Found
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/NotFoundError'
+          examples:
+            NotFoundExample:
+              $ref: '#/components/examples/NotFoundExample'
   securitySchemes:
     personalAccessToken:
       type: http
@@ -1176,6 +1204,11 @@ components:
       bearerFormat: Token
       description: |
         The personal access token is meant to be used as an alternative to basic-auth when accessing Konnect via APIs.
-        You can generate a Personal Access Token (PAT) from the [personal access token page](https://cloud.konghq.com/global/tokens/) in the Konnect dashboard.
+        You can generate a Personal Access Token (PAT) from the [personal access token page](https://cloud.konghq.com/global/account/tokens/) in the Konnect dashboard.
         The PAT token must be passed in the header of a request, for example:
         `curl -X GET 'https://global.api.konghq.com/v2/users/' --header 'Authorization: Bearer kpat_xgfT...'`
+tags:
+  - name: Notifications
+    description: Operations related to notifications
+security:
+  - personalAccessToken: []


### PR DESCRIPTION
Raised gha change at https://github.com/Kong/platform-api/pull/1886

## Description

Since public spec is not updated, adding the spec manually via PR.
From next time onwards, gha action from platform-api will take care of this.

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
