### PR TITLE
Fix(GW): Add more info about license generation

### DIFF
--- a/app/_gateway_entities/license.md
+++ b/app/_gateway_entities/license.md
@@ -197,7 +197,7 @@ rows:
   - field: "`license`"
     description: "Details about the active license: `license_key` and `license_expiration_date`."
   - field: "`deployment_info`"
-    description: "The deployment topology type (`traditional`, `hybrid`, or `dbless`). In hybrid mode, this also includes `connected_dp_count`, the number of data planes currently connected to the control plane."
+    description: "The deployment topology type (`traditional`, `hybrid`, or `dbless`)."
   - field: "`system_info`"
     description: "Information about the node: `hostname`, `cores` (number of online processors), and `uname` (OS and architecture)."
   - field: "`services_count`"
@@ -211,9 +211,9 @@ rows:
   - field: "`rbac_users`"
     description: Total number of configured RBAC users.
   - field: "`plugins_count`"
-    description: "Plugin usage broken down into `tiers` (`free`, `enterprise`, `custom`), `unique_route_kafkas` (unique Kafka broker addresses on Service-less Routes), and `unique_route_lambdas` (unique Lambda function names on Service-less Routes)."
+    description: "Plugin usage broken down into `tiers` (`free`, `enterprise`, `custom`)"
   - field: "`counters`"
-    description: "Request counts as `total_requests` and a `buckets` array. Each bucket has a `bucket` field (year-month format, for example `2026-04`) and a `request_count`. A `bucket` value of `UNKNOWN` means requests were processed before {{site.base_gateway}} 2.7.0.1."
+    description: "Request counts as `total_requests` and a `buckets` array."
 {% endtable %}
 <!--vale on-->
 

