### PR TITLE
feat(expressions): add raw string literals usage

### DIFF
--- a/app/_includes/gateway/expressions/field-types.md
+++ b/app/_includes/gateway/expressions/field-types.md
@@ -28,6 +28,21 @@ features:
       * `\t`: Horizontal tab character
       * `\\`: The `\` character
       * `\"`: The `"` character
+      <br><br>
+       
+      In addition, expressions support raw string literals, like `r#"content"#`. This feature is useful if you want to write a regex and repeated escaping becomes tedious to deal with.
+      <br><br>
+      For example, if you want to match `http.path` against `/\d+\-\d+` using the regex `~` operator, the predicate will be written as the following with string literals:
+      <br>
+      ```text
+      http.path ~ "/\\d+\\-\\d+"
+      ```
+      <br>
+      With raw string literals, you can write:
+      <br>
+      ```text
+      http.path ~ r#"/\d+\-\d+"#
+      ```
     field_type: true
     constant_type: true
   - title: |


### PR DESCRIPTION
It seems that the documentation for raw string literal support in expressions got lost during the transfer from the old page, added it back on so user is aware of this useful tool.

## Description

- Fixed wording: "repeated escape becomes" → "repeated escaping becomes"
- Replaced inline code snippets with fenced code blocks for the before/after predicate examples, ensuring they render correctly on separate lines

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).