### PR TITLE
Fix insomnia update placeholder faq for SCIM tokens 3858

### DIFF
--- a/.github/styles/base/Dictionary.txt
+++ b/.github/styles/base/Dictionary.txt
@@ -749,6 +749,8 @@ SCCs
 SCCs
 schema's
 Scriptable
+scim 
+SCIM
 SDKs
 search_by_username
 secret_id

--- a/app/insomnia/scim.md
+++ b/app/insomnia/scim.md
@@ -20,9 +20,11 @@ related_resources:
   - text: Enterprise account management
     url: /insomnia/enterprise-account-management/
 faqs:
-  - q: How long are SCIM connector tokens valid?
+  - q: Do SCIM tokens expire?
     a: |
-      SCIM connector tokens in Insomnia are valid for **90 days**. After 90 days, generate a new token and update it in your Identity Provider to keep synchronization active. 
+      Yes. SCIM tokens can expire. However, Insomnia automatically attempts to refresh the token every 90 days. If the automatic refresh fails, Insomnia warns the account owner and co-owners by email starting 20 days before the token expires. They also see warnings on the [SCIM](https://app.insomnia.rest/app/enterprise/scim) view. 
+      
+      To fix an automatic token refresh failure, go to [SCIM](https://app.insomnia.rest/app/enterprise/scim), and click **Refresh Token**. Then, in the **Passphrase** field, enter your passphrase, and click **Refresh Token** again. This manually refreshes your SCIM connector token.
 ---
 
 System for Cross-domain Identity Management (SCIM) allows Insomnia to provision Enterprise member accounts and teams using an Identity Provider configured for [Single Sign-On](/insomnia/sso/). 

--- a/app/insomnia/scim.md
+++ b/app/insomnia/scim.md
@@ -22,9 +22,7 @@ related_resources:
 faqs:
   - q: Do SCIM tokens expire?
     a: |
-      Yes. SCIM tokens can expire. However, Insomnia automatically attempts to refresh the token every 90 days. If the automatic refresh fails, Insomnia warns the account owner and co-owners by email starting 20 days before the token expires. They also see warnings on the [SCIM](https://app.insomnia.rest/app/enterprise/scim) view. 
-      
-      To fix an automatic token refresh failure, go to [SCIM](https://app.insomnia.rest/app/enterprise/scim), and click **Refresh Token**. Then, in the **Passphrase** field, enter your passphrase, and click **Refresh Token** again. This manually refreshes your SCIM connector token.
+      Yes. SCIM tokens can expire. However, Insomnia automatically attempts to refresh the token every 90 days. If the automatic refresh fails, Insomnia warns the account owner and co-owners by email starting 20 days before the token expires. They also see warnings on the [SCIM](https://app.insomnia.rest/app/enterprise/scim) view.
 ---
 
 System for Cross-domain Identity Management (SCIM) allows Insomnia to provision Enterprise member accounts and teams using an Identity Provider configured for [Single Sign-On](/insomnia/sso/). 

--- a/app/insomnia/scim.md
+++ b/app/insomnia/scim.md
@@ -22,7 +22,7 @@ related_resources:
 faqs:
   - q: Do SCIM tokens expire?
     a: |
-      Yes. SCIM tokens can expire. However, Insomnia automatically attempts to refresh the token every 90 days. If the automatic refresh fails, Insomnia warns the account owner and co-owners by email starting 20 days before the token expires. They also see warnings on the [SCIM](https://app.insomnia.rest/app/enterprise/scim) view.
+      Yes. SCIM tokens can expire. However, Insomnia automatically attempts to refresh the token every 90 days. If the automatic refresh fails, Insomnia warns the account owner and co-owners by email and on the SCIM view starting 20 days before the token expires. If it fails, on the [SCIM](https://app.insomnia.rest/app/enterprise/scim) view, manually refresh the token.
 ---
 
 System for Cross-domain Identity Management (SCIM) allows Insomnia to provision Enterprise member accounts and teams using an Identity Provider configured for [Single Sign-On](/insomnia/sso/). 


### PR DESCRIPTION
## Description

Request from PM - replace [this FAQ](https://developer.konghq.com/insomnia/scim/#how-long-are-scim-connector-tokens-valid) with:

> Do SCIM tokens expire?
As of January 2026, Insomnia attempts to automatically refresh your SCIM token every 90 days. If this is unsuccessful, the account owner and co-owners will see warnings and receive email notifications 20 days before the token expires, and you will need to manually refresh the token.

After 12.3 release, **this branch** will be replaced with the following branch and it's contents: https://github.com/Kong/developer.konghq.com/pull/3858
This replacement FAQ will be expanded to explicitly state where on the SCIM view to manually refresh tokens (SCIM view uplift tied to 12.3 release)

Fixes NA

## Preview Links

https://deploy-preview-3869--kongdeveloper.netlify.app/insomnia/scim/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
