### PR TITLE
ko: add docs for using KonnectAPIAuthConfiguration with Secrets

### DIFF
--- a/app/_how-tos/operator-konnect-getstarted-authentication.md
+++ b/app/_how-tos/operator-konnect-getstarted-authentication.md
@@ -74,7 +74,7 @@ metadata:
   name: konnect-api-auth-secret
   namespace: kong
   labels:
-    konghq.com/secret: konnect
+    konghq.com/credential: konnect
 stringData:
   token: "'$KONNECT_TOKEN'"' | kubectl apply -f -
 ```


### PR DESCRIPTION
## Description

Describe how to use `KonnectAPIAuthConfiguration` with Kubernetes `Secret`s.

## Preview Links

https://deploy-preview-3517--kongdeveloper.netlify.app/operator/konnect/get-started/authentication/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
