### PR TITLE
Feat (Insomnia) Add FAQ for Domain Lock and Domain Capture interaction

### DIFF
--- a/app/insomnia/enterprise-account-management.md
+++ b/app/insomnia/enterprise-account-management.md
@@ -31,7 +31,7 @@ faqs:
       - Member: Members access and work within projects assigned to them, based on the permissions granted by an owner or a co-owner. Members can't manage organization-wide settings, billing, or authentication configuration.
   - q: What happens if I enable both Domain Lock and Domain Capture on my account?
     a: |
-      If you enable both Domain Capture and Domain Lock, Domain Capture takes priority for new sign-ups. New users that sign up with a verified company email domain, are automatically added to the Enterprise organization and assigned a license, as long as license seats are available.
+      If you enable both Domain Capture and Domain Lock, Domain Capture takes priority for new sign-ups. New users that sign up with a verified company email domain are automatically added to the Enterprise organization and assigned a license, as long as license seats are available.
 
       Insomnia enforces Domain Lock in the following cases:
       - Existing users with a verified email domain who are not already part of the Enterprise organization must still be explicitly invited.


### PR DESCRIPTION
## Description

Jobs to be done (optional)
Enterprise administrators should be able to clearly understand how Domain Lock and Domain Capture interact when both settings are enabled, so they can predict user onboarding behavior and avoid confusion during rollout.

Definition of done
An FAQ entry > to the E. Account Management
The FAQ clearly explains what happens when both Domain Lock and Domain Capture are enabled

The behaviour is explicitly documented:

Domain Capture overrides Domain Lock for new sign-ups while seats are available

Domain Lock still applies to:

Existing users outside the organization
Situations where all seats are exhausted
Information
Slack

Fixes #4059

## Preview Links

https://deploy-preview-4069--kongdeveloper.netlify.app/insomnia/enterprise-account-management/#what-happens-if-i-enable-both-domain-lock-and-domain-capture-on-my-account

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
