### PR TITLE
Remove Consumer Group claim authorization flow section

### DIFF
--- a/app/konnect-platform/kong-identity.md
+++ b/app/konnect-platform/kong-identity.md
@@ -114,7 +114,7 @@ You can configure a claim in two ways:
 - Using the Konnect API.
 
 When configuring a claim, you can choose from the following options:
-
+<!--vale off-->
 {% table %}
 columns:
   - title: UI setting
@@ -137,7 +137,7 @@ rows:
     description: The claim exists in the auth server for internal reference but is never embedded in tokens.
     example: A "department" claim used to organize clients internally. It's saved in the auth server but never sent to APIs.
 {% endtable %}
-
+<!--vale on-->
 ### API parameters
 
 Configure the claim by sending a `POST` request to the [`/auth-servers/{authServerId}/claims` endpoint](/api/konnect/kong-identity/v1/#/operations/createAuthServerClaim).

--- a/app/konnect-platform/kong-identity.md
+++ b/app/konnect-platform/kong-identity.md
@@ -104,15 +104,6 @@ In the authorization code flow:
 6. The client uses the access token to call protected APIs.
 {% endcomment %}
 
-## Kong Consumer Group claim authorization flow
-When using plugins scoped to Consumer Groups:
-1. In **{{site.konnect_short_name}} > API Gateway > Consumers**, the client creates the Consumer. Each user that needs access is represented as a Consumer.
-
-   {:.info}
-   > If using OIDC, you don’t need to manually map credentials. The OIDC plugin automatically maps clients to Consumers based on token claims.
-2. The client defines the required Consumer Groups in {{site.konnect_short_name}}, and then applies the desired plugin at the Consumer Group scope.
-3. The client assigns each Consumer to the appropriate Consumer Group. Once assigned, the plugin configuration at the group level automatically applies to the Consumer.
-
 ## Claim configuration
 
 You can [configure each claim](#configure-kong-identity) to be included or not in the JWT token issued by the authorization server, based on the scopes the client requests. 


### PR DESCRIPTION
## Description

Removed the Kong Consumer Group claim authorization flow section from the documentation. It is not relevant to Kong Identity and shouldn't be here.

## Preview Links

https://deploy-preview-4995--kongdeveloper.netlify.app/kong-identity/
