### PR TITLE
Fix(gateway): decK example service

### DIFF
--- a/app/_how-tos/gateway/deck-get-started.md
+++ b/app/_how-tos/gateway/deck-get-started.md
@@ -60,7 +60,7 @@ You can use decK to configure a Service by providing a `name` and a `url`. Any r
 {% entity_examples %}
 entities:
   services:
-  - name: my-example-service
+  - name: example-service
     url: http://httpbin.konghq.com
 
 {% endentity_examples %}


### PR DESCRIPTION
## Description

Issue reported in #docs

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
