### PR TITLE
Feat/prompt hub v2

### DIFF
--- a/app/_assets/entrypoints/hub.js
+++ b/app/_assets/entrypoints/hub.js
@@ -11,18 +11,19 @@ class Hub {
     this.areFiltersOpen = false;
 
     this.deploymentTopologies = this.filters.querySelectorAll(
-      'input[name="deployment-topology"]'
+      'input[name="deployment-topology"]',
     );
     this.tiers = this.filters.querySelectorAll('input[name="tier"]');
     this.categories = this.filters.querySelectorAll('input[name="category"]');
     this.support = this.filters.querySelectorAll('input[name="support"]');
     this.trustedContent = this.filters.querySelectorAll(
-      'input[name="trusted-content"]'
+      'input[name="trusted-content"]',
     );
     this.phases = this.filters.querySelectorAll('input[name="phase"]');
     this.policyTargets = this.filters.querySelectorAll(
-      'input[name="policy-target"]'
+      'input[name="policy-target"]',
     );
+    this.products = this.filters.querySelectorAll('input[name="product"]');
 
     this.deploymentValues = [];
     this.categoryValues = [];
@@ -31,6 +32,7 @@ class Hub {
     this.tierValues = [];
     this.phaseValues = [];
     this.policyTargetValues = [];
+    this.productValues = [];
 
     this.typingTimer;
     this.typeInterval = 400;
@@ -48,6 +50,7 @@ class Hub {
       ...this.tiers,
       ...this.phases,
       ...this.policyTargets,
+      ...this.products,
     ];
     checkboxes.forEach((checkbox) => {
       checkbox.addEventListener("change", () => this.onChange());
@@ -77,7 +80,7 @@ class Hub {
     this.seeResults.addEventListener("click", () => this.toggleDrawer());
 
     this.toggleFiltersDrawer.addEventListener("click", () =>
-      this.toggleDrawer()
+      this.toggleDrawer(),
     );
   }
 
@@ -95,6 +98,7 @@ class Hub {
     this.trustedContentValues = this.getValues(this.trustedContent);
     this.phaseValues = this.getValues(this.phases);
     this.policyTargetValues = this.getValues(this.policyTargets);
+    this.productValues = this.getValues(this.products);
 
     this.updateURL();
     this.scrollCardsIntoView();
@@ -119,24 +123,24 @@ class Hub {
       const matchesDeploymentTopology = this.matchesFilter(
         plugin,
         this.deploymentTopologies,
-        "deploymentTopology"
+        "deploymentTopology",
       );
       const matchesCategory = this.matchesFilter(
         plugin,
         this.categories,
-        "category"
+        "category",
       );
 
       const matchesSupport = this.matchesFilter(
         plugin,
         this.support,
-        "support"
+        "support",
       );
 
       const matchesTrustedContent = this.matchesFilter(
         plugin,
         this.trustedContent,
-        "trustedContent"
+        "trustedContent",
       );
 
       const matchesPhases = this.matchesFilter(plugin, this.phases, "phases");
@@ -144,10 +148,16 @@ class Hub {
       const matchesPolicyTarget = this.matchesFilter(
         plugin,
         this.policyTargets,
-        "policyTarget"
+        "policyTarget",
       );
 
       const matchesTier = this.matchesFilter(plugin, this.tiers, "tier");
+
+      const matchesProducts = this.matchesFilter(
+        plugin,
+        this.products,
+        "products",
+      );
 
       const matchesText = this.matchesQuery(plugin);
 
@@ -159,6 +169,7 @@ class Hub {
         matchesTier &&
         matchesPhases &&
         matchesPolicyTarget &&
+        matchesProducts &&
         matchesText;
 
       plugin.classList.toggle("hidden", !showPlugin);
@@ -172,7 +183,7 @@ class Hub {
     this.categories.forEach((cat) => {
       const category = document.getElementById(cat.value);
       const showCategory = category.querySelectorAll(
-        '[data-card="plugin"]:not(.hidden)'
+        '[data-card="plugin"]:not(.hidden)',
       ).length;
 
       category.classList.toggle("hidden", !showCategory);
@@ -183,7 +194,7 @@ class Hub {
     const thirdParty = document.getElementById("third-party");
     if (thirdParty) {
       const showThirdParty = thirdParty.querySelectorAll(
-        '[data-card="plugin"]:not(.hidden)'
+        '[data-card="plugin"]:not(.hidden)',
       ).length;
 
       thirdParty.classList.toggle("hidden", !showThirdParty);
@@ -220,7 +231,7 @@ class Hub {
     params.delete("deployment-topology");
     if (this.deploymentValues.length > 0) {
       this.deploymentValues.forEach((value) =>
-        params.append("deployment-topology", value)
+        params.append("deployment-topology", value),
       );
     }
 
@@ -237,7 +248,7 @@ class Hub {
     params.delete("trusted-content");
     if (this.trustedContentValues.length > 0) {
       this.trustedContentValues.forEach((value) =>
-        params.append("trusted-content", value)
+        params.append("trusted-content", value),
       );
     }
 
@@ -260,8 +271,13 @@ class Hub {
     params.delete("policy-target");
     if (this.policyTargetValues.length > 0) {
       this.policyTargetValues.forEach((value) =>
-        params.append("policy-target", value)
+        params.append("policy-target", value),
       );
+    }
+
+    params.delete("product");
+    if (this.productValues.length > 0) {
+      this.productValues.forEach((value) => params.append("product", value));
     }
 
     let newUrl = window.location.pathname;
@@ -309,6 +325,11 @@ class Hub {
       checkbox.checked = policyTargetValues.includes(checkbox.value);
     });
 
+    const productValues = params.getAll("product") || [];
+    this.products.forEach((checkbox) => {
+      checkbox.checked = productValues.includes(checkbox.value);
+    });
+
     const termsValue = params.get("terms") || "";
     this.textInput.value = decodeURIComponent(termsValue);
 
@@ -320,6 +341,7 @@ class Hub {
       tierValues.length ||
       phaseValues.length ||
       policyTargetValues.length ||
+      productValues.length ||
       termsValue
     ) {
       this.onChange();

--- a/app/_assets/stylesheets/index.css
+++ b/app/_assets/stylesheets/index.css
@@ -834,6 +834,12 @@
     pre {
       @apply whitespace-pre overflow-auto !bg-code-block;
     }
+
+    &[data-ask-kai="true"] {
+      pre {
+        @apply whitespace-pre-wrap break-normal;
+      }
+    }
   }
 
   clipboard-copy {

--- a/app/_data/schemas/frontmatter/base.json
+++ b/app/_data/schemas/frontmatter/base.json
@@ -18,7 +18,7 @@
     },
     "content_type": {
       "type": "string",
-      "enum": ["landing_page", "how_to", "reference", "concept", "plugin", "plugin_example", "api", "policy", "support"]
+      "enum": ["landing_page", "how_to", "reference", "concept", "plugin", "plugin_example", "api", "policy", "support", "prompt"]
     },
     "description": {
       "type": "string"

--- a/app/_includes/cards/prompt.html
+++ b/app/_includes/cards/prompt.html
@@ -1,0 +1,22 @@
+{% assign prompt = include.prompt %}
+<div
+  class="card card__bordered min-h-[200px]"
+  data-card="plugin"
+  data-products="{{ prompt.products | join: ',' }}"
+>
+  <a href="{{ prompt.url }}" class="flex flex-col gap-5 hover:no-underline text-secondary w-full p-6">
+    <div class="flex flex-col gap-3 flex-grow">
+      <h4>{{ prompt.title | liquify }}</h4>
+
+      <p class="text-sm line-clamp-3">
+        {{ prompt.description | liquify }}
+      </p>
+
+      <div class="flex flex-wrap gap-2 mt-auto pt-2">
+        {% for product in prompt.products %}
+            {% include_cached product_icon.html product=product %}
+        {% endfor %}
+      </div>
+    </div>
+  </a>
+</div>

--- a/app/_includes/checkbox.html
+++ b/app/_includes/checkbox.html
@@ -1,6 +1,9 @@
 <div class="flex">
     <label class="flex gap-2 py-0.5 w-full text-sm text-primary md:pl-1 items-center">
         <input class="checkbox" type="checkbox" value="{{include.value}}" name="{{include.name}}">{{include.label}}
+        {% if include.icon %}
+        {{include.icon}}
+        {% endif %}
         {% if include.tooltip %}
         {% include tooltip.html text=include.tooltip %}
         {% endif %}

--- a/app/_includes/product_icon.html
+++ b/app/_includes/product_icon.html
@@ -1,0 +1,6 @@
+{% assign icon = site.data.products[include.product].icon %}
+<span
+class="product-icon product-icon--background {% if include.product == 'kic' or include.product == 'operator' %} product-icon--bordered {% endif %}"
+style="background-color: rgb(var(--color-{{include.product}}-background));">
+{% include_svg icon height="12" width="12" %}
+</span>

--- a/app/_includes/prompts/overview.md
+++ b/app/_includes/prompts/overview.md
@@ -1,0 +1,16 @@
+{% if page.extended_description %}
+{{page.extended_description | liquify }}
+{% else %}
+{{ page.description | liquify }}
+{% endif %}
+
+## Prompts
+
+{% html_tag type="dev" css_classes="grid grid-cols-1 md:grid-cols-2 gap-16" %}
+{% for prompt in page.prompts %}
+```text
+{{ prompt | liquify }}
+```
+{:data-ask-kai="true"}
+{% endfor %}
+{% endhtml_tag %}

--- a/app/_includes/syntax_highlighting.html
+++ b/app/_includes/syntax_highlighting.html
@@ -14,16 +14,21 @@
   {% for data in codeblock.data %}{{ data[0] }}="{{ data[1] }}" {% endfor %}
 >
     {% if codeblock.render_header %}
+    {% if codeblock.data['data-file'] %}
     <div class="custom-code-block__header grid grid-cols-[1fr_auto]  justify-items-end items-center px-3 py-1 bg-code-block-header rounded-t-lg border border-primary/5">
-        {% if codeblock.data['data-file'] %}
         <div class="text-sm text-white dark:text-primary justify-self-start">{{codeblock.data['data-file']}}</div>
-        {% endif %}
-        {% if codeblock.copy %}
-        <div class="flex items-center gap-2">
-            {{copy}}
-        </div>
-        {% endif %}
     </div>
+    {% endif %}
+    {% if codeblock.ask_kai %}
+        <div class="custom-code-block__header grid grid-cols-[1fr_auto]  justify-items-end items-center px-1 py-1 bg-code-block rounded-t-lg border border-primary/5 border-b-0">
+            <a href="{{codeblock.ask_kai}}" class="flex text-white dark:text-primary bg-code-block-header dark:bg-code-block border border-transparent dark:border-brand rounded text-xs p-1 items-center no-icon hover:no-underline" target="_blank">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <path d="M20 12.0884V12.4355C15.7128 12.4355 14.5598 16.2296 14.5598 19.3252H14.2229C14.2229 16.2296 12.8732 12.4355 8.78272 12.4355V12.0884C13.497 12.0884 14.2229 8.29432 14.2229 5.19878H14.5598C14.5598 8.29432 15.2977 12.0884 20 12.0884ZM7.28629 11.0361C7.28629 9.27503 7.94267 7.11656 10.3813 7.11656V6.91952C7.70577 6.91952 7.28629 4.76104 7.28629 3H7.09502C7.09502 4.76104 6.68206 6.91952 4 6.91952V7.11656C6.32779 7.11656 7.09502 9.27503 7.09502 11.0361H7.28629ZM9.21089 14.1529H9.04788C9.04788 15.6531 8.69578 17.4925 6.41038 17.4925V17.6604C8.39367 17.6604 9.04788 19.4998 9.04788 21H9.21089C9.21089 19.4998 9.76948 17.6604 11.8484 17.6604V17.4925C9.56843 17.4925 9.21089 15.6531 9.21089 14.1529Z" fill="currentColor"></path>
+                </svg>
+                <span>Run in KAi</span>
+            </a>
+        </div>
+    {% endif %}
     {% endif %}
     {% assign show_inline_actions = false %}
     {% if codeblock.render_header == false and codeblock.copy %}{% assign show_inline_actions = true %}{% endif %}
@@ -39,9 +44,6 @@
                 </span>
             </button>
             {% endif %}
-            {% if codeblock.copy %}
-            {{copy}}
-            {% endif %}
         </div>
         {% endif %}
     </div>
@@ -49,5 +51,5 @@
     <button class="collapsible-toggle collapsible-toggle--footer w-full py-2 px-3 text-xs text-secondary bg-code-block border border-primary/5 rounded-b-lg flex justify-center cursor-pointer transition-colors" aria-expanded="false" type="button">
         <span>Toggle code</span>
     </button>
-    {% endif %}
+{% endif %}
 </div>

--- a/app/_includes/syntax_highlighting.html
+++ b/app/_includes/syntax_highlighting.html
@@ -14,21 +14,26 @@
   {% for data in codeblock.data %}{{ data[0] }}="{{ data[1] }}" {% endfor %}
 >
     {% if codeblock.render_header %}
-    {% if codeblock.data['data-file'] %}
     <div class="custom-code-block__header grid grid-cols-[1fr_auto]  justify-items-end items-center px-3 py-1 bg-code-block-header rounded-t-lg border border-primary/5">
-        <div class="text-sm text-white dark:text-primary justify-self-start">{{codeblock.data['data-file']}}</div>
-    </div>
-    {% endif %}
-    {% if codeblock.ask_kai %}
-        <div class="custom-code-block__header grid grid-cols-[1fr_auto]  justify-items-end items-center px-1 py-1 bg-code-block rounded-t-lg border border-primary/5 border-b-0">
-            <a href="{{codeblock.ask_kai}}" class="flex text-white dark:text-primary bg-code-block-header dark:bg-code-block border border-transparent dark:border-brand rounded text-xs p-1 items-center no-icon hover:no-underline" target="_blank">
+        {% if codeblock.data['data-file'] %}
+            <div class="text-sm text-white dark:text-primary justify-self-start">{{codeblock.data['data-file']}}</div>
+        {% endif %}
+        {% if codeblock.ask_kai or codeblock.copy %}
+        <div class="flex items-center gap-2 relative">
+            {% if codeblock.ask_kai %}
+            <a href="{{codeblock.ask_kai}}" class="flex rounded text-xs p-1 items-center no-icon cursor-pointer hover:no-underline border border-transparent  hover:border-white text-white hover:text-white transition-colors" target="_blank">
                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                     <path d="M20 12.0884V12.4355C15.7128 12.4355 14.5598 16.2296 14.5598 19.3252H14.2229C14.2229 16.2296 12.8732 12.4355 8.78272 12.4355V12.0884C13.497 12.0884 14.2229 8.29432 14.2229 5.19878H14.5598C14.5598 8.29432 15.2977 12.0884 20 12.0884ZM7.28629 11.0361C7.28629 9.27503 7.94267 7.11656 10.3813 7.11656V6.91952C7.70577 6.91952 7.28629 4.76104 7.28629 3H7.09502C7.09502 4.76104 6.68206 6.91952 4 6.91952V7.11656C6.32779 7.11656 7.09502 9.27503 7.09502 11.0361H7.28629ZM9.21089 14.1529H9.04788C9.04788 15.6531 8.69578 17.4925 6.41038 17.4925V17.6604C8.39367 17.6604 9.04788 19.4998 9.04788 21H9.21089C9.21089 19.4998 9.76948 17.6604 11.8484 17.6604V17.4925C9.56843 17.4925 9.21089 15.6531 9.21089 14.1529Z" fill="currentColor"></path>
                 </svg>
                 <span>Run in KAi</span>
             </a>
+            {% endif %}
+            {% if codeblock.copy %}
+            {{copy}}
+            {% endif %}
         </div>
-    {% endif %}
+        {% endif %}
+    </div>
     {% endif %}
     {% assign show_inline_actions = false %}
     {% if codeblock.render_header == false and codeblock.copy %}{% assign show_inline_actions = true %}{% endif %}
@@ -43,6 +48,9 @@
                     <svg class="w-3 h-3 transition-transform rotate-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5"></path></svg>
                 </span>
             </button>
+            {% endif %}
+            {% if  codeblock.copy %}
+            {{copy}}
             {% endif %}
         </div>
         {% endif %}

--- a/app/_layouts/prompts/overview.html
+++ b/app/_layouts/prompts/overview.html
@@ -1,0 +1,5 @@
+---
+layout: without_aside
+---
+
+{{content}}

--- a/app/_plugins/converters/syntax_highlight.rb
+++ b/app/_plugins/converters/syntax_highlight.rb
@@ -17,13 +17,15 @@ module Kramdown
         id = SecureRandom.uuid
 
         snippet = CodeHighlighter.new.highlight(code, language, id)
+
         Liquid::Template.parse(template, { line_numbers: true }).render(
           {
             'codeblock' => {
               'copy' => copy,
               'css_classes' => el.attr['class'],
               'collapsible' => el.attr.fetch('class', '').include?('collapsible'),
-              'render_header' => !data['data-file'].nil?,
+              'ask_kai' => ask_kai(data, code),
+              'render_header' => !data['data-file'].nil? || !ask_kai(data, code).nil?,
               'id' => id,
               'data' => data,
               'snippet' => snippet
@@ -53,6 +55,12 @@ module Kramdown
         @data_attributes = attr.each_with_object({}) do |(key, value), data|
           data[key] = value if key.start_with?('data-')
         end
+      end
+
+      def ask_kai(data, code)
+        return nil if data['data-ask-kai'].nil?
+
+        "https://cloud.konghq.com/?agent=true&agent-prompt=#{URI.encode_www_form_component(code)}"
       end
     end
   end

--- a/app/_plugins/generators/data/search_tags/base.rb
+++ b/app/_plugins/generators/data/search_tags/base.rb
@@ -13,7 +13,8 @@ module Jekyll
           'plugin_example' => 'PluginExample',
           'reference' => 'Reference',
           'policy' => 'Policy',
-          'support' => 'Support'
+          'support' => 'Support',
+          'prompt' => 'Prompt'
         }.freeze
 
         def self.make_for(site:, page:)

--- a/app/_plugins/generators/data/search_tags/prompt.rb
+++ b/app/_plugins/generators/data/search_tags/prompt.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Jekyll
+  module Data
+    module SearchTags
+      class Prompt < Base
+      end
+    end
+  end
+end

--- a/app/_plugins/generators/data/title/base.rb
+++ b/app/_plugins/generators/data/title/base.rb
@@ -9,6 +9,8 @@ module Jekyll
             APIPage.new(page:, site:)
           elsif page.url.start_with?('/plugins/')
             Plugin.new(page:, site:)
+          elsif page.url.start_with?('/prompts/')
+            Prompt.new(page:, site:)
           elsif page.url.start_with?('/mesh/policies/') || page.url.start_with?('/event-gateway/policies/')
             Policy.new(page:, site:)
           elsif page.data['content_type'] && page.data['content_type'] == 'reference'

--- a/app/_plugins/generators/data/title/prompt.rb
+++ b/app/_plugins/generators/data/title/prompt.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require_relative 'base'
+
+module Jekyll
+  module Data
+    module Title
+      class Prompt < Base
+        def title_sections
+          [page_title, 'Prompts']
+        end
+
+        def llm_title
+          page_title
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/generators/prompts.rb
+++ b/app/_plugins/generators/prompts.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Jekyll
+  class PromptsGenerator < Jekyll::Generator
+    priority :high
+
+    def generate(site)
+      site.data['prompts'] ||= []
+      Jekyll::PromptPages::Generator.run(site)
+    end
+  end
+end

--- a/app/_plugins/generators/prompts/generator.rb
+++ b/app/_plugins/generators/prompts/generator.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module PromptPages
+    class Generator
+      PROMPTS_FOLDER = '_prompts'
+
+      def self.run(site)
+        new(site).run
+      end
+
+      attr_reader :site
+
+      def initialize(site)
+        @site = site
+      end
+
+      def run
+        return if site.config.dig('skip', 'prompts')
+
+        Dir.glob(File.join(site.source, "#{PROMPTS_FOLDER}/*.{yaml,yml}")).each do |file|
+          slug = File.basename(file, File.extname(file))
+          prompt = Jekyll::PromptPages::Prompt.new(file:, slug:)
+
+          generate_overview_page(prompt)
+        end
+      end
+
+      private
+
+      def generate_overview_page(prompt)
+        overview = Jekyll::PromptPages::Pages::Overview
+                   .new(prompt:)
+                   .to_jekyll_page
+
+        site.data['prompts'] << overview
+        site.pages << overview
+      end
+    end
+  end
+end

--- a/app/_plugins/generators/prompts/pages/base.rb
+++ b/app/_plugins/generators/prompts/pages/base.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require_relative '../../../lib/site_accessor'
+
+module Jekyll
+  module PromptPages
+    module Pages
+      class Base
+        include Jekyll::SiteAccessor
+
+        attr_reader :prompt
+
+        def initialize(prompt:)
+          @prompt = prompt
+        end
+
+        def to_jekyll_page
+          CustomJekyllPage.new(site:, page: self)
+        end
+
+        def dir
+          url
+        end
+
+        def relative_path
+          @relative_path ||= prompt.file.gsub("#{site.source}/", '')
+        end
+
+        def data
+          {
+            'title' => prompt.title,
+            'description' => prompt.description,
+            'extended_description' => prompt.extended_description,
+            'products' => prompt.products,
+            'prompts' => prompt.prompts,
+            'slug' => prompt.slug,
+            'content_type' => 'prompt',
+            'layout' => layout,
+            'breadcrumbs' => ['/prompts/']
+          }
+        end
+
+        def url
+          @url ||= self.class.url(prompt)
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/generators/prompts/pages/overview.rb
+++ b/app/_plugins/generators/prompts/pages/overview.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module PromptPages
+    module Pages
+      class Overview < Base
+        def self.url(prompt)
+          "/prompts/#{prompt.slug}/"
+        end
+
+        def content
+          @content ||= File.read('app/_includes/prompts/overview.md')
+        end
+
+        def layout
+          'prompts/overview'
+        end
+
+        def data
+          super.merge('overview?' => true, 'content_type' => 'prompt')
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/generators/prompts/prompt.rb
+++ b/app/_plugins/generators/prompts/prompt.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'yaml'
+require_relative '../../lib/site_accessor'
+
+module Jekyll
+  module PromptPages
+    class Prompt
+      include Jekyll::SiteAccessor
+
+      attr_reader :file, :slug
+
+      def initialize(file:, slug:)
+        @file = file
+        @slug = slug
+      end
+
+      def metadata
+        @metadata ||= YAML.load_file(@file)
+      end
+
+      def title
+        @title ||= metadata.fetch('title')
+      end
+
+      def description
+        @description ||= metadata.fetch('description')
+      end
+
+      def extended_description
+        @extended_description ||= metadata.fetch('extended_description', description)
+      end
+
+      def products
+        @products ||= metadata.fetch('products', [])
+      end
+
+      def prompts
+        @prompts ||= metadata.fetch('prompts', [])
+      end
+    end
+  end
+end

--- a/app/_prompts/debugging.yaml
+++ b/app/_prompts/debugging.yaml
@@ -1,0 +1,11 @@
+title: Debugging with KAi
+description: Help diagnose and fix issues in your Kong configuration with KAi's debugging capabilities.
+extended_description: Help diagnose and fix issues in your Kong configuration with KAi's debugging capabilities. Learn how to use KAi to identify and resolve common problems effectively.
+products:
+ - gateway
+
+prompts:
+  - Why is my `/api/checkout` endpoint slow? Create a debugging session, focusing on high-latency requests, and summarize where time is being spent.
+  - Help me initiate a debugging session to troubleshoot the recent latency spikes and give me an analysis of the results with recommendations.
+  - Help me diagnose intermittent 502s on my [ROUTE_NAME] Route.
+  - I'm seeing 429 errors on my API Gateway route. Walk me through diagnosing a rate limiting issue, including how to check plugin config, consumer credentials, and request headers.

--- a/app/_prompts/security.yaml
+++ b/app/_prompts/security.yaml
@@ -1,0 +1,12 @@
+
+title: Security with KAi
+description: Enhance the security of your Kong configuration with KAi's security auditing capabilities.
+extended_description: Enhance the security of your Kong configuration with KAi's security auditing capabilities. Learn how to use KAi to identify and fix common security misconfigurations effectively.
+products:
+ - gateway
+ - event-gateway
+
+prompts:
+  - "Audit my [CONTROL_PLANE] control plane for common security misconfigurations (for example: auth missing, weak TLS, or overly broad CORS). Suggest prioritized fixes."
+  - "Suggest a safe baseline policy set for a public API (rate limiting, authentication, and logging) and show how to apply it to the [SERVICE_NAME] Gateway Service."
+  - "Check if any Routes in my [CONTROL_PLANE] control plane expose endpoints without authentication, and list them."

--- a/app/prompts.html
+++ b/app/prompts.html
@@ -1,0 +1,89 @@
+---
+title: Prompt Hub
+layout: default
+hub: true
+no_edit_link: true
+edit_and_issue_links: false
+description: A curated collection of AI prompts for use with KAi, Konnect's AI assistant.
+---
+{% if page.output_format == 'markdown'%}
+{%- for category in site.data.prompts %}
+- [{{category.title | liquify }}]({{ category.url }}): {{ category.description | liquify }}{% for prompt in category.prompts %}
+    - {{ prompt | liquify }}{%- endfor -%}{%- endfor %}
+{% else %}
+<div class="flex flex-col gap-12 w-full">
+  <div class="flex justify-between gap-[60px]">
+    <div class="flex flex-col gap-6 py-24 self-center">
+      <div class="flex flex-col gap-2">
+        <div class="flex items-center gap-3"><h1 class="font-extrabold text-[40px] leading-[60px]">Prompt Hub</h1>{% include components/llm_dropdown.html url=page.url %}</div>
+        <span class="leading-7">A curated collection of AI prompts for KAi, Konnect's built-in AI assistant.
+          <br>Browse, filter, and run prompts directly in your Konnect environment.</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="grid grid-cols-1 md:grid-cols-4 gap-16">
+    <div id="filters" class="filters md:flex">
+
+      <div class="mobile-drawer hidden md:flex">
+        <div class="mobile-drawer__panel">
+          <div class="mobile-drawer__content">
+            <div class="flex flex-col gap-8 w-full">
+              <div class="flex flex-col gap-3">
+                <div class="text-sm text-brand font-semibold">Product</div>
+                <div class="flex flex-col gap-3">
+                  {% for product in site.data.products %}
+                  {% assign product_slug = product[0] %}{% assign product_name = product[1].name %}
+                  {% capture icon %}{% include_cached product_icon.html product=product_slug %}{% endcapture %}
+                  {% include checkbox.html value=product_slug name="product" label=product_name icon=icon %}
+                  {% endfor %}
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="mobile-drawer__footer">
+            <button class="button button--secondary" id="clear-filters">
+              Clear Filters
+            </button>
+            <button id="see-results" class="button button--primary grow justify-center">
+              See Results
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="searchbox-results-container">
+      <div class="flex md:flex-col md:col-span-3  w-full justify-between gap-2">
+        <div class="flex flex-col gap-3 w-full">
+          <div class="filter-results-field">
+            <svg class="filter-results-field__image" width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M10 18V16H14V18H10ZM6 13V11H18V13H6ZM3 8V6H21V8H3Z" fill="rgb(var(--color-text-terciary))"/>
+            </svg>
+            <input id="plugins-search" name="terms" type="search" class="filter-results-field__input" placeholder="Filter results">
+          </div>
+        </div>
+
+        <div class="flex md:hidden">
+          <button class="button button--secondary button--filters" id="toggle-filters-drawer">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M10 18V16H14V18H10ZM6 13V11H18V13H6ZM3 8V6H21V8H3Z" fill="rgb(var(--color-text-terciary))" />
+            </svg>
+            Filters
+          </button>
+        </div>
+      </div>
+
+      <div class="flex flex-col md:col-span-3 w-full gap-16" id="plugin-cards">
+        <div class="flex flex-col gap-4">
+        {%- for prompt in site.data.prompts %}
+          <div class="grid auto-rows-fr grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {% include cards/prompt.html prompt=prompt %}
+          </div>
+        {% endfor %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+{% endif %}

--- a/app/prompts.html
+++ b/app/prompts.html
@@ -76,11 +76,11 @@ description: A curated collection of AI prompts for use with KAi, Konnect's AI a
 
       <div class="flex flex-col md:col-span-3 w-full gap-16" id="plugin-cards">
         <div class="flex flex-col gap-4">
-        {%- for prompt in site.data.prompts %}
           <div class="grid auto-rows-fr grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+            {% for prompt in site.data.prompts %}
             {% include cards/prompt.html prompt=prompt %}
+            {% endfor %}
           </div>
-        {% endfor %}
         </div>
       </div>
     </div>

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -12,6 +12,7 @@ skip:
   auto_generated: true # skip auto_generated references, i.e. app/_referneces
   mesh: true # skip kuma to mesh generation
   llm_pages: true # skip markdown pages generation
+  prompts: true
 
 # exclude app/_references
 # even though we set skip.auto_generated: true and the collection has output:false


### PR DESCRIPTION
## Description

Based on https://github.com/Kong/developer.konghq.com/pull/4667/
Add prompt hub with `Run in Kai` button + markdown support.
TODO: We need to migrate the rest of the prompts

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
