### PR TITLE
Fix(Plugins): decK not mentioned as an option in jq plugin example

### DIFF
--- a/app/_kong_plugins/jq/examples/jq-request-program.yaml
+++ b/app/_kong_plugins/jq/examples/jq-request-program.yaml
@@ -12,6 +12,7 @@ config:
     select(.name == "James Dean").name = "John Doe"
 
 tools:
+  - deck
   - admin-api
   - konnect-api
   - kic


### PR DESCRIPTION
Tested this locally just in case there was a reason we didn't add it before. 