### PR TITLE
Feat (Insomnia) Clarify private repository access requirements in Git Sync documentation

### DIFF
--- a/app/_how-tos/insomnia/synchronize-with-git.md
+++ b/app/_how-tos/insomnia/synchronize-with-git.md
@@ -56,7 +56,7 @@ faqs:
     a: |  
       A **403 Forbidden** error usually indicates that Insomnia does not have access to the target repository.
 
-      If you use GitHub, navigate to [Github applications](https://github.com/apps/insomnia-desktop) tto ensure that the Insomnia GitHub App is installed and has access to the repository.
+      If you use GitHub, navigate to [Github applications](https://github.com/apps/insomnia-desktop) to ensure that the Insomnia GitHub App is installed and has access to the repository.
       
       {:.warning}
       > If you use a managed GitHub account that restricts GitHub App installation, use the **Git** tab and configure the repository with the generic Git workflow instead.    


### PR DESCRIPTION
## Description

> Jobs to be done (optional)
> Users connecting GitHub to Insomnia through Git Sync expect to see all repositories they have access to.
> 
> Some users report that only public repositories appear, while private repositories are missing. This creates confusion and appears to be a product bug.
> 
> In reality, this behavior is caused by GitHub App permissions or token scope configuration. The documentation does not clearly explain this requirement or provide troubleshooting guidance.
> 
> Users need clear instructions on:
> 
> Granting private repository access in the GitHub App installation
> Using a fine-grained Personal Access Token (PAT) when applicable
> Troubleshooting missing private repositories
> Definition of done
> Update Git Sync documentation to explicitly state that:
> 
> Private repositories must be granted access in the GitHub App installation settings.
> Users may need to reconfigure their GitHub App permissions to include private repositories.
> Fine-grained PATs should be used if authenticating via token.
> Information
> Slack
> 
> https://kongstrong.slack.com/archives/C0ABMBKCRDX/p1769531360343839
> 
> https://kongstrong.slack.com/archives/C044UFN49RT/p1770147763663839
> 
> Due date (optional)
> 4 March
> 
> Size

Fixes #4153 

## Preview Links

https://deploy-preview-4236--kongdeveloper.netlify.app/how-to/synchronize-with-git/#why-can-i-only-see-public-repositories-after-connecting-github

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
