### PR TITLE
Feat(GW): Adding /api to the dns links to ensure that the API calls work with PrivateLink

### DIFF
--- a/app/gateway/aws-private-link.md
+++ b/app/gateway/aws-private-link.md
@@ -109,25 +109,25 @@ columns:
 rows:
   - geo: AU
     service: com.amazonaws.vpce.us-east-1.vpce-svc-03eda50387fcc5e06
-    dns: ap.svc.konghq.com
+    dns: ap.svc.konghq.com/api
   - geo: EU
     service: com.amazonaws.vpce.us-east-1.vpce-svc-074b83bf704d87ba7
-    dns: eu.svc.konghq.com
+    dns: eu.svc.konghq.com/api
   - geo: GLOBAL
     service: com.amazonaws.vpce.us-east-1.vpce-svc-032c06bdabfc6005c
-    dns: global.svc.konghq.com
+    dns: global.svc.konghq.com/api
   - geo: IN
     service: com.amazonaws.vpce.us-east-1.vpce-svc-0785a7867f5cbed8b
-    dns: in.svc.konghq.com
+    dns: in.svc.konghq.com/api
   - geo: ME
     service: com.amazonaws.vpce.us-east-1.vpce-svc-09e6e8ec26383e748
-    dns: me.svc.konghq.com
+    dns: me.svc.konghq.com/api
   - geo: SG
     service: com.amazonaws.vpce.us-east-1.vpce-svc-0925688dce5416901
-    dns: sg.svc.konghq.com
+    dns: sg.svc.konghq.com/api
   - geo: US
     service: com.amazonaws.vpce.us-east-1.vpce-svc-0a701662e3ebe10b8
-    dns: us.svc.konghq.com
+    dns: us.svc.konghq.com/api
 {% endtable %}
 {% endnavtab %}
 
@@ -143,25 +143,25 @@ columns:
 rows:
   - geo: AU
     service: com.amazonaws.vpce.us-east-2.vpce-svc-03da89378358921bc
-    dns: ap.svc.konghq.com
+    dns: ap.svc.konghq.com/api
   - geo: EU
     service: com.amazonaws.vpce.us-east-2.vpce-svc-0cb28c923823735ac
-    dns: eu.svc.konghq.com
+    dns: eu.svc.konghq.com/api
   - geo: GLOBAL
     service: com.amazonaws.vpce.us-east-2.vpce-svc-0b6f58f5e17620d89
-    dns: global.svc.konghq.com
+    dns: global.svc.konghq.com/api
   - geo: IN
     service: com.amazonaws.vpce.us-east-2.vpce-svc-0b439785c0b06bb97
-    dns: in.svc.konghq.com
+    dns: in.svc.konghq.com/api
   - geo: ME
     service: com.amazonaws.vpce.us-east-2.vpce-svc-0f1c86fb6399d4fe5
-    dns: me.svc.konghq.com
+    dns: me.svc.konghq.com/api
   - geo: SG
     service: com.amazonaws.vpce.us-east-2.vpce-svc-05e1f7aec7fe36e70
-    dns: sg.svc.konghq.com
+    dns: sg.svc.konghq.com/api
   - geo: US
     service: com.amazonaws.vpce.us-east-2.vpce-svc-096fe7ba54ebc32db
-    dns: us.svc.konghq.com
+    dns: us.svc.konghq.com/api
 {% endtable %}
 {% endnavtab %}
 
@@ -177,25 +177,25 @@ columns:
 rows:
   - geo: AU
     service: com.amazonaws.vpce.us-west-2.vpce-svc-078156c9cc9048988
-    dns: ap.svc.konghq.com
+    dns: ap.svc.konghq.com/api
   - geo: EU
     service: com.amazonaws.vpce.us-west-2.vpce-svc-0e03b7c33104a4a4f
-    dns: eu.svc.konghq.com
+    dns: eu.svc.konghq.com/api
   - geo: GLOBAL
     service: com.amazonaws.vpce.us-west-2.vpce-svc-053325dfb74719cb9
-    dns: global.svc.konghq.com
+    dns: global.svc.konghq.com/api
   - geo: IN
     service: com.amazonaws.vpce.us-west-2.vpce-svc-0865c535fc28a3060
-    dns: in.svc.konghq.com
+    dns: in.svc.konghq.com/api
   - geo: ME
     service: com.amazonaws.vpce.us-west-2.vpce-svc-0fce4d5504650e9a3
-    dns: me.svc.konghq.com
+    dns: me.svc.konghq.com/api
   - geo: SG
     service: com.amazonaws.vpce.us-west-2.vpce-svc-03d71f4a064877f2e
