### PR TITLE
Update deck and kongctl cli docs to use `ansi`

### DIFF
--- a/app/_includes/deck/help/file/add-plugins.md
+++ b/app/_includes/deck/help/file/add-plugins.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck file add-plugins [flags] [...plugin-files]
 

--- a/app/_includes/deck/help/file/add-tags.md
+++ b/app/_includes/deck/help/file/add-tags.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck file add-tags [flags] tag [...tag]
 

--- a/app/_includes/deck/help/file/convert.md
+++ b/app/_includes/deck/help/file/convert.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck file convert [flags]
 

--- a/app/_includes/deck/help/file/kong2kic.md
+++ b/app/_includes/deck/help/file/kong2kic.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck file kong2kic [flags]
 

--- a/app/_includes/deck/help/file/kong2tf.md
+++ b/app/_includes/deck/help/file/kong2tf.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck file kong2tf [flags]
 

--- a/app/_includes/deck/help/file/lint.md
+++ b/app/_includes/deck/help/file/lint.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck file lint [flags] ruleset-file
 

--- a/app/_includes/deck/help/file/list-tags.md
+++ b/app/_includes/deck/help/file/list-tags.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck file list-tags [flags]
 

--- a/app/_includes/deck/help/file/merge.md
+++ b/app/_includes/deck/help/file/merge.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck file merge [flags] filename [...filename]
 

--- a/app/_includes/deck/help/file/namespace.md
+++ b/app/_includes/deck/help/file/namespace.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck file namespace [flags]
 

--- a/app/_includes/deck/help/file/openapi2kong.md
+++ b/app/_includes/deck/help/file/openapi2kong.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck file openapi2kong [flags]
 

--- a/app/_includes/deck/help/file/openapi2mcp.md
+++ b/app/_includes/deck/help/file/openapi2mcp.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck file openapi2mcp [flags]
 

--- a/app/_includes/deck/help/file/patch.md
+++ b/app/_includes/deck/help/file/patch.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck file patch [flags] [...patch-files]
 

--- a/app/_includes/deck/help/file/remove-tags.md
+++ b/app/_includes/deck/help/file/remove-tags.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck file remove-tags [flags] tag [...tag]
 

--- a/app/_includes/deck/help/file/render.md
+++ b/app/_includes/deck/help/file/render.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck file render [flags]
 

--- a/app/_includes/deck/help/file/validate.md
+++ b/app/_includes/deck/help/file/validate.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck file validate [flags] [kong-state-files...]
 

--- a/app/_includes/deck/help/gateway/apply.md
+++ b/app/_includes/deck/help/gateway/apply.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck gateway apply [flags] [kong-state-files...]
 

--- a/app/_includes/deck/help/gateway/diff.md
+++ b/app/_includes/deck/help/gateway/diff.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck gateway diff [flags] [kong-state-files...]
 

--- a/app/_includes/deck/help/gateway/dump.md
+++ b/app/_includes/deck/help/gateway/dump.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck gateway dump [flags]
 

--- a/app/_includes/deck/help/gateway/ping.md
+++ b/app/_includes/deck/help/gateway/ping.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck gateway ping [flags]
 

--- a/app/_includes/deck/help/gateway/reset.md
+++ b/app/_includes/deck/help/gateway/reset.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck gateway reset [flags]
 

--- a/app/_includes/deck/help/gateway/sync.md
+++ b/app/_includes/deck/help/gateway/sync.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck gateway sync [flags] [kong-state-files...]
 

--- a/app/_includes/deck/help/gateway/validate.md
+++ b/app/_includes/deck/help/gateway/validate.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   deck gateway validate [flags] [kong-state-files...]
 

--- a/app/_includes/kongctl/help/adopt/api.md
+++ b/app/_includes/kongctl/help/adopt/api.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl adopt api <api-id|api-name> [flags]
 

--- a/app/_includes/kongctl/help/adopt/auth-strategy.md
+++ b/app/_includes/kongctl/help/adopt/auth-strategy.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl adopt auth-strategy <auth-strategy-id|auth-strategy-name> [flags]
 

--- a/app/_includes/kongctl/help/adopt/control-plane.md
+++ b/app/_includes/kongctl/help/adopt/control-plane.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl adopt control-plane <control-plane-id|control-plane-name> [flags]
 

--- a/app/_includes/kongctl/help/adopt/index.md
+++ b/app/_includes/kongctl/help/adopt/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl adopt [command]
 

