### PR TITLE
feat(datakit): Call node support for running after proxying

### DIFF
--- a/app/_kong_plugins/datakit/index.md
+++ b/app/_kong_plugins/datakit/index.md
@@ -758,7 +758,7 @@ See [Third-party auth](/plugins/datakit/examples/authenticate-third-party/) for 
 
 #### Limitations
 
-In {{site.base_gateway}} 3.12 and earlier versions, the `call` node couldn't be executed after proxying a
+In {{site.base_gateway}} 3.12 and earlier, the `call` node couldn't be executed after proxying a
 request, so attempting to configure the node using outputs from the upstream service
 response would yield an error:
 

--- a/app/gateway/datakit-flow-editor.md
+++ b/app/gateway/datakit-flow-editor.md
@@ -27,7 +27,7 @@ related_resources:
 faqs:
   - q: I've configured a call node in the response section, why is it throwing an error?
     a: |
-      In {{site.base_gateway}} 3.12 and earlier versions, the `call` node couldn't be executed after proxying a request, and you would see the following error:
+      In {{site.base_gateway}} 3.12 and earlier, the `call` node couldn't be executed after proxying a request, and you would see the following error:
 
       ```
       invalid dependency (node #1 (CALL) -> node service_response): circular dependency


### PR DESCRIPTION
## Description

Fixes https://konghq.atlassian.net/browse/KAG-8176.

3.13 catch-up. Based on https://github.com/Kong/kong-ee/pull/13756

## Preview Links
https://deploy-preview-4100--kongdeveloper.netlify.app/plugins/datakit/#call-node
https://deploy-preview-4100--kongdeveloper.netlify.app/plugins/datakit/#limitations
https://deploy-preview-4100--kongdeveloper.netlify.app/gateway/datakit-flow-editor/
