### PR TITLE
fix(konnect-platform): Max duration of konnect SPAT

### DIFF
--- a/app/_landing_pages/konnect-api.yaml
+++ b/app/_landing_pages/konnect-api.yaml
@@ -130,7 +130,7 @@ rows:
             * System accounts are not associated with an email address, so they aren't attached to any person's identity.
             * When you use a user account as part of an automation or integration and that user leaves the company, automation and integrations break. 
             If you use a system account instead, the automation and integrations wouldn't break.
-            * A system account access token (SPAT) has a maximum duration of 24 months.
+            * A system account access token (SPAT) has a maximum duration of 12 months.
 
             An access token created by a system account inherits the roles assigned to the system account, 
             and can be assigned roles directly or inherit the roles of a [team](/konnect-platform/teams-and-roles/).


### PR DESCRIPTION
## Description

Question came up on Kapa. We currently document the max duration of the PAT, but not the SPAT. From testing in Konnect, I can create a token that lasts max one year from the current date.

<img width="589" height="693" alt="Screenshot 2026-01-23 at 11 51 31 AM" src="https://github.com/user-attachments/assets/1b4b3ed0-13e5-4095-b7c7-dd63d7ebae55" />


## Preview Links