--- a/app/_includes/kongctl/help/adopt/konnect/api.md
+++ b/app/_includes/kongctl/help/adopt/konnect/api.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl adopt konnect api <api-id|api-name> [flags]
 

--- a/app/_includes/kongctl/help/adopt/konnect/auth-strategy.md
+++ b/app/_includes/kongctl/help/adopt/konnect/auth-strategy.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl adopt konnect auth-strategy <auth-strategy-id|auth-strategy-name> [flags]
 

--- a/app/_includes/kongctl/help/adopt/konnect/control-plane.md
+++ b/app/_includes/kongctl/help/adopt/konnect/control-plane.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl adopt konnect control-plane <control-plane-id|control-plane-name> [flags]
 

--- a/app/_includes/kongctl/help/adopt/konnect/index.md
+++ b/app/_includes/kongctl/help/adopt/konnect/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl adopt konnect [command]
 

--- a/app/_includes/kongctl/help/adopt/konnect/organization.md
+++ b/app/_includes/kongctl/help/adopt/konnect/organization.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl adopt konnect organization [flags]
   kongctl adopt konnect organization [command]

--- a/app/_includes/kongctl/help/adopt/konnect/portal.md
+++ b/app/_includes/kongctl/help/adopt/konnect/portal.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl adopt konnect portal <portal-id|portal-name> [flags]
 

--- a/app/_includes/kongctl/help/adopt/organization/index.md
+++ b/app/_includes/kongctl/help/adopt/organization/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl adopt organization [flags]
   kongctl adopt organization [command]

--- a/app/_includes/kongctl/help/adopt/organization/team.md
+++ b/app/_includes/kongctl/help/adopt/organization/team.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl adopt organization team <team-id> [flags]
 

--- a/app/_includes/kongctl/help/adopt/portal.md
+++ b/app/_includes/kongctl/help/adopt/portal.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl adopt portal <portal-id|portal-name> [flags]
 

--- a/app/_includes/kongctl/help/api/delete.md
+++ b/app/_includes/kongctl/help/api/delete.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl api delete <endpoint> [flags]
 

--- a/app/_includes/kongctl/help/api/get.md
+++ b/app/_includes/kongctl/help/api/get.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl api get <endpoint> [flags]
 

--- a/app/_includes/kongctl/help/api/index.md
+++ b/app/_includes/kongctl/help/api/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl api <endpoint> [field=value ...] [flags]
   kongctl api [command]

--- a/app/_includes/kongctl/help/api/patch.md
+++ b/app/_includes/kongctl/help/api/patch.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl api patch <endpoint> [field=value ...] [flags]
 

--- a/app/_includes/kongctl/help/api/post.md
+++ b/app/_includes/kongctl/help/api/post.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl api post <endpoint> [field=value ...] [flags]
 

--- a/app/_includes/kongctl/help/api/put.md
+++ b/app/_includes/kongctl/help/api/put.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl api put <endpoint> [field=value ...] [flags]
 

--- a/app/_includes/kongctl/help/apply/index.md
+++ b/app/_includes/kongctl/help/apply/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl apply [flags]
   kongctl apply [command]

--- a/app/_includes/kongctl/help/apply/konnect.md
+++ b/app/_includes/kongctl/help/apply/konnect.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl apply konnect [flags]
 

--- a/app/_includes/kongctl/help/delete/index.md
+++ b/app/_includes/kongctl/help/delete/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl delete [flags]
 

--- a/app/_includes/kongctl/help/diff/index.md
+++ b/app/_includes/kongctl/help/diff/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl diff [flags]
   kongctl diff [command]

--- a/app/_includes/kongctl/help/diff/konnect.md
+++ b/app/_includes/kongctl/help/diff/konnect.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl diff konnect [flags]
 

--- a/app/_includes/kongctl/help/dump/declarative.md
+++ b/app/_includes/kongctl/help/dump/declarative.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl dump declarative [flags]
 

--- a/app/_includes/kongctl/help/dump/index.md
+++ b/app/_includes/kongctl/help/dump/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl dump [flags]
   kongctl dump [command]

--- a/app/_includes/kongctl/help/dump/tf-import.md
+++ b/app/_includes/kongctl/help/dump/tf-import.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl dump tf-import [flags]
 

--- a/app/_includes/kongctl/help/get/api/attributes.md
+++ b/app/_includes/kongctl/help/get/api/attributes.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get api attributes [flags]
 

--- a/app/_includes/kongctl/help/get/api/documents.md
+++ b/app/_includes/kongctl/help/get/api/documents.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get api documents [flags]
 

