### PR TITLE
feat(M&B): Use cases

### DIFF
--- a/.github/styles/base/Dictionary.txt
+++ b/.github/styles/base/Dictionary.txt
@@ -663,6 +663,7 @@ pagerduty
 palo
 param
 params
+parsable
 passthrough
 PayPal
 PayPal

--- a/app/_includes/konnect/metering-and-billing/discounts.md
+++ b/app/_includes/konnect/metering-and-billing/discounts.md
@@ -1,6 +1,4 @@
-## Discounts and commitments
-
-Rate Cards discounts and commitments allow you to adjust the price of a feature in a plan. 
+Rate card discounts and commitments allow you to adjust the price of a feature in a plan. 
 
 The following table describes the discounts and commitment types:
 

--- a/app/_indices/metering-and-billing.yaml
+++ b/app/_indices/metering-and-billing.yaml
@@ -37,7 +37,7 @@ sections:
         url: /metering-and-billing/product-catalog/#pricing-models
       - title: Entitlements
         description: Entitlements describe customer access, usage-limits, and configuration to features.
-        url: /metering-and-billing/product-catalog/#entitlements
+        url: /metering-and-billing/entitlements/
   - title: Collectors
     items:
       - path: /metering-and-billing/collectors/**/*

--- a/app/_landing_pages/metering-and-billing.yaml
+++ b/app/_landing_pages/metering-and-billing.yaml
@@ -165,7 +165,7 @@ rows:
               icon: /assets/icons/document-list.svg
               cta:
                 text: Learn more
-                url: /metering-and-billing/product-catalog/#entitlements
+                url: /metering-and-billing/entitlements/
 
   - header:
       type: h2

