### PR TITLE
Update JWT signer documentation for key management

### DIFF
--- a/app/_kong_plugins/jwt-signer/index.md
+++ b/app/_kong_plugins/jwt-signer/index.md
@@ -70,7 +70,7 @@ and [`config.channel_token_jwks_uri`](/plugins/jwt-signer/reference/#schema--con
 (such as `"my-company"` or `"kong"`), {{site.base_gateway}} autogenerates JWKS for supported algorithms.
 
 {:.info}
-> When this plugin used in Konnect, key sets are not currently supported. The token signing keys MUST be specified as a URI to a JWKS document. In addition, JWKS of public keys are not auto-generated.
+> When this plugin is used in Konnect, key sets are not currently supported. The token signing keys MUST be specified as a URI to a JWKS document. In addition, JWKS of public keys are not auto-generated.
 
 External JWKS specified with [`config.access_token_keyset`](/plugins/jwt-signer/reference/#schema--config-access-token-keyset) or
 [`config.channel_token_keyset`](/plugins/jwt-signer/reference/#schema--config-channel-token-keyset) should also contain private keys with supported `alg`,


### PR DESCRIPTION
Clarified that external token signing keys must be in a JWKS document and added a note about Konnect's limitations regarding key sets. In support of https://konghq.aha.io/features/RUN-96

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
