### PR TITLE
md extension on dev portal pages

### DIFF
--- a/app/_includes/faqs/portal-markdown.md
+++ b/app/_includes/faqs/portal-markdown.md
@@ -3,7 +3,7 @@
 How can agents consume documentation published in a {{site.dev_portal}}?
 {% elsif include.section == "answer" %}
 
-When you send a request to any {{site.dev_portal}} URL using the `Accept: text/markdown` header, it will return LLM-friendly markdown instead of HTML.
+When you send a request to any {{site.dev_portal}} URL using the `Accept: text/markdown` header or adding `.md` to the URL (e.g. `/guides/flights` as `guides/flights.md`), it will return LLM-friendly markdown instead of HTML.
 
 For example:
 ```sh

--- a/app/_includes/faqs/portal-markdown.md
+++ b/app/_includes/faqs/portal-markdown.md
@@ -3,7 +3,7 @@
 How can agents consume documentation published in a {{site.dev_portal}}?
 {% elsif include.section == "answer" %}
 
-When you send a request to any {{site.dev_portal}} URL using the `Accept: text/markdown` header or adding `.md` to the URL (e.g. `/guides/flights` as `guides/flights.md`), it will return LLM-friendly markdown instead of HTML.
+When you send a request to any {{site.dev_portal}} URL using the `Accept: text/markdown` header or adding `.md` to the URL (for example, `/guides/flights` as `/guides/flights.md`), it will return LLM-friendly markdown instead of HTML.
 
 For example:
 ```sh


### PR DESCRIPTION
Updated instructions for consuming documentation to include URL modification for markdown response.

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
