### PR TITLE
Fix(konnect): add control plane versioning and behavior change policy 

### DIFF
--- a/.github/styles/base/Dictionary.txt
+++ b/.github/styles/base/Dictionary.txt
@@ -993,6 +993,7 @@ untrusted
 untyped
 unvetted
 unversioned
+versionless
 unwanted
 updated_at
 unprefixed

--- a/app/konnect-platform/compatibility.md
+++ b/app/konnect-platform/compatibility.md
@@ -71,7 +71,7 @@ This reference explains which browsers, software versions, tools, and applicatio
 
 ## {{site.konnect_short_name}} control plane compatibility
 
-The {{site.konnect_short_name}} control plane is **versionless** and always runs the latest release. You can't pin a specific control plane version, and there is no per-plugin versioning. This means changes will take effect the next time you perform a`deck sync`, regardless of which data plane version you're running. Defaults only change at major {{site.base_gateway}} versions, so your configuration continues to work without modification across minor and patch releases. Breaking changes target major versions, security CVEs may require an update in a minor or patch version.
+Defaults change at major {{site.base_gateway}} versions or when a security vulnerability requires it. Your configuration continues to work without modification across minor and patch releases.
 
 
 ## {{site.mesh_product_name}} compatibility

--- a/app/konnect-platform/compatibility.md
+++ b/app/konnect-platform/compatibility.md
@@ -71,15 +71,12 @@ This reference explains which browsers, software versions, tools, and applicatio
 
 ## {{site.konnect_short_name}} control plane compatibility
 
-The {{site.konnect_short_name}} control plane is **versionless** and always runs the latest release. {{site.konnect_short_name}} manages upgrades automatically. You can't pin a specific control plane version.
+The {{site.konnect_short_name}} control plane is **versionless** and always runs the latest release. You can't pin a specific control plane version, and there is no per-plugin versioning.
 
-This means a behavior change or a tightened validation rule takes effect on your next `deck sync`, regardless of which data plane version you're running.
+This means changes take effect on your next `deck sync`, regardless of which data plane version you're running.
 
-To limit disruption from control plane updates:
-
-* **Behavior changes ship as opt-in flags first.** For example, stricter validation modes are introduced alongside a permissive mode that preserves the previous behavior.
-* **The previous behavior remains the default.** Existing configurations continue to work without modification until you explicitly opt in to the new behavior (is opt-in doing a `deck sync`?)
-* breaking changes place holder
+* **Defaults only change at major {{site.base_gateway}} versions.** Your configuration continues to work without modification across minor and patch releases.
+* **Breaking changes target major {{site.base_gateway}} versions.** Security CVEs may require an exception in a minor or patch version.
 
 
 ## {{site.mesh_product_name}} compatibility

--- a/app/konnect-platform/compatibility.md
+++ b/app/konnect-platform/compatibility.md
@@ -71,12 +71,7 @@ This reference explains which browsers, software versions, tools, and applicatio
 
 ## {{site.konnect_short_name}} control plane compatibility
 
-The {{site.konnect_short_name}} control plane is **versionless** and always runs the latest release. You can't pin a specific control plane version, and there is no per-plugin versioning.
-
-This means changes take effect on your next `deck sync`, regardless of which data plane version you're running.
-
-* **Defaults only change at major {{site.base_gateway}} versions.** Your configuration continues to work without modification across minor and patch releases.
-* **Breaking changes target major {{site.base_gateway}} versions.** Security CVEs may require an exception in a minor or patch version.
+The {{site.konnect_short_name}} control plane is **versionless** and always runs the latest release. You can't pin a specific control plane version, and there is no per-plugin versioning. This means changes will take effect the next time you perform a`deck sync`, regardless of which data plane version you're running. Defaults only change at major {{site.base_gateway}} versions, so your configuration continues to work without modification across minor and patch releases. Breaking changes target major versions, security CVEs may require an update in a minor or patch version.
 
 
 ## {{site.mesh_product_name}} compatibility

--- a/app/konnect-platform/compatibility.md
+++ b/app/konnect-platform/compatibility.md
@@ -51,6 +51,10 @@ faqs:
       You can see your support cases in the [Kong Support portal](https://support.konghq.com). 
       
       If you don't have a Kong Support portal account, request access from your org admin or reach out to a Kong representative for an invite.
+  - q: Why did a configuration that was previously valid start failing after a control plane update?
+    a: |
+      The {{site.konnect_short_name}} control plane is versionless, so it always runs the latest release. If a validation rule changes, a config that worked before can fail next time you perform a `deck sync`.
+
 ---
 
 This reference explains which browsers, software versions, tools, and applications {{site.konnect_short_name}} is compatible with.
@@ -64,6 +68,19 @@ This reference explains which browsers, software versions, tools, and applicatio
 ### Dedicated Cloud Gateway upgrades
 
 {% include /sections/dcgw-upgrades.md %}
+
+## {{site.konnect_short_name}} control plane compatibility
+
+The {{site.konnect_short_name}} control plane is **versionless** and always runs the latest release. {{site.konnect_short_name}} manages upgrades automatically. You can't pin a specific control plane version.
+
+This means a behavior change or a tightened validation rule takes effect on your next `deck sync`, regardless of which data plane version you're running.
+
+To limit disruption from control plane updates:
+
+* **Behavior changes ship as opt-in flags first.** For example, stricter validation modes are introduced alongside a permissive mode that preserves the previous behavior.
+* **The previous behavior remains the default.** Existing configurations continue to work without modification until you explicitly opt in to the new behavior (is opt-in doing a `deck sync`?)
+* breaking changes place holder
+
 
 ## {{site.mesh_product_name}} compatibility
 


### PR DESCRIPTION
https://deploy-preview-5020--kongdeveloper.netlify.app/konnect-platform/compatibility/#konnect-control-plane-compatibility

https://deploy-preview-5020--kongdeveloper.netlify.app/konnect-platform/compatibility/#why-did-a-configuration-that-was-previously-valid-start-failing-after-a-control-plane-update