### PR TITLE
fix: don't render external icon link twice on entity schemas

### DIFF
--- a/app/_assets/javascripts/apps/EntitySchema.vue
+++ b/app/_assets/javascripts/apps/EntitySchema.vue
@@ -77,4 +77,9 @@ async function fetchSpec() {
 :deep(.property-field-example-value) {
   @apply border border-brand-saturated/40 !important;
 }
+
+:deep(.default-markdown a[href^="http://"]),
+:deep(.default-markdown a[href^="https://"]) {
+  @apply bg-none pr-0 !important;
+}
 </style>


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
