### PR TITLE
fix(catalog): Update observability integration name

### DIFF
--- a/app/_how-tos/catalog/map-analytics-resources.md
+++ b/app/_how-tos/catalog/map-analytics-resources.md
@@ -2,7 +2,7 @@
 title: Map {{site.observability}} reports in Catalog
 permalink: /how-to/map-analytics-resources/
 content_type: how_to
-description: Learn how to map {{site.konnect_short_name}} {{site.observability}} resources in {{site.konnect_catalog}} to visualize {{site.observability}} Reports.
+description: Learn how to map {{site.konnect_short_name}} analytics resources in {{site.konnect_catalog}} to visualize {{site.observability}} Reports.
 products:
   - catalog
 works_on:
@@ -13,7 +13,7 @@ search_aliases:
   - konnect analytics
 tldr:
   q: How do I map {{site.observability}} reports in {{site.konnect_catalog}}?
-  a: Create a {{site.konnect_catalog}} service and associate it with your {{site.observability}} resources to visualize {{site.observability}} Reports. When listing resources with the API, the filter key is `integration.name=analytics`.
+  a: Create a {{site.konnect_catalog}} service and associate it with your {{site.konnect_short_name}} analytics resources to visualize {{site.observability}} Reports.
 prereqs:
   inline:
     - title: "{{site.observability}} reports"

--- a/app/_how-tos/catalog/map-analytics-resources.md
+++ b/app/_how-tos/catalog/map-analytics-resources.md
@@ -1,8 +1,8 @@
 ---
-title: Map Konnect Analytics reports in Catalog
+title: Map {{site.observability}} reports in Catalog
 permalink: /how-to/map-analytics-resources/
 content_type: how_to
-description: Learn how to map {{site.konnect_short_name}} Analytics resources in {{site.konnect_catalog}} to visualize Analytics Reports.
+description: Learn how to map {{site.konnect_short_name}} {{site.observability}} resources in {{site.konnect_catalog}} to visualize {{site.observability}} Reports.
 products:
   - catalog
 works_on:
@@ -10,18 +10,19 @@ works_on:
 entities: []
 search_aliases:
   - service catalog
+  - konnect analytics
 tldr:
-  q: How do I map {{site.konnect_short_name}} Analytics reports in {{site.konnect_catalog}}?
-  a: Create a {{site.konnect_catalog}} service and associate it with your {{site.konnect_short_name}} Analytics resources to visualize Analytics Reports.
+  q: How do I map {{site.observability}} reports in {{site.konnect_catalog}}?
+  a: Create a {{site.konnect_catalog}} service and associate it with your {{site.konnect_short_name}} Analytics resources to visualize {{site.observability}} Reports.
 prereqs:
   inline:
-    - title: "{{site.konnect_short_name}} Analytics reports"
+    - title: "{{site.observability}} reports"
       content: |
-        You'll need a [{{site.konnect_short_name}} Analytics report](https://cloud.konghq.com/analytics/reports) to ingest in {{site.konnect_catalog}} as resources.
+        You'll need a [{{site.observability}} report](https://cloud.konghq.com/analytics/reports) to ingest in {{site.konnect_catalog}} as resources.
       icon_url: /assets/icons/analytics.svg
 related_resources:
-  - text: "{{site.konnect_short_name}} Analytics integration"
-    url: /catalog/integrations/konnect-analytics/
+  - text: "{{site.observability}} integration"
+    url: /catalog/integrations/observability/
   - text: "{{site.konnect_catalog}}"
     url: /catalog/
   - text: "{{site.konnect_catalog}} integrations"
@@ -30,9 +31,9 @@ related_resources:
 
 ## Create a service in {{site.konnect_catalog}}
 
-In this tutorial, you'll map Reports from {{site.konnect_short_name}} Analytics to a service in {{site.konnect_catalog}}. Because the {{site.konnect_short_name}} Analytics integration is built-in, you don't need to install or authorize it like other {{site.konnect_catalog}} integrations. 
+In this tutorial, you'll map Reports from {{site.observability}} to a service in {{site.konnect_catalog}}. Because the {{site.observability}} integration is built-in, you don't need to install or authorize it like other {{site.konnect_catalog}} integrations. 
 
-Create a service that you'll map to your {{site.konnect_short_name}} Analytics resources:
+Create a service that you'll map to your {{site.observability}} resources:
 
 <!--vale off-->
 {% konnect_api_request %}
