### PR TITLE
Feat (Insomnia): MCP Clients as top level units

### DIFF
--- a/app/_landing_pages/insomnia.yaml
+++ b/app/_landing_pages/insomnia.yaml
@@ -46,6 +46,7 @@ rows:
   - header:
       type: h2
       text: Get started
+  - column_count: 3  
     columns:
       - blocks:
         - type: card


### PR DESCRIPTION
## Description

Jobs to be done (optional)
Investigate and analyse: MCP Clients as a top level item on developer.konghq.com/insomnia.

What if Get Started was 6 items (Docs, Collections, MCP, Mocks, Environments, Inso CLI) followed by Your Account (Manage Insomnia, Insomnia Enterprise, Plugins)? Might need a slightly better name for the second section... open to any pitch here including a completely different one.

Definition of done

Get started tiles: of Docs, Collections, MCP clients, Mocks, Environments, Inso CLI
Your Account tiles: (Manage Insomnia, Insomnia Enterprise, Plugins)?

Information
https://github.com/Kong/developer.konghq.com/issues/3388#issue-3591827659

Fixes #3416 

## Preview Links

- https://deploy-preview-3446--kongdeveloper.netlify.app/insomnia/


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
