### PR TITLE
Fix(KO): Incorrect variable in step

### DIFF
--- a/app/_how-tos/gateway/gateway-install-helm-konnect.md
+++ b/app/_how-tos/gateway/gateway-install-helm-konnect.md
@@ -141,8 +141,8 @@ env:
   cluster_mtls: pki
 
   cluster_control_plane: "'$CONTROL_PLANE_ENDPOINT'"
-  cluster_telemetry_endpoint: "'$CONTROL_PLANE_ENDPOINT':443"
-  cluster_telemetry_server_name: "'$CONTROL_PLANE_ENDPOINT'"
+  cluster_telemetry_endpoint: "'$CONTROL_PLANE_TELEMETRY':443"
+  cluster_telemetry_server_name: "'$CONTROL_PLANE_TELEMETRY'"
   cluster_cert: /etc/secrets/kong-cluster-cert/tls.crt
   cluster_cert_key: /etc/secrets/kong-cluster-cert/tls.key
 


### PR DESCRIPTION
cluster_telemetry_endpoint and cluster_telemetry_server_name were both set to $CONTROL_PLANE_ENDPOINT they should be `$CONTROL_PLANE_TELEMETRY` 

Reported in Kong Community
https://kongcommunity.slack.com/archives/C093A9WB05T/p1776080805727469