### PR TITLE
fix(event-gateway): don't claim ACL policy can act on records

### DIFF
--- a/app/event-gateway/entities/policy.md
+++ b/app/event-gateway/entities/policy.md
@@ -118,7 +118,7 @@ columns:
     center: true
 features:
   - title: "[Kafka ACL](/event-gateway/policies/acl/)"
-    nonparsed: Yes
+    nonparsed: No
     parsed: No
   - title: "[Encrypt](/event-gateway/policies/encrypt/)"
     nonparsed: Yes


### PR DESCRIPTION
ACLs act on requests not record so this was wrong

## Description

Fixes #issue

## Preview Links


## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [x] Add new pages to the product documentation index (if applicable).
