### PR TITLE
fix(konnect-platform): IP restriction endpoint and region

### DIFF
--- a/app/konnect-platform/network.md
+++ b/app/konnect-platform/network.md
@@ -170,14 +170,14 @@ This IP allow list applies to all {{site.konnect_short_name}} communication that
 * If the source IP address you have allow-listed is no longer reachable and IP allow list enforcement is enabled, access to {{site.konnect_short_name}} will be blocked.
 > * If you're configuring IP allow list for the first time, it takes effect immediately. If you're editing existing IP allow list values, the changes will take effect after five minutes.
 
-To configure IP allow list for {{site.konnect_short_name}}, send a PATCH request to the `/source-ip-restriction` endpoint:
+To configure IP allow list for {{site.konnect_short_name}}, send a PUT request to the `/organizations/$ORG_ID/ip-allow-list` endpoint:
 
 <!--vale off-->
 {% konnect_api_request %}
 url: /v3/organizations/$ORG_ID/ip-allow-list
 status_code: 201
 region: global
-method: PATCH
+method: PUT
 body:
     enabled: true
     allowed_ips:


### PR DESCRIPTION
## Description

Fixes https://kongstrong.slack.com/archives/C04RXLGNB6K/p1774446287257819?thread_ts=1774416124.615609&cid=C04RXLGNB6K

For reviewers: Don't test this otherwise you'll lock us out of our Konnect account 😅 

## Preview Links
/konnect-platform/network/#specify-ip-addresses-that-can-connect-to-konnect

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
