### PR TITLE
feat(entity-schema): annotate x-referenceable fields with vault link

### DIFF
--- a/app/_assets/javascripts/apps/EntitySchema.vue
+++ b/app/_assets/javascripts/apps/EntitySchema.vue
@@ -14,7 +14,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted, watch, computed } from 'vue'
+import { ref, toRaw, onMounted, watch, computed } from 'vue'
 
 import { SchemaRenderer, parseSpecDocument, parsedDocument } from '@kong/spec-renderer'
 import ApiService from '../services/api.js'
@@ -33,6 +33,12 @@ const schema = computed(() => {
   }
 })
 
+watch(schema, (node) => {
+  if (node) {
+    annotateReferenceable(toRaw(node.data))
+  }
+}, { once: true })
+
 onMounted(async () => {
   await fetchSpec()
 })
@@ -46,6 +52,18 @@ watch((specText), async (newSpecText, oldSpecText) => {
     withCredentials: false,
   })
 })
+
+function annotateReferenceable(obj) {
+  if (Array.isArray(obj)) {
+    obj.forEach(annotateReferenceable)
+  } else if (obj && typeof obj === 'object') {
+    if (obj['x-referenceable'] === true) {
+      const note = 'This field is [referenceable](/gateway/entities/vault/#how-do-i-reference-secrets-stored-in-a-vault).'
+      obj.description = obj.description ? `${obj.description.trimEnd()}\n${note}` : note
+    }
+    Object.values(obj).forEach(annotateReferenceable)
+  }
+}
 
 async function fetchSpec() {
   let response = await versionsAPI.getProductVersionSpec({


### PR DESCRIPTION
## Description

Add client-side annotation for fields with `x-referenceable: true` in entity schemas. After the spec is parsed, the schema data is walked once to append a referenceable note linking to the vault documentation.

Uses `toRaw` to avoid Vue reactivity overhead during mutation and `{ once: true }` to ensure the annotation runs exactly once.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
