### PR TITLE
Removes Konnect warning for upstreams

### DIFF
--- a/app/_gateway_entities/upstream.md
+++ b/app/_gateway_entities/upstream.md
@@ -115,7 +115,7 @@ rows:
       Configure Upstreams to dynamically mark a target as healthy or unhealthy. This is an active check where a specific HTTP or HTTPS endpoint in the target is periodically requested and the health of the target is determined based on its response.
   - use_case: "[Circuit break](/gateway/traffic-control/health-checks-circuit-breakers/#passive-health-checks-circuit-breakers)"
     description: |
-      Configure Upstreams to allow {{site.base_gateway}} to passively analyze the ongoing traffic being proxied and determine the health of targets based on their behavior responding to requests. **This feature is not supported in {{site.konnect_short_name}} or hybrid mode.**
+      Configure Upstreams to allow {{site.base_gateway}} to passively analyze the ongoing traffic being proxied and determine the health of targets based on their behavior responding to requests.
 {% endtable %}
 <!--vale on -->
 ## Load balancing algorithms


### PR DESCRIPTION
## Description

Passive HCs do work and can disable a target, but you need to establish an active HC to re-enable a target, there's no way to do it manually or monitor the status in hybrid mode. (We have a proposal to fix this in a future release).

We had a similar warning about Konnect on the health check docs which we removed and replaced with a tutorial. This applies the same change to the Upstream.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
