### PR TITLE
feat(oidc): Multiple consumer claims

### DIFF
--- a/app/_how-tos/gateway/allow-multiple-authentication.md
+++ b/app/_how-tos/gateway/allow-multiple-authentication.md
@@ -51,7 +51,7 @@ faqs:
       If you want anonymous access to be forbidden, you **must** configure the Request Termination plugin on the anonymous Consumer.
   - q: Can I use the anonymous Consumer with OpenID Connect?
     a: |
-      If you are using the [OpenID Connect](/plugins/openid-connect/) plugin for handling Consumer authentication, you must set both [`config.anonymous`](/plugins/openid-connect/reference/#schema--config-anonymous) and [`config.consumer_claim`](/plugins/openid-connect/reference/#schema--config-consumer-claim) in the plugin's configuration, as setting `config.anonymous` alone doesn't map that Consumer.
+      If you are using the [OpenID Connect](/plugins/openid-connect/) plugin for handling Consumer authentication, you must set both [`config.anonymous`](/plugins/openid-connect/reference/#schema--config-anonymous) and [`config.consumer_claims`](/plugins/openid-connect/reference/#schema--config-consumer-claims) in the plugin's configuration, as setting `config.anonymous` alone doesn't map that Consumer.
   
 tools:
   - deck

--- a/app/_how-tos/gateway/configure-oidc-with-consumers.md
+++ b/app/_how-tos/gateway/configure-oidc-with-consumers.md
@@ -31,7 +31,7 @@ works_on:
   - konnect
 
 min_version:
-  gateway: '3.4'
+  gateway: '3.14'
 
 tools:
   - deck
@@ -102,8 +102,8 @@ entities:
         - client_secret_post
         auth_methods:
         - password
-        consumer_claim:
-        - preferred_username
+        consumer_claims:
+        - [preferred_username]
         consumer_by:
         - username
 variables:
@@ -118,7 +118,7 @@ variables:
 In this example:
 * `issuer`, `client ID`, `client secret`, and `client auth`: Settings that connect the plugin to your IdP (in this case, the sample Keycloak app).
 * `auth_methods`:  Specifies that the plugin should use the password grant, for easy testing.
-* `consumer_claim` and `consumer_by` : Looks for a `preferred_username` in the token payload and maps it to the Consumer entity by the entity's `username` value.
+* `consumer_claims` and `consumer_by` : Looks for a `preferred_username` in the token payload and maps it to the Consumer entity by the entity's `username` value. If you're running a version of {{site.base_gateway}} older than 3.14, use [`consumer_claim`](/plugins/openid-connect/reference/3.13/#schema--config-consumer-claim) instead of `consumer_claims`.
 
 {% include_cached plugins/oidc/client-auth.md %}
 

--- a/app/_kong_plugins/openid-connect/examples/consumer-auth.yaml
+++ b/app/_kong_plugins/openid-connect/examples/consumer-auth.yaml
@@ -7,6 +7,9 @@ extended_description: |
   
   This example uses password authentication, but you can use any supported [authentication type](/plugins/openid-connect/reference/#schema--config-auth-methods) with Consumers.
 
+  {:.info}
+  > If you're running a version of {{site.base_gateway}} older than 3.14, use `consumer_claim` instead of `consumer_claims`.
+
   For a full example that shows you how to set up the OpenID Connect plugin to map Consumers to IdP users, 
   see [Configure OpenID Connect with Consumer authorization](/how-to/configure-oidc-with-consumers/).
 
@@ -28,8 +31,8 @@ config:
     - client_secret_post
   auth_methods:
     - password
-  consumer_claim:
-    - preferred_username
+  consumer_claims:
+    - ["preferred_username"]
   consumer_by:
     - username
 

--- a/app/gateway/breaking-changes.md
+++ b/app/gateway/breaking-changes.md
@@ -33,6 +33,37 @@ affect your current installation.
 You may need to adopt different [upgrade paths](/gateway/upgrade/) depending on your
 deployment methods, set of features in use, or custom plugins, for example.
 
+## 3.14.x breaking changes
+
+Review the [changelog](/gateway/changelog/#3-14-0-0) for all the changes in this release.
+
+### 3.14.0.0
+
+Breaking changes in the 3.14.0.0 release.
+
+#### OpenID Connect: consumer claims data types
+
+The `config.consumer_claim` field in the [OpenID Connect plugin](/plugins/openid-connect/) has been converted to [`config.consumer_claims`](/plugins/openid-connect/reference/#schema--config-consumer-claims). 
+The parameter now accepts an array of arrays instead of an array of strings. 
+
+Old format example:
+
+```yaml
+config:
+  consumer_claim:
+    - email
+```
+New format example:
+
+```yaml
+config:
+  consumer_claims:
+    - ["email"]
+```
+
+We recommend updating your configurations, as the old `config.consumer_claim` field is deprecated and will be removed in a future version.
+
+
 ## 3.13.x breaking changes
 
 Review the [changelog](/gateway/changelog/#3-13-0-0) for all the changes in this release.


### PR DESCRIPTION
## Description

Replacing `consumer_claim` with `consumer_claims` for the OIDC plugin. Tested example; Fabian had to add support for nested arrays in arrays to get this one to work.

Fixes #4223 

## Preview Links


https://deploy-preview-4402--kongdeveloper.netlify.app/plugins/openid-connect/examples/consumer-auth/
https://deploy-preview-4402--kongdeveloper.netlify.app/how-to/configure-oidc-with-consumers/
https://deploy-preview-4402--kongdeveloper.netlify.app/gateway/breaking-changes/