### PR TITLE
Update to make 3.5 EOS the same as 3.4 LTS

### DIFF
--- a/app/kubernetes-ingress-controller/support.md
+++ b/app/kubernetes-ingress-controller/support.md
@@ -61,7 +61,7 @@ columns:
 rows:
   - version: "3.5.x"
     release: "2025-07-04"
-    support: "2026-07-04"
+    support: "2027-12-18"
   - version: "**3.4.x**"
     release: "**2024-12-18**"
     support: "**2027-12-18**"


### PR DESCRIPTION
## Description

We have made the decision to extend support for 3.5 to be the same EOS as 3.4 to allow customers to roll off to KO in due time.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
