### PR TITLE
fix(gateway): Kafka upstream schema registry examples

### DIFF
--- a/app/_kong_plugins/confluent/examples/schema-registry.yaml
+++ b/app/_kong_plugins/confluent/examples/schema-registry.yaml
@@ -45,6 +45,8 @@ config:
         schema_version: latest
   cluster_api_key: ${cluster_api_key}
   cluster_api_secret: ${cluster_api_secret}
+  message_by_lua_functions:
+    - "return function(message) return message.body end"
 
 tools:
   - deck

--- a/app/_kong_plugins/kafka-upstream/examples/schema-registry.yaml
+++ b/app/_kong_plugins/kafka-upstream/examples/schema-registry.yaml
@@ -36,6 +36,9 @@ config:
       value_schema:
         subject_name: kong-value
         schema_version: latest
+  message_by_lua_functions:
+  - "return function(message) return message.body end"
+
 
 tools:
   - deck


### PR DESCRIPTION
## Description

Reported on Slack by Hugo:

>Can we update the docs for the http mediation schema registry validation for Kafka? It is not processing correctly the messages as they are wrapped in metadata and the schema is expecting just the body. We can fix it by adding this line at the plugin
> ```
> message_by_lua_functions:
>    - "return function(message) return message.body end"
> ```

Validated the fix against schema, didn't test with real schema registry.

## Preview Links
https://deploy-preview-4105--kongdeveloper.netlify.app/plugins/kafka-upstream/examples/schema-registry/
https://deploy-preview-4105--kongdeveloper.netlify.app/plugins/confluent/examples/schema-registry/
