### PR TITLE
fix(operator): Add missing double quotes

### DIFF
--- a/app/_how-tos/operator/operator-get-started-konnect-crds-2-authentication.md
+++ b/app/_how-tos/operator/operator-get-started-konnect-crds-2-authentication.md
@@ -76,7 +76,7 @@ metadata:
   namespace: kong
   labels:
     konghq.com/credential: konnect
-    konghq.com/secret: true
+    konghq.com/secret: "true"
 stringData:
   token: "'$KONNECT_TOKEN'"' | kubectl apply -f -
 ```


### PR DESCRIPTION
## Description

The ` konghq.com/secret: true` reference is missing double quotes around `true`. Double checked in our other guides and references, it uses double quotes everywhere else.

Issue reported on Slack.

## Preview Links

