### PR TITLE
fix(docs-platform): Linked badge colours in konami color scheme

### DIFF
--- a/app/_assets/stylesheets/index.css
+++ b/app/_assets/stylesheets/index.css
@@ -377,6 +377,10 @@
       linear-gradient(227.59deg, rgb(0, 37, 18) 6.43%, rgb(100, 230, 180) 30.81%, rgb(204, 255, 0) 50%, rgb(100, 230, 180) 65.64%, rgb(0, 37, 18) 100%) border-box !important;
   }
 
+  /* Konami theme; dark text on badges */
+  .konami a.badge.bg-brand {
+    color: rgb(0, 15, 6) !important;
+  }
   .button.button--secondary {
     @apply !border-brand !text-primary;
   }


### PR DESCRIPTION
## Description

Fixing this contrast issue on the [how-to search page](https://developer.konghq.com/how-to/?tags=1password&tags=access-control&tags=account-management):
<img width="262" height="264" alt="Screenshot 2026-03-02 at 8 22 06 AM" src="https://github.com/user-attachments/assets/5a1af09f-4f22-4aa8-abb9-1298964a75a2" />

Should now look like this:
<img width="268" height="273" alt="Screenshot 2026-03-02 at 8 20 11 AM" src="https://github.com/user-attachments/assets/befa5375-a675-4ceb-b9a9-1a1da957470b" />

I couldn't figure out how to fix the checkboxes in the same sidebar though - and it looks like the original stylesheet updates had also attempted to do that without any success:
```
  /* Konami theme: dark checkmark on lime checkbox */
  .konami .checkbox--checked,
  .konami .ais-RefinementList-checkbox:checked {
    color: rgb(0, 15, 6) !important;
  }
```
This doesn't do anything when the box is checked but not being hovered over.

## Preview Links
https://deploy-preview-4378--kongdeveloper.netlify.app/how-to/?tags=1password&tags=access-control&tags=account-management