-    dns: sg.svc.konghq.com
+    dns: sg.svc.konghq.com/api
   - geo: US
     service: com.amazonaws.vpce.us-west-2.vpce-svc-0d2994122fea007ca
-    dns: us.svc.konghq.com
+    dns: us.svc.konghq.com/api
 {% endtable %}
 {% endnavtab %}
 
@@ -211,25 +211,25 @@ columns:
 rows:
   - geo: AU
     service: com.amazonaws.vpce.eu-central-1.vpce-svc-0c3f0574080bdd859
-    dns: ap.svc.konghq.com
+    dns: ap.svc.konghq.com/api
   - geo: EU
     service: com.amazonaws.vpce.eu-central-1.vpce-svc-05e6822fbce58e1a0
-    dns: eu.svc.konghq.com
+    dns: eu.svc.konghq.com/api
   - geo: GLOBAL
     service: com.amazonaws.vpce.eu-central-1.vpce-svc-050c17c4f2970705f
-    dns: global.svc.konghq.com
+    dns: global.svc.konghq.com/api
   - geo: IN
     service: com.amazonaws.vpce.eu-central-1.vpce-svc-0a5c165336502e526
-    dns: in.svc.konghq.com
+    dns: in.svc.konghq.com/api
   - geo: ME
     service: com.amazonaws.vpce.eu-central-1.vpce-svc-0e6497e6df9928a80
-    dns: me.svc.konghq.com
+    dns: me.svc.konghq.com/api
   - geo: SG
     service: com.amazonaws.vpce.eu-central-1.vpce-svc-0c43e67226a4aa910
-    dns: sg.svc.konghq.com
+    dns: sg.svc.konghq.com/api
   - geo: US
     service: com.amazonaws.vpce.eu-central-1.vpce-svc-01d3dd232e277feeb
-    dns: us.svc.konghq.com
+    dns: us.svc.konghq.com/api
 {% endtable %}
 {% endnavtab %}
 
@@ -245,25 +245,25 @@ columns:
 rows:
   - geo: AU
     service: com.amazonaws.vpce.eu-west-1.vpce-svc-08edf59f8bc1d2262
-    dns: ap.svc.konghq.com
+    dns: ap.svc.konghq.com/api
   - geo: EU
     service: com.amazonaws.vpce.eu-west-1.vpce-svc-037bd988d9a9d4e3a
-    dns: eu.svc.konghq.com
+    dns: eu.svc.konghq.com/api
   - geo: GLOBAL
     service: com.amazonaws.vpce.eu-west-1.vpce-svc-0852df4643d76b28e
-    dns: global.svc.konghq.com
+    dns: global.svc.konghq.com/api
   - geo: IN
     service: com.amazonaws.vpce.eu-west-1.vpce-svc-029c2f6bedf7c346f
-    dns: in.svc.konghq.com
+    dns: in.svc.konghq.com/api
   - geo: ME
     service: com.amazonaws.vpce.eu-west-1.vpce-svc-0978fbaf50bfc67d9
-    dns: me.svc.konghq.com
+    dns: me.svc.konghq.com/api
   - geo: SG
     service: com.amazonaws.vpce.eu-west-1.vpce-svc-02451d65748600af6
-    dns: sg.svc.konghq.com
+    dns: sg.svc.konghq.com/api
   - geo: US
     service: com.amazonaws.vpce.eu-west-1.vpce-svc-01070d7c2137e0ee1
-    dns: us.svc.konghq.com
+    dns: us.svc.konghq.com/api
 {% endtable %}
 {% endnavtab %}
 
@@ -279,25 +279,25 @@ columns:
 rows:
   - geo: AU
     service: com.amazonaws.vpce.eu-west-2.vpce-svc-0500cb14757738225
-    dns: ap.svc.konghq.com
+    dns: ap.svc.konghq.com/api
   - geo: EU
     service: com.amazonaws.vpce.eu-west-2.vpce-svc-0b2d5879e15254e35
-    dns: eu.svc.konghq.com
+    dns: eu.svc.konghq.com/api
   - geo: GLOBAL
     service: com.amazonaws.vpce.eu-west-2.vpce-svc-06dfcb0204806e836
-    dns: global.svc.konghq.com
+    dns: global.svc.konghq.com/api
   - geo: IN
     service: com.amazonaws.vpce.eu-west-2.vpce-svc-08e51a56a0ee549c6
