### PR TITLE
Fix(KGW): fix cert instructions

### DIFF
--- a/app/_gateway_entities/certificate.md
+++ b/app/_gateway_entities/certificate.md
@@ -110,6 +110,7 @@ data:
       PXy3PkB8++6U4Y3vdk2Ni2WYYlIls8yqbM4327IKmkDc2TimS8u60CT47mKU7aDY
       cbTV5RDkrlaYwm5yqlTIglvCv7o=
       -----END CERTIFICATE-----
+  id: e95962d1-0793-40a1-8e99-252a45664d7a
   key: |
       -----BEGIN RSA PRIVATE KEY-----
       MIIEowIBAAKCAQEAvpnaPKLIKdvx98KW68lz8pGaRRcYersNGqPjpifMVjjE8LuC


### PR DESCRIPTION
Cert instructions missing `id`

https://kongstrong.slack.com/archives/C04349E4KRC/p1768290909463769


https://deploy-preview-4086--kongdeveloper.netlify.app/gateway/entities/certificate/