### PR TITLE
fix(dcgw): Move REP link to networking on landing page

### DIFF
--- a/app/_landing_pages/dedicated-cloud-gateways.yaml
+++ b/app/_landing_pages/dedicated-cloud-gateways.yaml
@@ -83,6 +83,8 @@ rows:
                   url: /dedicated-cloud-gateways/transit-gateways/
                 - text: VPC peering
                   url: /dedicated-cloud-gateways/aws-vpc-peering/
+                - text: AWS resource endpoints (REP)
+                  url: /dedicated-cloud-gateways/aws-resource-endpoints/
       - blocks:
           - type: card
             config:
@@ -151,21 +153,6 @@ rows:
                   url: /dedicated-cloud-gateways/azure-vnet-peering-with-private-dns/
                 - text: Outbound DNS resolver
                   url: /dedicated-cloud-gateways/azure-vnet-peering-with-outbound-dns-resolver/
-  - header:
-      type: h2
-      text: "Service-level private access"
-  - column_count: 3
-    columns:
-      - blocks:
-        - type: card
-          config:
-            title: AWS resource endpoints
-            icon: /assets/icons/aws.svg
-            description: |
-              AWS resource endpoints with Dedicated Cloud Gateway enables secure, one-way connectivity from {{site.konnect_short_name}}’s managed infrastructure to your upstream services without requiring VPC peering or Transit Gateway. 
-            cta:
-              text: Learn more
-              url: /dedicated-cloud-gateways/aws-resource-endpoints/  
       
   - header:
       type: h2


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links
/dedicated-cloud-gateways/#networking

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
