### PR TITLE
fix(docs-improvements): Move schema section to bottom of pages

### DIFF
--- a/app/_gateway_entities/admin.md
+++ b/app/_gateway_entities/admin.md
@@ -58,10 +58,6 @@ Admins can be managed using the Admin API or Kong Manager and are used in the fo
 
 Admins can only interact with entities from within their Workspace. Depending on the admin's specific role, they can enforce RBAC roles and permissions across that Workspace, including creating and inviting other admins. 
 
-## Schema
-
-{% entity_schema %}
-
 ## Invite an admin
 
 Inviting an admin can only be done if you have [enabled RBAC](/gateway/entities/rbac/#enable-rbac). You can invite an admin by issuing a `POST` request to [`/admins`](/api/gateway/admin-ee/#/operations/post-admins). 
@@ -82,3 +78,7 @@ You can copy the generated invite link from the Kong Manager UI and provide it d
 
 By default, the invite link expires after 259,200 seconds (3 days). 
 You can customize this time frame by adjusting the [`admin_invitation_expiry`](/gateway/configuration/#admin-invitation-expiry) parameter in `kong.conf`.
+
+## Schema
+
+{% entity_schema %}

--- a/app/_gateway_entities/ca-certificate.md
+++ b/app/_gateway_entities/ca-certificate.md
@@ -60,10 +60,6 @@ To verify server certificates, you can define your CA Certificate:
 
 To verify client certificates, you can use the [Mutual TLS Authentication plugin](/plugins/mtls-auth/) or the [Header Cert Authentication plugin](/plugins/header-cert-auth/).
 
-## Schema
-
-{% entity_schema %}
-
 ## Set up a CA Certificate
 
 {% entity_example %}
@@ -84,3 +80,7 @@ data:
     qKjBs0k=
     -----END CERTIFICATE-----
 {% endentity_example %}
+
+## Schema
+
+{% entity_schema %}

--- a/app/_gateway_entities/certificate.md
+++ b/app/_gateway_entities/certificate.md
@@ -77,10 +77,6 @@ data:
   snis: ["*"]
 {% endentity_example %}
 
-## Schema
-
-{% entity_schema %}
-
 ## Set up a Certificate
 
 {% entity_example %}
@@ -141,3 +137,6 @@ data:
       -----END RSA PRIVATE KEY-----
 {% endentity_example %}
 
+## Schema
+
+{% entity_schema %}

--- a/app/_gateway_entities/consumer-group.md
+++ b/app/_gateway_entities/consumer-group.md
@@ -127,10 +127,6 @@ rows:
 {% endtable %}
 <!--vale on-->
 
-## Schema
-
-{% entity_schema %}
-
 ## Set up a Consumer Group
 
 {% entity_example %}
@@ -138,3 +134,7 @@ type: consumer_group
 data:
     name: my_group
 {% endentity_example %}
+
+## Schema
+
+{% entity_schema %}

--- a/app/_gateway_entities/consumer.md
+++ b/app/_gateway_entities/consumer.md
@@ -215,10 +215,6 @@ For a complete tutorial, see [Create a centrally-managed Consumer in {{site.konn
 {:.info}
 > **Note:** If you are using KIC to manage your data plane nodes in {{site.konnect_short_name}}, ensure that you configure the [`cluster_telemetry_endpoint`](/gateway/configuration/#cluster-telemetry-endpoint) in the data plane. You can find your specific `cluster_telemetry_endpoint` when setting up a data plane node.
 
-## Consumer schema
-
-{% entity_schema %}
-
 ## Set up a Consumer
 
 {% entity_example %}
@@ -229,3 +225,7 @@ data:
   tags:
     - silver-tier
 {% endentity_example %}
+
+## Schema
+
+{% entity_schema %}

--- a/app/_gateway_entities/event-hook.md
+++ b/app/_gateway_entities/event-hook.md
@@ -156,10 +156,6 @@ These parameters can be used to issue notifications any time an upstream in your
 For information about specific events related to a source, issue a `GET` request to the `/event-hooks/sources/{source}` endpoint. 
 The API returns a list of all of the events associated to a source in the following format: `balancer: health`. 
 
-## Schema
-
-{% entity_schema %}
-
 ## Set up an Event Hook
 
 {% entity_example %}
@@ -172,3 +168,7 @@ data:
   config:
       "url": "$WEBHOOK_URL"
 {% endentity_example %}
+
+## Schema
+
+{% entity_schema %}

--- a/app/_gateway_entities/group.md
+++ b/app/_gateway_entities/group.md
@@ -68,11 +68,7 @@ This happens in the following order:
 
 <!--For more information, read the [LDAP Service Directory Mapping](/gateway/ldap-service-directory-mapping/) documentation.-->
 
-## Schema
-
-{% entity_schema %}
-
-## Create a group
+## Create an RBAC Group
 
 Creating an RBAC Group requires [RBAC to be enabled](/gateway/entities/rbac/#enable-rbac) for {{site.base_gateway}}.
 
@@ -82,3 +78,7 @@ data:
   name: my-group
   comment: A description associated with this group.
 {% endentity_example %}
+
+## Schema
+
+{% entity_schema %}

--- a/app/_gateway_entities/key-set.md
+++ b/app/_gateway_entities/key-set.md
@@ -47,10 +47,6 @@ Key Sets can be used with the following plugins:
 - [JWE Decrypt](/plugins/jwe-decrypt/), with the `config.key_sets` parameter
 - [JWT Signer](/plugins/jwt-signer/), with the `config.access_token_keyset` parameter
 
-## Schema
-
-{% entity_schema %}
-
 ## Set up a Key Set
 
 {% entity_example %}
@@ -58,3 +54,7 @@ type: key-set
 data:
   name: example-key-set
 {% endentity_example %}
+
+## Schema
+
+{% entity_schema %}

--- a/app/_gateway_entities/key.md
+++ b/app/_gateway_entities/key.md
@@ -51,10 +51,6 @@ A Key object holds a representation of asymmetric keys, either public or private
 
 Keys currently support JWK and PEM formats. Both formats carry the same base information, such as the public and private keys, but may allow you to specify additional meta information. For example, the JWK format carries more information than PEM. One key pair can have multiple different representations (JWK or PEM) while being the same key.
 
-## Schema
-
-{% entity_schema %}
-
 ## Set up a Key
 
 {% entity_example %}
@@ -64,3 +60,7 @@ data:
   kid: example-key-id
   jwk: '{"kty": "RSA","use": "enc","kid": "example-key-id","d": "jpq-eutUC5uNpVfYdsEZacbC9w0C3tPwl6jCLa2WB2yj1WcQRLRR5TJwCoPHUXucsKhtG8oHcvknmXgo1TzMWxUiSP2fhnqr9GEA4SSCvMqMvSazbgTLKtq1ZLyCBbyjlEBg2Leo9H4rsnh8p09WRQAbkq9S3Aq5kmUTLScWMCZLD5WZ95TxBJa7jRq8Ij1J69WI0v0Omb_jNbXfCYMZHaGxQrIYifwYYMtcrn70VxF2n0jh6TR5MnYggZdr84JdjQ564C-9ENYmAwyfKcWJ1yqMkLpRmy4dXV-MpBKuCarG1JdCu-r15595YtzObNd84-4B9JvaoJdy3hUXBsYTsQ","n": "9mXXIzrcNUohBgRU7GWsFd5rrToLEVZtY7kQY-M_ASpXBoMpxsUmfp5fk39YHRGThwiVYFw-c3h97qOlHDWggq0PhjA_TxNp8ZcLNGybyDSnmJIBFbGU2JxCyX4AJm9RY4ZHCWlyzmMNu3uL22s6ydirSdfWt5dKBSW2STRUVXTslGKH3VE3zpMR4J2T81jhQsuwhrdXg3My6G90FJ5ltSaksVgiErIjqFiu1y5cEG5Gvhz99QoomHY0enKaX7mrT9XfQVtUWkbsf8Pwi3W-zsZsHQsjZZ8u9F0AdNRkCIheH3NCw46H1ouzARgxT3mTxEn8dcFzbRFOlOtoTw98nw","e": "AQAB","p": "_qAspCgjxg-3eICW8V6wUgN61KZVGRKHCHCK9JqDmOj9d09y14zuQ9j10WjvxK4NPzdQUygJlzDRhB9Dbk4AHVj9eIIoCH1kpYk0SYWOhgqgdtQzbzJjM3X_03geghifuQc9VnjZxGymXAukS7EIGWTNQzurcrM70_TKDBGoErs","q": "97pMGP30n_e-DMMFuOoKaNKn_NKrh8KBJJXu3Bux5gV4YXh_IDDGI7qSu_7lvP24vrzBq9pj4zoMviBpfSz9YKrA9-Rs2_S6RngWxYAIie2gbqsbJ2ZvqiehLmuo3oUJBknUqDJ6b_K8Hy42e70ZXH27PHEwNWvWuXpZIPtt2W0","dp": "9GRa1KjuRTFaoR-TQVLoG5_ZanfH4AvHbdNPnB0eSEsA1V59VOSg4KBCuN9mmzmP32hBAb_BDMu_nXfAagQV2hVLHDqZICTy0GvTsums9X0HrWZZg9YyHveYN6noZmgqDhcjyXavVfgO6PQHmtrtciotVeXU1n-v4e3nbBQaZPc","dq": "2tCTpv-qtCIAnQUmaM9RooVwHMF5AdGsgMRu170exi7OxknJAIYUfjquoZ_lDaqPJOtVppag5HTCDK5Uf1zd8iThjhUWkrL4VoZ8lrcg07QxoY9BzOuOdp3KoVY3M1YPQp60WF0-COQ_hssrFOFTJX9pg1n3WziF0g9f6uIrhYE","qi": "AgC9YSgEgkwr0ucJiO-wk7PSXcmsbxh-tR_Zs3oVH32yKa0GbRw68ocneLrL9_3lfK3EfvEbbhNuWFdpi6szExx9tWz9y4xKdax5AmkceY-yYaCFV353NgEipmeJL7-olT-YS93zjomhVzATZNl400uGJ3TC90rt6Be5rDGWhNg"}'
 {% endentity_example %}
+
+## Schema
+
+{% entity_schema %}

--- a/app/_gateway_entities/partial.md
+++ b/app/_gateway_entities/partial.md
@@ -60,10 +60,6 @@ Any plugin that supports Redis configuration can reference those settings using 
 {:.info}
 > In {{site.konnect_short_name}}, Partials are only supported for bundled {{site.konnect_short_name}} plugins. Custom plugins don't support Partials.
 
-## Schema
-
-{% entity_schema %}
-
 ## Set up a Partial
 
 {% entity_example %}
@@ -211,3 +207,7 @@ Here is an example schema for a custom plugin using a Partial:
 >
 > To include the Partial's data within the plugin configuration, you must pass a special option parameter,
 > such as: `kong.db.plugins:select(plugin_id, { expand_partials = true })`.
+
+## Schema
+
+{% entity_schema %}

--- a/app/_gateway_entities/plugin.md
+++ b/app/_gateway_entities/plugin.md
@@ -245,10 +245,6 @@ See the following table for plugins and their compatible (default) protocols:
 
 {% plugin_protocols %}
 
-## Schema
-
-{% entity_schema %}
-
 ## Set up a Plugin
 
 Kong has many bundled plugins available, all of which have their own specific configurations and examples. See all 
@@ -266,3 +262,7 @@ data:
       - admin
     hide_groups_header: false
 {% endentity_example %}
+
+## Schema
+
+{% entity_schema %}

--- a/app/_gateway_entities/route.md
+++ b/app/_gateway_entities/route.md
@@ -541,10 +541,6 @@ The Route configuration to proxy TLS traffic is unique to every deployment, but 
 * Create a Route with the `tls_passthrough` protocol and assign an SNI. 
 * Create a Service, associated with the Route, with the protocol set to `tcp`.
 
-## Schema
-
-{% entity_schema %}
-
 ## Set up a Route
 
 {% entity_example %}
@@ -554,3 +550,7 @@ data:
   paths:
     - "/mock"
 {% endentity_example %}
+
+## Schema
+
+{% entity_schema %}

--- a/app/_gateway_entities/service.md
+++ b/app/_gateway_entities/service.md
@@ -121,10 +121,6 @@ The [`write_timeout`](#schema-service-write-timeout) parameter defines the idle 
 
 {{ retry }}
 
-## Schema
-
-{% entity_schema %}
-
 ## Set up a Gateway Service
 
 {% entity_example %}
@@ -133,3 +129,7 @@ data:
   name: example-service
   url: "http://httpbin.konghq.com"
 {% endentity_example %}
+
+## Schema
+
+{% entity_schema %}

--- a/app/_gateway_entities/sni.md
+++ b/app/_gateway_entities/sni.md
@@ -68,10 +68,6 @@ The prioritization for matching SNIs to Certificates follows this order:
  4. Search for a certificate associated with the SNI `*`
  5. The default certificate on the file system
 
-## Schema
-
-{% entity_schema %}
-
 ## Set up an SNI
 
 {% entity_example %}
@@ -81,3 +77,7 @@ data:
   certificate:
     id: 2e013e8-7623-4494-a347-6d29108ff68b
 {% endentity_example %}
+
+## Schema
+
+{% entity_schema %}

--- a/app/_gateway_entities/target.md
+++ b/app/_gateway_entities/target.md
@@ -72,10 +72,6 @@ When a DNS record has `ttl=0`, the hostname is added as a single target, with th
 
 {% include_cached /gateway/failover-targets.md %}
 
-## Schema
-
-{% entity_schema %}
-
 ## Set up a Target
 
 {% entity_example %}
@@ -84,3 +80,7 @@ data:
   target: httpbun.com:80
   weight: 100
 {% endentity_example %}
+
+## Schema
+
+{% entity_schema %}

--- a/app/_gateway_entities/upstream.md
+++ b/app/_gateway_entities/upstream.md
@@ -303,10 +303,6 @@ rows:
 
 {% include_cached /gateway/failover-targets.md %}
 
-## Schema
-
-{% entity_schema %}
-
 ## Set up an Upstream
 
 {% entity_example %}
@@ -315,3 +311,7 @@ data:
   name: example-upstream
   algorithm: round-robin
 {% endentity_example %}
+
+## Schema
+
+{% entity_schema %}

--- a/app/_gateway_entities/vault.md
+++ b/app/_gateway_entities/vault.md
@@ -314,20 +314,16 @@ There are two types of refresh configuration available:
 
 For more information, see [Secret management](/gateway/secrets-management/).
 
-## Schema
-
-The Vault entity can only be used once the database is initialized. Secrets for values that are used before the database is initialized can’t make use of the Vaults entity.
-
-{% entity_schema %}
-
 ## Vault provider-specific configuration parameters
 
-When you set up a Vault, each provider has specific parameters that you can or must configure to integrate the Vault with a provider.
+When you set up a Vault, each provider has specific parameters that you can or must configure to integrate the Vault with a provider. For the entire Vault configuration schema, see the [schema reference](#schema).
 
 You can set up a Vault in one of the following ways:
 * Using the Vault entity
 * Using environment variables, set at {{site.base_gateway}} startup
 * Using parameters in `kong.conf`, set at {{site.base_gateway}} startup
+
+The Vault entity can only be used once the database is initialized. Secrets for values that are used before the database is initialized can’t make use of the Vaults entity.
 
 {% navtabs "provider config" %}
 {% navtab "Environment variable" %}
@@ -939,7 +935,11 @@ To access secrets stored in the AWS Secrets Manager, {{site.base_gateway}} needs
 {:.info}
 > **Note:** IAM Identity Center credential provider and process credential provider are not supported.
 
-## Set up a Vault
+## Store values as secrets
+
+You can set up a Vault in one of the following ways.
+
+### Set up a Vault entity
 
 {% entity_example %}
 type: vault
@@ -951,7 +951,7 @@ data:
     prefix: MY_SECRET_
 {% endentity_example %}
 
-## Store secrets as environment variables
+### Store secrets as environment variables
 
 You can store secrets as environment variables instead of configuring a Vault entity or third-party backend vault. 
 
@@ -980,3 +980,7 @@ rows:
 
 {% endtable %}
 <!--vale on-->
+
+## Schema
+
+{% entity_schema %}

--- a/app/_gateway_entities/workspace.md
+++ b/app/_gateway_entities/workspace.md
@@ -183,11 +183,6 @@ deck gateway sync default.yaml --workspace default
 
 decK can't delete Workspaces. However, using `deck gateway reset` in combination with the `--workspace` or `--all-workspaces` flags forces decK to delete the entire configuration inside the Workspace, but not the Workspace itself.
 
-
-## Schema
-
-{% entity_schema %}
-
 ## Set up a Workspace
 
 {% entity_example %}
@@ -196,3 +191,6 @@ data:
   name: "my-workspace"
 {% endentity_example %}
 
+## Schema
+
+{% entity_schema %}


### PR DESCRIPTION
## Description

The schemas take a second to load in when the page loads.
When the schema section isn't at the bottom of the page, it can make the page jump, and makes for an annoying reading experience.

Also consistency.

## Preview Links
Pages under https://deploy-preview-4404--kongdeveloper.netlify.app/gateway/entities/

This now aligns with [event gateway entities](https://developer.konghq.com/event-gateway/entities/) as well, which already use this page structure.