--- a/app/_includes/kongctl/help/get/api/implementations.md
+++ b/app/_includes/kongctl/help/get/api/implementations.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get api implementations [flags]
 

--- a/app/_includes/kongctl/help/get/api/index.md
+++ b/app/_includes/kongctl/help/get/api/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get api [flags]
   kongctl get api [command]

--- a/app/_includes/kongctl/help/get/api/publications.md
+++ b/app/_includes/kongctl/help/get/api/publications.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get api publications [flags]
 

--- a/app/_includes/kongctl/help/get/api/versions.md
+++ b/app/_includes/kongctl/help/get/api/versions.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get api versions [flags]
 

--- a/app/_includes/kongctl/help/get/audit-logs/destination.md
+++ b/app/_includes/kongctl/help/get/audit-logs/destination.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get audit-logs destination <id|name> [flags]
 

--- a/app/_includes/kongctl/help/get/audit-logs/destinations.md
+++ b/app/_includes/kongctl/help/get/audit-logs/destinations.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get audit-logs destinations [flags]
 

--- a/app/_includes/kongctl/help/get/audit-logs/index.md
+++ b/app/_includes/kongctl/help/get/audit-logs/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get audit-logs [flags]
   kongctl get audit-logs [command]

--- a/app/_includes/kongctl/help/get/audit-logs/webhook.md
+++ b/app/_includes/kongctl/help/get/audit-logs/webhook.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get audit-logs webhook [flags]
 

--- a/app/_includes/kongctl/help/get/auth-strategy.md
+++ b/app/_includes/kongctl/help/get/auth-strategy.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get auth-strategy [flags]
 

--- a/app/_includes/kongctl/help/get/catalog/index.md
+++ b/app/_includes/kongctl/help/get/catalog/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get catalog [command]
 

--- a/app/_includes/kongctl/help/get/catalog/service.md
+++ b/app/_includes/kongctl/help/get/catalog/service.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get catalog service [name|id] [flags]
 

--- a/app/_includes/kongctl/help/get/gateway/consumer.md
+++ b/app/_includes/kongctl/help/get/gateway/consumer.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get gateway consumer [flags]
 

--- a/app/_includes/kongctl/help/get/gateway/control-plane.md
+++ b/app/_includes/kongctl/help/get/gateway/control-plane.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get gateway control-plane [flags]
 

--- a/app/_includes/kongctl/help/get/gateway/index.md
+++ b/app/_includes/kongctl/help/get/gateway/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get gateway [command]
 

--- a/app/_includes/kongctl/help/get/gateway/route.md
+++ b/app/_includes/kongctl/help/get/gateway/route.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get gateway route [flags]
 

--- a/app/_includes/kongctl/help/get/gateway/service.md
+++ b/app/_includes/kongctl/help/get/gateway/service.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get gateway service [flags]
 

--- a/app/_includes/kongctl/help/get/index.md
+++ b/app/_includes/kongctl/help/get/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get [flags]
   kongctl get [command]

--- a/app/_includes/kongctl/help/get/konnect/api.md
+++ b/app/_includes/kongctl/help/get/konnect/api.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get konnect api [flags]
   kongctl get konnect api [command]

--- a/app/_includes/kongctl/help/get/konnect/audit-logs.md
+++ b/app/_includes/kongctl/help/get/konnect/audit-logs.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get konnect audit-logs [flags]
   kongctl get konnect audit-logs [command]

--- a/app/_includes/kongctl/help/get/konnect/auth-strategy.md
+++ b/app/_includes/kongctl/help/get/konnect/auth-strategy.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get konnect auth-strategy [flags]
 

--- a/app/_includes/kongctl/help/get/konnect/gateway.md
+++ b/app/_includes/kongctl/help/get/konnect/gateway.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get konnect gateway [command]
 

--- a/app/_includes/kongctl/help/get/konnect/index.md
+++ b/app/_includes/kongctl/help/get/konnect/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get konnect [flags]
   kongctl get konnect [command]

--- a/app/_includes/kongctl/help/get/konnect/me.md
+++ b/app/_includes/kongctl/help/get/konnect/me.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get konnect me [flags]
 

--- a/app/_includes/kongctl/help/get/konnect/organization.md
+++ b/app/_includes/kongctl/help/get/konnect/organization.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get konnect organization [flags]
   kongctl get konnect organization [command]

--- a/app/_includes/kongctl/help/get/konnect/portal.md
+++ b/app/_includes/kongctl/help/get/konnect/portal.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get konnect portal [flags]
   kongctl get konnect portal [command]

