### PR TITLE
Add missing redirect for Kong Identity OAuth

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -33,6 +33,7 @@
 /mesh/gateway-api/  /how-to/set-up-a-built-in-kubernetes-gateway/
 /how-to/send-asychronous-llm-requests/ /how-to/send-asynchronous-llm-requests/
 /how-to/encrypt-kafka-messages-with-event-gateway/ /event-gateway/encrypt-kafka-messages-with-event-gateway/
+/how-to/event-gateway/kong-identity-oauth/  /event-gateway/kong-identity-oauth/
 
 # Mesh redirects
 /how-to/deploy-mesh-on-kubernetes/ /mesh/#get-started


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
