### PR TITLE
Feat (Deck) Add in --json-output flag

### DIFF
--- a/app/_includes/deck/help/gateway/diff.md
+++ b/app/_includes/deck/help/gateway/diff.md
@@ -7,7 +7,7 @@ Flags:
                                               This allows policy overrides to work with Kong GW versions >= 3.4
                                               Warning: do not mix with consumer-group scoped plugins
   -h, --help                                  help for diff
-      --json-output                           generate command execution report in a JSON format
+      --json-output                           Generate a JSON change report that includes a change summary and details for each entity       
       --no-mask-deck-env-vars-value           do not mask DECK_ environment variable values at diff output.
       --non-zero-exit-code                    return exit code 2 if there is a diff present,
                                               exit code 0 if no diff is found,

--- a/app/deck/gateway/diff.md
+++ b/app/deck/gateway/diff.md
@@ -99,7 +99,7 @@ Run the same command with JSON output enabled:
 deck gateway diff ./kong.yaml --json-output
 ```
 
-An example response from the `--json-output` flag is:
+An example of a change report from the `--json-output` flag:
 ```bash
 {
   "changes": {
@@ -142,5 +142,3 @@ An example response from the `--json-output` flag is:
   "errors": []
 }
 ```
-
-The JSON output groups changes by operation type and includes both the previous and updated versions of each affected object.

--- a/app/deck/gateway/diff.md
+++ b/app/deck/gateway/diff.md
@@ -80,13 +80,12 @@ If the live system has changed without a corresponding change to the state file,
 
 By default, `deck gateway diff` prints a unified diff that highlights changes line by line. This output is optimized for quick human review, but it can be difficult to interpret when configuration objects are large or when you need to inspect values in more detail.
 
-Use the `--json-output` flag to generate a JSON report that is easier to parse and inspect. The JSON output includes:
-- A `summary` of changes (creating, updating, deleting, total)
-- A `changes` object grouped by operation type (creating, updating, deleting)
+Use the `--json-output` flag to generate a JSON report that includes:
+- A `summary` of changes. For example, creating, updating, deleting, and total
+- A `changes` object grouped by operation type
 - For each updated entity, both the `old` and `new` configuration objects
 
 Use `--json-output` when you need to:
-
 - Inspect old and new configuration objects separately during troubleshooting
 - Parse diff output in scripts or CI pipelines
 - Investigate noisy diffs where ordering changes or large objects make unified diffs hard to read

--- a/app/deck/gateway/diff.md
+++ b/app/deck/gateway/diff.md
@@ -99,4 +99,48 @@ Run the same command with JSON output enabled:
 deck gateway diff ./kong.yaml --json-output
 ```
 
+An example response from the `--json-output` flag is:
+```bash
+{
+  "changes": {
+    "creating": [],
+    "updating": [
+      {
+        "kind": "plugin",
+        "name": "basic-auth (global)",
+        "body": {
+          "old": {
+            "config": {
+              "brute_force_protection": {
+                "redis": {
+                  "timeout": 2000
+                }
+              }
+            }
+          },
+          "new": {
+            "config": {
+              "brute_force_protection": {
+                "redis": {
+                  "timeout": 2001
+                }
+              }
+            }
+          }
+        }
+      }
+    ],
+    "deleting": []
+  },
+  "summary": {
+    "creating": 0,
+    "updating": 1,
+    "deleting": 0,
+    "total": 1
+  },
+  "warnings": [],
+  "errors": []
+}
+```
+
 The JSON output groups changes by operation type and includes both the previous and updated versions of each affected object.

--- a/app/deck/gateway/diff.md
+++ b/app/deck/gateway/diff.md
@@ -90,11 +90,7 @@ Use `--json-output` when you need to:
 - Parse diff output in scripts or CI pipelines
 - Investigate noisy diffs where ordering changes or large objects make unified diffs hard to read
 
-Run `deck gateway diff` with the default unified diff output:
-```bash
-deck gateway diff ./kong.yaml
-```
-Run the same command with JSON output enabled:
+Run `deck gateway diff` with JSON output enabled:
 ```bash
 deck gateway diff ./kong.yaml --json-output
 ```

--- a/app/deck/gateway/diff.md
+++ b/app/deck/gateway/diff.md
@@ -75,3 +75,29 @@ If the live system has changed without a corresponding change to the state file,
 ## Command usage
 
 {% include_cached deck/help/gateway/diff.md %}
+
+### Inspect detailed configuration changes
+
+By default, `deck gateway diff` prints a unified diff that highlights changes line by line. This output is optimized for quick human review, but it can be difficult to interpret when configuration objects are large or when you need to inspect values in more detail.
+
+Use the `--json-output` flag to generate a JSON report that is easier to parse and inspect. The JSON output includes:
+- A `summary` of changes (creating, updating, deleting, total)
+- A `changes` object grouped by operation type (creating, updating, deleting)
+- For each updated entity, both the `old` and `new` configuration objects
+
+Use `--json-output` when you need to:
+
+- Inspect old and new configuration objects separately during troubleshooting
+- Parse diff output in scripts or CI pipelines
+- Investigate noisy diffs where ordering changes or large objects make unified diffs hard to read
+
+Run `deck gateway diff` with the default unified diff output:
+```bash
+deck gateway diff ./kong.yaml
+```
+Run the same command with JSON output enabled:
+```bash
+deck gateway diff ./kong.yaml --json-output
+```
+
+The JSON output groups changes by operation type and includes both the previous and updated versions of each affected object.


### PR DESCRIPTION
## Description

> 
> Jobs to be done (optional)
> Users need clear guidance on how to generate a more accurate diff when using the deck gateway diff, using the --json -output flag.
> 
> This helps them inspect old and new configuration objects separately and troubleshoot configuration drift more effectively.
> 
> Definition of done
> Add documentation explaining that the --json-output flag with decK gateway diff offers more detail.
> Add the new content to https://developer.konghq.com/deck/gateway/diff/.
> Ensure the doc includes when and why a user should use --json-output.
> Information
> [Slack](https://kongstrong.slack.com/archives/CDSTDSG9J/p1763537537352229)
> Context: Customers have previously reported issues where this flag would have helped them interpret diffs more effectively.
> SME Contact: Harsha Dixit
> Size
> S (Small). Example: fixing a broken link, updating wording in an FAQ or paragraph
> 

Fixes #3516 

## Preview Links

https://deploy-preview-4008--kongdeveloper.netlify.app/deck/gateway/diff/
cmd file changed: https://github.com/Kong/deck/pull/1850


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
