### PR TITLE
fix(dev-site): Descriptions for index pages

### DIFF
--- a/app/_indices/ai-gateway.yaml
+++ b/app/_indices/ai-gateway.yaml
@@ -1,4 +1,5 @@
 title: AI Gateway Documentation
+description: Index containing all documentation for Kong AI Gateway.
 sections:
   - title: Overview
     items:

--- a/app/_indices/catalog.yaml
+++ b/app/_indices/catalog.yaml
@@ -1,4 +1,5 @@
 title: "Catalog Documentation"
+description: Index containing all documentation for {{site.konnect_catalog}}.
 sections:
   - title: Overview
     items:

--- a/app/_indices/deck.yaml
+++ b/app/_indices/deck.yaml
@@ -1,4 +1,5 @@
 title: decK Documentation
+description: Index containing all documentation for decK.
 sections:
   - title: Overview
     items:

--- a/app/_indices/dev-portal.yaml
+++ b/app/_indices/dev-portal.yaml
@@ -1,4 +1,5 @@
 title: Dev Portal Documentation
+description: Index containing all documentation for Kong Dev Portal in Konnect.
 sections:
   - title: Overview
     items:

--- a/app/_indices/event-gateway.yaml
+++ b/app/_indices/event-gateway.yaml
@@ -1,4 +1,5 @@
 title: Event Gateway Documentation
+description: Index containing all documentation for {{site.event_gateway}}.
 sections:
   - title: Overview
     items:

--- a/app/_indices/gateway.yaml
+++ b/app/_indices/gateway.yaml
@@ -1,4 +1,5 @@
 title: Gateway Documentation
+description: Index containing all documentation for {{site.base_gateway}}.
 sections:
   - title: Overview
     items:

--- a/app/_indices/insomnia.yaml
+++ b/app/_indices/insomnia.yaml
@@ -1,4 +1,5 @@
 title: Insomnia Documentation
+description: Index containing all documentation for Insomnia.
 sections:
   - title: Overview
     items:

--- a/app/_indices/kic.yaml
+++ b/app/_indices/kic.yaml
@@ -1,4 +1,5 @@
 title: All KIC Documentation
+description: Index containing all documentation for {{site.kic_product_name}}.
 sections:
   - title: Overview
     items:

--- a/app/_indices/konnect-reference-platform.yaml
+++ b/app/_indices/konnect-reference-platform.yaml
@@ -1,4 +1,5 @@
 title: "{{site.konnect_short_name}} Reference Platform Documentation"
+description: Index containing all documentation for the {{site.konnect_short_name}} Reference Platform.
 sections:
   - title: Overview
     items:

--- a/app/_indices/konnect.yaml
+++ b/app/_indices/konnect.yaml
@@ -1,4 +1,5 @@
 title: Konnect Platform Documentation
+description: Index containing all documentation for the {{site.konnect_short_name}} platform.
 sections:
   - title: About Konnect
     items:

--- a/app/_indices/mesh.yaml
+++ b/app/_indices/mesh.yaml
@@ -1,4 +1,5 @@
 title: Mesh Documentation
+description: Index containing all documentation for {{site.mesh_product_name}}.
 sections:
   - title: Overview
     items:

--- a/app/_indices/metering-and-billing.yaml
+++ b/app/_indices/metering-and-billing.yaml
@@ -1,4 +1,5 @@
 title: "{{site.metering_and_billing}} Documentation Index"
+description: "Index containing all documentation for {{site.metering_and_billing}}."
 sections:
   - title: Reference
     items:

--- a/app/_indices/observability.yaml
+++ b/app/_indices/observability.yaml
@@ -1,4 +1,5 @@
 title: Observability Documentation
+description: Index containing all documentation for {{site.observability}}.
 sections:
   - title: Overview
     items:

--- a/app/_indices/operator.yaml
+++ b/app/_indices/operator.yaml
@@ -1,4 +1,5 @@
 title: Operator Documentation
+description: Index containing all documentation for {{site.operator_product_name}}.
 groups:
   - title: Hidden
     hidden: true


### PR DESCRIPTION
## Description

Fixes issue where index pages come up in search with only a title and no way to tell what they are.

<img width="821" height="349" alt="Screenshot 2026-02-03 at 1 27 26 PM" src="https://github.com/user-attachments/assets/702a1c98-8cc4-4245-972c-80ae625a3ba7" />

## Preview Links
N/A
