### PR TITLE
Fix(catalog): Remove beta flag from Catalog integrations landing page

### DIFF
--- a/app/_landing_pages/catalog/integrations.yaml
+++ b/app/_landing_pages/catalog/integrations.yaml
@@ -8,7 +8,6 @@ metadata:
   description: Integrate third-party applications into your {{site.konnect_short_name}} organization.
   tags:
     - integrations
-  beta: true
   search_aliases:
     - service catalog
 


### PR DESCRIPTION
## Description

Removed beta flag. This was a leftover from an older time.

## Preview Links



