### PR TITLE
chore(deck): Add latest decK & kongctl version explicitly as FAQs

### DIFF
--- a/app/_landing_pages/deck.yaml
+++ b/app/_landing_pages/deck.yaml
@@ -371,6 +371,12 @@ rows:
 
                 To find out which endpoints your instance of decK is hitting, execute any decK command with the `--verbose 1` flag.
                 This outputs all of the queries being made. For example, here's a snippet from `deck gateway dump --verbose 1`:
+            - q: |
+                What is the latest version of decK, and where can I find all the releases?
+              a: |
+                The latest version of decK is **{{site.data.deck_latest.version}}**. We recommend keeping your decK version up-to-date whenever possible.
+
+                For all available versions of decK, see the [decK releases page on GitHub](https://github.com/Kong/deck/releases).
 
   - header:
       type: h2

--- a/app/_landing_pages/deck.yaml
+++ b/app/_landing_pages/deck.yaml
@@ -370,7 +370,7 @@ rows:
                 * `POST /workspaces`: Create missing workspaces.
 
                 To find out which endpoints your instance of decK is hitting, execute any decK command with the `--verbose 1` flag.
-                This outputs all of the queries being made. For example, here's a snippet from `deck gateway dump --verbose 1`:
+                This outputs all of the queries being made.
             - q: |
                 What is the latest version of decK, and where can I find all the releases?
               a: |

--- a/app/_landing_pages/kongctl.yaml
+++ b/app/_landing_pages/kongctl.yaml
@@ -328,6 +328,13 @@ rows:
                 * A command-line interface with human-friendly output formats
                 * Declarative configuration with plan-based workflows
                 * Interactive terminal UI for resource exploration
+            - q: |
+                What is the latest version of kongctl, and where can I find all the releases?
+              a: |
+                The latest version of kongctl is **{{site.data.kongctl_latest.version}}**. We recommend keeping your kongctl version up-to-date whenever possible.
+
+                For all available versions of kongctl, see the [kongctl releases page on GitHub](https://github.com/Kong/kongctl/releases).
+
 
   - header:
       type: h2

--- a/app/deck/support.md
+++ b/app/deck/support.md
@@ -37,3 +37,9 @@ The {{ site.konnect_short_name }} API returns the most recent {{ site.base_gatew
 decK guarantees compatibility with all supported {{ site.base_gateway }} versions.
 
 Changes to {{ site.base_gateway }} may result in changes to decK. We recommend updating decK regularly, as the most recent version will work with both old versions of {{ site.base_gateway }} _and_ the latest version simultaneously.
+
+## decK versions
+
+The latest version of decK is **{{site.data.deck_latest.version}}**. We recommend keeping your decK version up-to-date whenever possible.
+
+For all available versions of decK, see the [decK releases page on GitHub](https://github.com/Kong/deck/releases).


### PR DESCRIPTION
## Description

Kapa can't tell which decK version is the latest version based on our docs alone. Adding an FAQ to both decK and kongctl to let users know which version is the latest and where to find all of them.

This fixes a coverage gap in Kapa: https://app.kapa.ai/93b55f65-cffb-4d0b-9da7-c8915a838dce/coverage-gaps/clusters/ce6478f8-bbfd-4516-bdcf-c7af0acb4d40

## Preview Links
https://deploy-preview-5050--kongdeveloper.netlify.app/kongctl/
https://deploy-preview-5050--kongdeveloper.netlify.app/deck/
