### PR TITLE
update(mtls-auth): Clarify cert support in headers

### DIFF
--- a/app/_kong_plugins/mtls-auth/index.md
+++ b/app/_kong_plugins/mtls-auth/index.md
@@ -45,11 +45,22 @@ notes: |
 
 min_version:
   gateway: '1.0'
+
+faqs:
+  - q: Can the mTLS plugin read a certificate from a header?
+    a: |
+      No, the mTLS authentication plugin can't read certificates from headers.
+      The mTLS plugin is only designed for traditional TLS termination. For reading client certificates from headers, use the [Header Cert Authentication plugin](/plugins/header-cert-auth/).
+      
 ---
 
 The MTLS Auth plugin lets you add mutual TLS authentication based on a client-supplied or a server-supplied certificate, 
 and on the configured trusted certificate authority (CA) list.
 
+If you need to read client certificates from headers, see the [Header Cert Authentication plugin](/plugins/header-cert-auth/).
+
+{:.warning}
+> **Important:** To use this plugin, you must add [certificate authority (CA) Certificates](/gateway/entities/ca-certificate/). Set them up before configuring the plugin.
 
 ## How does the mTLS plugin work?
 


### PR DESCRIPTION
## Description

Clarifying that the mTLS auth plugin doesn't support certs in headers, and link to the Header Cert Auth plugin instead. Adding a missing note as well.

Based on Kapa. Kapa can sort of find this info by comparing the two plugins, but it's not sure about what the mTLS plugin supports.

## Preview Links

https://deploy-preview-4197--kongdeveloper.netlify.app/plugins/mtls-auth/
