### PR TITLE
feat(kongctl): Generate kongctl examples for event gateway entities

### DIFF
--- a/app/_data/entity_examples/config.yml
+++ b/app/_data/entity_examples/config.yml
@@ -23,6 +23,29 @@ konnect_variables: &konnect_variables
     placeholder: 'KONNECT_TOKEN'
     description: 'Your Personal Access Token (PAT) associated with your Konnect account.'
 
+event_gateway_variables: &event_gateway_variables
+  event_gateway:
+    placeholder: 'eventGatewayName'
+    description: "The `name` of your Event Gateway."
+  backend_cluster:
+    placeholder: 'backendClusterName'
+    description: "The `name` of the Backend Cluster."
+  virtual_cluster:
+    placeholder: 'virtualClusterName'
+    description: "The `name` of the Virtual Cluster."
+  listener:
+    placeholder: 'listenerName'
+    description: "The `name` of the Listener."
+  schema_registry:
+    placeholder: 'schemaRegistryName'
+    description: "The `name` of the Schema Registry."
+  static_key:
+    placeholder: 'staticKeyName'
+    description: "The `name` of the Static Key."
+  tls_trust_bundle:
+    placeholder: 'tlsTrustBundleName'
+    description: "The `name` of the TLS Trust Bundle."
+
 formats:
   deck:
     label: 'decK'
@@ -136,6 +159,10 @@ formats:
 
   terraform:
     label: 'Terraform'
+
+  kongctl:
+    label: 'kongctl'
+    event_gateway_variables: *event_gateway_variables
 
   ui:
     label: 'UI'

--- a/app/_event_gateway_policies/acl/examples/manage-consumer-groups.yml
+++ b/app/_event_gateway_policies/acl/examples/manage-consumer-groups.yml
@@ -22,3 +22,4 @@ config:
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_event_gateway_policies/acl/examples/match-claims-using-expressions.yml
+++ b/app/_event_gateway_policies/acl/examples/match-claims-using-expressions.yml
@@ -26,6 +26,7 @@ config:
 tools:
   - konnect-api
   - terraform
+  - kongctl
 
 min_version:
   event-gateway: '1.1.0'

