### PR TITLE
docs(plugins): fix example for redirect plugin with keep_path

### DIFF
--- a/app/_kong_plugins/redirect/examples/redirect-with-incoming-path.yaml
+++ b/app/_kong_plugins/redirect/examples/redirect-with-incoming-path.yaml
@@ -22,7 +22,7 @@ extended_description: |
     - incoming: "`https://example.com/demo?foo=bar`"
       location: "`https://new.example.com/some-path`"
       keep_path: "`true`"
-      new_url: "`https://new.example.com/demo?foo=bar`"
+      new_url: "`https://new.example.com/some-path/demo?foo=bar`"
   {% endtable %}
 
 title: "Keep the incoming request path"


### PR DESCRIPTION
## Description

If I'm not wrong, I think I found a little typo in one example for the `redirect` plugin.

The `keep_path` should append the incoming request’s path and query string at the end of the `location` URL.

## Preview Links

This PR is about doc page https://developer.konghq.com/plugins/redirect/examples/redirect-with-incoming-path/

## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [x] Add new pages to the product documentation index (if applicable).
