### PR TITLE
Add note on invalid configuration partials

### DIFF
--- a/app/gateway/data-plane-reference.md
+++ b/app/gateway/data-plane-reference.md
@@ -289,7 +289,7 @@ The default directory for {{site.base_gateway}} logs is [`/usr/local/kong/logs`]
     * Data Plane node failed to connect to the Control Plane.
     * Data Plane node failed to ping the Control Plane.
     * Data Plane node failed to receive a ping response from the Control Plane.
-    * Invalid [configuration partials](/gateway/entities/partial/)
+    * Invalid [configuration partials](/gateway/entities/partial/).
 
     You may have an issue on the host network where the node resides.
     Diagnose and resolve the issue, then restart the node and check the sync status in {{site.konnect_short_name}}.


### PR DESCRIPTION
Added a note about invalid configuration partials which can cause DP nodes to go out of sync

## Description


## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. n/a - just informational
- [ ] All pages contain metadata. n/a - just small update
- [x] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). N/A
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter. n/a - just change to existing page
- [ ] Add new pages to the product documentation index (if applicable). n/a - just change to existing page
