### PR TITLE
fix(ai-gateway): syntax wrong for Bedrock Files explanation

### DIFF
--- a/app/_data/plugins/ai-proxy.yaml
+++ b/app/_data/plugins/ai-proxy.yaml
@@ -47,7 +47,7 @@ providers:
       model_example: 'n/a'
       min_version: ''
       note:
-        content: 'Bedrock does not have a dedicated Files API. File storage uses Google Cloud Storage, similar to AWS S3.'
+        content: 'Bedrock does not have a dedicated Files API. File storage uses AWS S3, similar to Google Cloud Storage for Gemini.'
     image:
       generations:
         supported: true


### PR DESCRIPTION
## Description

Syntax is wrong for Bedrock Files explanation - mixed up provider SaaS names.

## Preview Links