--- a/app/_event_gateway_policies/acl/examples/read-only-topic.yml
+++ b/app/_event_gateway_policies/acl/examples/read-only-topic.yml
@@ -21,3 +21,4 @@ config:
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_event_gateway_policies/decrypt/examples/decrypt-with-aws.yml
+++ b/app/_event_gateway_policies/decrypt/examples/decrypt-with-aws.yml
@@ -23,3 +23,4 @@ config:
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_event_gateway_policies/decrypt/examples/decrypt-with-static-key.yml
+++ b/app/_event_gateway_policies/decrypt/examples/decrypt-with-static-key.yml
@@ -28,3 +28,4 @@ config:
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_event_gateway_policies/encrypt/examples/encrypt-with-aws.yml
+++ b/app/_event_gateway_policies/encrypt/examples/encrypt-with-aws.yml
@@ -27,3 +27,4 @@ variables:
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_event_gateway_policies/encrypt/examples/encrypt-with-static-key.yml
+++ b/app/_event_gateway_policies/encrypt/examples/encrypt-with-static-key.yml
@@ -28,3 +28,4 @@ config:
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_event_gateway_policies/forward-to-virtual-cluster/examples/port-mapping.yml
+++ b/app/_event_gateway_policies/forward-to-virtual-cluster/examples/port-mapping.yml
@@ -21,3 +21,4 @@ config:
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_event_gateway_policies/forward-to-virtual-cluster/examples/sni-routing-shared-suffix.yml
+++ b/app/_event_gateway_policies/forward-to-virtual-cluster/examples/sni-routing-shared-suffix.yml
@@ -21,3 +21,4 @@ config:
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_event_gateway_policies/forward-to-virtual-cluster/examples/sni-routing.yml
+++ b/app/_event_gateway_policies/forward-to-virtual-cluster/examples/sni-routing.yml
@@ -20,3 +20,4 @@ config:
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_event_gateway_policies/modify-headers/examples/add-header-based-on-condition.yml
+++ b/app/_event_gateway_policies/modify-headers/examples/add-header-based-on-condition.yml
@@ -22,3 +22,4 @@ config:
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_event_gateway_policies/modify-headers/examples/nested-policy.yml
+++ b/app/_event_gateway_policies/modify-headers/examples/nested-policy.yml
@@ -27,3 +27,4 @@ config:
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_event_gateway_policies/modify-headers/examples/remove-and-replace-header.yml
+++ b/app/_event_gateway_policies/modify-headers/examples/remove-and-replace-header.yml
@@ -20,3 +20,4 @@ config:
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_event_gateway_policies/schema-validation-consume/examples/validate-a-topic.yml
+++ b/app/_event_gateway_policies/schema-validation-consume/examples/validate-a-topic.yml
@@ -20,3 +20,4 @@ config:
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_event_gateway_policies/schema-validation-consume/examples/validate-all-confluent.yml
+++ b/app/_event_gateway_policies/schema-validation-consume/examples/validate-all-confluent.yml
@@ -19,3 +19,4 @@ config:
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_event_gateway_policies/schema-validation-consume/examples/validate-subset-json.yml
+++ b/app/_event_gateway_policies/schema-validation-consume/examples/validate-subset-json.yml
@@ -15,3 +15,4 @@ config:
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_event_gateway_policies/schema-validation-produce/examples/validate-a-topic.yml
+++ b/app/_event_gateway_policies/schema-validation-produce/examples/validate-a-topic.yml
@@ -20,3 +20,4 @@ config:
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_event_gateway_policies/schema-validation-produce/examples/validate-all-confluent.yml
+++ b/app/_event_gateway_policies/schema-validation-produce/examples/validate-all-confluent.yml
@@ -19,3 +19,4 @@ config:
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_event_gateway_policies/schema-validation-produce/examples/validate-subset-json.yml
+++ b/app/_event_gateway_policies/schema-validation-produce/examples/validate-subset-json.yml
@@ -15,3 +15,4 @@ config:
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_event_gateway_policies/skip-record/examples/nested-policy.yml
+++ b/app/_event_gateway_policies/skip-record/examples/nested-policy.yml
@@ -24,3 +24,4 @@ condition: >
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_event_gateway_policies/skip-record/examples/skip-based-on-name.yml
+++ b/app/_event_gateway_policies/skip-record/examples/skip-based-on-name.yml
@@ -17,3 +17,4 @@ condition: >
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_event_gateway_policies/tls-server/examples/tls-connection.yml
+++ b/app/_event_gateway_policies/tls-server/examples/tls-connection.yml
@@ -27,3 +27,4 @@ config:
 tools:
   - konnect-api
   - terraform
+  - kongctl

