### PR TITLE
fix(vaults): Rename to CyberArk Secrets Manager

### DIFF
--- a/app/_data/support/third-party.yml
+++ b/app/_data/support/third-party.yml
@@ -42,7 +42,7 @@ gcp-sm:
   name: Google Cloud Secret Manager
   icon: google-cloud.svg
 conjur:
-  name: CyberArk Conjur Vault
+  name: CyberArk Secrets Manager (Conjur)
   icon: cyberark.svg
 # IDP
 auth0:

--- a/app/_gateway_entities/vault.md
+++ b/app/_gateway_entities/vault.md
@@ -248,7 +248,7 @@ features:
     enterprise: true
     supports_konnect: true
   - title: |
-      CyberArk Conjur {% new_in 3.11 %}
+      CyberArk Secrets Manager (Conjur)  {% new_in 3.11 %}
     url: /how-to/configure-cyberark-as-a-vault-backend/
     oss: false
     enterprise: true
@@ -840,11 +840,11 @@ rows:
 {% endtable %}
 <!--vale on-->
 {% endnavtab %}
-{% navtab "Conjur" %}
+{% navtab "CyberArk Secrets Manager" %}
 
-See a tutorial about how to [set up CyberArk Conjur as a Kong Vault backend in {{site.base_gateway}}](/how-to/configure-cyberark-as-a-vault-backend/).
+See a tutorial about how to [set up CyberArk Secrets Manager (Conjur) as a Kong Vault backend in {{site.base_gateway}}](/how-to/configure-cyberark-as-a-vault-backend/).
 
-The following table lists the available configuration parameters for a CyberArk Conjur Vault:
+The following table lists the available configuration parameters for a CyberArk Secrets Manager Vault:
 
 <!--vale off-->
 {% table %}
@@ -863,21 +863,21 @@ rows:
       * **kong.conf parameter:** `vault_conjur_endpoint_url`
       * **Environment variable:** `KONG_VAULT_CONJUR_ENDPOINT_URL`
     description: |
-      The CyberArk Conjur backend URL to connect with. Accepts `http` or `https` protocols.
+      The CyberArk Secrets Manager backend URL to connect with. Accepts `http` or `https` protocols.
   - field: |
       Authentication method <br>{% new_in 3.11 %}
     parameter: |
       * **Vault entity:** `vaults.config.auth_method`
       * **kong.conf parameter:** `vault_conjur_auth_method`
       * **Environment variable:** `KONG_VAULT_CONJUR_AUTH_METHOD`
-    description: "Defines the authentication mechanism for connecting to the CyberArk Conjur Vault service. Accepted value: `api_key`."
+    description: "Defines the authentication mechanism for connecting to the CyberArk Secrets Manager Vault service. Accepted value: `api_key`."
   - field: |
       Account <br>{% new_in 3.11 %}
     parameter: |
       * **Vault entity:** `vaults.config.account`
       * **kong.conf parameter:** `vault_conjur_account`
       * **Environment variable:** `KONG_VAULT_CONJUR_ACCOUNT`
-    description: The Conjur organization account name.
+    description: The CyberArk Secrets Manager organization account name.
   - field: |
       Login <br>{% new_in 3.11 %}
     parameter: |

--- a/app/_how-tos/gateway/configure-cyberark-as-a-vault-backend.md
+++ b/app/_how-tos/gateway/configure-cyberark-as-a-vault-backend.md
@@ -1,15 +1,15 @@
 ---
-title: Configure CyberArk Conjur as a vault backend
+title: Configure CyberArk Secrets Manager (Conjur) as a vault backend
 permalink: /how-to/configure-cyberark-as-a-vault-backend/
 content_type: how_to
-description: "Learn how to reference CyberArk Conjur secrets from {{site.base_gateway}}."
+description: "Learn how to reference CyberArk Secrets Manager secrets from {{site.base_gateway}}."
 products:
     - gateway
 
 related_resources:
   - text: Secrets management
     url: /gateway/secrets-management/
-  - text: Configuration parameters for CyberArk Conjur vaults
+  - text: Configuration parameters for CyberArk Secrets Manager vaults
     url: /gateway/entities/vault/?tab=conjur#vault-provider-specific-configuration-parameters
 works_on:
     - on-prem
@@ -26,33 +26,34 @@ tags:
     - cyberark-conjur
 search_aliases:
   - Conjur
+  - CyberArk Secrets Manager
 tldr:
