### PR TITLE
fix(docs-platform): `ctas` element alignment

### DIFF
--- a/app/_includes/card.html
+++ b/app/_includes/card.html
@@ -44,7 +44,7 @@
             {{ card_content }}
         </a>
     {% else %}
-        <div class="flex flex-col gap-5 p-6">
+        <div class="flex flex-col gap-5 p-6 w-full">
             {{ card_content }}
         </div>
     {% endif %}


### PR DESCRIPTION
## Description

Fixing an alignment issue with `ctas`, where the width of the element was inconsistent on different cards.

Old:
<img width="762" height="974" alt="Screenshot 2026-04-23 at 2 06 22 PM" src="https://github.com/user-attachments/assets/ff3aaa57-9f5a-455d-96a9-ed550c8bd119" />

Fixed:
<img width="766" height="978" alt="Screenshot 2026-04-23 at 2 28 36 PM" src="https://github.com/user-attachments/assets/c9e6d6ca-9bd4-4c04-b14d-861394233443" />

## Preview Links

Check both full screen and mobile widths. It's more apparent on mobile, but some cards were misaligned on full screen as well.

/catalog/integrations/