### PR TITLE
Fix: Update plugin.md to clarify dynamic ordering limitations

### DIFF
--- a/app/_gateway_entities/plugin.md
+++ b/app/_gateway_entities/plugin.md
@@ -156,11 +156,6 @@ This can be [adjusted dynamically](#dynamic-plugin-ordering) using the plugin's 
 You can override the [priority](#plugin-priority) for any {{site.base_gateway}} plugin using each plugin’s `ordering` configuration parameter. 
 This determines plugin ordering during the [`access` phase](#plugin-contexts), and lets you create dynamic dependencies between plugins.
 
-{:.warning}
-> **Important**: Dynamic plugin ordering **does not** work with Consumers or Consumer Groups.
-> If you have any Consumers or Consumer Groups in your environment, do not use dynamic plugin ordering, as the plugins **will not trigger**.
-> See the [limitations](#known-limitations-of-dynamic-plugin-ordering) of this feature for more detail.
-
 You can choose to run a particular plugin `before` or `after` a specified plugin or list of plugins.
 
 The configuration looks like this:
@@ -215,12 +210,6 @@ If using dynamic ordering, manually test all configurations, and handle this fea
 
 There are a number of considerations that can affect your environment:
 
-* **Consumer and Consumer Group scoping**: If you have [Consumer or Consumer Group-scoped plugins](#scoping-plugins) anywhere in your Workspace or control plane, you can't use dynamic plugin ordering.
-  If you attempt to apply dynamic ordering in this case, your plugins **will not work**.
-
-  Consumer mapping and dynamic plugin ordering both run in the `access` phase, but the order of the  plugins must be determined after Consumer mapping has happened.
-  {{site.base_gateway}} can't reliably change the order of the plugins in relation to mapped Consumers or Consumer Groups.
-
 * **Cascading deletes**: Detecting if a plugin has a dependency to a deleted plugin isn't supported, so handle your configuration with care.
 
 * **Performance**: Dynamic plugin ordering requires sorting plugins during a request, which adds latency to the request. 
@@ -231,6 +220,9 @@ In some cases, this might be compensated for when you run rate limiting before a
 
 * **Validation**: Validating dynamic plugin ordering is a non-trivial task and would require insight into the user's business logic. 
 {{site.base_gateway}} tries to catch basic mistakes, but it can't detect all potentially dangerous configurations.
+
+{:.note}
+> **Note**: In Kong Gateway 3.13 and earlier, Consumer and Consumer Group scoping was not compatible with dynamic plugin ordering. If you had [Consumer or Consumer Group-scoped plugins](#scoping-plugins) anywhere in your Workspace or control plane, dynamic plugin ordering would cause those plugins **not to trigger**. This limitation was resolved in Kong Gateway 3.14.
 
 ## Conditional plugin execution {% new_in 3.14 %}
 

--- a/app/_gateway_entities/plugin.md
+++ b/app/_gateway_entities/plugin.md
@@ -221,8 +221,8 @@ In some cases, this might be compensated for when you run rate limiting before a
 * **Validation**: Validating dynamic plugin ordering is a non-trivial task and would require insight into the user's business logic. 
 {{site.base_gateway}} tries to catch basic mistakes, but it can't detect all potentially dangerous configurations.
 
-{:.note}
-> **Note**: In Kong Gateway 3.13 and earlier, Consumer and Consumer Group scoping was not compatible with dynamic plugin ordering. If you had [Consumer or Consumer Group-scoped plugins](#scoping-plugins) anywhere in your Workspace or control plane, dynamic plugin ordering would cause those plugins **not to trigger**. This limitation was resolved in Kong Gateway 3.14.
+{:.info}
+> **Note**: In {{site.base_gateway}} 3.13 and earlier, Consumer and Consumer Group scoping was not compatible with dynamic plugin ordering. If you had [Consumer or Consumer Group-scoped plugins](#scoping-plugins) anywhere in your Workspace or control plane, dynamic plugin ordering would cause those plugins **not to trigger**. This limitation was resolved in {{site.base_gateway}} 3.14.
 
 ## Conditional plugin execution {% new_in 3.14 %}
 


### PR DESCRIPTION
## Description

Removed warnings about dynamic plugin ordering limitations with Consumers and Consumer Groups, and added a note regarding compatibility changes in Kong Gateway 3.14. The limitation exists in 3.13 and lower, but is no longer a limitation in 3.14. Moved the bullet-point to a note below the current list of dynamic plugin ordering limitations.

Fixes: https://kongstrong.slack.com/archives/CDSTDSG9J/p1778010370054619