### PR TITLE
Feat(Platform): add token count to llm-mode and docs

### DIFF
--- a/app/_assets/javascripts/apps/LLMDropdown.vue
+++ b/app/_assets/javascripts/apps/LLMDropdown.vue
@@ -1,5 +1,10 @@
 <template>
-  <div class="relative inline-flex" ref="container">
+  <div class="relative inline-flex items-center gap-2" ref="container">
+    <span
+      v-if="tokenLabel"
+      class="text-xs text-terciary tabular-nums"
+      :title="`Approximate token count for this page (chars / 4)`"
+    >{{ tokenLabel }}</span>
     <div class="inline-flex items-stretch rounded-lg bg-secondary text-sm text-terciary">
       <button
         class="flex items-center gap-2 px-2 py-1.5 hover:bg-hover-component/100 transition-colors rounded-l-lg text-xs border border-primary/10 text-secondary"
@@ -155,6 +160,20 @@ const props = defineProps({
     type: String,
     required: true,
   },
+  tokens: {
+    type: Number,
+    default: null,
+  },
+});
+
+const tokenLabel = computed(() => {
+  if (props.tokens === null || !Number.isFinite(props.tokens) || props.tokens <= 0) {
+    return null;
+  }
+  if (props.tokens >= 1000) {
+    return `~${(props.tokens / 1000).toFixed(props.tokens >= 10000 ? 0 : 1)}K tokens`;
+  }
+  return `~${props.tokens} tokens`;
 });
 
 const isOpen = ref(false);

--- a/app/_assets/javascripts/llm_dropdown.js
+++ b/app/_assets/javascripts/llm_dropdown.js
@@ -2,8 +2,10 @@ import { createApp } from "vue";
 import LLMDropdown from "~/javascripts/apps/LLMDropdown.vue";
 
 document.querySelectorAll(".llm-dropdown-mount").forEach((el) => {
+  const tokens = parseInt(el.dataset.tokens, 10);
   const app = createApp(LLMDropdown, {
     mdUrl: el.dataset.mdUrl.replace(/\/$/, "") + ".md",
+    tokens: Number.isFinite(tokens) ? tokens : null,
   });
   app.mount(el);
 });

--- a/app/_includes/components/llm_dropdown.html
+++ b/app/_includes/components/llm_dropdown.html
@@ -1,1 +1,1 @@
-<div class="llm-dropdown-mount shrink-0 {{include.css_classes}}" data-md-url="{{ include.url }}"></div>
+<div class="llm-dropdown-mount shrink-0 {{include.css_classes}}" data-md-url="{{ include.url }}" data-tokens="{{ include.tokens }}"></div>

--- a/app/_includes/landing_pages/header.md
+++ b/app/_includes/landing_pages/header.md
@@ -3,7 +3,7 @@
 {% if include.config.type == 'h1' %}
 <div class="flex items-center">
 {{heading}}
-{% unless page.llm == false %}{% include components/llm_dropdown.html url=page.url css_classes="ml-auto" %}{% endunless %}
+{% unless page.llm == false %}{% include components/llm_dropdown.html url=page.url tokens=page.tokens css_classes="ml-auto" %}{% endunless %}
 </div>
 {% else %}
 {{heading}}

--- a/app/_includes/layouts/main.html
+++ b/app/_includes/layouts/main.html
@@ -34,7 +34,7 @@
             {% endif %}
 
             {% unless page.llm == false %}
-            {% include components/llm_dropdown.html url=page.url css_classes="lg:ml-auto" %}
+            {% include components/llm_dropdown.html url=page.url tokens=page.tokens css_classes="lg:ml-auto" %}
             {% endunless %}
         </div>
 

--- a/app/_llms.txt
+++ b/app/_llms.txt
@@ -4,30 +4,34 @@
 
 This file lists all available documentation pages as Markdown. Each link points to the LLM-optimized Markdown version of the page. Use this file to discover and fetch content for RAG pipelines, AI agents, or LLM context.
 
+Token counts are approximate (chars / 4) and reflect the rendered Markdown an agent receives.
+
+Total tokens across all pages: ~{{ total_tokens }}
+
 ---
 
 ## API Reference
 
 {% for api in api_pages -%}
-- [{{api.llm_title | liquify}}]({{site.links.web}}{{api.url}}): {{api.description | liquify | oneline | rstrip}}
+- [{{api.llm_title | liquify}}]({{site.links.web}}{{api.url}}) (~{{ api.tokens }} tokens): {{api.description | liquify | oneline | rstrip}}
 {% endfor %}
 
 {% for group in docs -%}
-## {{ group.name }}
+## {{ group.name }} (~{{ group.tokens }} tokens)
 
 {% for p in group.pages -%}
-- [{{ p.llm_title |liquify}}]({{ site.links.web }}{{ p.url }}){% if p.description %}: {{ p.description | liquify | oneline | rstrip}}{% endif %}
+- [{{ p.llm_title |liquify}}]({{ site.links.web }}{{ p.url }}) (~{{ p.tokens }} tokens){% if p.description %}: {{ p.description | liquify | oneline | rstrip}}{% endif %}
 {% endfor %}
 {% endfor %}
 
 ## How-To Guides
 
 {% for p in how_to_pages -%}
-- [{{ p.llm_title | liquify }}]({{ site.links.web }}{{ p.url }}): {{ p.description | liquify | rstrip }}
+- [{{ p.llm_title | liquify }}]({{ site.links.web }}{{ p.url }}) (~{{ p.tokens }} tokens): {{ p.description | liquify | rstrip }}
 {% endfor %}
 
 ## Plugins
 
 {% for p in plugin_pages -%}
