### PR TITLE
fix(operator): Update support for Catalog and Dev Portal

### DIFF
--- a/app/_landing_pages/operator.yaml
+++ b/app/_landing_pages/operator.yaml
@@ -118,9 +118,9 @@ rows:
               - product: Kong Mesh
                 supported: Planned
               - product: Developer Portal
-                supported: Planned
+                supported: true
               - product: Catalog
-                supported: Planned
+                supported: true
               - product: Analytics
                 supported: Planned
               - product: Team Management


### PR DESCRIPTION
## Description

KO 2.1 went out this past week, and it introduced support for Catalog and Dev Portal.

Issue reported on Slack: https://kongstrong.slack.com/archives/C045Y8G7VDW/p1770611303503339

## Preview Links
https://deploy-preview-4144--kongdeveloper.netlify.app/operator/