### PR TITLE
docs(mesh): deploy mesh-scoped zone proxies how-to

### DIFF
--- a/.github/styles/base/Dictionary.txt
+++ b/.github/styles/base/Dictionary.txt
@@ -69,6 +69,10 @@ backporting
 backports
 backreference
 backreferences
+wget
+meshtrust
+sectionName
+inotify
 backtrace
 balancer's
 bargineer

--- a/app/_data/series.yml
+++ b/app/_data/series.yml
@@ -41,3 +41,6 @@ mcp-acls:
 mesh-get-started-universal:
   title: Get started with {{site.mesh_product_name}} on Universal
   url: /mesh/get-started/universal/install/
+mesh-scoped-zone-proxy:
+  title: Deploy and configure mesh-scoped zone proxies
+  url: /mesh/zone-proxies/

--- a/app/_how-tos/mesh/apply-policies-to-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/apply-policies-to-mesh-scoped-zone-proxies.md
@@ -153,10 +153,13 @@ Mesh-scoped zone proxies are ordinary `Dataplane` resources, so you must select 
 
    ```sh
    kubectl --context $ZONE1_PROFILE -n kong-mesh-demo exec deploy/demo-app -c demo-app -- \
-     wget -qO /dev/null http://external-service-kube.extsvc.mesh.local
+     wget -S -O /dev/null http://external-service-kube.extsvc.mesh.local
    ```
 
-   The request should be denied by the egress policy.
+   The request should be denied by the egress policy and return `HTTP/1.1 403 Forbidden`.
+
+   {:.info}
+   > If the first attempt returns `wget: bad address`, wait a few seconds for the generated `extsvc.mesh.local` hostname to propagate and retry the same command.
 
 1. Check the RBAC stats on the zone-1 egress:
 
@@ -239,7 +242,7 @@ Match the traffic by SNI.
        - matches:
            - sni:
                type: Exact
-               value: sni.msvc.default.zone-2.kong-mesh-demo.demo-app.5000
+               value: sni.msvc.default.zone-2.kong-mesh-demo.demo-app.http
          default:
            backends:
              - type: File
@@ -268,6 +271,6 @@ Match the traffic by SNI.
    The output should contain:
 
    ```text
-   zone-ingress-sni=sni.msvc.default.zone-2.kong-mesh-demo.demo-app.5000
+   zone-ingress-sni=sni.msvc.default.zone-2.kong-mesh-demo.demo-app.http
    ```
    {:.no-copy-code}

--- a/app/_how-tos/mesh/apply-policies-to-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/apply-policies-to-mesh-scoped-zone-proxies.md
@@ -1,0 +1,305 @@
+---
+title: 'Apply policies to mesh-scoped zone proxies'
+description: 'Target mesh-scoped zone ingress and zone egress with MeshTrafficPermission, MeshMetric, and MeshAccessLog using Dataplane labels and sectionName.'
+content_type: how_to
+permalink: /mesh/zone-proxy-policies/
+bread-crumbs:
+  - /mesh/
+related_resources:
+  - text: 'Deploy mesh-scoped zone proxies'
+    url: '/mesh/zone-proxies/'
+  - text: 'Mesh Traffic Permission'
+    url: '/mesh/policies/meshtrafficpermission/'
+  - text: 'Mesh Metric'
+    url: '/mesh/policies/meshmetric/'
+  - text: 'Mesh Access Log'
+    url: '/mesh/policies/meshaccesslog/'
+
+min_version:
+  mesh: '2.14'
+
+products:
+  - mesh
+
+tldr:
+  q: How do I target mesh-scoped zone proxies with {{site.mesh_product_name}} policies?
+  a: |
+    1. Reuse the three-cluster setup from `/mesh/zone-proxies/`.
+    1. Select zone proxies with Dataplane labels such as `kuma.io/listener-zoneingress` and `kuma.io/listener-zoneegress`.
+    1. Inspect the generated listener names, then verify zone-ingress observability directly through Envoy config and logs.
+
+prereqs:
+  inline:
+    - title: Deploy mesh-scoped zone proxies
+      content: |
+        Follow [Deploy mesh-scoped zone proxies](/mesh/zone-proxies/) and leave the three minikube clusters running.
+---
+
+This guide reuses the `GLOBAL_PROFILE`, `ZONE1_PROFILE`, and `ZONE2_PROFILE` variables from [Deploy mesh-scoped zone proxies](/mesh/zone-proxies/).
+Mesh-scoped zone proxies are ordinary `Dataplane` resources, so you select them with policy `targetRef` labels instead of legacy `ZoneIngress` or `ZoneEgress` resources.
+
+## Inspect the stable zone proxy targets
+
+Kuma computes two Dataplane labels for mesh-scoped zone proxies:
+- `kuma.io/listener-zoneingress: enabled`
+- `kuma.io/listener-zoneegress: enabled`
+
+On Kubernetes, inspect the generated `Dataplane` resource to find the exact listener name for each zone proxy.
+With the current chart output, the ingress listener is `10001` and the egress listener is `10002`.
+
+1. Inspect the generated Dataplanes, confirm the zone proxy labels, and note the listener names:
+
+   ```sh
+   kubectl --context $GLOBAL_PROFILE get dataplane -A -o json | \
+     jq '.items[] |
+         select(.metadata.labels["kuma.io/listener-zoneingress"] == "enabled" or
+                .metadata.labels["kuma.io/listener-zoneegress"] == "enabled") |
+         {
+           name: .metadata.name,
+           zone: .metadata.labels["kuma.io/zone"],
+           ingress: .metadata.labels["kuma.io/listener-zoneingress"],
+           egress: .metadata.labels["kuma.io/listener-zoneegress"],
+           listeners: [.spec.networking.listeners[].name]
+         }'
+   ```
+
+## Target MeshTrafficPermission at zone egress
+
+The bootstrap allow-all policy from the first guide uses `spec.rules`.
+Zone proxy permissions use the same field, but with listener-specific selectors and matches.
+`spec.from` and `spec.rules` are mutually exclusive, so use only one model per resource.
+
+On zone egress, the destination is matched by SNI.
+
+{:.warning}
+> In the preview build used for this guide, the deny rule below did not yet change live traffic end-to-end.
+> Use this section as the current targeting pattern for mesh-scoped zone egress while the enforcement issue is being investigated.
+
+1. Create a simple unmeshed HTTP service in zone-1 and register it as a `MeshExternalService`:
+
+   ```sh
+   kubectl --context $ZONE1_PROFILE create namespace kuma-demo-ext \
+     --dry-run=client -o yaml | kubectl --context $ZONE1_PROFILE apply -f -
+
+   echo 'apiVersion: apps/v1
+   kind: Deployment
+   metadata:
+     name: external-service-kube
+     namespace: kuma-demo-ext
+   spec:
+     replicas: 1
+     selector:
+       matchLabels:
+         app: external-service-kube
+     template:
+       metadata:
+         labels:
+           app: external-service-kube
+       spec:
+         containers:
+           - name: http-echo
+             image: hashicorp/http-echo:1.0.0
+             args: ["-text=external-service-kube"]
+             ports:
+               - containerPort: 5678
+   ---
+   apiVersion: v1
+   kind: Service
+   metadata:
+     name: external-service-kube
+     namespace: kuma-demo-ext
+   spec:
+     selector:
+       app: external-service-kube
+     ports:
+       - port: 80
+         targetPort: 5678' | kubectl --context $ZONE1_PROFILE apply -f -
+
+   echo 'apiVersion: kuma.io/v1alpha1
+   kind: MeshExternalService
+   metadata:
+     name: external-service-kube
+     namespace: kong-mesh-system
+     labels:
+       kuma.io/origin: zone
+       kuma.io/mesh: default
+   spec:
+     match:
+       type: HostnameGenerator
+       port: 80
+       protocol: http
+     endpoints:
+       - address: external-service-kube.kuma-demo-ext.svc.cluster.local
+         port: 80' | kubectl --context $ZONE1_PROFILE apply -f -
+   ```
+
+1. Create a simple curl pod in the mesh namespace so you have a disposable client:
+
+   ```sh
+   kubectl --context $ZONE1_PROFILE -n kuma-demo run curl \
+    --image=curlimages/curl:8.12.1 \
+    --restart=Never \
+    --command -- sleep 3600
+   ```
+
+1. Apply a `MeshTrafficPermission` that targets the zone-1 egress listener directly:
+
+   ```sh
+   echo 'apiVersion: kuma.io/v1alpha1
+   kind: MeshTrafficPermission
+   metadata:
+     name: deny-external-service-kube
+     namespace: kong-mesh-system
+     labels:
+       kuma.io/mesh: default
+   spec:
+     targetRef:
+       kind: Dataplane
+       labels:
+         kuma.io/listener-zoneegress: enabled
+         kuma.io/zone: zone-1
+       sectionName: "10002"
+     rules:
+       - default:
+           deny:
+             - sni:
+                 type: Exact
+                 value: sni.extsvc.default.zone-1.kong-mesh-system.external-service-kube.80' | \
+     kubectl --context $GLOBAL_PROFILE apply -f -
+   ```
+
+1. Use the curl pod to exercise the zone-egress cluster:
+
+   ```sh
+   kubectl --context $ZONE1_PROFILE -n kuma-demo exec pod/curl -- \
+    curl -s http://external-service-kube.extsvc.mesh.local
+   ```
+
+   The current chart-generated zone-egress cluster name is:
+
+   ```text
+   cluster.kri_extsvc_default_zone-1_kong-mesh-system_external-service-kube_80
+   ```
+   {:.no-copy-code}
+
+## Add MeshMetric to zone ingress
+
+`MeshMetric` is proxy-wide.
+On zone-proxy-only dataplanes it skips application scraping config and exposes the proxy role instead.
+
+1. Apply a `MeshMetric` that targets the zone-2 ingress:
+
+   ```sh
+   echo 'apiVersion: kuma.io/v1alpha1
+   kind: MeshMetric
+   metadata:
+     name: zone-2-ingress-metrics
+     namespace: kong-mesh-system
+     labels:
+       kuma.io/mesh: default
+   spec:
+     targetRef:
+       kind: Dataplane
+       labels:
+         kuma.io/listener-zoneingress: enabled
+         kuma.io/zone: zone-2
+     default:
+       applications:
+         - name: ignored-on-zone-proxy
+           path: /metrics
+           port: 8888
+       backends:
+         - type: Prometheus
+           prometheus:
+             port: 5670
+             path: /metrics
+             tls:
+               mode: Disabled' | \
+     kubectl --context $GLOBAL_PROFILE apply -f -
+   ```
+
+1. Port-forward the zone-2 ingress admin endpoint if you don't already have it from the first guide:
+
+   ```sh
+   kubectl --context $ZONE2_PROFILE -n kong-mesh-system \
+     port-forward deploy/kong-mesh-default-ingress 9903:9902
+   ```
+
+1. Inspect the dynamic config payload in Envoy's config dump:
+
+   ```sh
+   curl -s http://127.0.0.1:9903/config_dump | \
+     jq -r '.. | strings? |
+       select(test("_kuma:dynamicconfig|kuma.proxy_role|ignored-on-zone-proxy|applications"))'
+   ```
+
+   The output should:
+   - include `_kuma:dynamicconfig`
+   - include `"applications":null`
+   - include `"kuma.proxy_role":"zone-ingress"`
+   - not include `ignored-on-zone-proxy`
+
+## Add MeshAccessLog to zone ingress
+
+Zone ingress does not terminate mTLS.
+That means the most reliable selector is the requested SNI, not downstream peer SAN fields.
+
+1. Apply a `MeshAccessLog` that logs the zone-2 `demo-app` SNI to a file on the ingress proxy:
+
+   ```sh
+   echo 'apiVersion: kuma.io/v1alpha1
+   kind: MeshAccessLog
+   metadata:
+     name: zone-2-ingress-log
+     namespace: kong-mesh-system
+     labels:
+       kuma.io/mesh: default
+   spec:
+     targetRef:
+       kind: Dataplane
+       labels:
+         kuma.io/listener-zoneingress: enabled
+         kuma.io/zone: zone-2
+       sectionName: "10001"
+     rules:
+       - matches:
+           - sni:
+               type: Exact
+               value: sni.msvc.default.zone-2.kuma-demo.demo-app.5000
+         default:
+           backends:
+             - type: File
+               file:
+                 path: /tmp/zone-2-demo-app.log
+                 format:
+                   type: Plain
+                   plain: "sni=%REQUESTED_SERVER_NAME%"' | \
+     kubectl --context $GLOBAL_PROFILE apply -f -
+   ```
+
+1. Remove any previous log file, send the cross-zone request again, and read the latest access log entry:
+
+   ```sh
+   kubectl --context $ZONE2_PROFILE -n kong-mesh-system exec deploy/kong-mesh-default-ingress -c kuma-sidecar -- \
+     rm -f /tmp/zone-2-demo-app.log
+
+   kubectl --context $ZONE1_PROFILE -n kuma-demo exec deploy/demo-app -c demo-app -- \
+     wget -qO- http://demo-app.kuma-demo.svc.zone-2.mesh.local:5000/ >/dev/null
+
+   kubectl --context $ZONE2_PROFILE -n kong-mesh-system exec deploy/kong-mesh-default-ingress -c kuma-sidecar -- \
+     tail -n 1 /tmp/zone-2-demo-app.log
+   ```
+
+   The log line should contain:
+
+   ```text
+   sni=sni.msvc.default.zone-2.kuma-demo.demo-app.5000
+   ```
+   {:.no-copy-code}
+
+## Next steps
+
+If you want to target a different zone proxy, keep the same pattern:
+- narrow `targetRef.kind: Dataplane` with `kuma.io/listener-zoneingress` or `kuma.io/listener-zoneegress`
+- add `kuma.io/zone` when you want one specific zone
+- inspect `.spec.networking.listeners[].name` on the generated `Dataplane` and use that as `sectionName` when you want one exact listener

--- a/app/_how-tos/mesh/apply-policies-to-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/apply-policies-to-mesh-scoped-zone-proxies.md
@@ -1,6 +1,6 @@
 ---
 title: 'Apply policies to mesh-scoped zone proxies'
-description: 'Target mesh-scoped zone ingress and zone egress with MeshTrafficPermission, MeshMetric, and MeshAccessLog using Dataplane labels and sectionName.'
+description: 'Target mesh-scoped zone ingress and zone egress with MeshTrafficPermission, MeshMetric, and MeshAccessLog.'
 content_type: how_to
 permalink: /mesh/zone-proxy-policies/
 bread-crumbs:
@@ -24,9 +24,9 @@ products:
 tldr:
   q: How do I target mesh-scoped zone proxies with {{site.mesh_product_name}} policies?
   a: |
-    1. Reuse the three-cluster setup from `/mesh/zone-proxies/`.
-    1. Select zone proxies with Dataplane labels such as `kuma.io/listener-zoneingress` and `kuma.io/listener-zoneegress`.
-    1. Inspect the generated listener names, then verify zone-ingress observability directly through Envoy config and logs.
+    1. Reuse the three-cluster setup from [Deploy mesh-scoped zone proxies](/mesh/zone-proxies/).
+    1. Find the zone proxy Dataplanes and their listener names.
+    1. Apply policies to the zone proxies and verify them through Envoy stats, metrics, and access logs.
 
 prereqs:
   inline:
@@ -36,46 +36,26 @@ prereqs:
 ---
 
 This guide reuses the `GLOBAL_PROFILE`, `ZONE1_PROFILE`, and `ZONE2_PROFILE` variables from [Deploy mesh-scoped zone proxies](/mesh/zone-proxies/).
-Mesh-scoped zone proxies are ordinary `Dataplane` resources, so you select them with policy `targetRef` labels instead of legacy `ZoneIngress` or `ZoneEgress` resources.
+Zone proxies appear as `Dataplane` resources, so you target them with `targetRef` labels and, when needed, a listener name.
 
-## Inspect the stable zone proxy targets
+## Find the zone proxy Dataplanes and listener names
 
-Kuma computes two Dataplane labels for mesh-scoped zone proxies:
+Zone proxy Dataplanes include these labels:
 - `kuma.io/listener-zoneingress: enabled`
 - `kuma.io/listener-zoneegress: enabled`
 
-On Kubernetes, inspect the generated `Dataplane` resource to find the exact listener name for each zone proxy.
-With the current chart output, the ingress listener is `10001` and the egress listener is `10002`.
+Inspect the Dataplanes to see which labels are present and to find the listener names for your environment.
+In the example output below, the ingress listener is `10001` and the egress listener is `10002`.
 
-1. Inspect the generated Dataplanes, confirm the zone proxy labels, and note the listener names:
+1. Inspect the zone proxy Dataplanes:
 
    ```sh
-   kubectl --context $GLOBAL_PROFILE get dataplane -A -o json | \
-     jq '.items[] |
-         select(.metadata.labels["kuma.io/listener-zoneingress"] == "enabled" or
-                .metadata.labels["kuma.io/listener-zoneegress"] == "enabled") |
-         {
-           name: .metadata.name,
-           zone: .metadata.labels["kuma.io/zone"],
-           ingress: .metadata.labels["kuma.io/listener-zoneingress"],
-           egress: .metadata.labels["kuma.io/listener-zoneegress"],
-           listeners: [.spec.networking.listeners[].name]
-         }'
+   kubectl --context $GLOBAL_PROFILE get dataplane -A -o json
    ```
 
-## Target MeshTrafficPermission at zone egress
+## Apply MeshTrafficPermission to zone egress
 
-The bootstrap allow-all policy from the first guide uses `spec.rules`.
-Zone proxy permissions use the same field, but with listener-specific selectors and matches.
-`spec.from` and `spec.rules` are mutually exclusive, so use only one model per resource.
-
-On zone egress, the destination is matched by SNI.
-
-{:.warning}
-> In the preview build used for this guide, the deny rule below did not yet change live traffic end-to-end.
-> Use this section as the current targeting pattern for mesh-scoped zone egress while the enforcement issue is being investigated.
-
-1. Create a simple unmeshed HTTP service in zone-1 and register it as a `MeshExternalService`:
+1. Create a simple HTTP service in zone-1 and register it as a `MeshExternalService`:
 
    ```sh
    kubectl --context $ZONE1_PROFILE create namespace kuma-demo-ext \
@@ -133,16 +113,26 @@ On zone egress, the destination is matched by SNI.
          port: 80' | kubectl --context $ZONE1_PROFILE apply -f -
    ```
 
