### PR TITLE
ko: add page about http proxy env variables

### DIFF
--- a/app/_indices/operator.yaml
+++ b/app/_indices/operator.yaml
@@ -25,6 +25,7 @@ groups:
           - path: /operator/reference/custom-resources/
           - path: /operator/reference/version-compatibility/
           - path: /operator/reference/control-plane-feature-gates-and-controllers/
+          - path: /operator/reference/http-proxy/
 
   - title: Security hardening
     sections:

--- a/app/operator/reference/http-proxy.md
+++ b/app/operator/reference/http-proxy.md
@@ -1,0 +1,64 @@
+---
+title: HTTP proxy configuration
+description: "Configure {{site.operator_product_name}} to route outbound traffic through an HTTP proxy using standard Go environment variables."
+content_type: reference
+layout: reference
+breadcrumbs:
+  - /operator/
+  - index: operator
+    group: Reference
+
+products:
+  - operator
+
+works_on:
+  - on-prem
+  - konnect
+---
+
+{{ site.operator_product_name }} is built with Go and respects the standard proxy environment variables defined by Go's [`ProxyFromEnvironment`](https://pkg.go.dev/net/http#ProxyFromEnvironment).
+This allows you to route the operator's outbound HTTP(S) traffic through a corporate proxy or forward proxy.
+
+## Supported environment variables
+
+{% table %}
+columns:
+  - title: Variable
+    key: variable
+  - title: Description
+    key: description
+rows:
+  - variable: '`HTTP_PROXY`'
+    description: "Proxy URL to use for outbound HTTP requests."
+  - variable: '`HTTPS_PROXY`'
+    description: "Proxy URL to use for outbound HTTPS requests."
+  - variable: '`NO_PROXY`'
+    description: "Comma-separated list of hosts, IP addresses, or CIDR ranges that should bypass the proxy."
+{% endtable %}
+
+The lowercase variants (`http_proxy`, `https_proxy`, `no_proxy`) are also supported.
+If both uppercase and lowercase variants are set, the uppercase variant takes precedence.
+
+## `NO_PROXY` format
+
+The `NO_PROXY` variable accepts a comma-separated list of entries. Each entry can be:
+
+- A hostname (e.g. `example.com`) &mdash; matches that host exactly.
+- A domain with a leading dot (e.g. `.example.com`) &mdash; matches the domain and all subdomains.
+- An IP address (e.g. `10.0.0.1`).
+- A CIDR range (e.g. `10.0.0.0/8`).
+- `*` &mdash; bypasses the proxy for all requests.
+
+## Configure proxy variables in Helm
+
+Set the environment variables through Helm values:
+
+```yaml
+customEnv:
+- HTTP_PROXY: "http://proxy.example.com:3128"
+- HTTPS_PROXY: "http://proxy.example.com:3128"
+- NO_PROXY: "10.0.0.0/8,127.0.0.1,localhost,.svc,.cluster.local"
+```
+
+{:.info}
+> Make sure to include Kubernetes internal addresses (such as `.svc` and `.cluster.local`) in `NO_PROXY` so that in-cluster communication is not routed through the proxy.

--- a/app/operator/reference/http-proxy.md
+++ b/app/operator/reference/http-proxy.md
@@ -55,9 +55,9 @@ Set the environment variables through Helm values:
 
 ```yaml
 customEnv:
-- HTTP_PROXY: "http://proxy.example.com:3128"
-- HTTPS_PROXY: "http://proxy.example.com:3128"
-- NO_PROXY: "10.0.0.0/8,127.0.0.1,localhost,.svc,.cluster.local"
+  HTTP_PROXY: "http://proxy.example.com:3128"
+  HTTPS_PROXY: "http://proxy.example.com:3128"
+  NO_PROXY: "10.0.0.0/8,127.0.0.1,localhost,.svc,.cluster.local"
 ```
 
 {:.info}

--- a/app/operator/reference/http-proxy.md
+++ b/app/operator/reference/http-proxy.md
@@ -17,9 +17,11 @@ works_on:
 ---
 
 {{ site.operator_product_name }} is built with Go and respects the standard proxy environment variables defined by Go's [`ProxyFromEnvironment`](https://pkg.go.dev/net/http#ProxyFromEnvironment).
-This allows you to route the operator's outbound HTTP(S) traffic through a corporate proxy or forward proxy.
+This allows you to route the {{ site.operator_product_name_short }}'s outbound HTTP(S) traffic through a corporate proxy or forward proxy.
 
 ## Supported environment variables
+
+Use the following environment variables to configure the proxying:
 
 {% table %}
 columns:


### PR DESCRIPTION
## Description

Ref: https://kongstrong.slack.com/archives/CA42V003B/p1774365778015359

## Preview Links

https://deploy-preview-4660--kongdeveloper.netlify.app/operator/reference/http-proxy/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
