### PR TITLE
fix(konnect-platform): Clarify which consumer group field the RLA plugin refers to

### DIFF
--- a/app/gateway/control-plane-groups.md
+++ b/app/gateway/control-plane-groups.md
@@ -245,7 +245,7 @@ rows:
   - entity: Consumer Groups
     behavior: >-
       Only Consumers from the same Control Plane can be added to a Consumer Group.<br><br>
-      In the Rate Limiting Advanced plugin, Consumer Group names can reference groups from other Control Plane Group members.
+      In the Rate Limiting Advanced plugin, the configuration field [`config.consumer_groups`](/plugins/rate-limiting-advanced/reference/#schema--config-consumer-groups) can reference Consumer Groups from other Control Plane Group members.
   - entity: Vaults
     behavior: >-
       Vault prefixes must be unique.<br><br>


### PR DESCRIPTION
## Description

Issue reported on Slack: https://kongstrong.slack.com/archives/CDSTDSG9J/p1770957669893319

Rephrasing to make it clear that this note refers to the config parameter and not to scope.

## Preview Links