--- a/app/_includes/kongctl/help/get/konnect/regions.md
+++ b/app/_includes/kongctl/help/get/konnect/regions.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get konnect regions [flags]
 

--- a/app/_includes/kongctl/help/get/me.md
+++ b/app/_includes/kongctl/help/get/me.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get me [flags]
 

--- a/app/_includes/kongctl/help/get/organization/index.md
+++ b/app/_includes/kongctl/help/get/organization/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get organization [flags]
   kongctl get organization [command]

--- a/app/_includes/kongctl/help/get/organization/system-account.md
+++ b/app/_includes/kongctl/help/get/organization/system-account.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get organization system-account [flags]
 

--- a/app/_includes/kongctl/help/get/organization/team.md
+++ b/app/_includes/kongctl/help/get/organization/team.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get organization team [flags]
 

--- a/app/_includes/kongctl/help/get/portal/application-registrations.md
+++ b/app/_includes/kongctl/help/get/portal/application-registrations.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get portal application-registrations [flags]
 

--- a/app/_includes/kongctl/help/get/portal/applications.md
+++ b/app/_includes/kongctl/help/get/portal/applications.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get portal applications [flags]
 

--- a/app/_includes/kongctl/help/get/portal/assets.md
+++ b/app/_includes/kongctl/help/get/portal/assets.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get portal assets [command]
 

--- a/app/_includes/kongctl/help/get/portal/auth-settings.md
+++ b/app/_includes/kongctl/help/get/portal/auth-settings.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get portal auth-settings [flags]
 

--- a/app/_includes/kongctl/help/get/portal/developers.md
+++ b/app/_includes/kongctl/help/get/portal/developers.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get portal developers [flags]
   kongctl get portal developers [command]

--- a/app/_includes/kongctl/help/get/portal/email-domains.md
+++ b/app/_includes/kongctl/help/get/portal/email-domains.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get portal email-domains [flags]
 

--- a/app/_includes/kongctl/help/get/portal/index.md
+++ b/app/_includes/kongctl/help/get/portal/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get portal [flags]
   kongctl get portal [command]

--- a/app/_includes/kongctl/help/get/portal/pages.md
+++ b/app/_includes/kongctl/help/get/portal/pages.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get portal pages [flags]
 

--- a/app/_includes/kongctl/help/get/portal/snippets.md
+++ b/app/_includes/kongctl/help/get/portal/snippets.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get portal snippets [flags]
 

--- a/app/_includes/kongctl/help/get/portal/team-roles.md
+++ b/app/_includes/kongctl/help/get/portal/team-roles.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get portal team-roles [flags]
 

--- a/app/_includes/kongctl/help/get/portal/teams.md
+++ b/app/_includes/kongctl/help/get/portal/teams.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get portal teams [flags]
   kongctl get portal teams [command]

--- a/app/_includes/kongctl/help/get/profile.md
+++ b/app/_includes/kongctl/help/get/profile.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get profile [flags]
 

--- a/app/_includes/kongctl/help/get/regions.md
+++ b/app/_includes/kongctl/help/get/regions.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl get regions [flags]
 

--- a/app/_includes/kongctl/help/install/index.md
+++ b/app/_includes/kongctl/help/install/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl install [flags]
   kongctl install [command]

--- a/app/_includes/kongctl/help/install/skills.md
+++ b/app/_includes/kongctl/help/install/skills.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl install skills [flags]
 

--- a/app/_includes/kongctl/help/lint/index.md
+++ b/app/_includes/kongctl/help/lint/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl lint [flags]
 

--- a/app/_includes/kongctl/help/list/api/attributes.md
+++ b/app/_includes/kongctl/help/list/api/attributes.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list api attributes [flags]
 

--- a/app/_includes/kongctl/help/list/api/documents.md
+++ b/app/_includes/kongctl/help/list/api/documents.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list api documents [flags]
 

--- a/app/_includes/kongctl/help/list/api/implementations.md
+++ b/app/_includes/kongctl/help/list/api/implementations.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list api implementations [flags]
 

--- a/app/_includes/kongctl/help/list/api/index.md
+++ b/app/_includes/kongctl/help/list/api/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list api [flags]
   kongctl list api [command]

--- a/app/_includes/kongctl/help/list/api/publications.md
+++ b/app/_includes/kongctl/help/list/api/publications.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list api publications [flags]
 

--- a/app/_includes/kongctl/help/list/api/versions.md
+++ b/app/_includes/kongctl/help/list/api/versions.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list api versions [flags]
 

