### PR TITLE
Fix: Ignores kongctl setup files in PR generation for sync-kongctl

### DIFF
--- a/.github/workflows/sync-kongctl.yml
+++ b/.github/workflows/sync-kongctl.yml
@@ -35,6 +35,10 @@ jobs:
       - name: Verify kongctl install
         run: kongctl version --full
 
+      - name: Clean kongctl setup artifacts
+        run: |
+          find . -maxdepth 1 -mindepth 1 -type d -name 'kongctl-*-linux' -exec rm -rf {} +
+
       - name: Fetch versions
         run: |
           cd tools/kongctl-versions
@@ -50,3 +54,7 @@ jobs:
           branch: sync-kongctl-releases
           labels: skip-changelog,review:general
           token: ${{ steps.app-token.outputs.token }}
+          add-paths: |
+            app/_includes/kongctl/help/**
+            app/kongctl/**
+            app/_data/tools/kongctl.yml


### PR DESCRIPTION
Removes kongctl installation files and ensures they aren't added to the PR 