### PR TITLE
kongctl: Adds docker instructions

### DIFF
--- a/app/_includes/tools/kongctl/install/docker.md
+++ b/app/_includes/tools/kongctl/install/docker.md
@@ -1,0 +1,13 @@
+Kong provides official Docker images for kongctl on [Docker Hub](https://hub.docker.com/r/kong/kongctl).
+
+Pull the latest image:
+
+```bash
+docker pull kong/kongctl:latest
+```
+
+Verify the installation:
+
+```bash
+docker run kong/kongctl version
+```

--- a/app/_landing_pages/kongctl.yaml
+++ b/app/_landing_pages/kongctl.yaml
@@ -63,6 +63,8 @@ rows:
               include_content: tools/kongctl/install/linux
             - title: Windows
               include_content: tools/kongctl/install/windows
+            - title: Docker
+              include_content: tools/kongctl/install/docker
             - title: Mise
               include_content: tools/kongctl/install/mise
 


### PR DESCRIPTION
## Description

Simply adds docker instructions for the `kongctl` tool to the existing landing page