### PR TITLE
fix(kongctl): Remove mentions of kongctl kai

### DIFF
--- a/app/_landing_pages/konnect-platform/kai.yaml
+++ b/app/_landing_pages/konnect-platform/kai.yaml
@@ -59,7 +59,6 @@ rows:
                   The agent can perform smart orchestration and analysis of {{site.konnect_short_name}} data and entities.
                   You can interact with the agent in the following ways:
                   * Use the chat in the {{site.konnect_short_name}} UI by clicking **Ask KAi** on the top right.
-                  * Use the `kongctl` command-line tool with the `kongctl kai` command.
                   * Click **Analyze with KAi** on an individual trace in the [Debugger](/observability/debugger/) to send the trace summary, spans, and logs directly to KAi.
 
                   The KAi agent uses backend LLMs for reasoning and natural language tasks. It also uses a {{site.konnect_short_name}} MCP server to provide information about {{site.konnect_short_name}} and the user's entities and data.
@@ -80,13 +79,12 @@ rows:
                   direction LR
                   LLM["LLM backend"]
                   MCP["Konnect MCP Server"]
-                  KB["Kong Docs & support knowledge base"]
+                  KB["Kong Docs & support <br>knowledge base"]
                 end
 
                 subgraph kai["<b>KAi Agent</b>"]
                   direction LR
                   UI["Konnect UI chat"]
-                  CLI["<code>kongctl kai</code>"]
                 end
 
                 User(("User"))


### PR DESCRIPTION
## Description

Resolving issue where Kapa was suggesting a `kongctl kai` command that doesn't exist. The command was removed a few weeks ago.

## Preview Links
