### PR TITLE
Feat (Insomnia): Logging out removes sensitive data

### DIFF
--- a/app/insomnia/data-security.md
+++ b/app/insomnia/data-security.md
@@ -38,6 +38,9 @@ faqs:
     a: No. Data sent to AI features is not end-to-end encrypted, and therefore is not covered by this document. Organization administrators can disable specific AI features for all users. Individual users can disable available features in **Preferences > AI Features**. When a feature is disabled at the organization level, its option appears greyed with a tooltip explaining that it has been turned off by an administrator.
   - q: What is a resource group in Insomnia and how are they securely shared?
     a: The ability to share Resource Groups is the reason that every Resource Group needs its own key, and every account needs a public/private key-pair to securely share said key. Here’s an example involving two users, Jane and Bob. For Jane to share a Resource Group with Bob, she must encrypt the Resource Group’s key with Bob’s public key and store it on the server (M_Link). Now, Bob can use his account’s private key to decrypt the Resource Group’s key and gain access to the data. This is a classic example of the Diffie-Hellman key exchange being put to good use.
+  - q: What happens to my sensitive data when I log out of Insomnia?
+    a: |
+      When you log out of Insomnia, the app removes the vault key from your local settings. Without this key, encrypted values from earlier sessions cannot be unlocked. Any files or projects that you saved locally stay on your device until you delete them.  
 ---
 
 Insomnia implements end-to-end encryption (E2EE), which means that all encryption keys are generated locally, all encryption is performed before sending any data over the network, and all decryption is performed after receiving data from the network. At no point in the sync process can the Insomnia servers, or an intruder read or access sensitive application project data.


### PR DESCRIPTION
## Description

> Jobs to be done (optional)
> Detail the exact process that sensitive data goes through when users logout of Insomnia, for e.g.:
> 
> vault key removed from settings...
> Definition of done
> FAQ on [Data Security page](https://developer.konghq.com/insomnia/data-security/)
> Paragraph/doc content depending on amount decided by engineering (plugins / AI features included etc [see Jira discussion]
> Information
> [Jira](https://konghq.atlassian.net/browse/INS-1629)
> Due date (optional)
> 19th Nov 2025
> 
> Size
> S (Small). Example: fixing a broken link, updating wording in an FAQ or paragraph

Fixes #3323 

## Preview Links

https://deploy-preview-3648--kongdeveloper.netlify.app/insomnia/data-security/#what-happens-to-my-sensitive-data-when-i-log-out-of-insomnia

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
