### PR TITLE
fix: duplicated Auhtorization header in konnect_api_request

### DIFF
--- a/app/_plugins/drops/konnect_api_request.rb
+++ b/app/_plugins/drops/konnect_api_request.rb
@@ -34,9 +34,11 @@ module Jekyll
       end
 
       def headers
-        h = @yaml['headers'] || []
-        h.unshift('Authorization: Bearer $KONNECT_TOKEN')
-        h
+        @headers ||= begin
+          h = @yaml['headers'] || []
+          h.unshift('Authorization: Bearer $KONNECT_TOKEN')
+          h.uniq
+        end
       end
 
       def config

--- a/app/serverless-gateways/reference.md
+++ b/app/serverless-gateways/reference.md
@@ -77,9 +77,9 @@ Provisioning a serverless gateway includes creating the serverless Control Plane
   status_code: 201
   method: POST
   headers:
+      - 'Authorization: Bearer $KONNECT_TOKEN'
       - 'Accept: application/json'
       - 'Content-Type: application/json'
-      - 'Authorization: Bearer $KONNECT_TOKEN'
   body:
 
       name: serverless-gateway-control-plane


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
