### PR TITLE
Feat (Insomnia) Clarify varying server support for MCP Auth

### DIFF
--- a/app/insomnia/mcp-clients-in-insomnia.md
+++ b/app/insomnia/mcp-clients-in-insomnia.md
@@ -121,6 +121,9 @@ When you connect to an MCP Server that requires authentication, Insomnia follows
 3. If it’s not selected, Insomnia prompts you to switch to the discovered auth flow.  
    Confirm to proceed or cancel to remain on your current method.
 
+{:.info}
+> Not all MCP-compatible servers handle authentication the same way. Because this standard evolves quickly, some setups may need manual tweaks to work as expected. Insomnia shows you every request and response so you can check what succeeded or failed.
+
 If the authorization server does not support Dynamic Client Registration, you can:
 - Use a **Personal Access Token (PAT)**, for example GitHub Copilot MCP Server.  
 - Register your own **OAuth application**, then enter the Client ID and Secret in Insomnia.


### PR DESCRIPTION
## Description

Clarify and manage the expectations: depending on the server, manual intervention might be required.

Fixes #3410 

## Preview Links

https://deploy-preview-3430--kongdeveloper.netlify.app/insomnia/mcp-clients-in-insomnia/#mcp-authentication

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
