### PR TITLE
Added in FAQ on centrally managing software updates

### DIFF
--- a/app/_includes/how-tos/steps/insomnia-scim.md
+++ b/app/_includes/how-tos/steps/insomnia-scim.md
@@ -4,3 +4,4 @@ Follow the instructions in the modal that opens to generate the connector URL an
 
 {:.warning}
 > The token will only be visible once in Insomnia. Make sure to store it in a secure location so you can retrieve it if needed.
+

--- a/app/insomnia/enterprise-user-management.md
+++ b/app/insomnia/enterprise-user-management.md
@@ -28,6 +28,17 @@ related_resources:
 faqs:
   - q: Why is there not a new free seat in my account after removing a user from my organization?
     a: Removing a user from an organization is not enough to free their seat, you need to remove the user from the [Licenses](https://app.insomnia.rest/app/enterprise/licenses) page.
+  - q: Can my organization’s IT department centrally manage Insomnia software updates?
+    a: |
+      Yes. In Enterprise deployments, an organization’s IT department can centrally manage Insomnia software updates instead of allowing users to install them individually.  
+      
+      To deactivate automatic updates across managed devices, set the following environment variable:
+      ```bash
+      INSOMNIA_DISABLE_AUTOMATIC_UPDATES=true
+      ```
+
+      Configure this variable through your organization’s device management system. When active, this setting prevents Insomnia from performing automatic updates and allows your IT department to control rollout and version management through its standard deployment process.
+  
 ---
 
 ## Insomnia teams


### PR DESCRIPTION
## Description

> Detail that:
> 
> For customers who only want their IT dept to manage software updates and not the users,
> we have an environment variable INSOMNIA_DISABLE_AUTOMATIC_UPDATES=true
> 
> Definition of done
> Include that the option is available for enterprise customers to have their IT dept. manage software updates, rather than individual users.
> 
> Information
> [Slack link](https://kongstrong.slack.com/archives/C044UFN49RT/p1761050502784949)

Fixes #3194 

## Preview Links

- https://deploy-preview-3286--kongdeveloper.netlify.app/insomnia/enterprise-user-management/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
