### PR TITLE
docs: fix code indent to fix leading space in generated html

### DIFF
--- a/app/_how-tos/kubernetes-ingress-controller/kic-get-started-key-authentication.md
+++ b/app/_how-tos/kubernetes-ingress-controller/kic-get-started-key-authentication.md
@@ -64,7 +64,7 @@ For more information, see [What is API Gateway Authentication?](https://konghq.c
 
 {% entity_example %}
 type: plugin
-indent: 4
+indent: 3
 data:
   name: key-auth
   
@@ -75,27 +75,27 @@ data:
 1. Test that the API is secure by sending a request using `curl -i $PROXY_IP/echo`:
 
 {% validation unauthorized-check %}
-indent: 4
+indent: 3
 url: /echo
 konnect_url: $PROXY_IP
 on_prem_url: $PROXY_IP
 {% endvalidation %}
 
-    You should see the response:
+   You should see the response:
 
-    ```text
-    HTTP/1.1 401 Unauthorized
-    Date: Wed, 11 Jan 2044 18:33:46 GMT
-    Content-Type: application/json; charset=utf-8
-    WWW-Authenticate: Key realm="kong"
-    Content-Length: 45
-    X-Kong-Response-Latency: 1
-    Server: kong/{{site.latest_gateway_oss_version}}
+   ```text
+   HTTP/1.1 401 Unauthorized
+   Date: Wed, 11 Jan 2044 18:33:46 GMT
+   Content-Type: application/json; charset=utf-8
+   WWW-Authenticate: Key realm="kong"
+   Content-Length: 45
+   X-Kong-Response-Latency: 1
+   Server: kong/{{site.latest_gateway_oss_version}}
 
-    {
-      "message":"No API key found in request"
-    }
-    ```
+   {
+     "message":"No API key found in request"
+   }
+   ```
 
 ## Set up Consumers and keys 
 
@@ -105,24 +105,24 @@ Keys are stored as Kubernetes `Secrets` and Consumers are managed with the `Kong
 
 1. Create a new `Secret` labeled to use `key-auth` credential type:
 
-    ```bash
-    echo '
-    apiVersion: v1
-    kind: Secret
-    metadata:
-       name: alex-key-auth
-       namespace: kong
-       labels:
-          konghq.com/credential: key-auth
-    stringData:
-       key: hello_world
-    ' | kubectl apply -f -
-    ```
+   ```bash
+   echo '
+   apiVersion: v1
+   kind: Secret
+   metadata:
+      name: alex-key-auth
+      namespace: kong
+      labels:
+         konghq.com/credential: key-auth
+   stringData:
+      key: hello_world
+   ' | kubectl apply -f -
+   ```
 
 1. Create a new Consumer and attach the credential:
 
 {% entity_example %}
-indent: 4
+indent: 3
 type: consumer
 data:
   username: alex
@@ -133,7 +133,7 @@ data:
 1. Make a request to the API and provide your `apikey`:
 
 {% validation request-check %}
-indent: 4
+indent: 3
 url: /echo
 headers:
   - 'apikey:hello_world'
@@ -142,14 +142,14 @@ konnect_url: $PROXY_IP
 on_prem_url: $PROXY_IP
 {% endvalidation %}
 
-    The results should look like this:
+   The results should look like this:
 
-    ```
-    Welcome, you are connected to node orbstack.
-    Running on Pod echo-965f7cf84-mvf6g.
-    In namespace default.
-    With IP address 192.168.194.10.
-    ```
+   ```
+   Welcome, you are connected to node orbstack.
+   Running on Pod echo-965f7cf84-mvf6g.
+   In namespace default.
+   With IP address 192.168.194.10.
+   ```
 
 ## Next Steps
 

--- a/app/_how-tos/kubernetes-ingress-controller/kic-plugin-acl.md
+++ b/app/_how-tos/kubernetes-ingress-controller/kic-plugin-acl.md
@@ -144,7 +144,7 @@ data:
   credentials:
     - my-admin-key-auth
   
-indent: 4
+indent: 3
 {% endentity_example %}
 
 {% entity_example %}
@@ -154,7 +154,7 @@ data:
   credentials:
     - my-user-key-auth
   
-indent: 4
+indent: 3
 {% endentity_example %}
 
 ## Secure the service
@@ -205,20 +205,20 @@ Create two plugins, one which allows only an admin group, and one which allows b
 
 1. Patch the Consumers:
 
-    ```bash
-    kubectl patch -n kong --type json kongconsumer my-admin \
-      -p='[{
-        "op":"add",
-        "path":"/credentials/-",
-        "value":"admin-acl"
-      }]'
-    kubectl patch -n kong --type json kongconsumer my-user \
-      -p='[{
-        "op":"add",
-        "path":"/credentials/-",
-        "value":"user-acl"
-      }]'
-    ```
+   ```bash
+   kubectl patch -n kong --type json kongconsumer my-admin \
+     -p='[{
+       "op":"add",
+       "path":"/credentials/-",
+       "value":"admin-acl"
+     }]'
+   kubectl patch -n kong --type json kongconsumer my-user \
+     -p='[{
+       "op":"add",
+       "path":"/credentials/-",
+       "value":"user-acl"
+     }]'
+   ```
 
 ## Add access control
 

--- a/app/_how-tos/kubernetes-ingress-controller/kic-plugin-authentication.md
+++ b/app/_how-tos/kubernetes-ingress-controller/kic-plugin-authentication.md
@@ -57,38 +57,38 @@ Create two [Consumers](/gateway/entities/consumer/) that use different authentic
 
 1. Create a secret to add a `basic-auth` credential for `consumer-1`:
 
-    ```bash
-    echo '
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: consumer-1-basic-auth
-      namespace: kong
-      labels:
-        konghq.com/credential: basic-auth
-    stringData:
-        username: consumer-1
-        password: consumer-1-password
-    ' | kubectl apply -f -
-    ```
+   ```bash
+   echo '
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: consumer-1-basic-auth
+     namespace: kong
+     labels:
+       konghq.com/credential: basic-auth
+   stringData:
+       username: consumer-1
+       password: consumer-1-password
+   ' | kubectl apply -f -
+   ```
 
 1. Create a secret to add a `key-auth` credential for `consumer-2`:
 
-    ```bash
-    echo '
-    apiVersion: v1
-    kind: Secret
-    metadata:
-      name: consumer-2-key-auth
-      namespace: kong
-      labels:
-        konghq.com/credential: key-auth
-    stringData:
-      key: consumer-2-password
-    ' | kubectl apply -f -
-    ```
+   ```bash
+   echo '
+   apiVersion: v1
+   kind: Secret
+   metadata:
+     name: consumer-2-key-auth
+     namespace: kong
+     labels:
+       konghq.com/credential: key-auth
+   stringData:
+     key: consumer-2-password
+   ' | kubectl apply -f -
+   ```
 
-1.  Create a Consumer named `consumer-1`:
+1. Create a Consumer named `consumer-1`:
 
 {% entity_example %}
 type: consumer
@@ -97,10 +97,10 @@ data:
   credentials:
     - consumer-1-basic-auth
   
-indent: 4
+indent: 3
 {% endentity_example %}
 
-1.  Create a Consumer named `consumer-2`:
+1. Create a Consumer named `consumer-2`:
 
 {% entity_example %}
 type: consumer
@@ -109,7 +109,7 @@ data:
   credentials:
     - consumer-2-key-auth
   
-indent: 4
+indent: 3
 {% endentity_example %}
 
 ## Secure the service

--- a/app/_how-tos/kubernetes-ingress-controller/kic-plugin-custom.md
+++ b/app/_how-tos/kubernetes-ingress-controller/kic-plugin-custom.md
@@ -82,37 +82,37 @@ The {{ site.kic_product_name }} Helm chart automatically configures all the envi
 
 1. Update your `values.yaml` file with the following contents. Ensure that you add in other configuration values you might need for your installation to be successful.
 
-    ```yaml
-    gateway:
-      plugins:
-        configMaps:
-          - name: kong-plugin-myheader
-            pluginName: myheader
-    ```
+   ```yaml
+   gateway:
+     plugins:
+       configMaps:
+         - name: kong-plugin-myheader
+           pluginName: myheader
+   ```
 
-    If you need to include the migration scripts to the plugin, configure `userDefinedVolumes` and `userDefinedVolumeMounts` in `values.yaml` to mount the migration scripts to the {{site.base_gateway}} pod:
+   If you need to include the migration scripts to the plugin, configure `userDefinedVolumes` and `userDefinedVolumeMounts` in `values.yaml` to mount the migration scripts to the {{site.base_gateway}} pod:
 
-    ```yaml
-    gateway:
-      plugins:
-        configMaps:
-          - name: kong-plugin-myheader
-            pluginName: myheader
-      deployment:
-        userDefinedVolumes:
-          - name: "kong-plugin-myheader-migrations"
-            configMap:
-              name: "kong-plugin-myheader-migrations"
-        userDefinedVolumeMounts:
-          - name: "kong-plugin-myheader-migrations"
-            mountPath: "/opt/kong/plugins/myheader/migrations" # Should be the path /opt/kong/plugins/<plugin-name>/migrations
-    ```
+   ```yaml
+   gateway:
+     plugins:
+       configMaps:
+         - name: kong-plugin-myheader
+           pluginName: myheader
+     deployment:
+       userDefinedVolumes:
+         - name: "kong-plugin-myheader-migrations"
+           configMap:
+             name: "kong-plugin-myheader-migrations"
+       userDefinedVolumeMounts:
+         - name: "kong-plugin-myheader-migrations"
+           mountPath: "/opt/kong/plugins/myheader/migrations" # Should be the path /opt/kong/plugins/<plugin-name>/migrations
+   ```
 
 1. Upgrade {{site.kic_product_name}} with the new values
 
-    ```bash
-    helm upgrade --install kong kong/ingress -n kong --create-namespace --values values.yaml
-    ```
+   ```bash
+   helm upgrade --install kong kong/ingress -n kong --create-namespace --values values.yaml
+   ```
 
 {% konnect %}
 title: Register the plugin schema in Konnect
@@ -140,7 +140,7 @@ After you have set up {{ site.base_gateway }} with the custom plugin installed, 
 
 {% entity_example %}
 type: plugin
-indent: 4
+indent: 3
 data:
   name: my-custom-plugin
   plugin: myheader

--- a/app/kubernetes-ingress-controller/admission-webhook.md
+++ b/app/kubernetes-ingress-controller/admission-webhook.md
@@ -38,39 +38,39 @@ You can test if the admission webhook is enabled for duplicate KongConsumers, in
 
 1. Create a KongConsumer with the username `alice`:
 
-    ```bash
-    echo '
-    apiVersion: configuration.konghq.com/v1
-    kind: KongConsumer
-    metadata:
-      name: alice
-      annotations:
-        kubernetes.io/ingress.class: kong
-    username: alice
-    ' | kubectl apply -f -
-    ```
-    The results should look like this:
-    ```
-    kongconsumer.configuration.konghq.com/alice created
-    ```
+   ```bash
+   echo '
+   apiVersion: configuration.konghq.com/v1
+   kind: KongConsumer
+   metadata:
+     name: alice
+     annotations:
+       kubernetes.io/ingress.class: kong
+   username: alice
+   ' | kubectl apply -f -
+   ```
+   The results should look like this:
+   ```
+   kongconsumer.configuration.konghq.com/alice created
+   ```
 
 1. Create another KongConsumer with the same username:
 
-    ```bash
-    echo '
-    apiVersion: configuration.konghq.com/v1
-    kind: KongConsumer
-    metadata:
-      name: alice2
-      annotations:
-        kubernetes.io/ingress.class: kong
-    username: alice
-    ' | kubectl apply -f -
-    ```
-    The results should look like this:
-    ```
-    Error from server: error when creating "STDIN": admission webhook "validations.kong.konghq.com" denied the request: consumer already exists
-    ```
+   ```bash
+   echo '
+   apiVersion: configuration.konghq.com/v1
+   kind: KongConsumer
+   metadata:
+     name: alice2
+     annotations:
+       kubernetes.io/ingress.class: kong
+   username: alice
+   ' | kubectl apply -f -
+   ```
+   The results should look like this:
+   ```
+   Error from server: error when creating "STDIN": admission webhook "validations.kong.konghq.com" denied the request: consumer already exists
+   ```
 
 The validation webhook rejected the KongConsumer resource as there already exists a Consumer in {{site.base_gateway}} with the same username.
 

--- a/app/kubernetes-ingress-controller/faq/upgrading-gateway.md
+++ b/app/kubernetes-ingress-controller/faq/upgrading-gateway.md
@@ -66,40 +66,40 @@ To see the available {{ site.base_gateway }} images, see [kong/kong-gateway](htt
 
 1. Edit or create a `values.yaml` file so that it contains a `gateway.image.tag` entry. Set this value to the version of {{ site.base_gateway }} to be installed.
 
-    ```yaml
-    gateway:
-      image:
-        tag: "{{site.data.gateway_latest.release}}"
-    ```
+   ```yaml
+   gateway:
+     image:
+       tag: "{{site.data.gateway_latest.release}}"
+   ```
 
 1. Run `helm upgrade` with the `--values` flag.
 
-    ```bash
-    helm upgrade -n kong kong kong/ingress --values values.yaml --wait
-    ```
+   ```bash
+   helm upgrade -n kong kong kong/ingress --values values.yaml --wait
+   ```
 
-    The result should look like this:
-    
-    ```bash
-    Release "kong" has been upgraded. Happy Helming!
-    NAME: kong
-    LAST DEPLOYED: Fri Nov  3 15:27:49 2023
-    NAMESPACE: kong
-    STATUS: deployed
-    REVISION: 5
-    TEST SUITE: None
-    ```
+   The result should look like this:
+   
+   ```bash
+   Release "kong" has been upgraded. Happy Helming!
+   NAME: kong
+   LAST DEPLOYED: Fri Nov  3 15:27:49 2023
+   NAMESPACE: kong
+   STATUS: deployed
+   REVISION: 5
+   TEST SUITE: None
+   ```
 
-    Pass `--wait` to `helm upgrade` to ensure that the command only returns when the rollout finishes successfully. 
+   Pass `--wait` to `helm upgrade` to ensure that the command only returns when the rollout finishes successfully. 
 
 1. Verify the upgrade by checking the version of {{ site.base_gateway }} Deployment running in your cluster.
 
-    ```bash
-    kubectl get deploy kong-gateway -n kong -ojsonpath='{.spec.template.spec.containers[0].image}'
-    ```
+   ```bash
+   kubectl get deploy kong-gateway -n kong -ojsonpath='{.spec.template.spec.containers[0].image}'
+   ```
 
-    You should see the new version of {{ site.base_gateway }}:
+   You should see the new version of {{ site.base_gateway }}:
 
-    ```bash
-    kong:{{site.data.gateway_latest.release}}
-    ```
+   ```bash
+   kong:{{site.data.gateway_latest.release}}
+   ```

--- a/app/kubernetes-ingress-controller/faq/upgrading-ingress-controller.md
+++ b/app/kubernetes-ingress-controller/faq/upgrading-ingress-controller.md
@@ -219,11 +219,11 @@ Upgrading from {{ site.kic_product_name }} 2.12 to 3.x+ is a major version chang
 
 1. **Update the {{ site.kic_product_name }} CRDs.**
 
-    Helm does not upgrade CRDs automatically. You must apply the 3.x CRDs before you upgrade your releases.
+   Helm does not upgrade CRDs automatically. You must apply the 3.x CRDs before you upgrade your releases.
 
-    ```bash
-    kubectl kustomize https://github.com/Kong/kubernetes-ingress-controller/config/crd/?ref=v3.0.0 | kubectl apply -f -
-    ```
+   ```bash
+   kubectl kustomize https://github.com/Kong/kubernetes-ingress-controller/config/crd/?ref=v3.0.0 | kubectl apply -f -
+   ```
 
 1. **Convert `KongIngress` `route` and `service` fields to annotations.**
 

--- a/app/kubernetes-ingress-controller/license.md
+++ b/app/kubernetes-ingress-controller/license.md
@@ -79,27 +79,27 @@ An alternative option is to use a static license Secret that will be used to pop
 
 1. Create a file named `license.json` containing your {{site.base_gateway}} license and store it in a Kubernetes secret:
 
-    ```bash
-    kubectl create namespace kong
-    kubectl create secret generic kong-enterprise-license --from-file=license=./license.json -n kong
-    ```
+   ```bash
+   kubectl create namespace kong
+   kubectl create secret generic kong-enterprise-license --from-file=license=./license.json -n kong
+   ```
 
 1. Create a `values.yaml` file:
 
-    ```yaml
-    gateway:
-      image:
-        repository: kong/kong-gateway
-      env:
-        LICENSE_DATA:
-          valueFrom:
-            secretKeyRef:
-              name: kong-enterprise-license
-              key: license
-    ```
+   ```yaml
+   gateway:
+     image:
+       repository: kong/kong-gateway
+     env:
+       LICENSE_DATA:
+         valueFrom:
+           secretKeyRef:
+             name: kong-enterprise-license
+             key: license
+   ```
 
 1. Install {{site.kic_product_name}} and {{ site.base_gateway }} with Helm:
 
-    ```bash
-    helm upgrade --install kong kong/ingress -n kong --create-namespace --values ./values.yaml
-    ```
+   ```bash
+   helm upgrade --install kong kong/ingress -n kong --create-namespace --values ./values.yaml
+   ```

--- a/app/kubernetes-ingress-controller/migrate/ingress-to-gateway.md
+++ b/app/kubernetes-ingress-controller/migrate/ingress-to-gateway.md
@@ -104,22 +104,22 @@ containing the Gateway API configurations.
 
 1. Export your source and destination paths:
 
-    ```bash
-    export SOURCE_DIR='YOUR SOURCE DIRECTORY'
-    export DEST_DIR='YOUR DESTINATION DIRECTORY'
-    ```
+   ```bash
+   export SOURCE_DIR='YOUR SOURCE DIRECTORY'
+   export DEST_DIR='YOUR DESTINATION DIRECTORY'
+   ```
 
 1. Convert the manifests and create new files in the destination directory:
 
-    ```bash
-    for file in $SOURCE_DIR/*.yaml; do ingress2gateway print --input-file ${file} -A --providers=kong > $DEST_DIR/$(basename -- $file); done
-    ```
+   ```bash
+   for file in $SOURCE_DIR/*.yaml; do ingress2gateway print --input-file ${file} -A --providers=kong > $DEST_DIR/$(basename -- $file); done
+   ```
 
 1. Check that the new manifest files are correctly created in the destination directory:
 
-    ```bash
-    ls $DEST_DIR
-    ```
+   ```bash
+   ls $DEST_DIR
+   ```
 
 1. Copy your annotations from the ingress resources to the Routes. The routes' names use the ingress name as prefix to help you track the route that the ingress generated. All the `konghq.com/` annotations must be copied except for these, that have been natively implemented as Gateway API features:
    * `konghq.com/methods`
@@ -138,15 +138,15 @@ Check that the new manifests converted correctly. The manifests are converted as
 
 1. Apply the new manifest files into the cluster:
 
-    ```bash
-    kubectl apply -f $DEST_DIR
-    ```
+   ```bash
+   kubectl apply -f $DEST_DIR
+   ```
 
 1. Wait for all the gateways to be programmed:
 
-    ```bash
-    kubectl wait --for=condition=programmed gateway -A --all
-    ```
+   ```bash
+   kubectl wait --for=condition=programmed gateway -A --all
+   ```
 
 ## Verify the migration
 
@@ -156,9 +156,9 @@ Before deleting the original resources, verify that your Gateway API resources a
 
    Ensure all Gateways have the `Programmed` condition set to `True`:
 
-    ```bash
-    kubectl get gateway -A -o wide
-    ```
+   ```bash
+   kubectl get gateway -A -o wide
+   ```
 
 2. **Verify route status**
 

--- a/app/kubernetes-ingress-controller/troubleshooting/kong-gateway-configuration.md
+++ b/app/kubernetes-ingress-controller/troubleshooting/kong-gateway-configuration.md
@@ -64,19 +64,19 @@ To use the diagnostic mode:
 
    ```yaml
    ingressController:
-    env:
-      dump_config: "true"
-      dump_sensitive_config: "true"
-    ```
+     env:
+       dump_config: "true"
+       dump_sensitive_config: "true"
+   ```
 
-    To enable configuration dumping temporarily for an existing deployment, run the following command:
+   To enable configuration dumping temporarily for an existing deployment, run the following command:
 
-    ```bash
-    kubectl set env -n kong deployment/kong-controller \
-      CONTROLLER_DUMP_CONFIG="true" \
-      CONTROLLER_DUMP_SENSITIVE_CONFIG="true" \
-      -c ingress-controller
-    ```
+   ```bash
+   kubectl set env -n kong deployment/kong-controller \
+     CONTROLLER_DUMP_CONFIG="true" \
+     CONTROLLER_DUMP_SENSITIVE_CONFIG="true" \
+     -c ingress-controller
+   ```
 
 1. (Optional) Make a change to a Kubernetes resource that you know will reproduce the issue. If you are unsure what change caused the issue originally, you can omit this step.
 

--- a/app/kubernetes-ingress-controller/troubleshooting/kubernetes-api-server.md
+++ b/app/kubernetes-ingress-controller/troubleshooting/kubernetes-api-server.md
@@ -109,17 +109,17 @@ Verify with the following commands:
 If it isn't working, there are two possible reasons:
 
 1. The contents of the tokens are invalid.
-    Find the secret name:
+   Find the secret name:
 
-    ```bash
-    kubectl get secrets --field-selector=type=kubernetes.io/service-account-token
-    ```
+   ```bash
+   kubectl get secrets --field-selector=type=kubernetes.io/service-account-token
+   ```
 
-    Delete the secret:
+   Delete the secret:
 
-    ```bash
-    kubectl delete secret $SECRET_NAME
-    ```
+   ```bash
+   kubectl delete secret $SECRET_NAME
+   ```
 
     It will automatically be recreated.
 


### PR DESCRIPTION
## Description

When I reading KIC related documents, I noticed that there a leading space each line in some code block:
<img width="1516" height="918" alt="image" src="https://github.com/user-attachments/assets/6c97c798-0cc2-42ff-8c9f-4b3223952ce9" />


This MR try fix some cases related to KIC by changing indent to 3: when we have code block under Numbered List, the indent should be 3.

we can check [Q: How can I get backtick fenced code blocks (e.g. ```) working inside lists (with kramdown)?
](https://github.com/planetjekyll/quickrefs/blob/master/FAQ.md#q-how-can-i-get-backtick-fenced-code-blocks-eg--working-inside-lists-with-kramdown) from https://github.com/gettalong/kramdown/issues/322
https://github.com/gettalong/kramdown/issues/787 for the reason, and below is the screenshot from FAQ:
<img width="2094" height="1286" alt="image" src="https://github.com/user-attachments/assets/99d3fb8e-3a97-49d5-be41-bb11ccb49787" />


## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
