### PR TITLE
feat(gateway): TLS verify support

### DIFF
--- a/app/gateway/ssl-certificates.md
+++ b/app/gateway/ssl-certificates.md
@@ -157,7 +157,13 @@ directives:
 
 ### Enforcing TLS verification globally {% new_in 3.13 %}
 
-You can set [`tls_certificate_verify`](/gateway/configuration/#tls_certificate_verify) to `true` to enforce global certificate verification when connecting to secure endpoints.
-When this setting is enabled, configurations containing Services or plugins where `tls_verify` is set to `off` will fail to be inserted or updated. You will need to manually update each Service or plugin instance to resolve this error.
+You can set [`tls_certificate_verify`](/gateway/configuration/#tls_certificate_verify) to `true` to enforce global certificate verification when connecting to secure endpoints. When this setting is enabled, configurations containing Services or plugins where `tls_verify` is set to `off` will fail to be inserted or updated. You will need to manually update each Service or plugin instance to resolve this error.
 
-If you need finer-grained control, you should not enable this feature and enable TLS certificate verification on a plugin-by-plugin basis. See the TLS verification setting for your [plugin](/plugins/) by choosing a plugin, going to the Configuration Reference tab for that plugin doc, and looking for the `*_verify` option.
+When certificate verification is enforced:
+
+* **Traditional deployments** will fail to start if {{site.base_gateway}} detects insecure configurations. This happens when an upstream is configured to use a secure protocol (such as HTTPS) but certificate verification is disabled.
+* **Hybrid deployments** will fail to push such insecure configurations to Data Planes that start with this option enabled.
+
+This feature is designed primarily for **highly federated environments**, where platform operators need to guarantee that all teams and users deploying configuration through {{site.base_gateway}} adhere to certificate-verification requirements.
+
+Keep in mind that enabling certificate verification does not change how {{site.base_gateway}} validates certificates themselves. If you configure Services or system components (such as Postgres or Redis) with certificates that are invalid or self-signed without an appropriate trusted CA, {{site.base_gateway}} will be unable to establish those connections. This behavior is not new. However, enabling global enforcement may surface misconfigurations that were previously unnoticed.


### PR DESCRIPTION
## Description

Fixes #2618 

No how-to doc here. This is a global version of an option that already exists for many plugins; this settings lets users manage TLS cert verification at a global level, rather than on a case-by-case basis.

To do: add any limitations as needed.

## Preview Links


