### PR TITLE
feat(serverless-gateway) Serverless V2

### DIFF
--- a/app/_landing_pages/serverless-gateways.yaml
+++ b/app/_landing_pages/serverless-gateways.yaml
@@ -26,9 +26,9 @@ rows:
               blocks:
                 - type: text
                   text: |
-                    Serverless gateways are lightweight API gateways. Their control plane is hosted by {{site.konnect_short_name}} and data plane nodes are automatically provisioned. Serverless gateways are ideal for developers who want to test or experiment in a pre-production environment.
+                    Serverless Gateways are lightweight API gateways. Their control plane is hosted by {{site.konnect_short_name}} and data plane nodes are automatically provisioned. Serverless gateways are ideal for developers who want to test or experiment in a pre-production environment.
 
-                    Serverless gateways offer the following benefits:
+                    Serverless Gateways offer the following benefits:
                     * {{site.konnect_short_name}} manages provisioning and placement.
                     * Can be deployed in under 30 seconds.
                     * Access to {{site.base_gateway}} plugins.
@@ -61,9 +61,9 @@ rows:
       - blocks:
           - type: card
             config:
-              title: Create a serverless gateway
+              title: Create a Serverless Gateway in the {{site.konnect_short_name}} UI
               description: |
-                Create a new serverless gateway in {{site.konnect_short_name}}.
+                Create a new Serverless Gateway in {{site.konnect_short_name}}.
               icon: /assets/logos/konglogo-gradient-secondary.svg
               cta:
                 text: Get started
@@ -71,10 +71,24 @@ rows:
       - blocks:
           - type: card
             config:
-              title: Serverless gateway reference
+              title: Serverless Gateway reference
               description: |
-                Learn about how serverless gateways work and how to configure them.
+                Learn about how Serverless Gateways work and how to configure them.
               icon: /assets/icons/serverless.svg
               cta:
-                text: Set up serverless Gateways
+                text: Set up Serverless Gateways
                 url: /serverless-gateways/reference/
+      - blocks:
+          - type: card
+            config:
+              title: Migrate to Serverless Gateway V1 (beta)
+              description: |
+                Migrate your existing Serverless Gateway V0 instance to a V1 to take advantage of new features.
+
+                Available in US regions only.
+              icon: /assets/icons/code.svg
+              cta:
+                text: Migrate
+                url: /serverless-gateways/migration/
+
+

--- a/app/_landing_pages/serverless-gateways.yaml
+++ b/app/_landing_pages/serverless-gateways.yaml
@@ -26,7 +26,7 @@ rows:
               blocks:
                 - type: text
                   text: |
-                    Serverless Gateways are lightweight API gateways. Their control plane is hosted by {{site.konnect_short_name}} and data plane nodes are automatically provisioned. Serverless gateways are ideal for developers who want to test or experiment in a pre-production environment.
+                    Serverless Gateways are lightweight API gateways. Their control plane is hosted by {{site.konnect_short_name}} and data plane nodes are automatically provisioned. Serverless Gateways are ideal for lightweight production workloads, as well as development and testing.
 
                     Serverless Gateways offer the following benefits:
                     * {{site.konnect_short_name}} manages provisioning and placement.

--- a/app/_landing_pages/serverless-gateways.yaml
+++ b/app/_landing_pages/serverless-gateways.yaml
@@ -81,11 +81,11 @@ rows:
       - blocks:
           - type: card
             config:
-              title: Migrate to Serverless Gateway V1 (beta)
+              title: Migrate to Serverless Gateway V1
               description: |
                 Migrate your existing Serverless Gateway V0 instance to a V1 to take advantage of new features.
 
-                Available in US regions only.
+                Available in US and EU regions only.
               icon: /assets/icons/code.svg
               cta:
                 text: Migrate

