### PR TITLE
Feat (Insomnia): External Vault/ Allow empty credential configs to work with different cloud providers

### DIFF
--- a/app/insomnia/external-vault.md
+++ b/app/insomnia/external-vault.md
@@ -30,7 +30,7 @@ faqs:
     a: | 
       When you sign out of Insomnia, you can choose to clear all of your stored cloud credentials. This removes any saved credentials used by External Vault providers from your local Insomnia configuration.
 
-      Clearing cloud credentials doesn't break External Vault integrations. Insomnia supports External
+      Clearing cloud credentials doesn't break External Vault integrations. Insomnia supports External Vault providers even when credential fields are empty. This allows you to sign out securely without losing your vault setup.
 
       After signing back in, you might need to re-authenticate or provide credentials again, depending on how the cloud provider handles authentication.
   - q: Do empty credential configurations work across all External Vault cloud providers?


### PR DESCRIPTION
## Description

> Jobs to be done (optional)
> Explain that with the newly adding features of clear cloud credentials when user logs out, we need to make sure empty credentials configs should be work with all type of cloud providers.
> 
> Definition of done
> FAQ explaining: empty credentials still work with all type of cloud providers
> on: https://developer.konghq.com/insomnia/external-vault/
> 
> Information
> [Jira](https://konghq.atlassian.net/browse/INS-1646)
> 
> Due date (optional)
> 14 Jan 2025
> 
> Size
> S (Small). Example: fixing a broken link, updating wording in an FAQ or paragraph
> 
> Fixes #3325 

## Preview Links

https://deploy-preview-3840--kongdeveloper.netlify.app/insomnia/external-vault/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
