### PR TITLE
feat(M&B): Migrate subscription billing info

### DIFF
--- a/app/metering-and-billing/billing-invoicing-subscriptions.md
+++ b/app/metering-and-billing/billing-invoicing-subscriptions.md
@@ -161,6 +161,10 @@ Subscriptions automate the billing lifecycle by:
 
 Subscriptions can be created from predefined plans or fully customized at creation time to accommodate unique customer requirements. This flexibility supports everything from self-serve sign-ups to enterprise contract negotiations.
 
+All subscriptions follow a monthly billing cycle anchored to one of the following:
+* The subscription start date, either the creation date or a specified future date.
+* The first day of the month, with usage prorated for the partial initial period.
+
 To add a subscription to a customer, navigate to **{{site.metering_and_billing}}** > **Billing**, click your customer, and then click the **Subscriptions** tab in the {{site.konnect_short_name}} UI.
 
 ## Plan migration

--- a/app/metering-and-billing/billing-invoicing-subscriptions.md
+++ b/app/metering-and-billing/billing-invoicing-subscriptions.md
@@ -161,7 +161,7 @@ Subscriptions automate the billing lifecycle by:
 
 Subscriptions can be created from predefined plans or fully customized at creation time to accommodate unique customer requirements. This flexibility supports everything from self-serve sign-ups to enterprise contract negotiations.
 
-All subscriptions follow a monthly billing cycle anchored to one of the following:
+Subscriptions follow a billing cycle determined by their related [rate card](/metering-and-billing/product-catalog/#rate-cards), anchored to one of the following:
 * The subscription start date, either the creation date or a specified future date.
 * The first day of the month, with usage prorated for the partial initial period.
 


### PR DESCRIPTION
## Description

Fixes #4334 

The migrated section is supposed to be https://openmeter.io/docs/billing/subscription/overview#subscription-alignment, but subscriptions are _not_ aligned by default anymore. 
* The billing cycle is aligned to the rate card
* The default setting is the start of the subscription, and you can set the 1st of the month as an option to align them. Based this info on spec and on testing.

## Preview Links