--- a/app/serverless-gateways/migration.md
+++ b/app/serverless-gateways/migration.md
@@ -1,0 +1,101 @@
+---
+title: "Migrating a V0 Serverless Gateway to a V1"
+content_type: reference
+layout: reference
+description: | 
+   Migrate a V0 Serverless Gateway to a V1.
+
+beta: true
+
+breadcrumbs:
+  - /serverless-gateways/
+tags:
+  - serverless-gateways
+  - hybrid-mode
+  - data-plane
+products:
+  - gateway
+works_on:
+  - konnect
+api_specs:
+  - konnect/control-planes-config
+  - konnect/cloud-gateways
+
+related_resources:
+  - text: Serverless Gateways reference
+    url: /serverless-gateways/reference/
+  - text: Migrate from V0 to V1
+    url: /serverless-gateways/migration/
+  - text: Dedicated Cloud Gateways
+    url: /dedicated-cloud-gateways/
+  - text: Control plane and data plane communication
+    url: /gateway/cp-dp-communication/
+  - text: Hybrid mode
+    url: /gateway/hybrid-mode/
+
+---
+
+{:.info}
+> **Note**: Serverless Gateways V1 are currently available for {{site.konnect_short_name}} organizations running in US regions only.
+
+Serverless Gateways V1 bring the following improvements to Serverless Gateways:
+* Support for rate limiting and authentication plugins
+* Custom domains and private networking (pre-shared key)
+* API spec upload and seamless Developer Portal
+* Metering, billing, and entitlements
+* Architecture tuning and performance enhancements
+
+You can upgrade to Serverless Gateways V1 using [decK](/deck/).
+
+## Breaking changes between V0 and V1
+
+Review the following changes before migrating to V1:
+
+* Change in proxy URL: The proxy URL format changes from `https://kong-0122456789.kongcloud.dev` to `https://01234567.us.serverless.gateways.konggateway.com`
+* Change to control plane type: The control plane type changes from `CLUSTER_TYPE_SERVERLESS` to `CLUSTER_TYPE_CLOUD_API_GATEWAY`.
+* Data plane type: The data plane gateway type changes from `serverless.v0` to `serverless.v1`
+
+## Migration 
+
+1. Set your {{site.konnect_short_name}} environment information:
+
+		```sh
+		export DECK_KONNECT_ADDR=https://us.api.konghq.com
+		export DECK_KONNECT_TOKEN=YOUR_ACCESS_TOKEN
+		export DECK_KONNECT_CONTROL_PLANE=YOUR_SERVERLESS_V0_CONTROL_PLANE_ID
+		```
+    
+		Set the `DECK_KONNECT_CONTROL_PLANE` variable to the ID of the control plane you'd like to upgrade.
+
+1. Export your current Serverless V0 control plane configuration into a decK file:
+
+		```sh
+		deck gateway dump > kong.yml
+		```
+
+1. Create a new Serverless Gateway using the {{site.konnect_short_name}} UI:
+    1. In the {{site.konnect_short_name}} sidebar, click **API Gateway**.
+		1. Click the **New** button, then select **New API Gateway**.
+		1. Select Serverless.
+		1. Give your Gateway a name and an optional description.
+		1. Click **Create** to save.
+
+		This creates a control plane and deploys a data plane node so that you don't have to run one yourself.
+
+1. Copy the ID of your new conrol plane and adjust the `DECK_KONNECT_CONTROL_PLANE` environment variable:
+
+		```sh
+		export DECK_KONNECT_CONTROL_PLANE=YOUR_SERVERLESS_V1_CONTROL_PLANE_ID
+		```
+
+1. Import the control plane configuration to your new Serverless V1 gateway. First, check the configuration diff:
+    
+		```sh
+    deck gateway diff ./kong.yml
+    ```
+
+1. If you're satisfied with the update, run a sync to update your control plane:
+    
+		```sh
+    deck gateway sync ./kong.yml
+    ```

--- a/app/serverless-gateways/migration.md
+++ b/app/serverless-gateways/migration.md
@@ -36,10 +36,7 @@ related_resources:
 {:.warning}
 > **Note**: Serverless Gateways V1 are currently available for {{site.konnect_short_name}} organizations running in US regions only.
 
-Serverless Gateways V1 bring the following improvements to Serverless Gateways:
-
-* Terraform support
-* 99.9% SLA
+Serverless Gateways V1 bring updates to the API, increased data plane provisioning speeds, and Terraform support.
 
 You can upgrade to Serverless Gateways V1 using [decK](/deck/).
 

--- a/app/serverless-gateways/migration.md
+++ b/app/serverless-gateways/migration.md
@@ -41,12 +41,6 @@ Serverless Gateways V1 bring the following improvements to Serverless Gateways:
 * Terraform support
 * 99.9% SLA
 
-<!-- * Support for rate limiting and authentication plugins
-* Custom domains and private networking (pre-shared key)
-* API spec upload through Dev Portal
-* Metering, billing, and entitlements
-* Architecture tuning and performance enhancements -->
-
 You can upgrade to Serverless Gateways V1 using [decK](/deck/).
 
 ## Breaking changes between V0 and V1
@@ -67,7 +61,7 @@ rows:
     v1: "`https://0123456789.us.serverless.gateways.konggateway.com`"
   - change: Control plane type
     v0: "`CLUSTER_TYPE_SERVERLESS`"
-    v1: "`CLUSTER_TYPE_CLOUD_API_GATEWAY`"
+    v1: "`CLUSTER_TYPE_SERVERLESS_V1`"
   - change: Data plane kind
     v0: "`serverless.v0`"
     v1: "`serverless.v1`"

