### PR TITLE
feat(gateway): OIDC jwks_endpoint override

### DIFF
--- a/app/_kong_plugins/openid-connect/examples/extra-jwks.yaml
+++ b/app/_kong_plugins/openid-connect/examples/extra-jwks.yaml
@@ -12,7 +12,7 @@ extended_description: |
 
   {:.info}
   > **Note**: `extra_jwks_uris` adds multiple discovery endpoints, but the plugin will still look at the `jwks_uri` returned by the internal discovery mechanism first, introducing potential latency.
-  If you want to override the default discovery JWKS endpoint instead of providing multiple fallback options, see the [Use a custom JWKS endpoint for discovery example](/examples/openid-connect/override-jwks/).
+  If you want to override the default discovery JWKS endpoint instead of providing multiple fallback options, see the [Use a custom JWKS endpoint for discovery example](/plugins/openid-connect/examples/override-jwks-endpoint/).
 weight: 698
 
 requirements:

--- a/app/_kong_plugins/openid-connect/examples/override-jwks-endpoint.yaml
+++ b/app/_kong_plugins/openid-connect/examples/override-jwks-endpoint.yaml
@@ -5,7 +5,7 @@ extended_description: |
   This is useful when the IdP exposes a non-standard JWKS endpoint.
 
   This option is similar to `extra_jwks_uris`, but it overrides the endpoint instead of providing multiple fallback options.
-  If you need to use multiple JWKS endpoints, see the [Token validation for multiple IdPs example](/examples/openid-connect/extra-jwks/).
+  If you need to use multiple JWKS endpoints, see the [Token validation for multiple IdPs example](/plugins/openid-connect/examples/extra-jwks/).
   
 weight: 698
 


### PR DESCRIPTION
## Description

Adding a plugin example for `jwks_override`, a new OIDC plugin feature in 3.14.

Fixes #4224 

## Preview Links

New example: https://deploy-preview-4691--kongdeveloper.netlify.app/plugins/openid-connect/examples/override-jwks-endpoint/
Note in https://deploy-preview-4691--kongdeveloper.netlify.app/plugins/openid-connect/examples/extra-jwks/