### PR TITLE
docs(router): add description on route_match_calculation

### DIFF
--- a/app/_gateway_entities/route.md
+++ b/app/_gateway_entities/route.md
@@ -5,7 +5,7 @@ entities:
   - route
 
 description: |
-  A Route uses specific URL patterns and HTTP verbs to match incoming requests and pass them to a Gateway Service. 
+  A Route uses specific URL patterns and HTTP verbs to match incoming requests and pass them to a Gateway Service.
   This determines which upstream services will process a given request.
 
 related_resources:
@@ -55,7 +55,7 @@ tags:
   - routing
 ---
 
-## What is a Route? 
+## What is a Route?
 
 Routes fulfill two responsibilities in {{ site.base_gateway }}:
 
@@ -66,16 +66,16 @@ A Route must be attached to a [Gateway Service](/gateway/entities/service/), and
 
 ## Route and Gateway Service interaction
 
-Routes, in conjunction with [Gateway Services](/gateway/entities/service/), let you expose upstream services to clients with {{site.base_gateway}}. 
+Routes, in conjunction with [Gateway Services](/gateway/entities/service/), let you expose upstream services to clients with {{site.base_gateway}}.
 Routes also allow the same client to access multiple applications and apply different policies based on the Route used.
 
 For example, say you have two client applications that need to access the `example_service` Gateway Service: an internal client and an external client.
-The *external* client should be limited in how often it can query the Gateway Service to avoid a denial of service. 
+The *external* client should be limited in how often it can query the Gateway Service to avoid a denial of service.
 If you apply a rate limit policy to the Gateway Service and the *internal* client calls it, the internal client is also limited. Routes can solve this problem.
 
-In this example, you can create two Routes with different hosts to handle the two clients, say `internal.example.com` and `external.example.com`, and point both of them to `example_service`. 
-You can configure a policy to limit how often the external Route is used. 
-When the external client tries to access the Gateway Service via {{site.base_gateway}} using `external.example.com`, it's rate limited. 
+In this example, you can create two Routes with different hosts to handle the two clients, say `internal.example.com` and `external.example.com`, and point both of them to `example_service`.
+You can configure a policy to limit how often the external Route is used.
+When the external client tries to access the Gateway Service via {{site.base_gateway}} using `external.example.com`, it's rate limited.
 But when the internal client accesses the Gateway Service using {{site.base_gateway}} using `internal.example.com`, the internal client isn't limited.
 
 The following diagram illustrates this example:
@@ -90,7 +90,7 @@ flowchart LR
   B2(Rate Limiting plugin)
   C("`Service (example-service)`")
   D(Upstream service)
