### PR TITLE
Fix typo and spacing

### DIFF
--- a/app/_how-tos/operator-get-started-kic-create-gateway.md
+++ b/app/_how-tos/operator-get-started-kic-create-gateway.md
@@ -27,7 +27,7 @@ entities: []
 
 tldr:
   q: How can I create a Gateway with {{ site.gateway_operator_product_name }} and {{ site.kic_product_name }}?
-  a: Create a `GatewayConfiguration` object, the. create`GatewayClass` instance and a `Gateway` resource.
+  a: Create a `GatewayConfiguration` object, then create a `GatewayClass` instance and a `Gateway` resource.
 
 prereqs:
   show_works_on: true


### PR DESCRIPTION
## Description

Fixes #3266 


## Checklist 

- [ ] Tested how-to docs. If not, note why here. - A simple typo fix. 
- [ ] All pages contain metadata. - Did not add any new page
- [ ] Any new docs link to existing docs. - Did not add any new docs
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). - Did not add any new page
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly. - Did not add any links, refer to any entities.
- [ ] Every page has a `description` entry in frontmatter. - Did not add any new page
- [ ] Add new pages to the product documentation index (if applicable). - Did not add any new page
