### PR TITLE
fix(gateway): Key auth enc plugin limitations

### DIFF
--- a/app/_kong_plugins/key-auth-enc/index.md
+++ b/app/_kong_plugins/key-auth-enc/index.md
@@ -42,11 +42,10 @@ search_aliases:
 
 
 notes: |
-  This plugin is not available in Konnect:
-  - Konnect automatically encrypts key authentication credentials at rest, so
+  This plugin is not available in Konnect.
+  Konnect automatically encrypts key authentication credentials at rest, so
   encryption via this plugin is not necessary.
-  Use the regular [Key Auth](/plugins/key-auth/) plugin instead.
-  - This setting determines the length of time a credential remains valid.
+  Use the regular [Key Auth](/plugins/key-auth/) plugin for API key authentication instead.
 
 min_version:
   gateway: '1.0'
@@ -57,9 +56,11 @@ The Key Authentication Encrypted plugin adds encrypted API key authentication to
 
 This plugin extends the functionality of the [Key Authentication](/plugins/key-auth/) plugin by allowing API keys to be stored in encrypted form within the {{site.base_gateway}} datastore.
 
-
 {:.warning}
 > **Important**: Before configuring this plugin, you must [enable {{site.base_gateway}}'s encryption Keyring](/gateway/keyring/#enable-keyring). 
+
+{:.info}
+> {{ page.notes }}
 
 ## Request behavior matrix
 

--- a/app/gateway/hybrid-mode.md
+++ b/app/gateway/hybrid-mode.md
@@ -354,10 +354,7 @@ Control Plane, all plugin configuration has to occur from the CP. Due to this
 setup, and the configuration sync format between the CP and the DP, some plugins
 have limitations in hybrid mode:
 
-* [**Key Auth Encrypted**](/plugins/key-auth-enc/): The time-to-live setting
-(`ttl`), which determines the length of time a credential remains valid, does
-not work in hybrid mode.
-* [**Rate Limiting**](/plugins/rate-limiting/), [**Rate Limiting Advanced**](/plugins/rate-limiting-advanced/), [**Response Rate Limiting**](/plugins/response-ratelimiting/), [AI Rate Limiting Advanced](/plugins/ai-rate-limiting-advanced/), and [Service Protection](/plugins/service-protection/):
+* [**Rate Limiting**](/plugins/rate-limiting/), [**Rate Limiting Advanced**](/plugins/rate-limiting-advanced/), [**Response Rate Limiting**](/plugins/response-ratelimiting/), [**AI Rate Limiting Advanced**](/plugins/ai-rate-limiting-advanced/), and [**Service Protection**](/plugins/service-protection/):
 These plugins don't support the `cluster` strategy/policy in hybrid mode. One of 
 the `local` or `redis` strategies/policies must be used instead.
 * [**GraphQL Rate Limiting Advanced**](/plugins/graphql-rate-limiting-advanced/):


### PR DESCRIPTION
## Description

* Fixes an issue where we were listing key auth as not supporting TTL in hybrid mode, but it was introduced in 3.4. Since we don't have any docs older than 3.4, I removed the line rather than using `new_in`.
* Fixed the key auth enc plugin note that explains why the plugin isn't available in konnect. 

Issue reported on Slack.


## Preview Links

