### PR TITLE
feat(catalog): Link APIs to services

### DIFF
--- a/app/_includes/catalog/note-api-spec-snapshot.md
+++ b/app/_includes/catalog/note-api-spec-snapshot.md
@@ -1,0 +1,2 @@
+{:.info}
+> **Note:** After an API spec is migrated to an API, the API spec is unlinked from the integration and will instead be stored as a snapshot by Kong. Since APIs take a snapshot of the API spec when it's linked, they **do not** update automatically. For example, if you update your ingested spec in AWS, it doesn't automatically pull changes in to the API, you must re-upload the spec manually.

--- a/app/catalog/migrate-api-specs-to-apis.md
+++ b/app/catalog/migrate-api-specs-to-apis.md
@@ -23,17 +23,52 @@ related_resources:
     url: /catalog/integrations/
 ---
 
-Need a migration guide, manually done via specs tab, three dot menu, click migrate. Team will need this link to add to the UI. This migration creates an API entity that has the specs from the integration?
+APIs can be associated with {{site.konnect_catalog}} services, which replaces the legacy API spec linking. We recommend migrating API specs that are associated with a {{site.konnect_catalog}} service to APIs because this allows API consumers and service owners to see which APIs and services are associated with each other. 
 
-It's recommended because ......
+{% include_cached /catalog/note-api-spec-snapshot.md %}
 
-steps here
+## Prerequisites
 
