### PR TITLE
fix(gateway): Adjust sandbox mode changelog entry for accuracy

### DIFF
--- a/app/_data/changelogs/gateway.json
+++ b/app/_data/changelogs/gateway.json
@@ -20791,7 +20791,7 @@
         "scope": "Core"
       },
       {
-        "message": "**sandbox**: Added `strict` and `lax` modes for `untrusted_lua`; deprecated `sandbox` mode. Default changed to `strict`.\n",
+        "message": "**sandbox**: Added `strict` and `lax` modes for `untrusted_lua`. The default mode changed from `sandbox` to `strict`.\n",
         "type": "feature",
         "scope": "Core"
       },


### PR DESCRIPTION
## Description

The `untrusted_lua` `sandbox` mode setting is not deprecated. The default changed, but there is no plan to remove the `sandbox` option.

The breaking changes entry for this item is already correct.

Issue reported on Slack.

## Preview Links

https://deploy-preview-4978--kongdeveloper.netlify.app/gateway/changelog/#:~:text=sandbox%3A%20Added%20strict%20and%20lax%20modes%20for%20untrusted_lua.%20The%20default%20mode%20changed%20from%20sandbox%20to%20strict.