### PR TITLE
fix(mesh): Update selectors for mesh service elements

### DIFF
--- a/app/_assets/javascripts/mesh_service_switcher.js
+++ b/app/_assets/javascripts/mesh_service_switcher.js
@@ -20,10 +20,10 @@ class MeshServiceSwitcher {
           // the $bits we need
           const $checkbox = $item.querySelector('input[type="checkbox"]');
           const $legacy = $item.parentNode.querySelector(
-            ".meshservice ~ .language-yaml:nth-child(2)"
+            ".meshservice ~ .custom-code-block:nth-child(2)"
           );
           const $meshService = $item.parentNode.querySelector(
-            ".meshservice ~ .language-yaml:nth-child(3)"
+            ".meshservice ~ .custom-code-block:nth-child(3)"
           );
 
           // get the changed value and update the view


### PR DESCRIPTION
## Description

Fixes `I'm using Meshservice` in policy examples.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
