### PR TITLE
feat(portal): Render Portal docs as markdown for Agents

### DIFF
--- a/app/_includes/faqs/portal-markdown.md
+++ b/app/_includes/faqs/portal-markdown.md
@@ -1,0 +1,14 @@
+{% if include.section == "question" %}
+
+How can agents consume documentation published in a {{site.dev_portal}}?
+{% elsif include.section == "answer" %}
+
+When you send a request to any {{site.dev_portal}} URL using the `Accept: text/markdown header`, it will return LLM-friendly markdown instead of HTML.
+
+For example:
+```sh
+curl https://portal.kongair.com/guides/prices \
+  -H "Accept: text/markdown"
+```
+
+{% endif %}

--- a/app/_includes/faqs/portal-markdown.md
+++ b/app/_includes/faqs/portal-markdown.md
@@ -3,7 +3,7 @@
 How can agents consume documentation published in a {{site.dev_portal}}?
 {% elsif include.section == "answer" %}
 
-When you send a request to any {{site.dev_portal}} URL using the `Accept: text/markdown header`, it will return LLM-friendly markdown instead of HTML.
+When you send a request to any {{site.dev_portal}} URL using the `Accept: text/markdown` header, it will return LLM-friendly markdown instead of HTML.
 
 For example:
 ```sh

--- a/app/catalog/apis.md
+++ b/app/catalog/apis.md
@@ -49,6 +49,10 @@ faqs:
       [API Products](/api-products/) were used to create and publish APIs to classic (v2) Dev Portals. When the new (v3) Dev Portal was released, the API Products menu item was removed from the sidebar navigation of any {{site.konnect_short_name}} organization that didn't have an existing API product. If you want to create and publish APIs, you can create a new (v3) Dev Portal. To get started, see [Automate your API catalog with the Konnect API](/how-to/automate-api-catalog/).
   - q: My team has a Dev Portal, why can't I see APIs?
     a: You need additional permissions to see APIs. See the [Catalog APIs roles](/konnect-platform/teams-and-roles/#catalog-apis) for more information.
+  - q: |
+      {% include faqs/portal-markdown.md section='question' %}
+    a: |
+      {% include faqs/portal-markdown.md section='answer' %}
 ---
 
 {:.success}

--- a/app/dev-portal/pages-and-content.md
+++ b/app/dev-portal/pages-and-content.md
@@ -76,6 +76,10 @@ faqs:
       ```
 
       The full path of the child page is the slug of the parent page with the slug of the child page. For example, if the parent slug is `/about` and the child slug is `/contact`, the full path to the child page is `/about/contact`.
+  - q: |
+      {% include faqs/portal-markdown.md section='question' %}
+    a: |
+      {% include faqs/portal-markdown.md section='answer' %}
 
 related_resources:
   - text: Dev Portal Markdown components reference


### PR DESCRIPTION
## Description

Fixes https://konghq.aha.io/epics/DEVP-E-143

## Preview Links
- /catalog/apis/#faqs
- /dev-portal/pages-and-content/#faqs

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
