### PR TITLE
feat(aws-lambda): add max_uri_args and reject_if_max_uri_args_exceede…

### DIFF
--- a/app/_schemas/gateway/plugins/3.14/AwsLambda.json
+++ b/app/_schemas/gateway/plugins/3.14/AwsLambda.json
@@ -134,7 +134,7 @@
         "max_uri_args": {
           "default": 100,
           "description": "The maximum number of query string parameters to parse from the request URI. Nginx's default limit is 100.",
-          "maximum": 10000,
+          "maximum": 1000,
           "minimum": 1,
           "type": "integer"
         },

--- a/app/_schemas/gateway/plugins/3.14/AwsLambda.json
+++ b/app/_schemas/gateway/plugins/3.14/AwsLambda.json
@@ -131,6 +131,13 @@
           ],
           "type": "string"
         },
+        "max_uri_args": {
+          "default": 100,
+          "description": "The maximum number of query string parameters to parse from the request URI. Nginx's default limit is 100.",
+          "maximum": 10000,
+          "minimum": 1,
+          "type": "integer"
+        },
         "port": {
           "default": 443,
           "description": "An integer representing a port number between 0 and 65535, inclusive.",
@@ -145,6 +152,11 @@
         "qualifier": {
           "description": "The qualifier to use when invoking the function.",
           "type": "string"
+        },
+        "reject_if_max_uri_args_exceeded": {
+          "default": false,
+          "description": "If enabled, the plugin returns a 414 URI Too Long response when the number of query string parameters exceeds `max_uri_args`, instead of forwarding the request to Lambda with truncated parameters.",
+          "type": "boolean"
         },
         "skip_large_bodies": {
           "default": true,


### PR DESCRIPTION
Add documentation for new aws-lambda plugin configuration options:
- `max_uri_args`: configurable limit for query string parameters (default: 100)
- `reject_if_max_uri_args_exceeded`: optional 414 URI Too Long rejection when the limit is exceeded (default: false)

## Description

Adds schema documentation for two new `aws-lambda` plugin config fields in the 3.14 schema. These allow users to override the default nginx limit of 100 query string parameters and optionally reject requests that exceed the limit with a 414 response instead of silently truncating.

Companion to the plugin implementation PR in Kong/kong.

## Preview Links


## Checklist 

- [x] Tested how-to docs. If not, note why here. (Schema-only change, no how-to docs affected.)
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [x] Add new pages to the product documentation index (if applicable). N/A — no new pages.
