### PR TITLE
feat(gateway): hide_credentials set to true by default

### DIFF
--- a/app/gateway/breaking-changes.md
+++ b/app/gateway/breaking-changes.md
@@ -61,7 +61,7 @@ For the following plugins, the SHA1 algorithm is still supported in existing con
 * [HMAC Auth plugin](/plugins/hmac-auth/): HMAC-SHA1 is no longer included in the default set of algorithms.
 * [OAuth2 plugin](/plugins/oauth2/): Uses SHA256 for the access token cache key instead of SHA1.
 
-### Hide credentials by default
+#### Hide credentials by default
 
 `hide_credentials` is now set to `true` by default in the following plugins:
 


### PR DESCRIPTION
## Description

`hide_credentials` is a plugin setting in most Gateway auth plugins that now defaults to `true`. This is a breaking change for any new plugins.

## Preview Links
https://deploy-preview-4613--kongdeveloper.netlify.app/gateway/breaking-changes/#hide-credentials-by-default
