### PR TITLE
Fix: Adds package-lock.json to kongctl-versions tool

### DIFF
--- a/tools/kongctl-versions/package-lock.json
+++ b/tools/kongctl-versions/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "kongctl-versions",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "kongctl-versions",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}


### PR DESCRIPTION
## Description

Adds a package lock file to the kongctl-versions tool so that the `npm ci` command will succeed. 

@kong-docs if you can review please