### PR TITLE
Feat(Insomnia): Add enterprise FAQ item about roles

### DIFF
--- a/app/insomnia/enterprise-onboarding.md
+++ b/app/insomnia/enterprise-onboarding.md
@@ -77,9 +77,7 @@ faqs:
       If you purchased Enterprise through the **sales team**, you will receive an activation code as part of the onboarding process.
   - q: How do I know that I have successfully upgraded to Insomnia Enterprise?
     a: |
-      Check the Insomnia app interface to confirm that your Enterprise upgrade is active:
-
-      - Look for the **Enterprise** badge in the top-right corner of the app.
+      Look for the **Enterprise** badge in the top-right corner of the app.
 
       If you don’t see the badge, you're either not part of an Enterprise workspace, or you don't have an **Owner** or **Co-owner** role. If you require support, reach out to **Insomnia Support** at support@insomnia.rest or [https://support.konghq.com/support/s/](https://support.konghq.com/support/s/).
     


### PR DESCRIPTION
## Description

> Jobs to be done (optional)
> Clarify in [this article](https://developer.konghq.com/insomnia/enterprise-onboarding/#1-activate-your-enterprise-membership) that:
> 
> If you're already an owner/co-owner of an upgraded account, you don't need to do point 1.
> Whether someone else did Step 1 before you did, or you just did it... after that, you should see Enterprise plan in the bottom left and 10+ menu options on the left (SSO, SCIM,Domains, Licenses, etc.). If you do not, none of the rest of the doc will work and the problem is either that you're not an enterprise account or you're not an owner of it. (Yes, we'll improve this in the UX soon, but it's still a good point to stop and check, otherwise you're gonna have a bad time following the rest of the steps)
> Definition of done
> Clarify owner/co-owner doesn't need to do step 1.
> Information
> https://github.com/Kong/developer.konghq.com/issues/3388#issue-3591827659
> 
> Due date (optional)
> Size
> S (Small). Example: fixing a broken link, updating wording in an FAQ or paragraph

Fixes #3415 

## Preview Links

https://deploy-preview-3433--kongdeveloper.netlify.app/insomnia/enterprise-onboarding/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
