### PR TITLE
chore(gateway): Add missing changelog entry for AI GCP Model Armor plugin

### DIFF
--- a/app/_data/changelogs/gateway.json
+++ b/app/_data/changelogs/gateway.json
@@ -17267,6 +17267,11 @@
         "message": "**Kong Manager**: In the Confluent Consume, Kafka Consume, Kafka Upstream, Kafka Log, and Confluent plugins, \nsetting `schema_registry.confluent.authentication.mode` or `topics.schema_registry.confluent.authentication.mode` to `none` may not be saved after submission.\n",
         "type": "known-issues",
         "scope": "Kong Manager"
+      },
+      {
+        "message": "**ai-gcp-model-armor**: Added a new `GCP Model Armor` plugin that can protect requests and responses to/from AI LLM.\n",
+        "scope": "Plugin",
+        "type": "feature"
       }
     ],
     "kong-manager-ee": [

--- a/app/_kong_plugins/ai-gcp-model-armor/changelog.json
+++ b/app/_kong_plugins/ai-gcp-model-armor/changelog.json
@@ -1,1 +1,9 @@
-{}
+{
+  "3.12.0.0": [
+    {
+      "message": "Added a new `GCP Model Armor` plugin that can protect requests and responses to/from AI LLM.\n",
+      "scope": "Plugin",
+      "type": "feature"
+    }
+  ]
+}


### PR DESCRIPTION
## Description

This entry was missing from the eng changelog for 3.12, and was just added today. Regenerated changelog based on this update.

## Preview Links


