### PR TITLE
feat(DCGW): Custom teams table

### DIFF
--- a/app/konnect-platform/teams-and-roles.md
+++ b/app/konnect-platform/teams-and-roles.md
@@ -233,19 +233,20 @@ rows:
   - persona: Platform engineer
     description: |
       A platform engineer has access to create and manage Dedicated Cloud Gateway networks and control planes.
+      They also can configure Dedicated Cloud Gateway add-ons, like managed cache.
     roles: |
       * Network Creator
       * Network Admin
       * Control Plane Creator
       * Cloud Gateway Cluster Admin
+      * Add On Viewer
+      * Add On Admin
   - persona: Network engineer
     description: |
       A network engineer has access to configure private networking, transit gateways, and DNS resolution for Dedicated Cloud Gateway networks.
-      They also can configure Dedicated Cloud Gateway add-ons, like managed cache.
     roles: |
       * Network Admin
       * Network Viewer
-      * Add On Admin
       * Cloud Gateway Cluster Admin
       * Cloud Gateway Cluster Viewer
   - persona: Serverless engineer

--- a/app/konnect-platform/teams-and-roles.md
+++ b/app/konnect-platform/teams-and-roles.md
@@ -217,7 +217,7 @@ rows:
 {% endtable %}
 <!--vale on-->
 
-### Dedicated Cloud Gateway custom teams
+#### Dedicated Cloud Gateway custom teams
 
 You can use custom teams in {{site.konnect_short_name}} to manage access for common Dedicated Cloud Gateway personas. The following table details the roles you can assign to each custom team:
 <!--vale off-->

--- a/app/konnect-platform/teams-and-roles.md
+++ b/app/konnect-platform/teams-and-roles.md
@@ -217,6 +217,62 @@ rows:
 {% endtable %}
 <!--vale on-->
 
+### Dedicated Cloud Gateway custom teams
+
+You can use custom teams in {{site.konnect_short_name}} to manage access for common Dedicated Cloud Gateway personas. The following table details the roles you can assign to each custom team:
+<!--vale off-->
+{% table %}
+columns:
+  - title: Persona
+    key: persona
+  - title: Custom team description
+    key: description
+  - title: Roles
+    key: roles
+rows:
+  - persona: Platform engineer
+    description: |
+      A platform engineer has access to create and manage Dedicated Cloud Gateway networks and control planes.
+    roles: |
+      * Network Creator
+      * Network Admin
+      * Control Plane Creator
+      * Cloud Gateway Cluster Admin
+  - persona: Network engineer
+    description: |
+      A network engineer has access to configure private networking, transit gateways, and DNS resolution for Dedicated Cloud Gateway networks.
+      They also can configure Dedicated Cloud Gateway add-ons, like managed cache.
+    roles: |
+      * Network Admin
+      * Network Viewer
+      * Add On Admin
+      * Cloud Gateway Cluster Admin
+      * Cloud Gateway Cluster Viewer
+  - persona: Serverless engineer
+    description: |
+      A serverless engineer has access to configure serverless gateways.
+    roles: |
+      * Serverless Cluster Admin
+      * Serverless Cluster Viewer
+  - persona: API/gateway developer
+    description: |
+      An API/gateway developer has access to configure Gateway Services, Routes, plugins, and Consumers within a Dedicated Cloud Gateway control plane.
+    roles: |
+      * Gateway Service Admin
+      * Route Admin
+      * Plugin Admin
+      * Consumer Admin
+  - persona: Ops viewer
+    description: |
+      An ops viewer has read-only access to Dedicated Cloud Gateway networks, control planes, and add-ons for monitoring and troubleshooting.
+    roles: |
+      * Network Viewer
+      * Cloud Gateway Cluster Viewer
+      * Add On Viewer
+      * Viewer (Control Plane)
+{% endtable %}
+<!--vale on-->
+
 ## Roles
 
 Roles predefine access to a particular resource, or

--- a/app/konnect-platform/teams-and-roles.md
+++ b/app/konnect-platform/teams-and-roles.md
@@ -247,8 +247,6 @@ rows:
     roles: |
       * Network Admin
       * Network Viewer
-      * Cloud Gateway Cluster Admin
-      * Cloud Gateway Cluster Viewer
   - persona: Serverless engineer
     description: |
       A serverless engineer has access to configure serverless gateways.


### PR DESCRIPTION
## Description

Similar to the Dev Portal custom teams table we have on the page that shows clusters of roles based on common personas, I wanted to create one for DCGW since we still have confusion on what roles people actually need. 

## Preview Links
https://deploy-preview-4998--kongdeveloper.netlify.app/konnect-platform/teams-and-roles/#dedicated-cloud-gateway-custom-teams

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
