### PR TITLE
Fix scoring range in plugin documentation

### DIFF
--- a/app/_kong_plugins/ai-llm-as-judge/index.md
+++ b/app/_kong_plugins/ai-llm-as-judge/index.md
@@ -75,7 +75,7 @@ rows:
 ## How it works
 
 1. The plugin sends the user prompt and response to the configured LLM as a judge.
-2. The LLM evaluates the response and returns a numeric score between `1` (ideal) and `100` (wrong or irrelevant).
+2. The LLM evaluates the response and returns a numeric score between `100` (ideal) and `1` (wrong or irrelevant).
 3. This score can be used in downstream workflows, such as automated grading, feedback systems, or learning pipelines.
 
 The following sequence diagram illustrates this simplified flow:


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
