### PR TITLE
fix: updating the description for /users/userId for each verb

### DIFF
--- a/api-specs/konnect/identity/v3/openapi.yaml
+++ b/api-specs/konnect/identity/v3/openapi.yaml
@@ -657,18 +657,18 @@ paths:
       tags:
         - Users
   '/users/{userId}':
-    parameters:
-      - name: userId
-        in: path
-        description: The ID of the user being deleted.
-        required: true
-        schema:
-          type: string
-          format: uuid
-          example: d32d905a-ed33-46a3-a093-d8f536af9a8a
     get:
       operationId: get-user
       summary: Get a User
+      parameters:
+        - name: userId
+          in: path
+          description: The ID of the user being retrived.
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: d32d905a-ed33-46a3-a093-d8f536af9a8a
       description: Returns the user object for the user ID specified as a path parameter.
       responses:
         '200':
@@ -682,6 +682,15 @@ paths:
     patch:
       operationId: update-user
       summary: Update User
+      parameters:
+        - name: userId
+          in: path
+          description: The ID of the user being updated.
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: d32d905a-ed33-46a3-a093-d8f536af9a8a
       description: Update an individual user.
       requestBody:
         $ref: '#/components/requestBodies/UpdateUser'
@@ -699,6 +708,15 @@ paths:
     delete:
       operationId: delete-user
       summary: Delete User
+      parameters:
+        - name: userId
+          in: path
+          description: The ID of the user being deleted.
+          required: true
+          schema:
+            type: string
+            format: uuid
+            example: d32d905a-ed33-46a3-a093-d8f536af9a8a
       description: Deletes an individual user. Returns 404 if the requested user was not found.
       responses:
         '204':


### PR DESCRIPTION
## Description
Updated the description for the path parameter userId of route /users/{userId} to relefect the real use of the parameter.

## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [x] Add new pages to the product documentation index (if applicable).