--- a/app/_gateway_entities/license.md
+++ b/app/_gateway_entities/license.md
@@ -164,7 +164,9 @@ You can update your License with a `PUT` request to the [`/license/{license-id}`
 
 ## License reports
 
-A license report contains information about your {{site.base_gateway}} deployment, including license usage and deployment information. Reports are generated manually on demand with the Admin API and aren't generated automatically or on a schedule. The report doesn't send data to Kong servers.
+A license report contains information about your {{site.base_gateway}} deployment, including license usage and deployment information. 
+Reports are generated manually on demand with the Admin API, you can't generate them automatically or on a schedule. 
+The report doesn't send data to Kong servers.
 
 You can share the report with Kong Support to perform a health-check analysis of product usage and overall deployment performance to ensure your organization is optimized with the best license and deployment plan for your needs.
 
@@ -195,21 +197,21 @@ rows:
   - field: "`license`"
     description: "Details about the active license: `license_key` and `license_expiration_date`."
   - field: "`deployment_info`"
-    description: "The deployment topology type (`traditional`, `hybrid`, or `dbless`). In hybrid mode, also includes `connected_dp_count`: the number of data planes currently connected to the control plane."
+    description: "The deployment topology type (`traditional`, `hybrid`, or `dbless`). In hybrid mode, this also includes `connected_dp_count`, the number of data planes currently connected to the control plane."
   - field: "`system_info`"
     description: "Information about the node: `hostname`, `cores` (number of online processors), and `uname` (OS and architecture)."
   - field: "`services_count`"
-    description: Total number of services configured in this deployment.
+    description: Total number of Services configured in this deployment.
   - field: "`routes_count`"
-    description: Total number of routes configured in this deployment.
+    description: Total number of Routes configured in this deployment.
   - field: "`consumers_count`"
-    description: Total number of consumers configured in this deployment.
+    description: Total number of Consumers configured in this deployment.
   - field: "`workspaces_count`"
-    description: Total number of workspaces in this deployment.
+    description: Total number of Workspaces in this deployment.
   - field: "`rbac_users`"
-    description: Total number of RBAC users configured.
+    description: Total number of configured RBAC users.
   - field: "`plugins_count`"
-    description: "Plugin usage broken down into `tiers` (`free`, `enterprise`, `custom`), `unique_route_kafkas` (unique Kafka broker addresses on service-less routes), and `unique_route_lambdas` (unique Lambda function names on service-less routes)."
+    description: "Plugin usage broken down into `tiers` (`free`, `enterprise`, `custom`), `unique_route_kafkas` (unique Kafka broker addresses on Service-less Routes), and `unique_route_lambdas` (unique Lambda function names on Service-less Routes)."
   - field: "`counters`"
     description: "Request counts as `total_requests` and a `buckets` array. Each bucket has a `bucket` field (year-month format, for example `2026-04`) and a `request_count`. A `bucket` value of `UNKNOWN` means requests were processed before {{site.base_gateway}} 2.7.0.1."
 {% endtable %}

--- a/app/_gateway_entities/license.md
+++ b/app/_gateway_entities/license.md
@@ -185,27 +185,19 @@ columns:
     key: description
 rows:
   - field: "`checksum`"
-    description: A checksum of the report contents.
+    description: SHA-256 digest of the full report contents.
   - field: "`timestamp`"
     description: Unix timestamp of when the report was generated.
   - field: "`kong_version`"
     description: The version of {{site.base_gateway}} running on this node.
   - field: "`db_version`"
     description: The database engine and version in use.
-  - field: "`license.license_key`"
-    description: The unique key identifying this license.
-  - field: "`license.license_expiration_date`"
-    description: The date on which the license expires.
-  - field: "`deployment_info.type`"
-    description: "The deployment topology: `traditional`, `hybrid`, or `dbless`."
-  - field: "`deployment_info.connected_dp_count`"
-    description: Number of data planes currently connected to the control plane. Only present when `deployment_info.type` is `hybrid`.
-  - field: "`system_info.hostname`"
-    description: The hostname of the node generating the report.
-  - field: "`system_info.cores`"
-    description: The number of CPU cores available to the node.
-  - field: "`system_info.uname`"
-    description: The operating system and architecture of the node.
+  - field: "`license`"
+    description: "Details about the active license: `license_key` and `license_expiration_date`."
+  - field: "`deployment_info`"
+    description: "The deployment topology type (`traditional`, `hybrid`, or `dbless`). In hybrid mode, also includes `connected_dp_count`: the number of data planes currently connected to the control plane."
+  - field: "`system_info`"
+    description: "Information about the node: `hostname`, `cores` (number of online processors), and `uname` (OS and architecture)."
   - field: "`services_count`"
     description: Total number of services configured in this deployment.
   - field: "`routes_count`"
@@ -216,16 +208,10 @@ rows:
     description: Total number of workspaces in this deployment.
   - field: "`rbac_users`"
     description: Total number of RBAC users configured.
-  - field: "`plugins_count.unique_route_kafkas`"
-    description: Number of unique Kafka broker addresses (host:port) across Kafka plugins configured on service-less routes.
-  - field: "`plugins_count.unique_route_lambdas`"
-    description: Number of unique AWS Lambda function names across aws-lambda plugins configured on service-less routes.
-  - field: "`plugins_count.tiers`"
-    description: "Breakdown of active plugins by tier: `free`, `enterprise`, and `custom`."
-  - field: "`counters.total_requests`"
-    description: Total number of requests processed across all time periods.
-  - field: "`counters.buckets`"
-    description: "Monthly breakdown of request counts. Each entry has a `bucket` field (year-month format, for example `2025-01`) and a `request_count` field. A `bucket` value of `UNKNOWN` means requests were processed before {{site.base_gateway}} 2.7.0.1."
+  - field: "`plugins_count`"
+    description: "Plugin usage broken down into `tiers` (`free`, `enterprise`, `custom`), `unique_route_kafkas` (unique Kafka broker addresses on service-less routes), and `unique_route_lambdas` (unique Lambda function names on service-less routes)."
+  - field: "`counters`"
+    description: "Request counts as `total_requests` and a `buckets` array. Each bucket has a `bucket` field (year-month format, for example `2026-04`) and a `request_count`. A `bucket` value of `UNKNOWN` means requests were processed before {{site.base_gateway}} 2.7.0.1."
 {% endtable %}
 <!--vale on-->
 

--- a/app/_gateway_entities/license.md
+++ b/app/_gateway_entities/license.md
@@ -30,6 +30,8 @@ faqs:
     a: In hybrid mode, the license file must be deployed to each Control Plane and Data Plane node. As long as you deploy the License with the [`/licenses` Admin API endpoint](/api/gateway/admin-ee/#/operations/post-licenses), the Control Plane automatically applies the License to its Data Plane nodes. 
   - q: What happens to the license file in traditional mode when there are no separate Control Planes? 
     a: The license file must be manually deployed to each node running {{site.base_gateway}}.
+  - q: How do I package a license report to send to Kong Support?
+    a: "Run `curl http://localhost:8001/license/report -o response.json && tar -cf report-$(date +\"%Y_%m_%d_%I_%M_%p\").tar response.json`. This saves the report as `response.json` and creates a timestamped `.tar` archive ready to share with Kong Support."
 
 works_on:
   - on-prem
@@ -162,9 +164,70 @@ You can update your License with a `PUT` request to the [`/license/{license-id}`
 
 ## License reports
 
-A license report contains information about your {{site.base_gateway}} database-backed deployment, including License usage and deployment information. You can generate a license report by sending a request to the [`/license/report` endpoint](/api/gateway/admin-ee/#/operations/get-license-report). You can't automatically generate a license report and the report doesn't send data to Kong servers. License reports aren't supported in a DB-less deployment.
+A license report contains information about your {{site.base_gateway}} database-backed deployment, including license usage and deployment information. You can't automatically generate a license report, and the report doesn't send data to Kong servers. License reports aren't supported in a DB-less deployment.
 
-You can share the report with Kong Support to perform a health-check analysis of product usage and overall deployment performance to ensure your organization is optimized with the best License and deployment plan for your needs.
+You can share the report with Kong Support to perform a health-check analysis of product usage and overall deployment performance to ensure your organization is optimized with the best license and deployment plan for your needs.
+
+To generate a license report, send a `GET` request to the [`/license/report` endpoint](/api/gateway/admin-ee/#/operations/get-license-report):
+
+```sh
+curl http://localhost:8001/license/report
+```
+
+The response contains the following fields:
+
+<!--vale off-->
+{% table %}
+columns:
+  - title: Field
+    key: field
+  - title: Description
+    key: description
+rows:
+  - field: "`checksum`"
+    description: A checksum of the report contents.
+  - field: "`timestamp`"
+    description: Unix timestamp of when the report was generated.
+  - field: "`kong_version`"
+    description: The version of {{site.base_gateway}} running on this node.
+  - field: "`db_version`"
+    description: The database engine and version in use.
+  - field: "`license.license_key`"
+    description: The unique key identifying this license.
+  - field: "`license.license_expiration_date`"
+    description: The date on which the license expires.
+  - field: "`deployment_info.type`"
+    description: "The deployment topology: `traditional`, `hybrid`, or `dbless`."
+  - field: "`deployment_info.connected_dp_count`"
+    description: Number of data planes currently connected to the control plane. Only present when `deployment_info.type` is `hybrid`.
+  - field: "`system_info.hostname`"
+    description: The hostname of the node generating the report.
+  - field: "`system_info.cores`"
+    description: The number of CPU cores available to the node.
+  - field: "`system_info.uname`"
+    description: The operating system and architecture of the node.
+  - field: "`services_count`"
+    description: Total number of services configured in this deployment.
+  - field: "`routes_count`"
+    description: Total number of routes configured in this deployment.
+  - field: "`consumers_count`"
+    description: Total number of consumers configured in this deployment.
+  - field: "`workspaces_count`"
+    description: Total number of workspaces in this deployment.
+  - field: "`rbac_users`"
+    description: Total number of RBAC users configured.
+  - field: "`plugins_count.unique_route_kafkas`"
+    description: Number of unique Kafka broker addresses (host:port) across Kafka plugins configured on service-less routes.
+  - field: "`plugins_count.unique_route_lambdas`"
+    description: Number of unique AWS Lambda function names across aws-lambda plugins configured on service-less routes.
+  - field: "`plugins_count.tiers`"
+    description: "Breakdown of active plugins by tier: `free`, `enterprise`, and `custom`."
+  - field: "`counters.total_requests`"
+    description: Total number of requests processed across all time periods.
+  - field: "`counters.buckets`"
+    description: "Monthly breakdown of request counts. Each entry has a `bucket` field (year-month format, for example `2025-01`) and a `request_count` field. A `bucket` value of `UNKNOWN` means requests were processed before {{site.base_gateway}} 2.7.0.1."
+{% endtable %}
+<!--vale on-->
 
 ## Common errors
 

--- a/app/_gateway_entities/license.md
+++ b/app/_gateway_entities/license.md
@@ -164,7 +164,7 @@ You can update your License with a `PUT` request to the [`/license/{license-id}`
 
 ## License reports
 
-A license report contains information about your {{site.base_gateway}} database-backed deployment, including license usage and deployment information. You can't automatically generate a license report, and the report doesn't send data to Kong servers. License reports aren't supported in a DB-less deployment.
+A license report contains information about your {{site.base_gateway}} deployment, including license usage and deployment information. Reports are generated manually on demand with the Admin API and aren't generated automatically or on a schedule. The report doesn't send data to Kong servers.
 
 You can share the report with Kong Support to perform a health-check analysis of product usage and overall deployment performance to ensure your organization is optimized with the best license and deployment plan for your needs.
 


### PR DESCRIPTION
Reported here: https://kongstrong.slack.com/archives/CDSTDSG9J/p1776701469866279

You can test this by deploying GW and running: 
`curl -s http://localhost:8001/license/report | python3 -m json.tool`