### PR TITLE
Fix(operator): Missing custom plugin step

### DIFF
--- a/app/_how-tos/operator-dataplane-custom-plugins.md
+++ b/app/_how-tos/operator-dataplane-custom-plugins.md
@@ -102,7 +102,7 @@ jq: ".data[0].id"
 {% endkonnect_api_request %}
 <!--vale on-->
 
-Upload your schema file to {{site.konnect_short_name}}:
+Run the following command to upload your schema file to your {{site.konnect_short_name}} control plane:
 
 ```sh
 curl -X POST \


### PR DESCRIPTION
## Description

Fixes #3703 

## Preview Links

https://deploy-preview-3756--kongdeveloper.netlify.app/operator/dataplanes/how-to/deploy-custom-plugins/

## Note to reviewers

I didn't fully test the how-to since it requires pushing to a registry, so I just added the missing step and prereqs and tested that

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
