### PR TITLE
Fix(KGW): Mention the KONG_PASSWORD env in tldr

### DIFF
--- a/app/_how-tos/gateway/enable-basic-auth-on-kong-manager.md
+++ b/app/_how-tos/gateway/enable-basic-auth-on-kong-manager.md
@@ -29,7 +29,7 @@ tags:
 
 tldr:
     q: How do I enable basic authentication for Kong Manager?
-    a: Set `enforce-rbac = on`, `admin_gui_auth = basic-auth`, and `admin_gui_session_conf = { "secret":"kong" }` in your Kong configuration file or as environment variables. And run [database migrations](https://developer.konghq.com/how-to/configure-datastore/#run-a-kong-gateway-database-migration) with environment variable `KONG_PASSWORD=kong` to create admin user. Then, log in to Kong Manager with `kong_admin` as your username and `kong` as your password.
+    a: Set `enforce-rbac = on`, `admin_gui_auth = basic-auth`, and `admin_gui_session_conf = { "secret":"kong" }` in your Kong configuration file or as environment variables. And run [database migrations](/how-to/configure-datastore/#run-a-kong-gateway-database-migration) with environment variable `KONG_PASSWORD=kong` to create admin user. Then, log in to Kong Manager with `kong_admin` as your username and `kong` as your password.
 
 tools: []
 


### PR DESCRIPTION
## Description

For those who are not using quickstart script, they need to create kong_admin user by running migrations with KONG_PASSWORD env.

## Preview Links


## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
