### PR TITLE
fix(event-gateway): How-to guides link on home page

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -212,6 +212,7 @@ edit_and_issue_links: false
                 <div class="flex flex-col w-full text-primary text-sm">
                     <a class="flex justify-between py-3 border-b border-primary/5  hover:bg-hover-component/100 hover:px-6 hover:-mx-6 hover:no-underline" href="/event-gateway/">Overview <span class="text-terciary">&rarr;</span></a>
                     <a class="flex justify-between py-3 border-b border-primary/5  hover:bg-hover-component/100 hover:px-6 hover:-mx-6 hover:no-underline" href="/event-gateway/get-started/">Install <span class="text-terciary">&rarr;</span></a>
+                    <a class="flex justify-between py-3 border-b border-primary/5  hover:bg-hover-component/100 hover:px-6 hover:-mx-6 hover:no-underline" href="/how-to/?products=event-gateway">How-to guides <span class="text-terciary">&rarr;</span></a>
                     <a class="flex justify-between py-3 hover:bg-hover-component/100 hover:px-6 hover:-mx-6 hover:no-underline" href="/index/event-gateway/">All documentation<span class="text-terciary">&rarr;</span></a>
                 </div>
             </div>


### PR DESCRIPTION
Add a missing link to Event Gateway how-to guides from the home page.

https://deploy-preview-4542--kongdeveloper.netlify.app/