### PR TITLE
Feat (Insomnia) Explain maximum number of lines for 3 way merge

### DIFF
--- a/app/insomnia/three-way-merge.md
+++ b/app/insomnia/three-way-merge.md
@@ -31,7 +31,7 @@ faqs:
   - q: Can I create a Git-sync project now and connect the repository later?
     a: Yes. You can create a Git-sync project and add the repository later (supported in recent versions). See Storage options → Git sync.
   - q: Does 3-way merge work for collections and design documents?
-    a: Yes. 3-way merge applies to the same project resources that Git sync manages—collections, design documents, tests, and environments—so you can resolve conflicts on the content you version in Git. See the Insomnia docs index and storage overview.
+    a: Yes. 3-way merge applies to the same project resources that Git sync manages—collections, design documents, tests, and environments—so you can resolve conflicts on the content you version in Git. See the [Insomnia docs index](/index/insomnia/) and [storage overview](/insomnia/storage/).
   - q: Why does Insomnia sometimes fall back to the “choose local or remote file” conflict resolution instead of 3-way merge?
     a: |
       Insomnia uses 3-way merge to resolve Git conflicts when files are at least 20,000 lines. To protect performance and prevent errors with very large files, Insomnia applies a safety limit.


### PR DESCRIPTION
## Description

> Jobs to be done (optional)
> Create an FAQ that explains that there is a maximum number of lines [tbd] before insomnia reverts to the prior “pick the entire local file or entire remote file” approach.
> 
> Definition of done
> Include FAQ to https://developer.konghq.com/insomnia/three-way-merge/ explaining the maximum number allowed
> 
> Information
> Due date (optional)
> [Jira](https://konghq.atlassian.net/browse/INS-1643)
> 
> Size
> S (Small). Example: fixing a broken link, updating wording in an FAQ or paragraph
> 

Fixes #3573 

## Preview Links

https://deploy-preview-3989--kongdeveloper.netlify.app/insomnia/three-way-merge/#why-does-insomnia-sometimes-fall-back-to-the-choose-local-or-remote-file-conflict-resolution-instead-of-3-way-merge



## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