-- [{{ p.llm_title | liquify }}]({{ site.links.web }}{{ p.url }}): {{ p.description | liquify | rstrip }}
+- [{{ p.llm_title | liquify }}]({{ site.links.web }}{{ p.url }}) (~{{ p.tokens }} tokens): {{ p.description | liquify | rstrip }}
 {% endfor %}

--- a/app/_plugins/generators/data/token_estimate.rb
+++ b/app/_plugins/generators/data/token_estimate.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module Jekyll
+  module Data
+    class TokenEstimate
+      CHARS_PER_TOKEN = 4
+
+      def self.estimate(text)
+        return 0 if text.nil? || text.empty?
+
+        (text.length / CHARS_PER_TOKEN.to_f).round
+      end
+
+      attr_reader :site, :page
+
+      def initialize(site:, page:)
+        @site = site
+        @page = page
+      end
+
+      def process
+        return if @page.url.start_with?('/assets/')
+        return if @page.data['llm'] == false
+
+        @page.data['tokens'] = self.class.estimate(estimable_text)
+      end
+
+      # Landing pages keep most of their copy in `page.data['rows']` rather than
+      # `page.content`, so fall back to dumping the structured config when the
+      # raw body is sparse. Same trick covers any other YAML-driven page type.
+      def estimable_text
+        body = @page.content.to_s
+        return body if body.length > 200
+
+        rows = @page.data['rows']
+        return body if rows.nil?
+
+        body + YAML.dump(rows)
+      end
+    end
+  end
+end

--- a/app/_plugins/generators/markdown_pages_generator.rb
+++ b/app/_plugins/generators/markdown_pages_generator.rb
@@ -86,7 +86,17 @@ module Jekyll
         content.gsub!(/{:\s*.#{type}}/, '')
       end
 
+      inject_token_count!(content)
       content
+    end
+
+    # Inject an approximate token count into the YAML frontmatter so agents
+    # fetching the .md can budget context. The count is chars / 4 of the
+    # rendered output, computed before injection (the line itself adds a
+    # handful of bytes, negligible at any meaningful page size).
+    def inject_token_count!(content)
+      tokens = (content.length / 4.0).round
+      content.sub!(/\A---\n/, "---\ntokens: #{tokens}\n")
     end
   end
 end

--- a/app/_plugins/generators/page_data.rb
+++ b/app/_plugins/generators/page_data.rb
@@ -22,6 +22,7 @@ module Jekyll
         Data::AddAllDocIndices.new(site:, page:).process
         Data::TitleTag.new(site:, page:).process
         Data::LlmMetadata.new(site:, page:).process
+        Data::TokenEstimate.new(site:, page:).process
       end
     end
 
@@ -37,6 +38,7 @@ module Jekyll
         Data::AddAllDocIndices.new(site:, page:).process
         Data::TitleTag.new(site:, page:).process
         Data::LlmMetadata.new(site:, page:).process
+        Data::TokenEstimate.new(site:, page:).process
       end
     end
   end

--- a/app/_plugins/hooks/site_post_write.rb
+++ b/app/_plugins/hooks/site_post_write.rb
@@ -64,6 +64,7 @@ end
 
 class LlmsTxtWriter # rubocop:disable Style/Documentation
   TEMPLATE_PATH = File.expand_path('../../_llms.txt', __dir__)
+  CHARS_PER_TOKEN = 4
 
   def self.process(site)
     new(site).process
@@ -74,6 +75,7 @@ class LlmsTxtWriter # rubocop:disable Style/Documentation
   end
 
   def process
+    refresh_token_counts
     content = Liquid::Template.parse(File.read(TEMPLATE_PATH)).render!(payload, info)
 
     File.write(File.join(@site.dest, 'llms.txt'), content)
@@ -84,8 +86,30 @@ class LlmsTxtWriter # rubocop:disable Style/Documentation
       'api_pages' => api_pages,
       'plugin_pages' => plugin_pages,
       'how_to_pages' => how_to_pages,
-      'docs' => docs
+      'docs' => docs_with_totals,
+      'total_tokens' => total_tokens
     )
+  end
+
+  # Replace pre-render estimates (from raw page.content) with counts based on
+  # the rendered Markdown files that MarkdownPagesWriter just emitted to disk.
+  def refresh_token_counts
+    pages.each do |page|
+      md_path = File.join(@site.dest, page.url, "#{File.basename(page.url)}.md")
+      next unless File.exist?(md_path)
+
+      page.data['tokens'] = (File.size(md_path) / CHARS_PER_TOKEN.to_f).round
+    end
+  end
+
+  def docs_with_totals
+    docs.map do |group|
+      group.merge('tokens' => group['pages'].sum { |p| p.data['tokens'].to_i })
+    end
+  end
+
+  def total_tokens
+    pages.sum { |p| p.data['tokens'].to_i }
   end
 
   def info


### PR DESCRIPTION
Exposes an estimated token count beside the copy mode and in the text version of the docs. 

I got the idea from this [article](https://addyosmani.com/blog/agentic-engine-optimization/), where it says: 

```
This one is simpler than it sounds but surprisingly high-leverage: surface token counts on your documentation pages. Ideally in both the llms.txt index and on the pages themselves (as metadata or a page header).

This gives agents the information they need to make smart decisions:

“This page is 8K tokens - I can include it fully in context”
“This page is 150K tokens - I should fetch only the relevant section”
“This page exceeds my context window - I’ll use the summary from llms.txt instead
```

<img width="950" height="215" alt="image" src="https://github.com/user-attachments/assets/071c1e87-a7e3-4dfc-b966-f35744b1d4dc" />
<img width="297" height="238" alt="image" src="https://github.com/user-attachments/assets/32e54c46-dbb2-47d6-a919-056b3dfb98cf" />
