### PR TITLE
fix(event-gateway): expectations in how-tos so that the tests pass

### DIFF
--- a/app/_how-tos/event-gateway/configure-observability-with-otel.md
+++ b/app/_how-tos/event-gateway/configure-observability-with-otel.md
@@ -448,7 +448,7 @@ Then produce a message through the virtual cluster:
 command: |
   kafkactl -C kafkactl.yaml --context vc produce my-test-topic --value="test message"
 expected:
-  message: "message produced (partition=0	offset=1)"
+  message: "message produced (partition=0	offset=0)"
   return_code: 0
 render_output: false
 {% endvalidation %}

--- a/app/_how-tos/event-gateway/get-started-with-event-gateway.md
+++ b/app/_how-tos/event-gateway/get-started-with-event-gateway.md
@@ -389,7 +389,7 @@ command: |
   kafkactl -C kafkactl.yaml --context vc produce blocked-topic --value="test message"
 expected:
   message: "Failed to produce message: kafka server: The client is not authorized to access this topic"
-  return_code: 0
+  return_code: 1
 render_output: false
 {% endvalidation %}
 


### PR DESCRIPTION
## Description

How-tos were working fine, but some expectations were wrong causing the tests to fail

[Failed run](https://github.com/Kong/developer.konghq.com/actions/runs/22532586387)

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