-1. Create a simple curl pod in the mesh namespace so you have a disposable client:
+1. Create a disposable curl client:
 
    ```sh
-   kubectl --context $ZONE1_PROFILE -n kuma-demo run curl \
-    --image=curlimages/curl:8.12.1 \
-    --restart=Never \
-    --command -- sleep 3600
+   kubectl --context $ZONE1_PROFILE create namespace mtp-client \
+     --dry-run=client -o yaml | kubectl --context $ZONE1_PROFILE apply -f -
+
+   kubectl --context $ZONE1_PROFILE label namespace mtp-client \
+     kuma.io/sidecar-injection=enabled --overwrite
+
+   kubectl --context $ZONE1_PROFILE -n mtp-client run debug-client \
+     --image=curlimages/curl:8.12.1 \
+     --restart=Never \
+     --command -- sleep 3600
+
+   kubectl --context $ZONE1_PROFILE -n mtp-client wait \
+     --for=condition=ready pod/debug-client --timeout=120s
    ```
 
-1. Apply a `MeshTrafficPermission` that targets the zone-1 egress listener directly:
+1. Apply a `MeshTrafficPermission` that targets the zone-1 egress listener directly.
+   The default is `10002`:
 
    ```sh
    echo 'apiVersion: kuma.io/v1alpha1
@@ -168,24 +158,25 @@ On zone egress, the destination is matched by SNI.
      kubectl --context $GLOBAL_PROFILE apply -f -
    ```
 
-1. Use the curl pod to exercise the zone-egress cluster:
+1. Send the request through zone egress:
 
    ```sh
-   kubectl --context $ZONE1_PROFILE -n kuma-demo exec pod/curl -- \
-    curl -s http://external-service-kube.extsvc.mesh.local
+   kubectl --context $ZONE1_PROFILE -n mtp-client exec debug-client -c debug-client -- \
+     curl -sv --max-time 15 http://external-service-kube.extsvc.mesh.local
    ```
 
-   The current chart-generated zone-egress cluster name is:
+1. Check the RBAC stats on the zone-1 egress:
 
-   ```text
-   cluster.kri_extsvc_default_zone-1_kong-mesh-system_external-service-kube_80
+   ```sh
+   kubectl --context $ZONE1_PROFILE -n kong-mesh-system exec deploy/kong-mesh-default-egress -c kuma-sidecar -- \
+     wget -qO- 'http://127.0.0.1:9902/stats?filter=external-service-kube.*rbac'
    ```
-   {:.no-copy-code}
+
+   The request should be denied, and `rbac.denied` should increase for the external-service cluster.
 
 ## Add MeshMetric to zone ingress
 
-`MeshMetric` is proxy-wide.
-On zone-proxy-only dataplanes it skips application scraping config and exposes the proxy role instead.
+Apply `MeshMetric` to the zone-2 ingress and read the Prometheus endpoint from inside the sidecar.
 
 1. Apply a `MeshMetric` that targets the zone-2 ingress:
 
@@ -204,10 +195,6 @@ On zone-proxy-only dataplanes it skips application scraping config and exposes t
          kuma.io/listener-zoneingress: enabled
          kuma.io/zone: zone-2
      default:
-       applications:
-         - name: ignored-on-zone-proxy
-           path: /metrics
-           port: 8888
        backends:
          - type: Prometheus
            prometheus:
@@ -218,31 +205,23 @@ On zone-proxy-only dataplanes it skips application scraping config and exposes t
      kubectl --context $GLOBAL_PROFILE apply -f -
    ```
 
-1. Port-forward the zone-2 ingress admin endpoint if you don't already have it from the first guide:
+1. Read the metrics from the zone-2 ingress sidecar:
 
    ```sh
-   kubectl --context $ZONE2_PROFILE -n kong-mesh-system \
-     port-forward deploy/kong-mesh-default-ingress 9903:9902
+   kubectl --context $ZONE2_PROFILE -n kong-mesh-system exec deploy/kong-mesh-default-ingress -c kuma-sidecar -- \
+     sh -c '
+      POD_IP=$(hostname -i | awk "{print \$1}")
+      wget -qO- "http://$POD_IP:5670/metrics" | \
+        grep "kuma_proxy_role=\"zone-ingress\"" | sed -n "1,10p"
+     '
    ```
 
-1. Inspect the dynamic config payload in Envoy's config dump:
-
-   ```sh
-   curl -s http://127.0.0.1:9903/config_dump | \
-     jq -r '.. | strings? |
-       select(test("_kuma:dynamicconfig|kuma.proxy_role|ignored-on-zone-proxy|applications"))'
-   ```
-
-   The output should:
-   - include `_kuma:dynamicconfig`
-   - include `"applications":null`
-   - include `"kuma.proxy_role":"zone-ingress"`
-   - not include `ignored-on-zone-proxy`
+   You should see Envoy metrics labeled `kuma_proxy_role="zone-ingress"`.
 
 ## Add MeshAccessLog to zone ingress
 
 Zone ingress does not terminate mTLS.
-That means the most reliable selector is the requested SNI, not downstream peer SAN fields.
+Match the traffic by SNI.
 
 1. Apply a `MeshAccessLog` that logs the zone-2 `demo-app` SNI to a file on the ingress proxy:
 
@@ -302,4 +281,4 @@ That means the most reliable selector is the requested SNI, not downstream peer 
 If you want to target a different zone proxy, keep the same pattern:
 - narrow `targetRef.kind: Dataplane` with `kuma.io/listener-zoneingress` or `kuma.io/listener-zoneegress`
 - add `kuma.io/zone` when you want one specific zone
-- inspect `.spec.networking.listeners[].name` on the generated `Dataplane` and use that as `sectionName` when you want one exact listener
+- inspect `.spec.networking.listeners[].name` on the zone proxy `Dataplane` and use that listener name in `sectionName` when you want one exact listener

--- a/app/_how-tos/mesh/apply-policies-to-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/apply-policies-to-mesh-scoped-zone-proxies.md
@@ -3,11 +3,9 @@ title: 'Apply policies to mesh-scoped zone proxies'
 description: 'Target mesh-scoped zone ingress and zone egress with MeshTrafficPermission, MeshMetric, and MeshAccessLog.'
 content_type: how_to
 permalink: /mesh/zone-proxy-policies/
-bread-crumbs:
+breadcrumbs:
   - /mesh/
 related_resources:
-  - text: 'Deploy mesh-scoped zone proxies'
-    url: '/mesh/zone-proxies/'
   - text: 'Mesh Traffic Permission'
     url: '/mesh/policies/meshtrafficpermission/'
   - text: 'Mesh Metric'
@@ -21,26 +19,30 @@ min_version:
 products:
   - mesh
 
+series:
+  id: mesh-scoped-zone-proxy
+  position: 2
+
 tldr:
   q: How do I target mesh-scoped zone proxies with {{site.mesh_product_name}} policies?
   a: |
-    1. Reuse the three-cluster setup from [Deploy mesh-scoped zone proxies](/mesh/zone-proxies/).
-    1. Find the zone proxy Dataplanes and their listener names.
+    1. Find the zone proxy `Dataplane` resources and their listener names.
     1. Apply policies to the zone proxies and verify them through Envoy stats, metrics, and access logs.
 
-prereqs:
-  inline:
-    - title: Deploy mesh-scoped zone proxies
-      content: |
-        Follow [Deploy mesh-scoped zone proxies](/mesh/zone-proxies/) and leave the three minikube clusters running.
+faqs:
+  - q: How do I target a different zone proxy?
+    a: |
+      Use the same pattern as this guide:
+      - Narrow `targetRef.kind: Dataplane` with `kuma.io/listener-zoneingress` or `kuma.io/listener-zoneegress`.
+      - Add `kuma.io/zone` to target one specific zone.
+      - Inspect `.spec.networking.listeners[].name` on the generated `Dataplane` and use that value as `sectionName` to target one exact listener.
 ---
 
-This guide reuses the `GLOBAL_PROFILE`, `ZONE1_PROFILE`, and `ZONE2_PROFILE` variables from [Deploy mesh-scoped zone proxies](/mesh/zone-proxies/).
-Zone proxies appear as `Dataplane` resources, so you target them with `targetRef` labels and, when needed, a listener name.
+Mesh-scoped zone proxies are ordinary `Dataplane` resources, so you must select them with policy `targetRef` labels instead of legacy `ZoneIngress` or `ZoneEgress` resources.
 
 ## Find the zone proxy Dataplanes and listener names
 
-Zone proxy Dataplanes include these labels:
+{{site.mesh_product_name}} computes two `Dataplane` labels for mesh-scoped zone proxies:
 - `kuma.io/listener-zoneingress: enabled`
 - `kuma.io/listener-zoneegress: enabled`
 
@@ -53,19 +55,23 @@ In the example output below, the ingress listener is `10001` and the egress list
    kubectl --context $GLOBAL_PROFILE get dataplane -A -o json
    ```
 
-## Apply MeshTrafficPermission to zone egress
+## Target MeshTrafficPermission at the zone egress
 
-1. Create a simple HTTP service in zone-1 and register it as a `MeshExternalService`:
+1. Create the namespace for the external service:
 
    ```sh
-   kubectl --context $ZONE1_PROFILE create namespace kuma-demo-ext \
+   kubectl --context $ZONE1_PROFILE create namespace kong-mesh-demo-ext \
      --dry-run=client -o yaml | kubectl --context $ZONE1_PROFILE apply -f -
+   ```
 
+1. Deploy the external service:
+
+   ```sh
    echo 'apiVersion: apps/v1
    kind: Deployment
    metadata:
      name: external-service-kube
-     namespace: kuma-demo-ext
+     namespace: kong-mesh-demo-ext
    spec:
      replicas: 1
      selector:
@@ -87,14 +93,18 @@ In the example output below, the ingress listener is `10001` and the egress list
    kind: Service
    metadata:
      name: external-service-kube
-     namespace: kuma-demo-ext
+     namespace: kong-mesh-demo-ext
    spec:
      selector:
        app: external-service-kube
      ports:
        - port: 80
          targetPort: 5678' | kubectl --context $ZONE1_PROFILE apply -f -
+   ```
 
+1. Register the external service as a `MeshExternalService`:
+
+   ```sh
    echo 'apiVersion: kuma.io/v1alpha1
    kind: MeshExternalService
    metadata:
@@ -109,26 +119,8 @@ In the example output below, the ingress listener is `10001` and the egress list
        port: 80
        protocol: http
      endpoints:
-       - address: external-service-kube.kuma-demo-ext.svc.cluster.local
+       - address: external-service-kube.kong-mesh-demo-ext.svc.cluster.local
          port: 80' | kubectl --context $ZONE1_PROFILE apply -f -
-   ```
-
-1. Create a disposable curl client:
-
-   ```sh
-   kubectl --context $ZONE1_PROFILE create namespace mtp-client \
-     --dry-run=client -o yaml | kubectl --context $ZONE1_PROFILE apply -f -
-
-   kubectl --context $ZONE1_PROFILE label namespace mtp-client \
-     kuma.io/sidecar-injection=enabled --overwrite
-
-   kubectl --context $ZONE1_PROFILE -n mtp-client run debug-client \
-     --image=curlimages/curl:8.12.1 \
-     --restart=Never \
-     --command -- sleep 3600
-
-   kubectl --context $ZONE1_PROFILE -n mtp-client wait \
-     --for=condition=ready pod/debug-client --timeout=120s
    ```
 
 1. Apply a `MeshTrafficPermission` that targets the zone-1 egress listener directly.
@@ -158,17 +150,20 @@ In the example output below, the ingress listener is `10001` and the egress list
      kubectl --context $GLOBAL_PROFILE apply -f -
    ```
 
-1. Send the request through zone egress:
+1. Send the request through zone egress from the zone-1 `demo-app` pod:
 
    ```sh
-   kubectl --context $ZONE1_PROFILE -n mtp-client exec debug-client -c debug-client -- \
-     curl -sv --max-time 15 http://external-service-kube.extsvc.mesh.local
+   kubectl --context $ZONE1_PROFILE -n kong-mesh-demo exec deploy/demo-app -c demo-app -- \
+     wget -qO /dev/null http://external-service-kube.extsvc.mesh.local
    ```
+
+   The request should be denied by the egress policy.
 
 1. Check the RBAC stats on the zone-1 egress:
 
    ```sh
-   kubectl --context $ZONE1_PROFILE -n kong-mesh-system exec deploy/kong-mesh-default-egress -c kuma-sidecar -- \
+   kubectl --context $ZONE1_PROFILE -n kong-mesh-system \
+     exec deploy/kong-mesh-default-egress -c kuma-sidecar -- \
      wget -qO- 'http://127.0.0.1:9902/stats?filter=external-service-kube.*rbac'
    ```
 
@@ -208,11 +203,12 @@ Apply `MeshMetric` to the zone-2 ingress and read the Prometheus endpoint from i
 1. Read the metrics from the zone-2 ingress sidecar:
 
    ```sh
-   kubectl --context $ZONE2_PROFILE -n kong-mesh-system exec deploy/kong-mesh-default-ingress -c kuma-sidecar -- \
+   kubectl --context $ZONE2_PROFILE -n kong-mesh-system \
+     exec deploy/kong-mesh-default-ingress -c kuma-sidecar -- \
      sh -c '
-      POD_IP=$(hostname -i | awk "{print \$1}")
-      wget -qO- "http://$POD_IP:5670/metrics" | \
-        grep "kuma_proxy_role=\"zone-ingress\"" | sed -n "1,10p"
+       POD_IP=$(hostname -i | awk "{print \$1}")
+       wget -qO- "http://$POD_IP:5670/metrics" | \
+         grep "kuma_proxy_role=\"zone-ingress\"" | sed -n "1,10p"
      '
    ```
 
@@ -223,7 +219,7 @@ Apply `MeshMetric` to the zone-2 ingress and read the Prometheus endpoint from i
 Zone ingress does not terminate mTLS.
 Match the traffic by SNI.
 
-1. Apply a `MeshAccessLog` that logs the zone-2 `demo-app` SNI to a file on the ingress proxy:
+1. Apply a `MeshAccessLog` that logs the zone-2 `demo-app` SNI to the ingress proxy's stdout:
 
    ```sh
    echo 'apiVersion: kuma.io/v1alpha1
@@ -244,41 +240,35 @@ Match the traffic by SNI.
        - matches:
            - sni:
                type: Exact
-               value: sni.msvc.default.zone-2.kuma-demo.demo-app.5000
+               value: sni.msvc.default.zone-2.kong-mesh-demo.demo-app.5000
          default:
            backends:
              - type: File
                file:
-                 path: /tmp/zone-2-demo-app.log
+                 path: /dev/stdout
                  format:
                    type: Plain
-                   plain: "sni=%REQUESTED_SERVER_NAME%"' | \
+                   plain: "zone-ingress-sni=%REQUESTED_SERVER_NAME%"' | \
      kubectl --context $GLOBAL_PROFILE apply -f -
    ```
 
-1. Remove any previous log file, send the cross-zone request again, and read the latest access log entry:
+1. Send the cross-zone request again:
 
    ```sh
-   kubectl --context $ZONE2_PROFILE -n kong-mesh-system exec deploy/kong-mesh-default-ingress -c kuma-sidecar -- \
-     rm -f /tmp/zone-2-demo-app.log
-
-   kubectl --context $ZONE1_PROFILE -n kuma-demo exec deploy/demo-app -c demo-app -- \
-     wget -qO- http://demo-app.kuma-demo.svc.zone-2.mesh.local:5000/ >/dev/null
-
-   kubectl --context $ZONE2_PROFILE -n kong-mesh-system exec deploy/kong-mesh-default-ingress -c kuma-sidecar -- \
-     tail -n 1 /tmp/zone-2-demo-app.log
+   kubectl --context $ZONE1_PROFILE -n kong-mesh-demo exec deploy/demo-app -c demo-app -- \
+     wget -qO /dev/null http://demo-app.kong-mesh-demo.svc.zone-2.mesh.local:5000/
    ```
 
-   The log line should contain:
+1. Check the ingress proxy logs for the access log entry:
+
+   ```sh
+   kubectl --context $ZONE2_PROFILE -n kong-mesh-system logs deploy/kong-mesh-default-ingress \
+     -c kuma-sidecar | grep "zone-ingress-sni"
+   ```
+
+   The output should contain:
 
    ```text
-   sni=sni.msvc.default.zone-2.kuma-demo.demo-app.5000
+   zone-ingress-sni=sni.msvc.default.zone-2.kong-mesh-demo.demo-app.5000
    ```
    {:.no-copy-code}
-
-## Next steps
-
-If you want to target a different zone proxy, keep the same pattern:
-- narrow `targetRef.kind: Dataplane` with `kuma.io/listener-zoneingress` or `kuma.io/listener-zoneegress`
-- add `kuma.io/zone` when you want one specific zone
-- inspect `.spec.networking.listeners[].name` on the zone proxy `Dataplane` and use that listener name in `sectionName` when you want one exact listener

--- a/app/_how-tos/mesh/apply-policies-to-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/apply-policies-to-mesh-scoped-zone-proxies.md
@@ -19,10 +19,12 @@ min_version:
 products:
   - mesh
 
+works_on:
+  - on-prem
+
 series:
   id: mesh-scoped-zone-proxy
   position: 2
-
 tldr:
   q: How do I target mesh-scoped zone proxies with {{site.mesh_product_name}} policies?
   a: |

--- a/app/_how-tos/mesh/apply-policies-to-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/apply-policies-to-mesh-scoped-zone-proxies.md
@@ -244,7 +244,7 @@ Match the traffic by SNI.
        - matches:
            - sni:
                type: Exact
