### PR TITLE
docs(vault): add statement for using azure vault with proxy for 3.12

### DIFF
--- a/app/_gateway_entities/vault.md
+++ b/app/_gateway_entities/vault.md
@@ -100,9 +100,9 @@ faqs:
       {{site.base_gateway}} will parse the response of the read secret API automatically and return the secret value.
   - q: Can Azure Key Vault be used with a proxy?
     a: |
-      {% new_in 3.12 %} Yes. Azure Vault supports proxy configuration using either environment variables or client constructor arguments.
+      {% new_in 3.12 %} Yes. Azure Key Vault supports proxy configuration using either environment variables or client constructor arguments.
 
-      **Environment Variables**
+      **Environment variables**
 
       ```sh
       export AZURE_HTTP_PROXY=http://proxy.example.com:8080
@@ -112,7 +112,7 @@ faqs:
       export AZURE_AUTH_PASSWORD=proxypass
       ```
 
-      **Constructor Arguments**
+      **Constructor arguments**
 
       ```lua
       local azure_client = require("resty.azure"):new({
@@ -126,7 +126,7 @@ faqs:
         auth_password = "proxypass",
       })
       ```
-      
+
       {:.info}
       > **Notes:**
       > * Constructor arguments take precedence over environment variables.


### PR DESCRIPTION
## Description

Add statement for using Azure Vault with proxy for 3.12

https://konghq.atlassian.net/browse/FTI-7089

## Preview Links


## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
