### PR TITLE
fix(event-gateway): expectation on one test and skip two how-tos for now

### DIFF
--- a/app/_how-tos/event-gateway/configure-mtls-backend-cluster-auth.md
+++ b/app/_how-tos/event-gateway/configure-mtls-backend-cluster-auth.md
@@ -49,6 +49,8 @@ related_resources:
 
 min_version:
   event_gateway: '1.1.0'
+
+automated_tests: false
 ---
 
 In this guide you'll configure {{site.event_gateway_short}} to connect to a secured Kafka cluster by presenting a mutual TLS client certificate.

--- a/app/_how-tos/event-gateway/configure-sasl-plain-backend-cluster-auth.md
+++ b/app/_how-tos/event-gateway/configure-sasl-plain-backend-cluster-auth.md
@@ -46,6 +46,8 @@ related_resources:
     url: /event-gateway/get-started/
   - text: Authenticate connections to Kafka using mTLS
     url: /event-gateway/configure-mtls-backend-cluster-auth/
+
+automated_tests: false
 ---
 
 In this guide you'll configure {{site.event_gateway_short}} to connect to a secured Kafka cluster using SASL/PLAIN credentials.

--- a/app/_how-tos/event-gateway/kong-identity-oauth.md
+++ b/app/_how-tos/event-gateway/kong-identity-oauth.md
@@ -405,16 +405,16 @@ command: |
 expected:
   return_code: 0
   message: |
-    TOPIC             PARTITIONS     REPLICATION FACTOR
-    products-topic    1              1
+    TOPIC              PARTITIONS     REPLICATION FACTOR
+    products-topic     1              1
 render_output: false
 {% endvalidation %}
 
 The output should look like this:
 
 ```shell
-TOPIC             PARTITIONS     REPLICATION FACTOR
-products-topic    1              1
+TOPIC           PARTITIONS     REPLICATION FACTOR
+products-topic  1              1
 ```
 {:.no-copy-code}
 


### PR DESCRIPTION
## Description

There's an issue with the relative paths in docker-compose and the way we run things

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