-               value: sni.msvc.default.zone-2.kong-mesh-demo.demo-app.http
+               value: sni.msvc.default.zone-2.kong-mesh-demo.demo-app.5000
          default:
            backends:
              - type: File
@@ -273,6 +273,6 @@ Match the traffic by SNI.
    The output should contain:
 
    ```text
-   zone-ingress-sni=sni.msvc.default.zone-2.kong-mesh-demo.demo-app.http
+   zone-ingress-sni=sni.msvc.default.zone-2.kong-mesh-demo.demo-app.5000
    ```
    {:.no-copy-code}

--- a/app/_how-tos/mesh/apply-policies-to-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/apply-policies-to-mesh-scoped-zone-proxies.md
@@ -30,6 +30,20 @@ tldr:
     1. Apply policies to the zone proxies and verify them through Envoy stats, metrics, and access logs.
 
 faqs:
+  - q: How do I find the Dataplane labels and listener names for zone proxies?
+    a: |
+      {{site.mesh_product_name}} computes two `Dataplane` labels for mesh-scoped zone proxies:
+      - `kuma.io/listener-zoneingress: enabled`
+      - `kuma.io/listener-zoneegress: enabled`
+
+      Inspect the zone proxy `Dataplane` resources to find the listener names for your environment:
+
+      ```sh
+      kubectl --context $GLOBAL_PROFILE get dataplane -A -o json
+      ```
+
+      The ingress listener is typically `10001` and the egress listener `10002`.
+
   - q: How do I target a different zone proxy?
     a: |
       Use the same pattern as this guide:
@@ -39,21 +53,6 @@ faqs:
 ---
 
 Mesh-scoped zone proxies are ordinary `Dataplane` resources, so you must select them with policy `targetRef` labels instead of legacy `ZoneIngress` or `ZoneEgress` resources.
-
-## Find the zone proxy Dataplanes and listener names
-
-{{site.mesh_product_name}} computes two `Dataplane` labels for mesh-scoped zone proxies:
-- `kuma.io/listener-zoneingress: enabled`
-- `kuma.io/listener-zoneegress: enabled`
-
-Inspect the Dataplanes to see which labels are present and to find the listener names for your environment.
-In the example output below, the ingress listener is `10001` and the egress listener is `10002`.
-
-1. Inspect the zone proxy Dataplanes:
-
-   ```sh
-   kubectl --context $GLOBAL_PROFILE get dataplane -A -o json
-   ```
 
 ## Target MeshTrafficPermission at the zone egress
 

--- a/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
@@ -322,6 +322,5 @@ Each entry renders its own Deployment, Service, and ServiceAccount for the ingre
 
 ## Next steps
 
-- Target individual zone proxy listeners from policies with `sectionName` - covered in a follow-up guide.
-- Add a second mesh by appending another entry to `kuma.meshes[]`.
-- Read the [`MeshIdentity`](/mesh/mesh-identity/) guide to switch the bundled CA for a production issuer.
+<!--- Target individual zone proxy listeners from policies with `sectionName` - covered in a follow-up guide.-->
+<!--- Read the [`MeshIdentity`](/mesh/mesh-identity/) guide to switch the bundled CA for a production issuer.-->

--- a/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
@@ -171,8 +171,8 @@ spec:
 
 ## Deploy zone-1 with mesh-scoped zone proxies
 
-This is the step that differs from the [federation guide](/mesh/federate/).
-Instead of `--set kuma.ingress.enabled=true`, we set a `kuma.meshes[]` entry that describes which mesh the zone proxies belong to.
+A `kuma.meshes[]` entry tells the chart which mesh the zone proxies belong to.
+Each entry renders its own Deployment, Service, and ServiceAccount for the ingress and egress roles.
 
 1. Start the zone-1 cluster and its tunnel:
 
@@ -181,22 +181,34 @@ Instead of `--set kuma.ingress.enabled=true`, we set a `kuma.meshes[]` entry tha
    nohup minikube tunnel -p mesh-zone-1 &
    ```
 
+1. Save the following as `zone-1-values.yaml`, replacing `${EXTERNAL_IP}` with the value you exported earlier:
+
+   ```yaml
+   kuma:
+     controlPlane:
+       mode: zone
+       zone: zone-1
+       kdsGlobalAddress: grpcs://${EXTERNAL_IP}:5685
+       tls:
+         kdsZoneClient:
+           skipVerify: true
+     meshes:
+       - name: default
+         ingress:
+           enabled: true
+         egress:
+           enabled: true
+   ```
+
+   To deploy zone proxies for additional meshes, append more entries to `kuma.meshes`.
+
 1. Install the zone control plane together with the zone ingress and egress for `default`:
 
    ```sh
    helm install --kube-context mesh-zone-1 --create-namespace --namespace kong-mesh-system \
-     --set kuma.controlPlane.mode=zone \
-     --set kuma.controlPlane.zone=zone-1 \
-     --set kuma.controlPlane.kdsGlobalAddress=grpcs://${EXTERNAL_IP}:5685 \
-     --set kuma.controlPlane.tls.kdsZoneClient.skipVerify=true \
-     --set 'kuma.meshes[0].name=default' \
-     --set 'kuma.meshes[0].ingress.enabled=true' \
-     --set 'kuma.meshes[0].egress.enabled=true' \
+     -f zone-1-values.yaml \
      kong-mesh kong-mesh/kong-mesh
    ```
-
-   Each entry in `kuma.meshes[]` renders its own Deployment, Service, and ServiceAccount.
-   To deploy zone proxies for additional meshes, append more entries to the list.
 
 ## Deploy zone-2 with the same configuration
 
@@ -207,17 +219,30 @@ Instead of `--set kuma.ingress.enabled=true`, we set a `kuma.meshes[]` entry tha
    nohup minikube tunnel -p mesh-zone-2 &
    ```
 
+1. Save the following as `zone-2-values.yaml`, replacing `${EXTERNAL_IP}` with the value you exported earlier:
+
+   ```yaml
+   kuma:
+     controlPlane:
+       mode: zone
+       zone: zone-2
+       kdsGlobalAddress: grpcs://${EXTERNAL_IP}:5685
+       tls:
+         kdsZoneClient:
+           skipVerify: true
+     meshes:
+       - name: default
+         ingress:
+           enabled: true
+         egress:
+           enabled: true
+   ```
+
 1. Install the zone control plane and its zone proxies:
 
    ```sh
    helm install --kube-context mesh-zone-2 --create-namespace --namespace kong-mesh-system \
-     --set kuma.controlPlane.mode=zone \
-     --set kuma.controlPlane.zone=zone-2 \
-     --set kuma.controlPlane.kdsGlobalAddress=grpcs://${EXTERNAL_IP}:5685 \
-     --set kuma.controlPlane.tls.kdsZoneClient.skipVerify=true \
-     --set 'kuma.meshes[0].name=default' \
-     --set 'kuma.meshes[0].ingress.enabled=true' \
-     --set 'kuma.meshes[0].egress.enabled=true' \
+     -f zone-2-values.yaml \
      kong-mesh kong-mesh/kong-mesh
    ```
 

--- a/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
@@ -61,9 +61,10 @@ This guide walks through a fresh three-cluster setup: a global control plane and
 
    {:.info}
    > Using `nohup` lets the tunnel continue running if your terminal session ends.
+   > The `--bind-address=0.0.0.0` flag exposes the tunnel to other minikube clusters via `host.minikube.internal`.
 
    ```sh
-   nohup minikube tunnel -p mesh-global &
+   nohup minikube tunnel -p mesh-global --bind-address=0.0.0.0 &
    ```
 
 ## Deploy the global control plane
@@ -178,7 +179,7 @@ Each entry renders its own Deployment, Service, and ServiceAccount for the ingre
 
    ```sh
    minikube start -p mesh-zone-1
-   nohup minikube tunnel -p mesh-zone-1 &
+   nohup minikube tunnel -p mesh-zone-1 --bind-address=0.0.0.0 &
    ```
 
 1. Save the following as `zone-1-values.yaml`, replacing `${EXTERNAL_IP}` with the value you exported earlier:
@@ -216,7 +217,7 @@ Each entry renders its own Deployment, Service, and ServiceAccount for the ingre
 
    ```sh
    minikube start -p mesh-zone-2
-   nohup minikube tunnel -p mesh-zone-2 &
+   nohup minikube tunnel -p mesh-zone-2 --bind-address=0.0.0.0 &
    ```
 
 1. Save the following as `zone-2-values.yaml`, replacing `${EXTERNAL_IP}` with the value you exported earlier:
@@ -234,9 +235,14 @@ Each entry renders its own Deployment, Service, and ServiceAccount for the ingre
        - name: default
          ingress:
            enabled: true
+           service:
+             port: 10002
          egress:
            enabled: true
    ```
+
+   {:.info}
+   > Zone-2's ingress uses port `10002` so it doesn't collide with zone-1's ingress on port `10001` when both tunnels publish to the same host address.
 
 1. Install the zone control plane and its zone proxies:
 
@@ -245,6 +251,68 @@ Each entry renders its own Deployment, Service, and ServiceAccount for the ingre
      -f zone-2-values.yaml \
      kong-mesh kong-mesh/kong-mesh
    ```
+
+## Patch the ingress Services for cross-cluster routing
+
+Minikube tunnels assign `127.0.0.1` as the external IP, which doesn't route between clusters.
+Patch each zone's ingress Service to advertise `host.minikube.internal`'s IP instead.
+
+1. Get the host IP that all minikube clusters can reach:
+
+   ```sh
+   export HOST_IP=$(minikube ssh -p mesh-zone-1 -- getent hosts host.minikube.internal | awk '{print $1}')
+   echo $HOST_IP
+   ```
+
+1. Patch the ingress Service in zone-1:
+
+   ```sh
+   kubectl --context mesh-zone-1 -n kong-mesh-system patch svc kong-mesh-default-ingress \
+     --type merge -p "{\"spec\":{\"externalIPs\":[\"$HOST_IP\"]}}"
+   ```
+
+1. Patch the ingress Service in zone-2:
+
+   ```sh
+   kubectl --context mesh-zone-2 -n kong-mesh-system patch svc kong-mesh-default-ingress \
+     --type merge -p "{\"spec\":{\"externalIPs\":[\"$HOST_IP\"]}}"
+   ```
+
+The `MeshZoneAddress` controller will pick up the new external IP and regenerate the address resources.
+
+## Propagate trust between zones
+
+Each zone generates a `MeshTrust` containing its local CA bundle.
+For cross-zone mTLS to work, each zone must trust the other zone's CA.
+Republish each zone's trust bundle to the global control plane so it syncs everywhere.
+
+1. Export zone-1's trust bundle and apply it to the global CP:
+
+   ```sh
+   kubectl --context mesh-zone-1 -n kong-mesh-system get meshtrust identity -o yaml | \
+     sed 's/name: identity/name: trust-of-zone-1/' | \
+     sed '/resourceVersion:/d' | \
+     sed '/uid:/d' | \
+     sed '/creationTimestamp:/d' | \
+     sed '/generation:/d' | \
+     sed 's/kuma.io\/origin: zone/kuma.io\/origin: global/' | \
+     kubectl --context mesh-global apply -f -
+   ```
+
+1. Export zone-2's trust bundle and apply it to the global CP:
+
+   ```sh
+   kubectl --context mesh-zone-2 -n kong-mesh-system get meshtrust identity -o yaml | \
+     sed 's/name: identity/name: trust-of-zone-2/' | \
+     sed '/resourceVersion:/d' | \
+     sed '/uid:/d' | \
+     sed '/creationTimestamp:/d' | \
+     sed '/generation:/d' | \
+     sed 's/kuma.io\/origin: zone/kuma.io\/origin: global/' | \
+     kubectl --context mesh-global apply -f -
+   ```
+
+The global control plane syncs these trust bundles to all zones, enabling cross-zone certificate validation.
 
 ## Inspect what the chart produced
 
@@ -294,9 +362,9 @@ Each entry renders its own Deployment, Service, and ServiceAccount for the ingre
 
    ```sh
    for ctx in mesh-zone-1 mesh-zone-2; do
-     kubectl --context $ctx create namespace kong-mesh-demo \
+     kubectl --context $ctx create namespace kuma-demo \
        --dry-run=client -o yaml | kubectl --context $ctx apply -f -
-     kubectl --context $ctx label namespace kong-mesh-demo \
+     kubectl --context $ctx label namespace kuma-demo \
        kuma.io/sidecar-injection=enabled --overwrite
      kubectl --context $ctx apply -f https://raw.githubusercontent.com/kumahq/kuma-counter-demo/refs/heads/master/demo.yaml
    done
@@ -305,11 +373,15 @@ Each entry renders its own Deployment, Service, and ServiceAccount for the ingre
 1. From a `demo-app` pod in zone-1, curl the `demo-app` Service in zone-2 using its cross-zone hostname:
 
    ```sh
-   kubectl --context mesh-zone-1 -n kong-mesh-demo exec deploy/demo-app -c demo-app -- \
-     curl -s http://demo-app.kong-mesh-demo.svc.zone-2.mesh.local:5050/
+   kubectl --context mesh-zone-1 -n kuma-demo exec deploy/demo-app -c demo-app -- \
+     curl -s http://demo-app.kuma-demo.svc.zone-2.mesh.local:5050/
    ```
 
    The request leaves zone-1 through the zone egress, enters zone-2 through the zone ingress, and hits the `demo-app` pod there.
+
+   {:.info}
+   > If the request times out, check that the minikube tunnels are still running.
+   > Tunnels can become unresponsive after sleep/wake cycles; restart them with `minikube tunnel -p <profile> --bind-address=0.0.0.0`.
 
 1. Confirm the traffic passed through the zone-2 zone ingress by reading its sidecar stats:
 

--- a/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
@@ -387,7 +387,6 @@ The global control plane syncs these trust bundles to all zones, enabling cross-
    ```
 
    `upstream_rq_total` for the `demo-app` cluster should be greater than zero.
-   The global control plane proxies inspect calls to whichever zone owns the dataplane, so you don't need a port-forward into zone-2.
 
 ## Next steps
 

--- a/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
@@ -272,32 +272,29 @@ Each entry renders its own Deployment, Service, and ServiceAccount for the ingre
 ## Propagate trust between zones
 
 Each zone generates a `MeshTrust` containing its local CA bundle.
+The `MeshIdentity` controller appends a content hash to the trust name (for example, `identity-xf4d5dz5c4w47645`), so look it up by prefix rather than hardcoding the name.
 For cross-zone mTLS to work, each zone must trust the other zone's CA.
 Republish each zone's trust bundle to the global control plane so it syncs everywhere.
 
 1. Export zone-1's trust bundle and apply it to the global CP:
 
    ```sh
-   kubectl --context mesh-zone-1 -n kong-mesh-system get meshtrust identity -o yaml | \
-     sed 's/name: identity/name: trust-of-zone-1/' | \
-     sed '/resourceVersion:/d' | \
-     sed '/uid:/d' | \
-     sed '/creationTimestamp:/d' | \
-     sed '/generation:/d' | \
-     sed 's/kuma.io\/origin: zone/kuma.io\/origin: global/' | \
+   kubectl --context mesh-zone-1 -n kong-mesh-system get meshtrust -o json | \
+     jq '.items[] | select(.metadata.name | startswith("identity-")) |
+         .metadata.name = "trust-of-zone-1" |
+         .metadata.labels["kuma.io/origin"] = "global" |
+         del(.metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation)' | \
      kubectl --context mesh-global apply -f -
    ```
 
 1. Export zone-2's trust bundle and apply it to the global CP:
 
    ```sh
-   kubectl --context mesh-zone-2 -n kong-mesh-system get meshtrust identity -o yaml | \
-     sed 's/name: identity/name: trust-of-zone-2/' | \
-     sed '/resourceVersion:/d' | \
-     sed '/uid:/d' | \
-     sed '/creationTimestamp:/d' | \
-     sed '/generation:/d' | \
-     sed 's/kuma.io\/origin: zone/kuma.io\/origin: global/' | \
+   kubectl --context mesh-zone-2 -n kong-mesh-system get meshtrust -o json | \
+     jq '.items[] | select(.metadata.name | startswith("identity-")) |
+         .metadata.name = "trust-of-zone-2" |
+         .metadata.labels["kuma.io/origin"] = "global" |
+         del(.metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation)' | \
      kubectl --context mesh-global apply -f -
    ```
 
@@ -359,11 +356,12 @@ The global control plane syncs these trust bundles to all zones, enabling cross-
    done
    ```
 
-1. From a `demo-app` pod in zone-1, curl the `demo-app` Service in zone-2 using its cross-zone hostname:
+1. From a `demo-app` pod in zone-1, request the `demo-app` Service in zone-2 using its cross-zone hostname.
+   The `demo-app` image ships with `wget` but not `curl`:
 
    ```sh
    kubectl --context mesh-zone-1 -n kuma-demo exec deploy/demo-app -c demo-app -- \
-     curl -s http://demo-app.kuma-demo.svc.zone-2.mesh.local:5000/
+     wget -qO- http://demo-app.kuma-demo.svc.zone-2.mesh.local:5000/
    ```
 
    The request leaves zone-1 through the zone egress, enters zone-2 through the zone ingress, and hits the `demo-app` pod there.

--- a/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
@@ -272,18 +272,21 @@ Each entry renders its own Deployment, Service, and ServiceAccount for the ingre
 ## Propagate trust between zones
 
 Each zone generates a `MeshTrust` containing its local CA bundle.
-The `MeshIdentity` controller appends a content hash to the trust name (for example, `identity-xf4d5dz5c4w47645`), so look it up by prefix rather than hardcoding the name.
+The `MeshIdentity` controller appends a content hash to the trust name (for example, `identity-xf4d5dz5c4w47645`), so look it up by label rather than hardcoding the name.
 For cross-zone mTLS to work, each zone must trust the other zone's CA.
 Republish each zone's trust bundle to the global control plane so it syncs everywhere.
+
+The `jq` filter selects only resources where `kuma.io/origin: zone`, which is the trust the local zone created.
+Resources synced back from the global control plane carry `kuma.io/origin: global` and must be excluded - otherwise you'd republish the wrong zone's CA.
 
 1. Export zone-1's trust bundle and apply it to the global CP:
 
    ```sh
    kubectl --context mesh-zone-1 -n kong-mesh-system get meshtrust -o json | \
