### PR TITLE
feat: Add support for generating specific pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ Once you see the `Server now ready on …` message, the docs site is available a
 
 Building the entire docs site can take a while. To speed up build times, you can generate a specific subset of products by setting the `KONG_PRODUCTS` environment variable. This variable accepts a comma-separated list of products (product slugs as defined in `app/_data/products`), e.g `KONG_PRODUCTS=ai-gateway make run`.
 
+## Generating specific pages locally
+
+You can generate specific pages by setting the PAGE_PATHS environment variable. This variable accepts a comma-separated list of paths. For example:
+
+```sh
+PAGE_PATHS="/plugins/acme/,/gateway/entities/" make run
+```
+
+The platform will generate all pages that match each specified path. For instance, `/gateway/entities/` will generate all pages whose paths start with `/gateway/entities/`.
+
 ## Contributing to the docs
 
 If you want to contribute to the Kong Developer docs, see the [Contributing guide](https://developer.konghq.com/contributing/).

--- a/app/_plugins/generators/data/breadcrumbs.rb
+++ b/app/_plugins/generators/data/breadcrumbs.rb
@@ -12,6 +12,7 @@ module Jekyll
 
       def process
         return unless @page.data['breadcrumbs']
+        return if Jekyll.env == 'development' && ENV['PAGE_PATHS']
 
         @page.data['breadcrumbs'] = build_breadcrumbs
       end

--- a/app/_plugins/generators/plugins/generator.rb
+++ b/app/_plugins/generators/plugins/generator.rb
@@ -16,6 +16,8 @@ module Jekyll
       end
 
       def run
+        return if skip_locally?
+
         Dir.glob(File.join(site.source, "#{PLUGINS_FOLDER}/*/")).each do |folder|
           slug = folder.gsub("#{site.source}/#{PLUGINS_FOLDER}/", '').chomp('/')
 
@@ -87,6 +89,13 @@ module Jekyll
                .new(plugin)
                .to_jekyll_page
         site.pages << page if page
+      end
+
+      def skip_locally?
+        page_paths = ENV['PAGE_PATHS']&.split(',')&.map(&:strip)&.reject(&:empty?)
+        Jekyll.env == 'development' && page_paths&.none? do |p|
+          p.start_with?('/plugins/')
+        end
       end
     end
   end

--- a/app/_plugins/hooks/after_init.rb
+++ b/app/_plugins/hooks/after_init.rb
@@ -1,8 +1,20 @@
 # frozen_string_literal: true
 
 Jekyll::Hooks.register :site, :after_init do |site|
-  if ENV['JEKYLL_ENV'] == 'test'
+  if Jekyll.env == 'test'
     site.config['skip'] = {}
     site.config['exclude'].delete('_references')
+  end
+
+  if Jekyll.env == 'development' && ENV['PAGE_PATHS']
+    keep_prefixes = ['_', '.', 'assets']
+    paths = ENV['PAGE_PATHS']&.split(',')&.map(&:strip)&.reject(&:empty?)
+    url_segments = paths.map { |url| url.split('/').reject(&:empty?).first }
+    subfolders = Dir.children(site.source).select do |entry|
+      File.directory?(File.join(site.source, entry)) && keep_prefixes.none? { |prefix| entry.start_with?(prefix) }
+    end
+
+    # exclude folders that don't match the first segment of any of the urls
+    site.config['exclude'].concat(subfolders.difference(url_segments))
   end
 end

--- a/app/_plugins/hooks/products_renderer.rb
+++ b/app/_plugins/hooks/products_renderer.rb
@@ -7,7 +7,7 @@ class ProductsRenderer
   end
 
   def page_paths
-    @page_paths ||= ENV['PAGE_PATHS']&.split(',')
+    @page_paths ||= ENV['PAGE_PATHS']&.split(',')&.map(&:strip)&.reject(&:empty?)
   end
 
   def read?(page)

--- a/app/_plugins/hooks/products_renderer.rb
+++ b/app/_plugins/hooks/products_renderer.rb
@@ -6,8 +6,13 @@ class ProductsRenderer
                      .split(',')
   end
 
+  def page_paths
+    @page_paths ||= ENV['PAGE_PATHS']&.split(',')
+  end
+
   def read?(page)
     return false if page.relative_path.start_with?('assets')
+    return page_paths.any? { |path| page.url.start_with?(path) } if page_paths
 
     products.any? do |product|
       return true if page.respond_to?(:dir) && page.dir == '/'
@@ -24,6 +29,7 @@ class ProductsRenderer
 
   def render?(page)
     return false if page.relative_path.start_with?('assets')
+    return page_paths.any? { |path| page.url.start_with?(path) } if page_paths
 
     products.any? do |product|
       return true if page.respond_to?(:dir) && page.dir == '/'
@@ -42,8 +48,12 @@ end
 renderer = ProductsRenderer.new
 
 Jekyll::Hooks.register :site, :post_read do |site|
-  if ENV['KONG_PRODUCTS']
-    Jekyll.logger.info "Rendering the following products: #{ENV['KONG_PRODUCTS']}, skipping everything else..."
+  if ENV['KONG_PRODUCTS'] || ENV['PAGE_PATHS']
+    if ENV['KONG_PRODUCTS']
+      Jekyll.logger.info "Rendering the following products: #{ENV['KONG_PRODUCTS']}, skipping everything else..."
+    else
+      Jekyll.logger.info "Rendering the following urls: #{ENV['PAGE_PATHS']}, skipping everything else..."
+    end
 
     # Filter pages
     site.pages.delete_if do |page|
@@ -60,7 +70,7 @@ Jekyll::Hooks.register :site, :post_read do |site|
 end
 
 Jekyll::Hooks.register :site, :pre_render do |site|
-  if ENV['KONG_PRODUCTS']
+  if ENV['KONG_PRODUCTS'] || ENV['PAGE_PATHS']
     site.pages = site.pages.select do |page|
       renderer.render?(page)
     end

--- a/app/_plugins/lib/link_icon_assigner.rb
+++ b/app/_plugins/lib/link_icon_assigner.rb
@@ -50,7 +50,7 @@ module Jekyll
     end
 
     def icon_for_content_type
-      return 'service-document' if ENV['KONG_PRODUCTS']
+      return 'service-document' if Jekyll.env == 'development' && (ENV['KONG_PRODUCTS'] || ENV['PAGE_PATHS'])
 
       url = URI.parse(@resource['url']).path
       final_url = resolve_final_path(url, site_redirects)

--- a/app/_plugins/lib/site_accessor.rb
+++ b/app/_plugins/lib/site_accessor.rb
@@ -7,27 +7,27 @@ module Jekyll
     end
 
     def site_redirects
-      @site_redirects ||= begin
-        return {} if Jekyll.env == 'development' && ENV['PAGE_PATHS']
+      @site_redirects ||= if Jekyll.env == 'development' && ENV['PAGE_PATHS']
+                            {}
+                          else
+                            site.pages.detect do |p|
+                              p.url == '/_redirects'
+                            end.content.lines.each_with_object({}) do |line, hash|
+                              line = line.strip
 
-        site.pages.detect do |p|
-          p.url == '/_redirects'
-        end.content.lines.each_with_object({}) do |line, hash|
-          line = line.strip
+                              # Skip blank lines and comments
+                              next if line.empty? || line.start_with?('#')
 
-          # Skip blank lines and comments
-          next if line.empty? || line.start_with?('#')
+                              parts = line.split(/\s+/)
 
-          parts = line.split(/\s+/)
+                              # Only proceed if we have at least a source and destination
+                              next unless parts.size >= 2
 
-          # Only proceed if we have at least a source and destination
-          next unless parts.size >= 2
-
-          source = parts[0]
-          destination = parts[1]
-          hash[source] = destination
-        end
-      end
+                              source = parts[0]
+                              destination = parts[1]
+                              hash[source] = destination
+                            end
+                          end
     end
   end
 end

--- a/app/_plugins/lib/site_accessor.rb
+++ b/app/_plugins/lib/site_accessor.rb
@@ -7,16 +7,22 @@ module Jekyll
     end
 
     def site_redirects
-      @site_redirects ||= site.pages.detect { |p| p.url == '/_redirects' }.content.lines.each_with_object({}) do |line, hash|
-        line = line.strip
+      @site_redirects ||= begin
+        return {} if Jekyll.env == 'development' && ENV['PAGE_PATHS']
 
-        # Skip blank lines and comments
-        next if line.empty? || line.start_with?('#')
+        site.pages.detect do |p|
+          p.url == '/_redirects'
+        end.content.lines.each_with_object({}) do |line, hash|
+          line = line.strip
 
-        parts = line.split(/\s+/)
+          # Skip blank lines and comments
+          next if line.empty? || line.start_with?('#')
 
-        # Only proceed if we have at least a source and destination
-        if parts.size >= 2
+          parts = line.split(/\s+/)
+
+          # Only proceed if we have at least a source and destination
+          next unless parts.size >= 2
+
           source = parts[0]
           destination = parts[1]
           hash[source] = destination

--- a/app/_plugins/tags/how_to_list.rb
+++ b/app/_plugins/tags/how_to_list.rb
@@ -34,7 +34,7 @@ module Jekyll
         break result if result.size == quantity
       end
 
-      if how_tos.empty? && !config.fetch('allow_empty', false) && ENV['KONG_PRODUCTS'].nil?
+      if how_tos.empty? && !config.fetch('allow_empty', false) && ENV['KONG_PRODUCTS'].nil? && ENV['PAGE_PATHS'].nil?
         raise "No how-tos found for #{@context['page']['path']} - #{config}"
       end
 

--- a/app/_plugins/tags/reference_list.rb
+++ b/app/_plugins/tags/reference_list.rb
@@ -22,7 +22,7 @@ module Jekyll
 
       references = fetch_references(config)
 
-      if references.empty? && !config.fetch('allow_empty', false) && ENV['KONG_PRODUCTS'].nil?
+      if references.empty? && !config.fetch('allow_empty', false) && ENV['KONG_PRODUCTS'].nil? && ENV['PAGE_PATHS'].nil?
         raise "No references found for #{@context['page']['path']} - #{config}"
       end
 

--- a/jekyll-dev.yml
+++ b/jekyll-dev.yml
@@ -19,3 +19,4 @@ skip:
 # to disc though, but the first part is very time consuming.
 exclude:
   - _references
+  - assets/mesh


### PR DESCRIPTION
## Description

Add support for generating specific pages by setting the env variable `PAGE_PATHS`

It accepts a comma-separated list of paths. For example:

```
PAGE_PATHS="/plugins/acme/,/gateway/entities/" make run
```

This generates all pages that match each specified path. For instance, `/gateway/entities/` will generate all pages whose paths start with `/gateway/entities/`.


NOTE: this skips some checks we have in dev (breadcrumbs and related resource MUST exist) that will fail in production and preview apps, but I think it's a good tradeoff for the sake of performance.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
