### PR TITLE
chore(copilot): Tell copilot to ignore api specs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,3 +33,5 @@ This includes, but is not limited to:
 - Files in the `app/_schemas/gateway/plugins` directory
 - Files in the `app/_includes/deck/help` directory
 - Files in the `app/_includes/kongctl/help` directory
+- Files in the `app/_api` directory
+- Files in the `api-specs` directory


### PR DESCRIPTION
## Description

Copilot shouldn't be reviewing specs, since they're generated and not sourced in this repo.
