### PR TITLE
fix(mermaid) Add 'if' to alt/opt in mermaid diagrams

### DIFF
--- a/app/_event_gateway_policies/acl/index.md
+++ b/app/_event_gateway_policies/acl/index.md
@@ -77,11 +77,11 @@ sequenceDiagram
   client->>egw: message
   egw->>egw: check action against ACL
   
-  alt allowed action
+  alt If action allowed
 
   egw->>broker: send message
 
-  else blocked action
+  else If action blocked
   egw -x client: forbidden
   end
 

--- a/app/_event_gateway_policies/skip-record/index.md
+++ b/app/_event_gateway_policies/skip-record/index.md
@@ -73,11 +73,11 @@ sequenceDiagram
   broker->>egw: consume message
   egw->>egw: check message validity
   
-  alt message matches name pattern
+  alt If message matches <br> name pattern
 
   egw--xclient: skip passing to client
 
-  else message doesn't match name pattern
+  else If message doesn't match <br> name pattern
   egw ->> egw: apply other policies
   egw->>client: pass to client
 

--- a/app/_includes/knep/schema-validation-diagram-consume.md
+++ b/app/_includes/knep/schema-validation-diagram-consume.md
@@ -11,19 +11,19 @@ sequenceDiagram
   egw->>broker: Forward
   broker->>egw: Deliver message to consume
 
-  opt Schema not cached
+  opt If schema isn't cached
     egw->>schema: Fetch schema
     schema-->>egw: Return schema
   end
 
   egw->>egw: Validate payload against schema
 
-  alt Validation passed
+  alt If validation passed
     egw->>client: Forward
-  else Validation failed
-    alt Failure mode: skip
+  else If validation failed
+    alt If failure mode: skip
       egw->>egw: Drop message
-    else Failure mode: mark
+    else If failure mode: mark
       egw->>client: Forward (marked invalid)
     end
   end

--- a/app/_includes/knep/schema-validation-diagram-produce.md
+++ b/app/_includes/knep/schema-validation-diagram-produce.md
@@ -9,19 +9,19 @@ sequenceDiagram
 
   client->>egw: Produce message
 
-  opt Schema not cached
+  opt If schema isn't cached
     egw->>schema: Fetch schema
     schema-->>egw: Return schema
   end
 
   egw->>egw: Validate payload against schema
 
-  alt Validation passed
+  alt If validation passed
     egw->>broker: Forward
-  else Validation failed
-    alt Failure mode: reject
+  else If validation failed
+    alt If failure mode: reject
       egw -x client: Reject the message
-    else Failure mode: mark
+    else If failure mode: mark
       egw->>broker: Forward (marked invalid)
     end
   end

--- a/app/_includes/plugins/confluent-kafka-consume/websocket.md
+++ b/app/_includes/plugins/confluent-kafka-consume/websocket.md
@@ -21,7 +21,7 @@ sequenceDiagram
         Broker->>Kong: Broker message
         Kong->>Client: Stream JSON text frame
 
-        opt client-acks
+        opt If client-acks
             Client->>Kong: Acknowledge message/batch
         end
     end

--- a/app/_kong_plugins/ai-mcp-oauth2/index.md
+++ b/app/_kong_plugins/ai-mcp-oauth2/index.md
@@ -106,13 +106,13 @@ sequenceDiagram
     AS-->>K: Valid / invalid
     deactivate AS
 
-    alt Token valid
+    alt If token valid
         K->>U: Forward request with claims as headers
         activate U
         U-->>K: MCP server response
         deactivate U
         K-->>C: MCP response
-    else Token invalid
+    else If token invalid
         K-->>C: 401 Unauthorized
     end
     deactivate K

--- a/app/_kong_plugins/ai-mcp-proxy/index.md
+++ b/app/_kong_plugins/ai-mcp-proxy/index.md
@@ -368,9 +368,9 @@ sequenceDiagram
     Auth-->>Kong: Consumer identity
     Kong->>ACL: Evaluate scoped default ACL
     ACL-->>Log: Audit entry
-    alt Allowed
+    alt If allowed
       Kong-->>Client: Filtered tool list
-    else Denied
+    else If denied
       Kong-->>Client: INVALID_PARAMS -32602
     end
   end
