### PR TITLE
fix(gateway): route supports `protocols` not `protocol`

### DIFF
--- a/app/_gateway_entities/route.md
+++ b/app/_gateway_entities/route.md
@@ -522,7 +522,7 @@ type: route
 data:
   name: example-route
   host: "*.tls-example.com"
-  protocol: 
+  protocols: 
     - https
     - tls
   paths:


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
