### PR TITLE
fix(event-gateway): Version support table

### DIFF
--- a/app/_data/products/event-gateway.yml
+++ b/app/_data/products/event-gateway.yml
@@ -3,9 +3,15 @@ icon: /_assets/icons/products/event-gateway.svg
 
 releases:
   - release: "1.0"
+    release_date: "2025-11-06"
+    eol: "2026-11-06"
+    sunset: "2027-11-06"
     version: "1.0.0"
     name: "v1"
   - release: "1.1"
+    release_date: "2026-03-25"
+    eol: "2027-03-25"
+    sunset: "2028-03-25"
     version: "1.1.0"
     name: "v1"
     latest: true

--- a/app/event-gateway/version-support-policy.md
+++ b/app/event-gateway/version-support-policy.md
@@ -124,7 +124,11 @@ This policy is a **summary** and is qualified by the broader [Kong Support and M
 
 
 ## Release timeline
+
+The following {{site.event_gateway}} versions are currently supported by Kong:
+
 <!--vale off-->
+{% assign egw_releases = site.data.products["event-gateway"].releases | reverse %}
 {% table %}
 columns:
   - title: Version
@@ -136,9 +140,11 @@ columns:
   - title: End of Sunset Support
     key: sunset
 rows:
-  - version: "1.0"
-    release: "2025-11-06"
-    full_support: "2026-11-06"
-    sunset: "2027-11-06"
+{% for release in egw_releases %}
+  - version: "{{ release.release }}.x"
+    release: "{{ release.release_date }}"
+    full_support: "{{ release.eol }}"
+    sunset: "{{ release.sunset }}"
+{% endfor %}
 {% endtable %}
 <!--vale on-->


### PR DESCRIPTION
## Description

Rewriting the EGW version support table to pull from `site.data.products.event-gateway.yml` and adding release dates to the data file. This, we only need to update one file at release time.

Fixes an issue where the 1.1 release is currently missing from the support table.

## Preview Links

