### PR TITLE
Fix 2.7 eol

### DIFF
--- a/app/_data/products/mesh.yml
+++ b/app/_data/products/mesh.yml
@@ -36,7 +36,7 @@ releases:
   - version: 2.7.19
     release: "2.7"
     releaseDate: "2024-04-19"
-    eol: "2026-04-19"
+    eol: "2026-10-19"
     branch: release-2.7
     lts: true
   - version: 2.8.8


### PR DESCRIPTION
## Description

Fixes wrong eol for 2.7

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
