### PR TITLE
Feat (Insomnia): Raw template syntax UI option clarified

### DIFF
--- a/app/insomnia/template-tags.md
+++ b/app/insomnia/template-tags.md
@@ -122,12 +122,12 @@ module.exports.templateTags = [{
 
 ### Raw template syntax
 
-Use raw template syntax to control how Insomnia inserts and edits template tags.
+Use **Raw template syntax** to control how Insomnia inserts and edits template tags.
 
-Raw template syntax is disabled by default, which means that Insomnia opens the template tag configuration form. You configure values using structured fields, and then Insomnia generates the template tag syntax automatically.
+It's disabled by default, which means that Insomnia opens the template tag configuration form. You configure values using structured fields, and then Insomnia generates the template tag syntax automatically.
 
 When enabled, Insomnia inserts template tags as plain text expressions instead of opening the configuration form. This means that you must write and edit the template tag syntax manually, and Insomnia won't display field hints, validation, or guided inputs in this mode.
 
-Use raw template syntax when you want direct control over template tag expressions. Leave it disabled if you want guided configuration and inline validation.
+Use **Raw template syntax** when you want direct control over template tag expressions. Leave it disabled if you want guided configuration and inline validation.
 
 To enable **Raw template syntax**, from inside the Insomnia application, go to **Preferences > General > Application > Raw template syntax**.


### PR DESCRIPTION
## Description

Definition of done
Add information about the Raw template syntax option, maybe in an FAQ in the template tags docs.
It should be off by default but if it's enabled users won't be able to configure template tags with the form, they'll have to write it directly. In that case they won't get hints about what each value should be, so we may need reference docs about template tags arguments. TBD, not in the scope of this ticket.

Information
https://kongstrong.slack.com/archives/C044UFN49RT/p1756981092215769

Size
S

Fixes #2769 

## Preview Links

https://deploy-preview-3837--kongdeveloper.netlify.app/insomnia/template-tags/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
