### PR TITLE
Include Control Plane ID setup for Konnect

### DIFF
--- a/app/_how-tos/operator/operator-get-started-gateway-api-2-create-gateway.md
+++ b/app/_how-tos/operator/operator-get-started-gateway-api-2-create-gateway.md
@@ -50,7 +50,7 @@ prereqs:
 content: |
   First, let's create a `GatewayConfiguration` resource to specify our Hybrid Gateway parameters. Set `spec.konnect.authRef.name` to the name of the `KonnectAPIAuthConfiguration` resource we created in the [prerequisites](#create-a-konnectapiauthconfiguration-resource) and specify your data plane configuration.
 
-1. If you want to create and manage the Control Plane from Kubernetes:
+  ### If you want to create and manage the Control Plane from Kubernetes:
 
   ```bash
   echo '
@@ -72,7 +72,7 @@ content: |
               image: kong/kong-gateway:{{ site.data.gateway_latest.release }}' | kubectl apply -f -
   ```
 
-2. If you already have a Control Plane in Konnect you need to specify the Control Plane ID with:
+  ### If you already have a Control Plane in Konnect you need to specify the Control Plane ID with:
 
   ```bash
   echo '

--- a/app/_how-tos/operator/operator-get-started-gateway-api-2-create-gateway.md
+++ b/app/_how-tos/operator/operator-get-started-gateway-api-2-create-gateway.md
@@ -50,7 +50,9 @@ prereqs:
 content: |
   First, let's create a `GatewayConfiguration` resource to specify our Hybrid Gateway parameters. Set `spec.konnect.authRef.name` to the name of the `KonnectAPIAuthConfiguration` resource we created in the [prerequisites](#create-a-konnectapiauthconfiguration-resource) and specify your data plane configuration.
 
-  ### If you want to create and manage the Control Plane from Kubernetes:
+  ### New control plane
+
+  To create a new control plane managed with Kubernetes, use the following command:
 
   ```bash
   echo '
@@ -72,8 +74,15 @@ content: |
               image: kong/kong-gateway:{{ site.data.gateway_latest.release }}' | kubectl apply -f -
   ```
 
-  ### If you already have a Control Plane in Konnect you need to specify the Control Plane ID with:
+  ### Existing {{site.konnect_short_name}} control plane
 
+  To use a control plane previously created in {{site.konnect_short_name}}, export the control plane ID:
+
+  ```bash
+  export KONNECT_CONTROL_PLANE_ID="YOUR KONNECT CONTROL PLANE ID"
+  ```
+
+  Run the following command:
   ```bash
   echo '
   kind: GatewayConfiguration
@@ -88,7 +97,7 @@ content: |
       source: Mirror
       mirror:
         konnect:
-          id: YOUR-KONNECT-CONTROL-PLANE-ID
+          id: "'$KONNECT_CONTROL_PLANE_ID'"
     dataPlaneOptions:
       deployment:
         podTemplateSpec:

--- a/app/_how-tos/operator/operator-get-started-gateway-api-2-create-gateway.md
+++ b/app/_how-tos/operator/operator-get-started-gateway-api-2-create-gateway.md
@@ -48,7 +48,9 @@ prereqs:
 
 {% konnect %}
 content: |
-  First, let's create a `GatewayConfiguration` resource to specify our Hybrid Gateway parameters. Set `spec.konnect.authRef.name` to the name of the `KonnectAPIAuthConfiguration` resource we created in the [prerequisites](#create-a-konnectapiauthconfiguration-resource) and specify your data plane configuration:
+  First, let's create a `GatewayConfiguration` resource to specify our Hybrid Gateway parameters. Set `spec.konnect.authRef.name` to the name of the `KonnectAPIAuthConfiguration` resource we created in the [prerequisites](#create-a-konnectapiauthconfiguration-resource) and specify your data plane configuration.
+
+1. If you want to create and manage the Control Plane from Kubernetes:
 
   ```bash
   echo '
@@ -70,9 +72,7 @@ content: |
               image: kong/kong-gateway:{{ site.data.gateway_latest.release }}' | kubectl apply -f -
   ```
 
