### PR TITLE
Fix: Broken code block on /contributing

### DIFF
--- a/app/contributing/index.md
+++ b/app/contributing/index.md
@@ -646,6 +646,7 @@ For example, you can have H1 > H2 > H3 > H2 > H3, but not H1 > H3 > H2.
   - header:
       type: h2
       text: "Traditional mode"
+```
 
 ### Structured text
 


### PR DESCRIPTION
Fixed a broken code block in the "Structured text" section.

## Description

Fixes #3369 

## Preview Links

N/A

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
