### PR TITLE
fix(how-tos): remove extra newline in curl commands when there aren't any variables to capture.

### DIFF
--- a/app/_includes/how-tos/validations/request-check/snippet.md
+++ b/app/_includes/how-tos/validations/request-check/snippet.md
@@ -24,9 +24,9 @@
 {%- elsif capture_size > 1 -%}
 _response=$({{ curl_cmd }})
 {%- else -%}
-{{ curl_cmd }}
-{%- endif -%}
-{% if count > 1 %}; done{%- endif %}
+{{ curl_cmd }}{% if count > 1 %}
+; done{% endif -%}
+{%- endif %}
 ```
 
 {% if capture_size > 1 %}


### PR DESCRIPTION
## Description

This was introduced when we added support for capturing multiple variables.


## Preview Links

/kubernetes-ingress-controller/service-health-checks/
/gateway/get-started/
/event-gateway/filter-records-by-classification/


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
