### PR TITLE
fix(terraform): add support for rendering arrays of arrays

### DIFF
--- a/app/_plugins/drops/entity_example/presenters/terraform.rb
+++ b/app/_plugins/drops/entity_example/presenters/terraform.rb
@@ -93,6 +93,8 @@ module Jekyll
               input.each do |v|
                 s += if v.is_a?(Hash)
                        output_hash_in_list(v, depth)
+                     elsif v.is_a?(Array)
+                       "#{render_inline_list(v)}, "
                      else
                        "#{line(quote(v), (depth + 1), '').strip}, "
                      end
@@ -100,6 +102,17 @@ module Jekyll
 
               s = s.rstrip.chomp(',')
               s + end_list(input, depth)
+            end
+
+            def render_inline_list(input)
+              items = input.map do |v|
+                if v.is_a?(Array)
+                  render_inline_list(v)
+                else
+                  quote(v)
+                end
+              end
+              "[#{items.join(', ')}]"
             end
 
             def end_list(input, depth)


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
