### PR TITLE
fix(event-gateway): Update version number to 1.1.0

### DIFF
--- a/app/event-gateway/changelog.md
+++ b/app/event-gateway/changelog.md
@@ -14,7 +14,7 @@ tags:
 
 Changelog for supported {{site.event_gateway}} versions.
 
-## 1.1
+## 1.1.0
 
 **Release date**: 2026/03/25
 


### PR DESCRIPTION
## Description
Version number in the changelog is 1.1, should be 1.1.0.
