### PR TITLE
fix(catalog): TF resource for associating an API with a Gateway

### DIFF
--- a/app/catalog/apis.md
+++ b/app/catalog/apis.md
@@ -308,6 +308,7 @@ resource "konnect_api_implementation" "my_apiimplementation" {
       control_plane_id = "9f5061ce-78f6-4452-9108-ad7c02821fd5"
       id               = "7710d5c4-d902-410b-992f-18b814155b53"
     }
+  }
 }
 ' >> main.tf
 ```

--- a/app/catalog/apis.md
+++ b/app/catalog/apis.md
@@ -298,15 +298,16 @@ body:
 <!--vale on-->
 {% endnavtab %}
 {% navtab "Terraform" %}
-Use the [`konnect_api_implementation` resource](https://github.com/Kong/terraform-provider-konnect/blob/main/examples/resources/konnect_api_implementation.tf):
+Use the [`konnect_api_implementation` resource](https://registry.terraform.io/providers/Kong/konnect/latest/docs/resources/api_implementation):
 ```hcl
 echo '
 resource "konnect_api_implementation" "my_apiimplementation" {
   api_id = "9f5061ce-78f6-4452-9108-ad7c02821fd5"
-  service = {
-    control_plane_id = "9f5061ce-78f6-4452-9108-ad7c02821fd5"
-    id               = "7710d5c4-d902-410b-992f-18b814155b53"
-  }
+  service_reference = {
+    service = {
+      control_plane_id = "9f5061ce-78f6-4452-9108-ad7c02821fd5"
+      id               = "7710d5c4-d902-410b-992f-18b814155b53"
+    }
 }
 ' >> main.tf
 ```


### PR DESCRIPTION
## Description

Fixes https://kongstrong.slack.com/archives/CDSTDSG9J/p1776785786087729

## Preview Links
/catalog/apis/?tab=terraform#allow-developers-to-consume-your-api

To test this, you'll need the pat, auth.tf, and the init command in [this prereq](https://developer.konghq.com/how-to/automate-api-catalog-with-terraform/#kong-konnect). 
Apply the TF resource (with your UUID values), then run `terraform apply -auto-approve`.

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
