### PR TITLE
fix(kong-conf): regenerate kong-conf fields after fixing source

### DIFF
--- a/app/_data/kong-conf/3.10.json
+++ b/app/_data/kong-conf/3.10.json
@@ -457,6 +457,11 @@
       "description": "Size of each of the two shared memory caches\nfor traditional mode database entities\nand runtime data, `kong_core_cache` and\n`kong_cache`.\n\nThe accepted units are `k` and `m`, with a minimum\nrecommended value of a few MBs.\n\n**Note**: As this option controls the size of two\ndifferent cache zones, the total memory Kong\nuses to cache entities might be double this value.\nThe created zones are shared by all worker\nprocesses and do not become larger when more\nworkers are used.\n",
       "sectionTitle": "NGINX"
     },
+    "lru_cache_size": {
+      "defaultValue": "500000",
+      "description": "The maximum number of entries allowed in the two LRU\ncaches on each worker process, used by Kong’s caching\nsystem. The LRU cache is the first-level cache and is\nchecked before the shared caches defined by\n`mem_cache_size`.\n\nLower values can significantly reduce Kong’s memory\nusage, but may result in reduced performance.\n\nThis argument can be set to an integer between 1000\n(thousand) and 1000000 (million).\n\n**Note**: This setting specifies the number of cache\nentries, not the amount of memory. Actual memory usage\ndepends on what is cached and can vary by deployment.\n",
+      "sectionTitle": "NGINX"
+    },
     "consumers_mem_cache_size": {
       "defaultValue": "128m",
       "description": "Size of the shared memory cache for consumers\nand credentials.\n\nThe accepted units are `k` and `m`, with a minimum\nrecommended value of a few MBs.\n\n**Note**: This is only used when the \"externalized consumers\"\nfeature is active.\n",
@@ -1244,6 +1249,11 @@
       "description": "Selects the router implementation to use when\nperforming request routing. Incremental router\nrebuild is available when the flavor is set\nto either `expressions` or\n`traditional_compatible`, which could\nsignificantly shorten rebuild time for a large\nnumber of routes.\n\nAccepted values are:\n\n- `traditional_compatible`: the DSL-based expression\n  router engine will be used under the hood. However,\n  the router config interface will be the same\n  as `traditional`, and expressions are\n  automatically generated at router build time.\n  The `expression` field on the `route` object\n  is not visible.\n- `expressions`: the DSL-based expression router engine\n  will be used under the hood. The traditional router\n  config interface is still visible, and you can also write\n  router Expressions manually and provide them in the\n  `expression` field on the `route` object.\n- `traditional`: the pre-3.0 router engine will be\n  used. The config interface will be the same as\n  pre-3.0 Kong, and the `expression` field on the\n  `route` object is not visible.\n\n  Deprecation warning: In Kong 3.0, `traditional`\n  mode should be avoided and only be used if\n  `traditional_compatible` does not work as expected.\n  This flavor of the router will be removed in the next\n  major release of Kong.\n",
       "sectionTitle": "TUNING & BEHAVIOR"
     },
