### PR TITLE
Fix json_schema tag in mesh docs

### DIFF
--- a/app/_plugins/tags/kuma-specific/json_schema.rb
+++ b/app/_plugins/tags/kuma-specific/json_schema.rb
@@ -16,6 +16,10 @@ module Jekyll
 
       def render(context)
         page = context.environments.first['page']
+
+        # Mark this page as having a plugin schema to load the relevant JS
+        page['plugin_schema'] = true
+
         release = page['release']
         schema_file = Drops::MeshPolicies::SchemaFile.new(release:, type: @params['type'], name: @name)
 


### PR DESCRIPTION
## Description

The {% json_schema %} tag relies on a js file to render the schema on the page, that js is loaded only if the page or its layout `plugin_schema = true` in its frontmattter.

Fix the issue by setting `plugin_schema = true` to the page if the `json_schema` tag is present

Fixes https://github.com/Kong/developer.konghq.com/issues/3891

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
