### PR TITLE
chore(gateway): Gateway 3.9 End of Support 

### DIFF
--- a/app/_data/products/gateway.yml
+++ b/app/_data/products/gateway.yml
@@ -555,7 +555,8 @@ releases:
   - release: "3.9"
     ee-version: "3.9.1.2"
     ce-version: "3.9.1"
-    eol: 2025-12-30
+    eol: 2025-12-12
+    sunset: true
     distributions:
       - amazonlinux2:
           package: true

--- a/app/_data/support/gateway.yml
+++ b/app/_data/support/gateway.yml
@@ -21,8 +21,8 @@
   konnect: true
   beginning: "3.9.0.0"
   release_date: "2025-01-08"
-  eol: "2025-12-30"
-  sunset: "2026-12-30"
+  eol: "2025-12-12"
+  sunset: "2026-12-12"
 - release: "3.8"
   konnect: true
   beginning: "3.8.0.0"


### PR DESCRIPTION
## Description

Fixes #2939 
Gateway 3.9 reaches end of support on Dec 12th, as it was released on Dec 12 2024.

This PR moves Gateway 3.9 into Sunset status.

## Preview Links
https://deploy-preview-3626--kongdeveloper.netlify.app/gateway/version-support-policy/#supported-versions
