### PR TITLE
fix(data-deployment-topology): Fix an issue when there's only one option

### DIFF
--- a/app/_assets/javascripts/components/switch.js
+++ b/app/_assets/javascripts/components/switch.js
@@ -48,7 +48,7 @@ export default class ToggleSwitchManager {
     });
 
     this.topologySwitcherOption = document.querySelector(
-      "[data-topology-switcher]"
+      "[data-topology-switcher]",
     );
 
     this.addEventListeners();
@@ -59,24 +59,34 @@ export default class ToggleSwitchManager {
     if (this.switches.length > 0) {
       this.setType();
       this.setInitialValue();
+    } else {
+      const value = document.querySelector("[data-works-on]")?.dataset.worksOn;
+      this.setInitialValue(value);
     }
   }
 
-  setInitialValue() {
-    if (this.getStoredValue()) {
-      this.initialValue = this.getStoredValue();
-    }
-    if (this.getParamValue()) {
-      this.initialValue = this.getParamValue();
-    }
-    if (this.getURLValue()) {
-      this.initialValue = this.getURLValue();
+  setInitialValue(value) {
+    if (value !== undefined) {
+      this.initialValue = value;
+    } else {
+      if (this.getStoredValue()) {
+        this.initialValue = this.getStoredValue();
+      }
+      if (this.getParamValue()) {
+        this.initialValue = this.getParamValue();
+      }
+      if (this.getURLValue()) {
+        this.initialValue = this.getURLValue();
+      }
     }
 
     const initialEvent = new CustomEvent("switch-state-change", {
       detail: { selectedValue: this.initialValue },
     });
-    document.dispatchEvent(initialEvent);
+
+    if (this.initialValue !== undefined) {
+      document.dispatchEvent(initialEvent);
+    }
   }
 
   setType() {
@@ -152,6 +162,7 @@ export default class ToggleSwitchManager {
         // Don't reload the page
         window.history.pushState({}, "", url);
       }
+
       this.switches.forEach((instance) => {
         instance.updateState(selectedValue);
       });

--- a/app/_includes/info_box/sections/controls.html
+++ b/app/_includes/info_box/sections/controls.html
@@ -8,5 +8,7 @@
     {% include how-tos/controls.html works_on=page.works_on mobile=include.mobile  %}
   </div>
 </div>
+{% else %}
+<div class="hidden" data-works-on="{{page.works_on}}"></div>
 {% endif %}
 {% endif %}


### PR DESCRIPTION
## Description

Fix an issue when there's only one option available.

The switch isn't rendered in that case so the js wasn't running causing some pages to have both on-prem and konnect options rendered at the same time.

This fixes the issue by handling the edge case gracefully. This is done by specifying in the html the available option at build time.

Fixes #3861 

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
