### PR TITLE
Fix (Analytics): Fix custom dashboard description

### DIFF
--- a/app/advanced-analytics/custom-dashboards-reference.md
+++ b/app/advanced-analytics/custom-dashboards-reference.md
@@ -132,9 +132,10 @@ rows:
     dashboard_viewer: ❌
 {% endtable %}
 <!--vale on -->
-Dashboard permissions only control access to the dashboard object. Access to the underlying data sources (such as a control plane) is enforced separately.
+Dashboard permissions control access to the dashboard object only. They don't grant access to the underlying data. Data visibility is enforced separately and must be explicitly scoped by the dashboard creator, for example by using preset filters to limit which control planes or data sets a user can see.
+
 {:.info}
-> A user may be able to open a dashboard but see empty or partial results if they lack permissions for one or more of its data sources.
+> A user may be able to open a dashboard but see empty or partial results if the dashboard is not scoped to data that they have permission to view.
 
 ### Roles
 


### PR DESCRIPTION
## Description

> Definition of done
> Adjust the "Dashboard permissions only control access to the dashboard object. Access to the underlying data sources (such as a control plane) is enforced separately." description [on this page](https://developer.konghq.com/advanced-analytics/custom-dashboards-reference/#permissions) with this feedback: "Maybe we can elaborate here a bit on "Access to the underlying data sources ..." to improve the AI response. Basically, dashboard permissions (viewer role today) only control access to the dashboard object; underlying data access still needs to be configured by who ever creates the dashboards using preset filters. Like if you want a user who only has access to Control Plane A, you need to add a preset filter for Control Plane A. Otherwise, without the filter, a user may be able to open a dashboard but see empty or partial results if they lack permissions. I'd also remove sources "data sources" and just keep "data" around."
> Information
> DRP: Christian H.
> 
> Size
> Small

Fixes #3089 

## Preview Links

https://deploy-preview-3839--kongdeveloper.netlify.app/advanced-analytics/custom-dashboards-reference/#permissions


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
