### PR TITLE
fix(konnect): Teams and roles reference

### DIFF
--- a/app/konnect-platform/teams-and-roles.md
+++ b/app/konnect-platform/teams-and-roles.md
@@ -327,7 +327,7 @@ rows:
 
 #### Audit logs
 
-The following table describes the predefined roles for [audit logs](konnect-platform/audit-logs/):
+The following table describes the predefined roles for [audit logs](/konnect-platform/audit-logs/):
 
 <!--vale off-->
 {% konnect_roles_table %}


### PR DESCRIPTION
## Description

Comprehensive update to Konnect teams and roles. Because these teams and roles are maintained outside of platform-api specs, it's harder for us to generate them. We've had a few requests to fix this page; updating it manually for now because we're missing a ton of roles.

Notes on testing & where the info came from & decisions:
* The permission details came from the kauth repo. I skipped any permissions or roles marked as internal (which is why I removed the Metering `viewer` role - that's an internal only role and isn't available to customers) or that have feature flags attached. I cross-referenced all of these with the UI in both an internal account and a free version personal account that has no extra feature flags.
* Made the tables as consistent as possible - added the third column with a breakdown of the exact permissions for each role to every table.
* Identity and audit logs sections: I left those as-is because they're not in my vanilla UI, but aren't behind any feature flag as far as I can see. 
* Just generally double-checked everything and updated based on the most recent state of things.

Fixes #3196 & requests from Slack.

## Preview Links

https://deploy-preview-4307--kongdeveloper.netlify.app/konnect-platform/teams-and-roles/

