### PR TITLE
feat(Insomnia): add info on project structure management

### DIFF
--- a/app/_landing_pages/insomnia/git-sync.yaml
+++ b/app/_landing_pages/insomnia/git-sync.yaml
@@ -142,7 +142,7 @@ rows:
               - q: Can administrators restrict available storage types?
                 a: |
                   Yes. Enterprise administrators can control which storage types are available to users through **Enterprise Controls** > **Storage**.
-              - q: Can I change the project structure (create folders, move files)?
+              - q: Can I change the project structure (for example, create folders or move files)?
                 a: |
                   Yes, but only through your Git provider or local Git tooling. Insomnia doesn't provide a way to change the project structure from its UI.
                   If you modify the project structure externally, Insomnia will still present the files as expected.

--- a/app/_landing_pages/insomnia/git-sync.yaml
+++ b/app/_landing_pages/insomnia/git-sync.yaml
@@ -142,3 +142,7 @@ rows:
               - q: Can administrators restrict available storage types?
                 a: |
                   Yes. Enterprise administrators can control which storage types are available to users through **Enterprise Controls** > **Storage**.
+              - q: Can I change the project structure (create folders, move files)?
+                a: |
+                  Yes, but only through your Git provider or local Git tooling. Insomnia doesn't provide a way to change the project structure from its UI.
+                  If you modify the project structure externally, Insomnia will still present the files as expected.


### PR DESCRIPTION
## Description

closes #2498 

Specify that users can't change a project structure from the Insomnia UI, but that changing it from an external git source still allows Insomnia to present the different files as expected.  

## Preview Links

https://deploy-preview-4882--kongdeveloper.netlify.app/insomnia/git-sync/#frequently-asked-questions

## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
