### PR TITLE
fix(gateway): Schema link for event hooks

### DIFF
--- a/app/_gateway_entities/event-hook.md
+++ b/app/_gateway_entities/event-hook.md
@@ -27,7 +27,7 @@ tools:
     - admin-api
 schema:
     api: gateway/admin-ee
-    path: /schemas/Event-hooks
+    path: /schemas/Event-Hooks
 
 api_specs:
     - gateway/admin-ee


### PR DESCRIPTION
## Description

Event Hooks schema is not being rendered because the link doesn't match the spec.

## Preview Links
https://deploy-preview-4423--kongdeveloper.netlify.app/gateway/entities/event-hook/#schema

