### PR TITLE
fix(plugins): Remove Guides link from navbar for third-party plugins

### DIFF
--- a/app/_includes/layouts/plugins/nav_header.html
+++ b/app/_includes/layouts/plugins/nav_header.html
@@ -4,7 +4,7 @@
       <div class="tablist">
         <a class="tab-button__horizontal{% if page.overview? %} tab-button__horizontal--active{% endif %}" href="{{page.overview_url}}">Overview</a>
         <a class="tab-button__horizontal{% if page.example? %} tab-button__horizontal--active{% endif %}" href="{{page.get_started_url}}">Examples</a>
-        <a class="tab-button__horizontal" href="/how-to/?kong_plugins={{page.slug}}" target="_blank" rel="noopener noreferrer">Guides</a>
+        {%- unless page.third_party -%}<a class="tab-button__horizontal" href="/how-to/?kong_plugins={{page.slug}}" target="_blank" rel="noopener noreferrer">Guides</a>{%- endunless -%}
         <a class="tab-button__horizontal{% if page.reference? %} tab-button__horizontal--active{% endif %}" href="{{page.reference_url}}">Configuration reference</a>
         {% if page.changelog_exists? %}
           <a class="tab-button__horizontal{% if page.changelog? %} tab-button__horizontal--active{% endif %}" href="{{page.changelog_url}}">Changelog</a>


### PR DESCRIPTION
## Description

Fixes #4108 

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