@@ -383,11 +383,11 @@ sequenceDiagram
     Auth-->>Kong: Consumer identity
     Kong->>ACL: Evaluate per-tool ACL
     ACL-->>Log: Audit entry
-    alt Allowed
+    alt If allowed
       Kong->>Up: Forward request
       Up-->>Kong: Response
       Kong-->>Client: Response
-    else Denied
+    else If denied
       Kong-->>Client: INVALID_PARAMS -32602
     end
   end

--- a/app/_kong_plugins/ai-prompt-compressor/index.md
+++ b/app/_kong_plugins/ai-prompt-compressor/index.md
@@ -192,12 +192,12 @@ sequenceDiagram
     activate KongAICompressor
     KongAICompressor->>KongAICompressor: Check for LLMLINGUA tags
 
-    alt Tagged content found
+    alt If tagged content found
         KongAICompressor->>LLMLingua2: Compress tagged sections
         activate LLMLingua2
         LLMLingua2-->>KongAICompressor: Return compressed sections
         deactivate LLMLingua2
-    else No LLMlingua tags
+    else If no LLMlingua tags
         KongAICompressor->>LLMLingua2: Compress entire prompt
         activate LLMLingua2
         LLMLingua2-->>KongAICompressor: Return compressed prompt

--- a/app/_kong_plugins/injection-protection/index.md
+++ b/app/_kong_plugins/injection-protection/index.md
@@ -72,10 +72,10 @@ sequenceDiagram
     Client->>Kong: Sends a request
     Kong->>Plugin: Evaluates for regex match
 
-    alt No regex match
+    alt If no regex match
         Plugin->>Client: 200 OK
         Plugin->>Upstream: Proxies request
-    else Regex match
+    else If regex matches
         Plugin->>Client: 400 Bad Request
         Plugin->>Kong: Logs injection 
     end

--- a/app/_kong_plugins/prisma-airs-intercept/index.md
+++ b/app/_kong_plugins/prisma-airs-intercept/index.md
@@ -110,18 +110,18 @@ autonumber
     Plugin->>Prisma: Send prompt for scanning
     Prisma-->>Plugin: Scan result
     
-    alt Prompt is malicious
+    alt If prompt is malicious
         Plugin->>Client: Return 403 Forbidden
-    else Prompt is benign
+    else If prompt is benign
         Plugin->>LLM: Forward request
         LLM-->>Plugin: Return completion
         Plugin->>Plugin: Buffer and extract response text
         Plugin->>Prisma: Send response for scanning
         Prisma-->>Plugin: Scan result
         
-        alt Response is malicious
+        alt If response is malicious
             Plugin->>Client: Return 403 Forbidden
-        else Response is benign
+        else If response is benign
             Plugin->>Client: Return LLM response
         end
     end

--- a/app/insomnia/request-authentication.md
+++ b/app/insomnia/request-authentication.md
@@ -72,10 +72,10 @@ sequenceDiagram
     participant Server
     Client->>Server: Requests a protected resource
     Server->>Client: Requests username and password
-    alt Correct credentials sent
+    alt If correct credentials sent
         Client->>Server: Sends username and password
         Server->>Client: Returns requested resource
-    else Wrong credentials sent
+    else If wrong credentials sent
         Client->>Server: Sends wrong username and password
         Server->>Client: Returns 401 Unauthorized status code
     end


### PR DESCRIPTION
## Description

In mermaid diagrams, when something is an option or alternative, it appears in a box with a dashed border and labelled either `alt` or `opt`. Some EGW users have gotten confused about the syntax, not realizing that this is an "if" and not applicable to all situations. Adding "if" to clarify; covering some AI diagrams as well.

See slack thread for context: https://kongstrong.slack.com/archives/C089Z3BMC9Z/p1770060209090989

## Preview Links

Example pages:
https://deploy-preview-4074--kongdeveloper.netlify.app/event-gateway/policies/acl/#how-it-works
https://deploy-preview-4074--kongdeveloper.netlify.app/event-gateway/policies/schema-validation-consume/#how-it-works
https://deploy-preview-4074--kongdeveloper.netlify.app/plugins/ai-mcp-proxy/#acl-tool-control-request-flow