### PR TITLE
a2a proxy mcp data only

### DIFF
--- a/app/observability/explorer.md
+++ b/app/observability/explorer.md
@@ -274,7 +274,7 @@ rows:
 {% endnavtab %}
 {% navtab "Agentic usage" %}
 
-Agentic usage tracks analytics data for agent-to-agent (A2A) traffic that flows through the [AI A2A Proxy plugin](/plugins/ai-a2a-proxy/).
+Agentic usage tracks analytics data for agent-to-agent (A2A) traffic that flows through the [AI A2A Proxy plugin](/plugins/ai-a2a-proxy/), such as agent tool use and agent MCP calls.
 You must [configure the AI A2A Proxy plugin](/how-to/proxy-a2a-agents/) before analytics display in {{site.konnect_short_name}} Explorer.
 
 With agentic usage reporting, you can:


### PR DESCRIPTION
## Description

Fixes the misunderstanding of the scope of MCP data mentioned in A2A observability docs: https://kongstrong.slack.com/archives/CDSTDSG9J/p1776694156224939