-## prereqs roles
+To migrate API specs to an API in {{site.konnect_catalog}}, you need the following [{{site.konnect_short_name}} roles](/konnect-platform/teams-and-roles/#catalog) at a minimum for the services and APIs:
 
-for mapping APIs to services the user needs at the minimum the following combo roles on the service and API entities for actions:
-Listing available APIs to link to a service: API viewer, Service viewer
-Creating/deleting APi-service links: API viewer, Service admin
-migration of legacy apis to new APIs: API creator, Service admin
-listing linked services on the API overview page: API viewer, Service viewer
-To perform all the above actions: API admin + creator and Service admin
+<!--vale off-->
+{% table %}
+columns:
+  - title: Action
+    key: action
+  - title: Required roles
+    key: roles
+rows:
+  - action: List available APIs to link to a service
+    roles: |
+      * API viewer
+      * Service viewer
+  - action: Create or delete API and service links
+    roles: |
+      * API viewer
+      * Service admin
+  - action: Migrate legacy APIs to new APIs
+    roles: |
+      * API creator
+      * Service admin
+  - action: List linked services on the API overview page
+    roles: |
+      * API viewer
+      * Service viewer
+  - action: Perform all the above actions
+    roles: |
+      * API admin and creator
+      * Service admin
+{% endtable %}
+<!--vale on-->
+
+## Migrate API specs to APIs
+
+1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
+1. In the Catalog sidebar, click **Services**.
+1. Click a Catalog service that has API specs associated with it.
+1. Click the **API specs (legacy)** tab.
+1. Click the action menu next to the API spec, and select "Migrate to API catalog". 
+1. Click **Start migration**.
+
+You will now see the API with your API spec linked to the {{site.konnect_catalog}} service. Users who view APIs will also be able to see any linked {{site.konnect_catalog}} services.

--- a/app/catalog/migrate-api-specs-to-apis.md
+++ b/app/catalog/migrate-api-specs-to-apis.md
@@ -1,0 +1,39 @@
+---
+title: "Migrate API specs in {{site.konnect_catalog}} to APIs"
+content_type: reference
+layout: reference
+permalink: /catalog/migrate-api-specs-to-apis/
+products:
+    - catalog
+works_on:
+  - konnect
+
+description: Learn how to migrate API specs in {{site.konnect_catalog}} to APIs.
+
+breadcrumbs:
+  - /catalog/
+search_aliases:
+  - service catalog
+related_resources:
+  - text: "{{site.konnect_catalog}}"
+    url: /catalog/
+  - text: Scorecards
+    url: /catalog/scorecards/
+  - text: "{{site.konnect_catalog}} integrations"
+    url: /catalog/integrations/
+---
+
+Need a migration guide, manually done via specs tab, three dot menu, click migrate. Team will need this link to add to the UI. This migration creates an API entity that has the specs from the integration?
+
+It's recommended because ......
+
+steps here
+
+## prereqs roles
+
+for mapping APIs to services the user needs at the minimum the following combo roles on the service and API entities for actions:
+Listing available APIs to link to a service: API viewer, Service viewer
+Creating/deleting APi-service links: API viewer, Service admin
+migration of legacy apis to new APIs: API creator, Service admin
+listing linked services on the API overview page: API viewer, Service viewer
+To perform all the above actions: API admin + creator and Service admin

--- a/app/catalog/services.md
+++ b/app/catalog/services.md
@@ -128,3 +128,25 @@ resource "konnect_catalog_service" "my_catalogservice" {
 {% endnavtab %}
 {% endnavtabs %}
 
+## Map APIs to a service in {{site.konnect_catalog}}
+
+Explanation of why. If you've already assigned API specs to a service from integrations, [migrate them to APIs](/catalog/migrate-api-specs-to-apis/). 
+
+{% navtabs "map-apis" %}
+{% navtab "UI" %}
+1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
+1. In the Catalog sidebar, click **Services**. 
+1. Click **New service** and configure the details about your service.
+{% endnavtab %}
+{% navtab "API" %}
+{% endnavtab %}
+{% navtab "Terraform" %}
+{% endnavtab %}
+{% endnavtabs %}
+
+for mapping APIs to services the user needs at the minimum the following combo roles on the service and API entities for actions:
+Listing available APIs to link to a service: API viewer, Service viewer
+Creating/deleting APi-service links: API viewer, Service admin
+migration of legacy apis to new APIs: API creator, Service admin
+listing linked services on the API overview page: API viewer, Service viewer
+To perform all the above actions: API admin + creator and Service admin

--- a/app/catalog/services.md
+++ b/app/catalog/services.md
@@ -130,23 +130,39 @@ resource "konnect_catalog_service" "my_catalogservice" {
 
 ## Map APIs to a service in {{site.konnect_catalog}}
 
-Explanation of why. If you've already assigned API specs to a service from integrations, [migrate them to APIs](/catalog/migrate-api-specs-to-apis/). 
+APIs can be associated with {{site.konnect_catalog}} services, which allows API consumers and service owners to see which APIs and services are associated with each other. If you've already assigned API specs to a service from integrations, [migrate them to APIs](/catalog/migrate-api-specs-to-apis/). 
 
+{% include_cached /catalog/note-api-spec-snapshot.md %}
+
+To link APIs with a {{site.konnect_catalog}} service, you need the following [{{site.konnect_short_name}} roles](/konnect-platform/teams-and-roles/#catalog) at a minimum for the services and APIs:
+* API viewer
+* Service viewer
+* Service admin
+
+To link APIs to a service, do the following:
 {% navtabs "map-apis" %}
 {% navtab "UI" %}
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
 1. In the Catalog sidebar, click **Services**. 
-1. Click **New service** and configure the details about your service.
+1. Click a service you want to associate an API with.
+1. Click the **APIs** tab.
+1. Click **Link API**.
+1. Select the APIs you want to link.
+1. Click **Link APIs**.
+
+You will now see the API with your API spec linked to the {{site.konnect_catalog}} service. Users who view APIs will also be able to see any linked {{site.konnect_catalog}} services.
 {% endnavtab %}
 {% navtab "API" %}
-{% endnavtab %}
-{% navtab "Terraform" %}
+
+To map a service to an API, send a `POST` request to the `/catalog-services/{serviceId}/api-mappings` endpoint:
+<!--vale off-->
+{% konnect_api_request %}
+url: /v1/catalog-services/$CATALOG_SERVICE_ID/api-mappings
+status_code: 201
+method: POST
+body:
+    api_id: $API_ID
+{% endkonnect_api_request %}
+<!--vale on-->
 {% endnavtab %}
 {% endnavtabs %}
-
-for mapping APIs to services the user needs at the minimum the following combo roles on the service and API entities for actions:
-Listing available APIs to link to a service: API viewer, Service viewer
-Creating/deleting APi-service links: API viewer, Service admin
-migration of legacy apis to new APIs: API creator, Service admin
-listing linked services on the API overview page: API viewer, Service viewer
-To perform all the above actions: API admin + creator and Service admin


### PR DESCRIPTION
## Description

Fixes #3819 

## Preview Links
- https://deploy-preview-4384--kongdeveloper.netlify.app/catalog/migrate-api-specs-to-apis/
- https://deploy-preview-4384--kongdeveloper.netlify.app/catalog/services/#map-apis-to-a-service-in-catalog

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
