### PR TITLE
fix(GW): remove grpc and grpcs from the 'compatible protocols' section of oas-validation plugin

### DIFF
--- a/app/_schemas/gateway/plugins/3.10/OasValidation.json
+++ b/app/_schemas/gateway/plugins/3.10/OasValidation.json
@@ -93,16 +93,12 @@
     },
     "protocols": {
       "default": [
-        "grpc",
-        "grpcs",
         "http",
         "https"
       ],
       "description": "A set of strings representing HTTP protocols.",
       "items": {
         "enum": [
-          "grpc",
-          "grpcs",
           "http",
           "https"
         ],

--- a/app/_schemas/gateway/plugins/3.11/OasValidation.json
+++ b/app/_schemas/gateway/plugins/3.11/OasValidation.json
@@ -93,16 +93,12 @@
     },
     "protocols": {
       "default": [
-        "grpc",
-        "grpcs",
         "http",
         "https"
       ],
       "description": "A set of strings representing HTTP protocols.",
       "items": {
         "enum": [
-          "grpc",
-          "grpcs",
           "http",
           "https"
         ],

--- a/app/_schemas/gateway/plugins/3.12/OasValidation.json
+++ b/app/_schemas/gateway/plugins/3.12/OasValidation.json
@@ -93,16 +93,12 @@
     },
     "protocols": {
       "default": [
-        "grpc",
-        "grpcs",
         "http",
         "https"
       ],
       "description": "A set of strings representing HTTP protocols.",
       "items": {
         "enum": [
-          "grpc",
-          "grpcs",
           "http",
           "https"
         ],

--- a/app/_schemas/gateway/plugins/3.13/OasValidation.json
+++ b/app/_schemas/gateway/plugins/3.13/OasValidation.json
@@ -98,16 +98,12 @@
     },
     "protocols": {
       "default": [
-        "grpc",
-        "grpcs",
         "http",
         "https"
       ],
       "description": "A set of strings representing HTTP protocols.",
       "items": {
         "enum": [
-          "grpc",
-          "grpcs",
           "http",
           "https"
         ],

--- a/app/_schemas/gateway/plugins/3.14/OasValidation.json
+++ b/app/_schemas/gateway/plugins/3.14/OasValidation.json
@@ -98,16 +98,12 @@
     },
     "protocols": {
       "default": [
-        "grpc",
-        "grpcs",
         "http",
         "https"
       ],
       "description": "A set of strings representing HTTP protocols.",
       "items": {
         "enum": [
-          "grpc",
-          "grpcs",
           "http",
           "https"
         ],

--- a/app/_schemas/gateway/plugins/3.4/OasValidation.json
+++ b/app/_schemas/gateway/plugins/3.4/OasValidation.json
@@ -92,16 +92,12 @@
     },
     "protocols": {
       "default": [
-        "grpc",
-        "grpcs",
         "http",
         "https"
       ],
       "description": "A set of strings representing HTTP protocols.",
       "items": {
         "enum": [
-          "grpc",
-          "grpcs",
           "http",
           "https"
         ],

--- a/app/_schemas/gateway/plugins/3.7/OasValidation.json
+++ b/app/_schemas/gateway/plugins/3.7/OasValidation.json
@@ -96,16 +96,12 @@
     },
     "protocols": {
       "default": [
-        "grpc",
-        "grpcs",
         "http",
         "https"
       ],
       "description": "A set of strings representing HTTP protocols.",
       "items": {
         "enum": [
-          "grpc",
-          "grpcs",
           "http",
           "https"
         ],

--- a/app/_schemas/gateway/plugins/3.8/OasValidation.json
+++ b/app/_schemas/gateway/plugins/3.8/OasValidation.json
@@ -96,16 +96,12 @@
     },
     "protocols": {
       "default": [
-        "grpc",
-        "grpcs",
         "http",
         "https"
       ],
       "description": "A set of strings representing HTTP protocols.",
       "items": {
         "enum": [
-          "grpc",
-          "grpcs",
           "http",
           "https"
         ],

--- a/app/_schemas/gateway/plugins/3.9/OasValidation.json
+++ b/app/_schemas/gateway/plugins/3.9/OasValidation.json
@@ -96,16 +96,12 @@
     },
     "protocols": {
       "default": [
-        "grpc",
-        "grpcs",
         "http",
         "https"
       ],
       "description": "A set of strings representing HTTP protocols.",
       "items": {
         "enum": [
-          "grpc",
-          "grpcs",
           "http",
           "https"
         ],


### PR DESCRIPTION

## Description

Fixes [FTI-7420](https://konghq.atlassian.net/browse/FTI-7420)


## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).


[FTI-7420]: https://konghq.atlassian.net/browse/FTI-7420?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