-### Do you already have a Control Plane in Konnect?
-
-If you already have a Control Plane in Konnect you need to specify the Control Plane ID with:
+2. If you already have a Control Plane in Konnect you need to specify the Control Plane ID with:
 
   ```bash
   echo '
@@ -88,7 +88,7 @@ If you already have a Control Plane in Konnect you need to specify the Control P
       source: Mirror
       mirror:
         konnect:
-          id: 876b58fd-ef30-4f29-81d7-792089593f56 # <-- Konnect Control Plane ID
+          id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx # <-- Konnect Control Plane ID
     dataPlaneOptions:
       deployment:
         podTemplateSpec:

--- a/app/_how-tos/operator/operator-get-started-gateway-api-2-create-gateway.md
+++ b/app/_how-tos/operator/operator-get-started-gateway-api-2-create-gateway.md
@@ -88,7 +88,7 @@ content: |
       source: Mirror
       mirror:
         konnect:
-          id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx # <-- Konnect Control Plane ID
+          id: YOUR-KONNECT-CONTROL-PLANE-ID
     dataPlaneOptions:
       deployment:
         podTemplateSpec:

--- a/app/_how-tos/operator/operator-get-started-gateway-api-2-create-gateway.md
+++ b/app/_how-tos/operator/operator-get-started-gateway-api-2-create-gateway.md
@@ -69,6 +69,35 @@ content: |
             - name: proxy
               image: kong/kong-gateway:{{ site.data.gateway_latest.release }}' | kubectl apply -f -
   ```
+
+### Do you already have a Control Plane in Konnect?
+
+If you already have a Control Plane in Konnect you need to specify the Control Plane ID with:
+
+  ```bash
+  echo '
+  kind: GatewayConfiguration
+  apiVersion: gateway-operator.konghq.com/{{ site.operator_gatewayconfiguration_api_version }}
+  metadata:
+    name: kong-configuration
+    namespace: kong
+  spec:
+    konnect:
+      authRef:
+        name: konnect-api-auth
+      source: Mirror
+      mirror:
+        konnect:
+          id: 876b58fd-ef30-4f29-81d7-792089593f56 # <-- Konnect Control Plane ID
+    dataPlaneOptions:
+      deployment:
+        podTemplateSpec:
+          spec:
+            containers:
+            - name: proxy
+              image: kong/kong-gateway:{{ site.data.gateway_latest.release }}' | kubectl apply -f -
+  ```
+
 {% endkonnect %}
 
 {% on_prem %}

--- a/app/_how-tos/operator/operator-get-started-konnect-crds-3-controlplane.md
+++ b/app/_how-tos/operator/operator-get-started-konnect-crds-3-controlplane.md
@@ -45,7 +45,9 @@ Use the `KonnectGatewayControlPlane` resource to define the {{site.konnect_short
 
 Apply the following configuration to define a Control Plane named `gateway-control-plane`:
 
-### If you want to create and manage the Control Plane from Kubernetes:
+### New control plane
+
+To create a new control plane managed with Kubernetes, use the following command:
 
 <!-- vale off -->
 {% konnect_crd %}
@@ -62,8 +64,15 @@ spec:
 {% endkonnect_crd %}
 <!-- vale on -->
 
-### If you already have a Control Plane in Konnect you need to specify the Control Plane ID with:
+### Existing {{site.konnect_short_name}} control plane
 
+To use a control plane previously created in {{site.konnect_short_name}}, export the control plane ID:
+
+```bash
+export KONNECT_CONTROL_PLANE_ID="YOUR KONNECT CONTROL PLANE ID"
+```
+
+Run the following command:
 <!-- vale off -->
 {% konnect_crd %}
 kind: KonnectGatewayControlPlane
@@ -79,7 +88,7 @@ spec:
     source: Mirror
     mirror:
       konnect:
-        id: YOUR-KONNECT-CONTROL-PLANE-ID
+        id: '$KONNECT_CONTROL_PLANE_ID'
 {% endkonnect_crd %}
 <!-- vale on -->
 

--- a/app/_how-tos/operator/operator-get-started-konnect-crds-3-controlplane.md
+++ b/app/_how-tos/operator/operator-get-started-konnect-crds-3-controlplane.md
@@ -45,6 +45,8 @@ Use the `KonnectGatewayControlPlane` resource to define the {{site.konnect_short
 
 Apply the following configuration to define a Control Plane named `gateway-control-plane`:
 
+### If you want to create and manage the Control Plane from Kubernetes:
+
 <!-- vale off -->
 {% konnect_crd %}
 kind: KonnectGatewayControlPlane
@@ -57,6 +59,27 @@ spec:
   konnect:
     authRef:
       name: konnect-api-auth
+{% endkonnect_crd %}
+<!-- vale on -->
+
+### If you already have a Control Plane in Konnect you need to specify the Control Plane ID with:
+
+<!-- vale off -->
+{% konnect_crd %}
+kind: KonnectGatewayControlPlane
+apiVersion: konnect.konghq.com/{{ site.operator_konnectgatewaycontrolplane_api_version }}
+metadata:
+  name: gateway-control-plane
+spec:
+  createControlPlaneRequest:
+    name: gateway-control-plane
+  konnect:
+    authRef:
+      name: konnect-api-auth
+    source: Mirror
+    mirror:
+      konnect:
+        id: YOUR-KONNECT-CONTROL-PLANE-ID
 {% endkonnect_crd %}
 <!-- vale on -->
 


### PR DESCRIPTION
Added instructions for specifying Control Plane ID in Konnect.

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
