### PR TITLE
Feat (Insomnia): URLs for local LLMs

### DIFF
--- a/app/_landing_pages/insomnia/ai-in-insomnia.yaml
+++ b/app/_landing_pages/insomnia/ai-in-insomnia.yaml
@@ -30,12 +30,14 @@ rows:
                     - [**AI-assisted mock server generation**](/insomnia/self-hosted-mocks/#create-an-auto-generated-mock-server), which transforms prompts or API definitions into mock APIs.  
                     - [**AI commit message suggestions**](/insomnia/ai-in-insomnia/#ai-driven-git-commits), which help maintain clear and atomic commit histories.
 
-                    Activate these features by enabling a **Large Language Model (LLM)** in **Preferences > AI Settings**.  
-                    Choose from one of the following providers:
-                    - **Local**
-                    - **Claude**
-                    - **OpenAI**
-                    - **Gemini**
+                    To activate these features, enable a **Large Language Model (LLM)** in **Preferences > AI Settings**.  
+                    
+                    From **Activate an LLM**, choose from one of the following providers, and connect an API Key:
+                    - **Claude**: A hosted LLM with very large context windows and alignment-focused training, well-suited for long-form document analysis and instruction-following tasks. For more information on how to retrieve a Claude API Token, naviagte to [Anthropic](https://platform.claude.com/docs/en/api/overview#prerequisites).
+                    - **OpenAI**: A general-purpose hosted LLM platform providing high-capability models with strong reasoning, code generation, and tool-calling support via a mature API ecosystem. For more information on how to retrieve an OpenAI API Token, naviagte to [OpenAI](https://platform.openai.com/docs/quickstart).
+                    - **Gemini**: A hosted multimodal LLM capable of joint reasoning over text, images, and other modalities, designed for deep integration with Google Cloud and Workspace services. For more information on how to retrieve a Gemini API Token, naviagte to [Gemini](https://ai.google.dev/gemini-api/docs/api-key).
+                    - **LLM URL**: A configurable HTTP endpoint that represents an externally hosted LLM service, that allows users to connect to custom, proxied, or self-hosted model deployments independent of a specific provider.
+                    - **Local LLM**: A self-hosted LLM deployed on local or private infrastructure, that enables full data residency and model control at the cost of higher operational and hardware requirements.
 
                     {:.info}
                     > Local models keep processing fully on your machine for privacy and control, but may run slower and produce less-refined responses than hosted models.


### PR DESCRIPTION
## Description

Jobs to be done (optional)
Outline the URL usages for local LLMs

Definition of done
Outline that users can specify a URL for a local or shared LLM
Explain that users can connect to AI Gateway
Proposed outcome from Engineering would mean = add FAQ into AI In Insomnia article

Information
https://konghq.atlassian.net/browse/INS-1612

Due date (optional)
4 Feb 2026

Size
S = Alert that the user can now use a URL for LLM


Fixes #3322

## Preview Links

https://deploy-preview-4027--kongdeveloper.netlify.app/insomnia/ai-in-insomnia/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
