### PR TITLE
Change Azure Managed Redis port from 6379 to 10000

### DIFF
--- a/app/_includes/plugins/redis/oss.md
+++ b/app/_includes/plugins/redis/oss.md
@@ -101,7 +101,7 @@ config:
     redis:
       host: $INSTANCE_ADDRESS
       username: $INSTANCE_USERNAME
-      port: 6379
+      port: 10000
       cloud_authentication:
         auth_provider: azure
         azure_client_id: $AZURE_CLIENT_ID
@@ -115,7 +115,7 @@ config:
   redis:
     host: $INSTANCE_ADDRESS
     username: $INSTANCE_USERNAME
-    port: 6379
+    port: 10000
     cloud_authentication:
       auth_provider: azure
       azure_client_id: $AZURE_CLIENT_ID
@@ -130,7 +130,7 @@ config:
     redis:
       host: $INSTANCE_ADDRESS
       username: $INSTANCE_USERNAME
-      port: 6379
+      port: 10000
       cloud_authentication:
         auth_provider: azure
         azure_client_id: $AZURE_CLIENT_ID


### PR DESCRIPTION
## Description

Azure Managed Redis uses port 10000 for connection. https://learn.microsoft.com/en-us/azure/redis/architecture#cluster-policies

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
