### PR TITLE
fix(metering): Call out Kong in Get started tiles

### DIFF
--- a/app/_landing_pages/metering-and-billing.yaml
+++ b/app/_landing_pages/metering-and-billing.yaml
@@ -42,19 +42,19 @@ rows:
       - blocks:
           - type: card
             config:
-              title: Start monetizing API traffic
+              title: Start monetizing {{site.base_gateway}} API traffic
               description: |
                 Learn how to meter and bill {{site.base_gateway}} API requests.
-              icon: /assets/icons/graduation.svg
+              icon: /assets/icons/KogoBlue.svg
               cta:
                 url: /metering-and-billing/get-started/
       - blocks:
           - type: card
             config:
-              title: "Monetize LLM traffic"
+              title: "Monetize Kong AI Gateway LLM traffic"
               description: |
                 Learn how to meter and bill AI Gateway LLM tokens.
-              icon: /assets/icons/ai.svg
+              icon: /assets/icons/KogoBlue.svg
               cta:
                 url: /how-to/meter-llm-traffic/
 


### PR DESCRIPTION
## Description

Fixes issue reported by Peter

Trying to clear up any confusion since lots of customers want to do these things with generic metering, so just making it clear that these include Kong. 

## Preview Links
/metering-and-billing/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
