### PR TITLE
Revert "fix(operator): Update support for Catalog and Dev Portal"

### DIFF
--- a/app/_landing_pages/operator.yaml
+++ b/app/_landing_pages/operator.yaml
@@ -118,9 +118,9 @@ rows:
               - product: Kong Mesh
                 supported: Planned
               - product: Developer Portal
-                supported: true
+                supported: Planned
               - product: Catalog
-                supported: true
+                supported: Planned
               - product: Analytics
                 supported: Planned
               - product: Team Management


### PR DESCRIPTION
While operator technically supports both per the latest announcement, we don't have CRD support for either one yet.

Reported here: https://kongstrong.slack.com/archives/CDSTDSG9J/p1770942389408469
Verified here: https://kongstrong.slack.com/archives/C08KFC895V0/p1770818506523309?thread_ts=1770051313.315799&cid=C08KFC895V0