### PR TITLE
Fix(OTEL): document tracing behavior with cached responses

### DIFF
--- a/app/_kong_plugins/opentelemetry/index.md
+++ b/app/_kong_plugins/opentelemetry/index.md
@@ -175,6 +175,11 @@ The top level span has the following attributes:
 
 For more information, see the [Tracing reference](/gateway/tracing/).
 
+{:.info}
+>**Note**: When the OpenTelemetry plugin is used together with the [Proxy Cache Advanced](/plugins/proxy-cache-advanced/) plugin, cache-HIT responses are not traced.
+> This is expected behavior. When a request results in a cache-HIT, the response is served before the request lifecycle reaches the phase where the OpenTelemetry plugin executes. As a result, no spans are generated for cache-HIT requests. Cache-MISS requests continue through the full request lifecycle and are traced normally.
+
+
 ### Gen AI tracing attributes {% new_in 3.13 %}
 
 When processing generative AI traffic through Kong AI Gateway, additional span attributes are emitted following the [OpenTelemetry Gen AI semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/). These attributes capture model parameters, token usage, and tool-call metadata.


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links

https://kongstrong.slack.com/archives/C06B5M262UU/p1765501334151679?thread_ts=1764962581.208579&cid=C06B5M262UU
## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
