### PR TITLE
Fix(operator): Gateway/GatewayClass wording

### DIFF
--- a/app/kubernetes-ingress-controller/gateway-api.md
+++ b/app/kubernetes-ingress-controller/gateway-api.md
@@ -182,6 +182,6 @@ If an IP address is shown, the `Gateway` is being managed by Kong:
 
 ## Unmanaged Gateways
 
-Using {{ site.kic_product_name }} without [{{ site.operator_product_name }}](/operator/) results in all `Gateway` resources with the same `spec.controllerName` being merged into a single configuration. {{ site.base_gateway }} deployments are created externally to {{ site.kic_product_name }}, which means that we cannot dynamically control the configuration in response to `Gateway` listeners.
+Using {{ site.kic_product_name }} without [{{ site.operator_product_name }}](/operator/) results in all `Gateway` resources associated with `GatewayClass` resources with the same `spec.controllerName` being merged into a single configuration. {{ site.base_gateway }} deployments are created externally to {{ site.kic_product_name }}, which means that we cannot dynamically control the configuration in response to `Gateway` listeners.
 
 When using _unmanaged_ mode, Routes from all `Gateway` instances are merged together and sent to all {{ site.base_gateway }} instances being managed by the single {{ site.kic_product_name }}.

--- a/app/operator/dataplanes/gateway-api.md
+++ b/app/operator/dataplanes/gateway-api.md
@@ -17,6 +17,6 @@ breadcrumbs:
 
 Both {{ site.operator_product_name }} and [{{ site.kic_product_name }}](/kubernetes-ingress-controller/) can be configured using the [Kubernetes Gateway API](https://github.com/kubernetes-sigs/gateway-api). Configure your vendor-independent `GatewayClass` and `Gateway` objects, and {{ site.operator_product_name }} translates those requirements into Kong specific configuration.
 
-When using [managed gateways](/operator/dataplanes/managed-gateways/), {{ site.operator_product_name }} watches for `GatewayClass` resources where the `spec.controllerName` is `konghq.com/gateway-operator`. When a `GatewayClass` resource is detected, {{ site.operator_product_name }} deploys an instance of {{ site.kic_product_name }} to act as a `ControlPlane` and an instance of {{ site.base_gateway }} to act a `DataPlane`.
+When using [managed gateways](/operator/dataplanes/managed-gateways/), {{ site.operator_product_name }} watches for `GatewayClass` resources where the `spec.controllerName` is `konghq.com/gateway-operator`. When a `Gateway` resource is detected, {{ site.operator_product_name }} creates a `ControlPlane` (an in memory instance of {{ site.kic_product_name }}) and a `DataPlane` ({{ site.base_gateway }}).
 
 You can configure traffic routing using Gateway API resources such as `HTTPRoute`, `GRPCRoute`, `TCPRoute` and `UDPRoute`. These resources are translated into Kong configuration objects by {{ site.kic_product_name }} which proxies traffic to your internal services through {{ site.base_gateway }}.


### PR DESCRIPTION
## Description

Fixes #3598 

## Preview Links

- https://deploy-preview-3836--kongdeveloper.netlify.app/kubernetes-ingress-controller/gateway-api/#unmanaged-gateways
- https://deploy-preview-3836--kongdeveloper.netlify.app/operator/dataplanes/gateway-api/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