+    "route_match_calculation": {
+      "defaultValue": "original",
+      "description": "When using the `traditional_compatible` or `expressions`\nrouter flavors, select the router matching calculation\nmethod to use.\n\nAccepted values are:\n- `original`: the default value. It retains the current\n `3.x` router matching behavior without changes.\n- `strict`: enforces the router matching behavior with\ncorrected calculation.\n",
+      "sectionTitle": "TUNING & BEHAVIOR"
+    },
     "lua_max_req_headers": {
       "defaultValue": "100",
       "description": "Maximum number of request headers to parse by default.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request headers,\nand this setting does not have any effect. It is used\nto limit Kong and its plugins from reading too many\nrequest headers.\n",
@@ -1460,6 +1470,11 @@
     "admin_gui_login_banner_body": {
       "defaultValue": null,
       "description": "Sets the body text for the Kong Manager login banner.\nLogin banner is not shown if both\n`admin_gui_login_banner_title` and\n`admin_gui_login_banner_body` are empty.\n",
+      "sectionTitle": "KONG MANAGER"
+    },
+    "admin_gui_hide_konnect_cta": {
+      "defaultValue": "off",
+      "description": "Hides all Konnect call to actions in Kong Manager.\nThis setting is only relevant for on-prem installations\nof Kong Enterprise.\n",
       "sectionTitle": "KONG MANAGER"
     },
     "konnect_mode": {

--- a/app/_data/kong-conf/3.11.json
+++ b/app/_data/kong-conf/3.11.json
@@ -27,115 +27,115 @@
     {
       "title": "NGINX",
       "start": 499,
-      "end": 1151,
+      "end": 1167,
       "description": ""
     },
     {
       "title": "NGINX injected directives",
-      "start": 1152,
-      "end": 1306,
+      "start": 1168,
+      "end": 1322,
       "description": "Nginx directives can be dynamically injected in the runtime nginx.conf file\nwithout requiring a custom Nginx configuration template.\n\nAll configuration properties following the naming scheme\n`nginx_<namespace>_<directive>` will result in `<directive>` being injected in\nthe Nginx configuration block corresponding to the property's `<namespace>`.\nExample:\n`nginx_proxy_large_client_header_buffers = 8 24k`\n\nWill inject the following directive in Kong's proxy `server {}` block:\n\n`large_client_header_buffers 8 24k;`\n\nThe following namespaces are supported:\n\n- `nginx_main_<directive>`: Injects `<directive>` in Kong's configuration\n`main` context.\n- `nginx_events_<directive>`: Injects `<directive>` in Kong's `events {}`\nblock.\n- `nginx_http_<directive>`: Injects `<directive>` in Kong's `http {}` block.\n- `nginx_proxy_<directive>`: Injects `<directive>` in Kong's proxy\n`server {}` block.\n- `nginx_location_<directive>`: Injects `<directive>` in Kong's proxy `/`\nlocation block (nested under Kong's proxy `server {}` block).\n- `nginx_upstream_<directive>`: Injects `<directive>` in Kong's proxy\n`upstream {}` block.\n- `nginx_admin_<directive>`: Injects `<directive>` in Kong's Admin API\n`server {}` block.\n- `nginx_status_<directive>`: Injects `<directive>` in Kong's Status API\n`server {}` block (only effective if `status_listen` is enabled).\n- `nginx_debug_<directive>`: Injects `<directive>` in Kong's Debug API\n`server{}` block (only effective if `debug_listen` or `debug_listen_local`\nis enabled).\n- `nginx_stream_<directive>`: Injects `<directive>` in Kong's stream module\n`stream {}` block (only effective if `stream_listen` is enabled).\n- `nginx_sproxy_<directive>`: Injects `<directive>` in Kong's stream module\n`server {}` block (only effective if `stream_listen` is enabled).\n- `nginx_supstream_<directive>`: Injects `<directive>` in Kong's stream\nmodule `upstream {}` block.\n\nAs with other configuration properties, Nginx directives can be injected via\nenvironment variables when capitalized and prefixed with `KONG_`.\nExample:\n`KONG_NGINX_HTTP_SSL_PROTOCOLS` -> `nginx_http_ssl_protocols`\n\nWill inject the following directive in Kong's `http {}` block:\n\n`ssl_protocols <value>;`\n\nIf different sets of protocols are desired between the proxy and Admin API\nserver, you may specify `nginx_proxy_ssl_protocols` and/or\n`nginx_admin_ssl_protocols`, both of which take precedence over the\n`http {}` block.\n"
     },
     {
       "title": "DATASTORE",
-      "start": 1307,
-      "end": 1589,
+      "start": 1323,
+      "end": 1605,
       "description": "Kong can run with a database to store coordinated data between Kong nodes in\na cluster, or without a database, where each node stores its information\nindependently in memory.\n\nWhen using a database, Kong will store data for all its entities (such as\nroutes, services, consumers, and plugins) in PostgreSQL,\nand all Kong nodes belonging to the same cluster must connect to the same database.\n\nKong supports PostgreSQL versions 9.5 and above.\n\nWhen not using a database, Kong is said to be in \"DB-less mode\": it will keep\nits entities in memory, and each node needs to have this data entered via a\ndeclarative configuration file, which can be specified through the\n`declarative_config` property, or via the Admin API using the `/config`\nendpoint.\n\nWhen using Postgres as the backend storage, you can optionally enable Kong\nto serve read queries from a separate database instance.\nWhen the number of proxies is large, this can greatly reduce the load\non the main Postgres instance and achieve better scalability. It may also\nreduce the latency jitter if the Kong proxy node's latency to the main\nPostgres instance is high.\n\nThe read-only Postgres instance only serves read queries, and write\nqueries still go to the main connection. The read-only Postgres instance\ncan be eventually consistent while replicating changes from the main\ninstance.\n\nAt least the `pg_ro_host` config is needed to enable this feature.\nBy default, all other database config for the read-only connection is\ninherited from the corresponding main connection config described above but\nmay be optionally overwritten explicitly using the `pg_ro_*` config below.\n"
     },
     {
       "title": "DATASTORE CACHE",
-      "start": 1590,
-      "end": 1665,
+      "start": 1606,
+      "end": 1681,
       "description": "In order to avoid unnecessary communication with the datastore, Kong caches\nentities (such as APIs, consumers, credentials...) for a configurable period\nof time. It also handles invalidations if such an entity is updated.\n\nThis section allows for configuring the behavior of Kong regarding the\ncaching of such configuration entities.\n"
     },
     {
       "title": "DNS RESOLVER",
-      "start": 1666,
-      "end": 1747,
+      "start": 1682,
+      "end": 1763,
       "description": "By default, the DNS resolver will use the standard configuration files\n`/etc/hosts` and `/etc/resolv.conf`. The settings in the latter file will be\noverridden by the environment variables `LOCALDOMAIN` and `RES_OPTIONS` if\nthey have been set.\n\nKong will resolve hostnames as either `SRV` or `A` records (in that order, and\n`CNAME` records will be dereferenced in the process).\nIn case a name is resolved as an `SRV` record, it will also override any given\nport number with the `port` field contents received from the DNS server.\n\nThe DNS options `SEARCH` and `NDOTS` (from the `/etc/resolv.conf` file) will\nbe used to expand short names to fully qualified ones. So it will first try\nthe entire `SEARCH` list for the `SRV` type, if that fails it will try the\n`SEARCH` list for `A`, etc.\n\nFor the duration of the `ttl`, the internal DNS resolver will load balance each\nrequest it gets over the entries in the DNS record. For `SRV` records, the\n`weight` fields will be honored, but it will only use the lowest `priority`\nfield entries in the record.\n\nFor DNS records returned with a TTL value of 0, Kong will default to caching\nthese records for 1 second. Strict adherence to the requirement of not caching\nTTL 0 records could generate excessive query frequency to upstream DNS servers,\nleading to unsustainable load and potential service degradation. As a result,\nmost DNS resolver implementations deviate from this requirement in practice.\n"
     },
     {
       "title": "New DNS RESOLVER",
-      "start": 1748,
-      "end": 1846,
+      "start": 1764,
+      "end": 1862,
       "description": "This DNS resolver introduces global caching for DNS records across workers,\nsignificantly reducing the query load on DNS servers.\n\nIt provides observable statistics, you can retrieve them through the Admin API\n`/status/dns`.\n"
     },
     {
       "title": "VAULTS",
-      "start": 1847,
-      "end": 2082,
+      "start": 1863,
+      "end": 2098,
       "description": "A secret is any sensitive piece of information required for API gateway\noperations. Secrets may be part of the core Kong Gateway configuration,\nused in plugins, or part of the configuration associated with APIs serviced\nby the gateway.\n\nSome of the most common types of secrets used by Kong Gateway include:\n\n- Data store usernames and passwords, used with PostgreSQL and Redis\n- Private X.509 certificates\n- API keys\n\nSensitive plugin configuration fields are generally used for authentication,\nhashing, signing, or encryption. Kong Gateway lets you store certain values\nin a vault. Here are the vault specific configuration options.\n"
     },
     {
       "title": "TUNING & BEHAVIOR",
-      "start": 2083,
-      "end": 2219,
+      "start": 2099,
+      "end": 2235,
       "description": ""
     },
     {
       "title": "MISCELLANEOUS",
-      "start": 2220,
-      "end": 2341,
+      "start": 2236,
+      "end": 2357,
       "description": "Additional settings inherited from lua-nginx-module allowing for more\nflexibility and advanced usage.\n\nSee the lua-nginx-module documentation for more information:\nhttps://github.com/openresty/lua-nginx-module\n"
     },
     {
       "title": "KONG MANAGER",
-      "start": 2342,
-      "end": 2617,
+      "start": 2358,
+      "end": 2633,
       "description": "\nThe Admin GUI for Kong Enterprise.\n\n"
     },
     {
       "title": "Konnect",
-      "start": 2618,
-      "end": 2624,
+      "start": 2634,
+      "end": 2639,
       "description": ""
     },
     {
       "title": "Analytics for Konnect",
-      "start": 2625,
-      "end": 2645,
-      "description": ""
-    },
-    {
-      "title": "ADMIN SMTP CONFIGURATION",
-      "start": 2646,
+      "start": 2640,
       "end": 2660,
       "description": ""
     },
     {
-      "title": "GENERAL SMTP CONFIGURATION",
+      "title": "ADMIN SMTP CONFIGURATION",
       "start": 2661,
-      "end": 2711,
+      "end": 2675,
+      "description": ""
+    },
+    {
+      "title": "GENERAL SMTP CONFIGURATION",
+      "start": 2676,
+      "end": 2726,
       "description": ""
     },
     {
       "title": "DATA & ADMIN AUDIT",
-      "start": 2712,
-      "end": 2757,
+      "start": 2727,
+      "end": 2772,
       "description": "When enabled, Kong will store detailed audit data regarding Admin API and\ndatabase access. In most cases, updates to the database are associated with\nAdmin API requests. As such, database object audit log data is tied to a\ngiven HTTP request via a unique identifier, providing built-in association of\nAdmin API and database traffic.\n\n"
     },
     {
       "title": "ROUTE COLLISION DETECTION/PREVENTION",
-      "start": 2758,
-      "end": 2805,
+      "start": 2773,
+      "end": 2820,
       "description": ""
     },
     {
       "title": "DATABASE ENCRYPTION & KEYRING MANAGEMENT",
-      "start": 2806,
-      "end": 3034,
+      "start": 2821,
+      "end": 3049,
       "description": "When enabled, Kong will transparently encrypt sensitive fields, such as consumer\ncredentials, TLS private keys, and RBAC user tokens, among others. A full list\nof encrypted fields is available from the Kong Enterprise documentation site.\nEncrypted data is transparently decrypted before being displayed to the Admin\nAPI or made available to plugins or core routing logic.\n\nWhile this feature is GA, do note that we currently do not provide normal semantic\nversioning compatibility guarantees on the keyring feature's APIs in that Kong may\nmake a breaking change to the feature in a minor version. Also note that\nmismanagement of keyring data may result in irrecoverable data loss.\n\n"
     },
     {
       "title": "CLUSTER FALLBACK CONFIGURATION",
-      "start": 3035,
-      "end": 3082,
+      "start": 3050,
+      "end": 3097,
       "description": ""
     },
     {
       "title": "REQUEST DEBUGGING",
-      "start": 3083,
-      "end": 3145,
+      "start": 3098,
+      "end": 3160,
       "description": "Request debugging is a mechanism that allows admins to collect the timing of\nproxy path requests in the response header (X-Kong-Request-Debug-Output)\nand optionally, the error log.\n\nThis feature provides insights into the time spent within various components of Kong,\nsuch as plugins, DNS resolution, load balancing, and more. It also provides contextual\ninformation such as domain names tried during these processes.\n\n"
     }
   ],
@@ -449,6 +449,11 @@
     "mem_cache_size": {
       "defaultValue": "128m",
       "description": "Size of each of the two shared memory caches\nfor traditional mode database entities\nand runtime data, `kong_core_cache` and\n`kong_cache`.\n\nThe accepted units are `k` and `m`, with a minimum\nrecommended value of a few MBs.\n\n**Note**: As this option controls the size of two\ndifferent cache zones, the total memory Kong\nuses to cache entities might be double this value.\nThe created zones are shared by all worker\nprocesses and do not become larger when more\nworkers are used.\n",
+      "sectionTitle": "NGINX"
+    },
+    "lru_cache_size": {
+      "defaultValue": "500000",
+      "description": "The maximum number of entries allowed in the two LRU\ncaches on each worker process, used by Kong’s caching\nsystem. The LRU cache is the first-level cache and is\nchecked before the shared caches defined by\n`mem_cache_size`.\n\nLower values can significantly reduce Kong’s memory\nusage, but may result in reduced performance.\n\nThis argument can be set to an integer between 1000\n(thousand) and 1000000 (million).\n\n**Note**: This setting specifies the number of cache\nentries, not the amount of memory. Actual memory usage\ndepends on what is cached and can vary by deployment.\n",
       "sectionTitle": "NGINX"
     },
     "consumers_mem_cache_size": {
@@ -1251,6 +1256,11 @@
     "router_flavor": {
       "defaultValue": "traditional_compatible",
       "description": "Selects the router implementation to use when\nperforming request routing. Incremental router\nrebuild is available when the flavor is set\nto either `expressions` or\n`traditional_compatible`, which could\nsignificantly shorten rebuild time for a large\nnumber of routes.\n\nAccepted values are:\n\n- `traditional_compatible`: the DSL-based expression\n  router engine will be used under the hood. However,\n  the router config interface will be the same\n  as `traditional`, and expressions are\n  automatically generated at router build time.\n  The `expression` field on the `route` object\n  is not visible.\n- `expressions`: the DSL-based expression router engine\n  will be used under the hood. The traditional router\n  config interface is still visible, and you can also write\n  router Expressions manually and provide them in the\n  `expression` field on the `route` object.\n- `traditional`: the pre-3.0 router engine will be\n  used. The config interface will be the same as\n  pre-3.0 Kong, and the `expression` field on the\n  `route` object is not visible.\n\n  Deprecation warning: In Kong 3.0, `traditional`\n  mode should be avoided and only be used if\n  `traditional_compatible` does not work as expected.\n  This flavor of the router will be removed in the next\n  major release of Kong.\n",
+      "sectionTitle": "TUNING & BEHAVIOR"
+    },
+    "route_match_calculation": {
+      "defaultValue": "original",
+      "description": "When using the `traditional_compatible` or `expressions`\nrouter flavors, select the router matching calculation\nmethod to use.\n\nAccepted values are:\n- `original`: the default value. It retains the current\n `3.x` router matching behavior without changes.\n- `strict`: enforces the router matching behavior with\ncorrected calculation.\n",
       "sectionTitle": "TUNING & BEHAVIOR"
     },
     "lua_max_req_headers": {

--- a/app/_data/kong-conf/3.12.json
+++ b/app/_data/kong-conf/3.12.json
@@ -27,121 +27,121 @@
     {
       "title": "NGINX",
       "start": 499,
-      "end": 1151,
+      "end": 1167,
       "description": ""
     },
     {
       "title": "NGINX injected directives",
-      "start": 1152,
-      "end": 1306,
+      "start": 1168,
+      "end": 1322,
       "description": "Nginx directives can be dynamically injected in the runtime nginx.conf file\nwithout requiring a custom Nginx configuration template.\n\nAll configuration properties following the naming scheme\n`nginx_<namespace>_<directive>` will result in `<directive>` being injected in\nthe Nginx configuration block corresponding to the property's `<namespace>`.\nExample:\n`nginx_proxy_large_client_header_buffers = 8 24k`\n\nWill inject the following directive in Kong's proxy `server {}` block:\n\n`large_client_header_buffers 8 24k;`\n\nThe following namespaces are supported:\n\n- `nginx_main_<directive>`: Injects `<directive>` in Kong's configuration\n`main` context.\n- `nginx_events_<directive>`: Injects `<directive>` in Kong's `events {}`\nblock.\n- `nginx_http_<directive>`: Injects `<directive>` in Kong's `http {}` block.\n- `nginx_proxy_<directive>`: Injects `<directive>` in Kong's proxy\n`server {}` block.\n- `nginx_location_<directive>`: Injects `<directive>` in Kong's proxy `/`\nlocation block (nested under Kong's proxy `server {}` block).\n- `nginx_upstream_<directive>`: Injects `<directive>` in Kong's proxy\n`upstream {}` block.\n- `nginx_admin_<directive>`: Injects `<directive>` in Kong's Admin API\n`server {}` block.\n- `nginx_status_<directive>`: Injects `<directive>` in Kong's Status API\n`server {}` block (only effective if `status_listen` is enabled).\n- `nginx_debug_<directive>`: Injects `<directive>` in Kong's Debug API\n`server{}` block (only effective if `debug_listen` or `debug_listen_local`\nis enabled).\n- `nginx_stream_<directive>`: Injects `<directive>` in Kong's stream module\n`stream {}` block (only effective if `stream_listen` is enabled).\n- `nginx_sproxy_<directive>`: Injects `<directive>` in Kong's stream module\n`server {}` block (only effective if `stream_listen` is enabled).\n- `nginx_supstream_<directive>`: Injects `<directive>` in Kong's stream\nmodule `upstream {}` block.\n\nAs with other configuration properties, Nginx directives can be injected via\nenvironment variables when capitalized and prefixed with `KONG_`.\nExample:\n`KONG_NGINX_HTTP_SSL_PROTOCOLS` -> `nginx_http_ssl_protocols`\n\nWill inject the following directive in Kong's `http {}` block:\n\n`ssl_protocols <value>;`\n\nIf different sets of protocols are desired between the proxy and Admin API\nserver, you may specify `nginx_proxy_ssl_protocols` and/or\n`nginx_admin_ssl_protocols`, both of which take precedence over the\n`http {}` block.\n"
     },
     {
       "title": "DATASTORE",
-      "start": 1307,
-      "end": 1626,
+      "start": 1323,
+      "end": 1642,
       "description": "Kong can run with a database to store coordinated data between Kong nodes in\na cluster, or without a database, where each node stores its information\nindependently in memory.\n\nWhen using a database, Kong will store data for all its entities (such as\nroutes, services, consumers, and plugins) in PostgreSQL,\nand all Kong nodes belonging to the same cluster must connect to the same database.\n\nKong supports PostgreSQL versions 9.5 and above.\n\nWhen not using a database, Kong is said to be in \"DB-less mode\": it will keep\nits entities in memory, and each node needs to have this data entered via a\ndeclarative configuration file, which can be specified through the\n`declarative_config` property, or via the Admin API using the `/config`\nendpoint.\n\nWhen using Postgres as the backend storage, you can optionally enable Kong\nto serve read queries from a separate database instance.\nWhen the number of proxies is large, this can greatly reduce the load\non the main Postgres instance and achieve better scalability. It may also\nreduce the latency jitter if the Kong proxy node's latency to the main\nPostgres instance is high.\n\nThe read-only Postgres instance only serves read queries, and write\nqueries still go to the main connection. The read-only Postgres instance\ncan be eventually consistent while replicating changes from the main\ninstance.\n\nAt least the `pg_ro_host` config is needed to enable this feature.\nBy default, all other database config for the read-only connection is\ninherited from the corresponding main connection config described above but\nmay be optionally overwritten explicitly using the `pg_ro_*` config below.\n"
     },
     {
       "title": "DATASTORE CACHE",
-      "start": 1627,
-      "end": 1702,
+      "start": 1643,
+      "end": 1718,
       "description": "In order to avoid unnecessary communication with the datastore, Kong caches\nentities (such as APIs, consumers, credentials...) for a configurable period\nof time. It also handles invalidations if such an entity is updated.\n\nThis section allows for configuring the behavior of Kong regarding the\ncaching of such configuration entities.\n"
     },
     {
       "title": "DNS RESOLVER",
-      "start": 1703,
-      "end": 1784,
+      "start": 1719,
+      "end": 1800,
       "description": "By default, the DNS resolver will use the standard configuration files\n`/etc/hosts` and `/etc/resolv.conf`. The settings in the latter file will be\noverridden by the environment variables `LOCALDOMAIN` and `RES_OPTIONS` if\nthey have been set.\n\nKong will resolve hostnames as either `SRV` or `A` records (in that order, and\n`CNAME` records will be dereferenced in the process).\nIn case a name is resolved as an `SRV` record, it will also override any given\nport number with the `port` field contents received from the DNS server.\n\nThe DNS options `SEARCH` and `NDOTS` (from the `/etc/resolv.conf` file) will\nbe used to expand short names to fully qualified ones. So it will first try\nthe entire `SEARCH` list for the `SRV` type, if that fails it will try the\n`SEARCH` list for `A`, etc.\n\nFor the duration of the `ttl`, the internal DNS resolver will load balance each\nrequest it gets over the entries in the DNS record. For `SRV` records, the\n`weight` fields will be honored, but it will only use the lowest `priority`\nfield entries in the record.\n\nFor DNS records returned with a TTL value of 0, Kong will default to caching\nthese records for 1 second. Strict adherence to the requirement of not caching\nTTL 0 records could generate excessive query frequency to upstream DNS servers,\nleading to unsustainable load and potential service degradation. As a result,\nmost DNS resolver implementations deviate from this requirement in practice.\n"
     },
     {
       "title": "New DNS RESOLVER",
-      "start": 1785,
-      "end": 1883,
+      "start": 1801,
+      "end": 1899,
       "description": "This DNS resolver introduces global caching for DNS records across workers,\nsignificantly reducing the query load on DNS servers.\n\nIt provides observable statistics, you can retrieve them through the Admin API\n`/status/dns`.\n"
     },
     {
       "title": "VAULTS",
-      "start": 1884,
-      "end": 2117,
+      "start": 1900,
+      "end": 2133,
       "description": "A secret is any sensitive piece of information required for API gateway\noperations. Secrets may be part of the core Kong Gateway configuration,\nused in plugins, or part of the configuration associated with APIs serviced\nby the gateway.\n\nSome of the most common types of secrets used by Kong Gateway include:\n\n- Data store usernames and passwords, used with PostgreSQL and Redis\n- Private X.509 certificates\n- API keys\n\nSensitive plugin configuration fields are generally used for authentication,\nhashing, signing, or encryption. Kong Gateway lets you store certain values\nin a vault. Here are the vault specific configuration options.\n"
     },
     {
       "title": "AI",
-      "start": 2118,
-      "end": 2123,
+      "start": 2134,
+      "end": 2139,
       "description": ""
     },
     {
       "title": "TUNING & BEHAVIOR",
-      "start": 2124,
-      "end": 2260,
+      "start": 2140,
+      "end": 2276,
       "description": ""
     },
     {
       "title": "MISCELLANEOUS",
-      "start": 2261,
-      "end": 2382,
+      "start": 2277,
+      "end": 2398,
       "description": "Additional settings inherited from lua-nginx-module allowing for more\nflexibility and advanced usage.\n\nSee the lua-nginx-module documentation for more information:\nhttps://github.com/openresty/lua-nginx-module\n"
     },
     {
       "title": "KONG MANAGER",
-      "start": 2383,
-      "end": 2658,
+      "start": 2399,
+      "end": 2674,
       "description": "\nThe Admin GUI for Kong Enterprise.\n\n"
     },
     {
       "title": "Konnect",
-      "start": 2659,
-      "end": 2665,
+      "start": 2675,
+      "end": 2680,
       "description": ""
     },
     {
       "title": "Analytics for Konnect",
-      "start": 2666,
-      "end": 2686,
-      "description": ""
-    },
-    {
-      "title": "ADMIN SMTP CONFIGURATION",
-      "start": 2687,
+      "start": 2681,
       "end": 2701,
       "description": ""
     },
     {
-      "title": "GENERAL SMTP CONFIGURATION",
+      "title": "ADMIN SMTP CONFIGURATION",
       "start": 2702,
-      "end": 2752,
+      "end": 2716,
+      "description": ""
+    },
+    {
+      "title": "GENERAL SMTP CONFIGURATION",
+      "start": 2717,
+      "end": 2767,
       "description": ""
     },
     {
       "title": "DATA & ADMIN AUDIT",
-      "start": 2753,
-      "end": 2798,
+      "start": 2768,
+      "end": 2813,
       "description": "When enabled, Kong will store detailed audit data regarding Admin API and\ndatabase access. In most cases, updates to the database are associated with\nAdmin API requests. As such, database object audit log data is tied to a\ngiven HTTP request via a unique identifier, providing built-in association of\nAdmin API and database traffic.\n\n"
     },
     {
       "title": "ROUTE COLLISION DETECTION/PREVENTION",
-      "start": 2799,
-      "end": 2846,
+      "start": 2814,
+      "end": 2861,
       "description": ""
     },
     {
       "title": "DATABASE ENCRYPTION & KEYRING MANAGEMENT",
-      "start": 2847,
-      "end": 3075,
+      "start": 2862,
+      "end": 3090,
       "description": "When enabled, Kong will transparently encrypt sensitive fields, such as consumer\ncredentials, TLS private keys, and RBAC user tokens, among others. A full list\nof encrypted fields is available from the Kong Enterprise documentation site.\nEncrypted data is transparently decrypted before being displayed to the Admin\nAPI or made available to plugins or core routing logic.\n\nWhile this feature is GA, do note that we currently do not provide normal semantic\nversioning compatibility guarantees on the keyring feature's APIs in that Kong may\nmake a breaking change to the feature in a minor version. Also note that\nmismanagement of keyring data may result in irrecoverable data loss.\n\n"
     },
     {
       "title": "CLUSTER FALLBACK CONFIGURATION",
-      "start": 3076,
-      "end": 3123,
+      "start": 3091,
+      "end": 3138,
       "description": ""
     },
     {
       "title": "REQUEST DEBUGGING",
-      "start": 3124,
-      "end": 3186,
+      "start": 3139,
+      "end": 3201,
       "description": "Request debugging is a mechanism that allows admins to collect the timing of\nproxy path requests in the response header (X-Kong-Request-Debug-Output)\nand optionally, the error log.\n\nThis feature provides insights into the time spent within various components of Kong,\nsuch as plugins, DNS resolution, load balancing, and more. It also provides contextual\ninformation such as domain names tried during these processes.\n\n"
     }
   ],
@@ -455,6 +455,11 @@
     "mem_cache_size": {
       "defaultValue": "128m",
       "description": "Size of each of the two shared memory caches\nfor traditional mode database entities\nand runtime data, `kong_core_cache` and\n`kong_cache`.\n\nThe accepted units are `k` and `m`, with a minimum\nrecommended value of a few MBs.\n\n**Note**: As this option controls the size of two\ndifferent cache zones, the total memory Kong\nuses to cache entities might be double this value.\nThe created zones are shared by all worker\nprocesses and do not become larger when more\nworkers are used.\n",
+      "sectionTitle": "NGINX"
+    },
+    "lru_cache_size": {
+      "defaultValue": "500000",
+      "description": "The maximum number of entries allowed in the two LRU\ncaches on each worker process, used by Kong’s caching\nsystem. The LRU cache is the first-level cache and is\nchecked before the shared caches defined by\n`mem_cache_size`.\n\nLower values can significantly reduce Kong’s memory\nusage, but may result in reduced performance.\n\nThis argument can be set to an integer between 1000\n(thousand) and 1000000 (million).\n\n**Note**: This setting specifies the number of cache\nentries, not the amount of memory. Actual memory usage\ndepends on what is cached and can vary by deployment.\n",
       "sectionTitle": "NGINX"
     },
     "consumers_mem_cache_size": {
@@ -1302,6 +1307,11 @@
     "router_flavor": {
       "defaultValue": "traditional_compatible",
       "description": "Selects the router implementation to use when\nperforming request routing. Incremental router\nrebuild is available when the flavor is set\nto either `expressions` or\n`traditional_compatible`, which could\nsignificantly shorten rebuild time for a large\nnumber of routes.\n\nAccepted values are:\n\n- `traditional_compatible`: the DSL-based expression\n  router engine will be used under the hood. However,\n  the router config interface will be the same\n  as `traditional`, and expressions are\n  automatically generated at router build time.\n  The `expression` field on the `route` object\n  is not visible.\n- `expressions`: the DSL-based expression router engine\n  will be used under the hood. The traditional router\n  config interface is still visible, and you can also write\n  router Expressions manually and provide them in the\n  `expression` field on the `route` object.\n- `traditional`: the pre-3.0 router engine will be\n  used. The config interface will be the same as\n  pre-3.0 Kong, and the `expression` field on the\n  `route` object is not visible.\n\n  Deprecation warning: In Kong 3.0, `traditional`\n  mode should be avoided and only be used if\n  `traditional_compatible` does not work as expected.\n  This flavor of the router will be removed in the next\n  major release of Kong.\n",
+      "sectionTitle": "TUNING & BEHAVIOR"
+    },
+    "route_match_calculation": {
+      "defaultValue": "original",
+      "description": "When using the `traditional_compatible` or `expressions`\nrouter flavors, select the router matching calculation\nmethod to use.\n\nAccepted values are:\n- `original`: the default value. It retains the current\n `3.x` router matching behavior without changes.\n- `strict`: enforces the router matching behavior with\ncorrected calculation.\n",
       "sectionTitle": "TUNING & BEHAVIOR"
     },
     "lua_max_req_headers": {

--- a/app/_data/kong-conf/3.13.json
+++ b/app/_data/kong-conf/3.13.json
@@ -27,121 +27,121 @@
     {
       "title": "NGINX",
       "start": 505,
-      "end": 1157,
+      "end": 1173,
       "description": ""
     },
     {
       "title": "NGINX injected directives",
-      "start": 1158,
-      "end": 1312,
+      "start": 1174,
+      "end": 1328,
       "description": "Nginx directives can be dynamically injected in the runtime nginx.conf file\nwithout requiring a custom Nginx configuration template.\n\nAll configuration properties following the naming scheme\n`nginx_<namespace>_<directive>` will result in `<directive>` being injected in\nthe Nginx configuration block corresponding to the property's `<namespace>`.\nExample:\n`nginx_proxy_large_client_header_buffers = 8 24k`\n\nWill inject the following directive in Kong's proxy `server {}` block:\n\n`large_client_header_buffers 8 24k;`\n\nThe following namespaces are supported:\n\n- `nginx_main_<directive>`: Injects `<directive>` in Kong's configuration\n`main` context.\n- `nginx_events_<directive>`: Injects `<directive>` in Kong's `events {}`\nblock.\n- `nginx_http_<directive>`: Injects `<directive>` in Kong's `http {}` block.\n- `nginx_proxy_<directive>`: Injects `<directive>` in Kong's proxy\n`server {}` block.\n- `nginx_location_<directive>`: Injects `<directive>` in Kong's proxy `/`\nlocation block (nested under Kong's proxy `server {}` block).\n- `nginx_upstream_<directive>`: Injects `<directive>` in Kong's proxy\n`upstream {}` block.\n- `nginx_admin_<directive>`: Injects `<directive>` in Kong's Admin API\n`server {}` block.\n- `nginx_status_<directive>`: Injects `<directive>` in Kong's Status API\n`server {}` block (only effective if `status_listen` is enabled).\n- `nginx_debug_<directive>`: Injects `<directive>` in Kong's Debug API\n`server{}` block (only effective if `debug_listen` or `debug_listen_local`\nis enabled).\n- `nginx_stream_<directive>`: Injects `<directive>` in Kong's stream module\n`stream {}` block (only effective if `stream_listen` is enabled).\n- `nginx_sproxy_<directive>`: Injects `<directive>` in Kong's stream module\n`server {}` block (only effective if `stream_listen` is enabled).\n- `nginx_supstream_<directive>`: Injects `<directive>` in Kong's stream\nmodule `upstream {}` block.\n\nAs with other configuration properties, Nginx directives can be injected via\nenvironment variables when capitalized and prefixed with `KONG_`.\nExample:\n`KONG_NGINX_HTTP_SSL_PROTOCOLS` -> `nginx_http_ssl_protocols`\n\nWill inject the following directive in Kong's `http {}` block:\n\n`ssl_protocols <value>;`\n\nIf different sets of protocols are desired between the proxy and Admin API\nserver, you may specify `nginx_proxy_ssl_protocols` and/or\n`nginx_admin_ssl_protocols`, both of which take precedence over the\n`http {}` block.\n"
     },
     {
       "title": "DATASTORE",
-      "start": 1313,
-      "end": 1649,
+      "start": 1329,
+      "end": 1665,
       "description": "Kong can run with a database to store coordinated data between Kong nodes in\na cluster, or without a database, where each node stores its information\nindependently in memory.\n\nWhen using a database, Kong will store data for all its entities (such as\nroutes, services, consumers, and plugins) in PostgreSQL,\nand all Kong nodes belonging to the same cluster must connect to the same database.\n\nKong supports PostgreSQL versions 9.5 and above.\n\nWhen not using a database, Kong is said to be in \"DB-less mode\": it will keep\nits entities in memory, and each node needs to have this data entered via a\ndeclarative configuration file, which can be specified through the\n`declarative_config` property, or via the Admin API using the `/config`\nendpoint.\n\nWhen using Postgres as the backend storage, you can optionally enable Kong\nto serve read queries from a separate database instance.\nWhen the number of proxies is large, this can greatly reduce the load\non the main Postgres instance and achieve better scalability. It may also\nreduce the latency jitter if the Kong proxy node's latency to the main\nPostgres instance is high.\n\nThe read-only Postgres instance only serves read queries, and write\nqueries still go to the main connection. The read-only Postgres instance\ncan be eventually consistent while replicating changes from the main\ninstance.\n\nAt least the `pg_ro_host` config is needed to enable this feature.\nBy default, all other database config for the read-only connection is\ninherited from the corresponding main connection config described above but\nmay be optionally overwritten explicitly using the `pg_ro_*` config below.\n"
     },
     {
       "title": "DATASTORE CACHE",
-      "start": 1650,
-      "end": 1725,
+      "start": 1666,
+      "end": 1741,
       "description": "In order to avoid unnecessary communication with the datastore, Kong caches\nentities (such as APIs, consumers, credentials...) for a configurable period\nof time. It also handles invalidations if such an entity is updated.\n\nThis section allows for configuring the behavior of Kong regarding the\ncaching of such configuration entities.\n"
     },
     {
       "title": "DNS RESOLVER",
-      "start": 1726,
-      "end": 1807,
+      "start": 1742,
+      "end": 1823,
       "description": "By default, the DNS resolver will use the standard configuration files\n`/etc/hosts` and `/etc/resolv.conf`. The settings in the latter file will be\noverridden by the environment variables `LOCALDOMAIN` and `RES_OPTIONS` if\nthey have been set.\n\nKong will resolve hostnames as either `SRV` or `A` records (in that order, and\n`CNAME` records will be dereferenced in the process).\nIn case a name is resolved as an `SRV` record, it will also override any given\nport number with the `port` field contents received from the DNS server.\n\nThe DNS options `SEARCH` and `NDOTS` (from the `/etc/resolv.conf` file) will\nbe used to expand short names to fully qualified ones. So it will first try\nthe entire `SEARCH` list for the `SRV` type, if that fails it will try the\n`SEARCH` list for `A`, etc.\n\nFor the duration of the `ttl`, the internal DNS resolver will load balance each\nrequest it gets over the entries in the DNS record. For `SRV` records, the\n`weight` fields will be honored, but it will only use the lowest `priority`\nfield entries in the record.\n\nFor DNS records returned with a TTL value of 0, Kong will default to caching\nthese records for 1 second. Strict adherence to the requirement of not caching\nTTL 0 records could generate excessive query frequency to upstream DNS servers,\nleading to unsustainable load and potential service degradation. As a result,\nmost DNS resolver implementations deviate from this requirement in practice.\n"
     },
     {
       "title": "New DNS RESOLVER",
-      "start": 1808,
-      "end": 1906,
+      "start": 1824,
+      "end": 1922,
       "description": "This DNS resolver introduces global caching for DNS records across workers,\nsignificantly reducing the query load on DNS servers.\n\nIt provides observable statistics, you can retrieve them through the Admin API\n`/status/dns`.\n"
     },
     {
       "title": "VAULTS",
-      "start": 1907,
-      "end": 2154,
+      "start": 1923,
+      "end": 2170,
       "description": "A secret is any sensitive piece of information required for API gateway\noperations. Secrets may be part of the core Kong Gateway configuration,\nused in plugins, or part of the configuration associated with APIs serviced\nby the gateway.\n\nSome of the most common types of secrets used by Kong Gateway include:\n\n- Data store usernames and passwords, used with PostgreSQL and Redis\n- Private X.509 certificates\n- API keys\n\nSensitive plugin configuration fields are generally used for authentication,\nhashing, signing, or encryption. Kong Gateway lets you store certain values\nin a vault. Here are the vault specific configuration options.\n"
     },
     {
       "title": "AI",
-      "start": 2155,
-      "end": 2160,
+      "start": 2171,
+      "end": 2176,
       "description": ""
     },
     {
       "title": "TUNING & BEHAVIOR",
-      "start": 2161,
-      "end": 2312,
+      "start": 2177,
+      "end": 2328,
       "description": ""
     },
     {
       "title": "MISCELLANEOUS",
-      "start": 2313,
-      "end": 2434,
+      "start": 2329,
+      "end": 2450,
       "description": "Additional settings inherited from lua-nginx-module allowing for more\nflexibility and advanced usage.\n\nSee the lua-nginx-module documentation for more information:\nhttps://github.com/openresty/lua-nginx-module\n"
     },
     {
       "title": "KONG MANAGER",
-      "start": 2435,
-      "end": 2710,
+      "start": 2451,
+      "end": 2726,
       "description": "\nThe Admin GUI for Kong Enterprise.\n\n"
     },
     {
       "title": "Konnect",
-      "start": 2711,
-      "end": 2717,
+      "start": 2727,
+      "end": 2732,
       "description": ""
     },
     {
       "title": "Analytics for Konnect",
-      "start": 2718,
-      "end": 2738,
-      "description": ""
-    },
-    {
-      "title": "ADMIN SMTP CONFIGURATION",
-      "start": 2739,
+      "start": 2733,
       "end": 2753,
       "description": ""
     },
     {
-      "title": "GENERAL SMTP CONFIGURATION",
+      "title": "ADMIN SMTP CONFIGURATION",
       "start": 2754,
-      "end": 2804,
+      "end": 2768,
+      "description": ""
+    },
+    {
+      "title": "GENERAL SMTP CONFIGURATION",
+      "start": 2769,
+      "end": 2819,
       "description": ""
     },
     {
       "title": "DATA & ADMIN AUDIT",
-      "start": 2805,
-      "end": 2850,
+      "start": 2820,
+      "end": 2865,
       "description": "When enabled, Kong will store detailed audit data regarding Admin API and\ndatabase access. In most cases, updates to the database are associated with\nAdmin API requests. As such, database object audit log data is tied to a\ngiven HTTP request via a unique identifier, providing built-in association of\nAdmin API and database traffic.\n\n"
     },
     {
       "title": "ROUTE COLLISION DETECTION/PREVENTION",
-      "start": 2851,
-      "end": 2898,
+      "start": 2866,
+      "end": 2913,
       "description": ""
     },
     {
       "title": "DATABASE ENCRYPTION & KEYRING MANAGEMENT",
-      "start": 2899,
-      "end": 3127,
+      "start": 2914,
+      "end": 3142,
       "description": "When enabled, Kong will transparently encrypt sensitive fields, such as consumer\ncredentials, TLS private keys, and RBAC user tokens, among others. A full list\nof encrypted fields is available from the Kong Enterprise documentation site.\nEncrypted data is transparently decrypted before being displayed to the Admin\nAPI or made available to plugins or core routing logic.\n\nWhile this feature is GA, do note that we currently do not provide normal semantic\nversioning compatibility guarantees on the keyring feature's APIs in that Kong may\nmake a breaking change to the feature in a minor version. Also note that\nmismanagement of keyring data may result in irrecoverable data loss.\n\n"
     },
     {
       "title": "CLUSTER FALLBACK CONFIGURATION",
-      "start": 3128,
-      "end": 3187,
+      "start": 3143,
+      "end": 3202,
       "description": ""
     },
     {
       "title": "REQUEST DEBUGGING",
-      "start": 3188,
-      "end": 3250,
+      "start": 3203,
+      "end": 3265,
       "description": "Request debugging is a mechanism that allows admins to collect the timing of\nproxy path requests in the response header (X-Kong-Request-Debug-Output)\nand optionally, the error log.\n\nThis feature provides insights into the time spent within various components of Kong,\nsuch as plugins, DNS resolution, load balancing, and more. It also provides contextual\ninformation such as domain names tried during these processes.\n\n"
     }
   ],
@@ -460,6 +460,11 @@
     "mem_cache_size": {
       "defaultValue": "128m",
       "description": "Size of each of the two shared memory caches\nfor traditional mode database entities\nand runtime data, `kong_core_cache` and\n`kong_cache`.\n\nThe accepted units are `k` and `m`, with a minimum\nrecommended value of a few MBs.\n\n**Note**: As this option controls the size of two\ndifferent cache zones, the total memory Kong\nuses to cache entities might be double this value.\nThe created zones are shared by all worker\nprocesses and do not become larger when more\nworkers are used.\n",
+      "sectionTitle": "NGINX"
+    },
+    "lru_cache_size": {
+      "defaultValue": "500000",
+      "description": "The maximum number of entries allowed in the two LRU\ncaches on each worker process, used by Kong’s caching\nsystem. The LRU cache is the first-level cache and is\nchecked before the shared caches defined by\n`mem_cache_size`.\n\nLower values can significantly reduce Kong’s memory\nusage, but may result in reduced performance.\n\nThis argument can be set to an integer between 1000\n(thousand) and 1000000 (million).\n\n**Note**: This setting specifies the number of cache\nentries, not the amount of memory. Actual memory usage\ndepends on what is cached and can vary by deployment.\n",
       "sectionTitle": "NGINX"
     },
     "consumers_mem_cache_size": {
@@ -1386,7 +1391,7 @@
     },
     "via_header_comply_rfc": {
       "defaultValue": "off",
-      "description": "When enabled, the `Via` header added by Kong\nto proxied requests and responses will not\ninclude the Kong version number (like `1.1 kong`).\nPreviously `Via` header includes dashes `-` in it\n(like `1.1 kong/3.13.0.0-enterprise-edition`),\nwhich is not allowed by RFC 9001 and may cause\nissues with some HTTP servers.\n",
+      "description": "When enabled, the `Via` header added by Kong\nto proxied requests and responses will not\ninclude the Kong version number (like `1.1 kong`).\nPreviously `Via` header includes slash `/` in it\n(like `1.1 kong/3.13.0.0-enterprise-edition`),\nwhich is not allowed by RFC 9110 and may cause\nissues with some HTTP servers.\n",
       "sectionTitle": "TUNING & BEHAVIOR"
     },
     "lua_ssl_trusted_certificate": {

--- a/app/_data/kong-conf/3.14.json
+++ b/app/_data/kong-conf/3.14.json
@@ -1564,6 +1564,11 @@
       "description": "Selects the router implementation to use when\nperforming request routing. Incremental router\nrebuild is available when the flavor is set\nto either `expressions` or\n`traditional_compatible`, which could\nsignificantly shorten rebuild time for a large\nnumber of routes.\n\nAccepted values are:\n\n- `traditional_compatible`: the DSL-based expression\n  router engine will be used under the hood. However,\n  the router config interface will be the same\n  as `traditional`, and expressions are\n  automatically generated at router build time.\n  The `expression` field on the `route` object\n  is not visible.\n- `expressions`: the DSL-based expression router engine\n  will be used under the hood. The traditional router\n  config interface is still visible, and you can also write\n  router Expressions manually and provide them in the\n  `expression` field on the `route` object.\n- `traditional`: the pre-3.0 router engine will be\n  used. The config interface will be the same as\n  pre-3.0 Kong, and the `expression` field on the\n  `route` object is not visible.\n\n  Deprecation warning: In Kong 3.0, `traditional`\n  mode should be avoided and only be used if\n  `traditional_compatible` does not work as expected.\n  This flavor of the router will be removed in the next\n  major release of Kong.\n",
       "sectionTitle": "TUNING & BEHAVIOR"
     },
+    "route_match_calculation": {
+      "defaultValue": "original",
+      "description": "When using the `traditional_compatible` or `expressions`\nrouter flavors, select the router matching calculation\nmethod to use.\n\nAccepted values are:\n- `original`: the default value. It retains the current\n `3.x` router matching behavior without changes.\n- `strict`: enforces the router matching behavior with\ncorrected calculation.\n",
+      "sectionTitle": "TUNING & BEHAVIOR"
+    },
     "lua_max_req_headers": {
       "defaultValue": "100",
       "description": "Maximum number of request headers to parse by default.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request headers,\nand this setting does not have any effect. It is used\nto limit Kong and its plugins from reading too many\nrequest headers.\n",

--- a/app/_data/kong-conf/3.4.json
+++ b/app/_data/kong-conf/3.4.json
@@ -15,151 +15,151 @@
     {
       "title": "HYBRID MODE DATA PLANE",
       "start": 402,
-      "end": 444,
+      "end": 439,
       "description": ""
     },
     {
       "title": "HYBRID MODE CONTROL PLANE",
-      "start": 445,
-      "end": 520,
+      "start": 440,
+      "end": 515,
       "description": ""
     },
     {
       "title": "NGINX",
-      "start": 521,
-      "end": 1128,
+      "start": 516,
+      "end": 1123,
       "description": ""
     },
     {
       "title": "NGINX injected directives",
-      "start": 1129,
-      "end": 1279,
+      "start": 1124,
+      "end": 1274,
       "description": "Nginx directives can be dynamically injected in the runtime nginx.conf file\nwithout requiring a custom Nginx configuration template.\n\nAll configuration properties respecting the naming scheme\n`nginx_<namespace>_<directive>` will result in `<directive>` being injected in\nthe Nginx configuration block corresponding to the property's `<namespace>`.\nExample:\n`nginx_proxy_large_client_header_buffers = 8 24k`\n\nWill inject the following directive in Kong's proxy `server {}` block:\n\n`large_client_header_buffers 8 24k;`\n\nThe following namespaces are supported:\n\n- `nginx_main_<directive>`: Injects `<directive>` in Kong's configuration\n`main` context.\n- `nginx_events_<directive>`: Injects `<directive>` in Kong's `events {}`\nblock.\n- `nginx_http_<directive>`: Injects `<directive>` in Kong's `http {}` block.\n- `nginx_proxy_<directive>`: Injects `<directive>` in Kong's proxy\n`server {}` block.\n- `nginx_upstream_<directive>`: Injects `<directive>` in Kong's proxy\n`upstream {}` block.\n- `nginx_admin_<directive>`: Injects `<directive>` in Kong's Admin API\n`server {}` block.\n- `nginx_status_<directive>`: Injects `<directive>` in Kong's Status API\n`server {}` block  (only effective if `status_listen` is enabled).\n- `nginx_debug_<directive>`: Injects `<directive>` in Kong's Debug API\n`server {}` block  (only effective if `debug_listen` is enabled).\n- `nginx_stream_<directive>`: Injects `<directive>` in Kong's stream module\n`stream {}` block (only effective if `stream_listen` is enabled).\n- `nginx_sproxy_<directive>`: Injects `<directive>` in Kong's stream module\n`server {}` block (only effective if `stream_listen` is enabled).\n- `nginx_supstream_<directive>`: Injects `<directive>` in Kong's stream\nmodule `upstream {}` block.\n\nAs with other configuration properties, Nginx directives can be injected via\nenvironment variables when capitalized and prefixed with `KONG_`.\nExample:\n`KONG_NGINX_HTTP_SSL_PROTOCOLS` -> `nginx_http_ssl_protocols`\n\nWill inject the following directive in Kong's `http {}` block:\n\n`ssl_protocols <value>;`\n\nIf different sets of protocols are desired between the proxy and Admin API\nserver, you may specify `nginx_proxy_ssl_protocols` and/or\n`nginx_admin_ssl_protocols`, both of which taking precedence over the\n`http {}` block.\n"
     },
     {
       "title": "DATASTORE",
-      "start": 1280,
-      "end": 1563,
+      "start": 1275,
+      "end": 1558,
       "description": "Kong can run with a database to store coordinated data between Kong nodes in\na cluster, or without a database, where each node stores its information\nindependently in memory.\n\nWhen using a database, Kong will store data for all its entities (such as\nRoutes, Services, Consumers, and Plugins) in PostgreSQL,\nand all Kong nodes belonging to the same cluster must connect themselves\nto the same database.\n\nKong supports PostgreSQL versions 9.5 and above.\n\nWhen not using a database, Kong is said to be in \"DB-less mode\": it will keep\nits entities in memory, and each node needs to have this data entered via a\ndeclarative configuration file, which can be specified through the\n`declarative_config` property, or via the Admin API using the `/config`\nendpoint.\n\nWhen using Postgres as the backend storage, you can optionally enable Kong\nto serve read queries from a separate database instance.\nWhen the number of proxies is large, this can greatly reduce the load\non the main Postgres instance and achieve better scalability. It may also\nreduce the latency jitter if the Kong proxy node's latency to the main\nPostgres instance is high.\n\nThe read-only Postgres instance only serves read queries and write\nqueries still goes to the main connection. The read-only Postgres instance\ncan be eventually consistent while replicating changes from the main\ninstance.\n\nAt least the `pg_ro_host` config is needed to enable this feature.\nBy default, all other database config for the read-only connection are\ninherited from the corresponding main connection config described above but\nmay be optionally overwritten explicitly using the `pg_ro_*` config below.\n"
     },
     {
       "title": "DATASTORE CACHE",
-      "start": 1564,
-      "end": 1640,
+      "start": 1559,
+      "end": 1635,
       "description": "In order to avoid unnecessary communication with the datastore, Kong caches\nentities (such as APIs, Consumers, Credentials...) for a configurable period\nof time. It also handles invalidations if such an entity is updated.\n\nThis section allows for configuring the behavior of Kong regarding the\ncaching of such configuration entities.\n"
     },
     {
       "title": "DNS RESOLVER",
-      "start": 1641,
-      "end": 1716,
+      "start": 1636,
+      "end": 1711,
       "description": "By default, the DNS resolver will use the standard configuration files\n`/etc/hosts` and `/etc/resolv.conf`. The settings in the latter file will be\noverridden by the environment variables `LOCALDOMAIN` and `RES_OPTIONS` if\nthey have been set.\n\nKong will resolve hostnames as either `SRV` or `A` records (in that order, and\n`CNAME` records will be dereferenced in the process).\nIn case a name was resolved as an `SRV` record it will also override any given\nport number by the `port` field contents received from the DNS server.\n\nThe DNS options `SEARCH` and `NDOTS` (from the `/etc/resolv.conf` file) will\nbe used to expand short names to fully qualified ones. So it will first try\nthe entire `SEARCH` list for the `SRV` type, if that fails it will try the\n`SEARCH` list for `A`, etc.\n\nFor the duration of the `ttl`, the internal DNS resolver will loadbalance each\nrequest it gets over the entries in the DNS record. For `SRV` records the\n`weight` fields will be honored, but it will only use the lowest `priority`\nfield entries in the record.\n"
     },
     {
       "title": "VAULTS",
-      "start": 1717,
-      "end": 1942,
+      "start": 1712,
+      "end": 1937,
       "description": "A secret is any sensitive piece of information required for API gateway\noperations. Secrets may be part of the core Kong Gateway configuration,\nused in plugins, or part of the configuration associated with APIs serviced\nby the gateway.\n\nSome of the most common types of secrets used by Kong Gateway include:\n\n- Data store usernames and passwords, used with PostgreSQL and Redis\n- Private X.509 certificates\n- API keys\n\nSensitive plugin configuration fields are generally used for authentication,\nhashing, signing, or encryption. Kong Gateway lets you store certain values\nin a vault. Here are the vault specific configuration options.\n"
     },
     {
       "title": "TUNING & BEHAVIOR",
-      "start": 1943,
-      "end": 2063,
+      "start": 1938,
+      "end": 2068,
       "description": ""
     },
     {
       "title": "MISCELLANEOUS",
-      "start": 2064,
-      "end": 2184,
+      "start": 2069,
+      "end": 2189,
       "description": "Additional settings inherited from lua-nginx-module allowing for more\nflexibility and advanced usage.\n\nSee the lua-nginx-module documentation for more information:\nhttps://github.com/openresty/lua-nginx-module\n"
     },
     {
       "title": "KONG MANAGER",
-      "start": 2185,
-      "end": 2414,
+      "start": 2190,
+      "end": 2419,
       "description": "\nThe Admin GUI for Kong Enterprise.\n\n"
     },
     {
       "title": "VITALS",
-      "start": 2415,
-      "end": 2480,
+      "start": 2420,
+      "end": 2485,
       "description": ""
     },
     {
       "title": "Konnect",
-      "start": 2481,
-      "end": 2487,
+      "start": 2486,
+      "end": 2492,
       "description": ""
     },
     {
       "title": "Analytics for Konnect",
-      "start": 2488,
-      "end": 2498,
+      "start": 2493,
+      "end": 2503,
       "description": ""
     },
     {
       "title": "DEVELOPER PORTAL",
-      "start": 2499,
-      "end": 2731,
+      "start": 2504,
+      "end": 2736,
       "description": ""
     },
     {
       "title": "DEFAULT DEVELOPER PORTAL AUTHENTICATION",
-      "start": 2732,
-      "end": 2848,
+      "start": 2737,
+      "end": 2853,
       "description": "Referenced on workspace creation to set Dev Portal authentication defaults\nin the database for that particular workspace.\n\n"
     },
     {
       "title": "DEFAULT PORTAL SMTP CONFIGURATION",
-      "start": 2849,
-      "end": 3037,
+      "start": 2854,
+      "end": 3042,
       "description": "Referenced on workspace creation to set SMTP defaults in the database\nfor that particular workspace.\n\n"
     },
     {
       "title": "ADMIN SMTP CONFIGURATION",
-      "start": 3038,
-      "end": 3052,
+      "start": 3043,
+      "end": 3057,
       "description": ""
     },
     {
       "title": "GENERAL SMTP CONFIGURATION",
-      "start": 3053,
-      "end": 3103,
+      "start": 3058,
+      "end": 3108,
       "description": ""
     },
     {
       "title": "DATA & ADMIN AUDIT",
-      "start": 3104,
-      "end": 3149,
+      "start": 3109,
+      "end": 3154,
       "description": "When enabled, Kong will store detailed audit data regarding Admin API and\ndatabase access. In most cases, updates to the database are associated with\nAdmin API requests. As such, database object audit log data is tied to a\ngiven HTTP via a unique identifier, providing built-in association of Admin\nAPI and database traffic.\n\n"
     },
     {
       "title": "GRANULAR TRACING",
-      "start": 3150,
-      "end": 3256,
+      "start": 3155,
+      "end": 3261,
       "description": "{:.warning}\n> **Deprecation warning**: Granular tracing is deprecated. This means the feature will eventually be removed.\nOur target for Granular tracing removal is the Kong Gateway 4.0 release.\n\nGranular tracing offers a mechanism to expose metrics and detailed debug data\nabout the lifecycle of Kong in a human- or machine-consumable format.\n\n"
     },
     {
       "title": "ROUTE COLLISION DETECTION/PREVENTION",
-      "start": 3257,
-      "end": 3292,
+      "start": 3262,
+      "end": 3297,
       "description": ""
     },
     {
       "title": "DATABASE ENCRYPTION & KEYRING MANAGEMENT",
-      "start": 3293,
-      "end": 3543,
+      "start": 3298,
+      "end": 3548,
       "description": "When enabled, Kong will transparently encrypt sensitive fields, such as Consumer\ncredentials, TLS private keys, and RBAC user tokens, among others. A full list\nof encrypted fields is available from the Kong Enterprise documentation site.\nEncrypted data is transparently decrypted before being displayed to the Admin\nAPI or made available to plugins or core routing logic.\n\nWhile this feature is GA, do note that we currently do not provide normal semantic\nversioning compatibility guarantees on the keyring feature's APIs in that Kong may\nmake a breaking change to the feature in a minor version. Also note that\nmis-management of keyring data may result in irrecoverable data loss.\n\n"
     },
     {
       "title": "WASM",
-      "start": 3544,
-      "end": 3655,
+      "start": 3549,
+      "end": 3660,
       "description": ""
     },
     {
       "title": "REQUEST DEBUGGING",
-      "start": 3656,
-      "end": 3713,
+      "start": 3661,
+      "end": 3718,
       "description": "Request debugging is a mechanism that allows admin to collect the timing of\nproxy path request in the response header (X-Kong-Request-Debug-Output)\nand optionally, the error log.\n\nThis feature provides insights into the time spent within various components of Kong,\nsuch as plugins, DNS resolution, load balancing, and more. It also provides contextual\ninformation such as domain name tried during these processes.\n\n"
     }
   ],
@@ -366,7 +366,7 @@
     },
     "cluster_dp_labels": {
       "defaultValue": null,
-      "description": "Comma separated list of Labels for the data plane.\nLabels are key-value pairs that provide additional\ncontext information for each DP.\nEach label must be configured as a string in the\nformat `key:value`.\n\nLabels are only compatible with hybrid mode\ndeployments with Kong Konnect (SaaS),\nthis configuration doesn't work with\nself-hosted deployments.\n\nKeys and values follow the AIP standards:\nhttps://kong-aip.netlify.app/aip/129/\n\nExample:\n`deployment:mycloud,region:us-east-1`\n",
+      "description": "Comma separated list of Labels for the data plane.\nLabels are key-value pairs that provide additional\ncontext information for each DP.\nEach label must be configured as a string in the\nformat `key:value`.\n\nKeys and values follow the AIP standards:\nhttps://kong-aip.netlify.app/aip/129/\n\nExample:\n`deployment:mycloud,region:us-east-1`\n",
       "sectionTitle": "HYBRID MODE DATA PLANE"
     },
     "cluster_listen": {
@@ -1192,6 +1192,11 @@
     "router_flavor": {
       "defaultValue": "traditional_compatible",
       "description": "Selects the router implementation to use when\nperforming request routing. Incremental router\nrebuild is available when the flavor is set\nto either `expressions` or\n`traditional_compatible` which could\nsignificantly shorten rebuild time for large\nnumber of routes.\n\nAccepted values are:\n\n- `traditional_compatible`: the DSL based expression\n  router engine will be used under the hood. However\n  the router config interface will be the same\n  as `traditional` and expressions are\n  automatically generated at router build time.\n  The `expression` field on the `Route` object\n  is not visible.\n- `expressions`: the DSL based expression router engine\n  will be used under the hood. Traditional router\n  config interface is not visible and you must write\n  Router Expression manually and provide them in the\n  `expression` field on the `Route` object.\n- `traditional`: the pre-3.0 Router engine will be\n  used. Config interface will be the same as\n  pre-3.0 Kong and the `expression` field on the\n  `Route` object is not visible.\n\n  Deprecation warning: In Kong 3.0, `traditional`\n  mode should be avoided and only be used in case\n  `traditional_compatible` did not work as expected.\n  This flavor of router will be removed in the next\n  major release of Kong.\n",
+      "sectionTitle": "TUNING & BEHAVIOR"
+    },
+    "route_match_calculation": {
+      "defaultValue": "original",
+      "description": "When using the `traditional_compatible` router flavor,\nselect the router matching calculation method to use.\n\nAccepted values are:\n- `original`: the default value. It retains the current\n `3.x` router matching behavior without changes.\n- `strict`: enforces the router matching behavior with\ncorrected calculation.\n",
       "sectionTitle": "TUNING & BEHAVIOR"
     },
     "lua_max_req_headers": {

--- a/app/_data/kong-conf/3.5.json
+++ b/app/_data/kong-conf/3.5.json
@@ -39,109 +39,109 @@
     {
       "title": "DATASTORE",
       "start": 1298,
-      "end": 1547,
+      "end": 1581,
       "description": "Kong can run with a database to store coordinated data between Kong nodes in\na cluster, or without a database, where each node stores its information\nindependently in memory.\n\nWhen using a database, Kong will store data for all its entities (such as\nRoutes, Services, Consumers, and Plugins) in PostgreSQL,\nand all Kong nodes belonging to the same cluster must connect themselves\nto the same database.\n\nKong supports PostgreSQL versions 9.5 and above.\n\nWhen not using a database, Kong is said to be in \"DB-less mode\": it will keep\nits entities in memory, and each node needs to have this data entered via a\ndeclarative configuration file, which can be specified through the\n`declarative_config` property, or via the Admin API using the `/config`\nendpoint.\n\nWhen using Postgres as the backend storage, you can optionally enable Kong\nto serve read queries from a separate database instance.\nWhen the number of proxies is large, this can greatly reduce the load\non the main Postgres instance and achieve better scalability. It may also\nreduce the latency jitter if the Kong proxy node's latency to the main\nPostgres instance is high.\n\nThe read-only Postgres instance only serves read queries and write\nqueries still goes to the main connection. The read-only Postgres instance\ncan be eventually consistent while replicating changes from the main\ninstance.\n\nAt least the `pg_ro_host` config is needed to enable this feature.\nBy default, all other database config for the read-only connection are\ninherited from the corresponding main connection config described above but\nmay be optionally overwritten explicitly using the `pg_ro_*` config below.\n"
     },
     {
       "title": "DATASTORE CACHE",
-      "start": 1548,
-      "end": 1624,
+      "start": 1582,
+      "end": 1658,
       "description": "In order to avoid unnecessary communication with the datastore, Kong caches\nentities (such as APIs, Consumers, Credentials...) for a configurable period\nof time. It also handles invalidations if such an entity is updated.\n\nThis section allows for configuring the behavior of Kong regarding the\ncaching of such configuration entities.\n"
     },
     {
       "title": "DNS RESOLVER",
-      "start": 1625,
-      "end": 1700,
+      "start": 1659,
+      "end": 1734,
       "description": "By default, the DNS resolver will use the standard configuration files\n`/etc/hosts` and `/etc/resolv.conf`. The settings in the latter file will be\noverridden by the environment variables `LOCALDOMAIN` and `RES_OPTIONS` if\nthey have been set.\n\nKong will resolve hostnames as either `SRV` or `A` records (in that order, and\n`CNAME` records will be dereferenced in the process).\nIn case a name was resolved as an `SRV` record it will also override any given\nport number by the `port` field contents received from the DNS server.\n\nThe DNS options `SEARCH` and `NDOTS` (from the `/etc/resolv.conf` file) will\nbe used to expand short names to fully qualified ones. So it will first try\nthe entire `SEARCH` list for the `SRV` type, if that fails it will try the\n`SEARCH` list for `A`, etc.\n\nFor the duration of the `ttl`, the internal DNS resolver will loadbalance each\nrequest it gets over the entries in the DNS record. For `SRV` records the\n`weight` fields will be honored, but it will only use the lowest `priority`\nfield entries in the record.\n"
     },
     {
       "title": "VAULTS",
-      "start": 1701,
-      "end": 1914,
+      "start": 1735,
+      "end": 1960,
       "description": "A secret is any sensitive piece of information required for API gateway\noperations. Secrets may be part of the core Kong Gateway configuration,\nused in plugins, or part of the configuration associated with APIs serviced\nby the gateway.\n\nSome of the most common types of secrets used by Kong Gateway include:\n\n- Data store usernames and passwords, used with PostgreSQL and Redis\n- Private X.509 certificates\n- API keys\n\nSensitive plugin configuration fields are generally used for authentication,\nhashing, signing, or encryption. Kong Gateway lets you store certain values\nin a vault. Here are the vault specific configuration options.\n"
     },
     {
       "title": "TUNING & BEHAVIOR",
-      "start": 1915,
-      "end": 2035,
+      "start": 1961,
+      "end": 2081,
       "description": ""
     },
     {
       "title": "MISCELLANEOUS",
-      "start": 2036,
-      "end": 2157,
+      "start": 2082,
+      "end": 2203,
       "description": "Additional settings inherited from lua-nginx-module allowing for more\nflexibility and advanced usage.\n\nSee the lua-nginx-module documentation for more information:\nhttps://github.com/openresty/lua-nginx-module\n"
     },
     {
       "title": "KONG MANAGER",
-      "start": 2158,
-      "end": 2391,
+      "start": 2204,
+      "end": 2437,
       "description": "\nThe Admin GUI for Kong Enterprise.\n\n"
     },
     {
       "title": "Konnect",
-      "start": 2392,
-      "end": 2398,
+      "start": 2438,
+      "end": 2444,
       "description": ""
     },
     {
       "title": "Analytics for Konnect",
-      "start": 2399,
-      "end": 2412,
+      "start": 2445,
+      "end": 2458,
       "description": ""
     },
     {
       "title": "ADMIN SMTP CONFIGURATION",
-      "start": 2413,
-      "end": 2427,
+      "start": 2459,
+      "end": 2473,
       "description": ""
     },
     {
       "title": "GENERAL SMTP CONFIGURATION",
-      "start": 2428,
-      "end": 2478,
+      "start": 2474,
+      "end": 2524,
       "description": ""
     },
     {
       "title": "DATA & ADMIN AUDIT",
-      "start": 2479,
-      "end": 2524,
+      "start": 2525,
+      "end": 2570,
       "description": "When enabled, Kong will store detailed audit data regarding Admin API and\ndatabase access. In most cases, updates to the database are associated with\nAdmin API requests. As such, database object audit log data is tied to a\ngiven HTTP via a unique identifier, providing built-in association of Admin\nAPI and database traffic.\n\n"
     },
     {
       "title": "GRANULAR TRACING",
-      "start": 2525,
-      "end": 2631,
+      "start": 2571,
+      "end": 2677,
       "description": "{:.warning}\n> **Deprecation warning**: Granular tracing is deprecated. This means the feature will eventually be removed.\nOur target for Granular tracing removal is the Kong Gateway 4.0 release.\n\nGranular tracing offers a mechanism to expose metrics and detailed debug data\nabout the lifecycle of Kong in a human- or machine-consumable format.\n\n"
     },
     {
       "title": "ROUTE COLLISION DETECTION/PREVENTION",
-      "start": 2632,
-      "end": 2667,
+      "start": 2678,
+      "end": 2713,
       "description": ""
     },
     {
       "title": "DATABASE ENCRYPTION & KEYRING MANAGEMENT",
-      "start": 2668,
-      "end": 2888,
+      "start": 2714,
+      "end": 2934,
       "description": "When enabled, Kong will transparently encrypt sensitive fields, such as Consumer\ncredentials, TLS private keys, and RBAC user tokens, among others. A full list\nof encrypted fields is available from the Kong Enterprise documentation site.\nEncrypted data is transparently decrypted before being displayed to the Admin\nAPI or made available to plugins or core routing logic.\n\nWhile this feature is GA, do note that we currently do not provide normal semantic\nversioning compatibility guarantees on the keyring feature's APIs in that Kong may\nmake a breaking change to the feature in a minor version. Also note that\nmis-management of keyring data may result in irrecoverable data loss.\n\n"
     },
     {
       "title": "CLUSTER FALLBACK CONFIGURATION",
-      "start": 2889,
-      "end": 2937,
+      "start": 2935,
+      "end": 2983,
       "description": ""
     },
     {
       "title": "WEBASSEMBLY (WASM)",
-      "start": 2938,
-      "end": 3049,
+      "start": 2984,
+      "end": 3095,
       "description": ""
     },
     {
       "title": "REQUEST DEBUGGING",
-      "start": 3050,
-      "end": 3107,
+      "start": 3096,
+      "end": 3153,
       "description": "Request debugging is a mechanism that allows admin to collect the timing of\nproxy path request in the response header (X-Kong-Request-Debug-Output)\nand optionally, the error log.\n\nThis feature provides insights into the time spent within various components of Kong,\nsuch as plugins, DNS resolution, load balancing, and more. It also provides contextual\ninformation such as domain name tried during these processes.\n\n"
     }
   ],
@@ -696,6 +696,21 @@
       "description": "Determines whether the AWS IAM database\nAuthentication will be used. When switch to\n`on`, the username defined in `pg_user` will\nbe used as the database account, and the\ndatabase connection will be forced to using\nTLS. `pg_password` will not be used when\nthe switch is `on`. Note that the corresponding\nIAM policy must be correct, otherwise connecting\nwill fail.\n",
       "sectionTitle": "DATASTORE"
     },
+    "pg_iam_auth_assume_role_arn": {
+      "defaultValue": null,
+      "description": "The target AWS IAM role ARN that will be\nassumed when using AWS IAM database\nauthentication. Typically this is used\nfor operating between multiple roles\nor cross-accounts.\nIf you are not using assume role\nyou should not specify this value.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_iam_auth_role_session_name": {
+      "defaultValue": "KongPostgres",
+      "description": "The role session name used for role\nassuming in AWS IAM Database\nAuthentication. The default value is\n`KongPostgres`.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_iam_auth_sts_endpoint_url": {
+      "defaultValue": null,
+      "description": "The custom STS endpoint URL used for role assuming\nin AWS IAM Database Authentication.\n\nNote that this value will override the default\nSTS endpoint URL(which should be\n`https://sts.amazonaws.com`, or\n`https://sts.<region>.amazonaws.com` if you have\n`AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).\n\nIf you are not using private VPC endpoint for STS\nservice, you should not specify this value.\n",
+      "sectionTitle": "DATASTORE"
+    },
     "pg_database": {
       "defaultValue": "kong",
       "description": "The database name to connect to.\n",
@@ -789,6 +804,21 @@
     "pg_ro_iam_auth": {
       "defaultValue": "<pg_iam_auth>",
       "description": "Same as `pg_iam_auth`, but for the\nread-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_iam_auth_assume_role_arn": {
+      "defaultValue": null,
+      "description": "Same as `pg_iam_auth_assume_role_arn',\nbut for the read-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_iam_auth_role_session_name": {
+      "defaultValue": "KongPostgres",
+      "description": "Same as `pg_iam_auth_role_session_name`,\nbut for the read-only connection.\n",
+      "sectionTitle": "DATASTORE"
+    },
+    "pg_ro_iam_auth_sts_endpoint_url": {
+      "defaultValue": null,
+      "description": "Same as `pg_iam_auth_sts_endpoint_url`,\nbut for the read-only connection.\n",
       "sectionTitle": "DATASTORE"
     },
     "pg_ro_database": {
@@ -969,6 +999,11 @@
     "vault_aws_role_session_name": {
       "defaultValue": "KongVault",
       "description": "The role session name used for role\nassuming. The default value is\n`KongVault`.\n",
+      "sectionTitle": "VAULTS"
+    },
+    "vault_aws_sts_endpoint_url": {
+      "defaultValue": null,
+      "description": "The custom STS endpoint URL used for role assuming\nin AWS Vault.\n\nNote that this value will override the default\nSTS endpoint URL(which should be\n`https://sts.amazonaws.com`, or\n`https://sts.<region>.amazonaws.com` if you have\n`AWS_STS_REGIONAL_ENDPOINTS` set to `regional`).\n\nIf you are not using private VPC endpoint for STS\nservice, you should not specify this value.\n",
       "sectionTitle": "VAULTS"
     },
     "vault_aws_ttl": {

--- a/app/_data/kong-conf/3.8.json
+++ b/app/_data/kong-conf/3.8.json
@@ -1234,6 +1234,11 @@
       "description": "Selects the router implementation to use when\nperforming request routing. Incremental router\nrebuild is available when the flavor is set\nto either `expressions` or\n`traditional_compatible`, which could\nsignificantly shorten rebuild time for a large\nnumber of routes.\n\nAccepted values are:\n\n- `traditional_compatible`: the DSL-based expression\n  router engine will be used under the hood. However,\n  the router config interface will be the same\n  as `traditional`, and expressions are\n  automatically generated at router build time.\n  The `expression` field on the `route` object\n  is not visible.\n- `expressions`: the DSL-based expression router engine\n  will be used under the hood. The traditional router\n  config interface is still visible, and you can also write\n  router Expressions manually and provide them in the\n  `expression` field on the `route` object.\n- `traditional`: the pre-3.0 router engine will be\n  used. The config interface will be the same as\n  pre-3.0 Kong, and the `expression` field on the\n  `route` object is not visible.\n\n  Deprecation warning: In Kong 3.0, `traditional`\n  mode should be avoided and only be used if\n  `traditional_compatible` does not work as expected.\n  This flavor of the router will be removed in the next\n  major release of Kong.\n",
       "sectionTitle": "TUNING & BEHAVIOR"
     },
+    "route_match_calculation": {
+      "defaultValue": "original",
+      "description": "When using the `traditional_compatible` or `expressions`\nrouter flavors, select the router matching calculation\nmethod to use.\n\nAccepted values are:\n- `original`: the default value. It retains the current\n `3.x` router matching behavior without changes.\n- `strict`: enforces the router matching behavior with\ncorrected calculation.\n",
+      "sectionTitle": "TUNING & BEHAVIOR"
+    },
     "lua_max_req_headers": {
       "defaultValue": "100",
       "description": "Maximum number of request headers to parse by default.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request headers,\nand this setting does not have any effect. It is used\nto limit Kong and its plugins from reading too many\nrequest headers.\n",

--- a/app/_data/kong-conf/3.9.json
+++ b/app/_data/kong-conf/3.9.json
@@ -1234,6 +1234,11 @@
       "description": "Selects the router implementation to use when\nperforming request routing. Incremental router\nrebuild is available when the flavor is set\nto either `expressions` or\n`traditional_compatible`, which could\nsignificantly shorten rebuild time for a large\nnumber of routes.\n\nAccepted values are:\n\n- `traditional_compatible`: the DSL-based expression\n  router engine will be used under the hood. However,\n  the router config interface will be the same\n  as `traditional`, and expressions are\n  automatically generated at router build time.\n  The `expression` field on the `route` object\n  is not visible.\n- `expressions`: the DSL-based expression router engine\n  will be used under the hood. The traditional router\n  config interface is still visible, and you can also write\n  router Expressions manually and provide them in the\n  `expression` field on the `route` object.\n- `traditional`: the pre-3.0 router engine will be\n  used. The config interface will be the same as\n  pre-3.0 Kong, and the `expression` field on the\n  `route` object is not visible.\n\n  Deprecation warning: In Kong 3.0, `traditional`\n  mode should be avoided and only be used if\n  `traditional_compatible` does not work as expected.\n  This flavor of the router will be removed in the next\n  major release of Kong.\n",
       "sectionTitle": "TUNING & BEHAVIOR"
     },
+    "route_match_calculation": {
+      "defaultValue": "original",
+      "description": "When using the `traditional_compatible` or `expressions`\nrouter flavors, select the router matching calculation\nmethod to use.\n\nAccepted values are:\n- `original`: the default value. It retains the current\n `3.x` router matching behavior without changes.\n- `strict`: enforces the router matching behavior with\ncorrected calculation.\n",
+      "sectionTitle": "TUNING & BEHAVIOR"
+    },
     "lua_max_req_headers": {
       "defaultValue": "100",
       "description": "Maximum number of request headers to parse by default.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request headers,\nand this setting does not have any effect. It is used\nto limit Kong and its plugins from reading too many\nrequest headers.\n",

--- a/app/_data/kong-conf/index.json
+++ b/app/_data/kong-conf/index.json
@@ -80,8 +80,8 @@
     },
     {
       "title": "VITALS",
-      "start": 2415,
-      "end": 2480,
+      "start": 2420,
+      "end": 2485,
       "description": ""
     },
     {
@@ -98,20 +98,20 @@
     },
     {
       "title": "DEVELOPER PORTAL",
-      "start": 2499,
-      "end": 2731,
+      "start": 2504,
+      "end": 2736,
       "description": ""
     },
     {
       "title": "DEFAULT DEVELOPER PORTAL AUTHENTICATION",
-      "start": 2732,
-      "end": 2848,
+      "start": 2737,
+      "end": 2853,
       "description": "Referenced on workspace creation to set Dev Portal authentication defaults\nin the database for that particular workspace.\n\n"
     },
     {
       "title": "DEFAULT PORTAL SMTP CONFIGURATION",
-      "start": 2849,
-      "end": 3037,
+      "start": 2854,
+      "end": 3042,
       "description": "Referenced on workspace creation to set SMTP defaults in the database\nfor that particular workspace.\n\n"
     },
     {
@@ -1212,6 +1212,11 @@
       "description": "Selects the router implementation to use when\nperforming request routing. Incremental router\nrebuild is available when the flavor is set\nto either `expressions` or\n`traditional_compatible`, which could\nsignificantly shorten rebuild time for a large\nnumber of routes.\n\nAccepted values are:\n\n- `traditional_compatible`: the DSL-based expression\n  router engine will be used under the hood. However,\n  the router config interface will be the same\n  as `traditional`, and expressions are\n  automatically generated at router build time.\n  The `expression` field on the `route` object\n  is not visible.\n- `expressions`: the DSL-based expression router engine\n  will be used under the hood. The traditional router\n  config interface is still visible, and you can also write\n  router Expressions manually and provide them in the\n  `expression` field on the `route` object.\n- `traditional`: the pre-3.0 router engine will be\n  used. The config interface will be the same as\n  pre-3.0 Kong, and the `expression` field on the\n  `route` object is not visible.\n\n  Deprecation warning: In Kong 3.0, `traditional`\n  mode should be avoided and only be used if\n  `traditional_compatible` does not work as expected.\n  This flavor of the router will be removed in the next\n  major release of Kong.\n",
       "sectionTitle": "TUNING & BEHAVIOR"
     },
+    "route_match_calculation": {
+      "defaultValue": "original",
+      "description": "When using the `traditional_compatible` or `expressions`\nrouter flavors, select the router matching calculation\nmethod to use.\n\nAccepted values are:\n- `original`: the default value. It retains the current\n `3.x` router matching behavior without changes.\n- `strict`: enforces the router matching behavior with\ncorrected calculation.\n",
+      "sectionTitle": "TUNING & BEHAVIOR"
+    },
     "lua_max_req_headers": {
       "defaultValue": "100",
       "description": "Maximum number of request headers to parse by default.\n\nThis argument can be set to an integer between 1 and 1000.\n\nWhen proxying, Kong sends all the request headers,\nand this setting does not have any effect. It is used\nto limit Kong and its plugins from reading too many\nrequest headers.\n",
@@ -2139,6 +2144,14 @@
         "gateway": "3.10"
       }
     },
+    "lru_cache_size": {
+      "defaultValue": "500000",
+      "description": "The maximum number of entries allowed in the two LRU\ncaches on each worker process, used by Kong’s caching\nsystem. The LRU cache is the first-level cache and is\nchecked before the shared caches defined by\n`mem_cache_size`.\n\nLower values can significantly reduce Kong’s memory\nusage, but may result in reduced performance.\n\nThis argument can be set to an integer between 1000\n(thousand) and 1000000 (million).\n\n**Note**: This setting specifies the number of cache\nentries, not the amount of memory. Actual memory usage\ndepends on what is cached and can vary by deployment.\n",
+      "sectionTitle": "NGINX",
+      "min_version": {
+        "gateway": "3.10"
+      }
+    },
     "consumers_mem_cache_size": {
       "defaultValue": "128m",
       "description": "Size of the shared memory cache for consumers\nand credentials.\n\nThe accepted units are `k` and `m`, with a minimum\nrecommended value of a few MBs.\n\n**Note**: This is only used when the \"externalized consumers\"\nfeature is active.\n",
@@ -2158,6 +2171,14 @@
     "admin_gui_csp_header_value": {
       "defaultValue": null,
       "description": "The value of the `Content-Security-Policy` (CSP) header for Kong Manager.\n\nThis configuration controls the value of the CSP header when serving\nKong Manager. If omitted or left empty, the default CSP header value\nwill be used.\n\nThis is an advanced configuration intended for cases where the default\nCSP header value does not meet your requirements. Use with caution.\n\nFor more information on the CSP header, see:\nhttps://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy\n",
+      "sectionTitle": "KONG MANAGER",
+      "min_version": {
+        "gateway": "3.10"
+      }
+    },
+    "admin_gui_hide_konnect_cta": {
+      "defaultValue": "off",
+      "description": "Hides all Konnect call to actions in Kong Manager.\nThis setting is only relevant for on-prem installations\nof Kong Enterprise.\n",
       "sectionTitle": "KONG MANAGER",
       "min_version": {
         "gateway": "3.10"
@@ -2191,14 +2212,6 @@
       "defaultValue": "off",
       "description": "When enabled, plugin options stored as vault secrets are\nloaded only when they are first requested. This can improve\nstartup performance when using many vault references. When\ndisabled, all vault secrets are loaded during initialization.\n",
       "sectionTitle": "TUNING & BEHAVIOR",
-      "min_version": {
-        "gateway": "3.11"
-      }
-    },
-    "admin_gui_hide_konnect_cta": {
-      "defaultValue": "off",
-      "description": "Hides all Konnect call to actions in Kong Manager.\nThis setting is only relevant for on-prem installations\nof Kong Enterprise.\n",
-      "sectionTitle": "KONG MANAGER",
       "min_version": {
         "gateway": "3.11"
       }
@@ -2383,14 +2396,6 @@
       "defaultValue": "error",
       "description": "Controls the behavior when a deprecated\n(alias) field and its canonical replacement\nfield are both present in a configuration\nwith mismatched values.\n\nAccepted values are:\n\n- `error`: (default) reject the configuration\n  with a schema violation error, requiring the\n  operator to resolve the conflict before\n  proceeding. This is the recommended setting\n  for most deployments.\n- `warn`: accept the configuration and log a\n  warning instead of rejecting it. When a\n  conflict is detected, the canonical (new)\n  field value always takes precedence over the\n  deprecated alias value.\n\nThis option is intended for deployments with\na large number of legacy plugin configurations\n(e.g. deprecated `timeout` coexisting with\n`connect_timeout` / `read_timeout` /\n`send_timeout`) that cannot be corrected\nprior to upgrading. Setting this to `warn`\nunblocks the upgrade while still surfacing\nthe conflicts in logs for future cleanup.\n",
       "sectionTitle": "GENERAL",
-      "min_version": {
-        "gateway": "3.14"
-      }
-    },
-    "lru_cache_size": {
-      "defaultValue": "500000",
-      "description": "The maximum number of entries allowed in the two LRU\ncaches on each worker process, used by Kong’s caching\nsystem. The LRU cache is the first-level cache and is\nchecked before the shared caches defined by\n`mem_cache_size`.\n\nLower values can significantly reduce Kong’s memory\nusage, but may result in reduced performance.\n\nThis argument can be set to an integer between 1000\n(thousand) and 1000000 (million).\n\n**Note**: This setting specifies the number of cache\nentries, not the amount of memory. Actual memory usage\ndepends on what is cached and can vary by deployment.\n",
-      "sectionTitle": "NGINX",
       "min_version": {
         "gateway": "3.14"
       }


### PR DESCRIPTION
## Description

Reported in slack, there's a filed that didn't followed the pattern so our parser didn't pick it up.
Re-generate the kong-conf files from source after applying the changes.

Note: regenerating everything wasn't really necessary, we could add `min_version` to the fields, but I wanted to double-check if we were missing anything.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