--- a/app/_includes/components/entity_example/format/kongctl.md
+++ b/app/_includes/components/entity_example/format/kongctl.md
@@ -13,11 +13,9 @@ The following creates a new static key called **{{ include.presenter.data['name'
 {% when 'tls_trust_bundle' %}
 The following creates a new TLS trust bundle called **{{ include.presenter.data['name'] }}**.
 {% when 'event_gateway_policy' %}
+The following example creates a new `{{ include.presenter.data['type'] }}` policy.
 {% endcase %}
-Add this snippet to your declarative configuration file and [apply](/kongctl/apply/) or [sync](/kongctl/sync/) it with kongctl:
-
-{:.info}
-> If you have already created {{site.event_gateway}} outside of kongctl (via the UI or API), you must [adopt them](/kongctl/declarative/#adopting-existing-resources) before managing them declaratively.
+Add this snippet to an `event_gateways` resource in your declarative configuration file, and then [manage it with kongctl](/kongctl/declarative/#declarative-commands):
 {% endif %}
 
 {% include components/entity_example/format/snippets/kongctl.md presenter=include.presenter %}

--- a/app/_includes/components/entity_example/format/kongctl.md
+++ b/app/_includes/components/entity_example/format/kongctl.md
@@ -1,20 +1,23 @@
 {% if include.render_context %}
 {% case include.presenter.entity_type %}
 {% when 'backend_cluster' %}
-The following creates a new backend cluster called **{{ include.presenter.data['name'] }}**:
+The following creates a new backend cluster called **{{ include.presenter.data['name'] }}**.
 {% when 'virtual_cluster' %}
-The following creates a new virtual cluster called **{{ include.presenter.data['name'] }}**:
+The following creates a new virtual cluster called **{{ include.presenter.data['name'] }}**.
 {% when 'listener' %}
-The following creates a new listener called **{{ include.presenter.data['name'] }}** with basic configuration:
+The following creates a new listener called **{{ include.presenter.data['name'] }}** with basic configuration.
 {% when 'schema_registry' %}
-The following creates a new schema registry called **{{ include.presenter.data['name'] }}**:
+The following creates a new schema registry called **{{ include.presenter.data['name'] }}**.
 {% when 'static_key' %}
-The following creates a new static key called **{{ include.presenter.data['name'] }}**:
+The following creates a new static key called **{{ include.presenter.data['name'] }}**.
 {% when 'tls_trust_bundle' %}
-The following creates a new TLS trust bundle called **{{ include.presenter.data['name'] }}**:
+The following creates a new TLS trust bundle called **{{ include.presenter.data['name'] }}**.
 {% when 'event_gateway_policy' %}
-Add this section to your configuration file:
 {% endcase %}
+Add this snippet to your declarative configuration file and [apply](/kongctl/apply/) or [sync](/kongctl/sync/) it with kongctl:
+
+{:.info}
+> If you have already created {{site.event_gateway}} outside of kongctl (via the UI or API), you must [adopt them](/kongctl/declarative/#adopting-existing-resources) before managing them declaratively.
 {% endif %}
 
 {% include components/entity_example/format/snippets/kongctl.md presenter=include.presenter %}

--- a/app/_includes/components/entity_example/format/kongctl.md
+++ b/app/_includes/components/entity_example/format/kongctl.md
@@ -1,0 +1,24 @@
+{% if include.render_context %}
+{% case include.presenter.entity_type %}
+{% when 'backend_cluster' %}
+The following creates a new backend cluster called **{{ include.presenter.data['name'] }}**:
+{% when 'virtual_cluster', 'virtual-cluster' %}
+The following creates a new virtual cluster called **{{ include.presenter.data['name'] }}**:
+{% when 'listener' %}
+The following creates a new listener called **{{ include.presenter.data['name'] }}** with basic configuration:
+{% when 'schema_registry' %}
+The following creates a new schema registry called **{{ include.presenter.data['name'] }}**:
+{% when 'static_key' %}
+The following creates a new static key called **{{ include.presenter.data['name'] }}**:
+{% when 'tls_trust_bundle' %}
+The following creates a new TLS trust bundle called **{{ include.presenter.data['name'] }}**:
+{% when 'event_gateway_policy' %}
+Add this section to your configuration file:
+{% endcase %}
+{% endif %}
+
+{% include components/entity_example/format/snippets/kongctl.md presenter=include.presenter %}
+
+{% if include.render_context %}
+{% include components/entity_example/replace_variables.md missing_variables=include.presenter.missing_variables %}
+{% endif %}

--- a/app/_includes/components/entity_example/format/kongctl.md
+++ b/app/_includes/components/entity_example/format/kongctl.md
@@ -2,7 +2,7 @@
 {% case include.presenter.entity_type %}
 {% when 'backend_cluster' %}
 The following creates a new backend cluster called **{{ include.presenter.data['name'] }}**:
-{% when 'virtual_cluster', 'virtual-cluster' %}
+{% when 'virtual_cluster' %}
 The following creates a new virtual cluster called **{{ include.presenter.data['name'] }}**:
 {% when 'listener' %}
 The following creates a new listener called **{{ include.presenter.data['name'] }}** with basic configuration:

--- a/app/_includes/components/entity_example/format/snippets/kongctl.md
+++ b/app/_includes/components/entity_example/format/snippets/kongctl.md
@@ -1,0 +1,4 @@
+```yaml
+{{ include.presenter.config }}
+```
+{: data-file="kong.yaml" }

--- a/app/_includes/components/entity_example/format/snippets/kongctl.md
+++ b/app/_includes/components/entity_example/format/snippets/kongctl.md
@@ -1,4 +1,4 @@
 ```yaml
 {{ include.presenter.config }}
 ```
-{: data-file="kong.yaml" }
+{: data-file="{{ include.presenter.entity_type }}.yaml" }

--- a/app/_landing_pages/event-gateway.yaml
+++ b/app/_landing_pages/event-gateway.yaml
@@ -334,11 +334,11 @@ rows:
             config:
               blocks:
               - type: unordered_list
-                items: # links TBA, they don't exist yet
-                    - "**{{site.konnect_short_name}} UI**: Manage {{site.event_gateway_short}} entities within {{site.konnect_short_name}} control planes using a UI."
-                    - "**Control Plane API**: Manage {{site.event_gateway_short}} entities within {{site.konnect_short_name}} control planes via an API."
+                items:
+                    - "[**{{site.konnect_short_name}} UI**](https://cloud.konghq.com/event-gateway): Manage {{site.event_gateway_short}} control planes, data planes, and configurations using a UI."
+                    - "[**Control Plane API**](/api/konnect/event-gateway/): Manage {{site.event_gateway_short}} entities within {{site.konnect_short_name}} control planes via an API."
                     - "[**Terraform**](/terraform/): Manage infrastructure as code and automated deployments to streamline setup and configuration of {{site.konnect_short_name}} and {{site.event_gateway}}."
-
+                    - "[**kongctl**](/kongctl/): Manage {{site.event_gateway_short}} control planes and the entities within them declaratively via a CLI."
   - header:
       type: h2
       text: Key references

--- a/app/_plugins/drops/entity_example/formatted_example.rb
+++ b/app/_plugins/drops/entity_example/formatted_example.rb
@@ -11,7 +11,8 @@ module Jekyll
           'kic'         => 'KIC',
           'operator'    => 'KIC',
           'ui'          => 'UI',
-          'terraform'   => 'Terraform'
+          'terraform'   => 'Terraform',
+          'kongctl'     => 'Kongctl'
         }
 
         def initialize(format:, presenter_class:, example_drop:)

--- a/app/_plugins/drops/entity_example/presenters/kongctl.rb
+++ b/app/_plugins/drops/entity_example/presenters/kongctl.rb
@@ -11,7 +11,6 @@ module Jekyll
             ENTITY_TO_CHILD_KEY = {
               'backend_cluster'  => 'backend_clusters',
               'virtual_cluster'  => 'virtual_clusters',
-              'virtual-cluster'  => 'virtual_clusters',
               'listener'         => 'listeners',
               'static_key'       => 'static_keys',
               'tls_trust_bundle' => 'tls_trust_bundles',

--- a/app/_plugins/drops/entity_example/presenters/kongctl.rb
+++ b/app/_plugins/drops/entity_example/presenters/kongctl.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require_relative './base'
+
+module Jekyll
+  module Drops
+    module EntityExample
+      module Presenters
+        module Kongctl
+          class Base < Presenters::Base
+            ENTITY_TO_CHILD_KEY = {
+              'backend_cluster'  => 'backend_clusters',
+              'virtual_cluster'  => 'virtual_clusters',
+              'virtual-cluster'  => 'virtual_clusters',
+              'listener'         => 'listeners',
+              'static_key'       => 'static_keys',
+              'tls_trust_bundle' => 'tls_trust_bundles',
+              'schema_registry'  => 'schema_registries'
+            }.freeze
+
+            def data
+              @data ||= @example_drop.data
+            end
+
+            def config
+              @config ||= Jekyll::Utils::HashToYAML.new(build_config_hash).convert
+            end
+
+            def missing_variables
+              @missing_variables ||= [formats['kongctl']['event_gateway_variables']['event_gateway']]
+            end
+
+            def template_file
+              '/components/entity_example/format/kongctl.md'
+            end
+
+            private
+
+            def build_config_hash
+              {
+                'event_gateways' => [
+                  {
+                    'ref'  => event_gateway_placeholder,
+                    'name' => event_gateway_placeholder,
+                    child_key => [{ 'ref' => data['name'] }.merge(data)]
+                  }
+                ]
+              }
+            end
+
+            def child_key
+              ENTITY_TO_CHILD_KEY[entity_type]
+            end
+
+            def event_gateway_placeholder
+              formats['kongctl']['event_gateway_variables']['event_gateway']['placeholder']
+            end
+          end
+
+          class EventGatewayPolicy < Base
+            def config
+              @config ||= if policy_target == 'listener'
+                            Jekyll::Utils::HashToYAML.new(build_listener_policy_hash).convert
+                          else
+                            Jekyll::Utils::HashToYAML.new(build_virtual_cluster_policy_hash).convert
+                          end
+            end
+
+            def missing_variables
+              @missing_variables ||= begin
+                vars = [formats['kongctl']['event_gateway_variables']['event_gateway']]
+                if policy_target == 'listener'
+                  vars << formats['kongctl']['event_gateway_variables']['listener']
+                else
+                  vars << formats['kongctl']['event_gateway_variables']['virtual_cluster']
+                end
+                vars
+              end
+            end
+
+            private
+
+            def policy_target
+              @example_drop.policy_target
+            end
+
+            def phase_key
+              "#{@example_drop.target.key}_policies"
+            end
+
+            def policy_item
+              {
+                'ref'           => data['name'],
+                'type'          => data['type'],
+                data['type']    => data.except('type')
+              }.compact
+            end
+
+            def virtual_cluster_placeholder
+              formats['kongctl']['event_gateway_variables']['virtual_cluster']['placeholder']
+            end
+
+            def listener_placeholder
+              formats['kongctl']['event_gateway_variables']['listener']['placeholder']
+            end
+
+            def build_virtual_cluster_policy_hash
+              {
+                'event_gateways' => [
+                  {
+                    'ref'              => event_gateway_placeholder,
+                    'name'             => event_gateway_placeholder,
+                    'virtual_clusters' => [
+                      {
+                        'ref'    => virtual_cluster_placeholder,
+                        'name'   => virtual_cluster_placeholder,
+                        phase_key => [policy_item]
+                      }
+                    ]
+                  }
+                ]
+              }
+            end
+
+            def build_listener_policy_hash
+              {
+                'event_gateways' => [
+                  {
+                    'ref'       => event_gateway_placeholder,
+                    'name'      => event_gateway_placeholder,
+                    'listeners' => [
+                      {
+                        'ref'      => listener_placeholder,
+                        'name'     => listener_placeholder,
+                        'policies' => [policy_item]
+                      }
+                    ]
+                  }
+                ]
+              }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/drops/entity_example/presenters/kongctl.rb
+++ b/app/_plugins/drops/entity_example/presenters/kongctl.rb
@@ -48,7 +48,10 @@ module Jekyll
             end
 
             def child_key
-              ENTITY_TO_CHILD_KEY[entity_type]
+              ENTITY_TO_CHILD_KEY.fetch(entity_type) do
+                raise ArgumentError,
+                      "Unsupported kongctl entity_type `#{entity_type}`. Supported entity types: #{ENTITY_TO_CHILD_KEY.keys.join(', ')}"
+              end
             end
 
             def event_gateway_placeholder

--- a/app/_plugins/generators/plugins/plugin.rb
+++ b/app/_plugins/generators/plugins/plugin.rb
@@ -38,7 +38,7 @@ module Jekyll
 
       def formats
         @formats ||= site.data.dig('entity_examples', 'config', 'formats')
-                         .except('ui')
+                         .except('ui', 'kongctl')
                          .tap { |h| h.delete('konnect-api') unless works_on.include?('konnect') }
                          .keys
       end

--- a/app/event-gateway/entities/backend-cluster.md
+++ b/app/event-gateway/entities/backend-cluster.md
@@ -17,7 +17,8 @@ related_resources:
 tools:
     - konnect-api
     - terraform
-tags: 
+    - kongctl
+tags:
   - policy
 works_on:
   - konnect

--- a/app/event-gateway/entities/listener.md
+++ b/app/event-gateway/entities/listener.md
@@ -17,6 +17,7 @@ related_resources:
 tools:
     - konnect-api
     - terraform
+    - kongctl
 works_on:
   - konnect
 tags:

--- a/app/event-gateway/entities/policy.md
+++ b/app/event-gateway/entities/policy.md
@@ -20,6 +20,7 @@ related_resources:
 tools:
     - konnect-api
     - terraform
+    - kongctl
 
 tags:
   - policy

--- a/app/event-gateway/entities/schema-registry.md
+++ b/app/event-gateway/entities/schema-registry.md
@@ -13,6 +13,7 @@ related_resources:
 tools:
     - konnect-api
     - terraform
+    - kongctl
 
 works_on:
   - konnect

--- a/app/event-gateway/entities/static-key.md
+++ b/app/event-gateway/entities/static-key.md
@@ -14,6 +14,7 @@ related_resources:
     url: /event-gateway/encrypt-kafka-messages-with-event-gateway/
 tools:
     - konnect-api
+    - kongctl
 
 works_on:
   - konnect

--- a/app/event-gateway/entities/tls-trust-bundle.md
+++ b/app/event-gateway/entities/tls-trust-bundle.md
@@ -16,6 +16,7 @@ related_resources:
 
 tools:
     - konnect-api
+    - kongctl
 
 works_on:
   - konnect

--- a/app/event-gateway/entities/virtual-cluster.md
+++ b/app/event-gateway/entities/virtual-cluster.md
@@ -18,6 +18,7 @@ related_resources:
 tools:
     - konnect-api
     - terraform
+    - kongctl
 tags:
   - policy
 

--- a/app/event-gateway/entities/virtual-cluster.md
+++ b/app/event-gateway/entities/virtual-cluster.md
@@ -332,7 +332,7 @@ Before setting up a virtual cluster, make sure you have a [backend cluster](/eve
 A virtual cluster must connect to an existing backend cluster.
 
 {% entity_example %}
-type: virtual-cluster
+type: virtual_cluster
 data:
   name: example-name
   destination:


### PR DESCRIPTION
## Description

Introduces `kongctl` as an example format for Event Gateway entities and policies.

To do:
- [ ] Test all of them (I've only tested some)
- [x] Add intro text to examples, link to kongctl
- [x] Add kongctl to event gateway landing page
- [x] Not sure about this: what level of detail should we provide? Is including the config snippet, similar to decK, enough? Or does this need more handholding, ie examples of how to use an external ref, or how to use `kongctl apply` vs `kongctl sync`?
- [x] Build didn't fail locally, but now it's failing in the PR, and I think it's because of llm format. Need to look into that.

## Preview Links

Any event gateway policy example, e.g.:
https://deploy-preview-5236--kongdeveloper.netlify.app/event-gateway/policies/acl/examples/manage-consumer-groups/?format=kongctl

All the event gateway entity references: 
https://deploy-preview-5236--kongdeveloper.netlify.app/event-gateway/entities/ - go to a doc, scroll to "Set up a [entity]", and open the kongctl tab.

For example:
https://deploy-preview-5236--kongdeveloper.netlify.app/event-gateway/entities/backend-cluster/#set-up-a-backend-cluster/?tab=kongctl