--- a/app/serverless-gateways/migration.md
+++ b/app/serverless-gateways/migration.md
@@ -37,11 +37,15 @@ related_resources:
 > **Note**: Serverless Gateways V1 are currently available for {{site.konnect_short_name}} organizations running in US regions only.
 
 Serverless Gateways V1 bring the following improvements to Serverless Gateways:
-* Support for rate limiting and authentication plugins
+
+* Terraform support
+* 99.9% SLA
+
+<!-- * Support for rate limiting and authentication plugins
 * Custom domains and private networking (pre-shared key)
-* API spec upload and seamless Developer Portal
+* API spec upload through Dev Portal
 * Metering, billing, and entitlements
-* Architecture tuning and performance enhancements
+* Architecture tuning and performance enhancements -->
 
 You can upgrade to Serverless Gateways V1 using [decK](/deck/).
 
@@ -60,7 +64,7 @@ columns:
 rows:
   - change: Proxy URL format
     v0: "`https://kong-0122456789.kongcloud.dev`"
-    v1: "`https://01234567.us.serverless.gateways.konggateway.com`"
+    v1: "`https://0123456789.us.serverless.gateways.konggateway.com`"
   - change: Control plane type
     v0: "`CLUSTER_TYPE_SERVERLESS`"
     v1: "`CLUSTER_TYPE_CLOUD_API_GATEWAY`"
@@ -86,6 +90,7 @@ rows:
    ```
 
 1. Create a new Serverless Gateway using the {{site.konnect_short_name}} UI:
+    
     1. In the {{site.konnect_short_name}} sidebar, click **API Gateway**.
     1. Click the **New** button, then select **New API Gateway**.
     1. Select Serverless.
@@ -93,6 +98,8 @@ rows:
     1. Click **Create** to save.
 
     This creates a control plane and deploys a data plane node so that you don't have to run one yourself.
+    
+    If you prefer to use the API to create control planes and data planes, see the [Serverless Gateway reference](/serverless-gateways/reference/#konnect-apis).
 
 1. Import the control plane configuration to your new Serverless V1 gateway, making sure to target the new control plane.
 First, check the configuration diff:

--- a/app/serverless-gateways/migration.md
+++ b/app/serverless-gateways/migration.md
@@ -99,7 +99,7 @@ rows:
 
     This creates a control plane and deploys a data plane node so that you don't have to run one yourself.
 
-1. Copy the ID of your new conrol plane and adjust the `DECK_KONNECT_CONTROL_PLANE` environment variable:
+1. Copy the ID of your new control plane and adjust the `DECK_KONNECT_CONTROL_PLANE` environment variable:
 
    ```sh
    export DECK_KONNECT_CONTROL_PLANE=YOUR_SERVERLESS_V1_CONTROL_PLANE_ID

--- a/app/serverless-gateways/migration.md
+++ b/app/serverless-gateways/migration.md
@@ -24,8 +24,6 @@ api_specs:
 related_resources:
   - text: Serverless Gateways reference
     url: /serverless-gateways/reference/
-  - text: Migrate from V0 to V1
-    url: /serverless-gateways/migration/
   - text: Dedicated Cloud Gateways
     url: /dedicated-cloud-gateways/
   - text: Control plane and data plane communication
@@ -35,7 +33,7 @@ related_resources:
 
 ---
 
-{:.info}
+{:.warning}
 > **Note**: Serverless Gateways V1 are currently available for {{site.konnect_short_name}} organizations running in US regions only.
 
 Serverless Gateways V1 bring the following improvements to Serverless Gateways:
@@ -49,53 +47,72 @@ You can upgrade to Serverless Gateways V1 using [decK](/deck/).
 
 ## Breaking changes between V0 and V1
 
-Review the following changes before migrating to V1:
+Review the following breaking changes before migrating to V1:
 
-* Change in proxy URL: The proxy URL format changes from `https://kong-0122456789.kongcloud.dev` to `https://01234567.us.serverless.gateways.konggateway.com`
-* Change to control plane type: The control plane type changes from `CLUSTER_TYPE_SERVERLESS` to `CLUSTER_TYPE_CLOUD_API_GATEWAY`.
-* Data plane type: The data plane gateway type changes from `serverless.v0` to `serverless.v1`
+{% table %}
+columns:
+  - title: Change
+    key: change
+  - title: V0 (old)
+    key: v0
+  - title: V1 (new)
+    key: v1
+rows:
+  - change: Change in proxy URL format
+    v0: "`https://kong-0122456789.kongcloud.dev`"
+    v1: "`https://01234567.us.serverless.gateways.konggateway.com`"
+  - change: Change to control plane type
+    v0: "`CLUSTER_TYPE_SERVERLESS`"
+    v1: "`CLUSTER_TYPE_CLOUD_API_GATEWAY`"
+  - change: Change to data plane type
+    v0: "`serverless.v0`"
+    v1: "`serverless.v1`"
+{% endtable %}
 