-    q: How can I access CyberArk Conjur secrets in {{site.base_gateway}}? 
+    q: How can I access CyberArk Secrets Manager secrets in {{site.base_gateway}}? 
     a: |
-      Configure a Vault entity with `config.auth_method: api_key`, your Conjur endpoint URL (`config.endpoint_url`), account name (`config.account`), login (`config.login`), and API key (`config.api_key`). Reference the secret like `{vault://conjur-vault/BotApp%2FsecretVar}`, assuming your Vault prefix is `conjur-vault` and your secret was stored as `BotApp/secretVar`.
+      Configure a Vault entity with `config.auth_method: api_key`, your CyberArk Secrets Manager endpoint URL (`config.endpoint_url`), account name (`config.account`), login (`config.login`), and API key (`config.api_key`). Reference the secret like `{vault://conjur-vault/BotApp%2FsecretVar}`, assuming your Vault prefix is `conjur-vault` and your secret was stored as `BotApp/secretVar`.
 
 tools:
     - deck
 
 prereqs:
   inline: 
-    - title: CyberArk Conjur
+    - title: CyberArk Secrets Manager
       content: |
-        To run this tutorial, you'll need CyberArk Conjur running with a secret stored.  
+        To run this tutorial, you'll need CyberArk Secrets Manager running with a secret stored.  
         
-        If you don't already have CyberArk Conjur, you can follow the Docker quickstart guide to [setup an OSS environment](https://www.conjur.org/get-started/quick-start/oss-environment/), [define a policy](https://www.conjur.org/get-started/quick-start/define-policy/), and [store a secret](https://www.conjur.org/get-started/quick-start/store-secret/). 
+        If you don't already have CyberArk Secrets Manager, you can follow the Docker quickstart guide to [setup an OSS environment](https://www.conjur.org/get-started/quick-start/oss-environment/), [define a policy](https://www.conjur.org/get-started/quick-start/define-policy/), and [store a secret](https://www.conjur.org/get-started/quick-start/store-secret/). 
 
         {:.warning}
-        > If you're running Conjur in Docker, change the proxy ports in `docker-compose.yml` to `"9443:443"`. Make sure the {{site.base_gateway}} and Conjur containers are using the same Docker network. If they aren't, you can run `docker network connect kong-quickstart-net conjur_server` to connect the Conjur compose stack to the {{site.base_gateway}} quickstart network.
+        > If you're running CyberArk Secrets Manager in Docker, change the proxy ports in `docker-compose.yml` to `"9443:443"`. Make sure the {{site.base_gateway}} and CyberArk Secrets Manager containers are using the same Docker network. If they aren't, you can run `docker network connect kong-quickstart-net conjur_server` to connect the CyberArk Secrets Manager compose stack to the {{site.base_gateway}} quickstart network.
         
-        Export the Conjur environment variables:
+        Export the CyberArk Secrets Manager environment variables:
         {% env_variables %}
         DECK_CONJUR_ENDPOINT_URL: 'http://conjur_server:80'
         DECK_CONJUR_ACCOUNT: 'myConjurAccount'
         DECK_CONJUR_LOGIN: 'host/BotApp/myDemoApp'
         DECK_CONJUR_API_KEY: 'YOUR-API-KEY'
         {% endenv_variables%}
-        These environment variables use values from the Conjur Docker quickstart. If you are running Conjur in a different environment, modify them as needed.
+        These environment variables use values from the CyberArk Secrets Manager Docker quickstart. If you are running CyberArk Secrets Manager in a different environment, modify them as needed.
 
         You can find your API key listed under `myConjurAccount:host:BotApp/myDemoApp` in the `my_app_data` file.
 
@@ -60,21 +61,21 @@ prereqs:
 
 cleanup:
   inline:
-    - title: Clean up CyberArk Conjur
+    - title: Clean up CyberArk Secrets Manager
       content: |
-        If you're using the Conjur Docker quickstart, you can clean up Conjur by deleting the `conjur-quickstart` Docker compose stack.
+        If you're using the CyberArk Secrets Manager Docker quickstart, you can clean up CyberArk Secrets Manager by deleting the `conjur-quickstart` Docker compose stack.
       icon_url: /assets/icons/cyberark.svg
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg
 
 faqs:
