### PR TITLE
fix(portal): reserved page paths

### DIFF
--- a/app/dev-portal/pages-and-content.md
+++ b/app/dev-portal/pages-and-content.md
@@ -135,10 +135,10 @@ columns:
     key: regexp
 rows:
   - path: "`/login/*`"
-    description: Login
+    description: The login page is itself customizable, but the path is enforced for authentication to work properly.
     regexp: "`^/login(?:\\/.*)?`"
   - path: "`/register`"
-    description: Registration
+    description: The registration page is customizable; however, a default page is provided at this path if it does not exist.
     regexp: "`^/register`"
   - path: "`/forgot-password`"
     description: Forgot password
@@ -169,7 +169,7 @@ rows:
     regexp: "`^/_api\\/.*`"
   - path: "`/api/oauth/*`"
     description: OAuth endpoints
-    regexp: "`^/api//oauth\\/.*`"
+    regexp: "`^/api/oauth\\/.*`"
   - path: "`/npm/*`"
     description: CDN proxy
     regexp: "`^/npm\\/.*`"


### PR DESCRIPTION
## Description

Update the description of a few portal reserved paths. Also fixes a typo in the oauth path.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