--- a/app/_includes/kongctl/help/list/auth-strategy.md
+++ b/app/_includes/kongctl/help/list/auth-strategy.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list auth-strategy [flags]
 

--- a/app/_includes/kongctl/help/list/gateway/consumer.md
+++ b/app/_includes/kongctl/help/list/gateway/consumer.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list gateway consumer [flags]
 

--- a/app/_includes/kongctl/help/list/gateway/control-plane.md
+++ b/app/_includes/kongctl/help/list/gateway/control-plane.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list gateway control-plane [flags]
 

--- a/app/_includes/kongctl/help/list/gateway/index.md
+++ b/app/_includes/kongctl/help/list/gateway/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list gateway [command]
 

--- a/app/_includes/kongctl/help/list/gateway/route.md
+++ b/app/_includes/kongctl/help/list/gateway/route.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list gateway route [flags]
 

--- a/app/_includes/kongctl/help/list/gateway/service.md
+++ b/app/_includes/kongctl/help/list/gateway/service.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list gateway service [flags]
 

--- a/app/_includes/kongctl/help/list/index.md
+++ b/app/_includes/kongctl/help/list/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list [command]
 

--- a/app/_includes/kongctl/help/list/konnect/api.md
+++ b/app/_includes/kongctl/help/list/konnect/api.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list konnect api [flags]
   kongctl list konnect api [command]

--- a/app/_includes/kongctl/help/list/konnect/auth-strategy.md
+++ b/app/_includes/kongctl/help/list/konnect/auth-strategy.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list konnect auth-strategy [flags]
 

--- a/app/_includes/kongctl/help/list/konnect/event-gateway.md
+++ b/app/_includes/kongctl/help/list/konnect/event-gateway.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list konnect event-gateway [flags]
   kongctl list konnect event-gateway [command]

--- a/app/_includes/kongctl/help/list/konnect/gateway.md
+++ b/app/_includes/kongctl/help/list/konnect/gateway.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list konnect gateway [command]
 

--- a/app/_includes/kongctl/help/list/konnect/index.md
+++ b/app/_includes/kongctl/help/list/konnect/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list konnect [command]
 

--- a/app/_includes/kongctl/help/list/konnect/organization.md
+++ b/app/_includes/kongctl/help/list/konnect/organization.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list konnect organization [flags]
   kongctl list konnect organization [command]

--- a/app/_includes/kongctl/help/list/konnect/portal.md
+++ b/app/_includes/kongctl/help/list/konnect/portal.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list konnect portal [flags]
   kongctl list konnect portal [command]

--- a/app/_includes/kongctl/help/list/organization/index.md
+++ b/app/_includes/kongctl/help/list/organization/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list organization [flags]
   kongctl list organization [command]

--- a/app/_includes/kongctl/help/list/organization/system-account.md
+++ b/app/_includes/kongctl/help/list/organization/system-account.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list organization system-account [flags]
 

--- a/app/_includes/kongctl/help/list/organization/team.md
+++ b/app/_includes/kongctl/help/list/organization/team.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list organization team [flags]
 

--- a/app/_includes/kongctl/help/list/portal/application-registrations.md
+++ b/app/_includes/kongctl/help/list/portal/application-registrations.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list portal application-registrations [flags]
 

--- a/app/_includes/kongctl/help/list/portal/applications.md
+++ b/app/_includes/kongctl/help/list/portal/applications.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list portal applications [flags]
 

--- a/app/_includes/kongctl/help/list/portal/assets.md
+++ b/app/_includes/kongctl/help/list/portal/assets.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list portal assets [command]
 

--- a/app/_includes/kongctl/help/list/portal/auth-settings.md
+++ b/app/_includes/kongctl/help/list/portal/auth-settings.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list portal auth-settings [flags]
 

--- a/app/_includes/kongctl/help/list/portal/developers.md
+++ b/app/_includes/kongctl/help/list/portal/developers.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list portal developers [flags]
   kongctl list portal developers [command]

--- a/app/_includes/kongctl/help/list/portal/email-domains.md
+++ b/app/_includes/kongctl/help/list/portal/email-domains.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list portal email-domains [flags]
 

--- a/app/_includes/kongctl/help/list/portal/index.md
+++ b/app/_includes/kongctl/help/list/portal/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list portal [flags]
   kongctl list portal [command]

--- a/app/_includes/kongctl/help/list/portal/pages.md
+++ b/app/_includes/kongctl/help/list/portal/pages.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list portal pages [flags]
 

