### PR TITLE
fix(kongctl): Installation instructions

### DIFF
--- a/app/_includes/tools/kongctl/install/linux.md
+++ b/app/_includes/tools/kongctl/install/linux.md
@@ -2,12 +2,12 @@ Download the latest kongctl binary for Linux from the [GitHub releases page](htt
 
 1. Download the binary:
    ```sh
-   curl -sL https://github.com/Kong/kongctl/releases/download/v{{site.data.kongctl_latest.version}}/kongctl_{{site.data.kongctl_latest.version}}_linux_amd64.tar.gz -o kongctl.tar.gz
+   curl -sL https://github.com/Kong/kongctl/releases/download/v{{site.data.kongctl_latest.version}}/kongctl_linux_amd64.zip -o kongctl.zip
    ```
 
 1. Extract the archive: 
    ```sh
-   tar -xzf kongctl.tar.gz
+   unzip kongctl.zip
    ```
 
 1. Move the binary to your PATH:

--- a/app/_includes/tools/kongctl/install/mise.md
+++ b/app/_includes/tools/kongctl/install/mise.md
@@ -9,7 +9,7 @@ mise use -g github:Kong/kongctl@latest
 Or install a specific version:
 
 ```bash
-mise use -g github:Kong/kongctl@0.3.8
+mise use -g github:Kong/kongctl@{{site.data.kongctl_latest.version}}
 ```
 
 Verify the installation:

--- a/app/_includes/tools/kongctl/install/windows.md
+++ b/app/_includes/tools/kongctl/install/windows.md
@@ -1,7 +1,7 @@
 Download the latest kongctl binary for Windows from the [GitHub releases page](https://github.com/Kong/kongctl/releases).
 
 1. Navigate to the [kongctl releases page](https://github.com/Kong/kongctl/releases).
-2. Download the Windows binary (for example, `kongctl_{{site.data.kongctl_latest.version}}_windows_amd64.zip`)
+2. Download the Windows binary (for example, `kongctl_windows_amd64.zip`)
 3. Extract the ZIP archive.
 4. Move `kongctl.exe` to a directory in your PATH, or add the extracted directory to your PATH.
 5. Verify the installation:


### PR DESCRIPTION
## Description

Fixes #5005 

The install instructions were written before kongctl was released, and the format was changed/standardized since then.

Tested the instructions, should work now.

## Preview Links
