### PR TITLE
fix(dev-portal): markdown fetch example url

### DIFF
--- a/app/_includes/faqs/portal-markdown.md
+++ b/app/_includes/faqs/portal-markdown.md
@@ -7,7 +7,7 @@ When you send a request to any {{site.dev_portal}} URL using the `Accept: text/m
 
 For example:
 ```sh
-curl https://portal.kongair.com/guides/prices \
+curl https://portal.kongair.dev/guides/flights \
   -H "Accept: text/markdown"
 ```
 


### PR DESCRIPTION
## Description

Replaces the example URL from https://github.com/Kong/developer.konghq.com/pull/5158 with a valid URL (working example)

## Preview Links


## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
