### PR TITLE
chore(deck): Bump deck version required for 3.10 to 3.14 convert command

### DIFF
--- a/app/_how-tos/gateway/convert-gateway-lts-3.10-3.14.md
+++ b/app/_how-tos/gateway/convert-gateway-lts-3.10-3.14.md
@@ -30,10 +30,10 @@ prereqs:
     - title: "{{site.base_gateway}} {% new_in 3.10 %}"
       content: "You have {{site.base_gateway}} running on version 3.10."
     - title: |
-        decK &nbsp; {% new_in 1.56.2 %}
+        decK &nbsp; {% new_in 1.57.3 %}
       content: |
         decK is a CLI tool for managing {{site.base_gateway}} declaratively with state files.
-        To complete this tutorial, install [decK](/deck/) **version 1.56.2** or later.
+        To complete this tutorial, install [decK](/deck/) **version 1.57.3** or later.
 
         This guide uses `deck gateway apply`, which directly applies entity configuration to your Gateway instance.
         We recommend upgrading your decK installation to take advantage of this tool.
@@ -69,7 +69,7 @@ You can use `deck file convert` to automatically perform many of the changes tha
 See the [deck file convert](/deck/file/convert/) reference for a list of all the conversions that decK will perform.
 
 {:.info}
-> **Note:** Update your decK version to 1.56.2 or later before converting files.
+> **Note:** Update your decK version to 1.57.3 or later before converting files.
 
 ## Export configuration
 

--- a/app/deck/file/convert.md
+++ b/app/deck/file/convert.md
@@ -77,7 +77,7 @@ rows:
       - AI Rate Limiting Advanced plugin:
         - Transform `llm_providers.window_size` from a single value to a list
   - path: |
-      `3.10` to `3.14` {% new_in 1.56.0 %}
+      `3.10` to `3.14` {% new_in 1.57.3 %}
     transforms: |
       - Routes without an explicit `protocols` field: Set `protocols` to `["http", "https"]` to preserve the 3.10 default (3.14 changes the default to `["https"]` only)
       - Services using secure protocols (`https`, `tls`, `grpcs`, `wss`) without an explicit `tls_verify` field: Set `tls_verify` to `false` to preserve the 3.10 default (3.14 enables TLS certificate verification by default)


### PR DESCRIPTION
## Description

decK 1.57.3 fixes some issues with converting ssl verify parameters, so users should upgrade to this version to run their LTS convert commands: https://github.com/Kong/deck/releases/tag/v1.57.3

## Preview Links