-    dns: in.svc.konghq.com
+    dns: in.svc.konghq.com/api
   - geo: ME
     service: com.amazonaws.vpce.eu-west-2.vpce-svc-0ab99eeae8121c7d8
-    dns: me.svc.konghq.com
+    dns: me.svc.konghq.com/api
   - geo: SG
     service: com.amazonaws.vpce.eu-west-2.vpce-svc-0646cf4c72df9e4fc
-    dns: sg.svc.konghq.com
+    dns: sg.svc.konghq.com/api
   - geo: US
     service: com.amazonaws.vpce.eu-west-2.vpce-svc-0c23345bb2ef7b298
-    dns: us.svc.konghq.com
+    dns: us.svc.konghq.com/api
 {% endtable %}
 {% endnavtab %}
 
@@ -313,25 +313,25 @@ columns:
 rows:
   - geo: AU
     service: com.amazonaws.vpce.ap-east-1.vpce-svc-0c7b67a477740b8cb
-    dns: ap.svc.konghq.com
+    dns: ap.svc.konghq.com/api
   - geo: EU
     service: com.amazonaws.vpce.ap-east-1.vpce-svc-0ca74e27b8d0a5c3c
-    dns: eu.svc.konghq.com
+    dns: eu.svc.konghq.com/api
   - geo: GLOBAL
     service: com.amazonaws.vpce.ap-east-1.vpce-svc-09dcb6580ddeff0ae
-    dns: global.svc.konghq.com
+    dns: global.svc.konghq.com/api
   - geo: IN
     service: com.amazonaws.vpce.ap-east-1.vpce-svc-0731d524d482bfb04
-    dns: in.svc.konghq.com
+    dns: in.svc.konghq.com/api
   - geo: ME
     service: com.amazonaws.vpce.ap-east-1.vpce-svc-09ca173aa8de2dd02
-    dns: me.svc.konghq.com
+    dns: me.svc.konghq.com/api
   - geo: SG
     service: com.amazonaws.vpce.ap-east-1.vpce-svc-0b4d34906c77a8e29
-    dns: sg.svc.konghq.com
+    dns: sg.svc.konghq.com/api
   - geo: US
     service: com.amazonaws.vpce.ap-east-1.vpce-svc-02c00c62584350b46
-    dns: us.svc.konghq.com
+    dns: us.svc.konghq.com/api
 {% endtable %}
 {% endnavtab %}
 
@@ -347,25 +347,25 @@ columns:
 rows:
   - geo: AU
     service: com.amazonaws.vpce.ap-southeast-1.vpce-svc-08f76d27d29b02a09
-    dns: ap.svc.konghq.com
+    dns: ap.svc.konghq.com/api
   - geo: EU
     service: com.amazonaws.vpce.ap-southeast-1.vpce-svc-0a04604ecaed18457
-    dns: eu.svc.konghq.com
+    dns: eu.svc.konghq.com/api
   - geo: GLOBAL
     service: com.amazonaws.vpce.ap-southeast-1.vpce-svc-0b1da0ec96942fdb0
-    dns: global.svc.konghq.com
+    dns: global.svc.konghq.com/api
   - geo: IN
     service: com.amazonaws.vpce.ap-southeast-1.vpce-svc-0c6699c89ac27323c
-    dns: in.svc.konghq.com
+    dns: in.svc.konghq.com/api
   - geo: ME
     service: com.amazonaws.vpce.ap-southeast-1.vpce-svc-00689717c9085d08a
-    dns: me.svc.konghq.com
+    dns: me.svc.konghq.com/api
   - geo: SG
     service: com.amazonaws.vpce.ap-southeast-1.vpce-svc-06ec4681cc9fde9c9
-    dns: sg.svc.konghq.com
+    dns: sg.svc.konghq.com/api
   - geo: US
     service: com.amazonaws.vpce.ap-southeast-1.vpce-svc-0eeaa22ed2d6268eb
-    dns: us.svc.konghq.com
+    dns: us.svc.konghq.com/api
 {% endtable %}
 {% endnavtab %}
 
@@ -381,25 +381,25 @@ columns:
 rows:
   - geo: AU
     service: com.amazonaws.vpce.ap-southeast-2.vpce-svc-055ba6ff5a3f551c9
-    dns: ap.svc.konghq.com
+    dns: ap.svc.konghq.com/api
   - geo: EU
     service: com.amazonaws.vpce.ap-southeast-2.vpce-svc-02a339e8dc8ec72c6