-     jq '.items[] | select(.metadata.name | startswith("identity-")) |
+     jq '.items[] | select(.metadata.labels["kuma.io/origin"] == "zone") |
          .metadata.name = "trust-of-zone-1" |
          .metadata.labels["kuma.io/origin"] = "global" |
-         del(.metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation)' | \
+         del(.metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation, .metadata.ownerReferences)' | \
      kubectl --context mesh-global apply -f -
    ```
 
@@ -291,10 +294,10 @@ Republish each zone's trust bundle to the global control plane so it syncs every
 
    ```sh
    kubectl --context mesh-zone-2 -n kong-mesh-system get meshtrust -o json | \
-     jq '.items[] | select(.metadata.name | startswith("identity-")) |
+     jq '.items[] | select(.metadata.labels["kuma.io/origin"] == "zone") |
          .metadata.name = "trust-of-zone-2" |
          .metadata.labels["kuma.io/origin"] = "global" |
-         del(.metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation)' | \
+         del(.metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation, .metadata.ownerReferences)' | \
      kubectl --context mesh-global apply -f -
    ```
 
@@ -370,14 +373,21 @@ The global control plane syncs these trust bundles to all zones, enabling cross-
    > If the request times out, check that the minikube tunnels are still running.
    > Tunnels can become unresponsive after sleep/wake cycles; restart them with `minikube tunnel -p <profile> --bind-address=0.0.0.0`.
 
-1. Confirm the traffic passed through the zone-2 zone ingress by reading its sidecar stats:
+1. Confirm the traffic passed through the zone-2 zone ingress by reading its sidecar stats through the global control plane's inspect API.
+   The ingress dataplane name carries a hash suffix, so look it up by the `app` and `kuma.io/zone` labels:
 
    ```sh
-   kubectl --context mesh-zone-2 -n kong-mesh-system exec deploy/kong-mesh-default-ingress -c kuma-sidecar -- \
-     wget -qO- 'localhost:9901/stats?filter=upstream_rq_total'
+   DP=$(kubectl --context mesh-global -n kong-mesh-system exec deploy/kong-mesh-control-plane -- \
+     wget -qO- 'http://localhost:5681/meshes/default/dataplanes' | \
+     jq -r '.items[] | select(.labels.app=="kong-mesh-default-ingress" and .labels["kuma.io/zone"]=="zone-2") | .name')
+
+   kubectl --context mesh-global -n kong-mesh-system exec deploy/kong-mesh-control-plane -- \
+     wget -qO- "http://localhost:5681/meshes/default/dataplanes/${DP}/stats" | \
+     grep "kri_msvc_default_zone-2_kuma-demo_demo-app_5000.upstream_rq_total"
    ```
 
    `upstream_rq_total` for the `demo-app` cluster should be greater than zero.
+   The global control plane proxies inspect calls to whichever zone owns the dataplane, so you don't need a port-forward into zone-2.
 
 ## Next steps
 

--- a/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
@@ -225,7 +225,7 @@ Each entry renders its own Deployment, Service, and ServiceAccount for the ingre
      kong-mesh kong-mesh/kong-mesh
    ```
 
-## Deploy zone-2 with the same configuration
+## Deploy zone-2
 
 1. Start the zone-2 cluster and its tunnel:
 

--- a/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
@@ -182,7 +182,14 @@ Each entry renders its own Deployment, Service, and ServiceAccount for the ingre
    nohup minikube tunnel -p mesh-zone-1 --bind-address=0.0.0.0 &
    ```
 
-1. Save the following as `zone-1-values.yaml`, replacing `${EXTERNAL_IP}` with the value you exported earlier:
+1. Get the host IP that all minikube clusters can reach:
+
+   ```sh
+   export HOST_IP=$(minikube ssh -p mesh-zone-1 -- getent hosts host.minikube.internal | awk '{print $1}')
+   echo $HOST_IP
+   ```
+
+1. Save the following as `zone-1-values.yaml`, replacing `${EXTERNAL_IP}` and `${HOST_IP}` with the values you exported:
 
    ```yaml
    kuma:
@@ -197,9 +204,16 @@ Each entry renders its own Deployment, Service, and ServiceAccount for the ingre
        - name: default
          ingress:
            enabled: true
+           service:
+             spec:
+               externalIPs:
+                 - ${HOST_IP}
          egress:
            enabled: true
    ```
+
+   `service.spec` is merged into the ingress `Service` spec, so the ingress advertises a `MeshZoneAddress` that other zones can reach.
+   Without it, minikube's tunnel sets the external address to `127.0.0.1`, which does not route between clusters.
 
    To deploy zone proxies for additional meshes, append more entries to `kuma.meshes`.
 
@@ -220,7 +234,7 @@ Each entry renders its own Deployment, Service, and ServiceAccount for the ingre
    nohup minikube tunnel -p mesh-zone-2 --bind-address=0.0.0.0 &
    ```
 
-1. Save the following as `zone-2-values.yaml`, replacing `${EXTERNAL_IP}` with the value you exported earlier:
+1. Save the following as `zone-2-values.yaml`, replacing `${EXTERNAL_IP}` and `${HOST_IP}` with the values you exported:
 
    ```yaml
    kuma:
@@ -237,6 +251,9 @@ Each entry renders its own Deployment, Service, and ServiceAccount for the ingre
            enabled: true
            service:
              port: 10002
+             spec:
+               externalIPs:
+                 - ${HOST_IP}
          egress:
            enabled: true
    ```
@@ -251,34 +268,6 @@ Each entry renders its own Deployment, Service, and ServiceAccount for the ingre
      -f zone-2-values.yaml \
      kong-mesh kong-mesh/kong-mesh
    ```
-
-## Patch the ingress Services for cross-cluster routing
-
-Minikube tunnels assign `127.0.0.1` as the external IP, which doesn't route between clusters.
-Patch each zone's ingress Service to advertise `host.minikube.internal`'s IP instead.
-
-1. Get the host IP that all minikube clusters can reach:
-
-   ```sh
-   export HOST_IP=$(minikube ssh -p mesh-zone-1 -- getent hosts host.minikube.internal | awk '{print $1}')
-   echo $HOST_IP
-   ```
-
-1. Patch the ingress Service in zone-1:
-
-   ```sh
-   kubectl --context mesh-zone-1 -n kong-mesh-system patch svc kong-mesh-default-ingress \
-     --type merge -p "{\"spec\":{\"externalIPs\":[\"$HOST_IP\"]}}"
-   ```
-
-1. Patch the ingress Service in zone-2:
-
-   ```sh
-   kubectl --context mesh-zone-2 -n kong-mesh-system patch svc kong-mesh-default-ingress \
-     --type merge -p "{\"spec\":{\"externalIPs\":[\"$HOST_IP\"]}}"
-   ```
-
-The `MeshZoneAddress` controller will pick up the new external IP and regenerate the address resources.
 
 ## Propagate trust between zones
 
@@ -374,7 +363,7 @@ The global control plane syncs these trust bundles to all zones, enabling cross-
 
    ```sh
    kubectl --context mesh-zone-1 -n kuma-demo exec deploy/demo-app -c demo-app -- \
-     curl -s http://demo-app.kuma-demo.svc.zone-2.mesh.local:5050/
+     curl -s http://demo-app.kuma-demo.svc.zone-2.mesh.local:5000/
    ```
 
    The request leaves zone-1 through the zone egress, enters zone-2 through the zone ingress, and hits the `demo-app` pod there.

--- a/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
@@ -6,22 +6,20 @@ permalink: /mesh/zone-proxies/
 bread-crumbs:
   - /mesh/
 related_resources:
-  - text: 'Federate a zone control plane'
-    url: /mesh/federate/
   - text: 'Multi-zone deployment'
     url: '/mesh/mesh-multizone-service-deployment/'
 
 min_version:
-  mesh: '2.12'
+  mesh: '2.14'
 
 products:
   - mesh
 
 tldr:
-  q: How do I deploy zone ingress and zone egress with the new per-mesh Helm configuration?
+  q: How do I deploy mesh-scoped zone ingress and zone egress with the new Helm configuration?
   a: |
     1. Create a `Mesh` with `spec.meshServices.mode: Exclusive` and a `MeshIdentity` on the global control plane.
-    1. Install each zone control plane with a `kuma.meshes[]` entry, setting `ingress.enabled: true` and `egress.enabled: true` for the mesh.
+    1. Install each zone control plane with a `kuma.meshes[]` entry.
     1. {{site.mesh_product_name}} renders a per-mesh Deployment and Service for each role, and generates the Dataplane listeners automatically.
 
 prereqs:
@@ -45,7 +43,9 @@ cleanup:
         ```
 ---
 
-Starting in {{site.mesh_product_name}} 2.12, zone ingress and zone egress are **mesh-scoped**. Instead of the cluster-scoped `kuma.ingress.enabled` / `kuma.egress.enabled` Helm keys, you declare a `kuma.meshes[]` list in your zone control plane's values. Each entry renders its own Deployment, Service, and Dataplane for that mesh, and zone proxies now carry per-mesh workload identity so policies can target them directly.
+Starting in {{site.mesh_product_name}} 2.14, zone ingress and zone egress are **mesh-scoped**.
+Instead of the cluster-scoped `kuma.ingress.enabled` / `kuma.egress.enabled` Helm keys, you declare a `kuma.meshes[]` list in your zone control plane's values.
+Each entry renders its own Deployment, Service, and Dataplane for that mesh, and zone proxies now carry per-mesh workload identity so policies can target them directly.
 
 This guide walks through a fresh three-cluster setup: a global control plane and two zone control planes, each deploying a zone ingress and zone egress through the new `kuma.meshes[]` configuration.
 
@@ -104,7 +104,8 @@ This guide walks through a fresh three-cluster setup: a global control plane and
 
 ## Create the mesh on the global control plane
 
-Zone proxy listeners are only generated when the mesh uses `MeshService` exclusive mode. If you skip this, the zone proxies install but produce no listeners.
+Zone proxy listeners are only generated when the mesh uses `MeshService` exclusive mode.
+If you skip this, the zone proxies install but produce no listeners.
 
 1. Create the mesh and allow all traffic:
 
@@ -136,7 +137,8 @@ Zone proxy listeners are only generated when the mesh uses `MeshService` exclusi
 
 ## Create a MeshIdentity
 
-Zone egress listeners need a workload identity to terminate mTLS for cross-zone traffic. Apply a `MeshIdentity` on the global control plane so it syncs to every zone.
+Zone egress listeners need a workload identity to terminate mTLS for cross-zone traffic.
+Apply a `MeshIdentity` on the global control plane so it syncs to every zone.
 
 ```sh
 {% raw %}echo 'apiVersion: kuma.io/v1alpha1
@@ -164,11 +166,13 @@ spec:
 ```
 
 {:.info}
-> `insecureAllowSelfSigned: true` keeps the demo simple by using the bundled CA. For production, follow the [`MeshIdentity` guide](/mesh/mesh-identity/) to integrate a SPIRE trust domain or an external CA.
+> `insecureAllowSelfSigned: true` keeps the demo simple by using the bundled CA.
+> For production, follow the [`MeshIdentity` guide](/mesh/mesh-identity/) to integrate a SPIRE trust domain or an external CA.
 
 ## Deploy zone-1 with mesh-scoped zone proxies
 
-This is the step that differs from the [federation guide](/mesh/federate/). Instead of `--set kuma.ingress.enabled=true`, we set a `kuma.meshes[]` entry that describes which mesh the zone proxies belong to.
+This is the step that differs from the [federation guide](/mesh/federate/).
+Instead of `--set kuma.ingress.enabled=true`, we set a `kuma.meshes[]` entry that describes which mesh the zone proxies belong to.
 
 1. Start the zone-1 cluster and its tunnel:
 
@@ -191,7 +195,8 @@ This is the step that differs from the [federation guide](/mesh/federate/). Inst
      kong-mesh kong-mesh/kong-mesh
    ```
 
-   Each entry in `kuma.meshes[]` renders its own Deployment, Service, and ServiceAccount. To deploy zone proxies for additional meshes, append more entries to the list.
+   Each entry in `kuma.meshes[]` renders its own Deployment, Service, and ServiceAccount.
+   To deploy zone proxies for additional meshes, append more entries to the list.
 
 ## Deploy zone-2 with the same configuration
 
@@ -224,29 +229,34 @@ This is the step that differs from the [federation guide](/mesh/federate/). Inst
    kubectl --context mesh-zone-1 -n kong-mesh-system get deploy,svc -l kuma.io/mesh=default
    ```
 
-   You'll see a `kong-mesh-default-ingress` and `kong-mesh-default-egress` Deployment, each with a matching Service. A second mesh would produce another pair named after its mesh.
+   You'll see a `kong-mesh-default-ingress` and `kong-mesh-default-egress` Deployment, each with a matching Service.
+   A second mesh would produce another pair named after its mesh.
 
-1. Confirm the Services carry the new `k8s.kuma.io/zone-proxy-type` label. The Pod controller watches this label and generates the Dataplane listeners from it:
+1. Confirm the Services carry the new `k8s.kuma.io/zone-proxy-type` label.
+   The Pod controller watches this label and generates the Dataplane listeners from it:
 
    ```sh
    kubectl --context mesh-zone-1 -n kong-mesh-system get svc \
      -l k8s.kuma.io/zone-proxy-type -L k8s.kuma.io/zone-proxy-type
    ```
 
-1. From the global control plane, look at the Dataplanes. Zone proxies are now ordinary `Dataplane` resources with `networking.listeners[]` entries instead of separate `ZoneIngress` or `ZoneEgress` resources:
+1. From the global control plane, look at the Dataplanes.
+   Zone proxies are now ordinary `Dataplane` resources with `networking.listeners[]` entries instead of separate `ZoneIngress` or `ZoneEgress` resources:
 
    ```sh
    kubectl --context mesh-global get dataplane -A
    ```
 
-1. Confirm that no legacy zone proxy resources exist. Both lists should be empty:
+1. Confirm that no legacy zone proxy resources exist.
+   Both lists should be empty:
 
    ```sh
    kubectl --context mesh-global get zoneingresses,zoneegresses -A
    ```
    {:.no-copy-code}
 