--- a/app/_includes/kongctl/help/list/portal/snippets.md
+++ b/app/_includes/kongctl/help/list/portal/snippets.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list portal snippets [flags]
 

--- a/app/_includes/kongctl/help/list/portal/team-roles.md
+++ b/app/_includes/kongctl/help/list/portal/team-roles.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list portal team-roles [flags]
 

--- a/app/_includes/kongctl/help/list/portal/teams.md
+++ b/app/_includes/kongctl/help/list/portal/teams.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list portal teams [flags]
   kongctl list portal teams [command]

--- a/app/_includes/kongctl/help/list/themes.md
+++ b/app/_includes/kongctl/help/list/themes.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl list themes [flags]
 

--- a/app/_includes/kongctl/help/listen/audit-logs.md
+++ b/app/_includes/kongctl/help/listen/audit-logs.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl listen audit-logs [flags]
 

--- a/app/_includes/kongctl/help/listen/index.md
+++ b/app/_includes/kongctl/help/listen/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl listen [flags]
   kongctl listen [command]

--- a/app/_includes/kongctl/help/listen/konnect/audit-logs.md
+++ b/app/_includes/kongctl/help/listen/konnect/audit-logs.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl listen konnect audit-logs [flags]
 

--- a/app/_includes/kongctl/help/listen/konnect/index.md
+++ b/app/_includes/kongctl/help/listen/konnect/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl listen konnect [command]
 

--- a/app/_includes/kongctl/help/login/index.md
+++ b/app/_includes/kongctl/help/login/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl login [flags]
   kongctl login [command]

--- a/app/_includes/kongctl/help/login/konnect.md
+++ b/app/_includes/kongctl/help/login/konnect.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl login konnect [flags]
 

--- a/app/_includes/kongctl/help/logout/index.md
+++ b/app/_includes/kongctl/help/logout/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl logout [flags]
   kongctl logout [command]

--- a/app/_includes/kongctl/help/logout/konnect.md
+++ b/app/_includes/kongctl/help/logout/konnect.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl logout konnect [flags]
 

--- a/app/_includes/kongctl/help/patch/file.md
+++ b/app/_includes/kongctl/help/patch/file.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl patch file <input-file> [patch-files...] [flags]
 

--- a/app/_includes/kongctl/help/patch/index.md
+++ b/app/_includes/kongctl/help/patch/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl patch [flags]
   kongctl patch [command]

--- a/app/_includes/kongctl/help/plan/index.md
+++ b/app/_includes/kongctl/help/plan/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl plan [flags]
   kongctl plan [command]

--- a/app/_includes/kongctl/help/plan/konnect.md
+++ b/app/_includes/kongctl/help/plan/konnect.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl plan konnect [flags]
 

--- a/app/_includes/kongctl/help/ps/index.md
+++ b/app/_includes/kongctl/help/ps/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl ps [flags]
   kongctl ps [command]

--- a/app/_includes/kongctl/help/ps/stop.md
+++ b/app/_includes/kongctl/help/ps/stop.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl ps stop <pid> [flags]
 

--- a/app/_includes/kongctl/help/sync/index.md
+++ b/app/_includes/kongctl/help/sync/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl sync [flags]
   kongctl sync [command]

--- a/app/_includes/kongctl/help/sync/konnect.md
+++ b/app/_includes/kongctl/help/sync/konnect.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl sync konnect [flags]
 

--- a/app/_includes/kongctl/help/tail/audit-logs.md
+++ b/app/_includes/kongctl/help/tail/audit-logs.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl tail audit-logs [flags]
 

--- a/app/_includes/kongctl/help/tail/index.md
+++ b/app/_includes/kongctl/help/tail/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl tail [flags]
   kongctl tail [command]

--- a/app/_includes/kongctl/help/tail/konnect/audit-logs.md
+++ b/app/_includes/kongctl/help/tail/konnect/audit-logs.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl tail konnect audit-logs [flags]
 

--- a/app/_includes/kongctl/help/tail/konnect/index.md
+++ b/app/_includes/kongctl/help/tail/konnect/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl tail konnect [command]
 

--- a/app/_includes/kongctl/help/view/index.md
+++ b/app/_includes/kongctl/help/view/index.md
@@ -1,4 +1,4 @@
-```bash
+```ansi
 Usage:
   kongctl view [flags]
 

--- a/app/_plugins/converters/shiki.rb
+++ b/app/_plugins/converters/shiki.rb
@@ -27,7 +27,8 @@ class CodeHighlighter < Nodo::Core # rubocop:disable Style/Documentation
           "terraform",
           "nginx",
           "html",
