### PR TITLE
feat(dev-portal): Define portalaccesstoken 

### DIFF
--- a/app/_includes/dev-portal/portal-access-token.md
+++ b/app/_includes/dev-portal/portal-access-token.md
@@ -1,0 +1,15 @@
+A `portalaccesstoken` is a cookie that gets generated when a developer authenticates to Dev Portal. 
+It's used only by the [Dev Portal API](/api/konnect/dev-portal/).
+
+Unlike the {{site.konnect_short_name}} PAT, it can't be generated or managed manually, but it can expire.
+You can find the `portalaccesstoken` cookie value in an outgoing request to the API after you login, or in the cookie storage section of your browser's dev tools.
+If the token expires, you need to re-authenticate with Dev Portal to generate a new cookie.
+
+When using the Dev Portal API, you need to send the `portalaccesstoken` in a cookie header with requests access any resources that require authentication.
+For example, the `POST /v3/applications` endpoint requires auth, so you would access it like this:
+
+```sh
+curl -X POST https://global.api.konghq.com/v3/applications \
+-H 'Content-Type: application/json' \
+-H 'Cookie: portalaccesstoken=$JWT_ACCESS_TOKEN_VALUE' \
+```

--- a/app/_landing_pages/konnect-api.yaml
+++ b/app/_landing_pages/konnect-api.yaml
@@ -154,21 +154,7 @@ rows:
     - blocks:
         - type: text
           config: |
-            A `portalaccesstoken` is a cookie that gets generated when a developer authenticates to Dev Portal. 
-            It's used only by the [Dev Portal API](/api/konnect/dev-portal/).
-
-            Unlike the {{site.konnect_short_name}} PAT, it can't be generated or managed manually, but it can expire.
-            You can find the `portalaccesstoken` cookie value in an outgoing request to the API after you login, or in the cookie storage section of your browser's dev tools.
-            If the token expires, you need to re-authenticate with Dev Portal to generate a new cookie.
-
-            When using the Dev Portal API, you need to send the `portalaccesstoken` in a cookie header with requests access any resources that require authentication.
-            For example, the `POST /v3/applications` endpoint requires auth, so you would access it like this:
-
-            ```sh
-            curl -X POST https://global.api.konghq.com/v3/applications \
-              -H 'Content-Type: application/json' \
-              -H 'Cookie: portalaccesstoken=$JWT_ACCESS_TOKEN_VALUE' \
-            ```
+            {% include_cached /dev-portal/portal-access-token.md %}
 
   - header:
         type: h3

--- a/app/dev-portal/developer-signup.md
+++ b/app/dev-portal/developer-signup.md
@@ -27,6 +27,13 @@ related_resources:
     url: /dev-portal/authentication-strategies/
   - text: Dev Portal developer RBAC
     url: /dev-portal/developer-rbac/
+
+faqs:
+  - q: |
+      I've logged into the Dev Portal and want to use the Dev Portal API to manage my assets, but it asks for a `portalaccesstoken`. 
+      What is this token and where can I find it?
+    a: |
+      {% include_cached /dev-portal/portal-access-token.md %}
 ---
 
 The Dev Portal enables you to quickly get access to your APIs of interest, in a self-serve way. 


### PR DESCRIPTION
## Description

Fixes #4073 

Explain what a portalaccesstoken does, how to find it, and how to use it to authenticate with the Dev Portal API.

Note: I added this to the Konnect APIs page, which is where we have the info about all the other Konnect tokens. I couldn't find a better spot for it in the Dev Portal docs. @cloudjumpercat what do you think?

## Preview Links

https://deploy-preview-4148--kongdeveloper.netlify.app/dev-portal/developer-signup/#faqs
https://deploy-preview-4148--kongdeveloper.netlify.app/konnect-api/#dev-portal-access-tokens-for-developers