-1. Inspect the `MeshZoneAddress` resources. The `meshzoneaddress` controller in each zone generates these automatically from the zone ingress Service's external address, so remote zones can route to them:
+1. Inspect the `MeshZoneAddress` resources.
+   The `meshzoneaddress` controller in each zone generates these automatically from the zone ingress Service's external address, so remote zones can route to them:
 
    ```sh
    kubectl --context mesh-zone-1 get meshzoneaddress -A

--- a/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
@@ -1,0 +1,292 @@
+---
+title: 'Deploy mesh-scoped zone proxies'
+description: 'Deploy {{site.mesh_product_name}} zone ingress and zone egress using the new per-mesh Helm configuration. Each entry in `kuma.meshes[]` renders its own Deployment, Service, and Dataplane listeners, replacing the cluster-scoped `kuma.ingress` and `kuma.egress` keys.'
+content_type: how_to
+permalink: /mesh/zone-proxies/
+bread-crumbs:
+  - /mesh/
+related_resources:
+  - text: 'Federate a zone control plane'
+    url: /mesh/federate/
+  - text: 'Multi-zone deployment'
+    url: '/mesh/mesh-multizone-service-deployment/'
+
+min_version:
+  mesh: '2.12'
+
+products:
+  - mesh
+
+tldr:
+  q: How do I deploy zone ingress and zone egress with the new per-mesh Helm configuration?
+  a: |
+    1. Create a `Mesh` with `spec.meshServices.mode: Exclusive` and a `MeshIdentity` on the global control plane.
+    1. Install each zone control plane with a `kuma.meshes[]` entry, setting `ingress.enabled: true` and `egress.enabled: true` for the mesh.
+    1. {{site.mesh_product_name}} renders a per-mesh Deployment and Service for each role, and generates the Dataplane listeners automatically.
+
+prereqs:
+  inline:
+    - title: Helm
+      include_content: prereqs/helm
+    - title: minikube
+      content: |
+        You will need [minikube](https://minikube.sigs.k8s.io/docs/start/) to run three local Kubernetes clusters (one global and two zones).
+
+cleanup:
+  inline:
+    - title: Clean up {{site.mesh_product_name}} resources
+      content: |
+        Delete the three minikube profiles:
+
+        ```sh
+        minikube delete -p mesh-global
+        minikube delete -p mesh-zone-1
+        minikube delete -p mesh-zone-2
+        ```
+---
+
+Starting in {{site.mesh_product_name}} 2.12, zone ingress and zone egress are **mesh-scoped**. Instead of the cluster-scoped `kuma.ingress.enabled` / `kuma.egress.enabled` Helm keys, you declare a `kuma.meshes[]` list in your zone control plane's values. Each entry renders its own Deployment, Service, and Dataplane for that mesh, and zone proxies now carry per-mesh workload identity so policies can target them directly.
+
+This guide walks through a fresh three-cluster setup: a global control plane and two zone control planes, each deploying a zone ingress and zone egress through the new `kuma.meshes[]` configuration.
+
+## Start the global control plane cluster
+
+1. Create a new minikube cluster for the global control plane:
+
+   ```sh
+   minikube start -p mesh-global
+   ```
+
+1. Start a minikube tunnel so the `LoadBalancer` services we create later get an external address:
+
+   {:.info}
+   > Using `nohup` lets the tunnel continue running if your terminal session ends.
+
+   ```sh
+   nohup minikube tunnel -p mesh-global &
+   ```
+
+## Deploy the global control plane
+
+1. Install the global control plane:
+
+   ```sh
+   helm repo add kong-mesh https://kong.github.io/kong-mesh-charts
+   helm repo update
+   helm install --kube-context mesh-global --create-namespace --namespace kong-mesh-system \
+     --set kuma.controlPlane.mode=global \
+     --set kuma.controlPlane.defaults.skipMeshCreation=true \
+     kong-mesh kong-mesh/kong-mesh
+   ```
+
+   We skip default mesh creation because we will apply a custom `Mesh` in the next step.
+
+1. Wait for the control plane to become ready:
+
+   ```sh
+   kubectl --context mesh-global -n kong-mesh-system wait \
+     --for=condition=ready pod --selector=app=kong-mesh-control-plane --timeout=120s
+   ```
+
+1. Export the KDS address that the zone control planes will connect to:
+
+   ```sh
+   export EXTERNAL_IP=host.minikube.internal
+   ```
+
+   {:.info}
+   > Outside minikube, resolve the `kong-mesh-global-zone-sync` service address instead:
+   >
+   > ```sh
+   > export EXTERNAL_IP=$(kubectl --context mesh-global -n kong-mesh-system \
+   >   get svc kong-mesh-global-zone-sync -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+   > ```
+
+## Create the mesh on the global control plane
+
+Zone proxy listeners are only generated when the mesh uses `MeshService` exclusive mode. If you skip this, the zone proxies install but produce no listeners.
+
+1. Create the mesh and allow all traffic:
+
+   ```sh
+   echo 'apiVersion: kuma.io/v1alpha1
+   kind: Mesh
+   metadata:
+     name: default
+   spec:
+     meshServices:
+       mode: Exclusive
+   ---
+   apiVersion: kuma.io/v1alpha1
+   kind: MeshTrafficPermission
+   metadata:
+     name: allow-all
+     namespace: kong-mesh-system
+     labels:
+       kuma.io/mesh: default
+   spec:
+     targetRef:
+       kind: Mesh
+     from:
+       - targetRef:
+           kind: Mesh
+         default:
+           action: Allow' | kubectl --context mesh-global apply -f -
+   ```
+
+## Create a MeshIdentity
+
+Zone egress listeners need a workload identity to terminate mTLS for cross-zone traffic. Apply a `MeshIdentity` on the global control plane so it syncs to every zone.
+
+```sh
+{% raw %}echo 'apiVersion: kuma.io/v1alpha1
+kind: MeshIdentity
+metadata:
+  name: identity
+  namespace: kong-mesh-system
+  labels:
+    kuma.io/mesh: default
+spec:
+  selector:
+    dataplane:
+      matchLabels: {}
+  spiffeID:
+    trustDomain: "{{ .Mesh }}.{{ .Zone }}.mesh.local"
+  provider:
+    type: Bundled
+    bundled:
+      meshTrustCreation: Enabled
+      insecureAllowSelfSigned: true
+      certificateParameters:
+        expiry: 24h
+      autogenerate:
+        enabled: true' | kubectl --context mesh-global apply -f -{% endraw %}
+```
+
+{:.info}
+> `insecureAllowSelfSigned: true` keeps the demo simple by using the bundled CA. For production, follow the [`MeshIdentity` guide](/mesh/mesh-identity/) to integrate a SPIRE trust domain or an external CA.
+
+## Deploy zone-1 with mesh-scoped zone proxies
+
+This is the step that differs from the [federation guide](/mesh/federate/). Instead of `--set kuma.ingress.enabled=true`, we set a `kuma.meshes[]` entry that describes which mesh the zone proxies belong to.
+
+1. Start the zone-1 cluster and its tunnel:
+
+   ```sh
+   minikube start -p mesh-zone-1
+   nohup minikube tunnel -p mesh-zone-1 &
+   ```
+
+1. Install the zone control plane together with the zone ingress and egress for `default`:
+
+   ```sh
+   helm install --kube-context mesh-zone-1 --create-namespace --namespace kong-mesh-system \
+     --set kuma.controlPlane.mode=zone \
+     --set kuma.controlPlane.zone=zone-1 \
+     --set kuma.controlPlane.kdsGlobalAddress=grpcs://${EXTERNAL_IP}:5685 \
+     --set kuma.controlPlane.tls.kdsZoneClient.skipVerify=true \
+     --set 'kuma.meshes[0].name=default' \
+     --set 'kuma.meshes[0].ingress.enabled=true' \
+     --set 'kuma.meshes[0].egress.enabled=true' \
+     kong-mesh kong-mesh/kong-mesh
+   ```
+
+   Each entry in `kuma.meshes[]` renders its own Deployment, Service, and ServiceAccount. To deploy zone proxies for additional meshes, append more entries to the list.
+
+## Deploy zone-2 with the same configuration
+
+1. Start the zone-2 cluster and its tunnel:
+
+   ```sh
+   minikube start -p mesh-zone-2
+   nohup minikube tunnel -p mesh-zone-2 &
+   ```
+
+1. Install the zone control plane and its zone proxies:
+
+   ```sh
+   helm install --kube-context mesh-zone-2 --create-namespace --namespace kong-mesh-system \
+     --set kuma.controlPlane.mode=zone \
+     --set kuma.controlPlane.zone=zone-2 \
+     --set kuma.controlPlane.kdsGlobalAddress=grpcs://${EXTERNAL_IP}:5685 \
+     --set kuma.controlPlane.tls.kdsZoneClient.skipVerify=true \
+     --set 'kuma.meshes[0].name=default' \
+     --set 'kuma.meshes[0].ingress.enabled=true' \
+     --set 'kuma.meshes[0].egress.enabled=true' \
+     kong-mesh kong-mesh/kong-mesh
+   ```
+
+## Inspect what the chart produced
+
+1. List the per-mesh Deployments and Services in zone-1:
+
+   ```sh
+   kubectl --context mesh-zone-1 -n kong-mesh-system get deploy,svc -l kuma.io/mesh=default
+   ```
+
+   You'll see a `kong-mesh-default-ingress` and `kong-mesh-default-egress` Deployment, each with a matching Service. A second mesh would produce another pair named after its mesh.
+
+1. Confirm the Services carry the new `k8s.kuma.io/zone-proxy-type` label. The Pod controller watches this label and generates the Dataplane listeners from it:
+
+   ```sh
+   kubectl --context mesh-zone-1 -n kong-mesh-system get svc \
+     -l k8s.kuma.io/zone-proxy-type -L k8s.kuma.io/zone-proxy-type
+   ```
+
+1. From the global control plane, look at the Dataplanes. Zone proxies are now ordinary `Dataplane` resources with `networking.listeners[]` entries instead of separate `ZoneIngress` or `ZoneEgress` resources:
+
+   ```sh
+   kubectl --context mesh-global get dataplane -A
+   ```
+
+1. Confirm that no legacy zone proxy resources exist. Both lists should be empty:
+
+   ```sh
+   kubectl --context mesh-global get zoneingresses,zoneegresses -A
+   ```
+   {:.no-copy-code}
+
+1. Inspect the `MeshZoneAddress` resources. The `meshzoneaddress` controller in each zone generates these automatically from the zone ingress Service's external address, so remote zones can route to them:
+
+   ```sh
+   kubectl --context mesh-zone-1 get meshzoneaddress -A
+   kubectl --context mesh-zone-2 get meshzoneaddress -A
+   ```
+
+## Verify cross-zone traffic
+
+1. Deploy the {{site.mesh_product_name}} demo app into each zone:
+
+   ```sh
+   for ctx in mesh-zone-1 mesh-zone-2; do
+     kubectl --context $ctx create namespace kong-mesh-demo \
+       --dry-run=client -o yaml | kubectl --context $ctx apply -f -
+     kubectl --context $ctx label namespace kong-mesh-demo \
+       kuma.io/sidecar-injection=enabled --overwrite
+     kubectl --context $ctx apply -f https://raw.githubusercontent.com/kumahq/kuma-counter-demo/refs/heads/master/demo.yaml
+   done
+   ```
+
+1. From a `demo-app` pod in zone-1, curl the `demo-app` Service in zone-2 using its cross-zone hostname:
+
+   ```sh
+   kubectl --context mesh-zone-1 -n kong-mesh-demo exec deploy/demo-app -c demo-app -- \
+     curl -s http://demo-app.kong-mesh-demo.svc.zone-2.mesh.local:5050/
+   ```
+
+   The request leaves zone-1 through the zone egress, enters zone-2 through the zone ingress, and hits the `demo-app` pod there.
+
+1. Confirm the traffic passed through the zone-2 zone ingress by reading its sidecar stats:
+
+   ```sh
+   kubectl --context mesh-zone-2 -n kong-mesh-system exec deploy/kong-mesh-default-ingress -c kuma-sidecar -- \
+     wget -qO- 'localhost:9901/stats?filter=upstream_rq_total'
+   ```
+
+   `upstream_rq_total` for the `demo-app` cluster should be greater than zero.
+
+## Next steps
+
+- Target individual zone proxy listeners from policies with `sectionName` - covered in a follow-up guide.
+- Add a second mesh by appending another entry to `kuma.meshes[]`.
+- Read the [`MeshIdentity`](/mesh/mesh-identity/) guide to switch the bundled CA for a production issuer.

--- a/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
@@ -1,6 +1,6 @@
 ---
 title: 'Deploy mesh-scoped zone proxies'
-description: 'Deploy {{site.mesh_product_name}} zone ingress and zone egress using the new per-mesh Helm configuration. Each entry in `kuma.meshes[]` renders its own Deployment, Service, and Dataplane listeners, replacing the cluster-scoped `kuma.ingress` and `kuma.egress` keys.'
+description: 'Deploy {{site.mesh_product_name}} zone ingress and zone egress with per-mesh Helm values. Each entry in `kuma.meshes[]` creates the Deployment, Service, and Dataplane listeners for one mesh.'
 content_type: how_to
 permalink: /mesh/zone-proxies/
 bread-crumbs:
@@ -18,7 +18,7 @@ products:
   - mesh
 
 tldr:
-  q: How do I deploy mesh-scoped zone ingress and zone egress with the new Helm configuration?
+  q: How do I deploy mesh-scoped zone ingress and zone egress with per-mesh Helm values?
   a: |
     1. Create a `Mesh` with `spec.meshServices.mode: Exclusive` and a `MeshIdentity` on the global control plane.
     1. Install each zone control plane with a `kuma.meshes[]` entry.
@@ -47,12 +47,11 @@ cleanup:
 ---
 
 Starting in {{site.mesh_product_name}} 2.14, zone ingress and zone egress are **mesh-scoped**.
-Instead of the cluster-scoped `kuma.ingress.enabled` / `kuma.egress.enabled` Helm keys, you declare a `kuma.meshes[]` list in your zone control plane's values.
-Each entry renders its own Deployment, Service, and Dataplane for that mesh, and zone proxies now carry per-mesh workload identity so policies can target them directly.
+Declare them in your zone control plane values under `kuma.meshes[]`.
+Each entry creates a Deployment, Service, and Dataplane for that mesh, and the zone proxies carry per-mesh workload identity so policies can target them directly.
 
-This guide walks through a fresh three-cluster setup: a global control plane and two zone control planes, each deploying a zone ingress and zone egress through the new `kuma.meshes[]` configuration.
+This guide walks through a fresh three-cluster setup: a global control plane and two zone control planes, each deploying a zone ingress and zone egress through `kuma.meshes[]`.
 It uses the minikube Docker driver and one shared Docker bridge so the three clusters can reach each other directly through `NodePort` Services.
-That removes the need for `minikube tunnel`, `host.minikube.internal`, and `externalIPs` workarounds.
 
 ## Start the global control plane cluster
 
@@ -69,7 +68,7 @@ That removes the need for `minikube tunnel`, `host.minikube.internal`, and `exte
    export KDS_NODEPORT=30685
    ```
 
-1. Create the shared Docker bridge if it does not already exist:
+1. Create the shared Docker bridge:
 
    ```sh
    docker network inspect $MZ_NETWORK >/dev/null 2>&1 || \
@@ -77,13 +76,14 @@ That removes the need for `minikube tunnel`, `host.minikube.internal`, and `exte
    ```
 
 {:.info}
-> On Docker Desktop, a third Docker-driver minikube profile can leave `kube-proxy` crashlooping with `failed complete: too many open files`.
-> If that happens, raise the shared Linux VM's inotify limits once, then restart the affected profile:
+> If Docker Desktop fails with `failed complete: too many open files` while starting a profile, run:
 >
 > ```sh
 > docker run --rm --privileged alpine \
 >   sysctl -w fs.inotify.max_user_instances=8192 fs.inotify.max_user_watches=524288
 > ```
+>
+> Then restart the affected profile.
 
 1. Create a new minikube cluster for the global control plane:
 
@@ -107,7 +107,6 @@ That removes the need for `minikube tunnel`, `host.minikube.internal`, and `exte
    ```
 
    We skip default mesh creation because we will apply a custom `Mesh` in the next step.
-   `NodePort` makes the zone sync endpoint reachable on the shared Docker bridge without a tunnel.
 
 1. Wait for the control plane to become ready:
 
@@ -197,8 +196,8 @@ spec:
 
 ## Deploy zone-1 with mesh-scoped zone proxies
 
-A `kuma.meshes[]` entry tells the chart which mesh the zone proxies belong to.
-Each entry renders its own Deployment, Service, and ServiceAccount for the ingress and egress roles.
+A `kuma.meshes[]` entry defines which mesh the zone proxies belong to.
+Each entry creates its own Deployment, Service, and ServiceAccount for the ingress and egress roles.
 
 1. Start the zone-1 cluster on the shared Docker bridge:
 
@@ -227,10 +226,8 @@ Each entry renders its own Deployment, Service, and ServiceAccount for the ingre
            enabled: true
    ```
 
-   `service.spec` is still available for additional `Service` fields such as `externalIPs` or `loadBalancerSourceRanges`,
-   but the chart does not expose a dedicated per-mesh `nodePort` override.
-   When the Service type is `NodePort`, Kubernetes assigns the port automatically and the `meshzoneaddress` controller advertises the resulting `${ZONE1_IP}:<nodePort>` address for you.
-   You no longer need `externalIPs` or a host-level tunnel.
+   Set the ingress Service type to `NodePort` so the other minikube clusters can reach it on the shared Docker network.
+   Kubernetes assigns the port automatically, and `MeshZoneAddress` advertises the resulting `${ZONE1_IP}:<nodePort>` address for you.
 
    To deploy zone proxies for additional meshes, append more entries to `kuma.meshes`.
 
@@ -316,7 +313,7 @@ Resources synced back from the global control plane carry `kuma.io/origin: globa
 
 The global control plane syncs these trust bundles to all zones, enabling cross-zone certificate validation.
 
-## Inspect what the chart produced
+## Inspect the zone proxy resources
 
 1. List the per-mesh Deployments and Services in zone-1:
 
@@ -327,8 +324,7 @@ The global control plane syncs these trust bundles to all zones, enabling cross-
    You'll see a `kong-mesh-default-ingress` and `kong-mesh-default-egress` Deployment, each with a matching Service.
    A second mesh would produce another pair named after its mesh.
 
-1. Confirm the Services carry the new `k8s.kuma.io/zone-proxy-type` label.
-   The Pod controller watches this label and generates the Dataplane listeners from it:
+1. Confirm the Services carry the `k8s.kuma.io/zone-proxy-type` label:
 
    ```sh
   kubectl --context $ZONE1_PROFILE -n kong-mesh-system get svc \
@@ -358,22 +354,13 @@ The global control plane syncs these trust bundles to all zones, enabling cross-
       ] | @tsv'
   ```
 
-  These addresses should match the shared Docker bridge you created earlier, not `127.0.0.1`.
+  These addresses should use the shared Docker bridge IPs and the published ingress `NodePort` values.
 
-1. From the global control plane, look at the Dataplanes.
-  Zone proxies are now ordinary `Dataplane` resources with `networking.listeners[]` entries instead of separate `ZoneIngress` or `ZoneEgress` resources:
+1. From the global control plane, look at the zone proxy Dataplanes:
 
   ```sh
   kubectl --context $GLOBAL_PROFILE get dataplane -A
   ```
-
-1. Confirm that no legacy zone proxy resources exist.
-  Both lists should be empty:
-
-  ```sh
-  kubectl --context $GLOBAL_PROFILE get zoneingresses,zoneegresses -A
-  ```
-  {:.no-copy-code}
 
 ## Verify cross-zone traffic
 
@@ -390,7 +377,7 @@ The global control plane syncs these trust bundles to all zones, enabling cross-
   ```
 
 1. From a `demo-app` pod in zone-1, request the `demo-app` Service in zone-2 using its cross-zone hostname.
-   The `demo-app` image ships with `wget` but not `curl`:
+   The `demo-app` image includes `wget`, so use:
 
    ```sh
   kubectl --context $ZONE1_PROFILE -n kuma-demo exec deploy/demo-app -c demo-app -- \

--- a/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
@@ -15,10 +15,12 @@ min_version:
 products:
   - mesh
 
+works_on:
+  - on-prem
+
 series:
   id: mesh-scoped-zone-proxy
   position: 1
-
 tldr:
   q: How do I deploy mesh-scoped zone ingress and zone egress with per-mesh Helm values?
   a: |

--- a/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
@@ -3,19 +3,21 @@ title: 'Deploy mesh-scoped zone proxies'
 description: 'Deploy {{site.mesh_product_name}} zone ingress and zone egress with per-mesh Helm values. Each entry in `kuma.meshes[]` creates the Deployment, Service, and Dataplane listeners for one mesh.'
 content_type: how_to
 permalink: /mesh/zone-proxies/
-bread-crumbs:
+breadcrumbs:
   - /mesh/
 related_resources:
   - text: 'Multi-zone deployment'
     url: '/mesh/mesh-multizone-service-deployment/'
-  - text: 'Apply policies to mesh-scoped zone proxies'
-    url: '/mesh/zone-proxy-policies/'
 
 min_version:
   mesh: '2.14'
 
 products:
   - mesh
+
+series:
+  id: mesh-scoped-zone-proxy
+  position: 1
 
 tldr:
   q: How do I deploy mesh-scoped zone ingress and zone egress with per-mesh Helm values?
@@ -25,12 +27,13 @@ tldr:
     1. {{site.mesh_product_name}} renders a per-mesh Deployment and Service for each role, and generates the Dataplane listeners automatically.
 
 prereqs:
+  skip_product: true
   inline:
     - title: Helm
       include_content: prereqs/helm
     - title: minikube
       content: |
-        You will need [minikube](https://minikube.sigs.k8s.io/docs/start/) with the Docker driver to run three local Kubernetes clusters (one global and two zones).
+        This series requires [minikube](https://minikube.sigs.k8s.io/docs/start/) with the Docker driver to run three local Kubernetes clusters (one global and two zones).
 
 cleanup:
   inline:
@@ -46,11 +49,11 @@ cleanup:
         ```
 ---
 
-Starting in {{site.mesh_product_name}} 2.14, zone ingress and zone egress are **mesh-scoped**.
+Starting in {{site.mesh_product_name}} 2.14, zone ingresses and zone egresses are mesh-scoped.
 Declare them in your zone control plane values under `kuma.meshes[]`.
-Each entry creates a Deployment, Service, and Dataplane for that mesh, and the zone proxies carry per-mesh workload identity so policies can target them directly.
+Each entry creates a Deployment, Service, and Dataplane for that mesh, and the zone proxies carry per-mesh workload identities so policies can target them directly.
 
-This guide walks through a fresh three-cluster setup: a global control plane and two zone control planes, each deploying a zone ingress and zone egress through `kuma.meshes[]`.
+This guide walks through a three-cluster setup: a global control plane and two zone control planes, each deploying a zone ingress and zone egress through `kuma.meshes[]`.
 It uses the minikube Docker driver and one shared Docker bridge so the three clusters can reach each other directly through `NodePort` Services.
 
 ## Start the global control plane cluster
@@ -75,15 +78,15 @@ It uses the minikube Docker driver and one shared Docker bridge so the three clu
      docker network create --driver bridge --subnet 192.168.240.0/24 $MZ_NETWORK
    ```
 
-{:.info}
-> If Docker Desktop fails with `failed complete: too many open files` while starting a profile, run:
->
-> ```sh
-> docker run --rm --privileged alpine \
->   sysctl -w fs.inotify.max_user_instances=8192 fs.inotify.max_user_watches=524288
-> ```
->
-> Then restart the affected profile.
+   {:.info}
+   > If Docker Desktop fails with `failed complete: too many open files` while starting a profile, run:
+   >
+   > ```sh
+   > docker run --rm --privileged alpine \
+   >   sysctl -w fs.inotify.max_user_instances=8192 fs.inotify.max_user_watches=524288
+   > ```
+   >
+   > Then restart the affected profile.
 
 1. Create a new minikube cluster for the global control plane:
 
@@ -106,7 +109,7 @@ It uses the minikube Docker driver and one shared Docker bridge so the three clu
      kong-mesh kong-mesh/kong-mesh
    ```
 
-   We skip default mesh creation because we will apply a custom `Mesh` in the next step.
+   We're skipping default mesh creation because we'll apply a custom `Mesh` in the next step.
 
 1. Wait for the control plane to become ready:
 
@@ -125,8 +128,8 @@ It uses the minikube Docker driver and one shared Docker bridge so the three clu
 
 ## Create the mesh on the global control plane
 
-Zone proxy listeners are only generated when the mesh uses `MeshService` exclusive mode.
-If you skip this, the zone proxies install but produce no listeners.
+Zone proxy listeners are only generated when the mesh uses the `MeshService` exclusive mode.
+Without this, the zone proxies install but produce no listeners.
 
 1. Create the mesh and allow all traffic:
 
@@ -157,16 +160,16 @@ If you skip this, the zone proxies install but produce no listeners.
                  value: "spiffe://default."' | kubectl --context $GLOBAL_PROFILE apply -f -
    ```
 
-   This rule allows any workload identity whose SPIFFE trust domain starts with `default.`.
+   This rule allows traffic from any workload identity whose SPIFFE trust domain starts with `default.`.
    That includes the mesh-scoped zone proxies and the demo workloads in both zones.
 
 ## Create a MeshIdentity
 
 Zone egress listeners need a workload identity to terminate mTLS for cross-zone traffic.
-Apply a `MeshIdentity` on the global control plane so it syncs to every zone.
+Apply a `MeshIdentity` on the global control plane:
 
 ```sh
-{% raw %}echo 'apiVersion: kuma.io/v1alpha1
+echo 'apiVersion: kuma.io/v1alpha1
 kind: MeshIdentity
 metadata:
   name: identity
@@ -178,7 +181,7 @@ spec:
     dataplane:
       matchLabels: {}
   spiffeID:
-    trustDomain: "{{ .Mesh }}.{{ .Zone }}.mesh.local"
+    trustDomain: "{% raw %}{{ .Mesh }}.{{ .Zone }}.mesh.local{% endraw %}"
   provider:
     type: Bundled
     bundled:
@@ -187,8 +190,10 @@ spec:
       certificateParameters:
         expiry: 24h
       autogenerate:
-        enabled: true' | kubectl --context $GLOBAL_PROFILE apply -f -{% endraw %}
+        enabled: true' | kubectl --context $GLOBAL_PROFILE apply -f -
 ```
+
+The resource will sync to every zone automatically.
 
 {:.info}
 > `insecureAllowSelfSigned: true` keeps the demo simple by using the bundled CA.
@@ -205,9 +210,10 @@ Each entry creates its own Deployment, Service, and ServiceAccount for the ingre
    minikube start -p $ZONE1_PROFILE --driver=docker --network=$MZ_NETWORK --static-ip=$ZONE1_IP
    ```
 
-1. Save the following as `zone-1-values.yaml`:
+1. Create the values file for zone-1:
 
-   ```yaml
+   ```sh
+   cat <<EOF > zone-1-values.yaml
    kuma:
      controlPlane:
        mode: zone
@@ -224,6 +230,7 @@ Each entry creates its own Deployment, Service, and ServiceAccount for the ingre
              type: NodePort
          egress:
            enabled: true
+   EOF
    ```
 
    Set the ingress Service type to `NodePort` so the other minikube clusters can reach it on the shared Docker network.
@@ -247,9 +254,10 @@ Each entry creates its own Deployment, Service, and ServiceAccount for the ingre
    minikube start -p $ZONE2_PROFILE --driver=docker --network=$MZ_NETWORK --static-ip=$ZONE2_IP
    ```
 
-1. Save the following as `zone-2-values.yaml`:
+1. Create the values file for zone-2:
 
-   ```yaml
+   ```sh
+   cat <<EOF > zone-2-values.yaml
    kuma:
      controlPlane:
        mode: zone
@@ -266,6 +274,7 @@ Each entry creates its own Deployment, Service, and ServiceAccount for the ingre
              type: NodePort
          egress:
            enabled: true
+   EOF
    ```
 
    Zone-2 follows the same pattern.
@@ -282,33 +291,33 @@ Each entry creates its own Deployment, Service, and ServiceAccount for the ingre
 ## Propagate trust between zones
 
 Each zone generates a `MeshTrust` containing its local CA bundle.
-The `MeshIdentity` controller appends a content hash to the trust name (for example, `identity-xf4d5dz5c4w47645`), so look it up by label rather than hardcoding the name.
+The `MeshIdentity` controller appends a content hash to the trust name (for example, `identity-xf4d5dz5c4w47645`), so you should look it up by label rather than hardcoding the name.
 For cross-zone mTLS to work, each zone must trust the other zone's CA.
-Republish each zone's trust bundle to the global control plane so it syncs everywhere.
-
-The `jq` filter selects only resources where `kuma.io/origin: zone`, which is the trust the local zone created.
-Resources synced back from the global control plane carry `kuma.io/origin: global` and must be excluded - otherwise you'd republish the wrong zone's CA.
+Publish each zone's trust bundle to the global control plane so it syncs everywhere.
 
 1. Export zone-1's trust bundle and apply it to the global CP:
 
    ```sh
-  kubectl --context $ZONE1_PROFILE -n kong-mesh-system get meshtrust -o json | \
+   kubectl --context $ZONE1_PROFILE -n kong-mesh-system get meshtrust -o json | \
      jq '.items[] | select(.metadata.labels["kuma.io/origin"] == "zone") |
          .metadata.name = "trust-of-zone-1" |
          .metadata.labels["kuma.io/origin"] = "global" |
          del(.metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation, .metadata.ownerReferences)' | \
-    kubectl --context $GLOBAL_PROFILE apply -f -
+     kubectl --context $GLOBAL_PROFILE apply -f -
    ```
+
+   The `jq` filter selects only resources where `kuma.io/origin: zone`, which is the trust the local zone created.
+   Resources synced back from the global control plane carry `kuma.io/origin: global` and must be excluded, otherwise you would publish the wrong zone's CA.
 
 1. Export zone-2's trust bundle and apply it to the global CP:
 
    ```sh
-  kubectl --context $ZONE2_PROFILE -n kong-mesh-system get meshtrust -o json | \
+   kubectl --context $ZONE2_PROFILE -n kong-mesh-system get meshtrust -o json | \
      jq '.items[] | select(.metadata.labels["kuma.io/origin"] == "zone") |
          .metadata.name = "trust-of-zone-2" |
          .metadata.labels["kuma.io/origin"] = "global" |
          del(.metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation, .metadata.ownerReferences)' | \
-    kubectl --context $GLOBAL_PROFILE apply -f -
+     kubectl --context $GLOBAL_PROFILE apply -f -
    ```
 
 The global control plane syncs these trust bundles to all zones, enabling cross-zone certificate validation.
@@ -318,7 +327,7 @@ The global control plane syncs these trust bundles to all zones, enabling cross-
 1. List the per-mesh Deployments and Services in zone-1:
 
    ```sh
-  kubectl --context $ZONE1_PROFILE -n kong-mesh-system get deploy,svc -l kuma.io/mesh=default
+   kubectl --context $ZONE1_PROFILE -n kong-mesh-system get deploy,svc -l kuma.io/mesh=default
    ```
 
    You'll see a `kong-mesh-default-ingress` and `kong-mesh-default-egress` Deployment, each with a matching Service.
@@ -327,95 +336,103 @@ The global control plane syncs these trust bundles to all zones, enabling cross-
 1. Confirm the Services carry the `k8s.kuma.io/zone-proxy-type` label:
 
    ```sh
-  kubectl --context $ZONE1_PROFILE -n kong-mesh-system get svc \
+   kubectl --context $ZONE1_PROFILE -n kong-mesh-system get svc \
      -l k8s.kuma.io/zone-proxy-type -L k8s.kuma.io/zone-proxy-type
    ```
 
-1. Confirm that each ingress Service is a `NodePort` and note the published port:
+1. Confirm that the zone-1 ingress Service is a `NodePort` and note the published port:
 
-  ```sh
-  kubectl --context $ZONE1_PROFILE -n kong-mesh-system get svc kong-mesh-default-ingress \
-    -o jsonpath='{.spec.type}{"\t"}{.spec.ports[0].nodePort}{"\n"}'
+   ```sh
+   kubectl --context $ZONE1_PROFILE -n kong-mesh-system get svc kong-mesh-default-ingress \
+     -o jsonpath='{.spec.type}{"\t"}{.spec.ports[0].nodePort}{"\n"}'
+   ```
 
-  kubectl --context $ZONE2_PROFILE -n kong-mesh-system get svc kong-mesh-default-ingress \
-    -o jsonpath='{.spec.type}{"\t"}{.spec.ports[0].nodePort}{"\n"}'
-  ```
+1. Confirm that the zone-2 ingress Service is a `NodePort` and note the published port:
+
+   ```sh
+   kubectl --context $ZONE2_PROFILE -n kong-mesh-system get svc kong-mesh-default-ingress \
+     -o jsonpath='{.spec.type}{"\t"}{.spec.ports[0].nodePort}{"\n"}'
+   ```
 
 1. Inspect the `MeshZoneAddress` resources on the global control plane.
-  They are namespaced resources, so query `kong-mesh-system` explicitly:
+   They are namespaced resources, so query `kong-mesh-system` explicitly:
 
-  ```sh
-  kubectl --context $GLOBAL_PROFILE -n kong-mesh-system get meshzoneaddress -o json | \
-    jq -r '.items[] |
-      [
-        .metadata.labels["kuma.io/zone"],
-        .metadata.name,
-        (.spec.address + ":" + (.spec.port | tostring))
-      ] | @tsv'
-  ```
+   ```sh
+   kubectl --context $GLOBAL_PROFILE -n kong-mesh-system get meshzoneaddress -o json | \
+     jq -r '.items[] |
+       [
+         .metadata.labels["kuma.io/zone"],
+         .metadata.name,
+         (.spec.address + ":" + (.spec.port | tostring))
+       ] | @tsv'
+   ```
 
-  These addresses should use the shared Docker bridge IPs and the published ingress `NodePort` values.
+   These addresses should use the shared Docker bridge IPs and the published ingress `NodePort` values.
 
-1. From the global control plane, look at the zone proxy Dataplanes:
+1. From the global control plane, look at the zone proxy `Dataplane` resources:
 
-  ```sh
-  kubectl --context $GLOBAL_PROFILE get dataplane -A
-  ```
+   ```sh
+   kubectl --context $GLOBAL_PROFILE get dataplane -A
+   ```
 
 ## Verify cross-zone traffic
 
+1. Create the demo app configuration:
+
+   {% capture demo %}{% include /mesh/demo.md %}{% endcapture %}{{demo | indent}}
+
 1. Deploy the {{site.mesh_product_name}} demo app into each zone:
 
-  ```sh
-  for ctx in $ZONE1_PROFILE $ZONE2_PROFILE; do
-    kubectl --context $ctx create namespace kuma-demo \
-      --dry-run=client -o yaml | kubectl --context $ctx apply -f -
-    kubectl --context $ctx label namespace kuma-demo \
-      kuma.io/sidecar-injection=enabled --overwrite
-    kubectl --context $ctx apply -f https://raw.githubusercontent.com/kumahq/kuma-counter-demo/refs/heads/master/demo.yaml
-  done
-  ```
+   ```sh
+   for ctx in $ZONE1_PROFILE $ZONE2_PROFILE; do
+     kubectl --context $ctx apply -f demo.yaml
+   done
+   ```
 
-1. From a `demo-app` pod in zone-1, request the `demo-app` Service in zone-2 using its cross-zone hostname.
-   The `demo-app` image includes `wget`, so use:
+1. Wait for the demo app to become ready in both zones:
 
    ```sh
-  kubectl --context $ZONE1_PROFILE -n kuma-demo exec deploy/demo-app -c demo-app -- \
-     wget -qO- http://demo-app.kuma-demo.svc.zone-2.mesh.local:5000/
+   for ctx in $ZONE1_PROFILE $ZONE2_PROFILE; do
+     kubectl --context $ctx -n kong-mesh-demo wait \
+       --for=condition=available deployment --all --timeout=120s
+   done
+   ```
+
+1. From a `demo-app` pod in zone-1, request the `demo-app` Service in zone-2 using its cross-zone hostname:
+
+   ```sh
+   kubectl --context $ZONE1_PROFILE -n kong-mesh-demo exec deploy/demo-app -c demo-app -- \
+     wget -qO /dev/null http://demo-app.kong-mesh-demo.svc.zone-2.mesh.local:5000/
    ```
 
    The request leaves zone-1 through the zone egress, enters zone-2 through the zone ingress, and hits the `demo-app` pod there.
 
    {:.info}
-  > If the request times out, re-check the `MeshZoneAddress` output and confirm the ingress Services still publish the expected `NodePort` values.
+   > If the request times out, re-check the `MeshZoneAddress` output and confirm the ingress Services still publish the expected `NodePort` values.
 
-1. Port-forward the zone-2 ingress to the local machine:
+1. Reset the stats counters on the zone-2 ingress:
 
-  ```sh
-  kubectl --context $ZONE2_PROFILE -n kong-mesh-system \
-    port-forward deploy/kong-mesh-default-ingress 9903:9902
-  ```
+   ```sh
+   kubectl --context $ZONE2_PROFILE -n kong-mesh-system \
+     exec deploy/kong-mesh-default-ingress -c kuma-sidecar -- \
+     wget -qO- --post-data='' 'http://127.0.0.1:9902/reset_counters'
+   ```
 
-1. Reset the counters, send the cross-zone request again, and inspect the ingress Envoy cluster stats:
+1. Send the cross-zone request again:
 
-  ```sh
-  curl -s -X POST http://127.0.0.1:9903/reset_counters
+   ```sh
+   kubectl --context $ZONE1_PROFILE -n kong-mesh-demo exec deploy/demo-app -c demo-app -- \
+     wget -qO /dev/null http://demo-app.kong-mesh-demo.svc.zone-2.mesh.local:5000/
+   ```
 
-  kubectl --context $ZONE1_PROFILE -n kuma-demo exec deploy/demo-app -c demo-app -- \
-    wget -qO- http://demo-app.kuma-demo.svc.zone-2.mesh.local:5000/ >/dev/null
+1. Inspect the ingress Envoy cluster stats:
 
-  curl -s 'http://127.0.0.1:9903/stats?format=json&filter=demo-app' | \
-    jq '.stats[] | select(.name | test("upstream_rq_total"))'
-  ```
+   ```sh
+   kubectl --context $ZONE2_PROFILE -n kong-mesh-system \
+     exec deploy/kong-mesh-default-ingress -c kuma-sidecar -- \
+     wget -qO- 'http://127.0.0.1:9902/stats?format=json&filter=demo-app' | \
+     jq '.stats[] | select(.name | strings | test("upstream_rq_total"))'
+   ```
 
-  `upstream_rq_total` for the zone-2 `demo-app` ingress cluster should be greater than zero.
-  The follow-up guide shows how to inspect zone-egress-specific traffic on top of this setup.
-
-  {:.info}
-  > On Kubernetes, port `9902` is the readiness reporter proxy for the Envoy admin API.
-  > It forwards `/stats`, `/config_dump`, and `/reset_counters` to the underlying admin socket.
-
-## Next steps
-
-Follow [Apply policies to mesh-scoped zone proxies](/mesh/zone-proxy-policies/) to add `MeshTrafficPermission`, `MeshMetric`, and `MeshAccessLog` on top of this three-cluster setup.
-<!--- Read the [`MeshIdentity`](/mesh/mesh-identity/) guide to switch the bundled CA for a production issuer.-->
+   `upstream_rq_total` for the zone-2 `demo-app` ingress cluster should be greater than zero.
+   The follow-up guide shows how to inspect zone-egress-specific traffic on top of this setup.

--- a/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
@@ -26,6 +26,58 @@ tldr:
     1. Install each zone control plane with a `kuma.meshes[]` entry.
     1. {{site.mesh_product_name}} renders a per-mesh Deployment and Service for each role, and generates the Dataplane listeners automatically.
 
+faqs:
+  - q: How do I list the per-mesh Deployments and Services?
+    a: |
+      Query `kong-mesh-system` filtered by mesh label:
+
+      ```sh
+      kubectl --context $ZONE1_PROFILE -n kong-mesh-system get deploy,svc -l kuma.io/mesh=default
+      ```
+
+      You'll see a `kong-mesh-default-ingress` and `kong-mesh-default-egress` Deployment, each with a matching Service.
+      A second mesh produces another pair named after its mesh.
+
+  - q: How do I confirm the Services carry the zone-proxy-type label?
+    a: |
+      ```sh
+      kubectl --context $ZONE1_PROFILE -n kong-mesh-system get svc \
+        -l k8s.kuma.io/zone-proxy-type -L k8s.kuma.io/zone-proxy-type
+      ```
+
+  - q: How do I confirm the ingress Services are NodePort?
+    a: |
+      Run the following for each zone and note the published port:
+
+      ```sh
+      kubectl --context $ZONE1_PROFILE -n kong-mesh-system get svc kong-mesh-default-ingress \
+        -o jsonpath='{.spec.type}{"\t"}{.spec.ports[0].nodePort}{"\n"}'
+      kubectl --context $ZONE2_PROFILE -n kong-mesh-system get svc kong-mesh-default-ingress \
+        -o jsonpath='{.spec.type}{"\t"}{.spec.ports[0].nodePort}{"\n"}'
+      ```
+
+  - q: How do I inspect the MeshZoneAddress resources?
+    a: |
+      `MeshZoneAddress` resources are namespaced, so query `kong-mesh-system` explicitly:
+
+      ```sh
+      kubectl --context $GLOBAL_PROFILE -n kong-mesh-system get meshzoneaddress -o json | \
+        jq -r '.items[] |
+          [
+            .metadata.labels["kuma.io/zone"],
+            .metadata.name,
+            (.spec.address + ":" + (.spec.port | tostring))
+          ] | @tsv'
+      ```
+
+      The addresses should use the shared Docker bridge IPs and the published ingress `NodePort` values.
+
+  - q: How do I view the zone proxy Dataplane resources?
+    a: |
+      ```sh
+      kubectl --context $GLOBAL_PROFILE get dataplane -A
+      ```
+
 prereqs:
   skip_product: true
   inline:
@@ -321,59 +373,6 @@ Publish each zone's trust bundle to the global control plane so it syncs everywh
    ```
 
 The global control plane syncs these trust bundles to all zones, enabling cross-zone certificate validation.
-
-## Inspect the zone proxy resources
-
-1. List the per-mesh Deployments and Services in zone-1:
-
-   ```sh
-   kubectl --context $ZONE1_PROFILE -n kong-mesh-system get deploy,svc -l kuma.io/mesh=default
-   ```
-
-   You'll see a `kong-mesh-default-ingress` and `kong-mesh-default-egress` Deployment, each with a matching Service.
-   A second mesh would produce another pair named after its mesh.
-
-1. Confirm the Services carry the `k8s.kuma.io/zone-proxy-type` label:
-
-   ```sh
-   kubectl --context $ZONE1_PROFILE -n kong-mesh-system get svc \
-     -l k8s.kuma.io/zone-proxy-type -L k8s.kuma.io/zone-proxy-type
-   ```
-
-1. Confirm that the zone-1 ingress Service is a `NodePort` and note the published port:
-
-   ```sh
-   kubectl --context $ZONE1_PROFILE -n kong-mesh-system get svc kong-mesh-default-ingress \
-     -o jsonpath='{.spec.type}{"\t"}{.spec.ports[0].nodePort}{"\n"}'
-   ```
-
-1. Confirm that the zone-2 ingress Service is a `NodePort` and note the published port:
-
-   ```sh
-   kubectl --context $ZONE2_PROFILE -n kong-mesh-system get svc kong-mesh-default-ingress \
-     -o jsonpath='{.spec.type}{"\t"}{.spec.ports[0].nodePort}{"\n"}'
-   ```
-
-1. Inspect the `MeshZoneAddress` resources on the global control plane.
-   They are namespaced resources, so query `kong-mesh-system` explicitly:
-
-   ```sh
-   kubectl --context $GLOBAL_PROFILE -n kong-mesh-system get meshzoneaddress -o json | \
-     jq -r '.items[] |
-       [
-         .metadata.labels["kuma.io/zone"],
-         .metadata.name,
-         (.spec.address + ":" + (.spec.port | tostring))
-       ] | @tsv'
-   ```
-
-   These addresses should use the shared Docker bridge IPs and the published ingress `NodePort` values.
-
-1. From the global control plane, look at the zone proxy `Dataplane` resources:
-
-   ```sh
-   kubectl --context $GLOBAL_PROFILE get dataplane -A
-   ```
 
 ## Verify cross-zone traffic
 

--- a/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
+++ b/app/_how-tos/mesh/deploy-mesh-scoped-zone-proxies.md
@@ -8,6 +8,8 @@ bread-crumbs:
 related_resources:
   - text: 'Multi-zone deployment'
     url: '/mesh/mesh-multizone-service-deployment/'
+  - text: 'Apply policies to mesh-scoped zone proxies'
+    url: '/mesh/zone-proxy-policies/'
 
 min_version:
   mesh: '2.14'
@@ -28,18 +30,19 @@ prereqs:
       include_content: prereqs/helm
     - title: minikube
       content: |
-        You will need [minikube](https://minikube.sigs.k8s.io/docs/start/) to run three local Kubernetes clusters (one global and two zones).
+        You will need [minikube](https://minikube.sigs.k8s.io/docs/start/) with the Docker driver to run three local Kubernetes clusters (one global and two zones).
 
 cleanup:
   inline:
     - title: Clean up {{site.mesh_product_name}} resources
       content: |
-        Delete the three minikube profiles:
+        Delete the three minikube profiles and the shared Docker network:
 
         ```sh
-        minikube delete -p mesh-global
-        minikube delete -p mesh-zone-1
-        minikube delete -p mesh-zone-2
+        minikube delete -p guide-mz-global
+        minikube delete -p guide-mz-zone-1
+        minikube delete -p guide-mz-zone-2
+        docker network rm guide-mz-net
         ```
 ---
 
@@ -48,23 +51,44 @@ Instead of the cluster-scoped `kuma.ingress.enabled` / `kuma.egress.enabled` Hel
 Each entry renders its own Deployment, Service, and Dataplane for that mesh, and zone proxies now carry per-mesh workload identity so policies can target them directly.
 
 This guide walks through a fresh three-cluster setup: a global control plane and two zone control planes, each deploying a zone ingress and zone egress through the new `kuma.meshes[]` configuration.
+It uses the minikube Docker driver and one shared Docker bridge so the three clusters can reach each other directly through `NodePort` Services.
+That removes the need for `minikube tunnel`, `host.minikube.internal`, and `externalIPs` workarounds.
 
 ## Start the global control plane cluster
+
+1. Export the profile names, the shared Docker network, the static node IPs, and the fixed KDS `NodePort`:
+
+   ```sh
+   export MZ_NETWORK=guide-mz-net
+   export GLOBAL_PROFILE=guide-mz-global
+   export ZONE1_PROFILE=guide-mz-zone-1
+   export ZONE2_PROFILE=guide-mz-zone-2
+   export GLOBAL_IP=192.168.240.11
+   export ZONE1_IP=192.168.240.21
+   export ZONE2_IP=192.168.240.31
+   export KDS_NODEPORT=30685
+   ```
+
+1. Create the shared Docker bridge if it does not already exist:
+
+   ```sh
+   docker network inspect $MZ_NETWORK >/dev/null 2>&1 || \
+     docker network create --driver bridge --subnet 192.168.240.0/24 $MZ_NETWORK
+   ```
+
+{:.info}
+> On Docker Desktop, a third Docker-driver minikube profile can leave `kube-proxy` crashlooping with `failed complete: too many open files`.
+> If that happens, raise the shared Linux VM's inotify limits once, then restart the affected profile:
+>
+> ```sh
+> docker run --rm --privileged alpine \
+>   sysctl -w fs.inotify.max_user_instances=8192 fs.inotify.max_user_watches=524288
+> ```
 
 1. Create a new minikube cluster for the global control plane:
 
    ```sh
-   minikube start -p mesh-global
-   ```
-
-1. Start a minikube tunnel so the `LoadBalancer` services we create later get an external address:
-
-   {:.info}
-   > Using `nohup` lets the tunnel continue running if your terminal session ends.
-   > The `--bind-address=0.0.0.0` flag exposes the tunnel to other minikube clusters via `host.minikube.internal`.
-
-   ```sh
-   nohup minikube tunnel -p mesh-global --bind-address=0.0.0.0 &
+   minikube start -p $GLOBAL_PROFILE --driver=docker --network=$MZ_NETWORK --static-ip=$GLOBAL_IP
    ```
 
 ## Deploy the global control plane
@@ -74,34 +98,31 @@ This guide walks through a fresh three-cluster setup: a global control plane and
    ```sh
    helm repo add kong-mesh https://kong.github.io/kong-mesh-charts
    helm repo update
-   helm install --kube-context mesh-global --create-namespace --namespace kong-mesh-system \
+   helm install --kube-context $GLOBAL_PROFILE --create-namespace --namespace kong-mesh-system \
      --set kuma.controlPlane.mode=global \
      --set kuma.controlPlane.defaults.skipMeshCreation=true \
+     --set kuma.controlPlane.globalZoneSyncService.type=NodePort \
+     --set kuma.controlPlane.globalZoneSyncService.nodePort=$KDS_NODEPORT \
      kong-mesh kong-mesh/kong-mesh
    ```
 
    We skip default mesh creation because we will apply a custom `Mesh` in the next step.
+   `NodePort` makes the zone sync endpoint reachable on the shared Docker bridge without a tunnel.
 
 1. Wait for the control plane to become ready:
 
    ```sh
-   kubectl --context mesh-global -n kong-mesh-system wait \
+   kubectl --context $GLOBAL_PROFILE -n kong-mesh-system wait \
      --for=condition=ready pod --selector=app=kong-mesh-control-plane --timeout=120s
    ```
 
 1. Export the KDS address that the zone control planes will connect to:
 
    ```sh
-   export EXTERNAL_IP=host.minikube.internal
+   export KDS_ADDRESS=grpcs://${GLOBAL_IP}:${KDS_NODEPORT}
    ```
 
-   {:.info}
-   > Outside minikube, resolve the `kong-mesh-global-zone-sync` service address instead:
-   >
-   > ```sh
-   > export EXTERNAL_IP=$(kubectl --context mesh-global -n kong-mesh-system \
-   >   get svc kong-mesh-global-zone-sync -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-   > ```
+   The global control plane is now reachable at `${GLOBAL_IP}:${KDS_NODEPORT}` from the other two minikube clusters.
 
 ## Create the mesh on the global control plane
 
@@ -129,12 +150,16 @@ If you skip this, the zone proxies install but produce no listeners.
    spec:
      targetRef:
        kind: Mesh
-     from:
-       - targetRef:
-           kind: Mesh
-         default:
-           action: Allow' | kubectl --context mesh-global apply -f -
+     rules:
+       - default:
+           allow:
+             - spiffeID:
+                 type: Prefix
+                 value: "spiffe://default."' | kubectl --context $GLOBAL_PROFILE apply -f -
    ```
+
+   This rule allows any workload identity whose SPIFFE trust domain starts with `default.`.
+   That includes the mesh-scoped zone proxies and the demo workloads in both zones.
 
 ## Create a MeshIdentity
 
@@ -163,7 +188,7 @@ spec:
       certificateParameters:
         expiry: 24h
       autogenerate:
-        enabled: true' | kubectl --context mesh-global apply -f -{% endraw %}
+        enabled: true' | kubectl --context $GLOBAL_PROFILE apply -f -{% endraw %}
 ```
 
 {:.info}
@@ -175,28 +200,20 @@ spec:
 A `kuma.meshes[]` entry tells the chart which mesh the zone proxies belong to.
 Each entry renders its own Deployment, Service, and ServiceAccount for the ingress and egress roles.
 
-1. Start the zone-1 cluster and its tunnel:
+1. Start the zone-1 cluster on the shared Docker bridge:
 
    ```sh
-   minikube start -p mesh-zone-1
-   nohup minikube tunnel -p mesh-zone-1 --bind-address=0.0.0.0 &
+   minikube start -p $ZONE1_PROFILE --driver=docker --network=$MZ_NETWORK --static-ip=$ZONE1_IP
    ```
 
-1. Get the host IP that all minikube clusters can reach:
-
-   ```sh
-   export HOST_IP=$(minikube ssh -p mesh-zone-1 -- getent hosts host.minikube.internal | awk '{print $1}')
-   echo $HOST_IP
-   ```
-
-1. Save the following as `zone-1-values.yaml`, replacing `${EXTERNAL_IP}` and `${HOST_IP}` with the values you exported:
+1. Save the following as `zone-1-values.yaml`:
 
    ```yaml
    kuma:
      controlPlane:
        mode: zone
        zone: zone-1
-       kdsGlobalAddress: grpcs://${EXTERNAL_IP}:5685
+       kdsGlobalAddress: ${KDS_ADDRESS}
        tls:
          kdsZoneClient:
            skipVerify: true
@@ -205,43 +222,42 @@ Each entry renders its own Deployment, Service, and ServiceAccount for the ingre
          ingress:
            enabled: true
            service:
-             spec:
-               externalIPs:
-                 - ${HOST_IP}
+             type: NodePort
          egress:
            enabled: true
    ```
 
-   `service.spec` is merged into the ingress `Service` spec, so the ingress advertises a `MeshZoneAddress` that other zones can reach.
-   Without it, minikube's tunnel sets the external address to `127.0.0.1`, which does not route between clusters.
+   `service.spec` is still available for additional `Service` fields such as `externalIPs` or `loadBalancerSourceRanges`,
+   but the chart does not expose a dedicated per-mesh `nodePort` override.
+   When the Service type is `NodePort`, Kubernetes assigns the port automatically and the `meshzoneaddress` controller advertises the resulting `${ZONE1_IP}:<nodePort>` address for you.
+   You no longer need `externalIPs` or a host-level tunnel.
 
    To deploy zone proxies for additional meshes, append more entries to `kuma.meshes`.
 
 1. Install the zone control plane together with the zone ingress and egress for `default`:
 
    ```sh
-   helm install --kube-context mesh-zone-1 --create-namespace --namespace kong-mesh-system \
+   helm install --kube-context $ZONE1_PROFILE --create-namespace --namespace kong-mesh-system \
      -f zone-1-values.yaml \
      kong-mesh kong-mesh/kong-mesh
    ```
 
 ## Deploy zone-2
 
-1. Start the zone-2 cluster and its tunnel:
+1. Start the zone-2 cluster on the shared Docker bridge:
 
    ```sh
-   minikube start -p mesh-zone-2
-   nohup minikube tunnel -p mesh-zone-2 --bind-address=0.0.0.0 &
+   minikube start -p $ZONE2_PROFILE --driver=docker --network=$MZ_NETWORK --static-ip=$ZONE2_IP
    ```
 
-1. Save the following as `zone-2-values.yaml`, replacing `${EXTERNAL_IP}` and `${HOST_IP}` with the values you exported:
+1. Save the following as `zone-2-values.yaml`:
 
    ```yaml
    kuma:
      controlPlane:
        mode: zone
        zone: zone-2
-       kdsGlobalAddress: grpcs://${EXTERNAL_IP}:5685
+       kdsGlobalAddress: ${KDS_ADDRESS}
        tls:
          kdsZoneClient:
            skipVerify: true
@@ -250,21 +266,18 @@ Each entry renders its own Deployment, Service, and ServiceAccount for the ingre
          ingress:
            enabled: true
            service:
-             port: 10002
-             spec:
-               externalIPs:
-                 - ${HOST_IP}
+             type: NodePort
          egress:
            enabled: true
    ```
 
-   {:.info}
-   > Zone-2's ingress uses port `10002` so it doesn't collide with zone-1's ingress on port `10001` when both tunnels publish to the same host address.
+   Zone-2 follows the same pattern.
+   Kubernetes allocates the ingress `NodePort`, and `MeshZoneAddress` publishes the resulting `${ZONE2_IP}:<nodePort>` endpoint.
 
 1. Install the zone control plane and its zone proxies:
 
    ```sh
-   helm install --kube-context mesh-zone-2 --create-namespace --namespace kong-mesh-system \
+   helm install --kube-context $ZONE2_PROFILE --create-namespace --namespace kong-mesh-system \
      -f zone-2-values.yaml \
      kong-mesh kong-mesh/kong-mesh
    ```
@@ -282,23 +295,23 @@ Resources synced back from the global control plane carry `kuma.io/origin: globa
 1. Export zone-1's trust bundle and apply it to the global CP:
 
    ```sh
-   kubectl --context mesh-zone-1 -n kong-mesh-system get meshtrust -o json | \
+  kubectl --context $ZONE1_PROFILE -n kong-mesh-system get meshtrust -o json | \
      jq '.items[] | select(.metadata.labels["kuma.io/origin"] == "zone") |
          .metadata.name = "trust-of-zone-1" |
          .metadata.labels["kuma.io/origin"] = "global" |
          del(.metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation, .metadata.ownerReferences)' | \
-     kubectl --context mesh-global apply -f -
+    kubectl --context $GLOBAL_PROFILE apply -f -
    ```
 
 1. Export zone-2's trust bundle and apply it to the global CP:
 
    ```sh
-   kubectl --context mesh-zone-2 -n kong-mesh-system get meshtrust -o json | \
+  kubectl --context $ZONE2_PROFILE -n kong-mesh-system get meshtrust -o json | \
      jq '.items[] | select(.metadata.labels["kuma.io/origin"] == "zone") |
          .metadata.name = "trust-of-zone-2" |
          .metadata.labels["kuma.io/origin"] = "global" |
          del(.metadata.resourceVersion, .metadata.uid, .metadata.creationTimestamp, .metadata.generation, .metadata.ownerReferences)' | \
-     kubectl --context mesh-global apply -f -
+    kubectl --context $GLOBAL_PROFILE apply -f -
    ```
 
 The global control plane syncs these trust bundles to all zones, enabling cross-zone certificate validation.
@@ -308,7 +321,7 @@ The global control plane syncs these trust bundles to all zones, enabling cross-
 1. List the per-mesh Deployments and Services in zone-1:
 
    ```sh
-   kubectl --context mesh-zone-1 -n kong-mesh-system get deploy,svc -l kuma.io/mesh=default
+  kubectl --context $ZONE1_PROFILE -n kong-mesh-system get deploy,svc -l kuma.io/mesh=default
    ```
 
    You'll see a `kong-mesh-default-ingress` and `kong-mesh-default-egress` Deployment, each with a matching Service.
@@ -318,77 +331,104 @@ The global control plane syncs these trust bundles to all zones, enabling cross-
    The Pod controller watches this label and generates the Dataplane listeners from it:
 
    ```sh
-   kubectl --context mesh-zone-1 -n kong-mesh-system get svc \
+  kubectl --context $ZONE1_PROFILE -n kong-mesh-system get svc \
      -l k8s.kuma.io/zone-proxy-type -L k8s.kuma.io/zone-proxy-type
    ```
 
-1. From the global control plane, look at the Dataplanes.
-   Zone proxies are now ordinary `Dataplane` resources with `networking.listeners[]` entries instead of separate `ZoneIngress` or `ZoneEgress` resources:
+1. Confirm that each ingress Service is a `NodePort` and note the published port:
 
-   ```sh
-   kubectl --context mesh-global get dataplane -A
-   ```
+  ```sh
+  kubectl --context $ZONE1_PROFILE -n kong-mesh-system get svc kong-mesh-default-ingress \
+    -o jsonpath='{.spec.type}{"\t"}{.spec.ports[0].nodePort}{"\n"}'
+
+  kubectl --context $ZONE2_PROFILE -n kong-mesh-system get svc kong-mesh-default-ingress \
+    -o jsonpath='{.spec.type}{"\t"}{.spec.ports[0].nodePort}{"\n"}'
+  ```
+
+1. Inspect the `MeshZoneAddress` resources on the global control plane.
+  They are namespaced resources, so query `kong-mesh-system` explicitly:
+
+  ```sh
+  kubectl --context $GLOBAL_PROFILE -n kong-mesh-system get meshzoneaddress -o json | \
+    jq -r '.items[] |
+      [
+        .metadata.labels["kuma.io/zone"],
+        .metadata.name,
+        (.spec.address + ":" + (.spec.port | tostring))
+      ] | @tsv'
+  ```
+
+  These addresses should match the shared Docker bridge you created earlier, not `127.0.0.1`.
+
+1. From the global control plane, look at the Dataplanes.
+  Zone proxies are now ordinary `Dataplane` resources with `networking.listeners[]` entries instead of separate `ZoneIngress` or `ZoneEgress` resources:
+
+  ```sh
+  kubectl --context $GLOBAL_PROFILE get dataplane -A
+  ```
 
 1. Confirm that no legacy zone proxy resources exist.
-   Both lists should be empty:
+  Both lists should be empty:
 
-   ```sh
-   kubectl --context mesh-global get zoneingresses,zoneegresses -A
-   ```
-   {:.no-copy-code}
-
-1. Inspect the `MeshZoneAddress` resources.
-   The `meshzoneaddress` controller in each zone generates these automatically from the zone ingress Service's external address, so remote zones can route to them:
-
-   ```sh
-   kubectl --context mesh-zone-1 get meshzoneaddress -A
-   kubectl --context mesh-zone-2 get meshzoneaddress -A
-   ```
+  ```sh
+  kubectl --context $GLOBAL_PROFILE get zoneingresses,zoneegresses -A
+  ```
+  {:.no-copy-code}
 
 ## Verify cross-zone traffic
 
 1. Deploy the {{site.mesh_product_name}} demo app into each zone:
 
-   ```sh
-   for ctx in mesh-zone-1 mesh-zone-2; do
-     kubectl --context $ctx create namespace kuma-demo \
-       --dry-run=client -o yaml | kubectl --context $ctx apply -f -
-     kubectl --context $ctx label namespace kuma-demo \
-       kuma.io/sidecar-injection=enabled --overwrite
-     kubectl --context $ctx apply -f https://raw.githubusercontent.com/kumahq/kuma-counter-demo/refs/heads/master/demo.yaml
-   done
-   ```
+  ```sh
+  for ctx in $ZONE1_PROFILE $ZONE2_PROFILE; do
+    kubectl --context $ctx create namespace kuma-demo \
+      --dry-run=client -o yaml | kubectl --context $ctx apply -f -
+    kubectl --context $ctx label namespace kuma-demo \
+      kuma.io/sidecar-injection=enabled --overwrite
+    kubectl --context $ctx apply -f https://raw.githubusercontent.com/kumahq/kuma-counter-demo/refs/heads/master/demo.yaml
+  done
+  ```
 
 1. From a `demo-app` pod in zone-1, request the `demo-app` Service in zone-2 using its cross-zone hostname.
    The `demo-app` image ships with `wget` but not `curl`:
 
    ```sh
-   kubectl --context mesh-zone-1 -n kuma-demo exec deploy/demo-app -c demo-app -- \
+  kubectl --context $ZONE1_PROFILE -n kuma-demo exec deploy/demo-app -c demo-app -- \
      wget -qO- http://demo-app.kuma-demo.svc.zone-2.mesh.local:5000/
    ```
 
    The request leaves zone-1 through the zone egress, enters zone-2 through the zone ingress, and hits the `demo-app` pod there.
 
    {:.info}
-   > If the request times out, check that the minikube tunnels are still running.
-   > Tunnels can become unresponsive after sleep/wake cycles; restart them with `minikube tunnel -p <profile> --bind-address=0.0.0.0`.
+  > If the request times out, re-check the `MeshZoneAddress` output and confirm the ingress Services still publish the expected `NodePort` values.
 
-1. Confirm the traffic passed through the zone-2 zone ingress by reading its sidecar stats through the global control plane's inspect API.
-   The ingress dataplane name carries a hash suffix, so look it up by the `app` and `kuma.io/zone` labels:
+1. Port-forward the zone-2 ingress to the local machine:
 
-   ```sh
-   DP=$(kubectl --context mesh-global -n kong-mesh-system exec deploy/kong-mesh-control-plane -- \
-     wget -qO- 'http://localhost:5681/meshes/default/dataplanes' | \
-     jq -r '.items[] | select(.labels.app=="kong-mesh-default-ingress" and .labels["kuma.io/zone"]=="zone-2") | .name')
+  ```sh
+  kubectl --context $ZONE2_PROFILE -n kong-mesh-system \
+    port-forward deploy/kong-mesh-default-ingress 9903:9902
+  ```
 
-   kubectl --context mesh-global -n kong-mesh-system exec deploy/kong-mesh-control-plane -- \
-     wget -qO- "http://localhost:5681/meshes/default/dataplanes/${DP}/stats" | \
-     grep "kri_msvc_default_zone-2_kuma-demo_demo-app_5000.upstream_rq_total"
-   ```
+1. Reset the counters, send the cross-zone request again, and inspect the ingress Envoy cluster stats:
 
-   `upstream_rq_total` for the `demo-app` cluster should be greater than zero.
+  ```sh
+  curl -s -X POST http://127.0.0.1:9903/reset_counters
+
+  kubectl --context $ZONE1_PROFILE -n kuma-demo exec deploy/demo-app -c demo-app -- \
+    wget -qO- http://demo-app.kuma-demo.svc.zone-2.mesh.local:5000/ >/dev/null
+
+  curl -s 'http://127.0.0.1:9903/stats?format=json&filter=demo-app' | \
+    jq '.stats[] | select(.name | test("upstream_rq_total"))'
+  ```
+
+  `upstream_rq_total` for the zone-2 `demo-app` ingress cluster should be greater than zero.
+  The follow-up guide shows how to inspect zone-egress-specific traffic on top of this setup.
+
+  {:.info}
+  > On Kubernetes, port `9902` is the readiness reporter proxy for the Envoy admin API.
+  > It forwards `/stats`, `/config_dump`, and `/reset_counters` to the underlying admin socket.
 
 ## Next steps
 
-<!--- Target individual zone proxy listeners from policies with `sectionName` - covered in a follow-up guide.-->
+Follow [Apply policies to mesh-scoped zone proxies](/mesh/zone-proxy-policies/) to add `MeshTrafficPermission`, `MeshMetric`, and `MeshAccessLog` on top of this three-cluster setup.
 <!--- Read the [`MeshIdentity`](/mesh/mesh-identity/) guide to switch the bundled CA for a production issuer.-->

--- a/app/_includes/mesh/demo.md
+++ b/app/_includes/mesh/demo.md
@@ -1,0 +1,111 @@
+```sh
+cat <<'EOF' > demo.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kong-mesh-demo
+  labels:
+    kuma.io/sidecar-injection: enabled
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  namespace: kong-mesh-demo
+spec:
+  selector:
+    matchLabels:
+      app: redis
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: "redis"
+          ports:
+            - name: tcp
+              containerPort: 6379
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sleep", "30"]
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    for i in $(seq 1 30); do
+                      if /usr/local/bin/redis-cli ping >/dev/null 2>&1; then
+                        /usr/local/bin/redis-cli set zone local && exit 0
+                      fi
+                      sleep 1
+                    done
+                    echo "Redis not ready after 30s, skipping postStart"
+                    exit 0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: kong-mesh-demo
+  labels:
+    app: redis
+spec:
+  selector:
+    app: redis
+  ports:
+  - protocol: TCP
+    port: 6379
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: demo-app
+  namespace: kong-mesh-demo
+spec:
+  selector:
+    matchLabels:
+      app: demo-app
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: demo-app
+    spec:
+      containers:
+        - name: demo-app
+          image: "kumahq/kuma-demo"
+          env:
+            - name: REDIS_HOST
+              value: "redis.kong-mesh-demo.svc.cluster.local"
+            - name: REDIS_PORT
+              value: "6379"
+            - name: APP_VERSION
+              value: "1.0"
+            - name: APP_COLOR
+              value: "#efefef"
+          ports:
+            - name: http
+              containerPort: 5000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: demo-app
+  namespace: kong-mesh-demo
+  labels:
+    app: demo-app
+spec:
+  selector:
+    app: demo-app
+  ports:
+  - protocol: TCP
+    appProtocol: http
+    port: 5000
+EOF
+```
+{:.collapsible}

--- a/app/_indices/mesh.yaml
+++ b/app/_indices/mesh.yaml
@@ -43,6 +43,7 @@ sections:
       - path: /mesh/mesh-multi-tenancy/
       - path: /mesh/single-zone/
       - path: /mesh/mesh-multizone-service-deployment/
+      - path: /mesh/zone-proxies/
       - path: /mesh/interact-with-control-plane/
       - path: /mesh/use-mesh-cli/
       - path: /mesh/annotations/

--- a/app/_indices/mesh.yaml
+++ b/app/_indices/mesh.yaml
@@ -39,6 +39,7 @@ sections:
       - path: /mesh/mesh-multi-tenancy/
       - path: /mesh/single-zone/
       - path: /mesh/mesh-multizone-service-deployment/
+      - path: /mesh/zone-proxies/
       - path: /mesh/interact-with-control-plane/
       - path: /mesh/annotations/
       - path: /mesh/data-plane-proxy/

--- a/app/_indices/mesh.yaml
+++ b/app/_indices/mesh.yaml
@@ -40,6 +40,7 @@ sections:
       - path: /mesh/single-zone/
       - path: /mesh/mesh-multizone-service-deployment/
       - path: /mesh/zone-proxies/
+      - path: /mesh/zone-proxy-policies/
       - path: /mesh/interact-with-control-plane/
       - path: /mesh/annotations/
       - path: /mesh/data-plane-proxy/

--- a/app/_mesh_policies/meshtrafficpermission/index.md
+++ b/app/_mesh_policies/meshtrafficpermission/index.md
@@ -85,11 +85,11 @@ When `targetRef.kind: Dataplane` selects a mesh-scoped zone proxy, `MeshTrafficP
 The two forms are mutually exclusive.
 
 Use `targetRef.labels` to select the proxy role and zone.
-Use `targetRef.sectionName` to select the exact listener name from the generated `Dataplane`.
-With the current Helm chart output, zone ingress uses `10001` and zone egress uses `10002`.
+Use `targetRef.sectionName` to select the exact listener name from the zone proxy `Dataplane`.
+For example, zone ingress can use `10001` and zone egress can use `10002`.
 
 On zone egress, destination matching happens through `rules[].default.allow[]` or `deny[]` entries.
-The most precise selector is the destination SNI.
+Match the destination by SNI.
 
 {% policy_yaml namespace=kong-mesh-system %}
 ```yaml

--- a/app/_mesh_policies/meshtrafficpermission/index.md
+++ b/app/_mesh_policies/meshtrafficpermission/index.md
@@ -78,6 +78,43 @@ If you don't understand this table you should read [matching docs](/docs/{{ page
 
 ## Configuration
 
+{% if_version gte:2.14.x %}
+### Zone proxy listeners
+
+When `targetRef.kind: Dataplane` selects a mesh-scoped zone proxy, `MeshTrafficPermission` can use `spec.rules` instead of `spec.from`.
+The two forms are mutually exclusive.
+
+Use `targetRef.labels` to select the proxy role and zone.
+Use `targetRef.sectionName` to select the exact listener name from the generated `Dataplane`.
+With the current Helm chart output, zone ingress uses `10001` and zone egress uses `10002`.
+
+On zone egress, destination matching happens through `rules[].default.allow[]` or `deny[]` entries.
+The most precise selector is the destination SNI.
+
+{% policy_yaml namespace=kong-mesh-system %}
+```yaml
+type: MeshTrafficPermission
+name: deny-external-service-kube
+mesh: default
+spec:
+  targetRef:
+    kind: Dataplane
+    labels:
+      kuma.io/listener-zoneegress: enabled
+      kuma.io/zone: zone-1
+    sectionName: "10002"
+  rules:
+    - default:
+        deny:
+          - sni:
+              type: Exact
+              value: sni.extsvc.default.zone-1.kong-mesh-system.external-service-kube.80
+```
+{% endpolicy_yaml %}
+
+For a complete walkthrough, see [Apply policies to mesh-scoped zone proxies](/mesh/zone-proxy-policies/).
+{% endif_version %}
+
 ### Action
 
 {{ site.mesh_product_name }} allows configuring one of 3 actions for a group of service's clients:

--- a/app/_mesh_policies/meshtrafficpermission/index.md
+++ b/app/_mesh_policies/meshtrafficpermission/index.md
@@ -78,14 +78,12 @@ If you don't understand this table you should read [matching docs](/docs/{{ page
 
 ## Configuration
 
-{% if_version gte:2.14.x %}
-### Zone proxy listeners
+### Zone proxy listeners {% new_in 2.14 %}
 
 When `targetRef.kind: Dataplane` selects a mesh-scoped zone proxy, `MeshTrafficPermission` can use `spec.rules` instead of `spec.from`.
 The two forms are mutually exclusive.
 
-Use `targetRef.labels` to select the proxy role and zone.
-Use `targetRef.sectionName` to select the exact listener name from the zone proxy `Dataplane`.
+Use `targetRef.labels` to select the proxy role and zone, and `targetRef.sectionName` to select the exact listener name from the zone proxy `Dataplane`.
 For example, zone ingress can use `10001` and zone egress can use `10002`.
 
 On zone egress, destination matching happens through `rules[].default.allow[]` or `deny[]` entries.
@@ -113,7 +111,6 @@ spec:
 {% endpolicy_yaml %}
 
 For a complete walkthrough, see [Apply policies to mesh-scoped zone proxies](/mesh/zone-proxy-policies/).
-{% endif_version %}
 
 ### Action
 


### PR DESCRIPTION
## Description

EDIT: **I realised that not all connectivity might work on multicluster with minikube - need to investigate that**.

Walks through a multi-cluster minikube setup that deploys mesh scoped zone ingress and zone egress via the new `kuma.meshes[]` Helm configuration, with cross-zone traffic.

xrel https://github.com/Kong/kong-mesh/issues/9409

## Preview Links

https://deploy-preview-4963--kongdeveloper.netlify.app/mesh/zone-proxies/
https://deploy-preview-4963--kongdeveloper.netlify.app/mesh/zone-proxy-policies/

## Checklist 

- [X] Tested how-to docs. If not, note why here. 
- [X] All pages contain metadata.
- [X] Any new docs link to existing docs.
- [X] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [X] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [X] Every page has a `description` entry in frontmatter.
- [X] Add new pages to the product documentation index (if applicable).
