### PR TITLE
fix(Debugger): Improved payload sanitization documentation for clarity

### DIFF
--- a/app/observability/debugger.md
+++ b/app/observability/debugger.md
@@ -112,7 +112,7 @@ In critical scenarios, having access to payload details can help identify and pi
 ```
 
 ### Payload collection and sanitization
-When a debug session is initiated with payload capture, the debugger captures request/response headers and/or body for all requests matching a sampling criteria. Candidates are then validated using the log sanitizer, and sensitive data such as credit card numbers will be redacted from the payload. Authentication and identity headers (for example, `Authorization`, API key header values, and consumer ID header fields) are also masked by default.
+When a debug session is initiated with payload capture, the debugger captures request/response headers and/or body for all requests matching a sampling criteria. Sampling filters and sanitization occur on the Data Plane before any data is transmitted to {{site.konnect_short_name}}. Transactions are scrubbed using the log sanitizer, and sensitive data such as credit card numbers are redacted from the payload. Authentication and identity headers (for example, `Authorization`, API key header values, and consumer ID header fields) are also masked by default.
 
 {% new_in 3.14 %} Gzip-encoded bodies (`Content-Encoding: gzip` or `x-gzip`) are automatically decompressed before capture, so they appear as readable text in the debugger.
 

--- a/app/observability/debugger.md
+++ b/app/observability/debugger.md
@@ -112,7 +112,7 @@ In critical scenarios, having access to payload details can help identify and pi
 ```
 
 ### Payload collection and sanitization
-When a debug session is initiated with payload capture, the debugger captures request/response headers and/or body for all requests matching a sampling criteria. Sampling filters and sanitization occur on the Data Plane before any data is transmitted to {{site.konnect_short_name}}. Transactions are scrubbed using the log sanitizer, and sensitive data such as credit card numbers are redacted from the payload. Authentication and identity headers (for example, `Authorization`, API key header values, and consumer ID header fields) are also masked by default.
+When a debug session is initiated with payload capture, the debugger captures request/response headers and/or body for all requests matching sampling criteria. Sampling filters and sanitization occur on the data plane before any data is transmitted to {{site.konnect_short_name}}. Transactions are scrubbed using the log sanitizer, and sensitive data such as credit card numbers are redacted from the payload. Authentication and identity headers (for example, `Authorization`, API key header values, and consumer ID header fields) are also masked by default.
 
 {% new_in 3.14 %} Gzip-encoded bodies (`Content-Encoding: gzip` or `x-gzip`) are automatically decompressed before capture, so they appear as readable text in the debugger.
 


### PR DESCRIPTION
## Description

Improves debugger payload sanitization documentation for clarity

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
