### PR TITLE
Fix typo in MeshExternalService resource description

### DIFF
--- a/app/mesh/meshexternalservice.md
+++ b/app/mesh/meshexternalservice.md
@@ -31,7 +31,7 @@ faqs:
 > This resource is experimental.
 
 The `MeshExternalService` resource allows services running inside the mesh to consume services that are not part of the mesh.
-You can declare external resources instead of relying on a [`MeshPassthrough`](/mesh/policies/meshpassthrough/) policy or passthrough mode in the mesh configuration. 
+You can declare external resources instead of relying on a [`MeshPassthrough`](/mesh/policies/meshpassthrough/) policy or passthrough mode in the mesh configuration.
 
 {:.warning}
 > Currently you can't configure granular [`MeshTrafficPermission`](/mesh/policies/meshtrafficpermission/) policies for `MeshExternalService` resources.


### PR DESCRIPTION
Corrected a typo in the MeshExternalService documentation.

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
