### PR TITLE
fix(konnect): Adjust links to Konnect get started guide

### DIFF
--- a/app/_indices/konnect.yaml
+++ b/app/_indices/konnect.yaml
@@ -8,7 +8,7 @@ sections:
         url: /konnect/
       - title: Get started with Kong Gateway on Konnect
         description: Get started by setting up {{site.konnect_short_name}} hybrid deployment and walking through some common API management tasks. 
-        url: /gateway/get-started/
+        url: /gateway/get-started/?deployment=konnect
       - path: /gateway/topology-hosting-options/
       - path: /konnect-platform/kai/
   

--- a/app/_landing_pages/konnect.yaml
+++ b/app/_landing_pages/konnect.yaml
@@ -139,7 +139,7 @@ rows:
                 url: /gateway/
                 align: end
               - text: Get started
-                url: /gateway/get-started/
+                url: /gateway/get-started/?deployment=konnect
                 align: end
               
     - blocks:


### PR DESCRIPTION
## Description

Adjusting getting started guide link on Konnect pages to point to a Konnect deployment. 
Customers have run into issues when they have the toggle on on-prem and don't realize it. 

[Issue reported on Slack.](https://kongstrong.slack.com/archives/CDSTDSG9J/p1770665855427359)

## Preview Links


