### PR TITLE
Update index.md with body transformations section

### DIFF
--- a/app/_kong_plugins/request-transformer-advanced/index.md
+++ b/app/_kong_plugins/request-transformer-advanced/index.md
@@ -66,3 +66,8 @@ The Response Transformer Advanced plugin provides features that aren't available
 ## Arrays and nested objects
 
 {% include plugins/request-response-transformer/arrays-nested-objects.md %}
+
+## Body transformations
+
+Body transformations are only performed for:
+* Requests in which the `Content-Type` header is set to `application/json`

--- a/app/_kong_plugins/request-transformer-advanced/index.md
+++ b/app/_kong_plugins/request-transformer-advanced/index.md
@@ -69,5 +69,4 @@ The Response Transformer Advanced plugin provides features that aren't available
 
 ## Body transformations
 
-Body transformations are only performed for:
-* Requests in which the `Content-Type` header is set to `application/json`
+Body transformations are only performed for requests where the `Content-Type` header is set to `application/json`.


### PR DESCRIPTION
Added a section on body transformations and included related documentation.

## Description
Body transformations are not performed on requests without the content-type 'application/json'. This was not stated explicitly in the docs for the transformations plugins and is only stated explicitly in the request validator plugin doc.

https://developer.konghq.com/plugins/request-validator/#body-validation

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
