### PR TITLE
feat(event-gateway) SNI routing with shared suffix

### DIFF
--- a/.github/styles/frontmatter/Keys.txt
+++ b/.github/styles/frontmatter/Keys.txt
@@ -52,4 +52,4 @@ plugin_schema
 no_edit_link
 how_to_list
 toc_depth
-event_gateway
+event-gateway

--- a/app/_data/schemas/frontmatter/base.json
+++ b/app/_data/schemas/frontmatter/base.json
@@ -4,7 +4,7 @@
     "min_version": {
       "type": "object",
       "patternProperties": {
-        "^[a-zA-Z_]+$": {
+        "^[a-zA-Z_-]+$": {
           "type": "string"
         }
       },

--- a/app/_event_gateway_policies/acl/examples/match-claims-using-expressions.yml
+++ b/app/_event_gateway_policies/acl/examples/match-claims-using-expressions.yml
@@ -28,4 +28,4 @@ tools:
   - terraform
 
 min_version:
-  event_gateway: '1.1.0'
+  event-gateway: '1.1.0'

--- a/app/_event_gateway_policies/forward-to-virtual-cluster/examples/sni-routing-shared-suffix.yml
+++ b/app/_event_gateway_policies/forward-to-virtual-cluster/examples/sni-routing-shared-suffix.yml
@@ -15,7 +15,8 @@ config:
   type: sni
   sni_suffix: .example.mycompany.com
   advertised_port: 19095
-  broker_host_format: shared_suffix
+  broker_host_format:
+    type: shared_suffix
 
 tools:
   - konnect-api

--- a/app/_event_gateway_policies/forward-to-virtual-cluster/examples/sni-routing.yml
+++ b/app/_event_gateway_policies/forward-to-virtual-cluster/examples/sni-routing.yml
@@ -14,7 +14,8 @@ config:
   type: sni
   sni_suffix: .example.mycompany.com
   advertised_port: 19095
-  broker_host_format: per_cluster_suffix
+  broker_host_format:
+    type: per_cluster_suffix
 
 tools:
   - konnect-api

--- a/app/_how-tos/event-gateway/configure-mtls-backend-cluster-auth.md
+++ b/app/_how-tos/event-gateway/configure-mtls-backend-cluster-auth.md
@@ -48,7 +48,7 @@ related_resources:
     url: /event-gateway/configure-sasl-plain-backend-cluster-auth/
 
 min_version:
-  event_gateway: '1.1.0'
+  event-gateway: '1.1.0'
 
 automated_tests: false
 ---

--- a/app/_how-tos/event-gateway/configure-mtls-client-authentication.md
+++ b/app/_how-tos/event-gateway/configure-mtls-client-authentication.md
@@ -54,7 +54,7 @@ related_resources:
     url: /api/konnect/event-gateway/
 
 min_version:
-  event_gateway: '1.1.0'
+  event-gateway: '1.1.0'
 ---
 
 ## Overview

--- a/app/_how-tos/event-gateway/configure-observability-with-otel.md
+++ b/app/_how-tos/event-gateway/configure-observability-with-otel.md
@@ -57,7 +57,7 @@ related_resources:
 automated_tests: false
 
 min_version:
-  event_gateway: '1.1.0'
+  event-gateway: '1.1.0'
 ---
 
 In this guide, you’ll configure the [Grafana LGTM stack](https://github.com/grafana/docker-otel-lgtm) to receive and visualize observability data from {{site.event_gateway_short}}. The LGTM stack bundles Grafana, [Loki](https://grafana.com/oss/loki/) (logs), [Tempo](https://grafana.com/oss/tempo/) (traces), [Prometheus](https://prometheus.io/) (metrics), and a built-in [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) in a single container.

--- a/app/_how-tos/event-gateway/configure-sni-routing.md
+++ b/app/_how-tos/event-gateway/configure-sni-routing.md
@@ -138,7 +138,7 @@ Generate the certificates we'll need to enable TLS:
 
    We're setting the subject in the certificate signing request to `*.127-0-0-1.sslip.io`:
    * `*` is a wildcard that covers all broker and bootstrap hostnames across every virtual cluster on this listener.
-   * `.127-0-0-1.sslip.io` is the SNI suffix, which we'll use in the TLS listener policy configuration. In this example, we're using [sslip.io](https://sslip.io/) to resolve `127-0-0-1.sslip.io` to `127.0.0.1`.
+   * `.127-0-0-1.sslip.io` is the SNI suffix, which we'll use later in the Forward to Virtual Cluster policy configuration for SNI routing. In this example, we're using [sslip.io](https://sslip.io/) to resolve `127-0-0-1.sslip.io` to `127.0.0.1`.
 
 1. To explicitly set the subject alternative names for the certificate, create an OpenSSL extension file:
 
@@ -198,9 +198,9 @@ capture:
 {% endkonnect_api_request %}
 <!--vale on-->
 
-## Create a TLS server listener policy
+## Create a TLS Server listener policy
 
-Create a TLS server policy:
+Create a TLS Server policy on the listener:
 
 <!--vale off-->
 {% konnect_api_request %}
@@ -217,9 +217,9 @@ body:
 {% endkonnect_api_request %}
 <!--vale on-->
 
-## Create a Forward to virtual cluster policy
+## Create a Forward to Virtual Cluster policy
 
-Create a Forward to virtual cluster policy that configures SNI and defines a suffix to expose on the listener:
+Create a Forward to Virtual Cluster policy that configures SNI routing and defines a suffix to expose on the listener:
 
 <!--vale off-->
 {% konnect_api_request %}

--- a/app/_how-tos/event-gateway/configure-sni-routing.md
+++ b/app/_how-tos/event-gateway/configure-sni-routing.md
@@ -28,6 +28,8 @@ tldr:
     1. Create a TLS server listener policy using your certificate and key.
     1. Create a Forward to virtual cluster policy with the port ans SNI suffix.
 
+min_version:
+  event-gateway: '1.1.0'
 
 tools:
     - konnect-api
@@ -76,14 +78,14 @@ contexts:
       - localhost:9094
   analytics:
     brokers:
-      - bootstrap.analytics.127-0-0-1.sslip.io:19092
+      - bootstrap-analytics.127-0-0-1.sslip.io:19092
     tls:
       enabled: true
       ca: ./rootCA.crt
       insecure: true
   payments:
     brokers:
-      - bootstrap.payments.127-0-0-1.sslip.io:19092
+      - bootstrap-payments.127-0-0-1.sslip.io:19092
     tls:
       enabled: true
       ca: ./rootCA.crt
@@ -135,7 +137,7 @@ Generate the certificates we'll need to enable TLS:
    {: data-test-step="block" }
 
    We're setting the subject in the certificate signing request to `*.127-0-0-1.sslip.io`:
-   * `*` is used for the virtual cluster prefixes, which are the `analytics` and `payments` DNS labels we configured when creating the virtual clusters.
+   * `*` is a wildcard that covers all broker and bootstrap hostnames across every virtual cluster on this listener.
    * `.127-0-0-1.sslip.io` is the SNI suffix, which we'll use in the TLS listener policy configuration. In this example, we're using [sslip.io](https://sslip.io/) to resolve `127-0-0-1.sslip.io` to `127.0.0.1`.
 
 1. To explicitly set the subject alternative names for the certificate, create an OpenSSL extension file:
@@ -149,8 +151,7 @@ Generate the certificates we'll need to enable TLS:
    authorityKeyIdentifier = keyid,issuer
    
    [alt_names]
-   DNS.1 = *.analytics.127-0-0-1.sslip.io
-   DNS.2 = *.payments.127-0-0-1.sslip.io
+   DNS.1 = *.127-0-0-1.sslip.io
    EOF
    ```
    {: data-test-step="block" }
@@ -232,15 +233,17 @@ body:
     type: sni
     advertised_port: 19092
     sni_suffix: .127-0-0-1.sslip.io
+    broker_host_format:
+      type: shared_suffix
 {% endkonnect_api_request %}
 <!--vale on-->
 
 This policy enables routing to each virtual cluster and mapping brokers:
 
-* Bootstrap server to `bootstrap.analytics.127-0-0-1.sslip.io:19092` or `bootstrap.payments.127-0-0-1.sslip.io:19092`
-* Broker 1 to `broker-0.analytics.127-0-0-1.sslip.io:19092` or `broker-0.payments.127-0-0-1.sslip.io:19092`
-* Broker 2 to `broker-1.analytics.127-0-0-1.sslip.io:19092` or `broker-1.payments.127-0-0-1.sslip.io:19092`
-* Broker 3 to `broker-2.analytics.127-0-0-1.sslip.io:19092` or `broker-2.payments.127-0-0-1.sslip.io:19092`
+* Bootstrap server to `bootstrap-analytics.127-0-0-1.sslip.io:19092` or `bootstrap-payments.127-0-0-1.sslip.io:19092`
+* Broker 1 to `broker-0-analytics.127-0-0-1.sslip.io:19092` or `broker-0-payments.127-0-0-1.sslip.io:19092`
+* Broker 2 to `broker-1-analytics.127-0-0-1.sslip.io:19092` or `broker-1-payments.127-0-0-1.sslip.io:19092`
+* Broker 3 to `broker-2-analytics.127-0-0-1.sslip.io:19092` or `broker-2-payments.127-0-0-1.sslip.io:19092`
 
 ## Validate
 

--- a/app/_how-tos/event-gateway/kong-identity-oauth.md
+++ b/app/_how-tos/event-gateway/kong-identity-oauth.md
@@ -57,7 +57,7 @@ related_resources:
     url: /event-gateway/policies/acl/
 
 min_version:
-  event_gateway: '1.1.0'
+  event-gateway: '1.1.0'
 ---
 
 ## Create an auth server in Kong Identity

--- a/app/event-gateway/architecture.md
+++ b/app/event-gateway/architecture.md
@@ -143,7 +143,7 @@ You must provide a TLS certificate for every host exposed on the {{site.event_ga
 This can be done through a certificate with a wildcard SAN, a single certificate with multiple SANs, or multiple certificates in the same bundle.
 
 #### Shared suffix {% new_in 1.1 %}
-Alternatively, you can set `broker_host_format` to `shared_suffix` in the listener policy, so that you can use one wildcard SAN for all virtual clusters. In this case, the mapping looks like this
+Alternatively, you can set `broker_host_format` to `type: shared_suffix` in the listener policy, so that you can use one wildcard SAN for all virtual clusters. In this case, the mapping looks like this
 
 ```
 bootstrap-my-event-gateway.acme:9092 → kafka1:9092 (bootstrap hostname)

--- a/app/event-gateway/architecture.md
+++ b/app/event-gateway/architecture.md
@@ -143,7 +143,7 @@ You must provide a TLS certificate for every host exposed on the {{site.event_ga
 This can be done through a certificate with a wildcard SAN, a single certificate with multiple SANs, or multiple certificates in the same bundle.
 
 #### Shared suffix {% new_in 1.1 %}
-Alternatively, you can set `broker_host_format` to `type: shared_suffix` in the listener policy, so that you can use one wildcard SAN for all virtual clusters. In this case, the mapping looks like this
+Alternatively, you can set `broker_host_format.type` to `shared_suffix` in the listener policy, so that you can use one wildcard SAN for all virtual clusters. In this case, the mapping looks like this
 
 ```
 bootstrap-my-event-gateway.acme:9092 → kafka1:9092 (bootstrap hostname)


### PR DESCRIPTION
## Description

`shared_suffix` is a feature introduced in Event Gateway 1.1. Updating the how-to guide to use this method instead of the old way. This is meant to be simpler.

EGW team also requested combining the certs section into one script, which we did have during the draft stage. The reasoning is that for our audience, either they're testing this and want it as simple as possible (so one command is better), or they're bringing their own certs, in which case they know what they're doing and aren't going to follow the specific setup here anyway. 

## Preview Links

https://deploy-preview-4828--kongdeveloper.netlify.app/event-gateway/configure-sni-routing/