-    dns: eu.svc.konghq.com
+    dns: eu.svc.konghq.com/api
   - geo: GLOBAL
     service: com.amazonaws.vpce.ap-southeast-2.vpce-svc-0dddc28f5f8b68cbc
-    dns: global.svc.konghq.com
+    dns: global.svc.konghq.com/api
   - geo: IN
     service: com.amazonaws.vpce.ap-southeast-2.vpce-svc-050ea149424be6d3c
-    dns: in.svc.konghq.com
+    dns: in.svc.konghq.com/api
   - geo: ME
     service: com.amazonaws.vpce.ap-southeast-2.vpce-svc-008f231c7501e72c2
-    dns: me.svc.konghq.com
+    dns: me.svc.konghq.com/api
   - geo: SG
     service: com.amazonaws.vpce.ap-southeast-2.vpce-svc-0619b7120e5eb737b
-    dns: sg.svc.konghq.com
+    dns: sg.svc.konghq.com/api
   - geo: US
     service: com.amazonaws.vpce.ap-southeast-2.vpce-svc-0600dd84f39e7b12a
-    dns: us.svc.konghq.com
+    dns: us.svc.konghq.com/api
 {% endtable %}
 {% endnavtab %}
 
@@ -415,25 +415,25 @@ columns:
 rows:
   - geo: AU
     service: com.amazonaws.vpce.ap-northeast-1.vpce-svc-05a555912c88c3403
-    dns: ap.svc.konghq.com
+    dns: ap.svc.konghq.com/api
   - geo: EU
     service: com.amazonaws.vpce.ap-northeast-1.vpce-svc-01c086f3cb2a8e3b1
-    dns: eu.svc.konghq.com
+    dns: eu.svc.konghq.com/api
   - geo: GLOBAL
     service: com.amazonaws.vpce.ap-northeast-1.vpce-svc-0a5ef5e9cd65b180a
-    dns: global.svc.konghq.com
+    dns: global.svc.konghq.com/api
   - geo: IN
     service: com.amazonaws.vpce.ap-northeast-1.vpce-svc-0f1fed745c08bb4c2
-    dns: in.svc.konghq.com
+    dns: in.svc.konghq.com/api
   - geo: ME
     service: com.amazonaws.vpce.ap-northeast-1.vpce-svc-012f363a353acc0af
-    dns: me.svc.konghq.com
+    dns: me.svc.konghq.com/api
   - geo: SG
     service: com.amazonaws.vpce.ap-northeast-1.vpce-svc-08b4f9a82fe4dd518
-    dns: sg.svc.konghq.com
+    dns: sg.svc.konghq.com/api
   - geo: US
     service: com.amazonaws.vpce.ap-northeast-1.vpce-svc-087f56ff74f855a49
-    dns: us.svc.konghq.com
+    dns: us.svc.konghq.com/api
 {% endtable %}
 {% endnavtab %}
 
@@ -483,25 +483,25 @@ columns:
 rows:
   - geo: AU
     service: com.amazonaws.vpce.ap-northeast-3.vpce-svc-0774c82210d1e3a54
-    dns: ap.svc.konghq.com
+    dns: ap.svc.konghq.com/api
   - geo: EU
     service: com.amazonaws.vpce.ap-northeast-3.vpce-svc-016e2797bf4af4129
-    dns: eu.svc.konghq.com
+    dns: eu.svc.konghq.com/api
   - geo: GLOBAL
     service: com.amazonaws.vpce.ap-northeast-3.vpce-svc-07a3a4d6927b28ca8
-    dns: global.svc.konghq.com
+    dns: global.svc.konghq.com/api
   - geo: IN
     service: com.amazonaws.vpce.ap-northeast-3.vpce-svc-0e7bbd9cd5c64cab4
-    dns: in.svc.konghq.com
+    dns: in.svc.konghq.com/api
   - geo: ME
     service: com.amazonaws.vpce.ap-northeast-3.vpce-svc-0dea199a0496ca206
-    dns: me.svc.konghq.com
+    dns: me.svc.konghq.com/api
   - geo: SG
     service: com.amazonaws.vpce.ap-northeast-3.vpce-svc-0c107ea8a747b0572
-    dns: sg.svc.konghq.com
+    dns: sg.svc.konghq.com/api
   - geo: US
     service: com.amazonaws.vpce.ap-northeast-3.vpce-svc-07eed5d5d58364be2
-    dns: us.svc.konghq.com
+    dns: us.svc.konghq.com/api
 {% endtable %}
 {% endnavtab %}
 


### PR DESCRIPTION
Adding /api to the dns links to ensure that the API calls work with PrivateLink

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
