### PR TITLE
Fix prereq in how-to

### DIFF
--- a/app/_how-tos/use-ai-gcp-model-armor-plugin.md
+++ b/app/_how-tos/use-ai-gcp-model-armor-plugin.md
@@ -52,78 +52,78 @@ prereqs:
       content: |
         To use the AI GCP Model Armor plugin, you need a service account with **Model Armor Admin** permissions and a configured Model Armor template:
 
-            1. **Check your IAM permissions:**
-            Your service account must have the [`roles/modelarmor.admin`](https://cloud.google.com/iam/docs/roles-permissions/modelarmor) IAM role.
+        1. **Check your IAM permissions:**
+        Your service account must have the [`roles/modelarmor.admin`](https://cloud.google.com/iam/docs/roles-permissions/modelarmor) IAM role.
 
-            2. Create the `modelarmor-admin` service account in your GCP by executing the following command in your terminal:
-            {% capture modelarmor-admin %}
-            ```bash
-            gcloud iam service-accounts create modelarmor-admin \
-                --description="Service account for Model Armor administration" \
-                --display-name="Model Armor Admin" \
-                --project=$DECK_GCP_PROJECT_ID
-            ```
-            {% endcapture %}
-            {{ modelarmor-admin | indent: 3}}
+        2. Create the `modelarmor-admin` service account in your GCP by executing the following command in your terminal:
+        {% capture modelarmor-admin %}
+        ```bash
+        gcloud iam service-accounts create modelarmor-admin \
+            --description="Service account for Model Armor administration" \
+            --display-name="Model Armor Admin" \
+            --project=$DECK_GCP_PROJECT_ID
+        ```
+        {% endcapture %}
+        {{ modelarmor-admin | indent: 3}}
 
-            3. Create and activate a service account key file by executing the following commands:
+        3. Create and activate a service account key file by executing the following commands:
 
-            {% capture service-account %}
-            ```bash
-            gcloud iam service-accounts keys create modelarmor-admin-key.json \
-                --iam-account=modelarmor-admin@$DECK_GCP_PROJECT_ID.iam.gserviceaccount.com
+        {% capture service-account %}
+        ```bash
+        gcloud iam service-accounts keys create modelarmor-admin-key.json \
+            --iam-account=modelarmor-admin@$DECK_GCP_PROJECT_ID.iam.gserviceaccount.com
 
-            gcloud auth activate-service-account \
-                --key-file=modelarmor-admin-key.json
-            ```
-            {% endcapture %}
-            {{ service-account | indent: 3}}
+        gcloud auth activate-service-account \
+            --key-file=modelarmor-admin-key.json
+        ```
+        {% endcapture %}
+        {{ service-account | indent: 3}}
 
-               After creating the key, convert the contents of `modelarmor-admin-key.json` into a **single-line JSON string**.
-               Escape all necessary characters — quotes (`"`) and newlines (`\n`) — so that it becomes a valid one-line JSON string.
-               Then export it as an environment variable:
+           After creating the key, convert the contents of `modelarmor-admin-key.json` into a **single-line JSON string**.
+           Escape all necessary characters — quotes (`"`) and newlines (`\n`) — so that it becomes a valid one-line JSON string.
+           Then export it as an environment variable:
 
-               ```bash
-               export DECK_GCP_SERVICE_ACCOUNT_JSON="<single-line-escaped-json>"
-               ```
+           ```bash
+           export DECK_GCP_SERVICE_ACCOUNT_JSON="<single-line-escaped-json>"
+           ```
 
-            4. Enable the Model Armor API:
+        4. Enable the Model Armor API:
 
-            {% capture enable-model-armor %}
-            ```bash
-            gcloud config set api_endpoint_overrides/modelarmor "https://modelarmor.$DECK_GCP_LOCATION_ID.rep.googleapis.com/"
-            gcloud services enable modelarmor.googleapis.com --project=$DECK_GCP_PROJECT_ID
-            ```
-            {% endcapture %}
-            {{ enable-model-armor | indent: 3}}
+        {% capture enable-model-armor %}
+        ```bash
+        gcloud config set api_endpoint_overrides/modelarmor "https://modelarmor.$DECK_GCP_LOCATION_ID.rep.googleapis.com/"
+        gcloud services enable modelarmor.googleapis.com --project=$DECK_GCP_PROJECT_ID
+        ```
+        {% endcapture %}
+        {{ enable-model-armor | indent: 3}}
 
-            5. Create a Model Armor template with strict guardrails. This template blocks **hate speech, harassment, and sexually explicit content** at medium confidence or higher, enforces PI/jailbreak and malicious URI filters, and logs all inspection events. Execute the following command to create the template:
-            {% capture model-armor-template %}
-            ```bash
-            gcloud model-armor templates create strict-guardrails \
-                --project=$DECK_GCP_PROJECT_ID \
-                --location=$DECK_GCP_LOCATION_ID \
-                --rai-settings-filters='[
-                    { "filterType": "HATE_SPEECH", "confidenceLevel": "MEDIUM_AND_ABOVE" },
-                    { "filterType": "HARASSMENT", "confidenceLevel": "MEDIUM_AND_ABOVE" },
-                    { "filterType": "SEXUALLY_EXPLICIT", "confidenceLevel": "MEDIUM_AND_ABOVE" }
-                ]' \
-                --basic-config-filter-enforcement=enabled \
-                --pi-and-jailbreak-filter-settings-enforcement=enabled \
-                --pi-and-jailbreak-filter-settings-confidence-level=LOW_AND_ABOVE \
-                --malicious-uri-filter-settings-enforcement=enabled \
-                --template-metadata-log-operations \
-                --template-metadata-log-sanitize-operations
-            ```
-            {% endcapture %}
-            {{ model-armor-template | indent: 3}}
+        5. Create a Model Armor template with strict guardrails. This template blocks **hate speech, harassment, and sexually explicit content** at medium confidence or higher, enforces PI/jailbreak and malicious URI filters, and logs all inspection events. Execute the following command to create the template:
+        {% capture model-armor-template %}
+        ```bash
+        gcloud model-armor templates create strict-guardrails \
+            --project=$DECK_GCP_PROJECT_ID \
+            --location=$DECK_GCP_LOCATION_ID \
+            --rai-settings-filters='[
+                { "filterType": "HATE_SPEECH", "confidenceLevel": "MEDIUM_AND_ABOVE" },
+                { "filterType": "HARASSMENT", "confidenceLevel": "MEDIUM_AND_ABOVE" },
+                { "filterType": "SEXUALLY_EXPLICIT", "confidenceLevel": "MEDIUM_AND_ABOVE" }
+            ]' \
+            --basic-config-filter-enforcement=enabled \
+            --pi-and-jailbreak-filter-settings-enforcement=enabled \
+            --pi-and-jailbreak-filter-settings-confidence-level=LOW_AND_ABOVE \
+            --malicious-uri-filter-settings-enforcement=enabled \
+            --template-metadata-log-operations \
+            --template-metadata-log-sanitize-operations
+        ```
+        {% endcapture %}
+        {{ model-armor-template | indent: 3}}
 
 
-            6. Export the template ID:
-                
-               ```bash
-               export DECK_GCP_TEMPLATE_ID="strict-guardrails"
-               ```
+        6. Export the template ID:
+            
+           ```bash
+           export DECK_GCP_TEMPLATE_ID="strict-guardrails"
+           ```
       icon_url: /assets/icons/gcp-cloud-armor.svg
 
   entities:


### PR DESCRIPTION
Indentation was off, causing it not to render properly.

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