-## Migration 
+## Migration steps
 
 1. Set your {{site.konnect_short_name}} environment information:
 
-		```sh
-		export DECK_KONNECT_ADDR=https://us.api.konghq.com
-		export DECK_KONNECT_TOKEN=YOUR_ACCESS_TOKEN
-		export DECK_KONNECT_CONTROL_PLANE=YOUR_SERVERLESS_V0_CONTROL_PLANE_ID
-		```
-    
-		Set the `DECK_KONNECT_CONTROL_PLANE` variable to the ID of the control plane you'd like to upgrade.
+   ```sh
+   export DECK_KONNECT_ADDR=https://us.api.konghq.com
+   export DECK_KONNECT_TOKEN=YOUR_ACCESS_TOKEN
+   export DECK_KONNECT_CONTROL_PLANE=YOUR_SERVERLESS_V0_CONTROL_PLANE_ID
+   ```
+  
+    Where:
+    * `DECK_KONNECT_ADDR`: The {{site.konnect_short_name}} API URL, in this case, only for the `us` region.
+    * `DECK_KONNECT_TOKEN`: A  {{site.konnect_short_name}} [personal access token](/konnect-api/#konnect-api-authentication).
+    * `DECK_KONNECT_CONTROL_PLANE`: ID of the control plane you'd like to upgrade.
 
 1. Export your current Serverless V0 control plane configuration into a decK file:
 
-		```sh
-		deck gateway dump > kong.yml
-		```
+   ```sh
+   deck gateway dump > kong.yml
+   ```
 
 1. Create a new Serverless Gateway using the {{site.konnect_short_name}} UI:
     1. In the {{site.konnect_short_name}} sidebar, click **API Gateway**.
-		1. Click the **New** button, then select **New API Gateway**.
-		1. Select Serverless.
-		1. Give your Gateway a name and an optional description.
-		1. Click **Create** to save.
+    1. Click the **New** button, then select **New API Gateway**.
+    1. Select Serverless.
+    1. Give your Gateway a name and an optional description.
+    1. Click **Create** to save.
 
-		This creates a control plane and deploys a data plane node so that you don't have to run one yourself.
+    This creates a control plane and deploys a data plane node so that you don't have to run one yourself.
 
 1. Copy the ID of your new conrol plane and adjust the `DECK_KONNECT_CONTROL_PLANE` environment variable:
 
-		```sh
-		export DECK_KONNECT_CONTROL_PLANE=YOUR_SERVERLESS_V1_CONTROL_PLANE_ID
-		```
+   ```sh
+   export DECK_KONNECT_CONTROL_PLANE=YOUR_SERVERLESS_V1_CONTROL_PLANE_ID
+   ```
 
 1. Import the control plane configuration to your new Serverless V1 gateway. First, check the configuration diff:
     
-		```sh
-    deck gateway diff ./kong.yml
-    ```
+   ```sh
+   deck gateway diff ./kong.yml
+   ```
 
 1. If you're satisfied with the update, run a sync to update your control plane:
     
-		```sh
-    deck gateway sync ./kong.yml
-    ```
+   ```sh
+   deck gateway sync ./kong.yml
+   ```

--- a/app/serverless-gateways/migration.md
+++ b/app/serverless-gateways/migration.md
@@ -58,36 +58,31 @@ columns:
   - title: V1 (new)
     key: v1
 rows:
-  - change: Change in proxy URL format
+  - change: Proxy URL format
     v0: "`https://kong-0122456789.kongcloud.dev`"
     v1: "`https://01234567.us.serverless.gateways.konggateway.com`"
-  - change: Change to control plane type
+  - change: Control plane type
     v0: "`CLUSTER_TYPE_SERVERLESS`"
     v1: "`CLUSTER_TYPE_CLOUD_API_GATEWAY`"
-  - change: Change to data plane type
+  - change: Data plane kind
     v0: "`serverless.v0`"
     v1: "`serverless.v1`"
 {% endtable %}
 
 ## Migration steps
 
-1. Set your {{site.konnect_short_name}} environment information:
+1. Create a [personal access token](/konnect-api/#konnect-api-authentication) in {{site.konnect_short_name}} and export it as an environment variable:
 
    ```sh
-   export DECK_KONNECT_ADDR=https://us.api.konghq.com
-   export DECK_KONNECT_TOKEN=YOUR_ACCESS_TOKEN
-   export DECK_KONNECT_CONTROL_PLANE=YOUR_SERVERLESS_V0_CONTROL_PLANE_ID
+   export KONNECT_TOKEN=YOUR_ACCESS_TOKEN
    ```
-  
-    Where:
-    * `DECK_KONNECT_ADDR`: The {{site.konnect_short_name}} API URL, in this case, only for the `us` region.
-    * `DECK_KONNECT_TOKEN`: A  {{site.konnect_short_name}} [personal access token](/konnect-api/#konnect-api-authentication).
-    * `DECK_KONNECT_CONTROL_PLANE`: ID of the control plane you'd like to upgrade.
 
 1. Export your current Serverless V0 control plane configuration into a decK file:
 
    ```sh
-   deck gateway dump > kong.yml
+   deck gateway dump -o kong.yaml \
+    --konnect-token "$KONNECT_TOKEN" \
+    --konnect-control-plane-name "MY_SERVERLESS_V0_CP"
    ```
 
 1. Create a new Serverless Gateway using the {{site.konnect_short_name}} UI:
@@ -99,20 +94,19 @@ rows:
 
     This creates a control plane and deploys a data plane node so that you don't have to run one yourself.
 
-1. Copy the ID of your new control plane and adjust the `DECK_KONNECT_CONTROL_PLANE` environment variable:
-
-   ```sh
-   export DECK_KONNECT_CONTROL_PLANE=YOUR_SERVERLESS_V1_CONTROL_PLANE_ID
-   ```
-
-1. Import the control plane configuration to your new Serverless V1 gateway. First, check the configuration diff:
+1. Import the control plane configuration to your new Serverless V1 gateway, making sure to target the new control plane.
+First, check the configuration diff:
     
    ```sh
-   deck gateway diff ./kong.yml
+   deck gateway diff ./kong.yaml \
+    --konnect-token "$KONNECT_TOKEN" \
+    --konnect-control-plane-name "MY_NEW_SERVERLESS_V1_CP"
    ```
 
 1. If you're satisfied with the update, run a sync to update your control plane:
     
    ```sh
-   deck gateway sync ./kong.yml
+   deck gateway sync ./kong.yml \
+    --konnect-token "$KONNECT_TOKEN" \
+    --konnect-control-plane-name "MY_NEW_SERVERLESS_V1_CP"
    ```

--- a/app/serverless-gateways/migration.md
+++ b/app/serverless-gateways/migration.md
@@ -1,9 +1,9 @@
 ---
-title: "Migrating a V0 Serverless Gateway to a V1"
+title: "Migrating a V0 Serverless Gateway to V1"
 content_type: reference
 layout: reference
 description: | 
-   Migrate a V0 Serverless Gateway to a V1.
+   Migrate a V0 Serverless Gateway to V1.
 
 beta: true
 
@@ -93,7 +93,8 @@ rows:
     If you prefer to use the API to create control planes and data planes, see the [Serverless Gateway reference](/serverless-gateways/reference/#konnect-apis).
 
 1. Import the control plane configuration to your new Serverless V1 gateway, making sure to target the new control plane.
-First, check the configuration diff:
+
+   First, check the configuration diff:
     
    ```sh
    deck gateway diff ./kong.yaml \
@@ -104,7 +105,7 @@ First, check the configuration diff:
 1. If you're satisfied with the update, run a sync to update your control plane:
     
    ```sh
-   deck gateway sync ./kong.yml \
+   deck gateway sync ./kong.yaml \
     --konnect-token "$KONNECT_TOKEN" \
     --konnect-control-plane-name "MY_NEW_SERVERLESS_V1_CP"
    ```

--- a/app/serverless-gateways/migration.md
+++ b/app/serverless-gateways/migration.md
@@ -5,8 +5,6 @@ layout: reference
 description: | 
    Migrate a V0 Serverless Gateway to V1.
 
-beta: true
-
 breadcrumbs:
   - /serverless-gateways/
 tags:
@@ -34,7 +32,7 @@ related_resources:
 ---
 
 {:.warning}
-> **Note**: Serverless Gateways V1 are currently available for {{site.konnect_short_name}} organizations running in US regions only.
+> **Note**: Serverless Gateways V1 are currently available for {{site.konnect_short_name}} organizations running in US and EU regions only.
 
 Serverless Gateways V1 bring updates to the API, increased data plane provisioning speeds, and Terraform support.
 

--- a/app/serverless-gateways/reference.md
+++ b/app/serverless-gateways/reference.md
@@ -6,7 +6,7 @@ description: |
     Serverless Gateways are lightweight API gateways. Their control plane is hosted by {{site.konnect_short_name}} and data plane nodes are automatically provisioned.
 
 breadcrumbs:
-  - /konnect/
+  - /serverless-gateways/
 tags:
   - serverless-gateways
   - hybrid-mode
@@ -69,8 +69,71 @@ When you create a Serverless Gateway, {{site.konnect_short_name}} creates a cont
 
 To provision a Serverless Gateway, you need to create a serverless control plane and a hosted data plane. 
 Make sure that you have a [Konnect token](/konnect-api/#konnect-api-authentication) set in your environment.
+
+{% navtabs 'provision-serverless' %}
+{% navtab "Serverless V1 beta (US region only)" %}
+
+1. Create a Serverless Gateway control plane by issuing a `POST` request to the [Control Plane API](/api/konnect/control-planes/#/operations/create-control-plane):
+
+<!-- vale off -->
+{% capture request1 %}
+{% control_plane_request %}
+  url: /v2/control-planes/
+  status_code: 201
+  method: POST
+  region: us
+  headers:
+      - 'Authorization: Bearer $KONNECT_TOKEN'
+      - 'Accept: application/json'
+      - 'Content-Type: application/json'
+  body:
+      name: serverless-gateway-control-plane
+      description: A test control plane for Serverless Gateways.
+      cluster_type: CLUSTER_TYPE_CLOUD_API_GATEWAY
+      cloud_gateway: true
+      auth_type: pinned_client_certs
+{% endcontrol_plane_request %}
+{% endcapture %}
+
+{{ request1 | indent:3 }}
+
+1. Export the generated control plane ID to an environment variable: 
+
+    ```
+    export CONTROL_PLANE_ID=YOUR-GENERATED-ID-HERE
+    ```
+
+<!--vale on -->
+1. Create a hosted data plane by issuing a `PUT` request to the [Cloud Gateways API](/api/konnect/cloud-gateways/#/operations/create-configuration):
+<!--vale off -->
+{% capture request2 %}
+{% konnect_api_request %}
+  url: /v3/cloud-gateways/configurations
+  status_code: 201
+  region: us
+  method: PUT
+  headers:
+      - 'Accept: application/json'
+      - 'Content-Type: application/json'
+      - 'Authorization: Bearer $KONNECT_TOKEN'
+  body:
+      control_plane_id: $CONTROL_PLANE_ID
+      control_plane_geo: us
+      dataplane_groups: 
+        - region: us
+          provider: aws
+      kind: serverless.v1
+{% endkonnect_api_request %}
+{% endcapture %}
+
+{{ request2 | indent:3 }}
+<!--vale on -->
+
+{% endnavtab %}
+{% navtab "Global stable version (V0)" %}
 	
 1. Create a Serverless Gateway control plane by issuing a `POST` request to the [Control Plane API](/api/konnect/control-planes/#/operations/create-control-plane):
+
 <!-- vale off -->
 {% capture request1 %}
 {% control_plane_request %}
@@ -89,8 +152,8 @@ Make sure that you have a [Konnect token](/konnect-api/#konnect-api-authenticati
       auth_type: pinned_client_certs
 {% endcontrol_plane_request %}
 {% endcapture %}
+
 {{ request1 | indent:3 }}
-<!--vale on -->
 
 1. Export the generated control plane ID to an environment variable: 
 
@@ -98,6 +161,7 @@ Make sure that you have a [Konnect token](/konnect-api/#konnect-api-authenticati
     export CONTROL_PLANE_ID=YOUR-GENERATED-ID-HERE
     ```
 
+<!--vale on -->
 1. Create a hosted data plane by issuing a `PUT` request to the [Cloud Gateways API](/api/konnect/cloud-gateways/#/operations/create-configuration):
 <!--vale off -->
 {% capture request2 %}
@@ -121,6 +185,9 @@ Make sure that you have a [Konnect token](/konnect-api/#konnect-api-authenticati
 
 {{ request2 | indent:3 }}
 <!--vale on -->
+
+{% endnavtab %}
+{% endnavtabs %}
 
 You can now proxy requests through your Serverless Gateway, and it will use the hosted data plane to process traffic.
 

--- a/app/serverless-gateways/reference.md
+++ b/app/serverless-gateways/reference.md
@@ -46,6 +46,8 @@ faqs:
 
         If no CAA record exists, no changes are needed. For more information, see the [Let's Encrypt CAA Guide](https://letsencrypt.org/docs/caa/).
 related_resources:
+  - text: Migrate from V0 to V1
+    url: /serverless-gateways/migration/
   - text: Dedicated Cloud Gateways
     url: /dedicated-cloud-gateways/
   - text: Control plane and data plane communication
@@ -73,10 +75,9 @@ Make sure that you have a [Konnect token](/konnect-api/#konnect-api-authenticati
 {% navtabs 'provision-serverless' %}
 {% navtab "Serverless V1 beta (US region only)" %}
 
-1. Create a Serverless Gateway control plane by issuing a `POST` request to the [Control Plane API](/api/konnect/control-planes/#/operations/create-control-plane):
+Create a Serverless Gateway control plane by issuing a `POST` request to the [Control Plane API](/api/konnect/control-planes/#/operations/create-control-plane):
 
 <!-- vale off -->
-{% capture request1 %}
 {% control_plane_request %}
   url: /v2/control-planes/
   status_code: 201
@@ -93,20 +94,17 @@ Make sure that you have a [Konnect token](/konnect-api/#konnect-api-authenticati
       cloud_gateway: true
       auth_type: pinned_client_certs
 {% endcontrol_plane_request %}
-{% endcapture %}
 
-{{ request1 | indent:3 }}
+Export the generated control plane ID to an environment variable: 
 
-1. Export the generated control plane ID to an environment variable: 
-
-    ```
-    export CONTROL_PLANE_ID=YOUR-GENERATED-ID-HERE
-    ```
+```sh
+export CONTROL_PLANE_ID=YOUR-GENERATED-ID-HERE
+```
 
 <!--vale on -->
-1. Create a hosted data plane by issuing a `PUT` request to the [Cloud Gateways API](/api/konnect/cloud-gateways/#/operations/create-configuration):
+Create a hosted data plane by issuing a `PUT` request to the [Cloud Gateways API](/api/konnect/cloud-gateways/#/operations/create-configuration):
 <!--vale off -->
-{% capture request2 %}
+
 {% konnect_api_request %}
   url: /v3/cloud-gateways/configurations
   status_code: 201
@@ -124,18 +122,15 @@ Make sure that you have a [Konnect token](/konnect-api/#konnect-api-authenticati
           provider: aws
       kind: serverless.v1
 {% endkonnect_api_request %}
-{% endcapture %}
 
-{{ request2 | indent:3 }}
 <!--vale on -->
 
 {% endnavtab %}
 {% navtab "Global stable version (V0)" %}
 	
-1. Create a Serverless Gateway control plane by issuing a `POST` request to the [Control Plane API](/api/konnect/control-planes/#/operations/create-control-plane):
+Create a Serverless Gateway control plane by issuing a `POST` request to the [Control Plane API](/api/konnect/control-planes/#/operations/create-control-plane):
 
 <!-- vale off -->
-{% capture request1 %}
 {% control_plane_request %}
   url: /v2/control-planes/
   status_code: 201
@@ -151,20 +146,17 @@ Make sure that you have a [Konnect token](/konnect-api/#konnect-api-authenticati
       cloud_gateway: false
       auth_type: pinned_client_certs
 {% endcontrol_plane_request %}
-{% endcapture %}
 
-{{ request1 | indent:3 }}
+Export the generated control plane ID to an environment variable: 
 
-1. Export the generated control plane ID to an environment variable: 
-
-    ```
-    export CONTROL_PLANE_ID=YOUR-GENERATED-ID-HERE
-    ```
+```
+export CONTROL_PLANE_ID=YOUR-GENERATED-ID-HERE
+```
 
 <!--vale on -->
-1. Create a hosted data plane by issuing a `PUT` request to the [Cloud Gateways API](/api/konnect/cloud-gateways/#/operations/create-configuration):
+Create a hosted data plane by issuing a `PUT` request to the [Cloud Gateways API](/api/konnect/cloud-gateways/#/operations/create-configuration):
 <!--vale off -->
-{% capture request2 %}
+
 {% konnect_api_request %}
   url: /v3/cloud-gateways/configurations
   status_code: 201
@@ -181,9 +173,6 @@ Make sure that you have a [Konnect token](/konnect-api/#konnect-api-authenticati
         - region: na
       kind: serverless.v0
 {% endkonnect_api_request %}
-{% endcapture %}
-
-{{ request2 | indent:3 }}
 <!--vale on -->
 
 {% endnavtab %}

--- a/app/serverless-gateways/reference.md
+++ b/app/serverless-gateways/reference.md
@@ -1,5 +1,5 @@
 ---
-title: "Serverless Gateway"
+title: "Serverless Gateway reference"
 content_type: reference
 layout: reference
 description: | 
@@ -70,10 +70,29 @@ When you create a Serverless Gateway, {{site.konnect_short_name}} creates a cont
 ## How do I provision a Serverless Gateway?
 
 To provision a Serverless Gateway, you need to create a serverless control plane and a hosted data plane. 
+
+### {{site.konnect_short_name}} UI
+
+The easiest way to provision a Serverless Gateway is through the {{site.konnect_short_name}} UI, 
+where {{site.konnect_short_name}} creates both a control plane and a data plane in one step.
+
+1. In the {{site.konnect_short_name}} sidebar, click **API Gateway**.
+1. Click the **New** button, then select **New API Gateway**.
+1. Select Serverless.
+1. Give your Gateway a name and an optional description.
+1. Click **Create** to save.
+
+### {{site.konnect_short_name}} APIs
+
+You can use the {{site.konnect_short_name}} APIs to provision control planes and data planes programmatically.
+
 Make sure that you have a [Konnect token](/konnect-api/#konnect-api-authentication) set in your environment.
 
 {% navtabs 'provision-serverless' %}
 {% navtab "Serverless V1 beta (US region only)" %}
+
+{:.info}
+> **Note**: If you want to migrate an existing V0 control plane to V1, see the [migration guide](/serverless-gateways/migration/).
 
 Create a Serverless Gateway control plane by issuing a `POST` request to the [Control Plane API](/api/konnect/control-planes/#/operations/create-control-plane):
 

--- a/app/serverless-gateways/reference.md
+++ b/app/serverless-gateways/reference.md
@@ -56,9 +56,13 @@ related_resources:
     url: /gateway/hybrid-mode/
 
 ---
-Serverless Gateways are lightweight API gateways. Their control plane is hosted by {{site.konnect_short_name}} and data plane nodes are automatically provisioned. Serverless Gateways are ideal for developers who want to test or experiment in a pre-production environment.
 
-You can manage your Serverless Gateway nodes under **API Gateway** in {{site.konnect_short_name}}.
+Serverless Gateways are lightweight API gateways with a fully hosted control plane in {{site.konnect_short_name}} and automatically-provisioned data plane nodes.
+They are highly available, backed by a service-level agreement (SLA), and designed to handle lightweight production workloads. 
+
+Because you don't need to manage any infrastructure, Serverless Gateways are a strong fit for startups, new projects, and teams that want to run low-to-moderate production traffic, as well as for development, testing, and experimentation. 
+
+You can manage your Serverless Gateway nodes under [**API Gateway**](https://cloud.konghq.com/gateway-manager/) in {{site.konnect_short_name}}.
 
 ## How do Serverless Gateways work?
 
@@ -109,7 +113,7 @@ Create a Serverless Gateway control plane by issuing a `POST` request to the [Co
   body:
       name: serverless-gateway-control-plane
       description: A test control plane for Serverless Gateways.
-      cluster_type: CLUSTER_TYPE_CLOUD_API_GATEWAY
+      cluster_type: CLUSTER_TYPE_SERVERLESS_V1
       cloud_gateway: true
       auth_type: pinned_client_certs
 {% endcontrol_plane_request %}

--- a/app/serverless-gateways/reference.md
+++ b/app/serverless-gateways/reference.md
@@ -93,7 +93,7 @@ You can use the {{site.konnect_short_name}} APIs to provision control planes and
 Make sure that you have a [Konnect token](/konnect-api/#konnect-api-authentication) set in your environment.
 
 {% navtabs 'provision-serverless' %}
-{% navtab "Serverless V1 beta (US region only)" %}
+{% navtab "Serverless V1 (US and EU regions only)" %}
 
 {:.info}
 > **Note**: If you want to migrate an existing V0 control plane to V1, see the [migration guide](/serverless-gateways/migration/).
@@ -279,6 +279,17 @@ body:
         - 'Authorization:Bearer $SECRET_TOKEN_VALUE'
 {% endcontrol_plane_request %}
 <!--vale on-->
+
+### Egress IPs
+
+If you're using Serverless Gateways V1 (US and EU regions only), you can use egress IPs to filter IP addresses for your upstream Serverless Gateway applications.
+
+The Serverless V1 egress IPs are:
+* 18.207.85.202
+* 54.224.105.45
+* 52.202.189.172
+* 3.214.24.226
+* 3.228.135.57
 
 ## Limits
 Serverless Gateways have the following limits:


### PR DESCRIPTION
## Description

Fixes #2690 

The migration doc is currently a reference and not a how-to. I went with this because it's really not validateable unless you have an old Serverless Gateway, but the steps are concrete. There should be a decent amount of info they need to review before migrating, which is generally better in a reference format - thoughts?

To do:
- [x] The API command to create a data plane doesn't currently work, as it's marked internal. Find out if this is going to be changed for launch.
- [x] Verify exact feature changes for V1/V2
- [x] Verify version name - it's V1 in the spec, but V2 in all the materials. I'm currently using V1 because otherwise we skip V1.
- [x] Verify FAQs and limitations
- [ ] ~Turn reference "create a Serverless Gateway" section into a how-to, if we're launching the API~ Not for beta.
- [ ] Update https://developer.konghq.com/api/konnect/cloud-gateways/v2/ spec to v3 whenever it's ready
- [ ] Any updates for EU (requested more info here: https://kongstrong.slack.com/archives/C08KFC895V0/p1775595305114999)
- [ ] IPs https://kongstrong.slack.com/archives/C03NRECFJPM/p1775490982498709?thread_ts=1775483864.254599&cid=C03NRECFJPM

## Preview Links

https://deploy-preview-4013--kongdeveloper.netlify.app/serverless-gateways/
https://deploy-preview-4013--kongdeveloper.netlify.app/serverless-gateways/reference/#how-do-i-provision-a-serverless-gateway
https://deploy-preview-4013--kongdeveloper.netlify.app/serverless-gateways/migration/
