### PR TITLE
Add helm instructions

### DIFF
--- a/app/mesh/multi-zone-authentication.md
+++ b/app/mesh/multi-zone-authentication.md
@@ -78,7 +78,7 @@ kuma:
         Key: "token"
 ```
 
-And install the zone control plane:
+Install the zone control plane:
 
 ```sh
 helm --create-namespace --namespace kong-mesh-system kong-mesh kong-mesh/kong-mesh -f Values.yaml 


### PR DESCRIPTION
## Description

Fixes missing helm instructions for the Multi-zone auth instructions 

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
