### PR TITLE
chore(gateway): Log PCRE upgrade breaking change in 3.7

### DIFF
--- a/app/_includes/upgrade/lts-changes-34-310.md
+++ b/app/_includes/upgrade/lts-changes-34-310.md
@@ -188,11 +188,11 @@ rows:
     action: |
       No
   - category: Dependencies
-    description: | 
-      PCRE was upgraded from `libpcre` 8.45 to `libpcre2` 10.43. 
-      This upgrade changes the expected regex syntax, and any incompatible regular expressions will prevent {{site.base_gateway}} from applying configuration. 
+    description: |
+      PCRE was upgraded from `libpcre` 8.45 to `libpcre2` 10.43.
+      This upgrade changes the expected regex syntax, and any incompatible regular expressions will prevent {{site.base_gateway}} from applying configuration.
     action: |
-      Review any regexes in your entity configuration and adjust based on the [PCRE2 syntax reference](https://www.pcre.org/current/doc/html/pcre2syntax.html).
+      Review all regexes in your entity configuration and adjust based on the [PCRE2 syntax reference](https://www.pcre.org/current/doc/html/pcre2syntax.html).
 {% endtable %}
 
 

--- a/app/_includes/upgrade/lts-changes-34-310.md
+++ b/app/_includes/upgrade/lts-changes-34-310.md
@@ -187,7 +187,12 @@ rows:
       While the `+` character represents the correct encoding of space in query strings, Kong uses `%20` in many other APIs, which is inherited from Nginx/OpenResty.
     action: |
       No
-          
+  - category: Dependencies
+    description: | 
+      PCRE was upgraded from `libpcre` 8.45 to `libpcre2` 10.43. 
+      This upgrade changes the expected regex syntax, and any incompatible regular expressions will prevent {{site.base_gateway}} from applying configuration. 
+    action: |
+      Review any regexes in your entity configuration and adjust based on the [PCRE2 syntax reference](https://www.pcre.org/current/doc/html/pcre2syntax.html).
 {% endtable %}
 
 

--- a/app/gateway/breaking-changes.md
+++ b/app/gateway/breaking-changes.md
@@ -821,8 +821,8 @@ path of the `anthropic` setting for the `llm/v1/chat` Route type has changed fro
 
 #### PCRE version bump
 
-{{site.base_gateway}} 3.7 upgrades PCRE from `libpcre` 8.45 to `libpcre2` 10.43. 
-This upgrade changes the expected regex syntax, and any incompatible regular expressions will prevent {{site.base_gateway}} from applying configuration. 
+{{site.base_gateway}} 3.7 upgrades PCRE from `libpcre` 8.45 to `libpcre2` 10.43.
+This upgrade changes the expected regex syntax, and any incompatible regular expressions will prevent {{site.base_gateway}} from applying configuration.
 See the [PCRE2 syntax reference](https://www.pcre.org/current/doc/html/pcre2syntax.html) for more information on how to adjust your regexes.
 
 #### Known issues in 3.7.0.0

--- a/app/gateway/breaking-changes.md
+++ b/app/gateway/breaking-changes.md
@@ -819,6 +819,12 @@ entity when using the AppRole authentication method.
 [**AI Proxy**](/plugins/ai-proxy/) (`ai-proxy`): To support the new messages API of `Anthropic`, the upstream
 path of the `anthropic` setting for the `llm/v1/chat` Route type has changed from `/v1/complete` to `/v1/messages`.
 
+#### PCRE version bump
+
+{{site.base_gateway}} 3.7 upgrades PCRE from `libpcre` 8.45 to `libpcre2` 10.43. 
+This upgrade changes the expected regex syntax, and any incompatible regular expressions will prevent {{site.base_gateway}} from applying configuration. 
+See the [PCRE2 syntax reference](https://www.pcre.org/current/doc/html/pcre2syntax.html) for more information on how to adjust your regexes.
+
 #### Known issues in 3.7.0.0
 
 The following is a list of known issues in 3.7.x that may be fixed in a future release.


### PR DESCRIPTION
## Description

In 3.7, we bumped the PCRE dependency to PCRE2. This wasn't logged as a breaking change, but it affects any configs with old-format regexes, and will affect an LTS upgrade from 3.4 to 3.10.

Issue reported on Slack. I did my own digging around about the PCRE > PCRE2 bump and verified that it is a big breaking change for the library.

## Preview Links
