### PR TITLE
Feat (Insomnia): Reference page: Document converting project storage using storage type conversion

### DIFF
--- a/app/insomnia/convert-project-storage.md
+++ b/app/insomnia/convert-project-storage.md
@@ -78,7 +78,7 @@ When you convert a Git Sync project to Local Vault, Insomnia stores the project 
 To convert a project’s storage type:
 
 1. In the Insomnia application, from the **PROJECTS** panel, hover over a project.
-2. Select the dropdown arrow, and click **Settings**.
+2. Click the dropdown arrow, and click **Settings**.
 3. In **Type** field, click **Change**.
 4. Select the storage type.
 5. Click **Update**.


### PR DESCRIPTION
## Description

> Jobs to be done (optional)
> Users need clear guidance on converting a Git Sync project to Cloud Sync or Local Vault when changing collaboration models or troubleshooting storage issues.
> 
> The previous documentation implied that users must export and recreate projects. Insomnia now supports direct storage type conversion from within Project Settings. Documentation must reflect the current supported workflow.
> 
> Definition of done
> Conversion reference document:
> 
> Document the supported storage conversion workflow using Project Settings > Type > Change
> Clarify conversion behavior when converting:
> 
> 
> Git Sync → Cloud Sync
> 
> Git Sync → Local Vault
> 
> all project storage types - to available project storage types (Lets catch all conversion on this conversion reference doc)
> Clearly describe:
> 
> What happens to the Git repository
> What happens to unsynced changes
> Any limitations or data loss scenarios
> Information
> Due date (optional)
> 4 March
> 
> Size
> M (Medium) Example: writing a UI how to for a straightforward product, adding a plugin example
> 

Fixes #4129

## Preview Links

https://deploy-preview-4211--kongdeveloper.netlify.app/insomnia/convert-project-storage/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
