### PR TITLE
Fix(Mesh): MeshTrafficPermission example

### DIFF
--- a/app/_mesh_policies/meshtrafficpermission/examples/service-allow-requests.yaml
+++ b/app/_mesh_policies/meshtrafficpermission/examples/service-allow-requests.yaml
@@ -3,13 +3,11 @@ description: 'Use MeshTrafficPermission to allow traffic to a specific MeshServi
 
 weight: 900
 
-namespace: kuma-demo
-use_meshservice: true
+namespace: kong-mesh-demo
 config:
   type: MeshTrafficPermission
   name: mtp
   mesh: default
-  namespace: kong-mesh-demo
   spec:
     targetRef:
       kind: MeshService
@@ -19,4 +17,3 @@ config:
           kind: Mesh
         default:
           action: Allow
-    


### PR DESCRIPTION
## Description

Issue reported on [slack](https://kongstrong.slack.com/archives/CDSTDSG9J/p1763452542396839)

## Preview Links

https://deploy-preview-3519--kongdeveloper.netlify.app/mesh/policies/meshtrafficpermission/examples/service-allow-requests/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
