### PR TITLE
fix(gateway): Redirect for Kapa path from support tickets

### DIFF
--- a/app/_redirects
+++ b/app/_redirects
@@ -14,8 +14,11 @@
 /kongctl/list/gateway/route/     /kongctl/list/gateway/
 /kongctl/list/gateway/service/   /kongctl/list/gateway/
 
-# Plugin examples
+# Plugins
 /plugins/request-callout/examples/dynamic-url/ /plugins/request-callout/examples/dynamic-url-via-lua-code/
+/gateway/plugin-development/  /custom-plugins/
+/gateway/plugin-development/*  /custom-plugins/
+
 # Renames
 /mesh-manager/federate-zone/  /mesh/federate-zone/
 /mesh-manager/migrate-zone/  /mesh/migrate-zone/


### PR DESCRIPTION
## Description

Kapa occasionally makes up links using support KB combined with the new site. It tries to create a parallel link - in this case, the old `docs.konghq.com/gateway/plugin-development/` became `developer.konghq.com/gateway/plugin-development`, which doesn't exist. Adding a redirect here to capture the traffic.

## Preview Links
https://deploy-preview-5203--kongdeveloper.netlify.app/gateway/plugin-development/ should redirect to /custom-plugins/

