### PR TITLE
fix(gateway&mesh): Update link to report vulnerabilities

### DIFF
--- a/app/_includes/support/vulnerability-reporting.md
+++ b/app/_includes/support/vulnerability-reporting.md
@@ -1,0 +1,3 @@
+Kong offers a Responsible Disclosure Program to encourage the good-faith reporting of security vulnerabilities. 
+Researchers who follow our guidelines will not face legal action and may be publicly acknowledged for their contributions. 
+For more information, visit our [Responsible Disclosure page](https://hackerone.com/kong).

--- a/app/gateway/vulnerabilities.md
+++ b/app/gateway/vulnerabilities.md
@@ -117,4 +117,4 @@ Kong does not undertake to address third-party vulnerabilities in convenience im
 
 ## Reporting vulnerabilities in Kong code
 
-If you are reporting a vulnerability in Kong code, we request you to follow the instructions in the [Kong Vulnerability Disclosure Program](https://konghq.com/compliance/bug-bounty). 
+{% include_cached /support/vulnerability-reporting.md %}

--- a/app/mesh/vulnerability-patching-process.md
+++ b/app/mesh/vulnerability-patching-process.md
@@ -87,4 +87,4 @@ Vulnerabilities reported in third-party code that is part of the convenience Doc
 
 ## Reporting vulnerabilities in Kong code
 
-If you are reporting a vulnerability in Kong code, we request you to follow the instructions in the [Kong Vulnerability Disclosure Program](https://konghq.com/compliance/bug-bounty). 
+{% include_cached /support/vulnerability-reporting.md %}


### PR DESCRIPTION
## Description

Fixes #4976 

The vulnerability reporting page changed to HackerOne. Double-checked with the compliance team; using the exact language from the trust center FAQ: https://app.vanta.com/kong.com/trust/nb4f60uiejmvr4jxtes2d/faq?search=Responsible+Disclosure+-+Reporting+Security+Vulnerabilities+to+Kong

## Preview Links

