### PR TITLE
Feat: add release dates and minor versions to site_post_write.rb

### DIFF
--- a/app/_plugins/hooks/site_post_write.rb
+++ b/app/_plugins/hooks/site_post_write.rb
@@ -34,13 +34,18 @@ module SupportedVersionAPI # rubocop:disable Style/Documentation
       
       release_date = date&.gsub('/', '-')
       
+      # Generate changelog URL (e.g., "3.12.0.2" becomes "#3-12-0-2")
+      changelog_anchor = full_version.gsub('.', '-')
+      changelog_url = "https://developer.konghq.com/gateway/changelog/##{changelog_anchor}"
+      
       versions << {
         release: full_version,
         tag: full_version,
         releaseDate: release_date,
         endOfLifeDate: eol_date,
         endOfsunset_date: sunset_date,
-        label: metadata[:label]
+        label: metadata[:label],
+        changelogUrl: changelog_url
       }
     end
     


### PR DESCRIPTION
Entries look like this: 

```
  {
    "release": "3.12.0.2",
    "tag": "3.12",
    "releaseDate": "2025-12-10",
    "endOfLifeDate": "2026-10-01",
    "endOfsunset_date": "2027-10-01",
    "label": null
  },
  ```