### PR TITLE
feat(docs-platform): Beta banner

### DIFF
--- a/app/_how-tos/gateway/configure-conditional-plugin-execution.md
+++ b/app/_how-tos/gateway/configure-conditional-plugin-execution.md
@@ -65,9 +65,6 @@ faqs:
       When `result=false`, the plugin was skipped for that request.
 ---
 
-{:.warning}
-> This feature is currently in [beta](/stages-of-software-availability/#beta) and should not be used in a production environment.
-
 ## Add a plugin with a condition
 
 Add the Request Termination plugin to your Route with a `condition` expression. 

--- a/app/_includes/banners/stage.html
+++ b/app/_includes/banners/stage.html
@@ -1,0 +1,4 @@
+{%- if include.beta -%}{%- assign type = 'beta' -%}{%- endif -%}
+{%- if include.tech_preview -%}{%- assign type = 'tech_preview' -%}{%- endif -%}
+{%- assign stage = site.data.stages[type] -%}
+<blockquote class="warning"><span>This feature is currently in <a href="{{stage.url}}">{{ stage.text }}</a> and should not be used in a production environment.</span></blockquote>

--- a/app/_includes/layouts/main.html
+++ b/app/_includes/layouts/main.html
@@ -51,6 +51,10 @@
             {% contentblock nav_header %}
             </section>
         {% endifhascontent %}
+
+        {%- if page.beta == true or page.tech_preview == true -%}
+        {%- include_cached banners/stage.html beta=page.beta tech_preview=page.tech_preview -%}
+        {%- endif -%}
     </div>
 
     {% if page.layout == 'with_aside' or layout.layout == 'with_aside' %}
@@ -58,6 +62,5 @@
         {% include layouts/aside.html mobile=true %}
     </div>
     {% endif %}
-
     {{ content }}
 </main>

--- a/app/_plugins/generators/data/llm_metadata.rb
+++ b/app/_plugins/generators/data/llm_metadata.rb
@@ -38,7 +38,8 @@ module Jekyll
           'min_version' => @page.data['min_version'],
           'tier' => @page.data['tier'],
           'products' => resolve_names(@page.data['products'], 'products'),
-          'tools' => resolve_names(@page.data['tools'], 'tools')
+          'tools' => resolve_names(@page.data['tools'], 'tools'),
+          'beta' => @page.data['beta']
         }
         data['tags'] = @page.data['tags'] if @page.data.fetch('tags', []).any?
         data['canonical'] = @page.data['canonical?'] unless @page.data['canonical?'].nil?

--- a/app/gateway/plugins/expressions.md
+++ b/app/gateway/plugins/expressions.md
@@ -53,9 +53,6 @@ related_resources:
 
 ---
 
-{:.warning}
-> This feature is currently in [beta](/stages-of-software-availability/#beta) and should not be used in a production environment.
-
 Plugin conditions allow you to attach an optional `condition` expression to any plugin.
 When a request comes in, {{site.base_gateway}} evaluates the expression immediately before the plugin's `access` phase.
 If the expression evaluates to `true`, the plugin runs normally. If it evaluates to `false`, the plugin is skipped for that request.


### PR DESCRIPTION
PM recently manually added banners to beta docs pages because they couldn't see the "beta" badge on those pages. I'm making this into an automated change - if `beta:true` or `tech_preview:true`, the banner will appear.

I'm not sure how I feel about this; it feels like overkill, now that I've added these banners. Is there a better way to display the information?

Example preview pages:
https://deploy-preview-5259--kongdeveloper.netlify.app/kongctl/get-started/
https://deploy-preview-5259--kongdeveloper.netlify.app/kongctl/adopt/