### PR TITLE
fix(gateway): Clarify note on hybrid mode support of caching endpoints

### DIFF
--- a/app/_includes/plugins/caching/api.md
+++ b/app/_includes/plugins/caching/api.md
@@ -10,5 +10,5 @@ To access these endpoints, [enable the plugin](./examples/) first.
 The {{include.name}} caching endpoints will appear once the plugin has been enabled.
 
 {:.warning}
-> When using the [`memory` caching strategy](./reference/#schema--config-memory) and running in the Gateway in [hybrid mode](/gateway/hybrid-mode/), this plugin's API endpoints are not available. 
+> When using the [`memory` caching strategy](./reference/#schema--config-memory) and running the Gateway in [hybrid mode](/gateway/hybrid-mode/), this plugin's API endpoints are not available. 
 The data that this API targets is located on the data planes, and data planes can't use the Kong Admin API or {{site.konnect_short_name}} Control Plane API.


### PR DESCRIPTION
## Description

Fixes https://github.com/Kong/developer.konghq.com/issues/2531

Clarifies a warning about using the caching plugins in hybrid mode with the specific strategy.

## Preview Links


