### PR TITLE
Fix: Update minimum version in ai-proxy.yaml to 3.14 for Vertex batches

### DIFF
--- a/app/_data/plugins/ai-proxy.yaml
+++ b/app/_data/plugins/ai-proxy.yaml
@@ -490,7 +490,7 @@ providers:
       upstream_path: 'Uses `batchPredictionJobs` API'
       route_type: 'llm/v1/batches'
       model_example: 'n/a'
-      min_version: '3.13'
+      min_version: '3.14'
     image:
       generations:
         supported: true


### PR DESCRIPTION
## Description

This appears to have been an error, released in 3.14 not 3.13 for Gemini Vertex, according to the source code. Konnect documentation also has a schema validator page which reflects this too (see https://developer.konghq.com/gateway/data-plane-version-compatibility/ and search for "D554"), suggesting the solution is to upgrade to 3.14.0.0 or above.

Fixes support case #00073161.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
