### PR TITLE
Lacks a label for a Secret

### DIFF
--- a/app/_how-tos/operator-konnect-getstarted-authentication.md
+++ b/app/_how-tos/operator-konnect-getstarted-authentication.md
@@ -75,6 +75,7 @@ metadata:
   namespace: kong
   labels:
     konghq.com/credential: konnect
+    konghq.com/secret: true
 stringData:
   token: "'$KONNECT_TOKEN'"' | kubectl apply -f -
 ```


### PR DESCRIPTION
Needs to add "konghq.com/secret: true" for the Secret definition

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