--- a/app/metering-and-billing/billing-invoicing-subscriptions.md
+++ b/app/metering-and-billing/billing-invoicing-subscriptions.md
@@ -39,21 +39,21 @@ Billing profiles can be managed from the [**Billing Profiles**](https://cloud.ko
 {% table %}
 columns:
   - title: Use Case
-    key: usecase
+    key: case
   - title: Description
     key: description
 rows:
-  - usecase: "[Recurring billing](#subscriptions)"
+  - case: "[Recurring billing](#subscriptions)"
     description: Monthly, weekly, or annual subscriptions.
-  - usecase: "[Usage-based pricing](#subscriptions)"
+  - case: "[Usage-based pricing](#subscriptions)"
     description: Metered pay-as-you-go, tiered, and volume-based pricing.
-  - usecase: "[Custom deals](#customer-billing-profile-overrides)"
+  - case: "[Custom deals](#customer-billing-profile-overrides)"
     description: Custom pricing and discounts for specific customers.
-  - usecase: "[Commitments](#discounts-and-commitments)"
+  - case: "[Commitments](#discounts-and-commitments)"
     description: Pre-purchase commitments, minimum spends, and much more.
-  - usecase: "[Discounts](#discounts-and-commitments)"
+  - case: "[Discounts](#discounts-and-commitments)"
     description: Plan-specific or customer-specific discounts.
-  - usecase: "[Trials and ramp-ups](/metering-and-billing/product-catalog/#plan-phases)"
+  - case: "[Trials and ramp-ups](/metering-and-billing/product-catalog/#plan-phases)"
     description: Time-based phases with different pricing and limits.
 {% endtable %}
 
@@ -100,14 +100,14 @@ Customer overrides can be useful for the following use cases:
 {% table %}
 columns:
   - title: Use Case
-    key: usecase
+    key: case
   - title: Description
     key: description
 rows:
-  - usecase: "Enterprise billing"
+  - case: "Enterprise billing"
     description: |
       Set up one billing profile for SaaS customers and another for Enterprise customers (with send invoice for bank transfer selected).
-  - usecase: "Migrating customers' billing"
+  - case: "Migrating customers' billing"
     description: |
       Create a new billing profile that you want to migrate customers to and then assign them to the new profile with a customer override. 
       <br><br>
@@ -119,9 +119,9 @@ rows:
       1. Finally, migrate existing customers one by one from the old billing profile to the new one, allowing you to monitor and control the migration process while maintaining service continuity.
       <br><br>
       
-      If you want to migrate a customer to an existing billing profile instead of creating a new one, make sure that the customer has a valid payment method in the that profile.
+      If you want to migrate a customer to an existing billing profile instead of creating a new one, make sure that the customer has a valid payment method in that profile.
 
-  - usecase: "Migrate customers to Stripe billing"
+  - case: "Migrate customers to Stripe billing"
     description: |
       Migrate customers to a Stripe billing profile using the [Stripe integration](/metering-and-billing/stripe-integration/).
 {% endtable %}

--- a/app/metering-and-billing/billing-invoicing-subscriptions.md
+++ b/app/metering-and-billing/billing-invoicing-subscriptions.md
@@ -43,17 +43,17 @@ columns:
   - title: Description
     key: description
 rows:
-  - usecase: [Recurring billing](#subscriptions)
+  - usecase: "[Recurring billing](#subscriptions)"
     description: Monthly, weekly, or annual subscriptions.
-  - usecase: [Usage-based pricing]
+  - usecase: "[Usage-based pricing](#subscriptions)"
     description: Metered pay-as-you-go, tiered, and volume-based pricing.
-  - usecase: [Custom deals](#customer-billing-profile-overrides)
+  - usecase: "[Custom deals](#customer-billing-profile-overrides)"
     description: Custom pricing and discounts for specific customers.
-  - usecase: [Commitments](#discounts-and-commitments)
+  - usecase: "[Commitments](#discounts-and-commitments)"
     description: Pre-purchase commitments, minimum spends, and much more.
-  - usecase: [Discounts](#discounts-and-commitments)
+  - usecase: "[Discounts](#discounts-and-commitments)"
     description: Plan-specific or customer-specific discounts.
-  - usecase: [Trials and ramp-ups](/metering-and-billing/product-catalog/#plan-phases)
+  - usecase: "[Trials and ramp-ups](/metering-and-billing/product-catalog/#plan-phases)"
     description: Time-based phases with different pricing and limits.
 {% endtable %}
 
@@ -93,11 +93,39 @@ By default, customers are pinned to the default billing profile. Customer overri
 This is useful when you have different billing needs for different customers. 
 For example, you might want some customers to be billed via Stripe and others via bank transfer.
 
-Customer overrides can be useful for the following use cases:
-* **Enterprise billing**: Set up one billing profile for SaaS customers and another for Enterprise customers (with send invoice for bank transfer selected).
-* **Migrating customers billing**: Create a new billing profile that you want to migrate customers to and then assign them to the new profile with a customer override.
-
 Configure customer overrides by navigating to **{{site.metering_and_billing}}** > [**Billing**](https://cloud.konghq.com/metering-billing/customers), click a customer, then navigate to the **Billing Profile** section of the customer settings.
+
+Customer overrides can be useful for the following use cases:
+
+{% table %}
+columns:
+  - title: Use Case
+    key: usecase
+  - title: Description
+    key: description
+rows:
+  - usecase: "Enterprise billing"
+    description: |
+      Set up one billing profile for SaaS customers and another for Enterprise customers (with send invoice for bank transfer selected).
+  - usecase: "Migrating customers' billing"
+    description: |
+      Create a new billing profile that you want to migrate customers to and then assign them to the new profile with a customer override. 
+      <br><br>
+      Here's how to safely migrate customers:
+      <br><br>
+      1. Create a new billing profile that will serve as the target for migration.
+      1. Ensure all existing customers are explicitly pinned to the old billing profile. This prevents any disruption during the migration process.
+      1. Set the new billing profile as the default, which means any new customers will automatically use it.
+      1. Finally, migrate existing customers one by one from the old billing profile to the new one, allowing you to monitor and control the migration process while maintaining service continuity.
+      <br><br>
+      
+      If you want to migrate a customer to an existing billing profile instead of creating a new one, make sure that the customer has a valid payment method in the that profile.
+
+  - usecase: "Migrate customers to Stripe billing"
+    description: |
+      Migrate customers to a Stripe billing profile using the [Stripe integration](/metering-and-billing/stripe-integration/).
+{% endtable %}
+
 
 ## Tax calculations
 

--- a/app/metering-and-billing/billing-invoicing-subscriptions.md
+++ b/app/metering-and-billing/billing-invoicing-subscriptions.md
@@ -32,6 +32,31 @@ A billing profile is linked to a specific App. This association is established d
 
 Billing profiles can be managed from the [**Billing Profiles**](https://cloud.konghq.com/metering-billing/billing-profiles) tab in **{{site.metering_and_billing}} > Settings** in the {{site.konnect_short_name}} UI.
 
+### Use cases
+
+{{site.metering_and_billing}} can help implement various pricing strategies:
+
+{% table %}
+columns:
+  - title: Use Case
+    key: usecase
+  - title: Description
+    key: description
+rows:
+  - usecase: [Recurring billing](#subscriptions)
+    description: Monthly, weekly, or annual subscriptions.
+  - usecase: [Usage-based pricing]
+    description: Metered pay-as-you-go, tiered, and volume-based pricing.
+  - usecase: [Custom deals](#customer-billing-profile-overrides)
+    description: Custom pricing and discounts for specific customers.
+  - usecase: [Commitments](#discounts-and-commitments)
+    description: Pre-purchase commitments, minimum spends, and much more.
+  - usecase: [Discounts](#discounts-and-commitments)
+    description: Plan-specific or customer-specific discounts.
+  - usecase: [Trials and ramp-ups](/metering-and-billing/product-catalog/#plan-phases)
+    description: Time-based phases with different pricing and limits.
+{% endtable %}
+
 ### Invoicing settings
 
 The invoicing settings define the invoice creation process and lifecycle management parameters, including:
@@ -64,7 +89,9 @@ Invoice due after/Payment due after specifies the duration allowed for invoice p
 
 ### Customer billing profile overrides
 
-Customer overrides allows you to assign a different billing profile to customers other than the default. By default customers are pinned to the default billing profile. This is useful when you have different billing needs for different customers. For example, you might want some customers to be billed via Stripe and others via bank transfer.
+By default, customers are pinned to the default billing profile. Customer overrides allow you to assign different billing profiles to specific customers or customer groups.
+This is useful when you have different billing needs for different customers. 
+For example, you might want some customers to be billed via Stripe and others via bank transfer.
 
 Customer overrides can be useful for the following use cases:
 * **Enterprise billing**: Set up one billing profile for SaaS customers and another for Enterprise customers (with send invoice for bank transfer selected).
@@ -145,6 +172,8 @@ Given an invoice is always single currency, if the customer was migrated between
 
 {:.warning}
 > **Important:** For systematic changes that need to persist across billing cycles, we recommend modifying the subscription directly rather than editing gathering invoices. This ensures consistent billing behavior aligned with the intended subscription terms.
+
+## Discounts and commitments
 
 {% include_cached /konnect/metering-and-billing/discounts.md %}
 

--- a/app/metering-and-billing/entitlements.md
+++ b/app/metering-and-billing/entitlements.md
@@ -20,7 +20,7 @@ related_resources:
 
 ---
 
-Entitlements let you control customer access to features defined on a [rate card](/metering-and-billing/product-catalog/#rate-cards) making it possible to implement complex pricing scenarios such as monthly quotas, prepaid billing, and per-customer pricing.
+Entitlements let you control customer access to features defined on a [rate card](/metering-and-billing/product-catalog/#rate-cards), making it possible to implement complex pricing scenarios such as monthly quotas, prepaid billing, and per-customer pricing.
 
 Entitlements are an attribute of rate cards. You must configure entitlements when configuring a rate card.
 
@@ -31,19 +31,19 @@ Entitlements are an attribute of rate cards. You must configure entitlements whe
 {% table %}
 columns:
   - title: Use Case
-    key: usecase
+    key: case
   - title: Description
     key: description
 rows:
-  - usecase: Usage limits
+  - case: Usage limits
     description: Enforce usage limits like monthly token allowances.
-  - usecase: Plan variance
+  - case: Plan variance
     description: Offer tiered plans with different feature sets.
-  - usecase: Custom quotes
+  - case: Custom quotes
     description: Offer custom quotes and per-customer pricing.
-  - usecase: Prepaid billing
+  - case: Prepaid billing
     description: Adopt prepaid billing and handle top-ups.
-  - usecase: Commitments
+  - case: Commitments
     description: Define and track pre-purchase commitments.
 {% endtable %}
 
@@ -63,7 +63,7 @@ rows:
       Allow customers to consume features up to a certain usage limit. For example, 10 million monthly tokens.
       <br><br>
       This is useful when the underlying resources are expensive, as is the case for most AI products. 
-      Metered entitlements leverage the usage information collected by {{site.metering_and_billing}} and give you the ability to do real time usage enforcement, as well as historical queries and access checks.
+      Metered entitlements leverage the usage information collected by {{site.metering_and_billing}} and give you the ability to do real-time usage enforcement, as well as historical queries and access checks.
       <br><br>
       When configuring a metered entitlement, you can set the following:
 
@@ -81,7 +81,7 @@ rows:
     description: |
       Describe access to specific features, like SAML SSO, without needing configuration or metering.
       <br><br>
-      In cases where you don't need to set up usage limits or configure customer level settings,
+      In cases where you don't need to set up usage limits or configure customer-level settings,
       you can use boolean entitlements. 
       These are simple `true` or `false` access grants to a feature.
 {% endtable %}
@@ -104,9 +104,9 @@ When toggled **on**, overage accumulated in the previous period is deducted from
 ### Static entitlements
 
 Static entitlements let you define customer- or plan-specific configuration for a given feature as a JSON value. 
-For example, you could give freemium users access to only a subset of AI models by specifying which models are available based on their tier.
+For example, you could give free trial users access to only a subset of AI models by specifying which models are available based on their tier.
 
-The configuration you pass has to be a JSON parsable string in object format. 
+The configuration you pass has to be a JSON-parsable string in object format. 
 For example:
 
 ```json

--- a/app/metering-and-billing/entitlements.md
+++ b/app/metering-and-billing/entitlements.md
@@ -1,0 +1,135 @@
+---
+title: "Entitlements"
+content_type: reference
+description: "Use entitlements to control customer access to features, enforce usage limits, and implement pricing strategies like prepaid billing and custom quotes."
+layout: reference
+products:
+  - metering-and-billing
+tools:
+  - konnect-api
+works_on:
+  - konnect
+breadcrumbs:
+  - /metering-and-billing/
+  - /metering-and-billing/product-catalog/
+related_resources:
+  - text: "{{site.konnect_short_name}} {{site.metering_and_billing}}"
+    url: /metering-and-billing/
+  - text: "Rate Cards"
+    url: /metering-and-billing/product-catalog/#rate-cards
+
+---
+
+Entitlements let you control customer access to features defined on a [rate card](/metering-and-billing/product-catalog/#rate-cards) making it possible to implement complex pricing scenarios such as monthly quotas, prepaid billing, and per-customer pricing.
+
+Entitlements are an attribute of rate cards. You must configure entitlements when configuring a rate card.
+
+## Use cases
+
+{{site.metering_and_billing}} entitlements can help implement various monetization strategies:
+
+{% table %}
+columns:
+  - title: Use Case
+    key: usecase
+  - title: Description
+    key: description
+rows:
+  - usecase: Usage limits
+    description: Enforce usage limits like monthly token allowances.
+  - usecase: Plan variance
+    description: Offer tiered plans with different feature sets.
+  - usecase: Custom quotes
+    description: Offer custom quotes and per-customer pricing.
+  - usecase: Prepaid billing
+    description: Adopt prepaid billing and handle top-ups.
+  - usecase: Commitments
+    description: Define and track pre-purchase commitments.
+{% endtable %}
+
+## Entitlement types
+
+There are three different types of entitlements:
+
+{% table %}
+columns:
+  - title: Type
+    key: type
+  - title: Description
+    key: description
+rows:
+  - type: "[Metered](#metered-entitlements)"
+    description: |
+      Allow customers to consume features up to a certain usage limit. For example, 10 million monthly tokens.
+      <br><br>
+      This is useful when the underlying resources are expensive, as is the case for most AI products. 
+      Metered entitlements leverage the usage information collected by {{site.metering_and_billing}} and give you the ability to do real time usage enforcement, as well as historical queries and access checks.
+      <br><br>
+      When configuring a metered entitlement, you can set the following:
+
+      * **Usage period**: Daily, weekly, monthly, or a custom [ISO 8601](https://www.iso.org/iso-8601-date-and-time-format.html) duration.
+      * **Allowance for period**: Number of grants automatically issued on creation and in each usage period.
+      * **Preserve overage**: Enable to deduct accumulated overage from the starting balance in the next period. Off by default.
+      * **Soft limit**: Enable to always grant access to the feature, even when balance is zero. Off by default.
+  - type: "[Static](#static-entitlements)"
+    description: |
+      Define customer-specific configurations as a JSON value. 
+      <br><br>
+      For example, you could give free users access to a subset of AI models. 
+      With static entitlements, you can specify which models the customer can use based on their tier: `{ "enabledModels": ["gpt-3", "gpt-4"] }`.
+  - type: "[Boolean](#boolean-entitlements)"
+    description: |
+      Describe access to specific features, like SAML SSO, without needing configuration or metering.
+      <br><br>
+      In cases where you don't need to set up usage limits or configure customer level settings,
+      you can use boolean entitlements. 
+      These are simple `true` or `false` access grants to a feature.
+{% endtable %}
+
+### Metered entitlements
+
+Metered entitlements control access to features where you want to impose usage limits. 
+They leverage the usage information collected by {{site.metering_and_billing}} to enable real-time usage enforcement.
+
+#### Usage period
+
+Metered entitlements require a usage period setting that defines the interval over which usage is calculated. This is typically a day, week, or month. In most cases, this should match your customers' billing cycles. 
+
+The start of each period is marked by a reset: at reset, a new marker is set from which usage is queried and aggregated.
+{{site.metering_and_billing}} automatically executes the reset when a new usage period starts, based on the entitlement configuration.
+
+If you want to maintain a continuous running balance where overage carries forward rather than being forgiven at the end of each period, set the **Preserve Overage** field on the entitlement.
+When toggled **on**, overage accumulated in the previous period is deducted from the starting balance of the new period.
+
+### Static entitlements
+
+Static entitlements let you define customer- or plan-specific configuration for a given feature as a JSON value. 
+For example, you could give freemium users access to only a subset of AI models by specifying which models are available based on their tier.
+
+The configuration you pass has to be a JSON parsable string in object format. 
+For example:
+
+```json
+{ "enabledModels": ["gpt-3", "gpt-4"] }
+```
+
+### Boolean entitlements
+
+Boolean entitlements are simple true or false access grants to a feature. 
+Use them when you don't need usage limits or customer-level configuration. 
+For example, you could use a boolean entitlement to grant or deny access to a SAML SSO feature.
+
+## Configuring and checking entitlements
+
+Entitlements must be configured as part of rate cards in {{site.konnect_short_name}}. 
+See the [{{site.metering_and_billing}} getting started guide](/metering-and-billing/get-started/) for setup steps.
+
+Once configured, you can check entitlements for a customer through the {{site.konnect_short_name}} UI, or using the {{site.metering_and_billing}} `/entitlement-access` API:
+
+<!--vale off-->
+{% konnect_api_request %}
+url: /v3/openmeter/customers/{customerId}/entitlement-access
+status_code: 200
+method: GET
+{% endkonnect_api_request %}
+<!--vale on-->

--- a/app/metering-and-billing/entitlements.md
+++ b/app/metering-and-billing/entitlements.md
@@ -99,7 +99,7 @@ The start of each period is marked by a reset: at reset, a new marker is set fro
 {{site.metering_and_billing}} automatically executes the reset when a new usage period starts, based on the entitlement configuration.
 
 If you want to maintain a continuous running balance where overage carries forward rather than being forgiven at the end of each period, set the **Preserve Overage** field on the entitlement.
-When toggled **on**, overage accumulated in the previous period is deducted from the starting balance of the new period.
+When this is enabled, overage accumulated in the previous period is deducted from the starting balance of the new period.
 
 ### Static entitlements
 

--- a/app/metering-and-billing/product-catalog.md
+++ b/app/metering-and-billing/product-catalog.md
@@ -17,10 +17,11 @@ related_resources:
   - text: "Subjects"
     url: /metering-and-billing/subjects/
 
+toc_depth: 4
 ---
 
 
-{{site.konnect_short_name}} {{site.metering_and_billing}}'s Product Catalog lets you centrally define the different plans and plan features that make up your offering—so you can manage pricing, entitlements, and packaging in one place. 
+{{site.konnect_short_name}} {{site.metering_and_billing}}'s Product Catalog lets you centrally define the different plans and plan features that make up your offering, so you can manage pricing, entitlements, and packaging in one place. 
 
 Each Product Catalog plan consists of:
 * [Features](#features) that you want to price or govern. Can be metered or static.
@@ -336,6 +337,7 @@ Example for reverse trials with plan phases:
 * Phase 2 (Free): limited to 1,000 tokens
 
 
+## Discounts and commitments
 {% include_cached /konnect/metering-and-billing/discounts.md %}
 
 

--- a/app/metering-and-billing/product-catalog.md
+++ b/app/metering-and-billing/product-catalog.md
@@ -261,41 +261,20 @@ Besides the **Free** pricing model, other models require configuration that you 
 {% include_cached /konnect/metering-and-billing/tax.md %}
 
 #### Entitlements
+  
+Entitlements are used to control access to different features.
 
-Entitlements are used to control access to different features, they make it possible to implement complex pricing scenarios such as monthly quotas, prepaid billing, and per-customer pricing.
+They make it possible to implement complex pricing scenarios such as monthly quotas, prepaid billing, and per-customer pricing.
 
 Entitlements can help you implement various monetization strategies:
+
 * Enforce usage limits, like monthly token allowances.
 * Sell plans with various feature sets.
 * Offer custom quotes and per-customer pricing.
 * Adopt prepaid billing and grant usage, and handle top-ups.
 * Define and track pre-purchase commitments.
 
-There are three different types of entitlements:
-
-{% table %}
-columns:
-  - title: Type
-    key: type
-  - title: Description
-    key: description
-rows:
-  - type: Metered
-    description: |
-      Allow customers to consume features up to a certain usage limit, e.g., 10 million monthly tokens.
-
-      This is useful for example when the underlying resources are expensive, as is the case for most AI products. Metered entitlements leverage the usage information collected by {{site.metering_and_billing}} and give you the ability to do real time usage enforcement as well as historical queries and access checks.
-  - type: Static
-    description: |
-      Define customer-specific configurations as a JSON value. e.g. `{ "enabledModels": ["gpt-3", "gpt-4"] }`
-
-      For example, you may only give free users access to a subset of AI models. With static entitlements, you can specify which models the customer can use based on their tier.
-  - type: Boolean
-    description: |
-      Describe access to specific features, like SAML SSO, without needing configuration or metering.
-
-      In cases where you don't need to set up usage limits or configure customer level settings you can use boolean entitlements. These are simple true or false access grants to a feature. 
-{% endtable %}
+Entitlements are available in three types: metered, static, and boolean. See the [Entitlements reference](/metering-and-billing/entitlements/) to learn more.
 
 #### Billing cadence
 


### PR DESCRIPTION
## Description

Fixes #4333 #4335 #4338 

Migrates OpenMeter use cases and entitlement types.
This is all in one PR because they're interconnected and I wanted to avoid conflicts.

Changes made:
* New page for entitlements
  * There is a separate ticket that asks to create a separate page for entitlements and add more info to it; I'm not covering all of that here, so I'll address that ticket after this is merged.
* More detail on entitlement types
  * They can only be configured through the UI so the examples don't need to be migrated. Also removed any mention of the Grants API, as this doesn't exist (and I believe won't be migrated, based on info I saw on slack)
* Use cases for billing, entitlements, and customer overrides
* Minor cleanup edits

## Preview Links

https://deploy-preview-4857--kongdeveloper.netlify.app/metering-and-billing/billing-invoicing-subscriptions/
https://deploy-preview-4857--kongdeveloper.netlify.app/metering-and-billing/product-catalog/#entitlements
https://deploy-preview-4857--kongdeveloper.netlify.app/metering-and-billing/entitlements/
