### PR TITLE
Change group from 'authentication' to 'providers'

### DIFF
--- a/app/_kong_plugins/openid-connect/examples/auth0.yaml
+++ b/app/_kong_plugins/openid-connect/examples/auth0.yaml
@@ -39,4 +39,4 @@ tools:
   - kic
   - terraform
 
-group: authentication
+group: providers


### PR DESCRIPTION
Fixed incorrect categorization of Auth0 integration example

## Description
![Uploading 2026-04-22_08-50-03.png…]()
