### PR TITLE
fix(dcgw): Add section on failover

### DIFF
--- a/app/dedicated-cloud-gateways/network-architecture.md
+++ b/app/dedicated-cloud-gateways/network-architecture.md
@@ -144,6 +144,11 @@ WAF configuration differs for [public](/dedicated-cloud-gateways/public-network/
 
 For more information about all {{site.base_gateway}} WAF configurations and plugins, see [{{site.base_gateway}} WAF capabilities](/waf/).
 
+## Dedicated Cloud Gateway failover
+
+To ensure your Gateway traffic can continue uninterrupted in the event of a control plane or provider outage, you can deploy data planes in multiple Dedicated Cloud Gateway regions and cloud service providers.
+This setup allows Kong to automatically re-route traffic to the secondary region or cloud provider during an outage. 
+
 ## Dedicated Cloud Gateway network CIDR range
 
 Before you create a Dedicated Cloud Gateway network, determine which CIDR range you want to use for your network.

--- a/app/dedicated-cloud-gateways/reference.md
+++ b/app/dedicated-cloud-gateways/reference.md
@@ -465,7 +465,7 @@ For more information, see the [Managed cache for Redis reference](/dedicated-clo
 
 ## Securing backend communication
 
-Dedicated Cloud Gateways only support public networking. If your use case requires private connectivity, consider using [Dedicated Cloud Gateways](/dedicated-cloud-gateways/) with AWS Transit Gateways.
+Dedicated Cloud Gateways support public and private networking.
 
 To securely connect a Dedicated Cloud Gateway to your backend, you can inject a shared secret into each request using the [Request Transformer plugin](/plugins/request-transformer).
 


### PR DESCRIPTION
## Description

Fixes kapa issue

source for content: https://kongstrong.slack.com/archives/C070FKK6GBT/p1777967510118359?thread_ts=1777650138.580929&cid=C070FKK6GBT

## Preview Links

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
