### PR TITLE
fix(oidc-plugin): Explain why/how to use multiple client IDs

### DIFF
--- a/app/_kong_plugins/openid-connect/index.md
+++ b/app/_kong_plugins/openid-connect/index.md
@@ -594,9 +594,9 @@ curl -X GET "http://localhost:8000?client_id=2"
 ```
 
 {{site.base_gateway}} will look for the client ID in the following locations, in order of precedence:
-1. If [`config.client_arg`](./reference/#schema--config-client-arg) is set, {{site.base_gateway}} looks for that value in the request header, URI argument, and body (in that order).
-2. If `config.client_arg` is not set, {{site.base_gateway}} looks for a `client_id` in the request header, URI argument, and body (in that order).
-2. If no client is found in either of those places, {{site.base_gateway}} uses the first client ID and client secret pair.
+1. If [`config.client_arg`](./reference/#schema--config-client-arg) is set, {{site.base_gateway}} checks for that value in the following order: in the request header, URI argument, and body.
+1. If `config.client_arg` is not set, {{site.base_gateway}} checks for a `client_id` in the following order: in the request header, URI argument, and body.
+1. If no client is found in either of those places, {{site.base_gateway}} uses the first client ID and client secret pair.
 
 {:.info}
 > **Note:** Configuring multiple clients is not possible with the client credentials grant, as the plugin always uses the client ID passed directly from the client.


### PR DESCRIPTION
## Description

Answering the following question, which came through our AI assistant:

> why does the openid connect plugin allow multiple client_id parameters?

Answer is from Aapo on Slack.

## Preview Links
https://deploy-preview-4049--kongdeveloper.netlify.app/plugins/openid-connect/#multiple-clients

