### PR TITLE
Update operator-konnect-cgw-configuration.md

### DIFF
--- a/app/_how-tos/operator/operator-konnect-cgw-configuration.md
+++ b/app/_how-tos/operator/operator-konnect-cgw-configuration.md
@@ -63,10 +63,9 @@ spec:
         namespacedRef:
           name: konnect-network-1
       autoscale:
-        type: static
-        static:
-          instance_type: small
-          requested_instances: 2
+        type: autopilot
+        autopilot:
+          base_rps: 100          
       environment:
         - name: KONG_LOG_LEVEL
           value: debug


### PR DESCRIPTION
Updated to remove static autoscale, no longer supported,  use autoscale type autopilot and base_rps w/out max_rps (deprecated)

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