-          "ruby"
+          "ruby",
+          "ansi"
         ],
       });
     JS

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "instantsearch.css": "^8.5.1",
         "mermaid": "^11.6.0",
         "node-fetch": "^3.3.2",
-        "shiki": "^4.0.0",
+        "shiki": "^4.0.2",
         "snowflake-sdk": "2.3.4",
         "uuid": "^13.0.0",
         "vue": "^3.4.38",
@@ -2713,12 +2713,12 @@
       }
     },
     "node_modules/@shikijs/primitive": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.1.tgz",
-      "integrity": "sha512-ns0hHZc5eWZuvuIEJz2pTx3Qecz0aRVYumVQJ8JgWY2tq/dH8WxdcVM49Fc2NsHEILNIT6vfdW9MF26RANWiTA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.0.1",
+        "@shikijs/types": "4.0.2",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       },
@@ -2727,9 +2727,9 @@
       }
     },
     "node_modules/@shikijs/primitive/node_modules/@shikijs/types": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.1.tgz",
-      "integrity": "sha512-EaygPEn57+jJ76mw+nTLvIpJMAcMPokFbrF8lufsZP7Ukk+ToJYEcswN1G0e49nUZAq7aCQtoeW219A8HK1ZOw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",
@@ -24602,17 +24602,17 @@
       }
     },
     "node_modules/shiki": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.1.tgz",
-      "integrity": "sha512-EkAEhDTN5WhpoQFXFw79OHIrSAfHhlImeCdSyg4u4XvrpxKEmdo/9x/HWSowujAnUrFsGOwWiE58a6GVentMnQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/core": "4.0.1",
-        "@shikijs/engine-javascript": "4.0.1",
-        "@shikijs/engine-oniguruma": "4.0.1",
-        "@shikijs/langs": "4.0.1",
-        "@shikijs/themes": "4.0.1",
-        "@shikijs/types": "4.0.1",
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4"
       },
@@ -24621,13 +24621,13 @@
       }
     },
     "node_modules/shiki/node_modules/@shikijs/core": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.1.tgz",
-      "integrity": "sha512-vWvqi9JNgz1dRL9Nvog5wtx7RuNkf7MEPl2mU/cyUUxJeH1CAr3t+81h8zO8zs7DK6cKLMoU9TvukWIDjP4Lzg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/primitive": "4.0.1",
-        "@shikijs/types": "4.0.1",
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
         "@shikijs/vscode-textmate": "^10.0.2",
         "@types/hast": "^3.0.4",
         "hast-util-to-html": "^9.0.5"
@@ -24637,12 +24637,12 @@
       }
     },
     "node_modules/shiki/node_modules/@shikijs/engine-javascript": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.1.tgz",
-      "integrity": "sha512-DJK9NiwtGYqMuKCRO4Ip0FKNDQpmaiS+K5bFjJ7DWFn4zHueDWgaUG8kAofkrnXF6zPPYYQY7J5FYVW9MbZyBg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.0.1",
+        "@shikijs/types": "4.0.2",
         "@shikijs/vscode-textmate": "^10.0.2",
         "oniguruma-to-es": "^4.3.4"
       },
@@ -24651,12 +24651,12 @@
       }
     },
     "node_modules/shiki/node_modules/@shikijs/engine-oniguruma": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.1.tgz",
-      "integrity": "sha512-oCWdCTDch3J8Kc0OZJ98KuUPC02O1VqIE3W/e2uvrHqTxYRR21RGEJMtchrgrxhsoJJCzmIciKsqG+q/yD+Cxg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.0.1",
+        "@shikijs/types": "4.0.2",
         "@shikijs/vscode-textmate": "^10.0.2"
       },
       "engines": {
@@ -24664,33 +24664,33 @@
       }
     },
     "node_modules/shiki/node_modules/@shikijs/langs": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.1.tgz",
-      "integrity": "sha512-v/mluaybWdnGJR4GqAR6zh8qAZohW9k+cGYT28Y7M8+jLbC0l4yG085O1A+WkseHTn+awd+P3UBymb2+MXFc8w==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.0.1"
+        "@shikijs/types": "4.0.2"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/shiki/node_modules/@shikijs/themes": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.1.tgz",
-      "integrity": "sha512-FW41C/D6j/yKQkzVdjrRPiJCtgeDaYRJFEyCKFCINuRJRj9WcmubhP4KQHPZ4+9eT87jruSrYPyoblNRyDFzvA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
       "license": "MIT",
       "dependencies": {
-        "@shikijs/types": "4.0.1"
+        "@shikijs/types": "4.0.2"
       },
       "engines": {
         "node": ">=20"
       }
     },
     "node_modules/shiki/node_modules/@shikijs/types": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.1.tgz",
