### PR TITLE
fix(operator): env indentation issue

### DIFF
--- a/app/operator/dataplanes/faq/license.md
+++ b/app/operator/dataplanes/faq/license.md
@@ -89,12 +89,12 @@ spec:
         containers:
         - name: proxy
           image: kong/kong-gateway:{{ site.data.gateway_latest.release }}
-        env:
-        - name: KONG_LICENSE_DATA
-          valueFrom:
-            secretKeyRef:
-              key: license
-              name: kong-enterprise-license
+          env:
+          - name: KONG_LICENSE_DATA
+            valueFrom:
+              secretKeyRef:
+                key: license
+                name: kong-enterprise-license
 ```
 
 ### GatewayConfiguration
@@ -113,10 +113,10 @@ spec:
           containers:
           - name: proxy
             image: kong/kong-gateway:{{ site.data.gateway_latest.release }}
-          env:
-          - name: KONG_LICENSE_DATA
-            valueFrom:
-              secretKeyRef:
-                key: license
-                name: kong-enterprise-license
+            env:
+            - name: KONG_LICENSE_DATA
+              valueFrom:
+                secretKeyRef:
+                  key: license
+                  name: kong-enterprise-license
 ```


### PR DESCRIPTION
## Description

Issue reported in #docs

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
