### PR TITLE
fix(dev): ignore algolia on missing config

### DIFF
--- a/app/_assets/javascripts/apps/SearchModal.vue
+++ b/app/_assets/javascripts/apps/SearchModal.vue
@@ -191,7 +191,9 @@ export default {
     });
 
     if (!import.meta.env.VITE_ALGOLIA_APPLICATION_ID || !import.meta.env.VITE_ALGOLIA_API_KEY) {
-      console.log('Search is disabled: missing Algolia configuration (VITE_ALGOLIA_APPLICATION_ID / VITE_ALGOLIA_API_KEY)');
+      if (import.meta.env.DEV) {
+        console.warn('Search is disabled: missing Algolia configuration (VITE_ALGOLIA_APPLICATION_ID / VITE_ALGOLIA_API_KEY)');
+      }
       return {};
     }
 


### PR DESCRIPTION
## Description

This thing is blocking rendering policies examples locally.

When I switched `event_gateway_policy` to `false` in `jekyll-dev` the website loaded but not the example. After this change, it works.
Not sure if this is right solution, but I'd like the policies example to be visible on local dev.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
