### PR TITLE
fix(catalog): add missing discovery roles [KHCP-19684]

### DIFF
--- a/app/konnect-platform/teams-and-roles.md
+++ b/app/konnect-platform/teams-and-roles.md
@@ -349,6 +349,28 @@ columns:
   - title: CRUD permissions
     key: permissions
 rows:
+  - role: "`Discovery Admin`"
+    description: Can read and create discovery ingestion jobs and fully manage suggestion rules, suggested actions and resources.
+    permissions: |
+      * Read and list integration instances.
+      * List integrations.
+      * Read and list integration auth credentials.
+      * Create and read discovery ingestion jobs.
+      * List resource actions.
+      * Read, list, create, edit, delete and test discovery suggestion rules.
+      * Read, list and edit discovery suggested actions.
+      * Read, list, create, edit and ingest resources.
+  - role: "`Discovery Viewer`"
+    description: Access to read-only permissions for discovery.
+    permissions: |
+      * Read and list integration instances.
+      * List integrations.
+      * Read and list integration auth credentials.
+      * Read and create discovery ingestion jobs.
+      * List resource actions.
+      * Read and list discovery suggestion rules.
+      * Read and list discovery suggested actions.
+      * Read and list resources.
   - role: "`Integration Admin`"
     description: Can view and edit all integrations (install/authorize).
     permissions: |


### PR DESCRIPTION
## Description

### Ticket
[KHCP-19684](https://konghq.atlassian.net/browse/KHCP-19684)

Adds missing discovery roles for Catalog.

Here are the role permission definitions in KAuth: https://github.com/kong-konnect/kauth/blob/main/permissions/servicehub.yaml#L554-L603

<img width="1728" height="781" alt="Screenshot 2026-02-24 at 4 20 26 PM" src="https://github.com/user-attachments/assets/0c0dce38-d302-4bb8-90ed-f32258c25455" />


[KHCP-19684]: https://konghq.atlassian.net/browse/KHCP-19684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