### PR TITLE
feat(konnect): Document org role FAQ and TGW limitation

### DIFF
--- a/app/_how-tos/operator/create-transit-gateway-with-operator-and-aws.md
+++ b/app/_how-tos/operator/create-transit-gateway-with-operator-and-aws.md
@@ -89,7 +89,7 @@ spec:
    > **Notes:**
    > * Make sure to create the transit gateway in the same region as the {{site.konnect_short_name}} network provider. You can set the region in the [AWS CLI configuration](#aws-cli) or use the `--region` flag in each command.
    > * If you have issues creating resources with AWS CLI, try using the env variables instead of the `aws configure` command for credentials. Make sure to include `AWS_REGION` or use the `--region` flag in every command.
-   * The same Transit Gateway cannot be used in multiple networks, even though it is shared via different RAM shares. You must create a Transit Gateway for each Dedicated Cloud Gateway network in your deployment.
+   * The same Transit Gateway can be used in multiple networks, but they must be shared by different RAM shares.
 
 1. Export the transit gateway ID and ARN to your environment:
    ```sh

--- a/app/_how-tos/operator/create-transit-gateway-with-operator-and-aws.md
+++ b/app/_how-tos/operator/create-transit-gateway-with-operator-and-aws.md
@@ -89,6 +89,7 @@ spec:
    > **Notes:**
    > * Make sure to create the transit gateway in the same region as the {{site.konnect_short_name}} network provider. You can set the region in the [AWS CLI configuration](#aws-cli) or use the `--region` flag in each command.
    > * If you have issues creating resources with AWS CLI, try using the env variables instead of the `aws configure` command for credentials. Make sure to include `AWS_REGION` or use the `--region` flag in every command.
+   * The same Transit Gateway cannot be used in multiple networks, even though it is shared via different RAM shares. You must create a Transit Gateway for each Dedicated Cloud Gateway network in your deployment.
 
 1. Export the transit gateway ID and ARN to your environment:
    ```sh

--- a/app/_how-tos/operator/create-transit-gateway-with-operator-and-aws.md
+++ b/app/_how-tos/operator/create-transit-gateway-with-operator-and-aws.md
@@ -87,9 +87,8 @@ spec:
 
    {:.warning}
    > **Notes:**
-   > * Make sure to create the transit gateway in the same region as the {{site.konnect_short_name}} network provider. You can set the region in the [AWS CLI configuration](#aws-cli) or use the `--region` flag in each command.
    > * If you have issues creating resources with AWS CLI, try using the env variables instead of the `aws configure` command for credentials. Make sure to include `AWS_REGION` or use the `--region` flag in every command.
-   * The same Transit Gateway can be used in multiple networks, but they must be shared by different RAM shares.
+   > * The same Transit Gateway can be used in multiple networks, but they must be shared by different RAM shares.
 
 1. Export the transit gateway ID and ARN to your environment:
    ```sh

--- a/app/dedicated-cloud-gateways/transit-gateways.md
+++ b/app/dedicated-cloud-gateways/transit-gateways.md
@@ -66,6 +66,9 @@ This process includes three main steps:
     1. Enable **Allow external accounts**, choose **AWS Account**, and enter the **AWS ID** from the {{site.konnect_short_name}} UI (**API Gateway > Networks**).
     1. Create the resource share and save the resulting **RAM Share ARN**.
 
+    {:.important}
+    > **Limitation for multi-network environments:** The same Transit Gateway cannot be used in multiple networks, even though it is shared via different RAM shares. You must create a Transit Gateway for each Dedicated Cloud Gateway network in your deployment.
+
 2. Accept the Transit Gateway Attachment in AWS:
 
     1. Go to **VPC > Transit Gateway Attachments** in the AWS Console.

--- a/app/dedicated-cloud-gateways/transit-gateways.md
+++ b/app/dedicated-cloud-gateways/transit-gateways.md
@@ -67,7 +67,7 @@ This process includes three main steps:
     1. Create the resource share and save the resulting **RAM Share ARN**.
 
     {:.warning}
-    > **Limitation for multi-network environments:** The same Transit Gateway cannot be used in multiple networks, even though it is shared via different RAM shares. You must create a Transit Gateway for each Dedicated Cloud Gateway network in your deployment.
+    > **Limitation for multi-network environments:** The same Transit Gateway can be used in multiple networks, but they must be shared by different RAM shares.
 
 2. Accept the Transit Gateway Attachment in AWS:
 

--- a/app/dedicated-cloud-gateways/transit-gateways.md
+++ b/app/dedicated-cloud-gateways/transit-gateways.md
@@ -66,7 +66,7 @@ This process includes three main steps:
     1. Enable **Allow external accounts**, choose **AWS Account**, and enter the **AWS ID** from the {{site.konnect_short_name}} UI (**API Gateway > Networks**).
     1. Create the resource share and save the resulting **RAM Share ARN**.
 
-    {:.important}
+    {:.warning}
     > **Limitation for multi-network environments:** The same Transit Gateway cannot be used in multiple networks, even though it is shared via different RAM shares. You must create a Transit Gateway for each Dedicated Cloud Gateway network in your deployment.
 
 2. Accept the Transit Gateway Attachment in AWS:

--- a/app/konnect-platform/teams-and-roles.md
+++ b/app/konnect-platform/teams-and-roles.md
@@ -36,6 +36,8 @@ faqs:
       {% include faqs/report-dashboard-sharing.md section='question' feature="report" %}
     a: |
       {% include faqs/report-dashboard-sharing.md section='answer' feature="report" %}
+  - q: "Can the Organization Owner role be assigned to an SSO-controlled account?"
+    a: "Yes, an SSO-controlled account is just a {{site.konnect_short_name}} user. As long as the account is an Organization Admin, they can be assigned to the Organization Owner role."
 ---
 
 To help secure and govern your environment, {{site.konnect_short_name}} provides


### PR DESCRIPTION
## Description

Fixes an issue in Kapa and a customer reported TGW limitation

## Preview Links
- https://deploy-preview-5229--kongdeveloper.netlify.app/dedicated-cloud-gateways/transit-gateways/#aws-configuration-for-transit-gateway-peering
- https://deploy-preview-5229--kongdeveloper.netlify.app/how-to/create-transit-gateway-with-operator-and-aws/#create-a-transit-gateway-in-aws
- https://deploy-preview-5229--kongdeveloper.netlify.app/konnect-platform/teams-and-roles/#can-the-organization-owner-role-be-assigned-to-an-sso-controlled-account

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
