### PR TITLE
feat(dcgw): Network architecture

### DIFF
--- a/.github/styles/base/Dictionary.txt
+++ b/.github/styles/base/Dictionary.txt
@@ -136,6 +136,7 @@ Cloudsmith
 cmd
 cncf
 cncf's
+CNAMEs
 Cohere
 cohere
 Cognito
@@ -1023,6 +1024,7 @@ vLLM
 vllm
 vms
 vnet
+VNets
 vpc
 vpcs
 VS Code

--- a/.github/styles/base/Dictionary.txt
+++ b/.github/styles/base/Dictionary.txt
@@ -109,6 +109,7 @@ CAs
 callout
 callouts
 camelCase
+CDNs
 cef
 Cerebras
 certificate_admin
@@ -284,6 +285,7 @@ failover
 fapi
 Fargate
 Fargate
+Fastly
 favicon
 filepath
 filetype
@@ -624,6 +626,7 @@ ngrok
 ngx
 ngx_stream_proxy_module
 ngx_wasm_module
+NLBs
 no_version
 node_quantifier
 Node.js

--- a/.github/styles/base/Dictionary.txt
+++ b/.github/styles/base/Dictionary.txt
@@ -61,6 +61,7 @@ autoscaler
 autoscalers
 autoscales
 autoscaling
+availability_zones
 Avalara
 Avro
 aws
@@ -118,6 +119,7 @@ chatbot
 chatbots
 chatwise
 cidr
+cidr_block
 cidrs
 cleartext
 cli
@@ -132,6 +134,7 @@ CloudFormation
 CloudFormation
 Cloudformation
 Cloudformation
+cloud_gateway_provider_account_id
 Cloudsmith
 cmd
 cncf

--- a/app/_how-tos/dedicated-cloud-gateways/aws-managed-cache-control-plane-group.md
+++ b/app/_how-tos/dedicated-cloud-gateways/aws-managed-cache-control-plane-group.md
@@ -21,6 +21,14 @@ related_resources:
     url: /dedicated-cloud-gateways/
   - text: Partials
     url: /gateway/entities/partial/
+  - text: Dedicated Cloud Gateways network architecture
+    url: /dedicated-cloud-gateways/network-architecture/
+  - text: Dedicated Cloud Gateways private network architecture and security
+    url: /dedicated-cloud-gateways/private-network/
+  - text: Dedicated Cloud Gateways public network architecture and security
+    url: /dedicated-cloud-gateways/public-network/
+  - text: Multi-cloud Dedicated Cloud Gateway network architecture and security
+    url: /dedicated-cloud-gateways/multi-cloud/
 min_version:
   gateway: '3.13'
 prereqs:

--- a/app/_how-tos/dedicated-cloud-gateways/aws-managed-cache-control-plane.md
+++ b/app/_how-tos/dedicated-cloud-gateways/aws-managed-cache-control-plane.md
@@ -21,6 +21,14 @@ related_resources:
     url: /dedicated-cloud-gateways/
   - text: Partials
     url: /gateway/entities/partial/
+  - text: Dedicated Cloud Gateways network architecture
+    url: /dedicated-cloud-gateways/network-architecture/
+  - text: Dedicated Cloud Gateways private network architecture and security
+    url: /dedicated-cloud-gateways/private-network/
+  - text: Dedicated Cloud Gateways public network architecture and security
+    url: /dedicated-cloud-gateways/public-network/
+  - text: Multi-cloud Dedicated Cloud Gateway network architecture and security
+    url: /dedicated-cloud-gateways/multi-cloud/
 min_version:
   gateway: '3.13'
 prereqs:

--- a/app/_how-tos/dedicated-cloud-gateways/aws-resource-endpoints.md
+++ b/app/_how-tos/dedicated-cloud-gateways/aws-resource-endpoints.md
@@ -19,6 +19,12 @@ related_resources:
     url: /dedicated-cloud-gateways/
   - text: AWS VPC endpoint documentation
     url: https://docs.aws.amazon.com/vpc/latest/privatelink/use-resource-endpoint.html
+  - text: Dedicated Cloud Gateways network architecture
+    url: /dedicated-cloud-gateways/network-architecture/
+  - text: Dedicated Cloud Gateways private network architecture and security
+    url: /dedicated-cloud-gateways/private-network/
+  - text: Multi-cloud Dedicated Cloud Gateway network architecture and security
+    url: /dedicated-cloud-gateways/multi-cloud/
 prereqs:
   skip_product: true
   inline:

--- a/app/_how-tos/dedicated-cloud-gateways/aws-vpc-peering.md
+++ b/app/_how-tos/dedicated-cloud-gateways/aws-vpc-peering.md
@@ -20,6 +20,12 @@ related_resources:
     url: https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html
   - text: Private hosted zones
     url: /dedicated-cloud-gateways/private-hosted-zones/
+  - text: Dedicated Cloud Gateways network architecture
+    url: /dedicated-cloud-gateways/network-architecture/
+  - text: Dedicated Cloud Gateways private network architecture and security
+    url: /dedicated-cloud-gateways/private-network/
+  - text: Multi-cloud Dedicated Cloud Gateway network architecture and security
+    url: /dedicated-cloud-gateways/multi-cloud/
 prereqs:
   skip_product: true
   inline:

--- a/app/_how-tos/dedicated-cloud-gateways/azure-managed-cache-control-plane-group.md
+++ b/app/_how-tos/dedicated-cloud-gateways/azure-managed-cache-control-plane-group.md
@@ -21,6 +21,14 @@ related_resources:
     url: /dedicated-cloud-gateways/
   - text: Partials
     url: /gateway/entities/partial/
+  - text: Dedicated Cloud Gateways network architecture
+    url: /dedicated-cloud-gateways/network-architecture/
+  - text: Dedicated Cloud Gateways private network architecture and security
+    url: /dedicated-cloud-gateways/private-network/
+  - text: Dedicated Cloud Gateways public network architecture and security
+    url: /dedicated-cloud-gateways/public-network/
+  - text: Multi-cloud Dedicated Cloud Gateway network architecture and security
+    url: /dedicated-cloud-gateways/multi-cloud/
 min_version:
   gateway: '3.13'
 prereqs:

--- a/app/_how-tos/dedicated-cloud-gateways/azure-managed-cache-control-plane.md
+++ b/app/_how-tos/dedicated-cloud-gateways/azure-managed-cache-control-plane.md
@@ -19,6 +19,14 @@ related_resources:
     url: /dedicated-cloud-gateways/
   - text: Partials
     url: /gateway/entities/partial/
+  - text: Dedicated Cloud Gateways network architecture
+    url: /dedicated-cloud-gateways/network-architecture/
+  - text: Dedicated Cloud Gateways private network architecture and security
+    url: /dedicated-cloud-gateways/private-network/
+  - text: Dedicated Cloud Gateways public network architecture and security
+    url: /dedicated-cloud-gateways/public-network/
+  - text: Multi-cloud Dedicated Cloud Gateway network architecture and security
+    url: /dedicated-cloud-gateways/multi-cloud/
 min_version:
   gateway: '3.13'
 prereqs:

--- a/app/_how-tos/dedicated-cloud-gateways/azure-vnet-peering-with-outbound-dns-resolver.md
+++ b/app/_how-tos/dedicated-cloud-gateways/azure-vnet-peering-with-outbound-dns-resolver.md
@@ -27,6 +27,12 @@ related_resources:
     url: /dedicated-cloud-gateways/azure-peering/
   - text: Configure an Azure Dedicated Cloud Gateway with VNET peering and private DNS
     url:  /dedicated-cloud-gateways/azure-vnet-peering-with-private-dns/
+  - text: Dedicated Cloud Gateways network architecture
+    url: /dedicated-cloud-gateways/network-architecture/
+  - text: Dedicated Cloud Gateways private network architecture and security
+    url: /dedicated-cloud-gateways/private-network/
+  - text: Multi-cloud Dedicated Cloud Gateway network architecture and security
+    url: /dedicated-cloud-gateways/multi-cloud/
 prereqs:
   show_works_on: false
   inline:

--- a/app/_how-tos/dedicated-cloud-gateways/azure-vnet-peering-with-private-dns.md
+++ b/app/_how-tos/dedicated-cloud-gateways/azure-vnet-peering-with-private-dns.md
@@ -27,6 +27,12 @@ related_resources:
     url: /dedicated-cloud-gateways/azure-peering/
   - text: Configure an Azure Dedicated Cloud Gateway with VNET peering and outbound DNS resolution
     url: /dedicated-cloud-gateways/azure-vnet-peering-with-outbound-dns-resolver/
+  - text: Dedicated Cloud Gateways network architecture
+    url: /dedicated-cloud-gateways/network-architecture/
+  - text: Dedicated Cloud Gateways private network architecture and security
+    url: /dedicated-cloud-gateways/private-network/
+  - text: Multi-cloud Dedicated Cloud Gateway network architecture and security
+    url: /dedicated-cloud-gateways/multi-cloud/
 prereqs:
   show_works_on: false
   inline:

--- a/app/_how-tos/dedicated-cloud-gateways/azure-vnet-peering.md
+++ b/app/_how-tos/dedicated-cloud-gateways/azure-vnet-peering.md
@@ -26,6 +26,12 @@ related_resources:
     url: /dedicated-cloud-gateways/azure-vnet-peering-with-private-dns/
   - text: Configure an Azure Dedicated Cloud Gateway with VNET peering and outbound DNS resolution
     url: /dedicated-cloud-gateways/azure-vnet-peering-with-outbound-dns-resolver/
+  - text: Dedicated Cloud Gateways network architecture
+    url: /dedicated-cloud-gateways/network-architecture/
+  - text: Dedicated Cloud Gateways private network architecture and security
+    url: /dedicated-cloud-gateways/private-network/
+  - text: Multi-cloud Dedicated Cloud Gateway network architecture and security
+    url: /dedicated-cloud-gateways/multi-cloud/
 prereqs:
   show_works_on: false
   inline:

--- a/app/_how-tos/dedicated-cloud-gateways/gcp-private-dns.md
+++ b/app/_how-tos/dedicated-cloud-gateways/gcp-private-dns.md
@@ -27,6 +27,12 @@ related_resources:
     url: https://cloud.google.com/dns/docs/zones
   - text: AWS private hosted zones
     url: /dedicated-cloud-gateways/private-hosted-zones/
+  - text: Dedicated Cloud Gateways network architecture
+    url: /dedicated-cloud-gateways/network-architecture/
+  - text: Dedicated Cloud Gateways private network architecture and security
+    url: /dedicated-cloud-gateways/private-network/
+  - text: Multi-cloud Dedicated Cloud Gateway network architecture and security
+    url: /dedicated-cloud-gateways/multi-cloud/
 prereqs:
   skip_product: true
   inline:

--- a/app/_how-tos/dedicated-cloud-gateways/gcp-vpc-peering.md
+++ b/app/_how-tos/dedicated-cloud-gateways/gcp-vpc-peering.md
@@ -22,6 +22,12 @@ related_resources:
     url: /dedicated-cloud-gateways/private-hosted-zones/
   - text: Set up a GCP private DNS
     url: /dedicated-cloud-gateways/gcp-private-dns/
+  - text: Dedicated Cloud Gateways network architecture
+    url: /dedicated-cloud-gateways/network-architecture/
+  - text: Dedicated Cloud Gateways private network architecture and security
+    url: /dedicated-cloud-gateways/private-network/
+  - text: Multi-cloud Dedicated Cloud Gateway network architecture and security
+    url: /dedicated-cloud-gateways/multi-cloud/
 prereqs:
   skip_product: true
   inline:

--- a/app/_how-tos/dedicated-cloud-gateways/outbound-dns-resolver.md
+++ b/app/_how-tos/dedicated-cloud-gateways/outbound-dns-resolver.md
@@ -26,6 +26,12 @@ related_resources:
     url: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-get-started.html
   - text: Amazon VPC Documentation
     url: /dedicated-cloud-gateways/aws-vpc-peering/
+  - text: Dedicated Cloud Gateways network architecture
+    url: /dedicated-cloud-gateways/network-architecture/
+  - text: Dedicated Cloud Gateways private network architecture and security
+    url: /dedicated-cloud-gateways/private-network/
+  - text: Multi-cloud Dedicated Cloud Gateway network architecture and security
+    url: /dedicated-cloud-gateways/multi-cloud/
 prereqs:
   skip_product: true
   inline:

--- a/app/_how-tos/dedicated-cloud-gateways/private-hosted-zones.md
+++ b/app/_how-tos/dedicated-cloud-gateways/private-hosted-zones.md
@@ -24,6 +24,12 @@ related_resources:
     url: /dedicated-cloud-gateways/outbound-dns-resolver/
   - text: Amazon VPC Documentation
     url: https://docs.aws.amazon.com/vpc/latest/userguide/what-is-amazon-vpc.html
+  - text: Dedicated Cloud Gateways network architecture
+    url: /dedicated-cloud-gateways/network-architecture/
+  - text: Dedicated Cloud Gateways private network architecture and security
+    url: /dedicated-cloud-gateways/private-network/
+  - text: Multi-cloud Dedicated Cloud Gateway network architecture and security
+    url: /dedicated-cloud-gateways/multi-cloud/
 prereqs:
   skip_product: true
   inline:

--- a/app/_includes/diagrams/dcgw-tgw.md
+++ b/app/_includes/diagrams/dcgw-tgw.md
@@ -1,0 +1,44 @@
+<!--vale off -->
+{% mermaid %}
+flowchart LR
+
+A(API or Service)
+B(API or Service)
+C(API or Service)
+D(<img src="/assets/icons/third-party/aws-transit-gateway-attachment.svg" style="max-height:32px" class="no-image-expand"/>AWS Transit Gateway attachment)
+E(<img src="/assets/icons/third-party/aws-transit-gateway.svg" style="max-height:32px" class="no-image-expand"/> AWS Transit Gateway)
+F(<img src="/assets/icons/third-party/aws-transit-gateway-attachment.svg" style="max-height:32px" class="no-image-expand"/>AWS Transit Gateway attachment)
+G(<img src="/assets/logos/konglogo-gradient-secondary.svg" style="max-height:32px" class="no-image-expand"/>Konnect #40;fully-managed Data Plane#41;)
+H(<img src="/assets/logos/konglogo-gradient-secondary.svg" style="max-height:32px" class="no-image-expand"/>Konnect #40;fully-managed Data Plane#41;)
+I(<img src="/assets/logos/konglogo-gradient-secondary.svg" style="max-height:32px" class="no-image-expand"/>Konnect #40;fully-managed Data Plane#41;)
+J(Internet)
+
+subgraph 1 [User AWS Cloud]
+    subgraph 2 [Region]
+        subgraph 3 [Virtual Private Cloud #40;VPC#41;]
+        A
+        B
+        C
+        end
+        A & B & C <--> D
+    end
+   D<-->E
+end
+
+subgraph 4 [Kong AWS Cloud]
+    subgraph 5 [Region]
+        E<-->F
+        F <--private API access--> G & H & I
+        subgraph 6 [Virtual Private Cloud #40;VPC#41;]
+        G
+        H
+        I
+        end
+    end
+end
+
+G & H & I <--public API access--> J
+
+
+{% endmermaid %}
+<!--vale on-->

--- a/app/_includes/sections/dcgw-multi-cloud-intro.md
+++ b/app/_includes/sections/dcgw-multi-cloud-intro.md
@@ -1,0 +1,6 @@
+A single {{site.konnect_short_name}} control plane can manage Dedicated Cloud Gateway deployments across AWS, Azure, and GCP simultaneously.
+Multi-cloud deployments are common in enterprise environments for high availability, regulatory requirements, or because upstream services are distributed across providers.
+
+When deploying across multiple cloud providers, you'll need to decide how API consumers discover and reach each deployment.
+{{site.konnect_short_name}} doesn't provide cross-cloud private networking.
+If a gateway in one cloud must reach backends in another, you're responsible for implementing that connectivity using your cloud provider's tools (for example, Transit Gateway, ExpressRoute, and Direct Connect).

--- a/app/_includes/sections/dcgw-waf-intro.md
+++ b/app/_includes/sections/dcgw-waf-intro.md
@@ -1,0 +1,7 @@
+You can use a Web Application Firewall (WAF) in front of your Dedicated Cloud Gateway as a first-line defense that filters and blocks malicious traffic before it reaches {{site.base_gateway}}.
+A WAF provides Layer 7 protection for HTTP(S) traffic and helps protect APIs against:
+* OWASP Top 10 vulnerabilities
+* Malicious bot traffic
+* IP reputation threats
+* Rate-based abuse
+* Geo-based access restrictions

--- a/app/_landing_pages/dedicated-cloud-gateways.yaml
+++ b/app/_landing_pages/dedicated-cloud-gateways.yaml
@@ -223,7 +223,7 @@ rows:
                 Learn how to deploy Dedicated Cloud Gateways across multiple cloud providers, including supported hostname strategies and their tradeoffs.
               icon: /assets/icons/cloud.svg
               cta:
-                url: /gateway/data-plane-reference/
+                url: /dedicated-cloud-gateways/multi-cloud/
   
   - header:
       type: h2

--- a/app/_landing_pages/dedicated-cloud-gateways.yaml
+++ b/app/_landing_pages/dedicated-cloud-gateways.yaml
@@ -186,6 +186,47 @@ rows:
                   url: /dedicated-cloud-gateways/azure-managed-cache-control-plane-group/
   - header:
       type: h2
+      text: "Dedicated Cloud Gateway network architecture"
+    columns:
+      - blocks:
+          - type: card
+            config:
+              title: Network architecture overview
+              description: |
+                Learn the architecture of Kong-managed Dedicated Cloud Gateways networks, how they communicate with your cloud infrastructure, and what you must decide before deploying a Dedicated Cloud Gateway.
+              icon: /assets/icons/gateway.svg
+              cta:
+                url: /dedicated-cloud-gateways/network-architecture/
+      - blocks:
+          - type: card
+            config:
+              title: Public network architecture
+              description: |
+                Learn about the public Dedicated Cloud Gateway network architecture and how to secure your public network.
+              icon: /assets/icons/world.svg
+              cta:
+                url: /dedicated-cloud-gateways/public-network/
+      - blocks:
+          - type: card
+            config:
+              title: Private network architecture
+              description: |
+                Learn about private Dedicated Cloud Gateway network architecture, connectivity options, and how to secure your private network.
+              icon: /assets/icons/lock.svg
+              cta:
+                url: /dedicated-cloud-gateways/private-network/
+      - blocks:
+          - type: card
+            config:
+              title: Multi-cloud architecture
+              description: |
+                Learn how to deploy Dedicated Cloud Gateways across multiple cloud providers, including supported hostname strategies and their tradeoffs.
+              icon: /assets/icons/cloud.svg
+              cta:
+                url: /gateway/data-plane-reference/
+  
+  - header:
+      type: h2
       text: "Cluster management"
     columns:
       - blocks:

--- a/app/_landing_pages/waf.yaml
+++ b/app/_landing_pages/waf.yaml
@@ -132,6 +132,33 @@ rows:
                   url: /plugins/response-transformer/examples/add-header/
   - header:
       type: h2
+      text: "WAF for Dedicated Cloud Gateways"
+      description: |
+        {% include /sections/dcgw-waf-intro.md %}
+    column_count: 3
+    columns:
+      - blocks:
+          - type: card
+            config:
+              title: Public network WAF
+              description: |
+                Learn how to secure your public Dedicated Cloud Gateway with WAF.
+              icon: /assets/icons/world.svg
+              ctas:
+                - text: Configure public network WAF
+                  url: /dedicated-cloud-gateways/public-network/
+      - blocks:
+          - type: card
+            config:
+              title: Private network WAF
+              description: |
+                Learn how to secure your private Dedicated Cloud Gateway with WAF.
+              icon: /assets/icons/lock.svg
+              ctas:
+                - text: Configure private network WAF
+                  url: /dedicated-cloud-gateways/private-network/
+  - header:
+      type: h2
       text: "Other security-related resources"
     columns:
       - blocks:

--- a/app/dedicated-cloud-gateways/multi-cloud.md
+++ b/app/dedicated-cloud-gateways/multi-cloud.md
@@ -27,12 +27,7 @@ tags:
   - dedicated-cloud-gateways
 ---
 
-A single {{site.konnect_short_name}} control plane can manage Dedicated Cloud Gateway deployments across AWS, Azure, and GCP simultaneously.
-Multi-cloud deployments are common in enterprise environments for high availability, regulatory requirements, or because upstream services are distributed across providers.
-
-When deploying across multiple cloud providers, you'll need to decide how API consumers discover and reach each deployment.
-{{site.konnect_short_name}} doesn't provide cross-cloud private networking.
-If a gateway in one cloud must reach backends in another, you're responsible for implementing that connectivity using your cloud provider's tools (for example, Transit Gateway, ExpressRoute, and Direct Connect).
+{% include sections/dcgw-multi-cloud-intro.md %}
 
 ## Hostname strategies
 

--- a/app/dedicated-cloud-gateways/multi-cloud.md
+++ b/app/dedicated-cloud-gateways/multi-cloud.md
@@ -1,0 +1,160 @@
+---
+title: "Multi-cloud Dedicated Cloud Gateway network architecture"
+content_type: reference
+layout: reference
+description: "Learn how to deploy Dedicated Cloud Gateways across multiple cloud providers, including supported hostname strategies and their tradeoffs."
+
+products:
+    - gateway
+breadcrumbs:
+  - /dedicated-cloud-gateways/
+works_on:
+  - konnect
+
+related_resources:
+  - text: Dedicated Cloud Gateways
+    url: /dedicated-cloud-gateways/
+  - text: Dedicated Cloud Gateways network architecture
+    url: /dedicated-cloud-gateways/network-architecture/
+  - text: Dedicated Cloud Gateways private network architecture and security
+    url: /dedicated-cloud-gateways/private-network/
+  - text: Dedicated Cloud Gateways public network architecture and security
+    url: /dedicated-cloud-gateways/public-network/
+next_steps:
+  - text: Dedicated Cloud Gateways production readiness checklist
+    url: /dedicated-cloud-gateways/production-readiness/
+tags:
+  - dedicated-cloud-gateways
+---
+
+A single {{site.konnect_short_name}} control plane can manage Dedicated Cloud Gateway deployments across AWS, Azure, and GCP simultaneously.
+Multi-cloud deployments are common in enterprise environments for high availability, regulatory requirements, or because upstream services are distributed across providers.
+
+When deploying across multiple cloud providers, you'll need to decide how API consumers discover and reach each deployment.
+{{site.konnect_short_name}} doesn't provide cross-cloud private networking.
+If a gateway in one cloud must reach backends in another, you're responsible for implementing that connectivity using your cloud provider's tools (for example, Transit Gateway, ExpressRoute, and Direct Connect).
+
+## Hostname strategies
+
+The three supported hostname strategies differ in how they route traffic across deployments, and what infrastructure they require:
+
+{% table %}
+columns:
+  - title: Option
+    key: option
+  - title: How it works
+    key: how
+  - title: Pros
+    key: pros
+  - title: Cons
+    key: cons
+rows:
+  - option: "**Cloud-specific hostnames** (recommended)"
+    how: |
+      Each cloud deployment gets its own hostname. Clients use the hostname for the cloud they want to target:
+      * `aws.api.example.com` → AWS DCGW → AWS upstreams
+      * `azure.api.example.com` → Azure DCGW → Azure upstreams
+      * `gcp.api.example.com` → GCP DCGW → GCP upstreams
+
+      You manage DNS records. Each hostname CNAMEs directly to that cloud's gateway endpoint.
+    pros: |
+      * Deterministic routing (no accidental cross-cloud traffic)
+      * Clear operational blast radius per cloud
+      * Predictable latency and egress costs
+      * No additional routing layer required
+    cons: |
+      * Clients must know which hostname to call
+      * Multiple DNS records and certificates to manage
+  - option: "**Single global hostname with geo-proximity DNS**"
+    how: |
+      A single hostname routes traffic to the nearest cloud deployment based on the client's geographic location.
+      DNS selects the closest gateway deployment and the request lands on that cloud's data planes, which route to upstream services configured in that deployment.
+
+      {:.warning}
+      > DNS routing is not HTTP-aware. `api.example.com/azure` does **not** guarantee traffic reaches the Azure deployment. If your APIs or upstreams differ per cloud, use cloud-specific hostnames to avoid cross-cloud routing.
+    pros: |
+      * Single hostname for all consumers
+      * Optimizes latency automatically
+      * Supports active/active resiliency
+    cons: |
+      * Only works when APIs and upstreams are identical across all clouds
+      * Can introduce cross-cloud latency or private networking issues if upstreams are cloud-specific
+      * No path, header, or tenant-based routing
+  - option: "**Single hostname with L7 edge routing**"
+    how: |
+      A CDN or global load balancer sits in front of all cloud deployments and routes traffic based on path, header, or tenant.
+      The L7 edge handles WAF, TLS termination, and traffic steering before forwarding requests to the correct deployment.
+    pros: |
+      * HTTP-aware routing under a single hostname
+      * Supports path-based, header-based, and tenant-based routing
+      * Centralized WAF and TLS termination
+    cons: |
+      * Adds an architectural component you own and operate
+      * Introduces an additional latency hop
+      * Most operationally complex option
+{% endtable %}
+
+## Architecture
+
+The following diagrams show the architecture for each multi-cloud configuration option:
+
+### Cloud-specific hostnames
+
+Each cloud deployment gets its own hostname. Clients use the hostname for the cloud they want to target:
+
+{% mermaid %}
+flowchart LR
+    client1["Client"] --> aws_dns["aws.api.example.com"]
+    client2["Client"] --> azure_dns["azure.api.example.com"]
+    client3["Client"] --> gcp_dns["gcp.api.example.com"]
+
+    aws_dns --> aws["AWS DCGW"]
+    azure_dns --> azure["Azure DCGW"]
+    gcp_dns --> gcp["GCP DCGW"]
+
+    aws --> aws_up["AWS upstreams"]
+    azure --> azure_up["Azure upstreams"]
+    gcp --> gcp_up["GCP upstreams"]
+{% endmermaid %}
+
+You can optionally use `api.name.com` (geo‑routed) for generic global access or disaster recovery.
+
+### Geo-proximity DNS
+
+A single hostname routes traffic to the nearest cloud deployment based on the client's geographic location.
+
+{% mermaid %}
+flowchart LR
+    client["Client"] --> dns["api.example.com (geo-proximity DNS)"]
+
+    dns --> aws["AWS DCGW"]
+    dns --> azure["Azure DCGW"]
+    dns --> gcp["GCP DCGW"]
+
+    aws --> aws_up["AWS upstreams"]
+    azure --> azure_up["Azure upstreams"]
+    gcp --> gcp_up["GCP upstreams"]
+{% endmermaid %}
+
+### L7 edge routing
+
+A CDN or global load balancer sits in front of all cloud deployments and routes traffic based on path, header, or tenant.
+
+{% mermaid %}
+flowchart LR
+    client["Client"] --> hostname["api.example.com"]
+    hostname --> edge["Global L7 edge (CDN/global load balancer)"]
+
+    edge --> aws["AWS DCGW"]
+    edge --> azure["Azure DCGW"]
+    edge --> gcp["GCP DCGW"]
+
+    aws --> aws_up["AWS upstreams"]
+    azure --> azure_up["Azure upstreams"]
+    gcp --> gcp_up["GCP upstreams"]
+{% endmermaid %}
+
+The global L7 edge would have:
+- Path-based routing (`/aws/*`, `/azure/*`, `/gcp/*`)
+- Header-based or tenant-based routing
+- Centralized WAF/TLS termination

--- a/app/dedicated-cloud-gateways/multi-cloud.md
+++ b/app/dedicated-cloud-gateways/multi-cloud.md
@@ -112,7 +112,7 @@ flowchart LR
     gcp --> gcp_up["GCP upstreams"]
 {% endmermaid %}
 
-You can optionally use `api.name.com` (geo‑routed) for generic global access or disaster recovery.
+You can optionally use `api.example.com` (geo‑routed) for generic global access or disaster recovery.
 
 ### Geo-proximity DNS
 

--- a/app/dedicated-cloud-gateways/network-architecture.md
+++ b/app/dedicated-cloud-gateways/network-architecture.md
@@ -48,7 +48,7 @@ Before you deploy a Dedicated Cloud Gateway, you must make some choices to deter
 
 ## Kong-managed gateway infrastructure architecture
 
-The Kong-managed gateway infrastructure consists of data plane nodes that run on a Kubernetes cluster inside of a Kong-managed network peering (VPC or VNET depending on your provider).
+The Kong-managed gateway infrastructure consists of data plane nodes that run inside of a Kong-managed network peering (VPC or VNET depending on your provider).
 The Kong-managed data plane nodes automatically scale with your throughput. 
 
 The following diagram shows what the Kong-managed architecture looks like if you chose AWS as your provider:
@@ -57,11 +57,9 @@ The following diagram shows what the Kong-managed architecture looks like if you
 flowchart LR
     subgraph kong_account["Kong-managed AWS infra"]
         subgraph kong_vpc["Kong-managed VPC"]
-            subgraph k8s["k8s cluster"]
-                dp1["<img src="/assets/icons/gateway.svg" style="max-height:20px"> Data plane node"]
-                dp2["<img src="/assets/icons/gateway.svg" style="max-height:20px"> Data plane node"]
-                dp3["<img src="/assets/icons/gateway.svg" style="max-height:20px"> Data plane node"]
-            end
+          dp1["<img src="/assets/icons/gateway.svg" style="max-height:20px"> Data plane node"]
+          dp2["<img src="/assets/icons/gateway.svg" style="max-height:20px"> Data plane node"]
+          dp3["<img src="/assets/icons/gateway.svg" style="max-height:20px"> Data plane node"]
         end
     end
 
@@ -86,11 +84,11 @@ Different connections distribute across nodes.
 Before you deploy a Dedicated Cloud Gateway, you'll need to determine if you should deploy a public or private gateway, or both.
 Which you deploy depends on how API consumers are reaching your gateway and how you want data planes to reach your backend services:
 
-* **[Public](/dedicated-cloud-gateways/public-network/):** Use public if:
+* Use [public](/dedicated-cloud-gateways/public-network/) if:
   * You expose services to the internet with custom access control
   * Want minimal setup and are securing at the Kong layer
   * You're proxying your own infrastructure over the public internet
-* **[Private](/dedicated-cloud-gateways/private-network/):** Use private if:
+* Use [private](/dedicated-cloud-gateways/private-network/) if:
   * Your upstream services are on one or more private network (VPC or VNET)
   * You don't expose services to the public internet
   * Require network isolation or full edge control

--- a/app/dedicated-cloud-gateways/network-architecture.md
+++ b/app/dedicated-cloud-gateways/network-architecture.md
@@ -128,6 +128,10 @@ features:
 
 For more information, see [Multi-cloud Dedicated Cloud Gateway network architecture](/dedicated-cloud-gateways/multi-cloud/).
 
+## WAF
+
+
+
 ## Dedicated Cloud Gateway network CIDR range
 
 Before you create a Dedicated Cloud Gateway network, determine which CIDR range you want to use for your network.

--- a/app/dedicated-cloud-gateways/network-architecture.md
+++ b/app/dedicated-cloud-gateways/network-architecture.md
@@ -2,7 +2,7 @@
 title: "Dedicated Cloud Gateways network architecture"
 content_type: reference
 layout: reference
-description: "Dedicated Cloud Gateways are Data Plane nodes that are fully managed by Kong in {{site.konnect_short_name}}."
+description: "Learn the architecture of Kong-managed Dedicated Cloud Gateways networks, how they communicate with your cloud infrastructure, and what you must decide before deploying a Dedicated Cloud Gateway."
 
 products:
     - gateway
@@ -11,30 +11,43 @@ breadcrumbs:
 works_on:
   - konnect
 
-faqs:
-  - q: 
-    a: 
-
 related_resources:
   - text: Dedicated Cloud Gateways 
     url: /dedicated-cloud-gateways/
-  - text: Serverless Gateways
-    url: /serverless-gateways/
-  - text: Private hosted zones
-    url: /dedicated-cloud-gateways/private-hosted-zones/
-  - text: Outbound DNS resolver
-    url: /dedicated-cloud-gateways/outbound-dns-resolver/
-next_steps:
-  - text: Dedicated Cloud Gateways production readiness checklist
-    url: /dedicated-cloud-gateways/production-readiness/
+  - text: Dedicated Cloud Gateways private network architecture and security
+    url: /dedicated-cloud-gateways/private-network/
+  - text: Dedicated Cloud Gateways public network architecture and security
+    url: /dedicated-cloud-gateways/public-network/
+  - text: Multi-cloud Dedicated Cloud Gateway network architecture and security
+    url: /dedicated-cloud-gateways/multi-cloud/
 tags:
   - dedicated-cloud-gateways
 ---
 
-In a Dedicated Cloud Gateway, Kong manages your data plane nodes for you in the cloud provider of your choice (AWS, GCP, Azure).
-A complete Dedicated Cloud Gateway deployment consists of this Kong-managed network infrastructure and the cloud infrastructure you manage.
-The Kong-managed infrastructure is automatically created in AWS, GCP, or Azure. 
-It consists of data plane nodes that run on a Kubernetes cluster inside of a Kong-managed network peering (VPC or VNET depending on your provider).
+In a Dedicated Cloud Gateway, Kong manages the gateway infrastructure (compute, Dedicated Cloud Gateway network, and data planes) for you in a single-tenant cloud environment dedicated to your organization (AWS, GCP, Azure).
+A complete Dedicated Cloud Gateway deployment consists of this Kong-managed network infrastructure and the cloud infrastructure with the upstream services you manage.
+
+The following diagram shows how traffic flows in a Dedicated Cloud Gateway:
+
+{% mermaid %}
+flowchart LR
+    A(API consumers) --> |inbound edge| B(Kong data planes)
+    B --> |upstream path| C(Your services)
+{% endmermaid %}
+
+The networking decisions you make govern both hops independently.
+
+Before you deploy a Dedicated Cloud Gateway, you must make some choices to determine how to deploy it based on your network and upstream service configuration:
+1. Decide which cloud provider or providers (AWS, Azure, GCP) you want to use based on where your upstream service cloud infrastructure is currently deployed.
+1. Decide if you want a [public or private Dedicated Cloud Gateway](#public-and-private-network-connectivity) (or both) depending on if your upstream traffic is public or private.
+1. For private Dedicated Cloud Gateways:
+   * Decide how {{site.base_gateway}} will connect to your upstream services via private network peering (VPC/VNET), hub-and-spoke networking (Transit gateway, VWAN), or private endpoints (AWS resource endpoints).
+   * Decide how to resolve hostnames, either via private DNS or outbound DNS resolver (when your hostnames live on a separate DNS server).
+1. Decide if you need a [multi-cloud Dedicated Cloud Gateway](#multi-cloud-architecture) for high-availability.
+
+## Kong-managed gateway infrastructure architecture
+
+The Kong-managed gateway infrastructure consists of data plane nodes that run on a Kubernetes cluster inside of a Kong-managed network peering (VPC or VNET depending on your provider).
 The Kong-managed data plane nodes automatically scale with your throughput. 
 
 The following diagram shows what the Kong-managed architecture looks like if you chose AWS as your provider:
@@ -57,18 +70,67 @@ flowchart LR
 In a Dedicated Cloud Gateway, the Kong-managed infrastructure would communicate with your own cloud infrastructure that contains your databases, APIs, and other resources.
 Your infrastructure can run on virtual machines (VMs), managed container platforms like ECS, Kubernetes managed pods, or a combination of multiple platforms.
 If the services are backed VMs or managed container platforms, Kong mostly expects you to expose them via load balancer. 
-If the services are in Kubernetes managed pods, they can either be exposed via a shared ingress or if only a small set of services need to be exposed, they can be directly exposed by a load balancer service.
+If the services are in Kubernetes managed pods, they can either be exposed via a shared ingress or if only a small set of services need to be exposed, they can be directly exposed by a load balancer service. 
 
-## Configure a Dedicated Cloud Gateway network
+## Public and private network connectivity
 
-You can configure a Dedicated Cloud Gateway network using the {{site.konnect_short_name}} UI, API, or Terraform.
+Before you deploy a Dedicated Cloud Gateway, you'll need to determine if you should deploy a public or private gateway, or both.
+Which you deploy depends on how API consumers are reaching your gateway and how you want data planes to reach your backend services:
+
+* **[Public](/dedicated-cloud-gateway/public-network/):** Use public if:
+  * You expose services to the internet with custom access control
+  * Want minimal setup and are securing at the Kong layer
+  * You're proxying your own infrastructure over the public internet
+* **[Private](/dedicated-cloud-gateway/private-network/):** Use private if:
+  * Your upstream services are on one or more private network (VPC or VNET)
+  * You don't expose services to the public internet
+  * Require network isolation or full edge control
+  * Operate under regulated security requirements
+
+Use both a public and private Dedicated Cloud Gateway if some of your traffic is public-facing and other traffic is private.
+
+The following table describes which cloud providers and private networking configurations are supported:
+
+{% feature_table %}
+item_title: Feature
+columns:
+  - title: AWS
+    key: aws
+  - title: GCP
+    key: gcp
+  - title: Azure
+    key: azure
+features:
+  - title: Public Dedicated Cloud Gateway
+    aws: true
+    gcp: true
+    azure: true
+  - title: Private network peering
+    aws: true
+    gcp: true
+    azure: true
+  - title: Private hub-and-spoke network
+    aws: true
+    gcp: false
+    azure: true
+  - title: Private endpoints
+    aws: true
+    gcp: false
+    azure: false
+{% endfeature_table %}
+
+
+## Multi-cloud architecture
+
+## Dedicated Cloud Gateway network CIDR range
 
 Before you create a Dedicated Cloud Gateway network, determine which CIDR range you want to use for your network.
-A CIDR block defines the range of IP addresses available for your Dedicated Cloud Gateway. If you're configuring private network connectivity, this CIDR block **must not** overlap with CIDR blocks assigned in your own cloud service provider networks to prevent conflicts.
+A CIDR block defines the range of IP addresses available for your Dedicated Cloud Gateway. 
+If you're configuring private network connectivity, this CIDR block **must not** overlap with CIDR blocks assigned in your own cloud service provider networks to prevent conflicts.
 Keep in mind that your Dedicated Cloud Gateway network CIDR block must be large enough to cover the Kong infrastructure Kong will provision inside it, such as the data plane nodes, the DNS proxy, internal load balancers, and any other components Kong manages. 
 
 Keep the following CIDR requirements in mind when you're deciding your network CIDR range:
-* **Prefix length:** The CIDR block must have a prefix length between `/16` and `/23`. `/23` blocks are only supported up to 3 availability zones.
+* **Prefix length:** The CIDR block must have a prefix length between `/16` and `/23`. `/23` blocks are only supported for up to 3 availability zones.
 * **Private IP Range:** The entire CIDR block must fall within one of these private IP ranges:
   * 10.0.0.0/8
   * 100.64.0.0/10
@@ -88,6 +150,10 @@ Keep the following CIDR requirements in mind when you're deciding your network C
   * 10.100.0.0/16
   * 172.17.0.0/16
 
+## Configure a Dedicated Cloud Gateway network
+
+You can configure a Dedicated Cloud Gateway network using the {{site.konnect_short_name}} UI, API, or Terraform.
+
 {% navtabs "dcgw-network" %}
 {% navtab "UI" %}
 1. In the {{site.konnect_short_name}} sidebar, click **Network**.
@@ -102,23 +168,21 @@ Keep the following CIDR requirements in mind when you're deciding your network C
 1. Click **Save**.
 {% endnavtab %}
 {% navtab "API" %}
-1. Send a `GET` request to the `/cloud-gateways/provider-accounts` endpoint to get all cloud provider IDs:
+1. Send a `GET` request to the [`/cloud-gateways/provider-accounts` endpoint](/api/konnect/cloud-gateways/v2/#/operations/list-provider-accounts) to get all cloud provider IDs:
 {% konnect_api_request %}
 url: /v2/cloud-gateways/provider-accounts
 method: GET
-headers:
-  - 'Accept: application/json, application/problem+json'
+region: global
 {% endkonnect_api_request %}
 1. In the response, copy and export the ID for the cloud provider you want to use for your Dedicated Cloud Gateway network:
    ```sh
    export CLOUD_PROVIDER_ID='YOUR CLOUD PROVIDER ID'
    ```
-1. Send a `POST` request to the `` endpoint to create your Dedicated Cloud Gateway network:
+1. Send a `POST` request to the [`/cloud-gateways/networks` endpoint](/api/konnect/cloud-gateways/v2/#/operations/create-network) to create your Dedicated Cloud Gateway network:
 {% konnect_api_request %}
 url: /v2/cloud-gateways/networks
 method: POST
-headers:
-  - 'Accept: application/json, application/problem+json'
+region: global
 body:
   name: "us-east-2 network"
   cloud_gateway_provider_account_id: "$CLOUD_PROVIDER_ID"
@@ -155,268 +219,14 @@ resource "konnect_cloud_gateway_network" "my_cloudgatewaynetwork" {
 }
 ' >> main.tf
 ```
+
+Apply changes:
+```sh
+terraform apply -auto-approve
+```
 {% endnavtab %}
 {% endnavtabs %}
 
 {:.warning}
 > **Important:** It can take 30-40 minutes for your network to initialize. 
-> You **must** wait for your network to display as `Ready` before you can configure private networking. 
-
-## Public vs private
-
-You can choose to have a private or public Dedicated Cloud Gateway, or use both public and private.
-* **Public:** Use public if all your proxy traffic is public.
-* **Private:** Use private if all your proxy traffic is private.
-* **Public and private:** Use both a public and private Dedicated Cloud Gateway if some of your traffic is public-facing and other traffic is private.
-
-The following table describes which cloud providers and private networking configurations are supported:
-
-{% table %}
-columns:
-  - title: Feature
-    key: feature
-  - title: AWS
-    key: aws
-  - title: GCP
-    key: gcp
-  - title: Azure
-    key: azure
-rows:
-  - feature: Public Dedicated Cloud Gateway
-    aws: "Y"
-    gcp: "Y"
-    azure: "Y"
-  - feature: Private network peering
-    aws: "Yes (VPC)"
-    gcp: "Yes (VPC)"
-    azure: "Yes (VNET)"
-  - feature: Private hub-and-spoke network
-    aws: "Yes (TGW)"
-    gcp: "No"
-    azure: "Yes (VWAN)"
-  - feature: Private endpoints
-    aws: "Yes (resource endpoints)"
-    gcp: "No"
-    azure: "No"
-{% endtable %}
-
-## Public architecture and connectivity
-
-When a Dedicated Cloud Gateway (DCGW) proxies traffic to upstream services over
-the public internet, you need security controls across the full request path —
-validating who can call your APIs, and ensuring your upstream services can trust
-that requests genuinely originate from Kong.
-
-This page covers controls at both layers and how to combine them for defense in
-depth.
-
-{:.note}
-> This page covers security controls for public internet upstream connectivity.
-> Some controls (mTLS Auth, OIDC) validate inbound API consumers before
-> requests reach your upstream. Others (upstream mTLS, shared secrets) authenticate
-> Kong to your upstream service. For securing the inbound entry point itself,
-> see [WAF and CDN integration with Dedicated Cloud Gateways](/).
-
-Public internet connectivity between Kong and your upstream services is
-appropriate when:
-
-- Your upstream services are already internet-facing (for example, SaaS
-  backends or services shared across business units without private networking)
-- Traffic volume doesn't justify the operational overhead of private network
-  peering
-- Your security model relies on application-layer controls rather than
-  network-layer isolation
-
-For workloads with stricter isolation requirements, consider
-[private upstream connectivity](#private-architecture-and-connectivity)
-instead.
-
-Kong data planes egress to your upstream services over the public internet.
-Konnect exposes **static egress IP addresses** for each DCGW network in the
-Konnect UI. You allowlist these IPs at your firewall or load balancer so that
-only Kong proxy traffic can reach your backends.
-
-IP allowlisting alone is a network-layer control — it restricts *who* can
-send traffic, not *what* the traffic contains or *who* sent it at the
-application layer. For production workloads, combine it with one or more of
-the controls below.
-
-### Securing public
-
-These controls are complementary. A robust public internet configuration
-typically combines multiple layers:
-
-| Layer | Control | Protects against |
-|---|---|---|
-| Network | Egress IP allowlisting | Unauthorized source IPs |
-| Transport | Upstream mTLS | Impersonation, MITM |
-| Application | Shared secret header | Bypassed IP rules |
-| Application | OIDC / JWT validation | Unauthorized callers |
-
-A minimal production configuration for sensitive services: **egress IP
-allowlisting + upstream mTLS**.
-
-A configuration for services that cannot do mTLS: **egress IP allowlisting +
-shared secret + OIDC**.
-
-Customer requirements:
-| Task | Your responsibility |
-|---|---|
-| Retrieve egress IPs | Konnect UI → your DCGW → **Connect** → Public Egress IPs |
-| Allowlist egress IPs | Cloud security groups, firewall rules, or load balancer ACLs |
-| Issue TLS certificates for mTLS | Provision a CA and issue certificates to Kong and your upstream services |
-| Store shared secrets | Use Konnect vault references or your secrets manager |
-| Configure identity provider for OIDC | Set up an IdP and issue credentials for Kong's OIDC plugin |
-
-#### Egress IP allowlisting
-
-Konnect exposes the static egress IP addresses for your DCGW network in the
-Konnect UI. Configure your upstream firewall,
-security group, or load balancer to accept inbound connections from these IPs
-only.
-
-This ensures that even if a service is publicly accessible, only your Kong data
-planes can call it.
-
-{:.note}
-> Egress IPs are scoped per DCGW network and per region. If you operate
-> multiple DCGW networks, allowlist the egress IPs from each relevant network.
-
-**Steps:**
-
-1. In Konnect, navigate to your DCGW and click **Connect**. The egress IP
-   addresses are listed under **Public Egress IPs**.
-2. In your cloud provider console, add inbound rules to your upstream service's
-   security group or firewall to allow traffic from those IP ranges on the
-   relevant port (typically 443 or 80).
-3. Restrict inbound traffic on that port to the allowlisted IPs, in addition
-   to any other legitimately permitted sources.
-
-
-#### Mutual TLS (mTLS)
-
-Mutual TLS authenticates both the Kong data plane and your upstream service
-cryptographically. The upstream rejects any connection that doesn't present a
-valid certificate, regardless of source IP. This provides a strong identity
-guarantee even if an IP allowlist is bypassed or shared with another system.
-
-Kong supports two mTLS modes for upstream connections:
-
-##### Upstream mTLS
-
-Kong presents a client certificate to your upstream service when establishing
-the connection. Configure this on the Kong Service object by referencing a
-certificate stored in Konnect via the `client_certificate` field.
-
-Example service configuration using decK:
-
-```yaml
-services:
-  - name: my-service
-    url: https://api.internal.example.com
-    client_certificate:
-      id: <cert-uuid>
-    tls_verify: true
-    ca_certificates:
-      - <ca-cert-uuid>
-```
-
-Your upstream verifies Kong's client certificate against a known CA before
-accepting the connection.
-
-##### Inbound mTLS with the mTLS Auth plugin
-
-The [mTLS Auth plugin](https://developer.konghq.com/plugins/mtls-auth/)
-validates client certificates presented *to* Kong from downstream API
-consumers. Use this when your consumers must also authenticate with
-certificates, creating end-to-end mutual authentication.
-
-For services handling sensitive data, combine upstream mTLS with egress IP
-allowlisting for defense in depth.
-
-
-
-#### Shared secrets with the Request Transformer plugin
-
-If your upstream service cannot terminate mTLS but you need a lightweight way
-to verify that requests originate from Kong, inject a shared secret header
-using the [Request Transformer plugin](https://developer.konghq.com/plugins/request-transformer/).
-
-Example plugin configuration:
-
-```yaml
-plugins:
-  - name: request-transformer
-    config:
-      add:
-        headers:
-          - "x-kong-origin-verify:{vault://env/KONG_SHARED_SECRET}"
-```
-
-{:.note}
-> Replace `env/KONG_SHARED_SECRET` with the path matching your configured
-> vault backend (`hcv`, `aws`, `gcp`, or `env`). See the
-> [Secrets management documentation](https://developer.konghq.com/gateway/secrets-management/)
-> for vault configuration options.
-
-Your upstream service validates the presence and value of this header before
-processing the request. If the header is absent or incorrect, the upstream
-rejects the request.
-
-**Security practices:**
-
-- Store the secret as a Konnect vault reference, not as a plaintext value
-- Rotate the secret on a regular schedule
-- Combine with egress IP allowlisting so the header alone is not the only
-  control
-
-
-#### Token-based authentication with OpenID Connect
-
-For APIs where caller identity matters beyond network origin, use the
-[OpenID Connect plugin](https://developer.konghq.com/plugins/openid-connect/)
-to validate JWTs or opaque tokens before forwarding requests upstream.
-
-Kong validates the token at the gateway and can forward claims to your upstream
-as headers, so your backend receives a verified identity without needing to
-perform its own token validation.
-
-This is particularly useful when:
-
-- Upstream services are shared across multiple calling systems
-- You want Kong to act as the centralized token validation and enforcement point
-- You need fine-grained authorization based on token claims (scopes, roles,
-  tenant ID)
-
-## Private architecture and connectivity
-
-When you want a private connection from your Dedicated Cloud Gateway to your managed cloud infrastructure, you can choose different bridging options depending on your use case:
-
-Private network peering: 
-Private hub-and-spoke network:
-Private endpoints:
-
-### Private network peering
-
-### Private hub-and-spoke network
-
-### Private endpoints
-
-AWS resource endpoints
-
-### Securing private
-
-
-
-## Multi-cloud architecture
-
-blah
-
-use case about when certain ones are recommended
-
-### Single Global Hostname (Geo‑Proximity DNS)
-
-### Cloud‑Specific Hostnames (Recommended Default)
-
-### Single Hostname + L7 Edge
-
+> You **must** wait for your network to display as `Ready` before you can configure private networking.

--- a/app/dedicated-cloud-gateways/network-architecture.md
+++ b/app/dedicated-cloud-gateways/network-architecture.md
@@ -24,7 +24,7 @@ tags:
   - dedicated-cloud-gateways
 ---
 
-In a Dedicated Cloud Gateway, Kong manages the gateway infrastructure (compute, Dedicated Cloud Gateway network, and data planes) for you in a single-tenant cloud environment dedicated to your organization (AWS, GCP, Azure).
+In a Dedicated Cloud Gateway, Kong manages the Gateway infrastructure (compute, Dedicated Cloud Gateway network, and data planes) for you in a single-tenant cloud environment dedicated to your organization (AWS, GCP, Azure).
 A complete Dedicated Cloud Gateway deployment consists of this Kong-managed network infrastructure and the cloud infrastructure with the upstream services you manage.
 
 The following diagram shows how traffic flows in a Dedicated Cloud Gateway:
@@ -39,16 +39,16 @@ flowchart LR
 The networking decisions you make govern both hops independently.
 
 Before you deploy a Dedicated Cloud Gateway, you must make some choices to determine how to deploy it based on your network and upstream service configuration:
-1. Decide which cloud provider or providers (AWS, Azure, GCP) you want to use based on where your upstream service cloud infrastructure is currently deployed.
+1. Decide which cloud provider or providers you want to use based on where your upstream service cloud infrastructure is currently deployed.
 1. Decide if you want a [public or private Dedicated Cloud Gateway](#public-and-private-network-connectivity) (or both) depending on if your upstream traffic is public or private.
 1. For private Dedicated Cloud Gateways:
    * Decide how {{site.base_gateway}} will connect to your upstream services via private network peering (VPC/VNET), hub-and-spoke networking (Transit gateway, VWAN), or private endpoints (AWS resource endpoints).
-   * Decide how to resolve hostnames, either via private DNS or outbound DNS resolver (when your hostnames live on a separate DNS server).
+   * Decide how to resolve hostnames, either via private DNS or an outbound DNS resolver (when your hostnames live on a separate DNS server).
 1. Decide if you need a [multi-cloud Dedicated Cloud Gateway](#multi-cloud-architecture) for high-availability.
 
 ## Kong-managed gateway infrastructure architecture
 
-The Kong-managed gateway infrastructure consists of data plane nodes that run inside of a Kong-managed network peering (VPC or VNET depending on your provider).
+The Kong-managed Gateway infrastructure consists of data plane nodes that run inside of a Kong-managed network peering (VPC or VNET depending on your provider).
 The Kong-managed data plane nodes automatically scale with your throughput. 
 
 The following diagram shows what the Kong-managed architecture looks like if you chose AWS as your provider:
@@ -67,7 +67,7 @@ flowchart LR
 {% endmermaid %}
 <!--vale on-->
 
-In a Dedicated Cloud Gateway, the Kong-managed infrastructure would communicate with your own cloud infrastructure that contains your databases, APIs, and other resources.
+In a Dedicated Cloud Gateway, the Kong-managed infrastructure communicates with your own cloud infrastructure that contains your databases, APIs, and other resources.
 Your infrastructure can run on virtual machines (VMs), managed container platforms like ECS, Kubernetes managed pods, or a combination of multiple platforms.
 If the services are backed VMs or managed container platforms, Kong mostly expects you to expose them via load balancer. 
 If the services are in Kubernetes managed pods, they can either be exposed via a shared ingress or if only a small set of services need to be exposed, they can be directly exposed by a load balancer service. 
@@ -84,13 +84,13 @@ Different connections distribute across nodes.
 Before you deploy a Dedicated Cloud Gateway, you'll need to determine if you should deploy a public or private gateway, or both.
 Which you deploy depends on how API consumers are reaching your gateway and how you want data planes to reach your backend services:
 
-* Use [public](/dedicated-cloud-gateways/public-network/) if:
-  * You expose services to the internet with custom access control
+* Use [public](/dedicated-cloud-gateways/public-network/) if you:
+  * Expose services to the internet with custom access control
   * Want minimal setup and are securing at the Kong layer
-  * You're proxying your own infrastructure over the public internet
-* Use [private](/dedicated-cloud-gateways/private-network/) if:
-  * Your upstream services are on one or more private network (VPC or VNET)
-  * You don't expose services to the public internet
+  * Proxy your own infrastructure over the public internet
+* Use [private](/dedicated-cloud-gateways/private-network/) if you:
+  * Deploy upstream services on one or more private network (VPC or VNET)
+  * Don't expose services to the public internet
   * Require network isolation or full edge control
   * Operate under regulated security requirements
 

--- a/app/dedicated-cloud-gateways/network-architecture.md
+++ b/app/dedicated-cloud-gateways/network-architecture.md
@@ -28,12 +28,13 @@ In a Dedicated Cloud Gateway, Kong manages the gateway infrastructure (compute, 
 A complete Dedicated Cloud Gateway deployment consists of this Kong-managed network infrastructure and the cloud infrastructure with the upstream services you manage.
 
 The following diagram shows how traffic flows in a Dedicated Cloud Gateway:
-
+<!--vale off-->
 {% mermaid %}
 flowchart LR
     A(API consumers) --> |inbound edge| B(Kong data planes)
     B --> |upstream path| C(Your services)
 {% endmermaid %}
+<!--vale on-->
 
 The networking decisions you make govern both hops independently.
 
@@ -51,7 +52,7 @@ The Kong-managed gateway infrastructure consists of data plane nodes that run on
 The Kong-managed data plane nodes automatically scale with your throughput. 
 
 The following diagram shows what the Kong-managed architecture looks like if you chose AWS as your provider:
-
+<!--vale off-->
 {% mermaid %}
 flowchart LR
     subgraph kong_account["Kong-managed AWS infra"]
@@ -66,6 +67,7 @@ flowchart LR
 
     style kong_account stroke-dasharray:3,rx:10,ry:10
 {% endmermaid %}
+<!--vale on-->
 
 In a Dedicated Cloud Gateway, the Kong-managed infrastructure would communicate with your own cloud infrastructure that contains your databases, APIs, and other resources.
 Your infrastructure can run on virtual machines (VMs), managed container platforms like ECS, Kubernetes managed pods, or a combination of multiple platforms.
@@ -77,11 +79,11 @@ If the services are in Kubernetes managed pods, they can either be exposed via a
 Before you deploy a Dedicated Cloud Gateway, you'll need to determine if you should deploy a public or private gateway, or both.
 Which you deploy depends on how API consumers are reaching your gateway and how you want data planes to reach your backend services:
 
-* **[Public](/dedicated-cloud-gateway/public-network/):** Use public if:
+* **[Public](/dedicated-cloud-gateways/public-network/):** Use public if:
   * You expose services to the internet with custom access control
   * Want minimal setup and are securing at the Kong layer
   * You're proxying your own infrastructure over the public internet
-* **[Private](/dedicated-cloud-gateway/private-network/):** Use private if:
+* **[Private](/dedicated-cloud-gateways/private-network/):** Use private if:
   * Your upstream services are on one or more private network (VPC or VNET)
   * You don't expose services to the public internet
   * Require network isolation or full edge control
@@ -121,6 +123,10 @@ features:
 
 
 ## Multi-cloud architecture
+
+{% include sections/dcgw-multi-cloud-intro.md %}
+
+For more information, see [Multi-cloud Dedicated Cloud Gateway network architecture](/dedicated-cloud-gateways/multi-cloud/).
 
 ## Dedicated Cloud Gateway network CIDR range
 
@@ -179,24 +185,25 @@ region: global
    export CLOUD_PROVIDER_ID='YOUR CLOUD PROVIDER ID'
    ```
 1. Send a `POST` request to the [`/cloud-gateways/networks` endpoint](/api/konnect/cloud-gateways/v2/#/operations/create-network) to create your Dedicated Cloud Gateway network:
-{% konnect_api_request %}
-url: /v2/cloud-gateways/networks
-method: POST
-region: global
-body:
-  name: "us-east-2 network"
-  cloud_gateway_provider_account_id: "$CLOUD_PROVIDER_ID"
-  region: "us-east-2"
-  availability_zones:
-    - "use2-az1"
-    - "use2-az2"
-    - "use2-az3"
-  cidr_block: "10.4.0.0/16"
-{% endkonnect_api_request %}
+   {% konnect_api_request %}
+   url: /v2/cloud-gateways/networks
+   method: POST
+   region: global
+   body:
+     name: "us-east-2 network"
+     cloud_gateway_provider_account_id: "$CLOUD_PROVIDER_ID"
+     region: "us-east-2"
+     availability_zones:
+       - "use2-az1"
+       - "use2-az2"
+       - "use2-az3"
+     cidr_block: "10.4.0.0/16"
+   {% endkonnect_api_request %}
 {% endnavtab %}
 {% navtab "Terraform" %}
 [Create a Dedicated Cloud Gateway network](https://github.com/Kong/terraform-provider-konnect/blob/main/examples/scenarios/cloud-gateways.tf):
 
+<!--vale off-->
 ```hcl
 echo '
 data "konnect_cloud_gateway_provider_account_list" "my_cloudgatewayprovideraccountlist" {
@@ -219,6 +226,7 @@ resource "konnect_cloud_gateway_network" "my_cloudgatewaynetwork" {
 }
 ' >> main.tf
 ```
+<!--vale on-->
 
 Apply changes:
 ```sh

--- a/app/dedicated-cloud-gateways/network-architecture.md
+++ b/app/dedicated-cloud-gateways/network-architecture.md
@@ -155,18 +155,18 @@ Keep the following CIDR requirements in mind when you're deciding your network C
   * 172.16.0.0/12
   * 192.168.0.0/16
   * 198.18.0.0/15
-  
-  {:.info}
-  > **Acceptable CIDR examples:**
-  > * 10.4.0.0/16
-  > * 100.68.0.0/20
-  > * 172.20.0.0/22
-  > * 192.168.128.0/18
-  > * 198.18.0.0/16
 * **No overlap with existing ranges:** Your CIDR block **must not** overlap with any IP ranges already in use by your organization. Overlapping ranges can prevent network peering from functioning correctly.
 * **No overlap with reserved CIDR blocks:** Your CIDR block must not overlap with these reserved ranges:
   * 10.100.0.0/16
   * 172.17.0.0/16
+
+{:.info}
+> **Acceptable CIDR examples:**
+> * 10.4.0.0/16
+> * 100.68.0.0/20
+> * 172.20.0.0/22
+> * 192.168.128.0/18
+> * 198.18.0.0/16
 
 ## Configure a Dedicated Cloud Gateway network
 
@@ -187,30 +187,36 @@ You can configure a Dedicated Cloud Gateway network using the {{site.konnect_sho
 {% endnavtab %}
 {% navtab "API" %}
 1. Send a `GET` request to the [`/cloud-gateways/provider-accounts` endpoint](/api/konnect/cloud-gateways/v2/#/operations/list-provider-accounts) to get all cloud provider IDs:
+{% capture get_csp %}
 {% konnect_api_request %}
 url: /v2/cloud-gateways/provider-accounts
 method: GET
 region: global
 {% endkonnect_api_request %}
+{% endcapture %}
+{{ get_csp | indent: 3 }}
 1. In the response, copy and export the ID for the cloud provider you want to use for your Dedicated Cloud Gateway network:
    ```sh
    export CLOUD_PROVIDER_ID='YOUR CLOUD PROVIDER ID'
    ```
 1. Send a `POST` request to the [`/cloud-gateways/networks` endpoint](/api/konnect/cloud-gateways/v2/#/operations/create-network) to create your Dedicated Cloud Gateway network:
-   {% konnect_api_request %}
-   url: /v2/cloud-gateways/networks
-   method: POST
-   region: global
-   body:
-     name: "us-east-2 network"
-     cloud_gateway_provider_account_id: "$CLOUD_PROVIDER_ID"
-     region: "us-east-2"
-     availability_zones:
-       - "use2-az1"
-       - "use2-az2"
-       - "use2-az3"
-     cidr_block: "10.4.0.0/16"
-   {% endkonnect_api_request %}
+{% capture create_network %}
+{% konnect_api_request %}
+url: /v2/cloud-gateways/networks
+method: POST
+region: global
+body:
+  name: "us-east-2 network"
+  cloud_gateway_provider_account_id: "$CLOUD_PROVIDER_ID"
+  region: "us-east-2"
+  availability_zones:
+    - "use2-az1"
+    - "use2-az2"
+    - "use2-az3"
+  cidr_block: "10.4.0.0/16"
+{% endkonnect_api_request %}
+{% endcapture %}
+{{ create_network | indent: 3 }}
 {% endnavtab %}
 {% navtab "Terraform" %}
 [Create a Dedicated Cloud Gateway network](https://github.com/Kong/terraform-provider-konnect/blob/main/examples/scenarios/cloud-gateways.tf):

--- a/app/dedicated-cloud-gateways/network-architecture.md
+++ b/app/dedicated-cloud-gateways/network-architecture.md
@@ -74,6 +74,13 @@ Your infrastructure can run on virtual machines (VMs), managed container platfor
 If the services are backed VMs or managed container platforms, Kong mostly expects you to expose them via load balancer. 
 If the services are in Kubernetes managed pods, they can either be exposed via a shared ingress or if only a small set of services need to be exposed, they can be directly exposed by a load balancer service. 
 
+## Load balancing
+
+{{site.konnect_short_name}} uses cross-availability zone load balancing to distribute traffic evenly across data plane nodes in all availability zones where your Dedicated Cloud Gateway is deployed. 
+Load balancing happens at the connection level, not per request.
+Multiple requests sent over the same TCP connection go to the same data plane node. 
+Different connections distribute across nodes.
+
 ## Public and private network connectivity
 
 Before you deploy a Dedicated Cloud Gateway, you'll need to determine if you should deploy a public or private gateway, or both.
@@ -130,7 +137,10 @@ For more information, see [Multi-cloud Dedicated Cloud Gateway network architect
 
 ## WAF
 
+{% include /sections/dcgw-waf-intro.md %}
 
+Kong strongly recommends configuring a WAF for public and private Dedicated Cloud Gateways. 
+WAF configuration differs for [public](/dedicated-cloud-gateways/public-network/) and [private](/dedicated-cloud-gateways/private-network/) deployments.
 
 ## Dedicated Cloud Gateway network CIDR range
 

--- a/app/dedicated-cloud-gateways/network-architecture.md
+++ b/app/dedicated-cloud-gateways/network-architecture.md
@@ -20,6 +20,8 @@ related_resources:
     url: /dedicated-cloud-gateways/public-network/
   - text: Multi-cloud Dedicated Cloud Gateway network architecture and security
     url: /dedicated-cloud-gateways/multi-cloud/
+  - text: "{{site.base_gateway}} WAF capabilities"
+    url: /waf/
 tags:
   - dedicated-cloud-gateways
 ---
@@ -139,6 +141,8 @@ For more information, see [Multi-cloud Dedicated Cloud Gateway network architect
 
 Kong strongly recommends configuring a WAF for public and private Dedicated Cloud Gateways. 
 WAF configuration differs for [public](/dedicated-cloud-gateways/public-network/) and [private](/dedicated-cloud-gateways/private-network/) deployments.
+
+For more information about all {{site.base_gateway}} WAF configurations and plugins, see [{{site.base_gateway}} WAF capabilities](/waf/).
 
 ## Dedicated Cloud Gateway network CIDR range
 

--- a/app/dedicated-cloud-gateways/network-architecture.md
+++ b/app/dedicated-cloud-gateways/network-architecture.md
@@ -1,0 +1,422 @@
+---
+title: "Dedicated Cloud Gateways network architecture"
+content_type: reference
+layout: reference
+description: "Dedicated Cloud Gateways are Data Plane nodes that are fully managed by Kong in {{site.konnect_short_name}}."
+
+products:
+    - gateway
+breadcrumbs:
+  - /dedicated-cloud-gateways/
+works_on:
+  - konnect
+
+faqs:
+  - q: 
+    a: 
+
+related_resources:
+  - text: Dedicated Cloud Gateways 
+    url: /dedicated-cloud-gateways/
+  - text: Serverless Gateways
+    url: /serverless-gateways/
+  - text: Private hosted zones
+    url: /dedicated-cloud-gateways/private-hosted-zones/
+  - text: Outbound DNS resolver
+    url: /dedicated-cloud-gateways/outbound-dns-resolver/
+next_steps:
+  - text: Dedicated Cloud Gateways production readiness checklist
+    url: /dedicated-cloud-gateways/production-readiness/
+tags:
+  - dedicated-cloud-gateways
+---
+
+In a Dedicated Cloud Gateway, Kong manages your data plane nodes for you in the cloud provider of your choice (AWS, GCP, Azure).
+A complete Dedicated Cloud Gateway deployment consists of this Kong-managed network infrastructure and the cloud infrastructure you manage.
+The Kong-managed infrastructure is automatically created in AWS, GCP, or Azure. 
+It consists of data plane nodes that run on a Kubernetes cluster inside of a Kong-managed network peering (VPC or VNET depending on your provider).
+The Kong-managed data plane nodes automatically scale with your throughput. 
+
+The following diagram shows what the Kong-managed architecture looks like if you chose AWS as your provider:
+
+{% mermaid %}
+flowchart LR
+    subgraph kong_account["Kong-managed AWS infra"]
+        subgraph kong_vpc["Kong-managed VPC"]
+            subgraph k8s["k8s cluster"]
+                dp1["<img src="/assets/icons/gateway.svg" style="max-height:20px"> Data plane node"]
+                dp2["<img src="/assets/icons/gateway.svg" style="max-height:20px"> Data plane node"]
+                dp3["<img src="/assets/icons/gateway.svg" style="max-height:20px"> Data plane node"]
+            end
+        end
+    end
+
+    style kong_account stroke-dasharray:3,rx:10,ry:10
+{% endmermaid %}
+
+In a Dedicated Cloud Gateway, the Kong-managed infrastructure would communicate with your own cloud infrastructure that contains your databases, APIs, and other resources.
+Your infrastructure can run on virtual machines (VMs), managed container platforms like ECS, Kubernetes managed pods, or a combination of multiple platforms.
+If the services are backed VMs or managed container platforms, Kong mostly expects you to expose them via load balancer. 
+If the services are in Kubernetes managed pods, they can either be exposed via a shared ingress or if only a small set of services need to be exposed, they can be directly exposed by a load balancer service.
+
+## Configure a Dedicated Cloud Gateway network
+
+You can configure a Dedicated Cloud Gateway network using the {{site.konnect_short_name}} UI, API, or Terraform.
+
+Before you create a Dedicated Cloud Gateway network, determine which CIDR range you want to use for your network.
+A CIDR block defines the range of IP addresses available for your Dedicated Cloud Gateway. If you're configuring private network connectivity, this CIDR block **must not** overlap with CIDR blocks assigned in your own cloud service provider networks to prevent conflicts.
+Keep in mind that your Dedicated Cloud Gateway network CIDR block must be large enough to cover the Kong infrastructure Kong will provision inside it, such as the data plane nodes, the DNS proxy, internal load balancers, and any other components Kong manages. 
+
+Keep the following CIDR requirements in mind when you're deciding your network CIDR range:
+* **Prefix length:** The CIDR block must have a prefix length between `/16` and `/23`. `/23` blocks are only supported up to 3 availability zones.
+* **Private IP Range:** The entire CIDR block must fall within one of these private IP ranges:
+  * 10.0.0.0/8
+  * 100.64.0.0/10
+  * 172.16.0.0/12
+  * 192.168.0.0/16
+  * 198.18.0.0/15
+  
+  {:.info}
+  > **Acceptable CIDR examples:**
+  > * 10.4.0.0/16
+  > * 100.68.0.0/20
+  > * 172.20.0.0/22
+  > * 192.168.128.0/18
+  > * 198.18.0.0/16
+* **No overlap with existing ranges:** Your CIDR block **must not** overlap with any IP ranges already in use by your organization. Overlapping ranges can prevent network peering from functioning correctly.
+* **No overlap with reserved CIDR blocks:** Your CIDR block must not overlap with these reserved ranges:
+  * 10.100.0.0/16
+  * 172.17.0.0/16
+
+{% navtabs "dcgw-network" %}
+{% navtab "UI" %}
+1. In the {{site.konnect_short_name}} sidebar, click **Network**.
+1. Click **New Network**.
+1. From the **Provider** dropdown menu, select the cloud provider you want to deploy your Dedicated Cloud Gateway in.
+1. From the **Region** dropdown menu, select the region you want to configure the cluster in. 
+1. In the **Network name** field, enter a unique display name for your network.
+1. In the **CIDR for Dedicated Cloud** field, enter your CIDR block.
+
+   {:.danger}
+   > **Important:** Your CIDR block **must not** overlap with any IP ranges already in use by your organization. Overlapping ranges can prevent network peering from functioning correctly. The default range is `10.0.0.0/16`, but this can be edited.
+1. Click **Save**.
+{% endnavtab %}
+{% navtab "API" %}
+1. Send a `GET` request to the `/cloud-gateways/provider-accounts` endpoint to get all cloud provider IDs:
+{% konnect_api_request %}
+url: /v2/cloud-gateways/provider-accounts
+method: GET
+headers:
+  - 'Accept: application/json, application/problem+json'
+{% endkonnect_api_request %}
+1. In the response, copy and export the ID for the cloud provider you want to use for your Dedicated Cloud Gateway network:
+   ```sh
+   export CLOUD_PROVIDER_ID='YOUR CLOUD PROVIDER ID'
+   ```
+1. Send a `POST` request to the `` endpoint to create your Dedicated Cloud Gateway network:
+{% konnect_api_request %}
+url: /v2/cloud-gateways/networks
+method: POST
+headers:
+  - 'Accept: application/json, application/problem+json'
+body:
+  name: "us-east-2 network"
+  cloud_gateway_provider_account_id: "$CLOUD_PROVIDER_ID"
+  region: "us-east-2"
+  availability_zones:
+    - "use2-az1"
+    - "use2-az2"
+    - "use2-az3"
+  cidr_block: "10.4.0.0/16"
+{% endkonnect_api_request %}
+{% endnavtab %}
+{% navtab "Terraform" %}
+[Create a Dedicated Cloud Gateway network](https://github.com/Kong/terraform-provider-konnect/blob/main/examples/scenarios/cloud-gateways.tf):
+
+```hcl
+echo '
+data "konnect_cloud_gateway_provider_account_list" "my_cloudgatewayprovideraccountlist" {
+  page_number = 1
+  page_size   = 1
+}
+
+resource "konnect_cloud_gateway_network" "my_cloudgatewaynetwork" {
+  name   = "Terraform Network"
+  region = "eu-west-1"
+  availability_zones = [
+    "euw1-az1",
+    "euw1-az2",
+    "euw1-az3"
+  ]
+
+  cidr_block      = "10.4.0.0/16"
+
+  cloud_gateway_provider_account_id = data.konnect_cloud_gateway_provider_account_list.my_cloudgatewayprovideraccountlist.data[0].id
+}
+' >> main.tf
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+{:.warning}
+> **Important:** It can take 30-40 minutes for your network to initialize. 
+> You **must** wait for your network to display as `Ready` before you can configure private networking. 
+
+## Public vs private
+
+You can choose to have a private or public Dedicated Cloud Gateway, or use both public and private.
+* **Public:** Use public if all your proxy traffic is public.
+* **Private:** Use private if all your proxy traffic is private.
+* **Public and private:** Use both a public and private Dedicated Cloud Gateway if some of your traffic is public-facing and other traffic is private.
+
+The following table describes which cloud providers and private networking configurations are supported:
+
+{% table %}
+columns:
+  - title: Feature
+    key: feature
+  - title: AWS
+    key: aws
+  - title: GCP
+    key: gcp
+  - title: Azure
+    key: azure
+rows:
+  - feature: Public Dedicated Cloud Gateway
+    aws: "Y"
+    gcp: "Y"
+    azure: "Y"
+  - feature: Private network peering
+    aws: "Yes (VPC)"
+    gcp: "Yes (VPC)"
+    azure: "Yes (VNET)"
+  - feature: Private hub-and-spoke network
+    aws: "Yes (TGW)"
+    gcp: "No"
+    azure: "Yes (VWAN)"
+  - feature: Private endpoints
+    aws: "Yes (resource endpoints)"
+    gcp: "No"
+    azure: "No"
+{% endtable %}
+
+## Public architecture and connectivity
+
+When a Dedicated Cloud Gateway (DCGW) proxies traffic to upstream services over
+the public internet, you need security controls across the full request path —
+validating who can call your APIs, and ensuring your upstream services can trust
+that requests genuinely originate from Kong.
+
+This page covers controls at both layers and how to combine them for defense in
+depth.
+
+{:.note}
+> This page covers security controls for public internet upstream connectivity.
+> Some controls (mTLS Auth, OIDC) validate inbound API consumers before
+> requests reach your upstream. Others (upstream mTLS, shared secrets) authenticate
+> Kong to your upstream service. For securing the inbound entry point itself,
+> see [WAF and CDN integration with Dedicated Cloud Gateways](/).
+
+Public internet connectivity between Kong and your upstream services is
+appropriate when:
+
+- Your upstream services are already internet-facing (for example, SaaS
+  backends or services shared across business units without private networking)
+- Traffic volume doesn't justify the operational overhead of private network
+  peering
+- Your security model relies on application-layer controls rather than
+  network-layer isolation
+
+For workloads with stricter isolation requirements, consider
+[private upstream connectivity](#private-architecture-and-connectivity)
+instead.
+
+Kong data planes egress to your upstream services over the public internet.
+Konnect exposes **static egress IP addresses** for each DCGW network in the
+Konnect UI. You allowlist these IPs at your firewall or load balancer so that
+only Kong proxy traffic can reach your backends.
+
+IP allowlisting alone is a network-layer control — it restricts *who* can
+send traffic, not *what* the traffic contains or *who* sent it at the
+application layer. For production workloads, combine it with one or more of
+the controls below.
+
+### Securing public
+
+These controls are complementary. A robust public internet configuration
+typically combines multiple layers:
+
+| Layer | Control | Protects against |
+|---|---|---|
+| Network | Egress IP allowlisting | Unauthorized source IPs |
+| Transport | Upstream mTLS | Impersonation, MITM |
+| Application | Shared secret header | Bypassed IP rules |
+| Application | OIDC / JWT validation | Unauthorized callers |
+
+A minimal production configuration for sensitive services: **egress IP
+allowlisting + upstream mTLS**.
+
+A configuration for services that cannot do mTLS: **egress IP allowlisting +
+shared secret + OIDC**.
+
+Customer requirements:
+| Task | Your responsibility |
+|---|---|
+| Retrieve egress IPs | Konnect UI → your DCGW → **Connect** → Public Egress IPs |
+| Allowlist egress IPs | Cloud security groups, firewall rules, or load balancer ACLs |
+| Issue TLS certificates for mTLS | Provision a CA and issue certificates to Kong and your upstream services |
+| Store shared secrets | Use Konnect vault references or your secrets manager |
+| Configure identity provider for OIDC | Set up an IdP and issue credentials for Kong's OIDC plugin |
+
+#### Egress IP allowlisting
+
+Konnect exposes the static egress IP addresses for your DCGW network in the
+Konnect UI. Configure your upstream firewall,
+security group, or load balancer to accept inbound connections from these IPs
+only.
+
+This ensures that even if a service is publicly accessible, only your Kong data
+planes can call it.
+
+{:.note}
+> Egress IPs are scoped per DCGW network and per region. If you operate
+> multiple DCGW networks, allowlist the egress IPs from each relevant network.
+
+**Steps:**
+
+1. In Konnect, navigate to your DCGW and click **Connect**. The egress IP
+   addresses are listed under **Public Egress IPs**.
+2. In your cloud provider console, add inbound rules to your upstream service's
+   security group or firewall to allow traffic from those IP ranges on the
+   relevant port (typically 443 or 80).
+3. Restrict inbound traffic on that port to the allowlisted IPs, in addition
+   to any other legitimately permitted sources.
+
+
+#### Mutual TLS (mTLS)
+
+Mutual TLS authenticates both the Kong data plane and your upstream service
+cryptographically. The upstream rejects any connection that doesn't present a
+valid certificate, regardless of source IP. This provides a strong identity
+guarantee even if an IP allowlist is bypassed or shared with another system.
+
+Kong supports two mTLS modes for upstream connections:
+
+##### Upstream mTLS
+
+Kong presents a client certificate to your upstream service when establishing
+the connection. Configure this on the Kong Service object by referencing a
+certificate stored in Konnect via the `client_certificate` field.
+
+Example service configuration using decK:
+
+```yaml
+services:
+  - name: my-service
+    url: https://api.internal.example.com
+    client_certificate:
+      id: <cert-uuid>
+    tls_verify: true
+    ca_certificates:
+      - <ca-cert-uuid>
+```
+
+Your upstream verifies Kong's client certificate against a known CA before
+accepting the connection.
+
+##### Inbound mTLS with the mTLS Auth plugin
+
+The [mTLS Auth plugin](https://developer.konghq.com/plugins/mtls-auth/)
+validates client certificates presented *to* Kong from downstream API
+consumers. Use this when your consumers must also authenticate with
+certificates, creating end-to-end mutual authentication.
+
+For services handling sensitive data, combine upstream mTLS with egress IP
+allowlisting for defense in depth.
+
+
+
+#### Shared secrets with the Request Transformer plugin
+
+If your upstream service cannot terminate mTLS but you need a lightweight way
+to verify that requests originate from Kong, inject a shared secret header
+using the [Request Transformer plugin](https://developer.konghq.com/plugins/request-transformer/).
+
+Example plugin configuration:
+
+```yaml
+plugins:
+  - name: request-transformer
+    config:
+      add:
+        headers:
+          - "x-kong-origin-verify:{vault://env/KONG_SHARED_SECRET}"
+```
+
+{:.note}
+> Replace `env/KONG_SHARED_SECRET` with the path matching your configured
+> vault backend (`hcv`, `aws`, `gcp`, or `env`). See the
+> [Secrets management documentation](https://developer.konghq.com/gateway/secrets-management/)
+> for vault configuration options.
+
+Your upstream service validates the presence and value of this header before
+processing the request. If the header is absent or incorrect, the upstream
+rejects the request.
+
+**Security practices:**
+
+- Store the secret as a Konnect vault reference, not as a plaintext value
+- Rotate the secret on a regular schedule
+- Combine with egress IP allowlisting so the header alone is not the only
+  control
+
+
+#### Token-based authentication with OpenID Connect
+
+For APIs where caller identity matters beyond network origin, use the
+[OpenID Connect plugin](https://developer.konghq.com/plugins/openid-connect/)
+to validate JWTs or opaque tokens before forwarding requests upstream.
+
+Kong validates the token at the gateway and can forward claims to your upstream
+as headers, so your backend receives a verified identity without needing to
+perform its own token validation.
+
+This is particularly useful when:
+
+- Upstream services are shared across multiple calling systems
+- You want Kong to act as the centralized token validation and enforcement point
+- You need fine-grained authorization based on token claims (scopes, roles,
+  tenant ID)
+
+## Private architecture and connectivity
+
+When you want a private connection from your Dedicated Cloud Gateway to your managed cloud infrastructure, you can choose different bridging options depending on your use case:
+
+Private network peering: 
+Private hub-and-spoke network:
+Private endpoints:
+
+### Private network peering
+
+### Private hub-and-spoke network
+
+### Private endpoints
+
+AWS resource endpoints
+
+### Securing private
+
+
+
+## Multi-cloud architecture
+
+blah
+
+use case about when certain ones are recommended
+
+### Single Global Hostname (Geo‑Proximity DNS)
+
+### Cloud‑Specific Hostnames (Recommended Default)
+
+### Single Hostname + L7 Edge
+

--- a/app/dedicated-cloud-gateways/private-network.md
+++ b/app/dedicated-cloud-gateways/private-network.md
@@ -38,11 +38,11 @@ All inbound traffic must arrive through your own edge infrastructure over a priv
 Your CDN, WAF, or Application Load Balancer terminates public traffic and handles TLS, then forwards requests to the {{site.base_gateway}} data plane using its private IP address. 
 The data plane has no public listener and is unreachable from the internet directly.
 
-Use a private Dedicated Cloud Gateway when:
-- Your upstream services are on one or more private networks (VPC or VNet)
-- You don't expose services to the public internet
-- You require network isolation or full edge control
-- You operate under regulated security requirements
+Use a private Dedicated Cloud Gateway when you:
+- Deploy upstream services on one or more private networks (VPC or VNet)
+- Don't expose services to the public internet
+- Require network isolation or full edge control
+- Operate under regulated security requirements
 
 {:.info}
 > **Note:** The inbound path (your edge to the Dedicated Cloud Gateway) and the upstream path (the Dedicated Cloud Gateway to your backend services) are independent network hops and can use different connectivity methods. 
@@ -249,7 +249,8 @@ There are two DNS options for private Dedicated Cloud Gateways depending on wher
 
 {% include /sections/dcgw-waf-intro.md %}
 
-Kong strongly recommends configuring a WAF for private Dedicated Cloud Gateways.
+{:.warning}
+> Kong strongly recommends configuring a WAF for private Dedicated Cloud Gateways.
 
 ### AWS WAF
 

--- a/app/dedicated-cloud-gateways/private-network.md
+++ b/app/dedicated-cloud-gateways/private-network.md
@@ -107,7 +107,7 @@ rows:
 > Dedicated Cloud Gateway data plane private IP addresses are static. 
 > You can retrieve them from the {{site.konnect_short_name}} UI or API to use as targets in your ALB target group or firewall rules.
 
-## Network peering
+### Network peering
 
 Network peering establishes a direct, private connection between the {{site.konnect_short_name}}-managed network and a single VPC or VNet in your cloud account. 
 Traffic routes over the cloud provider's internal network without traversing the public internet. 
@@ -164,7 +164,7 @@ After you've configured network peering in {{site.konnect_short_name}}, do the f
 - Configure security groups or network security group rules to allow inbound traffic from the {{site.base_gateway}} data plane private IPs on your service ports.
 - Configure private DNS so {{site.base_gateway}} can resolve your service hostnames to private IPs.
 
-## Hub-and-spoke network
+### Hub-and-spoke network
 
 A hub-and-spoke network uses a centrally managed hub that all networks connect to once. 
 The hub handles routing between all attached networks, so a single connection from the {{site.konnect_short_name}}-managed network can reach services across multiple VPCs or VNets without requiring individual peering connections to each one. 
@@ -182,7 +182,7 @@ After you've configured the hub-and-spoke network in {{site.konnect_short_name}}
 - Configure security groups or network security group rules to allow inbound traffic from {{site.base_gateway}} data plane private IPs on your service ports.
 - Configure private DNS so {{site.base_gateway}} can resolve your service hostnames to private IPs.
 
-## Private endpoints
+### Private endpoints
 
 Private endpoints provide one-way private connectivity from the {{site.konnect_short_name}}-managed network to resources in your AWS account using AWS VPC Lattice resource configurations. 
 There's no VPC-level network access, only what you explicitly expose via a resource configuration is reachable from the {{site.konnect_short_name}}-managed network. 
@@ -244,3 +244,5 @@ There are two DNS options for private Dedicated Cloud Gateways depending on wher
 - **Outbound DNS resolver:** Use this when your DNS records live on an on-premises or self-managed DNS server outside your cloud provider. 
   DNS traffic travels through your VPC peering or Transit Gateway connection. 
   See [Outbound DNS resolver](/dedicated-cloud-gateways/outbound-dns-resolver/).
+
+## WAF

--- a/app/dedicated-cloud-gateways/private-network.md
+++ b/app/dedicated-cloud-gateways/private-network.md
@@ -246,3 +246,49 @@ There are two DNS options for private Dedicated Cloud Gateways depending on wher
   See [Outbound DNS resolver](/dedicated-cloud-gateways/outbound-dns-resolver/).
 
 ## WAF
+
+{% include /sections/dcgw-waf-intro.md %}
+
+Kong strongly recommends configuring a WAF for private Dedicated Cloud Gateways.
+
+### AWS WAF
+
+In a private deployment, your Application Load Balancer (ALB) is the internet-facing entry point. 
+AWS WAF attaches directly to the ALB and inspects all inbound HTTP(S) traffic before it reaches your Dedicated Cloud Gateway.
+Traffic flows from the ALB to the Dedicated Cloud Gateway's static private IP addresses over your private network connection (VPC peering or Transit Gateway).
+
+To configure AWS WAF for a private Dedicated Cloud Gateway:
+
+1. [Create an internet-facing ALB](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-application-load-balancer.html) in your AWS account.
+1. [Create an AWS WAF Web ACL](https://docs.aws.amazon.com/waf/latest/developerguide/web-acl-creating.html) and associate it with the ALB.
+   Configure [AWS managed rule groups](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups.html) and any custom rules you need, such as IP blocklists or rate limiting.
+1. [Create a target group](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-target-group.html) with the following settings:
+   * **Target type:** IP
+   * **Targets:** The static private IP addresses of your Dedicated Cloud Gateway data plane nodes. 
+     You can find these by sending a GET request to the [`/cloud-gateways/configurations` endpoint](/api/konnect/cloud-gateways/v2/#/operations/list-configurations). 
+1. Configure ALB listener rules based on host headers and path patterns to route traffic to the correct target group.
+1. [Enable HTTPS](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/create-https-listener.html) on your ALB listener using AWS Certificate Manager (ACM).
+1. Ensure your [VPC peering](/dedicated-cloud-gateways/aws-vpc-peering/) or [Transit Gateway](/dedicated-cloud-gateways/transit-gateways/) route tables are updated to direct ALB traffic to the Dedicated Cloud Gateway private IP addresses.
+1. Validate connectivity by sending a test request to the ALB DNS name and confirming it routes through WAF, the ALB, and the Dedicated Cloud Gateway to your upstream API.
+
+Optionally, enable [AWS Shield Advanced](https://docs.aws.amazon.com/waf/latest/developerguide/shield-chapter.html) on the ALB for DDoS mitigation.
+
+### Azure WAF
+
+In a private deployment, Azure Front Door Premium acts as the internet-facing entry point with a built-in WAF policy.
+Traffic flows from Azure Front Door to an Internal Load Balancer (ILB) in your Azure VNet over Private Link, then reaches the Dedicated Cloud Gateway over VNet peering.
+
+To configure Azure WAF for a private Dedicated Cloud Gateway:
+
+1. [Deploy Azure Front Door Premium](https://learn.microsoft.com/en-us/azure/frontdoor/create-front-door-portal) with a custom domain for your APIs.
+1. Configure a [WAF policy](https://learn.microsoft.com/en-us/azure/web-application-firewall/afds/waf-front-door-create-portal) on the Front Door profile.
+   Include managed rulesets such as OWASP 3.2 and any custom rules for IP allow/deny, rate limiting, or bot control.
+   Set the mode to **Prevention** for production or **Detection** when testing rules.
+1. [Create an Internal Load Balancer](https://learn.microsoft.com/en-us/azure/load-balancer/quickstart-load-balancer-standard-internal-portal) in your Azure VNet.
+   Add the static private IP addresses of your Dedicated Cloud Gateway data plane nodes as backend targets.
+   You can find these by sending a GET request to the [`/cloud-gateways/configurations` endpoint](/api/konnect/cloud-gateways/v2/#/operations/list-configurations).
+1. [Enable Private Link](https://learn.microsoft.com/en-us/azure/frontdoor/private-link) for the Front Door origin configuration.
+   Azure Front Door creates a managed private endpoint that connects to the ILB over Microsoft's private backbone network.
+1. Ensure your [VNet peering](/dedicated-cloud-gateways/azure-peering/) or [Virtual WAN](/dedicated-cloud-gateways/azure-virtual-wan/) connection is configured between your VNet and the {{site.konnect_short_name}}-managed VNet.
+   Update your Network Security Group (NSG) rules and route tables to allow inbound traffic from the ILB subnet to the Dedicated Cloud Gateway private IP addresses.
+1. Validate connectivity by making test API calls from Azure Front Door through to your upstream API and confirming end-to-end request flow.

--- a/app/dedicated-cloud-gateways/private-network.md
+++ b/app/dedicated-cloud-gateways/private-network.md
@@ -24,6 +24,8 @@ related_resources:
     url: /dedicated-cloud-gateways/private-hosted-zones/
   - text: Outbound DNS resolver
     url: /dedicated-cloud-gateways/outbound-dns-resolver/
+  - text: "{{site.base_gateway}} WAF capabilities"
+    url: /waf/
 next_steps:
   - text: Dedicated Cloud Gateways production readiness checklist
     url: /dedicated-cloud-gateways/production-readiness/
@@ -251,6 +253,8 @@ There are two DNS options for private Dedicated Cloud Gateways depending on wher
 
 {:.warning}
 > Kong strongly recommends configuring a WAF for private Dedicated Cloud Gateways.
+
+For more information about all {{site.base_gateway}} WAF configurations and plugins, see [{{site.base_gateway}} WAF capabilities](/waf/).
 
 ### AWS WAF
 

--- a/app/dedicated-cloud-gateways/private-network.md
+++ b/app/dedicated-cloud-gateways/private-network.md
@@ -1,0 +1,246 @@
+---
+title: "Dedicated Cloud Gateways private network architecture and security"
+content_type: reference
+layout: reference
+description: "Learn about private Dedicated Cloud Gateway network architecture, connectivity options, and how to secure your private network."
+
+products:
+    - gateway
+breadcrumbs:
+  - /dedicated-cloud-gateways/
+works_on:
+  - konnect
+
+related_resources:
+  - text: Dedicated Cloud Gateways
+    url: /dedicated-cloud-gateways/
+  - text: Dedicated Cloud Gateways network architecture
+    url: /dedicated-cloud-gateways/network-architecture/
+  - text: Dedicated Cloud Gateways public network architecture and security
+    url: /dedicated-cloud-gateways/public-network/
+  - text: Multi-cloud Dedicated Cloud Gateway network architecture
+    url: /dedicated-cloud-gateways/multi-cloud/
+  - text: Private hosted zones
+    url: /dedicated-cloud-gateways/private-hosted-zones/
+  - text: Outbound DNS resolver
+    url: /dedicated-cloud-gateways/outbound-dns-resolver/
+next_steps:
+  - text: Dedicated Cloud Gateways production readiness checklist
+    url: /dedicated-cloud-gateways/production-readiness/
+tags:
+  - dedicated-cloud-gateways
+---
+
+
+In private mode, Dedicated Cloud Gateway endpoints have private IP addresses only. 
+There's no public listener. 
+All inbound traffic must arrive through your own edge infrastructure over a private network connection. 
+Your CDN, WAF, or Application Load Balancer terminates public traffic and handles TLS, then forwards requests to the {{site.base_gateway}} data plane using its private IP address. 
+The data plane has no public listener and is unreachable from the internet directly.
+
+Use a private Dedicated Cloud Gateway when:
+- Your upstream services are on one or more private networks (VPC or VNet)
+- You don't expose services to the public internet
+- You require network isolation or full edge control
+- You operate under regulated security requirements
+
+{:.info}
+> **Note:** The inbound path (your edge to the Dedicated Cloud Gateway) and the upstream path (the Dedicated Cloud Gateway to your backend services) are independent network hops and can use different connectivity methods. 
+> For example, your edge may reach the Dedicated Cloud Gateway over a Transit Gateway while the Dedicated Cloud Gateway reaches upstream services over a separate VNet peering connection.
+
+## Private connectivity options
+
+When you want a private connection from your Dedicated Cloud Gateway to your managed cloud infrastructure, you can choose from three connectivity types depending on your use case:
+
+{% table %}
+columns:
+  - title: Connectivity type
+    key: type
+  - title: Use when
+    key: when
+  - title: Supported clouds
+    key: clouds
+rows:
+  - type: "[Network peering](#network-peering)"
+    when: |
+      * Your upstream services are in a single VPC or VNet
+      * You want a direct, low-overhead connection without a transit hub
+      * Your CIDR ranges don't overlap
+    clouds: AWS, Azure, GCP
+  - type: "[Hub-and-spoke network](#hub-and-spoke-network)"
+    when: |
+      * Your upstream services are spread across multiple VPCs or VNets, including across accounts
+      * You want a scalable, centrally managed connectivity model
+      * You already operate a hub-and-spoke network topology
+    clouds: AWS, Azure
+  - type: "[Private endpoints](#private-endpoints)"
+    when: |
+      * Your security model requires a defined network boundary
+      * You want to avoid VPC-level peering while still connecting to one or many upstream services
+      * Your upstreams sit behind ALBs or other load balancers that handle L7 routing
+    clouds: AWS
+{% endtable %}
+
+Your team is responsible for the following components regardless of which connectivity type you use:
+
+{% table %}
+columns:
+  - title: Component
+    key: component
+  - title: Your responsibility
+    key: responsibility
+rows:
+  - component: Public entry point
+    responsibility: CDN, WAF, or ALB in your cloud account
+  - component: TLS termination
+    responsibility: At your edge (with re-origination to {{site.base_gateway}}) or L4 passthrough directly to {{site.base_gateway}}
+  - component: Private connectivity
+    responsibility: VPC peering, Transit Gateway, VNet peering, or Virtual Hub to the {{site.konnect_short_name}}-managed network
+  - component: DNS
+    responsibility: CNAME from your hostname to your edge, not directly to {{site.base_gateway}}
+  - component: Firewall rules
+    responsibility: Allow your edge to reach Dedicated Cloud Gateway private IPs on the gateway port
+{% endtable %}
+
+{:.info}
+> **Dedicated Cloud Gateway private IPs:**
+> Dedicated Cloud Gateway data plane private IP addresses are static. 
+> You can retrieve them from the {{site.konnect_short_name}} UI or API to use as targets in your ALB target group or firewall rules.
+
+## Network peering
+
+Network peering establishes a direct, private connection between the {{site.konnect_short_name}}-managed network and a single VPC or VNet in your cloud account. 
+Traffic routes over the cloud provider's internal network without traversing the public internet. 
+{{site.konnect_short_name}} initiates the peering request from the managed network. 
+You accept it in your cloud account and update your route tables to route traffic across the peering connection.
+
+The following diagram shows an example of a VPC peering network:
+<!--vale off -->
+{% mermaid %}
+flowchart LR
+
+A(API or Service)
+B(API or Service)
+C(API or Service)
+E(<img src="/assets/icons/aws.svg" style="max-height:32px" class="no-image-expand"/> AWS VPC peering)
+G(<img src="/assets/logos/konglogo-gradient-secondary.svg" style="max-height:32px" class="no-image-expand"/>Konnect #40;fully-managed Data Plane#41;)
+H(<img src="/assets/logos/konglogo-gradient-secondary.svg" style="max-height:32px" class="no-image-expand"/>Konnect #40;fully-managed Data Plane#41;)
+I(<img src="/assets/logos/konglogo-gradient-secondary.svg" style="max-height:32px" class="no-image-expand"/>Konnect #40;fully-managed Data Plane#41;)
+J(Internet)
+
+subgraph 1 [User AWS Cloud]
+    subgraph 2 [Region]
+        subgraph 3 [Virtual Private Cloud #40;VPC#41;]
+        A
+        B
+        C
+        end
+        A & B & C <--> E
+    end
+end
+
+subgraph 4 [Kong AWS Cloud]
+    subgraph 5 [Region]
+        E <--private API access--> G & H & I
+        subgraph 6 [Virtual Private Cloud #40;VPC#41;]
+        G
+        H
+        I
+        end
+    end
+end
+
+G & H & I <--public API access--> J
+{% endmermaid %}
+<!--vale on-->
+
+To set up network peering, use the following tutorials:
+* [Set up an AWS VPC peering connection](/dedicated-cloud-gateways/aws-vpc-peering/)
+* [Set up a GCP VPC peering connection](/dedicated-cloud-gateways/gcp-vpc-peering/)
+* [Configure an Azure Dedicated Cloud Gateway with VNET peering](/dedicated-cloud-gateways/azure-peering/)
+
+After you've configured network peering in {{site.konnect_short_name}}, do the following:
+- Update your route tables to route the {{site.konnect_short_name}}-managed network CIDR via the peering connection.
+- Configure security groups or network security group rules to allow inbound traffic from the {{site.base_gateway}} data plane private IPs on your service ports.
+- Configure private DNS so {{site.base_gateway}} can resolve your service hostnames to private IPs.
+
+## Hub-and-spoke network
+
+A hub-and-spoke network uses a centrally managed hub that all networks connect to once. 
+The hub handles routing between all attached networks, so a single connection from the {{site.konnect_short_name}}-managed network can reach services across multiple VPCs or VNets without requiring individual peering connections to each one. 
+Route tables on the hub let you define precisely which networks can communicate with each other, limiting {{site.base_gateway}}'s reachability to specific networks.
+
+The following diagram shows an example of a transit gateway hub-and-spoke network:
+{% include diagrams/dcgw-tgw.md %}
+
+To set up a hub-and-spoke network, use the following tutorials:
+* [AWS Transit Gateway peering](/dedicated-cloud-gateways/transit-gateways/)
+* [Configure an Azure Dedicated Cloud Gateway with virtual WAN](/dedicated-cloud-gateways/azure-virtual-wan/)
+
+After you've configured the hub-and-spoke network in {{site.konnect_short_name}}, do the following:
+- Update your route tables to route traffic between the {{site.konnect_short_name}}-managed network CIDR and your spoke networks.
+- Configure security groups or network security group rules to allow inbound traffic from {{site.base_gateway}} data plane private IPs on your service ports.
+- Configure private DNS so {{site.base_gateway}} can resolve your service hostnames to private IPs.
+
+## Private endpoints
+
+Private endpoints provide one-way private connectivity from the {{site.konnect_short_name}}-managed network to resources in your AWS account using AWS VPC Lattice resource configurations. 
+There's no VPC-level network access, only what you explicitly expose via a resource configuration is reachable from the {{site.konnect_short_name}}-managed network. 
+A resource configuration can be a single endpoint or a group configuration with multiple child resource configurations, each pointing to a different service endpoint.
+
+The following diagram shows an example of an AWS resource endpoint connection:
+<!--vale off -->
+{% mermaid %}
+flowchart LR
+
+A(API or Service)
+B(API or Service)
+C(API or Service)
+E(<img src="/assets/icons/aws.svg" style="max-height:32px" class="no-image-expand"/> AWS Resource Endpoint)
+G(<img src="/assets/logos/konglogo-gradient-secondary.svg" style="max-height:32px" class="no-image-expand"/>Konnect #40;fully-managed Data Plane#41;)
+H(<img src="/assets/logos/konglogo-gradient-secondary.svg" style="max-height:32px" class="no-image-expand"/>Konnect #40;fully-managed Data Plane#41;)
+I(<img src="/assets/logos/konglogo-gradient-secondary.svg" style="max-height:32px" class="no-image-expand"/>Konnect #40;fully-managed Data Plane#41;)
+J(Internet)
+
+subgraph 1 [User AWS Cloud]
+    subgraph 2 [Region]
+        subgraph 3 [Virtual Private Cloud #40;VPC#41;]
+        A
+        B
+        C
+        end
+        A & B & C --- E
+    end
+end
+
+subgraph 4 [Kong AWS Cloud]
+    subgraph 5 [Region]
+        E --private API access--> G & H & I
+        subgraph 6 [Virtual Private Cloud #40;VPC#41;]
+        G
+        H
+        I
+        end
+    end
+end
+
+G & H & I <--public API access--> J
+{% endmermaid %}
+<!--vale on-->
+
+To set up private endpoints, use the [Set up an AWS resource endpoint connection](/dedicated-cloud-gateways/aws-resource-endpoints/) tutorial.
+
+After you've set up the AWS resource endpoint in {{site.konnect_short_name}}, ensure your service is reachable via the configured domain name within the shared resource.
+
+## DNS for private upstream services
+
+Regardless of the connectivity type you use, {{site.base_gateway}} must be able to resolve your upstream service hostnames to private IP addresses. 
+Using private IPs directly in service configuration is possible but not recommended for services that require TLS, since certificates are typically issued to hostnames, not IPs.
+
+There are two DNS options for private Dedicated Cloud Gateways depending on where your authoritative DNS records live:
+- **Private hosted zone:** Use this when your DNS records live in your cloud provider's managed DNS service. 
+  DNS traffic travels over the cloud provider's backbone network. 
+  See [Private hosted zones](/dedicated-cloud-gateways/private-hosted-zones/).
+- **Outbound DNS resolver:** Use this when your DNS records live on an on-premises or self-managed DNS server outside your cloud provider. 
+  DNS traffic travels through your VPC peering or Transit Gateway connection. 
+  See [Outbound DNS resolver](/dedicated-cloud-gateways/outbound-dns-resolver/).

--- a/app/dedicated-cloud-gateways/public-network.md
+++ b/app/dedicated-cloud-gateways/public-network.md
@@ -138,16 +138,16 @@ We recommend creating and securing your public Dedicated Cloud Gateway in the fo
 1. *Before* creating Gateway Services and Routes, create the Dedicated Cloud Gateway network and control plane in {{site.konnect_short_name}}.
    The network will be scanned, but since there aren't any Routes, scanners get 404s or connection resets. 
 2. Configure your CDN/WAF in front of the Kong NLB before you configure any Routes or Services. 
-1. Allowlist the Dedicated Cloud Gateway network egress IPs.
-3. Configure the IP Restriction plugin globally (allowlisting your CDN's egress IPs) so that even if someone hits the Kong NLB directly, they get rejected before any Route matching happens.
-4. Configure your Routes and Services pointing to real upstreams.
+3. Allowlist the Dedicated Cloud Gateway network egress IPs.
+4. Configure the IP Restriction plugin globally (allowlisting your CDN's egress IPs) so that even if someone hits the Kong NLB directly, they get rejected before any Route matching happens.
+5. Configure your Routes and Services pointing to real upstreams.
 
 ### WAF
 
 {% include /sections/dcgw-waf-intro.md %}
 
 Kong strongly recommends configuring a WAF for public Dedicated Cloud Gateways. 
-WAF configuration differs for [public](/dedicated-cloud-gateways/public-network/) deployments.
+WAF configuration differs for public deployments.
 
 Public Dedicated Cloud Gateways are exposed via a Kong-managed NLB with a public FQDN.
 Most WAF services can't attach directly to a network-layer load balancer (NLB) because NLBs operate at Layer 4 and don't terminate HTTP. 

--- a/app/dedicated-cloud-gateways/public-network.md
+++ b/app/dedicated-cloud-gateways/public-network.md
@@ -144,6 +144,25 @@ We recommend creating and securing your public Dedicated Cloud Gateway in the fo
 
 ### WAF
 
+{% include /sections/dcgw-waf-intro.md %}
+
+Kong strongly recommends configuring a WAF for public Dedicated Cloud Gateways. 
+WAF configuration differs for [public](/dedicated-cloud-gateways/public-network/) deployments.
+
+Public Dedicated Cloud Gateways are exposed via a Kong-managed NLB with a public FQDN.
+Most WAF services can't attach directly to a network-layer load balancer (NLB) because NLBs operate at Layer 4 and don't terminate HTTP. 
+WAF inspection requires HTTP visibility, which means the WAF must sit at an HTTP-aware layer, like a CDN distribution, an Application Load Balancer, or a cloud edge service.
+
+Additionally, because the Kong-managed NLB exposes a DNS hostname instead of an IP address, you can't chain another public load balancer in front of it (most ALB and cloud LB target groups don't support DNS-based targets).
+Instead, you must use a CDN because it natively supports DNS-based origins and can attach WAF policies at the distribution level.
+
+Examples of CDN or edge services that support this pattern:
+- Amazon CloudFront with AWS WAF
+- Azure Front Door with Azure WAF
+- Cloudflare (WAF built in)
+- Fastly with Next-Gen WAF
+
+The following diagram shows how traffic flows through a public Dedicated Cloud Gateway with an AWS WAF:
 <!--vale off -->
 {% mermaid %}
 sequenceDiagram
@@ -172,7 +191,42 @@ sequenceDiagram
 {% endmermaid %}
 <!--vale on -->
 
+In this model:
+* CloudFront acts as the public edge entry point.
+* AWS WAF is attached to the CloudFront distribution.
+* The CloudFront origin is the Dedicated Cloud Gateway public DNS edge (public FQDN).
+* The Kong-managed NLB receives traffic from CloudFront and forwards it to the gateway data planes.
 
+This is the standard AWS-native pattern for protecting publicly accessible services behind an NLB.
+
+The sections in this guide describe how to configure a WAF in AWS, but they can be adapted for Azure and GCP.
+
+### Configure AWS WAF
+
+When a Dedicated Cloud Gateway is deployed in public mode, it exposes a public FQDN backed by a Kong-managed Network Load Balancer. 
+Without additional controls, clients could attempt to access this public endpoint directly and bypass CloudFront and AWS WAF protections.
+
+To ensure all traffic passes through CloudFront, configure origin validation between CloudFront and Kong:
+1. Configure CloudFront to inject a [custom origin header](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/add-origin-custom-headers.html). For example: `X-Origin-Verify: <shared-secret-value>`.
+1. Configure your Dedicated Cloud Gateway to require the header. You can do this in two different ways:
+   * Route-level header matching. For example:
+     
+     ```yaml
+     routes:
+      - name: my-route
+        paths:
+          - /anything
+        headers:
+          x-origin-verify:
+            - your-secret-value
+     ```
+   * Use a plugin, like [Pre-Function](/plugins/pre-function/) or [Request Termination](/plugins/request-termination/)
+1. Reject requests that don't include the expected header value.
+1. Store the shared header value securely, like in a [Vault](/gateway/entities/vault/), and rotate the shared secret periodically.
+1. If your CDN publishes static egress IP ranges, configure the [IP Restriction](/plugins/ip-restriction/examples/allow/) plugin globally (allowlisting your CDN's egress IPs). 
+   Requests arriving from IPs outside the CDN's published ranges are rejected at the Kong layer before any route matching occurs. 
+   Some CDNs that publish static egress IP ranges include CloudFront, Cloudflare, Azure Front Door, and Fastly.
+1. Combine origin validation with [AWS WAF managed rules](https://docs.aws.amazon.com/waf/latest/developerguide/aws-managed-rule-groups.html) and [rate limiting](https://docs.aws.amazon.com/waf/latest/developerguide/waf-rule-statement-type-rate-based-request-limiting.html) for layered protection.
 
 ### Egress IP allowlisting
 

--- a/app/dedicated-cloud-gateways/public-network.md
+++ b/app/dedicated-cloud-gateways/public-network.md
@@ -46,7 +46,7 @@ Kong data planes egress to your upstream services over the public internet.
 You must allowlist these IPs at your firewall or load balancer so that only Kong proxy traffic can reach your backends.
 
 The following diagram shows how the architecture of a public Dedicated Cloud Gateway:
-
+<!--vale off-->
 {% mermaid %}
 flowchart LR
     subgraph kong_account["Cloud provider"]
@@ -79,6 +79,7 @@ flowchart LR
 
     style kong_account stroke-dasharray:3,rx:10,ry:10
 {% endmermaid %}
+<!--vale on-->
 
 ## Security controls
 
@@ -148,7 +149,7 @@ You must configure your upstream firewall, security group, or load balancer to a
 This ensures that even if a Service is publicly accessible, only your Kong data
 planes can call it.
 
-{:.note}
+{:.info}
 > Egress IPs are scoped per Dedicated Cloud Gateway network and per region. 
 > If you use multiple Dedicated Cloud Gateway networks, allowlist the egress IPs from each relevant network.
 
@@ -237,7 +238,7 @@ formats:
   - deck
 {% endentity_examples %}
 
-{:.note}
+{:.info}
 > Replace `env/KONG_SHARED_SECRET` with the path matching your configured
 > vault backend (`hcv`, `aws`, `gcp`, or `env`). See the
 > [Secrets management documentation](/gateway/secrets-management/)

--- a/app/dedicated-cloud-gateways/public-network.md
+++ b/app/dedicated-cloud-gateways/public-network.md
@@ -80,10 +80,10 @@ When a Dedicated Cloud Gateway proxies traffic to upstream services over the pub
 These validate who can call your APIs, and ensure your upstream services can trust that requests genuinely originate from Kong.
  
 There are multiple security controls you can use to protect public Dedicated Cloud Gateways:
-* Allow Kong proxy traffic by allowlisting egress IPs
-* Validate inbound API consumers before requests reach your upstream (mTLS Auth, OIDC)
-* Authenticate Kong to your upstream service (upstream mTLS, shared secrets)
-* Secure the inbound entry point itself (CDN/WAF)
+* Allow Kong proxy traffic by allowlisting egress IPs.
+* Validate inbound API consumers before requests reach your upstream (mTLS Auth, OIDC).
+* Authenticate Kong to your upstream service (upstream mTLS, shared secrets).
+* Secure the inbound entry point itself (CDN/WAF).
 
 These security controls protect against the following:
 
@@ -112,9 +112,9 @@ rows:
 
 Public Dedicated Cloud Gateway security controls are complementary.
 A robust public internet configuration typically combines multiple layers:
-* **A minimal production configuration for sensitive services:** Egress IP
+* A minimal production configuration for sensitive services: Egress IP
 allowlisting with upstream mTLS
-* **A configuration for services that cannot do mTLS:** Egress IP allowlisting with
+* A configuration for services that cannot do mTLS: Egress IP allowlisting with
 shared secret and OIDC
 
 {:.warning}

--- a/app/dedicated-cloud-gateways/public-network.md
+++ b/app/dedicated-cloud-gateways/public-network.md
@@ -28,12 +28,12 @@ tags:
 ---
 
 Public Dedicated Cloud Gateways should be used when you are proxying your own infrastructure over public internet. 
-Use a public deployment when:
-- Your upstream services are already internet-facing (for example, SaaS
+Use a public deployment when your:
+- Upstream services are already internet-facing (for example, SaaS
   backends or services shared across business units without private networking)
 - Traffic volume doesn't justify the operational overhead of private network
   peering
-- Your security model relies on application-layer controls rather than
+- Security model relies on application-layer controls rather than
   network-layer isolation
 
 ## Public architecture and connectivity
@@ -135,17 +135,22 @@ We recommend creating and securing your public Dedicated Cloud Gateway in the fo
 4. Configure the IP Restriction plugin globally (allowlisting your CDN's egress IPs) so that even if someone hits the Dedicated Cloud Gateway data plane directly, they get rejected before any Route matching happens.
 5. Configure your Routes and Services pointing to real upstreams.
 
-### WAF
+### Web Application Firewall (WAF)
 
 {% include /sections/dcgw-waf-intro.md %}
 
-Kong strongly recommends configuring a WAF for public Dedicated Cloud Gateways. 
+{:.warning}
+> Kong strongly recommends configuring a WAF for public Dedicated Cloud Gateways. 
 WAF configuration differs for public deployments.
 
-Public Dedicated Cloud Gateways are exposed via a public FQDN.
-WAF inspection requires HTTP visibility, which means the WAF must sit at an HTTP-aware layer, like a CDN distribution, an Application Load Balancer, or a cloud edge service.
+A public Fully Qualified Domain Name (FQDN) exposes the Public Dedicated Cloud Gateways.
+WAF inspection requires HTTP visibility, which means the WAF must sit at an HTTP-aware layer, like:
 
-Additionally, because the Kong-managed Dedicated Cloud Gateway data plane exposes a DNS hostname instead of an IP address, you can't chain another public load balancer in front of it (most ALB and cloud load balancer target groups don't support DNS-based targets).
+* A CDN distribution
+* An Application Load Balancer
+* A cloud edge service
+
+Because the Kong-managed Dedicated Cloud Gateway data plane exposes a DNS hostname instead of an IP address, **you can't chain another public load balancer in front of it** (most load balancers' target groups don't support DNS-based targets).
 Instead, you must use a CDN because it natively supports DNS-based origins and can attach WAF policies at the distribution level.
 
 Examples of CDN or edge services that support this pattern:
@@ -208,7 +213,7 @@ To ensure all traffic passes through CloudFront, configure origin validation bet
           x-origin-verify:
             - your-secret-value
      ```
-   * Use a plugin, like [Pre-Function](/plugins/pre-function/) or [Request Termination](/plugins/request-termination/)
+   * Use a plugin, like [Pre-Function](/plugins/pre-function/) or [Request Termination](/plugins/request-termination/).
 1. Reject requests that don't include the expected header value.
 1. Store the shared header value securely, like in a [Vault](/gateway/entities/vault/), and rotate the shared secret periodically.
 1. If your CDN publishes static egress IP ranges, configure the [IP Restriction](/plugins/ip-restriction/examples/allow/) plugin globally (allowlisting your CDN's egress IPs). 
@@ -247,7 +252,7 @@ This provides a strong identity guarantee even if an IP allowlist is bypassed or
 
 Kong supports two mTLS modes for upstream connections: upstream mTLS and inbound mTLS.
 
-#### Upstream mTLS
+#### Upstream Mutual TLS (mTLS)
 
 Kong presents a client certificate to your upstream service when establishing
 the connection. 
@@ -333,9 +338,13 @@ For APIs where caller identity matters beyond network origin, use the
 [OpenID Connect plugin](/plugins/openid-connect/)
 to validate JWTs or opaque tokens before forwarding requests upstream.
 
-Kong validates the token at the gateway and can forward claims to your upstream
-as headers, so your backend receives a verified identity without needing to
-perform its own token validation.
+Kong does the following:
+
+1. Validates the token at the Gateway.
+2. Forwards claims to your upstream as headers.
+
+Your backend receives a verified identity without needing to perform its own token validation.
+
 
 This is particularly useful when:
 - Upstream services are shared across multiple calling systems

--- a/app/dedicated-cloud-gateways/public-network.md
+++ b/app/dedicated-cloud-gateways/public-network.md
@@ -20,6 +20,8 @@ related_resources:
     url: /dedicated-cloud-gateways/private-network/
   - text: Multi-cloud Dedicated Cloud Gateway network architecture and security
     url: /dedicated-cloud-gateways/multi-cloud/
+  - text: "{{site.base_gateway}} WAF capabilities"
+    url: /waf/
 next_steps:
   - text: Dedicated Cloud Gateways production readiness checklist
     url: /dedicated-cloud-gateways/production-readiness/
@@ -193,6 +195,8 @@ In this model:
 * The Dedicated Cloud Gateway data plane receives traffic from CloudFront and forwards it to the gateway data planes.
 
 The sections in this guide describe how to configure a WAF in AWS, but they can be adapted for Azure and GCP.
+
+For more information about all {{site.base_gateway}} WAF configurations and plugins, see [{{site.base_gateway}} WAF capabilities](/waf/).
 
 ### Configure AWS WAF
 

--- a/app/dedicated-cloud-gateways/public-network.md
+++ b/app/dedicated-cloud-gateways/public-network.md
@@ -38,8 +38,7 @@ Use a public deployment when:
 
 ## Public architecture and connectivity
 
-Public Dedicated Cloud Gateway endpoints are exposed via a Kong-managed Network Load Balancer (NLB)
-with a public fully-qualified domain name (FQDN) and static public IP addresses.
+Public Dedicated Cloud Gateway endpoints are exposed via a public fully-qualified domain name (FQDN) and static public IP addresses.
 
 Kong data planes egress to your upstream services over the public internet.
 {{site.konnect_short_name}} exposes **static egress IP addresses** for each public Dedicated Cloud Gateway network. 
@@ -50,16 +49,10 @@ The following diagram shows how the architecture of a public Dedicated Cloud Gat
 {% mermaid %}
 flowchart LR
     subgraph kong_account["Cloud provider"]
-      nlb["NLB"]
         subgraph kong_vpc["Kong-managed VPC"]
-            subgraph k8s["k8s cluster"]
                 dp1["Data plane node"]
                 dp2["Data plane node"]
                 dp3["Data plane node"]
-            end
-            nlb --> dp1
-            nlb --> dp2
-            nlb --> dp3
         end
     end
 
@@ -137,9 +130,9 @@ Public Dedicated Cloud Gateways are subjected to scanners when they are created,
 We recommend creating and securing your public Dedicated Cloud Gateway in the following order:
 1. *Before* creating Gateway Services and Routes, create the Dedicated Cloud Gateway network and control plane in {{site.konnect_short_name}}.
    The network will be scanned, but since there aren't any Routes, scanners get 404s or connection resets. 
-2. Configure your CDN/WAF in front of the Kong NLB before you configure any Routes or Services. 
+2. Configure your CDN/WAF in front of the Dedicated Cloud Gateway data plane before you configure any Routes or Services. 
 3. Allowlist the Dedicated Cloud Gateway network egress IPs.
-4. Configure the IP Restriction plugin globally (allowlisting your CDN's egress IPs) so that even if someone hits the Kong NLB directly, they get rejected before any Route matching happens.
+4. Configure the IP Restriction plugin globally (allowlisting your CDN's egress IPs) so that even if someone hits the Dedicated Cloud Gateway data plane directly, they get rejected before any Route matching happens.
 5. Configure your Routes and Services pointing to real upstreams.
 
 ### WAF
@@ -149,11 +142,10 @@ We recommend creating and securing your public Dedicated Cloud Gateway in the fo
 Kong strongly recommends configuring a WAF for public Dedicated Cloud Gateways. 
 WAF configuration differs for public deployments.
 
-Public Dedicated Cloud Gateways are exposed via a Kong-managed NLB with a public FQDN.
-Most WAF services can't attach directly to a network-layer load balancer (NLB) because NLBs operate at Layer 4 and don't terminate HTTP. 
+Public Dedicated Cloud Gateways are exposed via a public FQDN.
 WAF inspection requires HTTP visibility, which means the WAF must sit at an HTTP-aware layer, like a CDN distribution, an Application Load Balancer, or a cloud edge service.
 
-Additionally, because the Kong-managed NLB exposes a DNS hostname instead of an IP address, you can't chain another public load balancer in front of it (most ALB and cloud LB target groups don't support DNS-based targets).
+Additionally, because the Kong-managed Dedicated Cloud Gateway data plane exposes a DNS hostname instead of an IP address, you can't chain another public load balancer in front of it (most ALB and cloud load balancer target groups don't support DNS-based targets).
 Instead, you must use a CDN because it natively supports DNS-based origins and can attach WAF policies at the distribution level.
 
 Examples of CDN or edge services that support this pattern:
@@ -173,18 +165,16 @@ sequenceDiagram
         CloudFront/WAF-->>Client: 403 Forbidden
     else WAF passes request
         CloudFront/WAF->>CloudFront/WAF: CloudFront injects origin header
-        CloudFront/WAF->>Kong NLB: Forwards request with origin header
-        Kong NLB->>Kong DP node: Forwards request
-        Kong DP node->>Kong DP node: Validates header
+        CloudFront/WAF->>Kong DP: Forwards request
+        Kong DP->>Kong DP: Validates header
 
         alt Header missing or invalid
-            Kong DP node-->>Client: 403 Forbidden
+            Kong DP-->>Client: 403 Forbidden
         else Header valid
-            Kong DP node->>Kong DP node: Matches route
-            Kong DP node->>Your upstream in AWS: Applies plugins, proxies request
-            Your upstream in AWS-->>Kong DP node: Response
-            Kong DP node-->>Kong NLB: Response
-            Kong NLB-->>CloudFront/WAF: Response
+            Kong DP->>Kong DP: Matches route
+            Kong DP->>Your upstream in AWS: Applies plugins, proxies request
+            Your upstream in AWS-->>Kong DP: Response
+            Kong DP-->>CloudFront/WAF: Response
             CloudFront/WAF-->>Client: Response
         end
     end
@@ -195,15 +185,13 @@ In this model:
 * CloudFront acts as the public edge entry point.
 * AWS WAF is attached to the CloudFront distribution.
 * The CloudFront origin is the Dedicated Cloud Gateway public DNS edge (public FQDN).
-* The Kong-managed NLB receives traffic from CloudFront and forwards it to the gateway data planes.
-
-This is the standard AWS-native pattern for protecting publicly accessible services behind an NLB.
+* The Dedicated Cloud Gateway data plane receives traffic from CloudFront and forwards it to the gateway data planes.
 
 The sections in this guide describe how to configure a WAF in AWS, but they can be adapted for Azure and GCP.
 
 ### Configure AWS WAF
 
-When a Dedicated Cloud Gateway is deployed in public mode, it exposes a public FQDN backed by a Kong-managed Network Load Balancer. 
+When a Dedicated Cloud Gateway is deployed in public mode, it exposes a public FQDN. 
 Without additional controls, clients could attempt to access this public endpoint directly and bypass CloudFront and AWS WAF protections.
 
 To ensure all traffic passes through CloudFront, configure origin validation between CloudFront and Kong:

--- a/app/dedicated-cloud-gateways/public-network.md
+++ b/app/dedicated-cloud-gateways/public-network.md
@@ -1,0 +1,270 @@
+---
+title: "Dedicated Cloud Gateways public network architecture and security"
+content_type: reference
+layout: reference
+description: "Learn about the public Dedicated Cloud Gateway network architecture and how to secure your public network."
+
+products:
+    - gateway
+breadcrumbs:
+  - /dedicated-cloud-gateways/
+works_on:
+  - konnect 
+
+related_resources:
+  - text: Dedicated Cloud Gateways 
+    url: /dedicated-cloud-gateways/
+  - text: Dedicated Cloud Gateways network architecture
+    url: /dedicated-cloud-gateways/network-architecture/
+  - text: Dedicated Cloud Gateways private network architecture and security
+    url: /dedicated-cloud-gateways/private-network/
+  - text: Multi-cloud Dedicated Cloud Gateway network architecture and security
+    url: /dedicated-cloud-gateways/multi-cloud/
+next_steps:
+  - text: Dedicated Cloud Gateways production readiness checklist
+    url: /dedicated-cloud-gateways/production-readiness/
+tags:
+  - dedicated-cloud-gateways
+---
+
+Public Dedicated Cloud Gateways should be used when you are proxying your own infrastructure over public internet. 
+Use a public deployment when:
+- Your upstream services are already internet-facing (for example, SaaS
+  backends or services shared across business units without private networking)
+- Traffic volume doesn't justify the operational overhead of private network
+  peering
+- Your security model relies on application-layer controls rather than
+  network-layer isolation
+
+## Public architecture and connectivity
+
+Public Dedicated Cloud Gateway endpoints are exposed via a Kong-managed Network Load Balancer (NLB)
+with a public fully-qualified domain name (FQDN) and static public IP addresses.
+
+Kong data planes egress to your upstream services over the public internet.
+{{site.konnect_short_name}} exposes **static egress IP addresses** for each public Dedicated Cloud Gateway network. 
+You must allowlist these IPs at your firewall or load balancer so that only Kong proxy traffic can reach your backends.
+
+The following diagram shows how the architecture of a public Dedicated Cloud Gateway:
+
+{% mermaid %}
+flowchart LR
+    subgraph kong_account["Cloud provider"]
+      nlb["NLB"]
+        subgraph kong_vpc["Kong-managed VPC"]
+            subgraph k8s["k8s cluster"]
+                dp1["Data plane node"]
+                dp2["Data plane node"]
+                dp3["Data plane node"]
+            end
+            nlb --> dp1
+            nlb --> dp2
+            nlb --> dp3
+        end
+    end
+
+    subgraph customer_infra["Customer infra"]
+        lb["Load balancer"]
+        vm1["VM"]
+        vm2["VM"]
+        vm3["VM"]
+        lb -.-> vm1
+        lb -.-> vm2
+        lb -.-> vm3
+    end
+
+    dp1 --proxy--> lb
+    dp2 --proxy--> lb
+    dp3 --proxy--> lb
+
+    style kong_account stroke-dasharray:3,rx:10,ry:10
+{% endmermaid %}
+
+## Security controls
+
+When a Dedicated Cloud Gateway proxies traffic to upstream services over the public internet, you need security controls across the full request path.
+These validate who can call your APIs, and ensure your upstream services can trust that requests genuinely originate from Kong.
+ 
+There are multiple security controls you can use to protect public Dedicated Cloud Gateways:
+* Allow Kong proxy traffic by allowlisting egress IPs
+* Validate inbound API consumers before requests reach your upstream (mTLS Auth, OIDC)
+* Authenticate Kong to your upstream service (upstream mTLS, shared secrets)
+* Secure the inbound entry point itself (CDN/WAF)
+
+These security controls protect against the following:
+
+{% table %}
+columns:
+  - title: Layer
+    key: layer
+  - title: Control
+    key: control
+  - title: Protects against
+    key: protects
+rows:
+  - layer: Network
+    control: Egress IP allowlisting
+    protects: Unauthorized source IPs
+  - layer: Transport
+    control: Upstream mTLS
+    protects: Impersonation, man-in-the-middle (MITM)
+  - layer: Application
+    control: Shared secret header
+    protects: Bypassed IP rules
+  - layer: Application
+    control: OIDC/JWT validation
+    protects: Unauthorized callers
+{% endtable %}
+
+Public Dedicated Cloud Gateway security controls are complementary.
+A robust public internet configuration typically combines multiple layers:
+* **A minimal production configuration for sensitive services:** Egress IP
+allowlisting with upstream mTLS
+* **A configuration for services that cannot do mTLS:** Egress IP allowlisting with
+shared secret and OIDC
+
+{:.warning}
+> **Note:** We strongly recommend combining IP allowlisting with additional security controls in production.
+
+For workloads with stricter isolation requirements, consider
+[private upstream connectivity](/dedicated-cloud-gateways/private-network/)
+instead.
+
+### When to configure security controls
+
+Public Dedicated Cloud Gateways are subjected to scanners when they are created, like any other publicly-exposed network.
+We recommend creating and securing your public Dedicated Cloud Gateway in the following order:
+1. *Before* creating Gateway Services and Routes, create the Dedicated Cloud Gateway network and control plane in {{site.konnect_short_name}}.
+   The network will be scanned, but since there aren't any Routes, scanners get 404s or connection resets. 
+2. Configure your CDN/WAF in front of the Kong NLB before you configure any Routes or Services. 
+1. Allowlist the Dedicated Cloud Gateway network egress IPs.
+3. Configure the IP Restriction plugin globally (allowlisting your CDN's egress IPs) so that even if someone hits the Kong NLB directly, they get rejected before any Route matching happens.
+4. Configure your Routes and Services pointing to real upstreams.
+
+### Egress IP allowlisting
+
+{{site.konnect_short_name}} exposes the static egress IP addresses for your Dedicated Cloud Gateway network in the {{site.konnect_short_name}} UI. 
+You must configure your upstream firewall, security group, or load balancer to accept inbound connections from these IPs only.
+This ensures that even if a Service is publicly accessible, only your Kong data
+planes can call it.
+
+{:.note}
+> Egress IPs are scoped per Dedicated Cloud Gateway network and per region. 
+> If you use multiple Dedicated Cloud Gateway networks, allowlist the egress IPs from each relevant network.
+
+To allowlist the egress IPs, do the following:
+
+1. In the {{site.konnect_short_name}} sidebar, click **API Gateway**.
+1. Click your Dedicated Cloud Gateway.
+1. Click **Connect**.
+1. Copy and save the IPs listed in **Public Egress IPs**.
+2. In your cloud provider console, add inbound rules to your upstream service's
+   security group or firewall to allow traffic from those IP ranges on the
+   relevant port (typically 443 or 80).
+3. Restrict inbound traffic on that port to the allowlisted IPs, in addition
+   to any other legitimately permitted sources.
+
+### Mutual TLS (mTLS)
+
+Mutual TLS authenticates both the Kong data plane and your upstream service cryptographically. 
+The upstream rejects any connection that doesn't present a valid certificate, regardless of source IP. 
+This provides a strong identity guarantee even if an IP allowlist is bypassed or shared with another system.
+
+Kong supports two mTLS modes for upstream connections: upstream mTLS and inbound mTLS.
+
+#### Upstream mTLS
+
+Kong presents a client certificate to your upstream service when establishing
+the connection. 
+Configure this on the Kong Service object by referencing a
+certificate stored in {{site.konnect_short_name}} via the `client_certificate` field.
+
+The following is an example Service configuration using decK:
+
+{% entity_example %}
+type: service
+data:
+  name: my-service
+  url: https://api.internal.example.com
+  client_certificate:
+    id: $CERT_ID
+  tls_verify: true
+  ca_certificates:
+    - $CA_CERT_ID
+formats:
+  - deck
+{% endentity_example %}
+
+In this example, your upstream verifies Kong's client certificate against a known CA before accepting the connection.
+
+#### Inbound mTLS with the mTLS Auth plugin
+
+The [mTLS Auth plugin](/plugins/mtls-auth/) validates client certificates presented *to* Kong from downstream API consumers. 
+Use this when your consumers must also authenticate with certificates, creating end-to-end mutual authentication.
+For Services handling sensitive data, combine upstream mTLS with egress IP allowlisting for in-depth defense.
+
+Example plugin configuration:
+
+{% entity_examples %}
+entities:
+  plugins:
+    - name: mtls-auth
+      service: my-service
+      config:
+        ca_certificates:
+          - $CA_CERT_ID
+formats:
+  - deck
+{% endentity_examples %}
+
+### Shared secrets with the Request Transformer plugin
+
+If your upstream service cannot terminate mTLS but you need a lightweight way
+to verify that requests originate from Kong, inject a shared secret header
+using the [Request Transformer plugin](/plugins/request-transformer/).
+
+Example plugin configuration:
+
+{% entity_examples %}
+entities:
+  plugins:
+    - name: request-transformer
+      config:
+        add:
+          headers:
+            - "x-kong-origin-verify:{vault://env/KONG_SHARED_SECRET}"
+formats:
+  - deck
+{% endentity_examples %}
+
+{:.note}
+> Replace `env/KONG_SHARED_SECRET` with the path matching your configured
+> vault backend (`hcv`, `aws`, `gcp`, or `env`). See the
+> [Secrets management documentation](/gateway/secrets-management/)
+> for vault configuration options.
+
+Your upstream service validates the presence and value of this header before
+processing the request. If the header is absent or incorrect, the upstream
+rejects the request.
+
+Keep the following in mind: 
+- Store the secret as a {{site.konnect_short_name}} Vault reference, not as a plaintext value
+- Rotate the secret on a regular schedule
+- Combine with egress IP allowlisting so the header alone isn't the only control
+
+### Token-based authentication with OpenID Connect
+
+For APIs where caller identity matters beyond network origin, use the
+[OpenID Connect plugin](/plugins/openid-connect/)
+to validate JWTs or opaque tokens before forwarding requests upstream.
+
+Kong validates the token at the gateway and can forward claims to your upstream
+as headers, so your backend receives a verified identity without needing to
+perform its own token validation.
+
+This is particularly useful when:
+- Upstream services are shared across multiple calling systems
+- You want Kong to act as the centralized token validation and enforcement point
+- You need fine-grained authorization based on token claims (scopes, roles, tenant ID)
+
+For an example plugin configuration, see [JWT access token authentication](/plugins/openid-connect/examples/jwt-access-token/)

--- a/app/dedicated-cloud-gateways/public-network.md
+++ b/app/dedicated-cloud-gateways/public-network.md
@@ -142,6 +142,38 @@ We recommend creating and securing your public Dedicated Cloud Gateway in the fo
 3. Configure the IP Restriction plugin globally (allowlisting your CDN's egress IPs) so that even if someone hits the Kong NLB directly, they get rejected before any Route matching happens.
 4. Configure your Routes and Services pointing to real upstreams.
 
+### WAF
+
+<!--vale off -->
+{% mermaid %}
+sequenceDiagram
+    Client->>+CloudFront/WAF: Sends request, TLS terminated
+    CloudFront/WAF->>CloudFront/WAF: WAF evaluates
+
+    alt WAF blocks request
+        CloudFront/WAF-->>Client: 403 Forbidden
+    else WAF passes request
+        CloudFront/WAF->>CloudFront/WAF: CloudFront injects origin header
+        CloudFront/WAF->>Kong NLB: Forwards request with origin header
+        Kong NLB->>Kong DP node: Forwards request
+        Kong DP node->>Kong DP node: Validates header
+
+        alt Header missing or invalid
+            Kong DP node-->>Client: 403 Forbidden
+        else Header valid
+            Kong DP node->>Kong DP node: Matches route
+            Kong DP node->>Your upstream in AWS: Applies plugins, proxies request
+            Your upstream in AWS-->>Kong DP node: Response
+            Kong DP node-->>Kong NLB: Response
+            Kong NLB-->>CloudFront/WAF: Response
+            CloudFront/WAF-->>Client: Response
+        end
+    end
+{% endmermaid %}
+<!--vale on -->
+
+
+
 ### Egress IP allowlisting
 
 {{site.konnect_short_name}} exposes the static egress IP addresses for your Dedicated Cloud Gateway network in the {{site.konnect_short_name}} UI. 

--- a/app/dedicated-cloud-gateways/transit-gateways.md
+++ b/app/dedicated-cloud-gateways/transit-gateways.md
@@ -36,6 +36,12 @@ related_resources:
     url: /how-to/create-transit-gateway-with-operator-and-aws/
   - text: Use AWS workload identities
     url: /dedicated-cloud-gateways/reference/#aws-workload-identities
+  - text: Dedicated Cloud Gateways network architecture
+    url: /dedicated-cloud-gateways/network-architecture/
+  - text: Dedicated Cloud Gateways private network architecture and security
+    url: /dedicated-cloud-gateways/private-network/
+  - text: Multi-cloud Dedicated Cloud Gateway network architecture and security
+    url: /dedicated-cloud-gateways/multi-cloud/
 next_steps:
   - text: Dedicated Cloud Gateways production readiness checklist
     url: /dedicated-cloud-gateways/production-readiness/

--- a/app/dedicated-cloud-gateways/transit-gateways.md
+++ b/app/dedicated-cloud-gateways/transit-gateways.md
@@ -43,50 +43,7 @@ next_steps:
 
 When you host your Data Plane nodes on [Dedicated Cloud Gateways](/dedicated-cloud-gateways/) in {{site.konnect_short_name}}, you can use AWS Transit Gateway to establish private connectivity between your AWS-hosted services and the {{site.konnect_short_name}} platform. This creates a secure and scalable network path that avoids exposing internal APIs to the public internet.
 
-<!--vale off -->
-{% mermaid %}
-flowchart LR
-
-A(API or Service)
-B(API or Service)
-C(API or Service)
-D(<img src="/assets/icons/third-party/aws-transit-gateway-attachment.svg" style="max-height:32px" class="no-image-expand"/>AWS Transit Gateway attachment)
-E(<img src="/assets/icons/third-party/aws-transit-gateway.svg" style="max-height:32px" class="no-image-expand"/> AWS Transit Gateway)
-F(<img src="/assets/icons/third-party/aws-transit-gateway-attachment.svg" style="max-height:32px" class="no-image-expand"/>AWS Transit Gateway attachment)
-G(<img src="/assets/logos/konglogo-gradient-secondary.svg" style="max-height:32px" class="no-image-expand"/>Konnect #40;fully-managed Data Plane#41;)
-H(<img src="/assets/logos/konglogo-gradient-secondary.svg" style="max-height:32px" class="no-image-expand"/>Konnect #40;fully-managed Data Plane#41;)
-I(<img src="/assets/logos/konglogo-gradient-secondary.svg" style="max-height:32px" class="no-image-expand"/>Konnect #40;fully-managed Data Plane#41;)
-J(Internet)
-
-subgraph 1 [User AWS Cloud]
-    subgraph 2 [Region]
-        subgraph 3 [Virtual Private Cloud #40;VPC#41;]
-        A
-        B
-        C
-        end
-        A & B & C <--> D
-    end
-   D<-->E
-end
-
-subgraph 4 [Kong AWS Cloud]
-    subgraph 5 [Region]
-        E<-->F
-        F <--private API access--> G & H & I
-        subgraph 6 [Virtual Private Cloud #40;VPC#41;]
-        G
-        H
-        I
-        end
-    end
-end
-
-G & H & I <--public API access--> J
-
-
-{% endmermaid %}
-<!--vale on-->
+{% include diagrams/dcgw-tgw.md %}
 
 ## AWS configuration for Transit Gateway peering
 


### PR DESCRIPTION
## Description

Fixes #4606 #3274 

TODO:

- [x] Likely split public arch, private arch, and multi-cloud arch into different pages
- [x] Based on that ⬆️ consider if network architecture is a landing page or part of the existing DCGW landing page, with tiles for everything

## Preview Links
**For reviewers:** Please flag anything that doesn't make sense/if you have open questions. Ideally, this is written in a way that someone who is new to DCGW should be able to read it and understand how the pieces fit together. 

- [New landing page section](https://deploy-preview-4827--kongdeveloper.netlify.app/dedicated-cloud-gateways/#dedicated-cloud-gateway-network-architecture)
- [Network architecture overview](https://deploy-preview-4827--kongdeveloper.netlify.app/dedicated-cloud-gateways/network-architecture/)
- [Private networking](https://deploy-preview-4827--kongdeveloper.netlify.app/dedicated-cloud-gateways/private-network/)
- [Public networking](https://deploy-preview-4827--kongdeveloper.netlify.app/dedicated-cloud-gateways/public-network/)
- [Multi-cloud](https://deploy-preview-4827--kongdeveloper.netlify.app/dedicated-cloud-gateways/multi-cloud/)
- [WAF landing page](https://deploy-preview-4827--kongdeveloper.netlify.app/waf/#waf-for-dedicated-cloud-gateways)

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
