### PR TITLE
Document additional limitations for Forward Proxy plugin

### DIFF
--- a/app/_kong_plugins/forward-proxy/index.md
+++ b/app/_kong_plugins/forward-proxy/index.md
@@ -58,5 +58,5 @@ As a workaround for load balancing, configure the [`host` field in a Gateway Ser
 [DNS-based load balancing](/gateway/traffic-control/load-balancing-reference/#dns-based-load-balancing) technique.
 
 The Forward Proxy Advanced plugin also can't be used together with the following:
-- Validate the upstream response with the [OAS Validation](/plugins/oas-validation/) plugin
-- Use the `kong.service.response.get_raw_body()` from the PDK in the `header_filter` phase
+- Validating the upstream response with the [OAS Validation](/plugins/oas-validation/) plugin.
+- Using the `kong.service.response.get_raw_body()` from the PDK in the `header_filter` phase.

--- a/app/_kong_plugins/forward-proxy/index.md
+++ b/app/_kong_plugins/forward-proxy/index.md
@@ -57,3 +57,6 @@ The Forward Proxy Advanced plugin can't be used with an [Upstream](/gateway/enti
 As a workaround for load balancing, configure the [`host` field in a Gateway Service](/gateway/entities/service/#schema) to a domain name so that you can use a 
 [DNS-based load balancing](/gateway/traffic-control/load-balancing-reference/#dns-based-load-balancing) technique.
 
+The Forward Proxy Advanced plugin can't be used in this context too:
+- Validate the upstream response with the [OAS Validation](/plugins/oas-validation/) plugin
+- Use the `kong.service.response.get_raw_body()` from the PDK in the `header_filter` phase

--- a/app/_kong_plugins/forward-proxy/index.md
+++ b/app/_kong_plugins/forward-proxy/index.md
@@ -57,6 +57,6 @@ The Forward Proxy Advanced plugin can't be used with an [Upstream](/gateway/enti
 As a workaround for load balancing, configure the [`host` field in a Gateway Service](/gateway/entities/service/#schema) to a domain name so that you can use a 
 [DNS-based load balancing](/gateway/traffic-control/load-balancing-reference/#dns-based-load-balancing) technique.
 
-The Forward Proxy Advanced plugin can't be used in this context too:
+The Forward Proxy Advanced plugin also can't be used together with the following:
 - Validate the upstream response with the [OAS Validation](/plugins/oas-validation/) plugin
 - Use the `kong.service.response.get_raw_body()` from the PDK in the `header_filter` phase


### PR DESCRIPTION
Add limitations for Forward Proxy Advanced plugin usage.

See https://konghq.atlassian.net/browse/FTI-7359, which proves  the limitation in relation with our engineering team

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
