### PR TITLE
feat(gateway): authenticated_groups_delimiter for OIDC in KM

### DIFF
--- a/app/_data/kong-conf/3.12.json
+++ b/app/_data/kong-conf/3.12.json
@@ -63,79 +63,85 @@
     {
       "title": "VAULTS",
       "start": 1884,
-      "end": 2119,
+      "end": 2117,
       "description": "A secret is any sensitive piece of information required for API gateway\noperations. Secrets may be part of the core Kong Gateway configuration,\nused in plugins, or part of the configuration associated with APIs serviced\nby the gateway.\n\nSome of the most common types of secrets used by Kong Gateway include:\n\n- Data store usernames and passwords, used with PostgreSQL and Redis\n- Private X.509 certificates\n- API keys\n\nSensitive plugin configuration fields are generally used for authentication,\nhashing, signing, or encryption. Kong Gateway lets you store certain values\nin a vault. Here are the vault specific configuration options.\n"
     },
     {
+      "title": "AI",
+      "start": 2118,
+      "end": 2123,
+      "description": ""
+    },
+    {
       "title": "TUNING & BEHAVIOR",
-      "start": 2120,
-      "end": 2256,
+      "start": 2124,
+      "end": 2260,
       "description": ""
     },
     {
       "title": "MISCELLANEOUS",
-      "start": 2257,
-      "end": 2378,
+      "start": 2261,
+      "end": 2382,
       "description": "Additional settings inherited from lua-nginx-module allowing for more\nflexibility and advanced usage.\n\nSee the lua-nginx-module documentation for more information:\nhttps://github.com/openresty/lua-nginx-module\n"
     },
     {
       "title": "KONG MANAGER",
-      "start": 2379,
-      "end": 2654,
+      "start": 2383,
+      "end": 2658,
       "description": "\nThe Admin GUI for Kong Enterprise.\n\n"
     },
     {
       "title": "Konnect",
-      "start": 2655,
-      "end": 2661,
+      "start": 2659,
+      "end": 2665,
       "description": ""
     },
     {
       "title": "Analytics for Konnect",
-      "start": 2662,
-      "end": 2682,
+      "start": 2666,
+      "end": 2686,
       "description": ""
     },
     {
       "title": "ADMIN SMTP CONFIGURATION",
-      "start": 2683,
-      "end": 2697,
+      "start": 2687,
+      "end": 2701,
       "description": ""
     },
     {
       "title": "GENERAL SMTP CONFIGURATION",
-      "start": 2698,
-      "end": 2748,
+      "start": 2702,
+      "end": 2752,
       "description": ""
     },
     {
       "title": "DATA & ADMIN AUDIT",
-      "start": 2749,
-      "end": 2794,
+      "start": 2753,
+      "end": 2798,
       "description": "When enabled, Kong will store detailed audit data regarding Admin API and\ndatabase access. In most cases, updates to the database are associated with\nAdmin API requests. As such, database object audit log data is tied to a\ngiven HTTP request via a unique identifier, providing built-in association of\nAdmin API and database traffic.\n\n"
     },
     {
       "title": "ROUTE COLLISION DETECTION/PREVENTION",
-      "start": 2795,
-      "end": 2842,
+      "start": 2799,
+      "end": 2846,
       "description": ""
     },
     {
       "title": "DATABASE ENCRYPTION & KEYRING MANAGEMENT",
-      "start": 2843,
-      "end": 3071,
+      "start": 2847,
+      "end": 3075,
       "description": "When enabled, Kong will transparently encrypt sensitive fields, such as consumer\ncredentials, TLS private keys, and RBAC user tokens, among others. A full list\nof encrypted fields is available from the Kong Enterprise documentation site.\nEncrypted data is transparently decrypted before being displayed to the Admin\nAPI or made available to plugins or core routing logic.\n\nWhile this feature is GA, do note that we currently do not provide normal semantic\nversioning compatibility guarantees on the keyring feature's APIs in that Kong may\nmake a breaking change to the feature in a minor version. Also note that\nmismanagement of keyring data may result in irrecoverable data loss.\n\n"
     },
     {
       "title": "CLUSTER FALLBACK CONFIGURATION",
-      "start": 3072,
-      "end": 3119,
+      "start": 3076,
+      "end": 3123,
       "description": ""
     },
     {
       "title": "REQUEST DEBUGGING",
-      "start": 3120,
-      "end": 3182,
+      "start": 3124,
+      "end": 3186,
       "description": "Request debugging is a mechanism that allows admins to collect the timing of\nproxy path requests in the response header (X-Kong-Request-Debug-Output)\nand optionally, the error log.\n\nThis feature provides insights into the time spent within various components of Kong,\nsuch as plugins, DNS resolution, load balancing, and more. It also provides contextual\ninformation such as domain names tried during these processes.\n\n"
     }
   ],
@@ -1277,6 +1283,11 @@
       "defaultValue": null,
       "description": "Time (in seconds) for which stale secrets\nfrom the Azure Key Vault should be resurrected\nfor when they cannot be refreshed (e.g., the\nthe vault is unreachable). When this TTL\nexpires, a new attempt to refresh the stale\nsecrets will be made.\n",
       "sectionTitle": "VAULTS"
+    },
+    "ai_mcp_listener_enabled": {
+      "defaultValue": "on",
+      "description": "Enable or disable the MCP unix socket listener.\n",
+      "sectionTitle": "AI"
     },
     "worker_consistency": {
       "defaultValue": "eventual",

--- a/app/gateway/kong-manager/openid-connect.md
+++ b/app/gateway/kong-manager/openid-connect.md
@@ -193,6 +193,13 @@ rows:
       If the mapping doesn't work as expected, decode the JWT that's created by your IdP, and make sure that the admin ID token includes the key:value pair 
       `groups:["default:super-admin"]` for the case of this example, or the appropriate claim name and claim value as set in your IdP.
 
+  - param: |
+      `authenticated_groups_delimiter` {% new_in 3.12 %}
+    description: |
+      Specifies the delimiter for splitting group values retrieved from JWT claims. This lets you extract multiple groups from a single claim value.
+      <br><br>
+      The delimiter can be any of the following values: `,`, `;`, `|`.
+
   - param: "`admin_auto_create_rbac_token_disabled`"
     description: |
       This is a boolean value that enables or disables RBAC token creation when automatically creating admins with OpenID Connect. 
@@ -207,6 +214,7 @@ rows:
       <br><br>
       * Set to `true` to enable automatic admin creation
       * Set to `false` to disable automatic admin creation
+
 {% endtable %}
 
 ### Set up authenticated group mapping


### PR DESCRIPTION
## Description

Doc for https://github.com/Kong/kong-ee/pull/14962.
Document `authenticated_groups_delimiter` setting for OIDC auth group mapping in Kong Manager + generate kong.conf for the latest 3.12 version.

This will go out with the upcoming 3.12.0.2 patch.

## Preview Links