@@ -52,9 +53,9 @@ Export the {{site.konnect_catalog}} service ID:
 export SERVICE_ID='YOUR-SERVICE-ID'
 ```
 
-## List {{site.konnect_short_name}} Analytics resources
+## List {{site.observability}} resources
 
-Before you can map a resource to {{site.konnect_catalog}}, you first need to find the resources that are pulled in from {{site.konnect_short_name}} Analytics:
+Before you can map a resource to {{site.konnect_catalog}}, you first need to find the resources that are pulled in from {{site.observability}}:
 
 <!--vale off-->
 {% konnect_api_request %}
@@ -73,7 +74,7 @@ export ANALYTICS_RESOURCE_ID='YOUR-RESOURCE-ID'
 
 ## Map resources to a {{site.konnect_catalog}} service
 
-Now, you can map the {{site.konnect_short_name}} Analytics resource to the service:
+Now, you can map the {{site.observability}} resource to the service:
 
 <!--vale off-->
 {% konnect_api_request %}
@@ -89,7 +90,7 @@ body:
 
 ## Validate the mapping
 
-To confirm that the {{site.konnect_short_name}} Analytics resource is now mapped to the intended service, list the service’s mapped resources:
+To confirm that the {{site.observability}} resource is now mapped to the intended service, list the service’s mapped resources:
 
 <!--vale off-->
 {% konnect_api_request %}

--- a/app/_how-tos/catalog/map-analytics-resources.md
+++ b/app/_how-tos/catalog/map-analytics-resources.md
@@ -13,7 +13,7 @@ search_aliases:
   - konnect analytics
 tldr:
   q: How do I map {{site.observability}} reports in {{site.konnect_catalog}}?
-  a: Create a {{site.konnect_catalog}} service and associate it with your {{site.konnect_short_name}} Analytics resources to visualize {{site.observability}} Reports.
+  a: Create a {{site.konnect_catalog}} service and associate it with your {{site.observability}} resources to visualize {{site.observability}} Reports. When listing resources with the API, the filter key is `integration.name=analytics`.
 prereqs:
   inline:
     - title: "{{site.observability}} reports"
@@ -22,7 +22,7 @@ prereqs:
       icon_url: /assets/icons/analytics.svg
 related_resources:
   - text: "{{site.observability}} integration"
-    url: /catalog/integrations/observability/
+    url: /catalog/integrations/konnect-analytics/
   - text: "{{site.konnect_catalog}}"
     url: /catalog/
   - text: "{{site.konnect_catalog}} integrations"
@@ -31,7 +31,7 @@ related_resources:
 
 ## Create a service in {{site.konnect_catalog}}
 
-In this tutorial, you'll map Reports from {{site.observability}} to a service in {{site.konnect_catalog}}. Because the {{site.observability}} integration is built-in, you don't need to install or authorize it like other {{site.konnect_catalog}} integrations. 
+In this tutorial, you'll map Reports from {{site.observability}} to a service in {{site.konnect_catalog}}. Because the {{site.observability}} integration is built-in, you don't need to install or authorize it like other {{site.konnect_catalog}} integrations.
 
 Create a service that you'll map to your {{site.observability}} resources:
 

--- a/app/_landing_pages/catalog/integrations.yaml
+++ b/app/_landing_pages/catalog/integrations.yaml
@@ -210,7 +210,7 @@ rows:
       - blocks:
           - type: card
             config:
-              title: "{{site.konnect_short_name}} Analytics"
+              title: "{{site.observability}}"
               description: View real-time, highly contextual analytics to gain insight into API health, performance, and usage.
               icon: /assets/icons/analytics.svg
               ctas:

--- a/app/catalog/integrations/konnect-analytics.md
+++ b/app/catalog/integrations/konnect-analytics.md
@@ -1,5 +1,5 @@
 ---
-title: "{{site.konnect_short_name}} Analytics"
+title: "{{site.observability}}"
 content_type: reference
 layout: reference
 
@@ -16,11 +16,12 @@ breadcrumbs:
 
 works_on:
     - konnect
-description: Connect reports from {{site.konnect_short_name}} Analytics
+description: Connect reports from {{site.observability}}
 search_aliases:
   - service catalog
+  - konnect analytics
 related_resources:
-  - text: "Map {{site.konnect_short_name}} Analytics reports in {{site.konnect_catalog}}"
+  - text: "Map {{site.observability}} reports in {{site.konnect_catalog}}"
     url: /how-to/map-analytics-resources/
   - text: "{{site.konnect_catalog}}"
     url: /catalog/
@@ -29,16 +30,16 @@ discovery_default: true
 bindable_entities: "Report"
 ---
 
-The {{site.konnect_short_name}} Analytics integration will allow users to connect Reports from the {{site.konnect_short_name}} Analytics product directly to their services. Users browsing the catalog will be able to see what reports are important to that service, and be brought directly to the report by clicking through.
+The {{site.observability}} integration will allow users to connect Reports from the {{site.observability}} product directly to their services. Users browsing the catalog will be able to see what reports are important to that service, and be brought directly to the report by clicking through.
 
-## Authorize the {{site.konnect_short_name}} Analytics integration
+## Authorize the {{site.observability}} integration
 
-The {{site.konnect_short_name}} Analytics integration is built directly into {{site.konnect_catalog}}. No additional authorization is required.
+The {{site.observability}} integration is built directly into {{site.konnect_catalog}}. No additional authorization is required.
 
 
 ## Resources
 
-Available {{site.konnect_short_name}} Analytics entities:
+Available {{site.observability}} entities:
 
 {% table %}
 columns:
@@ -48,11 +49,8 @@ columns:
     key: description
 rows:
   - entity: "Report"
-    description: "A Report in the Konnect Analytics product"
+    description: "A Report in the {{site.observability}} product"
 {% endtable %}
-
-
-
 
 ## Discovery information
 


### PR DESCRIPTION
## Description

While merging in very old rename PRs for gateway manager and mesh manager, I noticed that the Konnect Analytics tile name also changed to Observability.

I updated the names in the docs to match the UI. I left the URLs and API commands as-is, since those pieces all still use either `analytics` or `konnect analytics` in both the API and UI descriptions & URLs.

## Preview Links
https://deploy-preview-4979--kongdeveloper.netlify.app/catalog/integrations/konnect-analytics/
