### PR TITLE
Bug (Insomnia): Remove incorrect statement about automatic SCIM token refresh

### DIFF
--- a/app/insomnia/scim.md
+++ b/app/insomnia/scim.md
@@ -123,8 +123,8 @@ SCIM tokens expire based on the configuration in your identity provider. When a 
 
 If the token expires and is not renewed:
 
-- New users are not provisioned from the identity provider.
-- Users that you deactivate in the identity provider are not removed from Insomnia.
+- New users aren't provisioned from the identity provider.
+- Users that you deactivate in the identity provider aren't removed from Insomnia.
 - SCIM provisioning stops until the token is refreshed.
 
 You must manually refresh the token from the [SCIM](https://app.insomnia.rest/app/enterprise/scim) settings:


### PR DESCRIPTION
## Description

> Jobs to be done (optional)
> The SCIM documentation currently states that Insomnia automatically refreshes SCIM tokens. This is inaccurate.
> 
> Users must receive correct information about SCIM token lifecycle behavior so they understand that Insomnia notifies administrators when a token requires attention but does not automatically refresh it.
> 
> We need to remove or correct the misleading statement to ensure the documentation reflects current product behavior.
> 
> Definition of done
> 
> Remove the section that describes automatic SCIM token refresh from:
> 
> 
> https://developer.konghq.com/insomnia/scim/#automatic-token-refresh
> 
> 
> Remove any additional references across the SCIM page that imply automatic token refresh.
> 
> 
> Ensure the documentation accurately states that Insomnia:
> 
> Surfaces warnings or notifications when a SCIM token requires attention.
> 
> Does not automatically refresh or regenerate tokens.
> 
> Information
> Slack
> 
> Due date (optional)
> ASAP
> 
> Size
> Rough estimate of effort:
> 
> S (Small). Example: fixing a broken link, updating wording in an FAQ or paragraph

Fixes #4151 

## Preview Links

https://deploy-preview-4152--kongdeveloper.netlify.app/insomnia/scim/#scim-token-expiration-and-renewal

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
