### PR TITLE
feat(how-tos): add kong_plugins meta tag

### DIFF
--- a/app/_plugins/blocks/entity_examples.rb
+++ b/app/_plugins/blocks/entity_examples.rb
@@ -16,11 +16,16 @@ module Jekyll
       config = config.merge('formats' => @page['tools']) unless config['formats']
 
       unless config['formats']
-        raise ArgumentError, "Missing key `tools` in metadata, or `formats` in entity_examples block on page #{@page['path']}"
+        raise ArgumentError,
+              "Missing key `tools` in metadata, or `formats` in entity_examples block on page #{@page['path']}"
       end
       unless config['formats'] == ['deck']
         raise ArgumentError, "entity_examples only supports deck, on page #{@page['path']}"
       end
+
+      @page['kong_plugins'] ||= []
+      kong_plugins = plugins(config)
+      @page['kong_plugins'].concat(kong_plugins) if kong_plugins.any?
 
       entity_examples_drop = Drops::EntityExamples.new(config:)
 
@@ -32,11 +37,17 @@ module Jekyll
       end
     rescue Psych::SyntaxError => e
       message = <<~STRING
-      On `#{@page['path']}`, the following {% entity_examples %} block contains a malformed yaml:
-      #{contents.strip.split("\n").each_with_index.map { |l, i| "#{i}: #{l}" }.join("\n")}
-      #{e.message}
+        On `#{@page['path']}`, the following {% entity_examples %} block contains a malformed yaml:
+        #{contents.strip.split("\n").each_with_index.map { |l, i| "#{i}: #{l}" }.join("\n")}
+        #{e.message}
       STRING
       raise ArgumentError.new(message)
+    end
+
+    def plugins(config)
+      return [] unless config.dig('entities', 'plugins')
+
+      config['entities']['plugins'].map { |plugin| plugin['name'] }.compact
     end
   end
 end


### PR DESCRIPTION
## Description

Extract the plugins used in the how-to and add a meta tag with them so that we can filter them in Algolia

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
