### PR TITLE
Fix (Gateway Manager) CP will fail and refuse to send payload

### DIFF
--- a/app/_data/version_errors_konnect.yml
+++ b/app/_data/version_errors_konnect.yml
@@ -2412,7 +2412,7 @@ messages:
       Please either update the redis timeout values to be the same or upgrade to Kong
       Gateway to versions 3.10.0.1 and above.
     DocumentationURL: |
-      [Kong Plugins](/plugins/))
+      [Kong Plugins](/plugins/)
   - ID: D337
     Severity: error
     Description: |


### PR DESCRIPTION
## Description

> Definition of done

> Update https://developer.konghq.com/gateway-manager/version-compatibility/ to contain information on cases where the CP will fail to communicate with the DP.
> 
> The cases are:
> 
> expression Routes used with a DP not supporting expression router flavour
> some specific incompatibility for the ai-advanced-rate-limiting plugin (API breaking change pre and post 3.10)
> For a few other cases the CP will send the payload knowing that it will fail the DP validation purposely to avoid security breaches (look for "out of sync" in the docs I linked above):
> when certificates are expired
> when some other incompatibilities cannot be resolved (including unsupported custom plugins)
> Information
> https://kongstrong.slack.com/archives/C04RXLGNB6K/p1759944513796129
> 
> Due date (optional)
> Size

Fixes #3155 
## Preview Links

https://deploy-preview-3536--kongdeveloper.netlify.app/gateway/data-plane-version-compatibility/
## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
