### PR TITLE
chore: add Konnect Vault limitation with Serverless Plugins

### DIFF
--- a/app/_gateway_entities/vault.md
+++ b/app/_gateway_entities/vault.md
@@ -310,6 +310,9 @@ features:
 {:.info}
 >When using Vault references in plugin configs to **add headers**, ensure that the secret value stored in your Vault follows the **`key:value` format**. The entire header definition, both name and value, needs to be provided by the resolved secret.
 
+{:.warning}
+> Serverless plugins, like Pre-Function and Post-Function, are not supported with {{site.konnect_short_name}} Config Store Vaults.
+
 ## Secret rotation in Vaults
 
 By default, {{site.base_gateway}} automatically refreshes secrets *once every minute* in the background. 


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
