### PR TITLE
Feat (Gateway): Document minimum IAM permissions for DP resilience

### DIFF
--- a/app/gateway/cp-outage.md
+++ b/app/gateway/cp-outage.md
@@ -35,6 +35,13 @@ faqs:
     a: The Data Plane will always fetch config from {{site.konnect_short_name}} first. It will only fetch config from storage if fetching it from {{site.konnect_short_name}} fails. If the Data Plane fails to fetch the config from storage, it won't retry fetching it.
   - q: Why won’t the exported configuration import, despite having been imported before?
     a: "Ensure the `KONG_VERSION` on both exporting and importing data plane instances is identical. If they differ, update one to use the full image tag (for example, `3.11.0.3` instead of 3.11). If problems persist, check the error logs and address any issues. In container or Kubernetes deployments, always specify the full tag to prevent inadvertent version drift. When upgrading, move both exporting and importing instances to the same new tag, and validate the config is re-exported successfully afterwards."
+  - q: What are the minimum S3 IAM policy requirements for DP resilience?
+    a: |
+      The minimum required IAM permissions for enabling data plane (DP) resilience with an S3 backend are:
+
+      - `s3:PutObject`: Upload configuration snapshots and other resilience artifacts to the S3 bucket.
+      - `s3:GetObject`: Download stored snapshots and configuration data from the bucket.
+      - `s3:ListBucket`: List objects within the bucket.
 
 ---
 


### PR DESCRIPTION
## Description

> Definition of done
> add an FAQ to https://developer.konghq.com/gateway/cp-outage/#how-data-plane-resilience-works. "Q: What are the minimum S3 IAM policy requirements for DP resilience?" A: s3:PutObject , s3:GetObject , s3:ListBucket
> Information
> Slack: https://kongstrong.slack.com/archives/C03CTMSHP6C/p1757053732475579
> 
> Size
> small

Fixes #3090 

## Preview Links

https://deploy-preview-3440--kongdeveloper.netlify.app/gateway/cp-outage/#what-are-the-minimum-s3-iam-policy-requirements-for-dp-resilience


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
