### PR TITLE
Release: Gateway 3.11.0.6

### DIFF
--- a/app/_data/changelogs/gateway.json
+++ b/app/_data/changelogs/gateway.json
@@ -17605,5 +17605,65 @@
         "scope": "Core"
       }
     ]
+  },
+  "3.11.0.6": {
+    "kong": [],
+    "kong-ee": [
+      {
+        "message": "**balancer**: Fixed an issue where the dns query not stopped when related upstream deleted.\n",
+        "type": "bugfix",
+        "scope": "Configuration"
+      },
+      {
+        "message": "Fixed an issue where for incremental sync, consumer group renaming may not be properly populated, causing stale data to be served.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**OpenID-Connect**: Fixed an issue where for incremental sync, consumer related caches may not be properly invalidated, causing stale data to be served.\n",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**event-hooks**: Fixed an issue where the event_hook crud events cannot be handled in traditional cluster mode.\n",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where HuggingFace embedding driver were incorrectly parsed responses from embedding API\n",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-consume, confluent-consume**: Added `enforce_latest_offset_reset` flag to fix incorrect `latest` offset behavior. When `false` (default), maintains backwards compatibility where `latest` acts like `earliest`. When `true`, `latest` correctly starts from end of topic. Also fixed offset commit bug when no records are consumed, preventing feedback loop with true latest behavior.\n",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Key-Auth-Enc**: Fixed an issue where for incremental sync, caches may not be properly invalidated, causing stale data to be served.\n",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**OpenID-Connect**: Fixed an issue where the `client_credentials`/`authorization_code` auth would not auto-recover if IdP was not accessible during Kong startup.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Fixed an issue where the data plane did not stop the health checker before cleaning up old configurations, which could lead to resource leaks.\n",
+        "type": "bugfix",
+        "scope": "Clustering"
+      }
+    ],
+    "kong-manager-ee": [
+      {
+        "message": "**Confluent/Kafka plugins**: Fixed issues where Kafka plugins did not work when configured via Kong Manager.",
+        "type": "bugfix",
+        "githubs": [
+          4092
+        ],
+        "scope": "Core"
+      }
+    ]
   }
 }

--- a/app/_data/products/gateway.yml
+++ b/app/_data/products/gateway.yml
@@ -922,7 +922,7 @@ releases:
               - Confluent Cloud
 
   - release: "3.11"
-    ee-version: "3.11.0.5"
+    ee-version: "3.11.0.6"
     eol: 2026-07-03
     distributions:
       - amazonlinux2:
@@ -1312,6 +1312,7 @@ marketplaces:
 
 release_dates:
   '3.12.0.0': 2025/10/01
+  '3.11.0.6': 2025/11/03
   '3.11.0.5': 2025/10/23
   '3.11.0.4': 2025/09/30
   '3.11.0.3': 2025/09/05

--- a/app/_kong_plugins/ai-proxy/changelog.json
+++ b/app/_kong_plugins/ai-proxy/changelog.json
@@ -238,6 +238,13 @@
       "scope": "Plugin"
     }
   ],
+  "3.11.0.6": [
+    {
+      "message": "Fixed an issue where HuggingFace embedding driver were incorrectly parsed responses from embedding API\n",
+      "type": "bugfix",
+      "scope": "Plugin"
+    }
+  ],
   "3.10.0.0": [
     {
       "message": "Deprecated `preserve` mode in `config.route_type`. Use `config.llm_format` instead. The `preserve` mode setting will be removed in a future release.",

--- a/app/_kong_plugins/key-auth-enc/changelog.json
+++ b/app/_kong_plugins/key-auth-enc/changelog.json
@@ -1,4 +1,11 @@
 {
+  "3.11.0.6": [
+    {
+      "message": "Fixed an issue where for incremental sync, caches may not be properly invalidated, causing stale data to be served.\n",
+      "type": "bugfix",
+      "scope": "Plugin"
+    }
+  ],
   "3.8.0.0": [
     {
       "message": "Added WWW-Authenticate headers to all 401 responses.",

--- a/app/_kong_plugins/openid-connect/changelog.json
+++ b/app/_kong_plugins/openid-connect/changelog.json
@@ -33,6 +33,18 @@
       "scope": "Plugin"
     }
   ],
+  "3.11.0.6": [
+    {
+      "message": "Fixed an issue where for incremental sync, consumer related caches may not be properly invalidated, causing stale data to be served.\n",
+      "type": "bugfix",
+      "scope": "Plugin"
+    },
+    {
+      "message": "Fixed an issue where the `client_credentials`/`authorization_code` auth would not auto-recover if IdP was not accessible during Kong startup.",
+      "type": "bugfix",
+      "scope": "Plugin"
+    }
+  ],
   "3.10.0.0": [
     {
       "message": "Fixed an issue where forbidden requests were redirected to `unauthorized_redirect_uri` if configured. After the fix, forbidden requests will be redirected to `forbidden_redirect_uri` if configured.\n",


### PR DESCRIPTION
## Description

Changelog and version bump for gateway 3.11.0.6.

Not released yet. Check https://hub.docker.com/r/kong/kong-gateway/tags to make sure the version is there before merging.

## Preview Links


