### PR TITLE
fix(changelog-workflow): Update Gateway patch version

### DIFF
--- a/.github/workflows/generate-gateway-plugins-changelogs.yml
+++ b/.github/workflows/generate-gateway-plugins-changelogs.yml
@@ -88,6 +88,8 @@ jobs:
       - name: Update release date in gateway.yml
         run: |
           sed -i "/^release_dates:/a\\  '${{ inputs.version }}': ${{ inputs.release_date }}" app/_data/products/gateway.yml
+          PATCH_VERSION=$(echo '${{ inputs.version }}' | sed 's/\.[0-9]*\.[0-9]*$//')
+          sed -i "s/ee-version: \"${PATCH_VERSION}\.[^\"]*\"/ee-version: \"${{ inputs.version }}\"/" app/_data/products/gateway.yml
 
       - name: Generate/update changelog file
         run: |
@@ -120,6 +122,7 @@ jobs:
             - Generated changelog entries for plugins
             ${{format('- Updated changelog for Gateway version {0}', inputs.version)}}
             ${{format('- Set release date for version {0} to {1}', inputs.version, inputs.release_date)}}
+            ${{format('- Updated ee-version to {0}', inputs.version)}}
 
           labels: skip-changelog,review:general
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Description

At the moment, when we update the changelog, there's a manual step to also update the patch version. This PR adds a line to the workflow that generates the `kong-ee` version for the release being updated. 

Successful run: 
https://github.com/Kong/developer.konghq.com/actions/runs/22589251511
https://github.com/Kong/developer.konghq.com/pull/4380/changes/0b8eb2bf10c2690f2191c2b5c782c9ccc3cfbab9

