### PR TITLE
feat(ai-gateway): MCP ACL error codes

### DIFF
--- a/app/_how-tos/mcp/use-access-controls-for-mcp-tools.md
+++ b/app/_how-tos/mcp/use-access-controls-for-mcp-tools.md
@@ -91,6 +91,12 @@ prereqs:
   konnect:
     - name: KONG_STATUS_LISTEN
       value: '0.0.0.0:8100'
+
+faqs:
+  - q: "Why do I see the error code `INVALID_PARAMS -32602` on failed requests instead of `HTTP 403 Forbidden`?"
+    a: |
+      Prior to {{site.ai_gateway}} 3.14, requests that matched an MCP ACL deny rule or failed to match an allow list returned the JSON-RPC error code `INVALID_PARAMS -32602`.
+      This has now changed to match the [MCP 2025-11-25 authorization specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#error-handling) and returns `HTTP 403 Forbidden`.
 ---
 ## Set up Consumer authentication
 
@@ -313,7 +319,8 @@ Now let's verify access for each user by connecting with their API key:
 1. Enter `apikey` in the Key field.
 1. Enter `carol-key` in the Value field.
 1. Click the **Connect** button.
-1. The connection should fail with a `INVALID_PARAMS -32602` response.<br/>
+   
+   The connection should fail with a `HTTP 403 Forbidden` response.<br/>
    Carol belongs to the **suspended** group, which is globally denied access to all tools.
 1. Click **Disconnect** to switch to another user.
 

--- a/app/_kong_plugins/ai-mcp-proxy/index.md
+++ b/app/_kong_plugins/ai-mcp-proxy/index.md
@@ -85,6 +85,10 @@ faqs:
       * 2025-11-25
 
       Versions from 2024 are not supported.
+  - q: "Why do I see the error code `INVALID_PARAMS -32602` on failed requests?"
+    a: |
+      Prior to {{site.ai_gateway}} 3.14, requests that matched an MCP ACL deny rule or failed to match an allow list returned the JSON-RPC error code `INVALID_PARAMS -32602`.
+      This has now changed to match the [MCP 2025-11-25 authorization specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#error-handling) and returns `HTTP 403 Forbidden`.
 
 next_steps:
   - text: Learn about Kong MCP traffic gateway
@@ -300,8 +304,8 @@ rows:
 
 Both default and per-tool ACLs use `allow` and `deny` lists. Evaluation follows this order:
 
-1. **Deny list configuration**: If a `deny` list exists and the subject matches any `deny` entry, the request is rejected (`INVALID_PARAMS -32602`).
-2. **Allow list configuration**: If an `allow` list exists, the subject must match at least one entry; otherwise, the request is denied (`INVALID_PARAMS -32602`).
+1. **Deny list configuration**: If a `deny` list exists and the subject matches any `deny` entry, the request is rejected (`HTTP 403 Forbidden`).
+2. **Allow list configuration**: If an `allow` list exists, the subject must match at least one entry; otherwise, the request is denied (`HTTP 403 Forbidden`).
 3. **No allow list configuration**: If no `allow` list exists and the subject is not in `deny`, the request is allowed.
 4. **No ACL configuration**: If neither list exists, the request is allowed.
 
@@ -320,10 +324,10 @@ columns:
 rows:
   - condition: "Subject matches any `deny` rule"
     proxy: No
-    response: INVALID_PARAMS -32602
+    response: HTTP 403 Forbidden
   - condition: "`allow` list exists and subject is not in it"
     proxy: No
-    response: INVALID_PARAMS -32602
+    response: HTTP 403 Forbidden
   - condition: "Only `deny` list exists and subject is not in it"
     proxy: Yes
     response: 200
@@ -350,7 +354,7 @@ The AI MCP Proxy plugin evaluates ACLs for both tool discovery and tool invocati
 3. AI MCP Proxy loads the Consumer's group memberships
 4. Plugin evaluates the tool-specific ACL if it exists, or the default ACL otherwise
 5. Plugin logs the access attempt (allowed or denied)
-6. Plugin returns `INVALID_PARAMS -32602` if denied, or forwards the request to the upstream MCP server if allowed
+6. Plugin returns `HTTP 403 Forbidden` if denied, or forwards the request to the upstream MCP server if allowed
 
 <!-- vale off -->
 {% mermaid %}
@@ -373,7 +377,7 @@ sequenceDiagram
     alt If allowed
       Kong-->>Client: Filtered tool list
     else If denied
-      Kong-->>Client: INVALID_PARAMS -32602
+      Kong-->>Client: HTTP 403 Forbidden
     end
   end
 
@@ -390,7 +394,7 @@ sequenceDiagram
       Up-->>Kong: Response
       Kong-->>Client: Response
     else If denied
-      Kong-->>Client: INVALID_PARAMS -32602
+      Kong-->>Client: HTTP 403 Forbidden
     end
   end
 {% endmermaid %}


### PR DESCRIPTION
## Description

The AI MCP Proxy plugin will now returns HTTP 403 Forbidden for ACL denials, whether the subject matches a deny rule or fails to match an allow list.

I chose not to use the inline `new_in` tag here, as it would be to a lot of visual clutter. Added an FAQ to address older users instead.

Fixes https://github.com/Kong/developer.konghq.com/issues/3940

## Preview Links

https://deploy-preview-4446--kongdeveloper.netlify.app/plugins/ai-mcp-proxy/#acl-evaluation-logic
https://deploy-preview-4446--kongdeveloper.netlify.app/plugins/ai-mcp-proxy/#why-do-i-see-the-error-code-invalid-params-32602-on-failed-requests
https://deploy-preview-4446--kongdeveloper.netlify.app/mcp/use-access-controls-for-mcp-tools/#validate-the-configuration