### PR TITLE
Feat (Insomnia): Add FAQ can cancel request if runtime too long

### DIFF
--- a/app/insomnia/mcp-clients-in-insomnia.md
+++ b/app/insomnia/mcp-clients-in-insomnia.md
@@ -56,7 +56,7 @@ faqs:
       Insomnia only restarts the MCP Authentication Flow when the server responds with `401 Unauthorized`.
 
       > **Note:** You can't re-run individual MCP Auth calls. Only the full flow can be restarted manually.
-  - q: My MCP request is running for a long time. What should I do?
+  - q: What should I do if an MCP request is taking a long time to run?
     a: |
       From the **Events** tab, click the cancel icon beside the request that is currently running. This ends the current MCP task and returns control to the app.
     


### PR DESCRIPTION
## Description

> Jobs to be done (optional)
> Explain that For long-running mcp request, Insomnia mcp client supports option to cancel it.
> 
> Definition of done
> Insert a tip or an FAQ that explains Users can cancel long-running MCP request.
> 
> on /insomnia/mcp-clients-in-insomnia/
> 
> Information
> [Jira](https://konghq.atlassian.net/browse/INS-1652)
> 
> Due date (optional)
> 19th Nov 2025
> 
> Size
> S (Small). Example: fixing a broken link, updating wording in an FAQ or paragraph
> 
> Fixes #3324 

## Preview Links

http://localhost:8888/insomnia/mcp-clients-in-insomnia/

https://deploy-preview-3485--kongdeveloper.netlify.app/insomnia/mcp-clients-in-insomnia/#my-mcp-request-is-running-for-a-long-time-what-should-i-do

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