-  E(Internal client 
+  E(Internal client
   application)
   F("`Route (internal.example.com)`")
 
@@ -125,7 +125,7 @@ columns:
 rows:
   - usecase: "Rate limiting"
     description: |
-      Use Routes to set different rate limits for clients accessing the upstream service via specific paths, for example `/internal` or `/external`. 
+      Use Routes to set different rate limits for clients accessing the upstream service via specific paths, for example `/internal` or `/external`.
       <br><br>
       [Enable a rate limiting plugin on Routes attached to the Service](/plugins/rate-limiting-advanced/)
   - usecase: "Perform a simple URL rewrite"
@@ -133,7 +133,7 @@ rows:
       Use the Routes entity to rename an endpoint. For example, you can rename your legacy `/api/old/` upstream endpoint to a publicly accessible API endpoint named `/new/api`.
   - usecase: "Perform a complex URL rewrite"
     description: |
-      Use the Routes entity to rewrite a group of paths, such as replacing `/api/<function>/old` with `/new/api/<function>`. 
+      Use the Routes entity to rewrite a group of paths, such as replacing `/api/<function>/old` with `/new/api/<function>`.
       <br><br>
       [Request Transformer Advanced plugin](/plugins/request-transformer-advanced/)
 {% endtable %}
@@ -141,7 +141,7 @@ rows:
 
 ## Configuration formats
 
-{{site.base_gateway}} provides two methods to define Routes: the traditional JSON format, and a more powerful DSL-based expressions format. 
+{{site.base_gateway}} provides two methods to define Routes: the traditional JSON format, and a more powerful DSL-based expressions format.
 The router used is configured via the [`router_flavor`](/gateway/configuration/#router-flavor) property in `kong.conf`.
 
 The router you should use depends on your use case and {{site.base_gateway}} version:
@@ -167,13 +167,17 @@ For detailed examples of each, see the dedicated [expressions](/gateway/routing/
 
 ## How routing works
 
-For each incoming request, {{site.base_gateway}} must determine which Gateway Service will handle it based on the Routes that are defined. 
+For each incoming request, {{site.base_gateway}} must determine which Gateway Service will handle it based on the Routes that are defined.
 
 The {{site.base_gateway}} router orders all defined Routes by their [priority](#priority-matching) and uses the highest priority matching Route to [proxy the request](/gateway/traffic-control/proxying/).
 
 ### Priority matching
 
 To maximise performance, the {{site.base_gateway}} router orders all defined Routes by their priority and uses the highest priority matching Route to handle a request. How Routes are prioritized depends on the router mode you're using.
+
+For Routes configured in the traditional JSON format, priority is dynamically calculated based on the [routing criteria](#routing-criteria) (`regex_priority` included) when the [`router_flavor`](/gateway/configuration/#router-flavor) property in `kong.conf` is set to `traditional_compat` or `expressions`. For example, a Route that specifies both `hosts` and `headers` will have a higher priority than one that only specifies `hosts`.
+
+If you find that a Route with lower priority is matched over Routes with higher priority and common [routing criteria](#routing-criteria) (e.g. same `hosts`), try setting the [`route_match_calculation`](/gateway/configuration/#route-match-calculation) property in `kong.conf` to `strict`.
 
 For more information, see the detailed [expressions](/gateway/routing/expressions/#priority-matching) or [traditional](/gateway/routing/traditional/#route-priority) sections.
 
@@ -368,7 +372,7 @@ You can use the following recommendations to increase routing performance:
 
 ## TLS Route configuration
 
-The Routes entity can dynamically serve TLS certificates on a per-connection basis. TLS certificates are managed by two resources: 
+The Routes entity can dynamically serve TLS certificates on a per-connection basis. TLS certificates are managed by two resources:
 
 * [Certificates](/gateway/entities/certificate/)
 * [SNIs](/gateway/entities/sni/)
@@ -380,12 +384,12 @@ type: route
 data:
   name: example-route
   host: "*.tls-example.com"
-  protocols: 
+  protocols:
     - https
     - tls
   paths:
     - "/mock"
-  snis: 
+  snis:
     - "my-sni"
 {% endentity_example %}
 
@@ -394,9 +398,9 @@ In this case, the Certificate is already associated with the SNI, so by default 
 ### Proxying TLS passthrough traffic
 
 {{site.base_gateway}} supports TLS passthrough. {{site.base_gateway}} uses the connecting SNI extension to find the matching Route and Service when forwarding a TLS request upstream.
-The Route configuration to proxy TLS traffic is unique to every deployment, but the two main configuration variables are: 
+The Route configuration to proxy TLS traffic is unique to every deployment, but the two main configuration variables are:
 
-* Create a Route with the `tls_passthrough` protocol and assign an SNI. 
+* Create a Route with the `tls_passthrough` protocol and assign an SNI.
 * Create a Service, associated with the Route, with the protocol set to `tcp`.
 
 ## Set up a Route

--- a/app/_gateway_entities/route.md
+++ b/app/_gateway_entities/route.md
@@ -177,7 +177,7 @@ To maximise performance, the {{site.base_gateway}} router orders all defined Rou
 
 For Routes configured in the traditional JSON format, priority is dynamically calculated based on the [routing criteria](#routing-criteria) (`regex_priority` included) when the [`router_flavor`](/gateway/configuration/#router-flavor) property in `kong.conf` is set to `traditional_compat` or `expressions`. For example, a Route that specifies both `hosts` and `headers` will have a higher priority than one that only specifies `hosts`.
 
-If you find that a Route with lower priority is matched over Routes with higher priority and common [routing criteria](#routing-criteria) (e.g. same `hosts`), try setting the [`route_match_calculation`](/gateway/configuration/#route-match-calculation) property in `kong.conf` to `strict`.
+If you find that a Route with lower priority is matched over Routes with higher priority and common [routing criteria](#routing-criteria) (for example, same `hosts`), try setting the [`route_match_calculation`](/gateway/configuration/#route-match-calculation) property in `kong.conf` to `strict`.
 
 For more information, see the detailed [expressions](/gateway/routing/expressions/#priority-matching) or [traditional](/gateway/routing/traditional/#route-priority) sections.
 

--- a/app/gateway/routing/expressions.md
+++ b/app/gateway/routing/expressions.md
@@ -129,6 +129,9 @@ priority: 50
 It's also best to reduce the number of `Route` entities created by leveraging the
 logical combination capability of the expressions language.
 
+If you find that a Route with lower priority is matched over Routes with higher priority and common [routing criteria](/gateway/entities/route/#routing-criteria) (for example, same `hosts`), 
+try setting the [`route_match_calculation`](/gateway/configuration/#route-match-calculation) property in `kong.conf` to `strict`.
+
 ### Combining routes
 
 If multiple routes result in the same `Service` and `Plugin` config being used,

--- a/app/gateway/routing/traditional.md
+++ b/app/gateway/routing/traditional.md
@@ -547,3 +547,6 @@ are listed. Route `A` will be selected over `B` if:
 - `A` has at least one regex path and `B` has only plain paths
 - `A`'s longest path is longer than `B`'s longest path
 - `A.created_at < B.created_at`
+
+If you find that a Route with lower priority is matched over Routes with higher priority and common [routing criteria](/gateway/entities/route/#routing-criteria) (for example, same `hosts`), 
+try setting the [`route_match_calculation`](/gateway/configuration/#route-match-calculation) property in `kong.conf` to `strict`.


### PR DESCRIPTION
## Description

Add the `route_match_calculation` description on routing behavior.

FTI-7435

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
