### PR TITLE
fix: add search aliases to ACE plugin

### DIFF
--- a/app/_kong_plugins/ace/index.md
+++ b/app/_kong_plugins/ace/index.md
@@ -35,6 +35,9 @@ categories:
 related_resources:
   - text: Dev Portal API packaging
     url: /dev-portal/api-catalog-and-packaging/
+
+search_aliases:
+  - ace
 ---
 
 {% include /plugins/ace/ace-overview.md %}


### PR DESCRIPTION
Add search aliases for the ACE plugin.

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
