### PR TITLE
fix(kapa): Version support tables

### DIFF
--- a/app/_includes/support/mesh.md
+++ b/app/_includes/support/mesh.md
@@ -1,3 +1,4 @@
+<!-- vale off-->
 {% assign releases = site.data.products.mesh.releases %}
 {% table %}
 columns:
@@ -17,3 +18,4 @@ rows:
     eol: "{{release.eol}}"
 {% endfor %}
 {% endtable %}
+<!-- vale on-->

--- a/app/_includes/support/mesh.md
+++ b/app/_includes/support/mesh.md
@@ -10,7 +10,7 @@ columns:
   - title: End of Full Support
     key: eol
 rows:
-{% for release in releases %}
+{% for release in releases reversed %}
   - version: "{{release.release}}.x{% if release.lts %} (LTS){% endif %}"
     patch: "{{release.version}}"
     releaseDate: "{{release.releaseDate}}"

--- a/app/gateway/version-support-policy.md
+++ b/app/gateway/version-support-policy.md
@@ -108,7 +108,6 @@ Kong supports the following versions of {{site.ee_product_name}}:
 {% assign tab_name = release.release %}
 {% if release.lts %}{% assign tab_name = tab_name | append: ' LTS' %}{% endif %}
 {% navtab {{tab_name}} %}
-
 {% assign first_version = release.release | append: ".0.0" %}
 {% assign release_date = site.data.products.gateway.release_dates[first_version] | split: '/' | join: '-' %}
 {% if release_date %}

--- a/app/gateway/version-support-policy.md
+++ b/app/gateway/version-support-policy.md
@@ -108,6 +108,12 @@ Kong supports the following versions of {{site.ee_product_name}}:
 {% assign tab_name = release.release %}
 {% if release.lts %}{% assign tab_name = tab_name | append: ' LTS' %}{% endif %}
 {% navtab {{tab_name}} %}
+
+{% assign first_version = release.release | append: ".0.0" %}
+{% assign release_date = site.data.products.gateway.release_dates[first_version] | split: '/' | join: '-' %}
+{% if release_date %}
+{{site.base_gateway}} version {{first_version}} was first released on {{release_date}}.
+{% endif %}
 {{site.ee_product_name}} {{tab_name}} supports the following deployment targets until {{release.eol}}, unless otherwise noted by an earlier OS vendor end of life (EOL) date.
   {% include support/gateway.html release=release %}
 {% endnavtab %}

--- a/app/mesh/support-policy.md
+++ b/app/mesh/support-policy.md
@@ -36,8 +36,6 @@ columns:
   - title: Planned release date
     key: date
 rows:
-  - version: "2.13"
-    date: January 2026
   - version: "2.17"
     date: January 2027
   - version: "2.21"
@@ -52,7 +50,7 @@ rows:
 > Each year, the first version we release will become an LTS release.
 > Starting from 2.13, we will have 1 LTS release every year, in January of that year.
 > <br><br>
-> Example of planned LTS schedule for next 4 years:
+> Example of planned LTS schedule for next 2 years:
 > {{long_term_support | strip | replace: "
 ", "
 > "}}


### PR DESCRIPTION
## Description

When asked about when 3.14 was released, Kapa looks at the version support policy and can't find the info. This info exists in the changelog, but the changelog is very long and difficult for Kapa to parse, so it prioritizes the support policy.

All of our other products include release dates for each version already, only Gateway is missing this.

Also fixing the Mesh releases table, which was in the wrong order (older release was first) and was still listing 2.13 as a future release, even though it went out earlier this year.

## Preview Links


https://deploy-preview-5100--kongdeveloper.netlify.app/gateway/version-support-policy/
https://deploy-preview-5100--kongdeveloper.netlify.app/mesh/support-policy/
