### PR TITLE
docs(gateway): document kong.request.get_raw_headers and sandbox allowlist

### DIFF
--- a/app/_references/gateway/pdk/reference/3.14/kong.request.md
+++ b/app/_references/gateway/pdk/reference/3.14/kong.request.md
@@ -645,6 +645,33 @@ headers["X-Another"][2] -- "baz"
 
 
 
+## kong.request.get_raw_headers()
+
+Returns request headers parsed from the raw HTTP header block.
+
+ This function reads `ngx.req.raw_header(true)` and parses it into a Lua
+ table. Header names are normalized to lowercase. If a header appears
+ multiple times, the value is an array preserving the original order.
+
+ This API is only available for HTTP/1.x. For HTTP/2 or unknown versions,
+ it returns `nil` and an error message.
+
+ Unlike `kong.request.get_headers()`, this function does not provide
+ dash/underscore normalization on lookup; use lowercase header names.
+
+
+**Phases**
+
+* rewrite, access, header_filter, response, body_filter, log, admin_api
+
+**Returns**
+
+1.  `table|nil`:  Parsed request headers table, or `nil` when unavailable.
+
+1.  `nil|string`:  Error message when raw headers are unavailable.
+
+
+
 ## kong.request.get_raw_body()
 
 Returns the plain request body.
@@ -817,6 +844,5 @@ Returns the unique request ID for the current request.
 **Returns**
 
 * `string`:  The unique request ID.
-
 
 

--- a/app/gateway/sandboxing.md
+++ b/app/gateway/sandboxing.md
@@ -218,6 +218,7 @@ kong.request.get_port
 kong.request.get_query
 kong.request.get_query_arg
 kong.request.get_raw_body
+kong.request.get_raw_headers
 kong.request.get_raw_path
 kong.request.get_raw_query
 kong.request.get_scheme


### PR DESCRIPTION
## Description

related to: https://github.com/Kong/kong-ee/pull/17370

And should I move to 3.15？

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