-      "integrity": "sha512-EaygPEn57+jJ76mw+nTLvIpJMAcMPokFbrF8lufsZP7Ukk+ToJYEcswN1G0e49nUZAq7aCQtoeW219A8HK1ZOw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
       "license": "MIT",
       "dependencies": {
         "@shikijs/vscode-textmate": "^10.0.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "instantsearch.css": "^8.5.1",
     "mermaid": "^11.6.0",
     "node-fetch": "^3.3.2",
-    "shiki": "^4.0.0",
+    "shiki": "^4.0.2",
     "snowflake-sdk": "2.3.4",
     "uuid": "^13.0.0",
     "vue": "^3.4.38",

--- a/tools/deck-versions/extract-help.js
+++ b/tools/deck-versions/extract-help.js
@@ -27,7 +27,7 @@ const __dirname = path.dirname(__filename);
 
         const help = extractCommandSpecificHelp(stdout);
         const escapedHelp = help.replace(/\$\{\{[^}]*\}\}/g, '{% raw %}$&{% endraw %}');
-        const content = "```bash\n" + escapedHelp + "\n```";
+        const content = "```ansi\n" + escapedHelp + "\n```";
 
         const filePath = path.join(outputDir, `${subCommand}.md`);
         fs.writeFileSync(filePath, content, 'utf8');

--- a/tools/kongctl-versions/extract-help.js
+++ b/tools/kongctl-versions/extract-help.js
@@ -33,7 +33,7 @@ const __dirname = path.dirname(__filename);
       }
 
       const commandIndexPath = path.join(commandDir, 'index.md');
-      fs.writeFileSync(commandIndexPath, "```bash\n" + cmdHelp + "\n```", 'utf8');
+      fs.writeFileSync(commandIndexPath, "```ansi\n" + cmdHelp + "\n```", 'utf8');
       console.log(`Wrote help for 'kongctl ${command} --help' to ${command}/index.md`);
 
       // Extract second-level subcommands (e.g. `api` in `kongctl get api`)
@@ -55,7 +55,7 @@ const __dirname = path.dirname(__filename);
           }
 
           const subIndexPath = path.join(nestedDir, 'index.md');
-          fs.writeFileSync(subIndexPath, "```bash\n" + subCmdHelp + "\n```", 'utf8');
+          fs.writeFileSync(subIndexPath, "```ansi\n" + subCmdHelp + "\n```", 'utf8');
           console.log(`Wrote help for 'kongctl ${command} ${subCommand}' to ${command}/${subCommand}/index.md`);
 
           // Write sub-subcommand files
@@ -64,7 +64,7 @@ const __dirname = path.dirname(__filename);
               const { stdout: subSubStdout } = await execAsync(`kongctl ${command} ${subCommand} ${subSubCommand} --help`);
               const subSubHelp = extractCommandSpecificHelp(subSubStdout);
               const subSubFilePath = path.join(nestedDir, `${subSubCommand}.md`);
-              fs.writeFileSync(subSubFilePath, "```bash\n" + subSubHelp + "\n```", 'utf8');
+              fs.writeFileSync(subSubFilePath, "```ansi\n" + subSubHelp + "\n```", 'utf8');
               console.log(`Wrote help for 'kongctl ${command} ${subCommand} ${subSubCommand}'`);
             } catch (err) {
               console.error(`Failed to get help for 'kongctl ${command} ${subCommand} ${subSubCommand}': ${err.message}`);
@@ -73,7 +73,7 @@ const __dirname = path.dirname(__filename);
         } else {
           // No further children: write subcommand.md directly under commandDir
           const subCommandFilePath = path.join(commandDir, `${subCommand}.md`);
-          fs.writeFileSync(subCommandFilePath, "```bash\n" + subCmdHelp + "\n```", 'utf8');
+          fs.writeFileSync(subCommandFilePath, "```ansi\n" + subCmdHelp + "\n```", 'utf8');
           console.log(`Wrote help for 'kongctl ${command} ${subCommand}' to ${command}/${subCommand}.md`);
         }
       }


### PR DESCRIPTION
## Description

Bump shiki to latest version (adds support for ansi).

Update deck and kongctl tools to use `ansi` instead of `bash` and update existing docs.

Fixes https://github.com/Kong/developer.konghq.com/issues/3037

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
