### PR TITLE
docs(plugins): clarify Service Protection namespace counter scoping

### DIFF
--- a/app/_schemas/gateway/plugins/3.10/ServiceProtection.json
+++ b/app/_schemas/gateway/plugins/3.10/ServiceProtection.json
@@ -40,7 +40,7 @@
           "type": "string"
         },
         "namespace": {
-          "description": "The rate limiting library namespace to use for this plugin instance. Counter data and sync configuration is isolated in each namespace. NOTE: For the plugin instances sharing the same namespace, all the configurations that are required for synchronizing counters, e.g. `strategy`, `redis`, `sync_rate`, `dictionary_name`, need to be the same.",
+          "description": "The rate limiting library namespace to use for this plugin instance. Counter data and sync configuration is isolated in each namespace. Counters are scoped per Service, so plugin instances configured on different Services maintain independent counters even when using the same namespace. NOTE: For plugin instances sharing the same namespace, all configurations that are required for synchronizing counters, e.g. `strategy`, `redis`, `sync_rate`, `dictionary_name`, need to be the same.",
           "type": "string"
         },
         "redis": {

--- a/app/_schemas/gateway/plugins/3.11/ServiceProtection.json
+++ b/app/_schemas/gateway/plugins/3.11/ServiceProtection.json
@@ -40,7 +40,7 @@
           "type": "string"
         },
         "namespace": {
-          "description": "The rate limiting library namespace to use for this plugin instance. Counter data and sync configuration is isolated in each namespace. NOTE: For the plugin instances sharing the same namespace, all the configurations that are required for synchronizing counters, e.g. `strategy`, `redis`, `sync_rate`, `dictionary_name`, need to be the same.",
+          "description": "The rate limiting library namespace to use for this plugin instance. Counter data and sync configuration is isolated in each namespace. Counters are scoped per Service, so plugin instances configured on different Services maintain independent counters even when using the same namespace. NOTE: For plugin instances sharing the same namespace, all configurations that are required for synchronizing counters, e.g. `strategy`, `redis`, `sync_rate`, `dictionary_name`, need to be the same.",
           "type": "string"
         },
         "redis": {

--- a/app/_schemas/gateway/plugins/3.12/ServiceProtection.json
+++ b/app/_schemas/gateway/plugins/3.12/ServiceProtection.json
@@ -40,7 +40,7 @@
           "type": "string"
         },
         "namespace": {
-          "description": "The rate limiting library namespace to use for this plugin instance. Counter data and sync configuration is isolated in each namespace. NOTE: For the plugin instances sharing the same namespace, all the configurations that are required for synchronizing counters, e.g. `strategy`, `redis`, `sync_rate`, `dictionary_name`, need to be the same.",
+          "description": "The rate limiting library namespace to use for this plugin instance. Counter data and sync configuration is isolated in each namespace. Counters are scoped per Service, so plugin instances configured on different Services maintain independent counters even when using the same namespace. NOTE: For plugin instances sharing the same namespace, all configurations that are required for synchronizing counters, e.g. `strategy`, `redis`, `sync_rate`, `dictionary_name`, need to be the same.",
           "type": "string"
         },
         "redis": {

--- a/app/_schemas/gateway/plugins/3.13/ServiceProtection.json
+++ b/app/_schemas/gateway/plugins/3.13/ServiceProtection.json
@@ -40,7 +40,7 @@
           "type": "string"
         },
         "namespace": {
-          "description": "The rate limiting library namespace to use for this plugin instance. Counter data and sync configuration is isolated in each namespace. NOTE: For the plugin instances sharing the same namespace, all the configurations that are required for synchronizing counters, e.g. `strategy`, `redis`, `sync_rate`, `dictionary_name`, need to be the same.",
+          "description": "The rate limiting library namespace to use for this plugin instance. Counter data and sync configuration is isolated in each namespace. Counters are scoped per Service, so plugin instances configured on different Services maintain independent counters even when using the same namespace. NOTE: For plugin instances sharing the same namespace, all configurations that are required for synchronizing counters, e.g. `strategy`, `redis`, `sync_rate`, `dictionary_name`, need to be the same.",
           "type": "string"
         },
         "redis": {

--- a/app/_schemas/gateway/plugins/3.14/ServiceProtection.json
+++ b/app/_schemas/gateway/plugins/3.14/ServiceProtection.json
@@ -40,7 +40,7 @@
           "type": "string"
         },
         "namespace": {
-          "description": "The rate limiting library namespace to use for this plugin instance. Counter data and sync configuration is isolated in each namespace. NOTE: For the plugin instances sharing the same namespace, all the configurations that are required for synchronizing counters, e.g. `strategy`, `redis`, `sync_rate`, `dictionary_name`, need to be the same.",
+          "description": "The rate limiting library namespace to use for this plugin instance. Counter data and sync configuration is isolated in each namespace. Counters are scoped per Service, so plugin instances configured on different Services maintain independent counters even when using the same namespace. NOTE: For plugin instances sharing the same namespace, all configurations that are required for synchronizing counters, e.g. `strategy`, `redis`, `sync_rate`, `dictionary_name`, need to be the same.",
           "type": "string"
         },
         "redis": {

--- a/app/_schemas/gateway/plugins/3.9/ServiceProtection.json
+++ b/app/_schemas/gateway/plugins/3.9/ServiceProtection.json
@@ -44,7 +44,7 @@
           "type": "string"
         },
         "namespace": {
-          "description": "The rate limiting library namespace to use for this plugin instance. Counter data and sync configuration is isolated in each namespace. NOTE: For the plugin instances sharing the same namespace, all the configurations that are required for synchronizing counters, e.g. `strategy`, `redis`, `sync_rate`, `dictionary_name`, need to be the same.",
+          "description": "The rate limiting library namespace to use for this plugin instance. Counter data and sync configuration is isolated in each namespace. Counters are scoped per Service, so plugin instances configured on different Services maintain independent counters even when using the same namespace. NOTE: For plugin instances sharing the same namespace, all configurations that are required for synchronizing counters, e.g. `strategy`, `redis`, `sync_rate`, `dictionary_name`, need to be the same.",
           "type": "string"
         },
         "redis": {


### PR DESCRIPTION
## Description
Clarify that Service Protection counters are scoped per Service, and plugin instances on different Services maintain independent counters even when using the same namespace. This corrects the misleading implication in the previous description that namespace alone enables cross-instance counter sharing.

Fixes #issue
Fix: [FTI-7259](https://konghq.atlassian.net/browse/FTI-7259)
## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).


[FTI-7259]: https://konghq.atlassian.net/browse/FTI-7259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