### PR TITLE
update docs for ingress2gateway

### DIFF
--- a/app/_how-tos/operator/operator-dataplane-handle-ingress.md
+++ b/app/_how-tos/operator/operator-dataplane-handle-ingress.md
@@ -26,6 +26,9 @@ tldr:
 
 While the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/) is the preferred mechanism for configuring inbound routing, {{ site.operator_product_name }} also supports the [Kubernetes Ingress resource](https://kubernetes.io/docs/concepts/services-networking/ingress/).
 
+
+You can use [ingress2gateway](/kubernetes-ingress-controller/migrate/ingress-to-gateway/) to help with the migration to the Gateway API from Ingress resources.
+
 {% include /k8s/kong-namespace.md %}
 
 ## Create the GatewayConfiguration

--- a/app/_how-tos/operator/operator-dataplane-handle-ingress.md
+++ b/app/_how-tos/operator/operator-dataplane-handle-ingress.md
@@ -27,7 +27,7 @@ tldr:
 While the [Kubernetes Gateway API](https://gateway-api.sigs.k8s.io/) is the preferred mechanism for configuring inbound routing, {{ site.operator_product_name }} also supports the [Kubernetes Ingress resource](https://kubernetes.io/docs/concepts/services-networking/ingress/).
 
 
-You can use [ingress2gateway](/kubernetes-ingress-controller/migrate/ingress-to-gateway/) to help with the migration to the Gateway API from Ingress resources.
+You can use [`ingress2gateway`](/kubernetes-ingress-controller/migrate/ingress-to-gateway/) to migrate from Ingress resources to the Gateway API.
 
 {% include /k8s/kong-namespace.md %}
 


### PR DESCRIPTION
## Description

Point users to ingress2gateway in the Ingress docs.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
