### PR TITLE
fix(include_svg): add aria-label and sr-only information to boolean icons.

### DIFF
--- a/app/_includes/icon_false.html
+++ b/app/_includes/icon_false.html
@@ -1,1 +1,1 @@
-<span class="inline-flex text-semantic-red-primary w-5 h-5">{% include_svg '/assets/icons/close.svg' %}</span>
+<span class="inline-flex text-semantic-red-primary w-5 h-5">{% include_svg '/assets/icons/close.svg' aria-hidden="true" %}</span><span class="sr-only">Not supported</span>

--- a/app/_includes/icon_true.html
+++ b/app/_includes/icon_true.html
@@ -1,1 +1,1 @@
-<span class="inline-flex text-terciary w-5 h-5">{% include_svg '/assets/icons/check.svg' %}</span>
+<span class="inline-flex text-terciary w-5 h-5">{% include_svg '/assets/icons/check.svg' aria-hidden="true" %}</span><span class="sr-only">Supported</span>

--- a/app/_plugins/tags/include_svg.rb
+++ b/app/_plugins/tags/include_svg.rb
@@ -25,6 +25,14 @@ module Jekyll
       svg['width'] = @params['width'] if @params['width']
       svg['height'] = @params['height'] if @params['height']
 
+      reserved = %w[file_path width height]
+      @params.each do |key, value|
+        next if reserved.include?(key)
+        next unless key.match?(/\Aaria-[\w-]+\z/) || %w[role class focusable id].include?(key)
+
+        svg[key] = value
+      end
+
       doc.to_s
     end
 
@@ -36,7 +44,7 @@ module Jekyll
       params['file_path'] = parts.shift
 
       parts.each do |part|
-        if part =~ /(\w+)=(.+)/
+        if part =~ /([\w-]+)=(.+)/
           key = Regexp.last_match(1)
           value = Regexp.last_match(2).gsub(/^["']|["']$/, '') # strip surrounding quotes
           params[key] = value


### PR DESCRIPTION
## Description

Kapa and Screen Readers can't parse svgs, so this provides context that they can undestand.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
