### PR TITLE
docs(event-gateway): use "principal" instead of "authenticated principal"

### DIFF
--- a/app/_event_gateway_policies/acl/examples/manage-consumer-groups.yml
+++ b/app/_event_gateway_policies/acl/examples/manage-consumer-groups.yml
@@ -1,8 +1,8 @@
 title: Allow consumer group management
 
-description: Allow the authenticated principal to create and delete consumer groups.
+description: Allow the principal to create and delete consumer groups.
 
-extended_description: Allow the authenticated principal to create and delete consumer groups.
+extended_description: Allow the principal to create and delete consumer groups.
 
 
 weight: 900

--- a/app/_event_gateway_policies/acl/examples/read-only-topic.yml
+++ b/app/_event_gateway_policies/acl/examples/read-only-topic.yml
@@ -1,8 +1,8 @@
 title: Allow read-only access to a topic
 
-description: Allow the authenticated principal to consume messages for a specific topic. 
+description: Allow the principal to consume messages for a specific topic.
 
-extended_description: Allow the authenticated principal to consume messages for a specific topic. 
+extended_description: Allow the principal to consume messages for a specific topic.
 
 
 weight: 900

--- a/app/_event_gateway_policies/acl/index.md
+++ b/app/_event_gateway_policies/acl/index.md
@@ -31,7 +31,7 @@ related_resources:
     url: /event-gateway/entities/policy/
 ---
 
-The ACL (Access Control List) policy manages authorization for your [virtual cluster](/event-gateway/entities/virtual-cluster/) by defining which actions authenticated principals can perform on specific resources.
+The ACL (Access Control List) policy manages authorization for your [virtual cluster](/event-gateway/entities/virtual-cluster/) by defining which actions principals can perform on specific resources.
 
 By default, when ACLs are enabled, principals have no access. You must explicitly define access rules through ACL policies.
 
@@ -48,9 +48,9 @@ columns:
     key: description
 rows:
   - use_case: "[Allow read-only access to a topic](./examples/read-only-topic/)"
-    description: Allow the authenticated principal to consume messages for a specific topic.
+    description: Allow the principal to consume messages for a specific topic.
   - use_case: "[Allow consumer group management](./examples/manage-consumer-groups/)"
-    description: Allow the authenticated principal to create and delete consumer groups.
+    description: Allow the principal to create and delete consumer groups.
 
 {% endtable %}
 <!--vale on-->


### PR DESCRIPTION
## Description

These policies don't apply only to authenticated principals.

## Preview Links

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
