### PR TITLE
fix(docs-platform): Landing page header formatting

### DIFF
--- a/app/_includes/landing_pages/header.md
+++ b/app/_includes/landing_pages/header.md
@@ -28,6 +28,10 @@
         </div>
     {% endif %}
     {% endunless %}
+
+    {% if include.config.description %}
+    <span>{{include.config.description | liquify | markdownify | markdown }}</span>
+    {% endif %}
 {% endcapture %}
 
 {% if include.config.sub_text %}

--- a/app/_includes/landing_pages/header.md
+++ b/app/_includes/landing_pages/header.md
@@ -30,7 +30,7 @@
     {% endunless %}
 
     {% if include.config.description %}
-    <span>{{include.config.description | liquify | markdownify | markdown }}</span>
+    <div class="flex flex-col gap-3">{{include.config.description | liquify | markdownify }}</div>
     {% endif %}
 {% endcapture %}
 

--- a/app/_includes/llm/landing_pages/header.md
+++ b/app/_includes/llm/landing_pages/header.md
@@ -2,3 +2,5 @@
 {%- case include.config.type -%}{%- when 'h1' -%}# {{ title }}{%- when 'h2' -%}## {{ title }}{%- when 'h3' -%}### {{ title }}{%- when 'h4' -%}#### {{ title }}{%- when 'h5' -%}##### {{ title }}{%- when 'h6' -%}###### {{ title }}{%- endcase %}
 
 {% if include.config.sub_text -%}{{ include.config.sub_text | liquify }}{%- endif -%}
+
+{% if include.config.description -%} {{include.config.description | liquify | markdown }}{%- endif -%}

--- a/app/_includes/llm/landing_pages/header.md
+++ b/app/_includes/llm/landing_pages/header.md
@@ -3,4 +3,6 @@
 
 {% if include.config.sub_text -%}{{ include.config.sub_text | liquify }}{%- endif -%}
 
-{% if include.config.description -%} {{include.config.description | liquify | markdown }}{%- endif -%}
+{% if include.config.description -%}
+{{include.config.description | liquify }}
+{% endif %}

--- a/app/_landing_pages/ai-gateway.yaml
+++ b/app/_landing_pages/ai-gateway.yaml
@@ -386,7 +386,7 @@ rows:
             blocks:
               - type: text
                 text: |
-                  Kong’s {{site.ai_gateway}} Universal API, delivered through the [AI Proxy](/plugins/ai-proxy/) and [AI Proxy Advanced](/plugins/ai-proxy-advanced/) plugins, simplifies AI model integration by providing a single, standardized interface for interacting with models across multiple providers.
+                  Kong's {{site.ai_gateway}} Universal API, delivered through the [AI Proxy](/plugins/ai-proxy/) and [AI Proxy Advanced](/plugins/ai-proxy-advanced/) plugins, simplifies AI model integration by providing a single, standardized interface for interacting with models across multiple providers.
 
                     - [**Easy to use**](/plugins/ai-proxy/examples/openai-chat-route/): Configure once and access any AI model with minimal integration effort.
 

--- a/app/_landing_pages/ai-gateway.yaml
+++ b/app/_landing_pages/ai-gateway.yaml
@@ -86,19 +86,12 @@ rows:
               align: end
 
   - header:
-    type: h2
-  - columns:
-    - blocks:
-        - type: structured_text
-          config:
-            header:
-              text: "{{site.ai_gateway}} providers"
-            blocks:
-              - type: text
-                text: |
-                  Kong AI Gatewy routes AI requests to various providers through a [provider-agnostic API](./#universal-api). This normalized API layer provides multiple benefits: client applications stay decoupled from provider-specific APIs, credentials are managed centrally, and request routing can be dynamic to optimize for cost, latency, or availability.
-
-  - column_count: 4
+      type: h2
+      text: "{{site.ai_gateway}} providers"
+      description: |
+        Kong AI Gateway routes AI requests to various providers through a [provider-agnostic API](./#universal-api). 
+        This normalized API layer provides multiple benefits: client applications stay decoupled from provider-specific APIs, credentials are managed centrally, and request routing can be dynamic to optimize for cost, latency, or availability.
+    column_count: 4
     columns:
       - blocks:
         - type: icon_card
@@ -185,16 +178,10 @@ rows:
   - header:
       type: h2
       text: "{{site.ai_gateway}} capabilities"
-    columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    You can enable the {{site.ai_gateway}} features through a set of modern and specialized plugins, using the same model you use for any other {{site.base_gateway}} plugin.
-                    When deployed alongside existing {{site.base_gateway}} plugins, {{site.base_gateway}} users can quickly assemble a sophisticated AI management platform without custom code or deploying new and unfamiliar tools.
-  - column_count: 3
+      description: |
+        You can enable the {{site.ai_gateway}} features through a set of modern and specialized plugins, using the same model you use for any other {{site.base_gateway}} plugin.
+        When deployed alongside existing {{site.base_gateway}} plugins, {{site.base_gateway}} users can quickly assemble a sophisticated AI management platform without custom code or deploying new and unfamiliar tools.
+    column_count: 3
     columns:
       - blocks:
         - type: card
@@ -425,49 +412,40 @@ rows:
             slug: ai-proxy-advanced
 
   - header:
-    type: h2
-  - columns:
-      - blocks:
-          - type: structured_text
-            config:
-              header:
-                text: "AI Usage Governance"
-              blocks:
-                - type: text
-                  text: |
-                    As AI technologies see broader adoption, developers and organizations face new risks: the risk of sensitive data leaking to AI providers, which exposes businesses and their customers to potential breaches and security threats.
+      type: h2
+      text: "AI usage governance"
+    columns:
+    - blocks:
+        - type: structured_text
+          config:
+            blocks:
+            - type: text
+              text: |
+                As AI technologies see broader adoption, developers and organizations face new risks: the risk of sensitive data leaking to AI providers, which exposes businesses and their customers to potential breaches and security threats.
 
-                    Managing how data flows to and from AI models has become critical not just for security, but also for compliance and reliability. Without the right controls in place, organizations risk losing visibility into how AI is used across their systems.
+                Managing how data flows to and from AI models has become critical not just for security, but also for compliance and reliability. Without the right controls in place, organizations risk losing visibility into how AI is used across their systems.
+    - blocks:
+        - type: structured_text
+          config:
+            blocks:
+            - type: text
+              text: |
+                {{site.ai_gateway}} helps mitigate these challenges by offering a suite of plugins that extend beyond basic AI traffic management.
 
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    <p/><p/>
-                    {{site.ai_gateway}} helps mitigate these challenges by offering a suite of plugins that extend beyond basic AI traffic management.
-
-                    - [**Data governance**](./#data-governance): Control how sensitive information is handled and shared with AI models.
-                    - [**Prompt engineering**](./#prompt-engineering): Customize and optimize prompts to deliver consistent, high-quality AI outputs.
-                    - [**Guardrails and content safety**](./#guardrails-and-content-safety): Enforce policies to prevent inappropriate, unsafe, or non-compliant responses.
-                    - [**Automated RAG injection**](./#automated-rag): Seamlessly inject relevant, vetted data into AI prompts without manual RAG implementations.
-                    - [**Load balancing**](./#load-balancing): Distribute AI traffic efficiently across multiple model endpoints to ensure performance and reliability.
-                    - [**LLM cost control**](./#llm-cost-control): Use the AI Compressor, RAG Injector, and Prompt Decorator to compress and structure prompts efficiently. Combine with AI Proxy Advanced to route requests across OpenAI models by semantic similarity—optimizing for cost and performance.
+                - [**Data governance**](./#data-governance): Control how sensitive information is handled and shared with AI models.
+                - [**Prompt engineering**](./#prompt-engineering): Customize and optimize prompts to deliver consistent, high-quality AI outputs.
+                - [**Guardrails and content safety**](./#guardrails-and-content-safety): Enforce policies to prevent inappropriate, unsafe, or non-compliant responses.
+                - [**Automated RAG injection**](./#automated-rag): Seamlessly inject relevant, vetted data into AI prompts without manual RAG implementations.
+                - [**Load balancing**](./#load-balancing): Distribute AI traffic efficiently across multiple model endpoints to ensure performance and reliability.
+                - [**LLM cost control**](./#llm-cost-control): Use the AI Compressor, RAG Injector, and Prompt Decorator to compress and structure prompts efficiently. Combine with AI Proxy Advanced to route requests across OpenAI models by semantic similarity—optimizing for cost and performance.
   - header:
       type: h3
       text: "Data governance"
-    columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                      {{site.ai_gateway}} enforces governance on outgoing AI prompts through allow/deny lists, blocking unauthorized requests with 4xx responses. It also provides built-in PII sanitization, automatically detecting and redacting sensitive data across 20 categories and 9 languages. Running privately and self-hosted for full control and compliance, {{site.ai_gateway}} ensures consistent protection without burdening developers, which helps simplify AI adoption at scale.
+      description: |
+        {{site.ai_gateway}} enforces governance on outgoing AI prompts through allow/deny lists, blocking unauthorized requests with 4xx responses. It also provides built-in PII sanitization, automatically detecting and redacting sensitive data across 20 categories and 9 languages. Running privately and self-hosted for full control and compliance, {{site.ai_gateway}} ensures consistent protection without burdening developers, which helps simplify AI adoption at scale.
 
-                      For more information, see the full list of [Data Governance](/ai-gateway/ai-data-gov/) capabilities.
-  - columns:
+        For more information, see the full list of [Data Governance](/ai-gateway/ai-data-gov/) capabilities.
+    columns:
       - blocks:
         - type: plugin
           config:
@@ -484,17 +462,11 @@ rows:
   - header:
       type: h3
       text: "Prompt engineering"
+      description: |
+        AI systems are built around prompts, and manipulating those prompts is important for successful adoption of the technologies.
+        Prompt engineering is the methodology of manipulating the linguistic inputs that guide the AI system.
+        {{site.ai_gateway}} supports a set of plugins that allow you to create a simplified and enhanced experience by setting default prompts or manipulating prompts from clients as they pass through the gateway.
     columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    AI systems are built around prompts, and manipulating those prompts is important for successful adoption of the technologies.
-                    Prompt engineering is the methodology of manipulating the linguistic inputs that guide the AI system.
-                    {{site.ai_gateway}} supports a set of plugins that allow you to create a simplified and enhanced experience by setting default prompts or manipulating prompts from clients as they pass through the gateway.
-  - columns:
       - blocks:
         - type: plugin
           config:
@@ -507,15 +479,9 @@ rows:
   - header:
       type: h3
       text: "Guardrails and content safety"
-    columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    As a platform owner, you may need to moderate all user request content against reputable services to comply with specific sensitive categories when proxying Large Language Model (LLM) traffic. {{site.ai_gateway}} provides built-in capabilities to handle content moderation and ensure content safety, that help you enforce compliance and protect your users across AI-powered applications.
-  - column_count: 3
+      description: |
+        As a platform owner, you may need to moderate all user request content against reputable services to comply with specific sensitive categories when proxying Large Language Model (LLM) traffic. {{site.ai_gateway}} provides built-in capabilities to handle content moderation and ensure content safety, that help you enforce compliance and protect your users across AI-powered applications.
+    column_count: 3
     columns:
       - blocks:
         - type: plugin
@@ -560,18 +526,12 @@ rows:
   - header:
       type: h3
       text: "Request transformations"
+      description: |
+        {{site.ai_gateway}} allows you to use AI technology to augment other API traffic.
+        One example is routing API responses through an AI language translation prompt before returning it to the client.
+        {{site.ai_gateway}} provides two plugins that can be used in conjunction with other upstream API services to weave AI capabilities into API request processing.
+        These plugins can be configured independently of the AI Proxy plugin.
     columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    {{site.ai_gateway}} allows you to use AI technology to augment other API traffic.
-                    One example is routing API responses through an AI language translation prompt before returning it to the client.
-                    {{site.ai_gateway}} provides two plugins that can be used in conjunction with other upstream API services to weave AI capabilities into API request processing.
-                    These plugins can be configured independently of the AI Proxy plugin.
-  - columns:
       - blocks:
         - type: plugin
           config:
@@ -585,18 +545,21 @@ rows:
   - header:
       type: h3
       text: "Automated RAG"
+    column_count: 1
     columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    LLMs are only as reliable as the data they can access. When faced with incomplete information, they often produce confident yet incorrect responses known as “hallucinations.” These hallucinations occur when LLMs lack the necessary domain knowledge.To address this, developers use the **Retrieval-augmented Generation (RAG)** approach, which enriches models with relevant data pulled from vector databases.
+    - blocks:
+        - type: structured_text
+          config:
+            blocks:
+            - type: text
+              text: |
+                LLMs are only as reliable as the data they can access. When faced with incomplete information, they often produce confident yet incorrect responses known as “hallucinations.” 
+                These hallucinations occur when LLMs lack the necessary domain knowledge.
+                To address this, developers use the **Retrieval-augmented Generation (RAG)** approach, which enriches models with relevant data pulled from vector databases.
 
-                    While standard RAG workflows are resource-heavy, as they require teams to generate embeddings and manually curate them in vector databases, Kong’s **AI RAG Injector** plugin automates this entire process. Instead of embedding RAG logic into every application individually, platform teams can inject vetted data into prompts directly at the gateway layer without any manual interventions.
-  - columns:
-      - blocks:
+                While standard RAG workflows are resource-heavy, as they require teams to generate embeddings and manually curate them in vector databases, Kong's **AI RAG Injector** plugin automates this entire process. 
+                Instead of embedding RAG logic into every application individually, platform teams can inject vetted data into prompts directly at the gateway layer without any manual interventions.
+    - blocks:
         - type: plugin
           config:
             slug: ai-rag-injector
@@ -604,16 +567,13 @@ rows:
   - header:
       type: h3
       text: "Load balancing"
-    columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    {{site.ai_gateway}}’s load balancer routes requests across AI models to optimize for speed, cost, and reliability. It supports algorithms like consistent hashing, lowest-latency, usage-based, round-robin, and semantic matching, with built-in retries and fallback for resilience {% new_in 3.10%}. The balancer dynamically selects models based on real-time performance and prompt relevance, and works across mixed environments including OpenAI, Mistral, and Llama models.
+      description: |
+        {{site.ai_gateway}}'s load balancer routes requests across AI models to optimize for speed, cost, and reliability. 
+        It supports algorithms like consistent hashing, lowest-latency, usage-based, round-robin, and semantic matching, with built-in retries and fallback for resilience {% new_in 3.10 %}. 
+        <br><br>
+        The balancer dynamically selects models based on real-time performance and prompt relevance, and works across mixed environments including OpenAI, Mistral, and Llama models.
 
-  - columns:
+    columns:
       - blocks:
         - type: card
           config:
@@ -635,16 +595,9 @@ rows:
   - header:
       type: h3
       text: "LLM cost control"
+      description: |
+        The {{site.ai_gateway}} helps reduce LLM usage costs by giving you control over how prompts are built and routed. You can compress and structure prompts efficiently using the AI Compressor, RAG Injector, and AI Prompt Decorator plugins. For further savings, you can use AI Proxy Advanced to route requests across OpenAI models based on semantic similarity.
     columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    The {{site.ai_gateway}} helps reduce LLM usage costs by giving you control over how prompts are built and routed. You can compress and structure prompts efficiently using the AI Compressor, RAG Injector, and AI Prompt Decorator plugins. For further savings, you can use AI Proxy Advanced to route requests across OpenAI models based on semantic similarity.
-
-  - columns:
       - blocks:
         - type: plugin
           config:
@@ -670,17 +623,12 @@ rows:
   - header:
       type: h3
       text: "Observability and metrics"
-    columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    {{site.ai_gateway}} provides multiple approaches to monitor LLM traffic and operations. Track token usage, latency, and costs through audit logs and metrics exporters. Instrument request flows with OpenTelemetry to trace prompts and responses across your infrastructure. Use {{site.konnect_short_name}} Advanced Analytics for pre-built dashboards, or integrate with your existing observability stack.
-
-
-  - column_count: 3
+      description: |
+        {{site.ai_gateway}} provides multiple approaches to monitor LLM traffic and operations. 
+        Track token usage, latency, and costs through audit logs and metrics exporters. 
+        Instrument request flows with OpenTelemetry to trace prompts and responses across your infrastructure. 
+        Use {{site.konnect_short_name}} Advanced Analytics for pre-built dashboards, or integrate with your existing observability stack.
+    column_count: 3
     columns:
       - blocks:
         - type: card

--- a/app/_landing_pages/ai-gateway.yaml
+++ b/app/_landing_pages/ai-gateway.yaml
@@ -480,7 +480,8 @@ rows:
       type: h3
       text: "Guardrails and content safety"
       description: |
-        As a platform owner, you may need to moderate all user request content against reputable services to comply with specific sensitive categories when proxying Large Language Model (LLM) traffic. {{site.ai_gateway}} provides built-in capabilities to handle content moderation and ensure content safety, that help you enforce compliance and protect your users across AI-powered applications.
+        As a platform owner, you may need to moderate all user request content against reputable services to comply with specific sensitive categories when proxying Large Language Model (LLM) traffic. 
+        {{site.ai_gateway}} provides built-in capabilities to handle content moderation and ensure content safety, that help you enforce compliance and protect your users across AI-powered applications.
     column_count: 3
     columns:
       - blocks:
@@ -570,9 +571,8 @@ rows:
       description: |
         {{site.ai_gateway}}'s load balancer routes requests across AI models to optimize for speed, cost, and reliability. 
         It supports algorithms like consistent hashing, lowest-latency, usage-based, round-robin, and semantic matching, with built-in retries and fallback for resilience {% new_in 3.10 %}. 
-        <br><br>
+        
         The balancer dynamically selects models based on real-time performance and prompt relevance, and works across mixed environments including OpenAI, Mistral, and Llama models.
-
     columns:
       - blocks:
         - type: card
@@ -596,7 +596,9 @@ rows:
       type: h3
       text: "LLM cost control"
       description: |
-        The {{site.ai_gateway}} helps reduce LLM usage costs by giving you control over how prompts are built and routed. You can compress and structure prompts efficiently using the AI Compressor, RAG Injector, and AI Prompt Decorator plugins. For further savings, you can use AI Proxy Advanced to route requests across OpenAI models based on semantic similarity.
+        The {{site.ai_gateway}} helps reduce LLM usage costs by giving you control over how prompts are built and routed. 
+        You can compress and structure prompts efficiently using the AI Compressor, RAG Injector, and AI Prompt Decorator plugins. 
+        For further savings, you can use AI Proxy Advanced to route requests across OpenAI models based on semantic similarity.
     columns:
       - blocks:
         - type: plugin

--- a/app/_landing_pages/ai-gateway/a2a.yaml
+++ b/app/_landing_pages/ai-gateway/a2a.yaml
@@ -85,18 +85,12 @@ rows:
   - header:
       type: h2
       text: "A2A traffic observability"
-    columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    {{site.ai_gateway}} records A2A protocol traffic data so you can analyze how agent-to-agent requests are processed and resolved.
-                    - Audit logs capture task IDs, JSON-RPC method calls, payloads, latencies, and errors.
-                    - OpenTelemetry spans record task state, context IDs, TTFB, SSE event counts, and response sizes.
-                    - Log plugins (File Log, HTTP Log, TCP Log, and others) consume the structured `ai.a2a` namespace emitted by the AI A2A Proxy plugin.
-  - column_count: 3
+      description: |
+        {{site.ai_gateway}} records A2A protocol traffic data so you can analyze how agent-to-agent requests are processed and resolved.
+        - Audit logs capture task IDs, JSON-RPC method calls, payloads, latencies, and errors.
+        - OpenTelemetry spans record task state, context IDs, TTFB, SSE event counts, and response sizes.
+        - Log plugins (File Log, HTTP Log, TCP Log, and others) consume the structured `ai.a2a` namespace emitted by the AI A2A Proxy plugin.
+    column_count: 3
     columns:
       - blocks:
         - type: card
@@ -147,15 +141,10 @@ rows:
   - header:
       type: h2
       text: "Govern A2A traffic"
-    columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    Use {{site.base_gateway}} plugins to control how A2A traffic flows through the gateway. Rate limiting, traffic control, and request transformation plugins work with A2A routes the same way they work with any other proxied traffic.
-  - column_count: 2
+      description: |
+        Use {{site.base_gateway}} plugins to control how A2A traffic flows through the gateway. 
+        Rate limiting, traffic control, and request transformation plugins work with A2A routes the same way they work with any other proxied traffic.         
+    column_count: 2
     columns:
       - blocks:
         - type: card

--- a/app/_landing_pages/ai-gateway/ai-clis.yaml
+++ b/app/_landing_pages/ai-gateway/ai-clis.yaml
@@ -40,15 +40,8 @@ rows:
   - header:
       type: h3
       text: "Claude Code"
-    columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    Claude Code is Anthropic's command-line tool that delegates coding tasks to Claude AI. Route Claude Code requests through {{site.ai_gateway}} to monitor usage, control costs, and enforce rate limits across your development team.
-  - column_count: 4
+      description: "Claude Code is Anthropic's command-line tool that delegates coding tasks to Claude AI. Route Claude Code requests through {{site.ai_gateway}} to monitor usage, control costs, and enforce rate limits across your development team."
+    column_count: 4
     columns:
       - blocks:
         - type: card
@@ -125,16 +118,8 @@ rows:
   - header:
       type: h3
       text: "Codex CLI"
-    columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    Codex CLI is OpenAI's command-line tool for code generation and assistance. Proxy Codex CLI requests through {{site.ai_gateway}} to gain visibility into API usage, implement rate limiting, and centralize credential management.
-
-  - column_count: 4
+      description: "Codex CLI is OpenAI's command-line tool for code generation and assistance. Proxy Codex CLI requests through {{site.ai_gateway}} to gain visibility into API usage, implement rate limiting, and centralize credential management."
+    column_count: 4
     columns:
       - blocks:
           - type: card
@@ -146,18 +131,10 @@ rows:
                 url: /how-to/use-codex-with-ai-gateway/
                 align: end
   - header:
-        type: h3
-        text: "Qwen Code CLI"
-    columns:
-        - blocks:
-            - type: structured_text
-              config:
-                blocks:
-                  - type: text
-                    text: |
-                      Qwen Code CLI is an AI-powered coding assistant that uses OpenAI-compatible endpoints. Proxy Qwen Code CLI requests through Kong AI Gateway to gain visibility into API usage, implement rate limiting, and centralize credential management.
-
-  - column_count: 4
+      type: h3
+      text: "Qwen Code CLI"
+      description: "Qwen Code CLI is an AI-powered coding assistant that uses OpenAI-compatible endpoints. Proxy Qwen Code CLI requests through Kong AI Gateway to gain visibility into API usage, implement rate limiting, and centralize credential management."
+    column_count: 4
     columns:
         - blocks:
             - type: card
@@ -171,15 +148,8 @@ rows:
   - header:
       type: h3
       text: "Gemini CLI"
-    columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    Gemini CLI is Google's command-line tool for interacting with Gemini models. Route Gemini CLI requests through Kong AI Gateway to monitor usage, control costs, and enforce rate limits across your development team.
-  - column_count: 4
+      description: "Gemini CLI is Google's command-line tool for interacting with Gemini models. Route Gemini CLI requests through Kong AI Gateway to monitor usage, control costs, and enforce rate limits across your development team."
+    column_count: 4
     columns:
       - blocks:
           - type: card

--- a/app/_landing_pages/ai-gateway/ai-data-gov.yaml
+++ b/app/_landing_pages/ai-gateway/ai-data-gov.yaml
@@ -35,15 +35,8 @@ rows:
   - header:
       type: h2
       text: "Observability"
-    columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    You can gather logs and metrics then analyze these using {{site.konnect_short_name}} or any OpenTelemetry tool.
-  - column_count: 2
+      description: "You can gather logs and metrics then analyze these using {{site.konnect_short_name}} or any OpenTelemetry tool."
+    column_count: 2
     columns:
       - blocks:
         - type: card
@@ -93,15 +86,8 @@ rows:
   - header:
       type: h2
       text: "User Safety"
-    columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    {{site.ai_gateway}} supports content safety features across providers and also includes our Prompt Guards that act on any `llm/v1/chat` or `llm/v1/completions` requests.
-  - column_count: 2
+      description: "{{site.ai_gateway}} supports content safety features across providers and also includes our Prompt Guards that act on any `llm/v1/chat` or `llm/v1/completions` requests."
+    column_count: 2
     columns:
       - blocks:
         - type: plugin
@@ -149,15 +135,8 @@ rows:
   - header:
       type: h2
       text: "Data Loss Prevention"
-    columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    You can use {{site.ai_gateway}} features to protect personally identifiable information and prevent data loss.
-  - column_count: 1
+      description: "You can use {{site.ai_gateway}} features to protect personally identifiable information and prevent data loss."
+    column_count: 1
     columns:
       - blocks:
         - type: plugin
@@ -168,15 +147,8 @@ rows:
   - header:
       type: h2
       text: "RAG Security"
-    columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    You can secure RAG pipelines by applying robust access controls.
-  - column_count: 1
+      description: "You can secure RAG pipelines by applying robust access controls."
+    column_count: 1
     columns:
       - blocks:
         - type: plugin

--- a/app/_landing_pages/custom-dashboards.yaml
+++ b/app/_landing_pages/custom-dashboards.yaml
@@ -22,8 +22,6 @@ rows:
       - blocks:
           - type: structured_text
             config:
-              header:
-                text: 'Overview'
               blocks:
                 - type: text
                   text: |

--- a/app/_landing_pages/custom-dashboards.yaml
+++ b/app/_landing_pages/custom-dashboards.yaml
@@ -74,7 +74,7 @@ rows:
   - header:
       type: h2
       text: 'FAQs'
-  - columns:
+    columns:
       - blocks:
           - type: faqs
             config:

--- a/app/_landing_pages/custom-plugins.yaml
+++ b/app/_landing_pages/custom-plugins.yaml
@@ -15,22 +15,16 @@ rows:
       type: h1
       text: "Custom plugins"
 
-  - columns:
-      - blocks:
-          - type: structured_text
-            config:
-              header:
-                text: "Developing custom plugins"
-              blocks:
-                - type: text
-                  text: |
-                    Kong provides a development environment for developing plugins, 
-                    including Plugin Development Kits (or PDKs), database abstractions, migrations, and more.
+  - header:
+      type: h2
+      text: "Developing custom plugins"
+      description: |
+        Kong provides a development environment for developing plugins, 
+        including Plugin Development Kits (or PDKs), database abstractions, migrations, and more.
 
-                    Plugins consist of modules interacting with the request/response objects or
-                    streams via a PDK to implement arbitrary logic. With custom plugins, you can configure these modules to provide custom functionality to {{site.base_gateway}}.
-
-  - columns:
+        Plugins consist of modules interacting with the request/response objects or
+        streams via a PDK to implement arbitrary logic. With custom plugins, you can configure these modules to provide custom functionality to {{site.base_gateway}}.
+    columns:
       - blocks:
           - type: card
             config:
@@ -98,19 +92,13 @@ rows:
                 text: See reference
                 url: "/dedicated-cloud-gateways/reference/#custom-plugins"
           
-  - columns:
-     - blocks:
-         - type: structured_text
-           config:
-             header:
-               text: "Plugin Development Kits (PDKs)"
-             blocks:
-               - type: text
-                 text:
-                   "PDKs are sets of functions that a plugin can use to facilitate interactions between plugins
-                   and the core (or other components) of Kong. Kong provides PDKs in the following languages:"
-
-  - columns:
+  - header:
+      type: h2
+      text: "Plugin Development Kits (PDKs)"
+      description: |
+        PDKs are sets of functions that a plugin can use to facilitate interactions between plugins
+        and the core (or other components) of Kong. Kong provides PDKs in the following languages:
+    columns:
     - blocks:
       - type: card
         config:

--- a/app/_landing_pages/deck.yaml
+++ b/app/_landing_pages/deck.yaml
@@ -276,7 +276,7 @@ rows:
                 If you are using Terraform and are happy with it, you should continue to use it. decK covers all the problems that Terraform solves and goes beyond it:
 
                 * With Terraform, you have to track and maintain Terraform files (*.tf) and the Terraform state (likely using a cloud storage solution). With decK, the entire configuration is stored in the YAML/JSON file(s) only. There is no separate state that needs to be tracked.
-                * decK can export and back up your existing {{site.base_gateway}}'s configuration, meaning, you can take an existing {{site.base_gateway}} installation, and have a backup, as well as a declarative configuration for it. With Terraform, you will have to import each and every entity in {{site.base_gateway}} into Terraform’s state.
+                * decK can export and back up your existing {{site.base_gateway}}'s configuration, meaning, you can take an existing {{site.base_gateway}} installation, and have a backup, as well as a declarative configuration for it. With Terraform, you will have to import each and every entity in {{site.base_gateway}} into Terraform's state.
                 * decK can check if a configuration file is valid or not (validate sub-command).
                 * decK can quickly [reset](/deck/gateway/reset/) your {{site.base_gateway}}'s configuration when needed.
                 * decK works out of the box with {{site.base_gateway}} features like Workspaces and RBAC.

--- a/app/_landing_pages/dedicated-cloud-gateways.yaml
+++ b/app/_landing_pages/dedicated-cloud-gateways.yaml
@@ -107,19 +107,14 @@ rows:
                   url: /dedicated-cloud-gateways/azure-peering/
                 - text: Virtual WAN (VWAN)
                   url: /dedicated-cloud-gateways/azure-virtual-wan/
-  - columns:
-      - blocks:
-        - type: structured_text
-          config:
-            header:
-              text: "Name resolution"
-            blocks:
-              - type: text
-                text: |
-                  We recommend using private name resolution for services running in the same cloud as your Dedicated Cloud Gateway. 
-                  Use private hosted zones or private DNS if your services are in the same cloud. 
-                  Use an outbound DNS resolver if your services are in an external or on-premise DNS server. 
-  - column_count: 3
+  - header:
+      type: h2
+      text: "Name resolution"
+      description: |
+        We recommend using private name resolution for services running in the same cloud as your Dedicated Cloud Gateway. 
+        Use private hosted zones or private DNS if your services are in the same cloud. 
+        Use an outbound DNS resolver if your services are in an external or on-premise DNS server. 
+    column_count: 3
     columns:
       - blocks:
           - type: card
@@ -216,7 +211,7 @@ rows:
   - header:
       type: h2
       text: "More information"
-  - column_count: 3
+    column_count: 3
     columns:
       - blocks:
           - type: card

--- a/app/_landing_pages/dedicated-cloud-gateways.yaml
+++ b/app/_landing_pages/dedicated-cloud-gateways.yaml
@@ -216,7 +216,8 @@ rows:
   - header:
       type: h2
       text: "More information"
-  - columns:
+  - column_count: 3
+    columns:
       - blocks:
           - type: card
             config:
@@ -247,8 +248,6 @@ rows:
               cta:
                 text: See the API
                 url: /api/konnect/cloud-gateways/v2/
-  - column_count: 3
-    columns:
       - blocks:
           - type: card
             config:

--- a/app/_landing_pages/dev-portal.yaml
+++ b/app/_landing_pages/dev-portal.yaml
@@ -168,7 +168,7 @@ rows:
   - header:
       type: h2
       text: "Developer authentication and access"
-  - columns:
+    columns:
       - blocks:
           - type: card
             config:
@@ -232,7 +232,7 @@ rows:
   - header:
       type: h2
       text: "Dev Portal integrations"
-  - column_count: 3
+    column_count: 3
     columns:
       - blocks:
           - type: card
@@ -256,7 +256,7 @@ rows:
   - header:
       type: h2
       text: "References"
-  - columns:
+    columns:
       - blocks:
           - type: card
             config:

--- a/app/_landing_pages/dev-portal/customizations/dev-portal-customizations.yaml
+++ b/app/_landing_pages/dev-portal/customizations/dev-portal-customizations.yaml
@@ -273,18 +273,16 @@ rows:
 
                     {:.info}
                     > Certain domain names are restricted. See [Domain name restrictions](/dev-portal/custom-domains/#domain-name-restrictions) for more information.
-  - column_count: 3
-    columns:
       - blocks:
-          - type: card
-            config:
-              title: Custom domains
-              description: |
-                Set up custom URLs for your {{site.dev_portal}}. 
-                Custom URLs require DNS setup and your portal’s default URL.
-              icon: /assets/icons/domain.svg
-              cta:
-                url: /dev-portal/custom-domains/
+        - type: card
+          config:
+            title: Custom domains
+            description: |
+              Set up custom URLs for your {{site.dev_portal}}. 
+              Custom URLs require DNS setup and your portal’s default URL.
+            icon: /assets/icons/domain.svg
+            cta:
+              url: /dev-portal/custom-domains/
   
   - header:
       text: "Frequently asked questions"

--- a/app/_landing_pages/dev-portal/customizations/dev-portal-customizations.yaml
+++ b/app/_landing_pages/dev-portal/customizations/dev-portal-customizations.yaml
@@ -279,7 +279,7 @@ rows:
             title: Custom domains
             description: |
               Set up custom URLs for your {{site.dev_portal}}. 
-              Custom URLs require DNS setup and your portal’s default URL.
+              Custom URLs require DNS setup and your portal's default URL.
             icon: /assets/icons/domain.svg
             cta:
               url: /dev-portal/custom-domains/

--- a/app/_landing_pages/dev-portal/self-service.yaml
+++ b/app/_landing_pages/dev-portal/self-service.yaml
@@ -224,8 +224,7 @@ rows:
   - header:
       type: h2
       text: "Learn more"
-
-  - columns:
+    columns:
       - blocks:
           - type: card
             config:

--- a/app/_landing_pages/event-gateway.yaml
+++ b/app/_landing_pages/event-gateway.yaml
@@ -347,7 +347,7 @@ rows:
   - header:
       type: h2
       text: Key references
-  - column_count: 4
+    column_count: 4
     columns:
       - blocks:
         - type: card

--- a/app/_landing_pages/gateway.yaml
+++ b/app/_landing_pages/gateway.yaml
@@ -206,6 +206,7 @@ rows:
   - header:
       type: h2
       text: Key functionality
+    column_count: 3
     columns:
       - blocks:
         - type: card
@@ -243,8 +244,6 @@ rows:
             cta:
               text: Add Rate Limiting with {{ site.base_gateway }}
               url: "/gateway/rate-limiting/"
-
-  - columns:
       - blocks:
         - type: card
           config:
@@ -289,7 +288,7 @@ rows:
   - header:
       type: h2
       text: Key references
-  - column_count: 3
+    column_count: 3
     columns:
       - blocks:
           - type: card

--- a/app/_landing_pages/gateway/authentication.yaml
+++ b/app/_landing_pages/gateway/authentication.yaml
@@ -37,7 +37,7 @@ rows:
   - header:
       type: h2
       text: "Common authentication methods"
-
+    column_count: 3
     columns:
       - blocks:
         - type: card
@@ -75,7 +75,6 @@ rows:
                 url: /gateway/openid-connect/
               - text: Plugin reference
                 url: /plugins/openid-connect/
-  - columns:
       - blocks:
         - type: card
           config:
@@ -111,43 +110,40 @@ rows:
                 url: /plugins/session/examples/
               - text: Plugin reference
                 url: /plugins/session/
+      - blocks:
+          - type: card
+            config:
+              title: Key authentication
+              description: |
+                Key authentication generates an API key for a Consumer, which can be passed in an `apikey` header to access Services and Routes.            
+                
+              ctas:
+                - text: Get started with open-source Key Auth
+                  url: /plugins/key-auth/examples/
+                - text: Key Auth plugin reference
+                  url: /plugins/key-auth/
+                - text: Get started with Key Auth Encrypted
+                  url: /plugins/key-auth-enc/examples/
+                - text: Key Auth Encrypted plugin reference
+                  url: /plugins/key-auth-enc/
 
-  - column_count: 3
-    columns:
-    - blocks:
-        - type: card
-          config:
-            title: Key authentication
-            description: |
-              Key authentication generates an API key for a Consumer, which can be passed in an `apikey` header to access Services and Routes.            
-              
-            ctas:
-              - text: Get started with open-source Key Auth
-                url: /plugins/key-auth/examples/
-              - text: Key Auth plugin reference
-                url: /plugins/key-auth/
-              - text: Get started with Key Auth Encrypted
-                url: /plugins/key-auth-enc/examples/
-              - text: Key Auth Encrypted plugin reference
-                url: /plugins/key-auth-enc/
-
-    - blocks:
-        - type: card
-          config:
-            title: LDAP authentication
-            description: |
-              LDAP is a protocol that uses a directory to check credentials provided by a client.
-              
-            ctas:
-              - text: Get started with open-source LDAP
-                url: /plugins/ldap-auth/examples/
-              - text: LDAP Auth plugin reference
-                url: /plugins/ldap-auth/
-              - text: Get started with LDAP Auth Advanced
-                url: /plugins/ldap-auth-advanced/examples/
-              - text: LDAP Auth Advanced plugin reference
-                url: /plugins/ldap-auth-advanced/
-      
+      - blocks:
+          - type: card
+            config:
+              title: LDAP authentication
+              description: |
+                LDAP is a protocol that uses a directory to check credentials provided by a client.
+                
+              ctas:
+                - text: Get started with open-source LDAP
+                  url: /plugins/ldap-auth/examples/
+                - text: LDAP Auth plugin reference
+                  url: /plugins/ldap-auth/
+                - text: Get started with LDAP Auth Advanced
+                  url: /plugins/ldap-auth-advanced/examples/
+                - text: LDAP Auth Advanced plugin reference
+                  url: /plugins/ldap-auth-advanced/
+        
 
   - header:
       type: h2
@@ -184,8 +180,10 @@ rows:
                   {{site.base_gateway}} offers tools that give visibility into all authentication attempts, which provides the ability to build monitoring and alerting capabilities supporting Service availability and compliance.
 
                   For more information, see [What is API Gateway Authentication](https://konghq.com/learning-center/api-gateway/api-gateway-authentication) in our Learning Center.
- 
-  - columns:
+  - header:
+      type: h3
+      text: "References"
+    columns:
       - blocks:
         - type: card
           config:

--- a/app/_landing_pages/gateway/datakit.yaml
+++ b/app/_landing_pages/gateway/datakit.yaml
@@ -219,7 +219,7 @@ rows:
           - type: card
             config:
               title: Debugging
-              description: Learn more about Datakit’s debug and tracing modes.
+              description: Learn more about Datakit's debug and tracing modes.
               icon: /assets/icons/monitor.svg
               cta:
                 text: See debugging section

--- a/app/_landing_pages/gateway/kong-manager.yaml
+++ b/app/_landing_pages/gateway/kong-manager.yaml
@@ -58,17 +58,11 @@ rows:
 
                   You can configure Kong Manager settings (like URL and path) and customization (like header and footer colors) using [parameters in `kong.conf`](/gateway/configuration/#kong-manager-section). If you want to enable Kong Manager for multiple domains, see [multiple domains](/gateway/kong-manager/configuration/#multiple-domains).
   
-  - columns:
-      - blocks:
-        - type: structured_text
-          config:
-            header:
-              text: "Kong Manager authentication"
-            blocks:
-              - type: text
-                text: |
-                  Kong Manager comes packaged with several authentication methods.
-  - column_count: 3
+  - header:
+      type: h2
+      text: "Kong Manager authentication"
+      description: "Kong Manager comes packaged with several authentication methods."
+    column_count: 3
     columns:
       - blocks:
         - type: card
@@ -118,17 +112,12 @@ rows:
   #           cta:
   #             url: "/how-to/configure-sessions-in-kong-manager/"
   
-  - columns:
-      - blocks:
-        - type: structured_text
-          config:
-            header:
-              text: "Access control with Roles and Workspaces"
-            blocks:
-              - type: text
-                text: |
-                  In Kong Manager, limiting permissions also restricts the visibility of the application interface and navigation. 
-  - columns:
+
+  - header:
+      type: h2
+      text: "Access control with Roles and Workspaces"
+      description: "In Kong Manager, limiting permissions also restricts the visibility of the application interface and navigation."
+    columns:
       - blocks:
         - type: card
           config:
@@ -171,7 +160,7 @@ rows:
   - header:
       type: h2
       text: "Kong Manager SMTP"
-  - columns:
+    columns:
       - blocks:
           - type: card
             config:

--- a/app/_landing_pages/gateway/load-balancing.yaml
+++ b/app/_landing_pages/gateway/load-balancing.yaml
@@ -15,17 +15,8 @@ rows:
   - header:
       type: h1
       text: "Load balancing with {{site.base_gateway}}"
-
-    columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    Distribute traffic across your upstream services.
-
-
+      sub_text: "Distribute traffic across your upstream services."
+                    
   - columns:
       - blocks:
         - type: card
@@ -65,17 +56,11 @@ rows:
   - header:
       type: h2
       text: "Load balancing algorithms for {{site.base_gateway}}"
+      description: |
+        Advanced load-balancing algorithms are available through the [Upstream](/gateway/entities/upstream/) entity,
+        and they let you load balance traffic across your upstream services using [Targets](/gateway/entities/target/).
+    column_count: 3
     columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    Advanced load-balancing algorithms are available through the [Upstream](/gateway/entities/upstream/) entity,
-                    and they let you load balance traffic across your upstream services using [Targets](/gateway/entities/target/).
-
-  - columns:
       - blocks:
         - type: card
           config:
@@ -96,7 +81,6 @@ rows:
             cta:
               text: Consistent-hashing load balancing
               url: /gateway/entities/upstream/#consistent-hashing
-
       - blocks:
         - type: card
           config:
@@ -127,8 +111,6 @@ rows:
             cta:
               text: Lowest-latency load balancing
               url: /gateway/entities/upstream/#latency
-
-
   - header:
       type: h2
       text: "Load balancing algorithms for {{site.ai_gateway}}"

--- a/app/_landing_pages/gateway/monitoring.yaml
+++ b/app/_landing_pages/gateway/monitoring.yaml
@@ -48,20 +48,13 @@ rows:
   - header:
       type: h2
       text: "How do I monitor {{site.base_gateway}} metrics?"
-    columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    API gateways isolate your applications from the outside world and provide critical path
-                    protection for your upstream services. Understanding the state of your API gateway
-                    system is critical to providing reliable API-based systems.
+      description: |
+        API gateways isolate your applications from the outside world and provide critical path
+        protection for your upstream services. Understanding the state of your API gateway system is critical to providing reliable API-based systems.
 
-                    There are many monitoring and alerting systems available, and {{site.base_gateway}} integrates with 
-                    multiple solutions:
-  - column_count: 4
+        There are many monitoring and alerting systems available, and {{site.base_gateway}} integrates with 
+        multiple solutions:
+    column_count: 4
     columns:
       - blocks:
         - type: card
@@ -170,7 +163,7 @@ rows:
   - header:
       type: h2
       text: "Related resources"
-  - column_count: 3
+    column_count: 3
     columns:
       - blocks:
         - type: card

--- a/app/_landing_pages/gateway/openid-connect.yaml
+++ b/app/_landing_pages/gateway/openid-connect.yaml
@@ -205,7 +205,8 @@ rows:
   - header:
       type: h2
       text: Examples with other supported IdPs
-  - columns:
+    column_count: 3
+    columns:
       - blocks:
         - type: card
           config:
@@ -230,7 +231,6 @@ rows:
             cta:
               text: Set up OIDC with Azure AD
               url: "/plugins/openid-connect/examples/azure-ad/"
-  - columns:
       - blocks:
         - type: card
           config:

--- a/app/_landing_pages/gateway/secrets-management.yaml
+++ b/app/_landing_pages/gateway/secrets-management.yaml
@@ -51,18 +51,13 @@ rows:
                   - Referenceable fields in Kong plugins
                   - Configuration associated with APIs serviced by {{site.base_gateway}}
 
-  - columns:
-      - blocks:
-        - type: structured_text
-          config:
-            header:
-              text: "How can I manage secrets in {{site.base_gateway}}?"
-            blocks:
-              - type: text
-                text: |
-                  Secret management options vary depending on which {{site.base_gateway}} tier you have. {{site.base_gateway}} OSS users can only manage secrets by storing them in [environment variables](/gateway/entities/vault/#store-secrets-as-environment-variables). 
-                  {{site.ee_product_name}} users can use environment variables as well as Vaults. The [Vaults entity](/gateway/entities/vault/) allows you to store and reference secrets from an external, third-party vault or {{site.konnect_short_name}} Config Store. 
-  - column_count: 3
+  - header:
+      type: h2
+      text: "How can I manage secrets in {{site.base_gateway}}?"
+      description: |
+        Secret management options vary depending on which {{site.base_gateway}} tier you have. {{site.base_gateway}} OSS users can only manage secrets by storing them in [environment variables](/gateway/entities/vault/#store-secrets-as-environment-variables). 
+        {{site.ee_product_name}} users can use environment variables as well as Vaults. The [Vaults entity](/gateway/entities/vault/) allows you to store and reference secrets from an external, third-party vault or {{site.konnect_short_name}} Config Store. 
+    column_count: 3
     columns:
       - blocks:
         - type: card
@@ -102,8 +97,6 @@ rows:
                 url: "/gateway/entities/vault/?tab=azure#vault-provider-specific-configuration-parameters"
               # - text: With {{ site.base_gateway }}
               #   url: "/how-to/configure-azure-key-vaults-as-a-vault-backend-with-vault-entity/"
-
-  - columns:
       - blocks:
         - type: card
           config:
@@ -148,8 +141,6 @@ rows:
                 url: "/how-to/configure-google-cloud-secret-as-a-vault-backend/"
               - text: With {{ site.kic_product_name }}
                 url: "/kubernetes-ingress-controller/vault/gcp/"
-  - column_count: 3
-    columns:
       - blocks:
         - type: card
           config:

--- a/app/_landing_pages/gateway/security.yaml
+++ b/app/_landing_pages/gateway/security.yaml
@@ -202,17 +202,12 @@ rows:
               text: See plugins 
               url: "/plugins/?category=analytics-monitoring%2Clogging"
 
-  - columns:
-      - blocks:
-        - type: structured_text
-          config:
-            header:
-              text: "Vulnerability management"
-            blocks:
-              - type: text
-                text: |
-                  If you suspect that you've found a security vulnerability or bug, you can report it to Kong.
-  - columns:
+  - header:
+      text: "Vulnerability management"
+      type: h2
+      description: |
+        If you suspect that you've found a security vulnerability or bug, you can report it to Kong.
+    columns:
       - blocks:
         - type: card
           config:

--- a/app/_landing_pages/gateway/traffic-control-and-routing.yaml
+++ b/app/_landing_pages/gateway/traffic-control-and-routing.yaml
@@ -18,17 +18,12 @@ rows:
       text: "{{site.base_gateway}} traffic control and routing"
       sub_text: "As an API gateway, one of {{site.base_gateway}}'s main roles is to listen for, route, and proxy traffic."
     
-  - columns:
-      - blocks:
-          - type: structured_text
-            config:
-              header:
-                text: "Listeners"
-              blocks:
-                - type: text
-                  text: | 
-                    From a high-level perspective, {{site.base_gateway}} listens for L4 and L7 traffic.
-  - columns:
+  - header:
+      text: "Listeners"
+      type: h2
+      description: "From a high-level perspective, {{site.base_gateway}} listens for L4 and L7 traffic."
+    column_count: 4
+    columns:
       - blocks:
           - type: card
             config:
@@ -47,7 +42,6 @@ rows:
               cta:
                 text: Learn more about proxy_listen 
                 url: /gateway/configuration/#proxy-listen
-  - columns:
       - blocks:
           - type: card
             config:
@@ -68,18 +62,12 @@ rows:
               cta:
                 text: Learn more about stream_listen 
                 url: /gateway/configuration/#stream-listen
-  - columns:
-      - blocks:
-          - type: structured_text
-            config:
-              header:
-                text: "Routing traffic"
-              blocks:
-                - type: text
-                  text: | 
-                    Learn how {{site.base_gateway}} searches for matching [Routes](/gateway/entities/route/).
-  
-  - columns:
+  - header:
+      type: h2
+      text: "Routing traffic"
+      description: "Learn how {{site.base_gateway}} searches for matching [Routes](/gateway/entities/route/)."
+    column_count: 4
+    columns:
       - blocks:
           - type: card
             config:
@@ -109,18 +97,12 @@ rows:
                 text: Learn more about the traditional router 
                 url: /gateway/routing/traditional/#routing-criteria
   
-  - columns:
-      - blocks:
-          - type: structured_text
-            config:
-              header:
-                text: "Proxying"
-              blocks:
-                - type: text
-                  text: | 
-                    Once a request is matched to a Route, {{site.base_gateway}} then proxies the request.
-  
-  - columns:
+  - header:
+      type: h2
+      text: "Proxying"
+      description: "Once a request is matched to a Route, {{site.base_gateway}} then proxies the request."
+    column_count: 4
+    columns:
       - blocks:
           - type: card
             config:
@@ -139,7 +121,6 @@ rows:
               cta:
                 text: Learn more about plugin phases 
                 url: /gateway/entities/plugin/#plugin-contexts
-  - columns:
       - blocks:
           - type: card
             config:
@@ -162,7 +143,7 @@ rows:
   - header:
       type: h2
       text: "Specialized traffic control plugins"
-    column_count: 3
+    column_count: 4
     columns:
       - blocks:
           - type: plugin

--- a/app/_landing_pages/insomnia.yaml
+++ b/app/_landing_pages/insomnia.yaml
@@ -63,7 +63,7 @@ rows:
   - header:
       type: h2
       text: Get started
-  - column_count: 3  
+    column_count: 3  
     columns:
       - blocks:
         - type: card
@@ -123,7 +123,8 @@ rows:
   - header:
       type: h2
       text: Account management      
-  - columns:
+    column_count: 3
+    columns:
       - blocks:
         - type: card
           config:

--- a/app/_landing_pages/insomnia/ai-in-insomnia.yaml
+++ b/app/_landing_pages/insomnia/ai-in-insomnia.yaml
@@ -81,8 +81,6 @@ rows:
       - blocks:
           - type: structured_text
             config:
-              header:
-                text:
               blocks:
                 - type: text
                   text: |
@@ -101,36 +99,34 @@ rows:
 
                     Credentials for hosted LLM providers are stored securely on your local system by the Insomnia app and are never synced across accounts or devices.
   - header:
-    type: h2
-  - columns:
-      - blocks:
-          - type: structured_text
-            config:
-              header:
-                text: "MCP Servers and Clients"
-              blocks:
-                - type: text
-                  text: |
-                    **Model Context Protocol (MCP)** Servers expose domain-specific operations through a **JSON-RPC interface**. For example:
-                      - `tools/CALL`
-                      - `resources/READ`
-                      - `prompts/GET`
+      type: h2
+      text: "MCP Servers and Clients"
+    columns:
+        - blocks:
+            - type: structured_text
+              config:
+                blocks:
+                  - type: text
+                    text: |
+                      **Model Context Protocol (MCP)** Servers expose domain-specific operations through a **JSON-RPC interface**. For example:
+                        - `tools/CALL`
+                        - `resources/READ`
+                        - `prompts/GET`
 
-                    When you connect Insomnia to an MCP Server, Insomnia creates an **MCP Client** that acts like a synchronized request group. The client stays updated with tools, prompts, and resources published by the server. When offline, you will view cached data until you resync.
-      - blocks:
+                      When you connect Insomnia to an MCP Server, Insomnia creates an **MCP Client** that acts like a synchronized request group. The client stays updated with tools, prompts, and resources published by the server. When offline, you will view cached data until you resync.
+        - blocks:
           - type: structured_text
             config:
               blocks:
                 - type: text
                   text: |
-                    <p/><p/>
                      **Use MCP Clients to:**
-                    - Discover and execute callable tools  
-                    - Retrieve structured resources  
-                    - Explore and test AI-driven prompts  
-                    - Resync data from the server as it changes 
+                      - Discover and execute callable tools  
+                      - Retrieve structured resources  
+                      - Explore and test AI-driven prompts  
+                      - Resync data from the server as it changes 
 
-                    **Transports available:** HTTP and STDIO.  
+                      **Transports available:** HTTP and STDIO.  
 
           - type: button
             config:
@@ -139,30 +135,22 @@ rows:
               align: left
   - header:
     type: h2
-  - columns:
-      - blocks:
-          - type: structured_text
-            config:
-              header:
-                text: "AI-driven Git commits"
-              blocks:
-                - type: text
-                  text: |
-                    Insomnia’s **Suggest comments and grouping for Commits** feature analyzes staged changes and helps maintain consistent, meaningful Git histories. For Git concepts and workflows, go to [**Git Sync**](/insomnia/git-sync/).
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    <p/><p/>
-                    **To use commit suggestions:**
-                    1. Open the **Git Sync** interface.  
-                    1. Click **Suggest comments and grouping for Commits**.  
-                    1. Review the suggested commit groups and messages.  
-                    1. (Optional) To edit a message inline, double-click the message.  
-                    1. Drag and drop files between commit groups, or exclude files.  
-                    1. Click **Commit** or **Commit & Push**.
+    text: "AI-driven Git commits"
+    description: |
+      "Insomnia's **Suggest comments and grouping for Commits** feature analyzes staged changes and helps maintain consistent, meaningful Git histories. For Git concepts and workflows, go to [**Git Sync**](/insomnia/git-sync/).
+    blocks:
+      - type: structured_text
+        config:
+          blocks:
+            - type: text
+              text: |
+                **To use commit suggestions:**
+                1. Open the **Git Sync** interface.  
+                1. Click **Suggest comments and grouping for Commits**.  
+                1. Review the suggested commit groups and messages.  
+                1. (Optional) To edit a message inline, double-click the message.  
+                1. Drag and drop files between commit groups, or exclude files.  
+                1. Click **Commit** or **Commit & Push**.
  
   - header:
       type: h2

--- a/app/_landing_pages/insomnia/ai-in-insomnia.yaml
+++ b/app/_landing_pages/insomnia/ai-in-insomnia.yaml
@@ -164,7 +164,7 @@ rows:
                 a: |
                   Yes. Go to **Preferences → AI Settings** and deactivate the toggles for **Auto-generate Mock Servers** and **Suggest commit comments**.  
                   To stop using an LLM entirely, click **Deactivate** under the provider configuration.
-              - q: Why don’t I see AI features in the app?
+              - q: Why don't I see AI features in the app?
                 a: |
                   You must first configure and activate an LLM under **Preferences → AI Settings**.  
                   If AI is deactivated at the instance level, the feature toggles will remain unavailable in the UI.

--- a/app/_landing_pages/insomnia/ai-in-insomnia.yaml
+++ b/app/_landing_pages/insomnia/ai-in-insomnia.yaml
@@ -137,20 +137,21 @@ rows:
     type: h2
     text: "AI-driven Git commits"
     description: |
-      "Insomnia's **Suggest comments and grouping for Commits** feature analyzes staged changes and helps maintain consistent, meaningful Git histories. For Git concepts and workflows, go to [**Git Sync**](/insomnia/git-sync/).
-    blocks:
-      - type: structured_text
-        config:
-          blocks:
-            - type: text
-              text: |
-                **To use commit suggestions:**
-                1. Open the **Git Sync** interface.  
-                1. Click **Suggest comments and grouping for Commits**.  
-                1. Review the suggested commit groups and messages.  
-                1. (Optional) To edit a message inline, double-click the message.  
-                1. Drag and drop files between commit groups, or exclude files.  
-                1. Click **Commit** or **Commit & Push**.
+      Insomnia's **Suggest comments and grouping for Commits** feature analyzes staged changes and helps maintain consistent, meaningful Git histories. For Git concepts and workflows, go to [**Git Sync**](/insomnia/git-sync/).
+    columns:
+      - blocks:
+          - type: structured_text
+            config:
+              blocks:
+                - type: text
+                  text: |
+                    **To use commit suggestions:**
+                    1. Open the **Git Sync** interface.  
+                    1. Click **Suggest comments and grouping for Commits**.  
+                    1. Review the suggested commit groups and messages.  
+                    1. (Optional) To edit a message inline, double-click the message.  
+                    1. Drag and drop files between commit groups, or exclude files.  
+                    1. Click **Commit** or **Commit & Push**.
  
   - header:
       type: h2

--- a/app/_landing_pages/insomnia/authentication-authorization.yaml
+++ b/app/_landing_pages/insomnia/authentication-authorization.yaml
@@ -66,7 +66,7 @@ rows:
   - header:
       type: h3
       text: "Set up SSO"
-  - column_count: 3
+    column_count: 3
     columns:
       - blocks:
         - type: card
@@ -100,22 +100,14 @@ rows:
                   text: |
                     Client certificates are used by some APIs as a means of authentication. Insomnia supports assigning a client certificate to a specific domain name and will automatically use them whenever a request to that domain is sent.
 
-                  
                     Insomnia supports PFX (Mac) and PEM (Windows and Linux) certificates.
   - header:
       type: h2
       text: "Authorization"
-    columns: 
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    Authorization controls who can do what in Insomnia. 
-                    Authorization ensures users have the correct permissions and that you can access the Insomnia app through allowlisting domains.
-  
-  - column_count: 3
+      description: |
+        Authorization controls who can do what in Insomnia. 
+        Authorization ensures users have the correct permissions and that you can access the Insomnia app through allowlisting domains.
+    column_count: 3
     columns:
       - blocks:
         - type: card

--- a/app/_landing_pages/insomnia/documents.yaml
+++ b/app/_landing_pages/insomnia/documents.yaml
@@ -51,7 +51,7 @@ rows:
               blocks:
                 - type: text
                   text: | 
-                    The interactive API spec renderer lets you develop and refine your API spec in the same environment where you’ll test it.
+                    The interactive API spec renderer lets you develop and refine your API spec in the same environment where you'll test it.
                      
                 - type: text
                   text: |

--- a/app/_landing_pages/insomnia/enterprise.yaml
+++ b/app/_landing_pages/insomnia/enterprise.yaml
@@ -24,7 +24,8 @@ rows:
 
                     To compare plans, see the [pricing page](https://insomnia.rest/pricing).
                     To learn how to set up your Insomnia Enterprise instance, see [Get started with Insomnia Enterprise](/insomnia/enterprise-onboarding/).
-  - columns:
+  - column_count: 4
+    columns:
       - blocks:
         - type: card
           config:
@@ -60,8 +61,7 @@ rows:
             icon: /assets/icons/lock.svg
             cta:
               text: Learn more
-              url: /insomnia/external-vault/                  
-  - columns:
+              url: /insomnia/external-vault/
       - blocks:
         - type: card
           config:

--- a/app/_landing_pages/insomnia/git-sync.yaml
+++ b/app/_landing_pages/insomnia/git-sync.yaml
@@ -72,7 +72,7 @@ rows:
               - Merge branches.
               - Resolve conflicts.
 
-              All operations follow your repository’s existing rules and protections.
+              All operations follow your repository's existing rules and protections.
 
               When both you and a collaborator change the same content, Insomnia opens a merge view so you can review and resolve conflicts without leaving the app. See [3-way merge](/insomnia/three-way-merge/) for details.
       - blocks:

--- a/app/_landing_pages/insomnia/insomnia-vs-postman.yaml
+++ b/app/_landing_pages/insomnia/insomnia-vs-postman.yaml
@@ -2,7 +2,7 @@
 metadata:
   title: "Insomnia vs Postman"
   content_type: landing_page
-  description: Compare Insomnia and Postman at a glance. See how Insomnia’s open-source foundation, plugin ecosystem, and Kong integrations make it faster, lighter, and more flexible for API design and testing.
+  description: Compare Insomnia and Postman at a glance. See how Insomnia's open-source foundation, plugin ecosystem, and Kong integrations make it faster, lighter, and more flexible for API design and testing.
   breadcrumbs:
     - /insomnia/
   products:
@@ -53,7 +53,7 @@ rows:
                   details: Insomnia is open source and extensible.
                 - title: Local Git-driven storage
                   insomnia: true
-                  details: Store and version your API definitions, collections, and tests in your own Git repositories. All data moves directly between your machine and Git, not through Insomnia’s servers.
+                  details: Store and version your API definitions, collections, and tests in your own Git repositories. All data moves directly between your machine and Git, not through Insomnia's servers.
                 - title: Self-hosted mock servers
                   insomnia: true
                   details: Run mocks locally or on your own infrastructure.
@@ -315,7 +315,7 @@ rows:
                     - Migrate collections with [Migrate collections and environments from Postman to Insomnia](/how-to/migrate-collections-and-environments-from-postman-to-insomnia/).
                     - Use Git automation with the [Inso CLI](/inso-cli/).
                     - Connect Insomnia to Kong Gateway and Konnect with [MCP Clients in Insomnia](/insomnia/mcp-clients-in-insomnia/).
-                    - Learn about Kong’s API workflows with [Kong Gateway](/gateway/).
+                    - Learn about Kong's API workflows with [Kong Gateway](/gateway/).
                     - View deployment and management options with [Konnect](/konnect/).
 
       - blocks:
@@ -326,7 +326,7 @@ rows:
                   text: |
                     **Next steps**
 
-                    Continue exploring Insomnia’s capabilities:
+                    Continue exploring Insomnia's capabilities:
 
                     - Learn about [Documents](/insomnia/documents/).
                     - Explore [Collections](/insomnia/collections/).

--- a/app/_landing_pages/insomnia/manage-insomnia.yaml
+++ b/app/_landing_pages/insomnia/manage-insomnia.yaml
@@ -14,16 +14,9 @@ metadata:
 rows:
   - header:
       type: h1
-      text: "Manage Insomnia"            
-  - columns:
-      - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    Manage your Insomnia account and security settings.
-  - columns:
+      text: "Manage Insomnia"
+      sub_text: Manage your Insomnia account and security settings.    
+    columns:
       - blocks:
         - type: card
           config:
@@ -54,6 +47,7 @@ rows:
   - header:
       type: h2
       text: "Security"
+    column_count: 3
     columns:
       - blocks:
         - type: card
@@ -82,7 +76,6 @@ rows:
             cta:
               text: Learn more
               url: /insomnia/scim/
-  - columns:
       - blocks:
         - type: card
           config:

--- a/app/_landing_pages/insomnia/mock-servers.yaml
+++ b/app/_landing_pages/insomnia/mock-servers.yaml
@@ -14,12 +14,11 @@ rows:
       - blocks:
           - type: structured_text
             config:
-              header:
-                text: "Mock servers in Insomnia"
               blocks:
                 - type: text
-                  text: | 
-                    A mock server is a tool used to simulate API endpoints. These can be particularly useful while [designing an API](/insomnia/design/). They can be self-hosted or hosted on the cloud.
+                  text: |
+                    A mock server (or a mock) is a tool used to simulate API endpoints. Mocks can be particularly useful while [designing an API](/insomnia/design/). They can be self-hosted or hosted on the cloud.
+    
   - columns:
       - blocks:
           - type: structured_text
@@ -30,7 +29,7 @@ rows:
               blocks:
                 - type: text
                   text: | 
-                    The Insomnia Cloud mock servers allow you to create a mock endpoint in a few steps. You simply need to provide an endpoint and a sample response. You get a number or free mock requests based on your plan. For more details, see the [pricing page](https://insomnia.rest/pricing).
+                    The Insomnia Cloud mock servers allow you to create a mock endpoint in a few steps. You simply need to provide an endpoint and a sample response. You get a number of free mock requests based on your plan. For more details, see the [pricing page](https://insomnia.rest/pricing).
                      
                     [Learn more about cloud-hosted mock servers &rarr;](/how-to/create-a-cloud-hosted-mock-server/)
       - blocks:
@@ -67,10 +66,11 @@ rows:
               blocks:
                 - type: text
                   text: | 
-                    * Always be sure you trust the author of a mock server before calling it, visiting it, or adding it to your code. 
-                    * Like any URL, mock servers can contain malicious content or redirects.
-                    * To enable easy use from anywhere, especially for front-end feature development, Insomnia's mock servers have a very permissive CORS configuration (`Access-Control-Allow-Origin: *`, `Access-Control-Allow-Credentials: true`). 
-                    A malicious API could be used to exfiltrate data.
+                    When using mock servers, keep the following security considerations in mind:
+                      * Always be sure you trust the author of a mock server before calling it, visiting it, or adding it to your code. 
+                      * Like any URL, mock servers can contain malicious content or redirects.
+                      * To enable easy use from anywhere, especially for front-end feature development, Insomnia's mock servers have a very permissive CORS configuration (`Access-Control-Allow-Origin: *`, `Access-Control-Allow-Credentials: true`). 
+                      A malicious API could be used to exfiltrate data.
   - columns:
       - blocks:
           - type: structured_text
@@ -81,7 +81,7 @@ rows:
               blocks:
                 - type: text
                   text: | 
-                    Dynamic mocking expands Insomnia’s mock servers with templates that generate context-aware and realistic responses.  
+                    Dynamic mocking expands Insomnia's mock servers with templates that generate context-aware and realistic responses.  
                     Each response is rendered server-side by the mock server using  templates with a safe, restricted tag set.  
                     Insomnia also provides **Faker template tags** for generating random names, dates, and other test data at runtime.
 

--- a/app/_landing_pages/insomnia/plugins.yaml
+++ b/app/_landing_pages/insomnia/plugins.yaml
@@ -85,16 +85,3 @@ rows:
                     config: |
                       1. Click **Generate New Plugin**.
                       1. Enter a name for the new plugin and click **Generate**.
-  - header:
-      type: h2
-      text: References
-    columns:
-      - blocks:
-          - type: reference_list
-            config:
-              products:
-                - insomnia
-              tags:
-                - plugins
-              quantity: 5
-              allow_empty: true

--- a/app/_landing_pages/konnect-platform/kai.yaml
+++ b/app/_landing_pages/konnect-platform/kai.yaml
@@ -184,7 +184,7 @@ rows:
                     **Questions about {{site.konnect_short_name}}:**
                     - How do I set up the plugin `PLUGIN_NAME` in {{site.konnect_short_name}} for a particular use case? Give me the exact steps and the limitations.
                     - Explain the difference between Gateway Service vs Route in {{site.konnect_short_name}}, with an example from my current control plane.
-                    - What’s the recommended way to troubleshoot `upstream timed out` errors in {{site.base_gateway}}?
+                    - What's the recommended way to troubleshoot `upstream timed out` errors in {{site.base_gateway}}?
                     - Search the Kong docs for best practices on rate limiting and summarize the key steps for my setup.
   - header:
       text: "Frequently asked questions"

--- a/app/_landing_pages/konnect-platform/konnect-mcp.yaml
+++ b/app/_landing_pages/konnect-platform/konnect-mcp.yaml
@@ -170,16 +170,10 @@ rows:
   - header:
       text: "Installation"
       type: h2
+      description: |
+        Configure the MCP client of your choice by adding the {{site.konnect_product_name}} MCP Server with your regional URL and PAT. Select your preferred client below for specific installation instructions.
+    column_count: 3
     columns:
-      - blocks:
-        - type: structured_text
-          config:
-            blocks:
-              - type: text
-                text: |
-                  Configure the MCP client of your choice by adding the {{site.konnect_product_name}} MCP Server with your regional URL and PAT. Select your preferred client below for specific installation instructions.
-
-  - columns:
       - blocks:
         - type: card
           config:
@@ -210,8 +204,6 @@ rows:
             ctas:
               - text: Installation guide
                 url: "/konnect-platform/konnect-mcp/installation/#cursor"
-
-  - columns:
       - blocks:
         - type: card
           config:

--- a/app/_landing_pages/konnect-reference-platform.yaml
+++ b/app/_landing_pages/konnect-reference-platform.yaml
@@ -160,7 +160,7 @@ rows:
                 Swiss army knife for the {{site.konnect_short_name}} Reference Platform
               icon: /assets/icons/code.svg
               cta:
-                text: See more... 
+                text: See more 
                 url: /konnect-reference-platform/orchestrator/
       - col_span: 2
         blocks:
@@ -190,7 +190,7 @@ rows:
                 An example implementation modeled after a fictional airline
               icon: /assets/icons/organization.svg
               cta:
-                text: See more... 
+                text: See more 
                 url: /konnect-reference-platform/kong-air/
       - col_span: 2
         blocks:
@@ -221,7 +221,7 @@ rows:
                 A set of CI/CD workflows that drive an API delivery pipeline
               icon: /assets/icons/load-balance.svg
               cta:
-                text: See more... 
+                text: See more 
                 url: /konnect-reference-platform/apiops/
       - col_span: 2
         blocks:
@@ -250,7 +250,7 @@ rows:
                 Step by step guide for building your own API delivery platform
               icon: /assets/icons/graduation.svg
               cta:
-                text: See more... 
+                text: See more 
                 url: /konnect-reference-platform/how-to/
       - col_span: 2
         blocks:

--- a/app/_landing_pages/konnect.yaml
+++ b/app/_landing_pages/konnect.yaml
@@ -41,16 +41,9 @@ rows:
   - header:
       type: h2
       text: "Applications"
+      description: |
+        {{site.konnect_short_name}} provides several built-in applications that run on top of the {{site.konnect_short_name}} platform to help manage, monitor, and secure your API ecosystem, as well as provide a customizable developer experience.
     columns:
-      - blocks:
-        - type: structured_text
-          config:
-            blocks:
-              - type: text
-                text: |
-                  {{site.konnect_short_name}} provides several built-in applications that run on top of the {{site.konnect_short_name}} platform to help manage, monitor, and secure your API ecosystem,
-                   as well as provide a customizable developer experience.
-  - columns:
       - blocks:
         - type: card
           config:
@@ -65,12 +58,12 @@ rows:
       - blocks:
         - type: card
           config:
-            title: Dev Portal
+            title: "{{site.dev_portal}}"
             description: |
-              The Konnect Dev Portal is a customizable website for developers to locate, access, and consume API services.
+              The {{site.dev_portal}} is a customizable website for developers to locate, access, and consume API services.
             icon: /assets/icons/dev-portal.svg
             ctas:
-              - text: Create a Dev Portal
+              - text: Create a {{site.dev_portal}}
                 url: /dev-portal/
                 align: end
       - blocks:
@@ -100,17 +93,11 @@ rows:
   - header:
       type: h2
       text: "Connectivity"
+      description: |
+        The {{site.konnect_short_name}} platform runs in [hybrid mode](/gateway/hybrid-mode/) and provides several hosted control plane options to manage all service configurations.
+        The control plane propagates those configurations to the data plane group, which is composed of data plane nodes (and in the case of {{site.mesh_product_name}}, proxies).
+        The individual nodes can be running either on-premise, in cloud-hosted environments, or fully managed by {{site.konnect_short_name}}.
     columns:
-      - blocks:
-        - type: structured_text
-          config:
-            blocks:
-              - type: text
-                text: |
-                  The {{site.konnect_short_name}} platform runs in [hybrid mode](/gateway/hybrid-mode/) and provides several hosted control plane options to manage all service configurations.
-                  The control plane propagates those configurations to the data plane group, which is composed of data plane nodes (and in the case of {{site.mesh_product_name}}, proxies).
-                  The individual nodes can be running either on-premise, in cloud-hosted environments, or fully managed by {{site.konnect_short_name}}.
-  - columns:
     - blocks:
           - type: card
             config:

--- a/app/_landing_pages/mesh.yaml
+++ b/app/_landing_pages/mesh.yaml
@@ -123,7 +123,8 @@ rows:
   - header:
       type: h2
       text: "Next steps"
-  - columns:
+    column_count: 3
+    columns:
       - blocks:
           - type: card
             config:
@@ -165,9 +166,6 @@ rows:
                   url: /mesh/policies/meshretry/
                 - text: Mesh Circuit Breaker 
                   url: /mesh/policies/meshcircuitbreaker/
-
-
-  - columns:
       - blocks:
           - type: card
             config:
@@ -250,7 +248,8 @@ rows:
   - header:
       type: h2
       text: Key references
-  - columns:
+    column_count: 3
+    columns:
       - blocks:
           - type: card
             config:
@@ -262,7 +261,6 @@ rows:
                   url: /mesh/policies-introduction/
                 - text: See all policies 
                   url: /mesh/policies/
-
       - blocks:
           - type: card
             config:

--- a/app/_landing_pages/mesh/guides.yaml
+++ b/app/_landing_pages/mesh/guides.yaml
@@ -14,19 +14,17 @@ rows:
       text: "Kong Mesh guides"
       sub_text: Learn how to use Mesh to solve common challenges
 
-
-
   - header:
       type: h2
-      text: "Security and Enforcing policies"
-      sub_text: "One of the key tenants of a Service Mesh is the ability to encrypt and control service to service communication.  With {{site.mesh_product_name}}, your application developers can concentrate on core business logic, whilst Mesh deals with security."
+      text: "Security and enforcing policies"
+      description: "One of the key tenets of a Service Mesh is the ability to encrypt and control service to service communication. With {{site.mesh_product_name}}, your application developers can concentrate on core business logic, while Mesh deals with security."
     columns:
       - blocks:
           - type: card
             config:
               title: Service to Service encryption (mTLS)
               description: |
-                Learn how to configure service to service encryption,  generate certificates, configure external Certificate Authorities
+                Learn how to configure service to service encryption, generate certificates, and configure external Certificate Authorities.
               icon: /assets/icons/lock.svg
               ctas:
                 - text: Enable mTLS
@@ -86,7 +84,8 @@ rows:
   - header:
       type: h2
       text: "Next steps"
-  - columns:
+    column_count: 4
+    columns:
       - blocks:
           - type: card
             config:
@@ -124,7 +123,6 @@ rows:
               cta:
                 text: Learn more 
                 url: /mesh/policies/
-  - columns:
       - blocks:
           - type: card
             config:
@@ -137,7 +135,8 @@ rows:
   - header:
       type: h2
       text: Key references
-  - columns:
+    column_count: 3
+    columns:
       - blocks:
           - type: card
             config:
@@ -166,7 +165,6 @@ rows:
               cta:
                 text: See enterprise features 
                 url: /mesh/enterprise/
-  - columns:
       - blocks:
           - type: card
             config:

--- a/app/_landing_pages/metering-and-billing.yaml
+++ b/app/_landing_pages/metering-and-billing.yaml
@@ -316,7 +316,7 @@ rows:
             config:
               title: PayPal
               description: |
-                Accept customer payments using PayPal’s global payment platform.
+                Accept customer payments using PayPal's global payment platform.
               icon: /assets/icons/third-party/paypal.svg
               cta:
                 text: Contact Sales
@@ -327,7 +327,7 @@ rows:
             config:
               title: Adyen
               description: |
-                Process global payments with Adyen’s payment infrastructure.
+                Process global payments with Adyen's payment infrastructure.
               icon: /assets/icons/third-party/adyen.svg
               cta:
                 text: Contact Sales

--- a/app/_landing_pages/observability.yaml
+++ b/app/_landing_pages/observability.yaml
@@ -68,7 +68,7 @@ rows:
             config:
               title: Custom Dashboards
               description: |
-                Custom Dashboards provide a flexible way to build, organize, and manage analytical views that are tailored to your organization’s needs.
+                Custom Dashboards provide a flexible way to build, organize, and manage analytical views that are tailored to your organization's needs.
               icon: /assets/icons/bars.svg
               cta:
                 text: See Custom Dashboards

--- a/app/_landing_pages/waf.yaml
+++ b/app/_landing_pages/waf.yaml
@@ -21,19 +21,12 @@ rows:
       text: "{{site.base_gateway}} WAF capabilities"
       sub_text: "Request filtering, validation, and abuse controls delivered through {{site.base_gateway}}"
 
-  - columns:
-      - blocks:
-          - type: structured_text
-            config:
-              header:
-                text: "WAF plugins"
-              blocks:
-                - type: text
-                  text: |
-                    {{site.base_gateway}} can act as a front door for your applications by enforcing authentication and authorization, applying rate limits, restricting abusive sources, and validating requests before they reach upstream services.
-
-
-  - column_count: 3
+  - header:
+      type: h2
+      text: "WAF plugins"
+      description: |
+        {{site.base_gateway}} can act as a front door for your applications by enforcing authentication and authorization, applying rate limits, restricting abusive sources, and validating requests before they reach upstream services.
+    column_count: 3
     columns:
       - blocks:
           - type: card
@@ -71,8 +64,6 @@ rows:
                 - text: Configure Javascript injection protection
                   url: /plugins/injection-protection/examples/javascript/
 
-  - column_count: 3
-    columns:
       - blocks:
           - type: card
             config:
@@ -108,8 +99,7 @@ rows:
                   url: /plugins/xml-threat-protection/
                 - text: Configure JSON Threat Protection
                   url: /plugins/json-threat-protection/  
-  - column_count: 3
-    columns:
+
       - blocks:
           - type: card
             config:


### PR DESCRIPTION
## Description

Fixes the following issues:
* Poor/inconsistent spacing between headers and tiles on landing pages
* Proper header nesting for LLM mode
* `’` was not being displayed correctly in LLM mode, cleaned up to replace with `'` in all landing pages
   <img width="274" height="60" alt="Screenshot 2026-04-23 at 10 34 00 AM" src="https://github.com/user-attachments/assets/ebf0894e-2f0d-477b-b9b8-c2cd16c64c32" />


Added a `description` to headers; @fabianrbz let me know if that was a bad idea. I couldn't find another clean way to attribute a description/intro text to a header without having it be subject to the column count rules.

Edit: I fixed formatting, I think this is the way forward.

Old - see spacing between tiles and after the description text:
<img width="1188" height="1166" alt="Screenshot 2026-04-22 at 9 10 22 AM" src="https://github.com/user-attachments/assets/c3a1b1e0-780a-4d87-8d16-6680546834f6" />

New:
<img width="1150" height="1110" alt="Screenshot 2026-04-22 at 9 10 02 AM" src="https://github.com/user-attachments/assets/d9364504-9ba8-4b2d-a97c-c5f665ab6c6e" />

## Preview Links
So many.

When looking at any guides in the preview, check the .md output of the page as well. The changes in this PR should've fixed some header nesting issues.

Example pages:
https://deploy-preview-4961--kongdeveloper.netlify.app/waf/
https://deploy-preview-4961--kongdeveloper.netlify.app/waf.md

https://deploy-preview-4961--kongdeveloper.netlify.app/konnect/
https://deploy-preview-4961--kongdeveloper.netlify.app/konnect.md

https://deploy-preview-4961--kongdeveloper.netlify.app/ai-gateway/
https://deploy-preview-4961--kongdeveloper.netlify.app/ai-gateway.md

https://deploy-preview-4961--kongdeveloper.netlify.app/ai-gateway/ai-clis/
https://deploy-preview-4961--kongdeveloper.netlify.app/ai-gateway/ai-clis.md