-  - q: How do I rotate my secrets in CyberArk Conjur and how does {{site.base_gateway}} pick up the new secret values?
-    a: You can rotate your secret in CyberArk Conjur by creating a new secret version with the updated value. You'll also want to configure the `ttl` settings in your {{site.base_gateway}} Vault entity so that {{site.base_gateway}} pulls the rotated secret periodically.
-  - q: How are CyberArk Conjur secrets referenced by {{site.base_gateway}}?
+  - q: How do I rotate my secrets in CyberArk Secrets Manager and how does {{site.base_gateway}} pick up the new secret values?
+    a: You can rotate your secret in CyberArk Secrets Manager by creating a new secret version with the updated value. You'll also want to configure the `ttl` settings in your {{site.base_gateway}} Vault entity so that {{site.base_gateway}} pulls the rotated secret periodically.
+  - q: How are CyberArk Secrets Manager secrets referenced by {{site.base_gateway}}?
     a: |
-        Because Conjur secrets are organized under policies, when referencing secrets defined in a non-root policy, you must encode the `/` in the secret reference. For example: `{vault://conjur-vault/BotApp%2FsecretVar}` is correct, `{vault://conjur-vault/BotApp/secretVar}` is incorrect.
-  - q: Can users and hosts be used to authenticate Conjur Vaults?
+        Because CyberArk Secrets Manager secrets are organized under policies, when referencing secrets defined in a non-root policy, you must encode the `/` in the secret reference. For example: `{vault://conjur-vault/BotApp%2FsecretVar}` is correct, `{vault://conjur-vault/BotApp/secretVar}` is incorrect.
+  - q: Can users and hosts be used to authenticate CyberArk Secrets Manager Vaults?
     a: |
         Yes. If you were authenticating the `Dave` user, you'd configure `"login": "Dave@BotApp"` along with the API key for `Dave`. If you were authenticating the host, you'd use `"login": "host/BotApp/myDemoApp"` along with the `host` API key.
   - q: |
@@ -91,16 +92,16 @@ next_steps:
 automated_tests: false
 ---
 
-## Create a Vault entity for CyberArk Conjur Vault 
+## Create a Vault entity for CyberArk Secrets Manager Vault 
 
-Using decK, create a [Vault](/gateway/entities/vault/) entity with the required parameters for CyberArk Conjur:
+Using decK, create a [Vault](/gateway/entities/vault/) entity with the required parameters for CyberArk Secrets Manager:
 
 <!--vale off-->
 {% entity_examples %}
 entities:
   vaults:
     - name: conjur
-      description: Storing secrets in Conjur Vault
+      description: Storing secrets in CyberArk Secrets Manager Vault
       prefix: conjur-vault
       config:
         endpoint_url: ${endpoint_url}
@@ -122,14 +123,14 @@ variables:
 
 ## Validate
 
-To validate that the secret was stored correctly in Conjur, you can call a secret from your vault using the `kong vault get` command within the Data Plane container: 
+To validate that the secret was stored correctly in CyberArk Secrets Manager, you can call a secret from your vault using the `kong vault get` command within the Data Plane container: 
 
 {% validation vault-secret %}
 secret: '{vault://conjur-vault/BotApp%2FsecretVar}'
 value: 'your-secret'
 {% endvalidation %}
 
-This assumes your secret was stored in `BotApp/secretVar` in Conjur.
+This assumes your secret was stored in `BotApp/secretVar` in CyberArk Secrets Manager.
 
 If the Vault was configured correctly, this command should return the value of the secret. You can use `{vault://my-conjur/BotApp%2FsecretVar}` to reference the secret in any referenceable field.
 

--- a/app/_landing_pages/gateway/secrets-management.yaml
+++ b/app/_landing_pages/gateway/secrets-management.yaml
@@ -153,9 +153,9 @@ rows:
       - blocks:
         - type: card
           config:
-            title: "CyberArk Conjur {% new_in 3.11 %}"
+            title: "CyberArk Secrets Manager (Conjur) {% new_in 3.11 %}"
             description: |
-              Connect CyberArk Conjur to {{site.base_gateway}} to reference secrets.
+              Connect CyberArk Secrets Manager to {{site.base_gateway}} to reference secrets.
               
             icon: /assets/icons/cyberark.svg
             ctas:


### PR DESCRIPTION
## Description

CyberArk renamed their product to CyberArk Secrets Manager. Using CyberArk Secrets Manager (Conjur) on the first instance here and in the UI for discoverability.

Slack thread: https://kongstrong.slack.com/archives/C04RXLGNB6K/p1771364402760069

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
