### PR TITLE
docs(mesh): add OpenTelemetry collector how-to

### DIFF
--- a/app/_data/kuma_to_mesh/config.yaml
+++ b/app/_data/kuma_to_mesh/config.yaml
@@ -16,21 +16,7 @@ links:
   '/features/?': '/mesh/enterprise/'
 
 pages:
-# Must for GA    
-  -
-    path: app/_src/guides/otel-metrics.md
-    title: 'Collect metrics with OpenTelemetry'
-    description: 'Collect and export metrics from {{site.mesh_product_name}} with OpenTelemetry and visualize them using Prometheus and Grafana.'
-    url: '/mesh/collect-metrics-with-opentelemetry/'
-    related_resources:
-      - text: Mesh observability
-        url: '/mesh/observability/'
-      - text: Policy Hub
-        url: /mesh/policies/
-      - text: Service meshes
-        url: /mesh/service-mesh/
-    min_version:
-      mesh: '2.7'
+# Must for GA
   -
     path: app/_src/networking/dns.md
     title: 'DNS'

--- a/app/_how-tos/mesh/deploy-an-opentelemetry-collector.md
+++ b/app/_how-tos/mesh/deploy-an-opentelemetry-collector.md
@@ -1,0 +1,416 @@
+---
+title: Deploy an OpenTelemetry collector for metrics, traces, and logs
+description: Run one OpenTelemetry collector that receives metrics, traces, and access logs from {{site.mesh_product_name}}, with guidance on Deployment vs DaemonSet topologies and passthrough handling.
+
+content_type: how_to
+permalink: /mesh/deploy-an-opentelemetry-collector/
+
+breadcrumbs:
+  - /mesh/
+
+products:
+  - mesh
+
+works_on:
+  - on-prem
+
+tags:
+  - observability
+  - metrics
+  - tracing
+  - logging
+  - kubernetes
+
+related_resources:
+  - text: MeshMetric policy
+    url: /mesh/policies/meshmetric/
+  - text: MeshTrace policy
+    url: /mesh/policies/meshtrace/
+  - text: MeshAccessLog policy
+    url: /mesh/policies/meshaccesslog/
+  - text: Observability
+    url: /mesh/observability/
+
+next_steps:
+  - text: MeshMetric policy
+    url: /mesh/policies/meshmetric/
+  - text: MeshTrace policy
+    url: /mesh/policies/meshtrace/
+  - text: MeshAccessLog policy
+    url: /mesh/policies/meshaccesslog/
+  - text: OpenTelemetry collector processors
+    url: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor
+
+tldr:
+  q: How do I deploy an OpenTelemetry collector for {{site.mesh_product_name}}?
+  a: Run a single OpenTelemetry collector that receives metrics, traces, and access logs from sidecars over OTLP, and pick between a Deployment or per-node DaemonSet topology.
+
+prereqs:
+  inline:
+    - title: A running Kubernetes cluster
+      include_content: prereqs/kubernetes/mesh-cluster
+    - title: Install {{site.mesh_product_name}} with demo configuration
+      include_content: prereqs/kubernetes/mesh-quickstart
+    - title: Install the observability backends
+      content: |
+        Install the {{site.mesh_product_name}} observability stack, or have your own Prometheus, Tempo or Jaeger, and Loki backends ready to receive OTLP:
+
+        ```sh
+        kumactl install observability | kubectl apply -f -
+        ```
+
+---
+
+This guide deploys a single OpenTelemetry collector that receives all three telemetry signals from {{site.mesh_product_name}}: metrics from [MeshMetric](/mesh/policies/meshmetric/), traces from [MeshTrace](/mesh/policies/meshtrace/), and access logs from [MeshAccessLog](/mesh/policies/meshaccesslog/). It covers two production topologies, how the collector fits with sidecar injection, and what changes when mesh passthrough is off.
+
+## How {{site.mesh_product_name}} talks to the collector
+
+Sidecars push telemetry to the collector over OTLP gRPC on port 4317. The collector receives, batches, and exports it to whatever backends you configure.
+
+This is a push model. Each sidecar opens an outbound connection to one collector pod and writes its own telemetry. Compare that to a pull model, where a collector scrapes Prometheus endpoints from every workload it can reach.
+
+The distinction matters when you pick a topology. A [CNCF post](https://www.cncf.io/blog/2025/12/16/how-to-build-a-cost-effective-observability-platform-with-opentelemetry/) warns about 20-40x metric explosion when DaemonSet collectors all scrape the same Prometheus targets. That problem is specific to the pull model. {{site.mesh_product_name}} pushes, so each metric reaches one collector instance regardless of how many collector pods exist.
+
+## Pick a topology
+
+Two patterns work for the OTLP receiver. Pick one before you write the manifests.
+
+### Deployment + ClusterIP service
+
+Run two or three collector replicas behind a `ClusterIP` service. Sidecars resolve `otel-collector.observability:4317` to whichever replica kube-proxy picks.
+
+This is the default recommendation. It's simple, the failure domain is the whole replica set, and a rolling update of the collector doesn't drop telemetry from any specific node. Use this for small and medium clusters, or any cluster where collector throughput isn't a bottleneck.
+
+### Per-node DaemonSet
+
+Run one collector pod per node and route traffic node-locally. With `internalTrafficPolicy: Local` on the service, kube-proxy sends each sidecar to the collector pod on the same node. Sidecars still resolve the same DNS name (`otel-collector.observability:4317`), but the hop never leaves the node.
+
+Pick this for large clusters or workloads where the extra network hop matters. It improves locality, distributes load across nodes, and isolates collector failure to a single node's telemetry.
+
+{:.warning}
+> The tradeoff is silent loss. If the collector pod on a node crashes or is being rescheduled, sidecars on that node have no fallback. Their telemetry drops on the floor until the pod is back. There is no cross-node failover with `Local` traffic policy.
+
+## Deploy the collector
+
+1. Create a dedicated namespace and exclude it from sidecar injection. If the collector pod runs a sidecar that pushes its own telemetry through itself, you get a circular dependency.
+
+   ```sh
+   kubectl create namespace observability
+   kubectl label namespace observability kuma.io/sidecar-injection=disabled
+   ```
+
+1. Apply the collector configuration. It defines three pipelines, a memory limiter as the first processor, a tuned batch processor, and a debug exporter you can switch on when something looks wrong.
+
+   ```sh
+   echo "apiVersion: v1
+   kind: ConfigMap
+   metadata:
+     name: otel-collector-config
+     namespace: observability
+   data:
+     config.yaml: |
+       receivers:
+         otlp:
+           protocols:
+             grpc:
+               endpoint: 0.0.0.0:4317
+             http:
+               endpoint: 0.0.0.0:4318
+
+       processors:
+         memory_limiter:
+           check_interval: 5s
+           limit_mib: 500
+           spike_limit_mib: 400
+         batch:
+           send_batch_size: 4096
+           send_batch_max_size: 8192
+           timeout: 10s
+
+       exporters:
+         debug:
+           verbosity: basic
+         otlp_grpc/tempo:
+           endpoint: tempo.observability:4317
+           tls:
+             insecure: true
+         prometheus:
+           endpoint: 0.0.0.0:8889
+         otlp_http/loki:
+           endpoint: http://loki.observability:3100/otlp
+
+       service:
+         pipelines:
+           traces:
+             receivers: [otlp]
+             processors: [memory_limiter, batch]
+             exporters: [otlp_grpc/tempo, debug]
+           metrics:
+             receivers: [otlp]
+             processors: [memory_limiter, batch]
+             exporters: [prometheus, debug]
+           logs:
+             receivers: [otlp]
+             processors: [memory_limiter, batch]
+             exporters: [otlp_http/loki, debug]" | kubectl apply -f -
+   ```
+
+   A few things worth flagging:
+
+   - `memory_limiter` runs first. The OpenTelemetry project recommends this so the collector can shed load before later processors allocate. If batching ran first, a burst could OOM the pod before the limiter ever saw it.
+   - `batch` reduces export overhead. `send_batch_size: 4096` is a reasonable starting point. Tune up if your backend complains about request rate, down if it complains about batch size.
+   - The `debug` exporter sits in every pipeline at `verbosity: basic`. It logs one line per batch. Bump to `detailed` and reload the config when you need to see individual records.
+   - Swap `otlp_grpc/tempo`, `prometheus`, and `otlp_http/loki` for whatever your backends are. A single OTLP-compatible backend can replace all three.
+
+1. Apply the workload and service. Both topologies share the same collector configuration. Only the workload kind and the service traffic policy change.
+
+   {% navtabs "topology" %}
+   {% navtab "Deployment" %}
+
+   ```sh
+   echo "apiVersion: apps/v1
+   kind: Deployment
+   metadata:
+     name: otel-collector
+     namespace: observability
+   spec:
+     replicas: 2
+     selector:
+       matchLabels:
+         app: otel-collector
+     template:
+       metadata:
+         labels:
+           app: otel-collector
+       spec:
+         containers:
+           - name: otel-collector
+             image: otel/opentelemetry-collector-contrib:latest
+             args: ['--config=/conf/config.yaml']
+             ports:
+               - name: otlp-grpc
+                 containerPort: 4317
+               - name: otlp-http
+                 containerPort: 4318
+               - name: prometheus
+                 containerPort: 8889
+             resources:
+               requests:
+                 cpu: 100m
+                 memory: 256Mi
+               limits:
+                 cpu: 500m
+                 memory: 512Mi
+             volumeMounts:
+               - name: config
+                 mountPath: /conf
+         volumes:
+           - name: config
+             configMap:
+               name: otel-collector-config
+   ---
+   apiVersion: v1
+   kind: Service
+   metadata:
+     name: otel-collector
+     namespace: observability
+   spec:
+     selector:
+       app: otel-collector
+     ports:
+       - name: otlp-grpc
+         port: 4317
+         targetPort: otlp-grpc
+         appProtocol: grpc
+       - name: otlp-http
+         port: 4318
+         targetPort: otlp-http
+       - name: prometheus
+         port: 8889
+         targetPort: prometheus" | kubectl apply -f -
+   ```
+
+   {% endnavtab %}
+   {% navtab "DaemonSet" %}
+
+   ```sh
+   echo "apiVersion: apps/v1
+   kind: DaemonSet
+   metadata:
+     name: otel-collector
+     namespace: observability
+   spec:
+     selector:
+       matchLabels:
+         app: otel-collector
+     template:
+       metadata:
+         labels:
+           app: otel-collector
+       spec:
+         containers:
+           - name: otel-collector
+             image: otel/opentelemetry-collector-contrib:latest
+             args: ['--config=/conf/config.yaml']
+             ports:
+               - name: otlp-grpc
+                 containerPort: 4317
+               - name: otlp-http
+                 containerPort: 4318
+               - name: prometheus
+                 containerPort: 8889
+             resources:
+               requests:
+                 cpu: 100m
+                 memory: 256Mi
+               limits:
+                 cpu: 500m
+                 memory: 512Mi
+             volumeMounts:
+               - name: config
+                 mountPath: /conf
+         volumes:
+           - name: config
+             configMap:
+               name: otel-collector-config
+   ---
+   apiVersion: v1
+   kind: Service
+   metadata:
+     name: otel-collector
+     namespace: observability
+   spec:
+     selector:
+       app: otel-collector
+     internalTrafficPolicy: Local
+     ports:
+       - name: otlp-grpc
+         port: 4317
+         targetPort: otlp-grpc
+         appProtocol: grpc
+       - name: otlp-http
+         port: 4318
+         targetPort: otlp-http
+       - name: prometheus
+         port: 8889
+         targetPort: prometheus" | kubectl apply -f -
+   ```
+
+   {% endnavtab %}
+   {% endnavtabs %}
+
+   The DNS name `otel-collector.observability:4317` works the same way in both options. With `internalTrafficPolicy: Local`, kube-proxy resolves it to the node-local pod transparently.
+
+1. Wait for the collector to be ready:
+
+   ```sh
+   kubectl wait -n observability --for=condition=ready pod -l app=otel-collector --timeout=120s
+   ```
+
+## Point {{site.mesh_product_name}} policies at the collector
+
+All three policies use the same endpoint. Apply them at the `Mesh` level to cover every sidecar in the mesh:
+
+```sh
+echo "apiVersion: kuma.io/v1alpha1
+kind: MeshMetric
+metadata:
+  name: all-metrics
+  namespace: kong-mesh-system
+  labels:
+    kuma.io/mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    backends:
+      - type: OpenTelemetry
+        openTelemetry:
+          endpoint: otel-collector.observability:4317
+---
+apiVersion: kuma.io/v1alpha1
+kind: MeshTrace
+metadata:
+  name: all-traces
+  namespace: kong-mesh-system
+  labels:
+    kuma.io/mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    backends:
+      - type: OpenTelemetry
+        openTelemetry:
+          endpoint: otel-collector.observability:4317
+    sampling:
+      overall: 100
+---
+apiVersion: kuma.io/v1alpha1
+kind: MeshAccessLog
+metadata:
+  name: all-access-logs
+  namespace: kong-mesh-system
+  labels:
+    kuma.io/mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+  rules:
+    - default:
+        backends:
+          - type: OpenTelemetry
+            openTelemetry:
+              endpoint: otel-collector.observability:4317" | kubectl apply -f -
+```
+
+{:.info}
+> Trace sampling is set to 100% so you see something during testing. Drop it to single digits in production.
+
+## Reach the collector when passthrough is off
+
+By default, sidecars can reach addresses outside the mesh through [passthrough mode](/mesh/policies/meshpassthrough/). The collector lives outside the mesh, so passthrough is what gets sidecar telemetry to it.
+
+If you disable passthrough at the `Mesh` level, sidecars can't reach the collector anymore and telemetry stops. To restore that path, declare the collector with a [MeshExternalService](/mesh/meshexternalservice/).
+
+{:.info}
+> `MeshExternalService` requires [ZoneEgress](/mesh/zone-egress/) and [mutual TLS](/mesh/mutual-tls/) on the mesh. If you already disabled passthrough, you likely have mTLS on already.
+
+```sh
+echo "apiVersion: kuma.io/v1alpha1
+kind: MeshExternalService
+metadata:
+  name: otel-collector
+  namespace: kong-mesh-system
+  labels:
+    kuma.io/mesh: default
+spec:
+  match:
+    type: HostnameGenerator
+    port: 4317
+    protocol: grpc
+  endpoints:
+    - address: otel-collector.observability
+      port: 4317" | kubectl apply -f -
+```
+
+The hostname generator publishes the service under `otel-collector.extsvc.mesh.local`. Update the three policies to point at that hostname on port 4317 instead of `otel-collector.observability:4317`.
+
+## Verify the collector
+
+1. Check that the collector is receiving data:
+
+   ```sh
+   kubectl logs -n observability -l app=otel-collector --tail=20
+   ```
+
+   With the `debug` exporter at `verbosity: basic`, each batch shows up as one line per signal. If you see nothing, walk back: is the policy applied to the right `Mesh`, does the collector pod's address match the policy `endpoint`, can a debug pod in a mesh namespace reach `otel-collector.observability:4317` on TCP?
+
+1. For the DaemonSet topology, confirm that traffic is going node-local:
+
+   ```sh
+   kubectl get pod -n observability -o wide -l app=otel-collector
+   kubectl get endpointslice -n observability -l kubernetes.io/service-name=otel-collector -o yaml
+   ```
+
+   The endpoint slice will list one collector pod per node. With `Local` traffic policy, each node's kube-proxy only routes to its own entry.

--- a/app/_how-tos/mesh/deploy-an-opentelemetry-collector.md
+++ b/app/_how-tos/mesh/deploy-an-opentelemetry-collector.md
@@ -90,7 +90,7 @@ Run one collector pod per node and route traffic node-locally. With `internalTra
 Pick this for large clusters or workloads where the extra network hop matters. It improves locality, distributes load across nodes, and isolates collector failure to a single node's telemetry.
 
 {:.warning}
-> The tradeoff is silent loss. If the collector pod on a node crashes or is being rescheduled, sidecars on that node have no fallback. Their telemetry drops on the floor until the pod is back. There is no cross-node failover with `Local` traffic policy.
+> The trade-off is silent loss. If the collector pod on a node crashes or is being rescheduled, sidecars on that node have no fallback. Their telemetry drops on the floor until the pod is back. There is no cross-node failover with `Local` traffic policy.
 
 ## Deploy the collector
 
@@ -168,6 +168,7 @@ Pick this for large clusters or workloads where the extra network hop matters. I
    - `batch` reduces export overhead. `send_batch_size: 4096` is a reasonable starting point. Tune up if your backend complains about request rate, down if it complains about batch size.
    - The `debug` exporter is enabled in every pipeline at `verbosity: basic` so each batch shows up as one log line. Drop it from the pipelines once you've verified the setup, or bump to `verbosity: detailed` when you need to see individual records.
    - `otlp_grpc/tempo`, `otlp_http/loki`, and `prometheus` are examples. The trace and log exporters send OTLP to a backend; the `prometheus` exporter exposes a `/metrics` endpoint on port 8889 for Prometheus to scrape. Swap the addresses to match your own backends.
+   - `tls.insecure: true` on the Tempo exporter disables certificate verification for the in-cluster example. In production, point the exporter at a TLS endpoint with a trusted CA and remove the `insecure` flag.
 
 1. Apply the workload and service. Both topologies share the same collector configuration. Only the workload kind and the service traffic policy change.
 
@@ -381,7 +382,7 @@ By default, sidecars can reach addresses outside the mesh through [passthrough m
 If you disable passthrough at the `Mesh` level, sidecars can't reach the collector anymore and telemetry stops. To restore that path, declare the collector with a [MeshExternalService](/mesh/meshexternalservice/).
 
 {:.info}
-> `MeshExternalService` requires [ZoneEgress](/mesh/zone-egress/) and [mutual TLS](/mesh/mutual-tls/) on the mesh. If you already disabled passthrough, you likely have mTLS on already.
+> `MeshExternalService` requires [ZoneEgress](/mesh/zone-egress/) and [mutual TLS](/mesh/policies/mutual-tls/) on the mesh. If you already disabled passthrough, you likely have mTLS on already.
 
 ```sh
 echo "apiVersion: kuma.io/v1alpha1

--- a/app/_how-tos/mesh/deploy-an-opentelemetry-collector.md
+++ b/app/_how-tos/mesh/deploy-an-opentelemetry-collector.md
@@ -124,7 +124,7 @@ faqs:
             targetPort: prometheus" | kubectl apply -f -
       ```
 
-      Sidecars resolve `otel-collector.observability:4317` to whichever replica kube-proxy picks. With a Deployment, you can skip the node-local checks (Pod node assignments and endpoint slice) in [Verify the collector](#verify-the-collector).
+      Sidecars resolve `otel-collector.observability:4317` to the Service IP, and Kubernetes forwards traffic to one of the collector replicas. With a Deployment, you can skip the node-local checks (Pod node assignments and endpoint slice) in [Verify the collector](#verify-the-collector).
 
 prereqs:
   inline:

--- a/app/_how-tos/mesh/deploy-an-opentelemetry-collector.md
+++ b/app/_how-tos/mesh/deploy-an-opentelemetry-collector.md
@@ -156,6 +156,9 @@ prereqs:
         helm install tempo grafana/tempo \
           --namespace observability --create-namespace \
           -f values-tempo.yaml
+
+        kubectl wait -n observability --for=condition=ready pod \
+          -l app.kubernetes.io/name=tempo --timeout=120s
         ```
       icon_url: /assets/icons/third-party/grafana.svg
     - title: Loki

--- a/app/_how-tos/mesh/deploy-an-opentelemetry-collector.md
+++ b/app/_how-tos/mesh/deploy-an-opentelemetry-collector.md
@@ -51,13 +51,15 @@ prereqs:
       include_content: prereqs/kubernetes/mesh-cluster
     - title: Install {{site.mesh_product_name}} with demo configuration
       include_content: prereqs/kubernetes/mesh-quickstart
-    - title: Install the observability backends
+    - title: Observability backends
       content: |
-        Install the {{site.mesh_product_name}} observability stack, or have your own Prometheus, Tempo or Jaeger, and Loki backends ready to receive OTLP:
+        Bring your own backends for the three signals the collector forwards. The examples in this guide assume:
 
-        ```sh
-        kumactl install observability | kubectl apply -f -
-        ```
+        - A trace backend that accepts OTLP gRPC (for example, Tempo or Jaeger)
+        - A log backend that accepts OTLP HTTP (for example, Loki)
+        - Prometheus scraping the collector's `/metrics` endpoint
+
+        Adjust the exporter section of the collector config to match the addresses of your backends.
 
 ---
 
@@ -83,7 +85,7 @@ This is the default recommendation. It's simple, the failure domain is the whole
 
 ### Per-node DaemonSet
 
-Run one collector pod per node and route traffic node-locally. With `internalTrafficPolicy: Local` on the service, kube-proxy sends each sidecar to the collector pod on the same node. Sidecars still resolve the same DNS name (`otel-collector.observability:4317`), but the hop never leaves the node.
+Run one collector pod per node and route traffic node-locally. With `internalTrafficPolicy: Local` on the service, kube-proxy on each node only forwards to the collector pod on that same node. Sidecars still resolve the same DNS name (`otel-collector.observability:4317`), but the hop never leaves the node.
 
 Pick this for large clusters or workloads where the extra network hop matters. It improves locality, distributes load across nodes, and isolates collector failure to a single node's telemetry.
 
@@ -92,14 +94,19 @@ Pick this for large clusters or workloads where the extra network hop matters. I
 
 ## Deploy the collector
 
-1. Create a dedicated namespace and exclude it from sidecar injection. If the collector pod runs a sidecar that pushes its own telemetry through itself, you get a circular dependency.
+1. Create a dedicated namespace for the collector. The collector pod must not run a sidecar that pushes its own telemetry through itself, which would create a circular dependency.
 
    ```sh
    kubectl create namespace observability
+   ```
+
+1. Exclude the namespace from sidecar injection:
+
+   ```sh
    kubectl label namespace observability kuma.io/sidecar-injection=disabled
    ```
 
-1. Apply the collector configuration. It defines three pipelines, a memory limiter as the first processor, a tuned batch processor, and a debug exporter you can switch on when something looks wrong.
+1. Apply the collector configuration. It defines three pipelines, a memory limiter as the first processor, a tuned batch processor, and a debug exporter on every pipeline so you can see what's flowing through during testing.
 
    ```sh
    echo "apiVersion: v1
@@ -159,8 +166,8 @@ Pick this for large clusters or workloads where the extra network hop matters. I
 
    - `memory_limiter` runs first. The OpenTelemetry project recommends this so the collector can shed load before later processors allocate. If batching ran first, a burst could OOM the pod before the limiter ever saw it.
    - `batch` reduces export overhead. `send_batch_size: 4096` is a reasonable starting point. Tune up if your backend complains about request rate, down if it complains about batch size.
-   - The `debug` exporter sits in every pipeline at `verbosity: basic`. It logs one line per batch. Bump to `detailed` and reload the config when you need to see individual records.
-   - Swap `otlp_grpc/tempo`, `prometheus`, and `otlp_http/loki` for whatever your backends are. A single OTLP-compatible backend can replace all three.
+   - The `debug` exporter is enabled in every pipeline at `verbosity: basic` so each batch shows up as one log line. Drop it from the pipelines once you've verified the setup, or bump to `verbosity: detailed` when you need to see individual records.
+   - `otlp_grpc/tempo`, `otlp_http/loki`, and `prometheus` are examples. The trace and log exporters send OTLP to a backend; the `prometheus` exporter exposes a `/metrics` endpoint on port 8889 for Prometheus to scrape. Swap the addresses to match your own backends.
 
 1. Apply the workload and service. Both topologies share the same collector configuration. Only the workload kind and the service traffic policy change.
 
@@ -185,7 +192,7 @@ Pick this for large clusters or workloads where the extra network hop matters. I
        spec:
          containers:
            - name: otel-collector
-             image: otel/opentelemetry-collector-contrib:latest
+             image: otel/opentelemetry-collector-contrib:0.141.0
              args: ['--config=/conf/config.yaml']
              ports:
                - name: otlp-grpc
@@ -250,7 +257,7 @@ Pick this for large clusters or workloads where the extra network hop matters. I
        spec:
          containers:
            - name: otel-collector
-             image: otel/opentelemetry-collector-contrib:latest
+             image: otel/opentelemetry-collector-contrib:0.141.0
              args: ['--config=/conf/config.yaml']
              ports:
                - name: otlp-grpc
@@ -406,10 +413,15 @@ The hostname generator publishes the service under `otel-collector.extsvc.mesh.l
 
    With the `debug` exporter at `verbosity: basic`, each batch shows up as one line per signal. If you see nothing, walk back: is the policy applied to the right `Mesh`, does the collector pod's address match the policy `endpoint`, can a debug pod in a mesh namespace reach `otel-collector.observability:4317` on TCP?
 
-1. For the DaemonSet topology, confirm that traffic is going node-local:
+1. For the DaemonSet topology, list the collector pods with their node assignments:
 
    ```sh
    kubectl get pod -n observability -o wide -l app=otel-collector
+   ```
+
+1. Inspect the endpoint slice to confirm traffic is going node-local:
+
+   ```sh
    kubectl get endpointslice -n observability -l kubernetes.io/service-name=otel-collector -o yaml
    ```
 

--- a/app/_how-tos/mesh/deploy-an-opentelemetry-collector.md
+++ b/app/_how-tos/mesh/deploy-an-opentelemetry-collector.md
@@ -1,6 +1,6 @@
 ---
 title: Deploy an OpenTelemetry collector for metrics, traces, and logs
-description: Run one OpenTelemetry collector that receives metrics, traces, and access logs from {{site.mesh_product_name}}, with guidance on Deployment vs DaemonSet topologies and passthrough handling.
+description: Run a per-node OpenTelemetry collector to receive metrics, traces, and access logs from {{site.mesh_product_name}} sidecars.
 
 content_type: how_to
 permalink: /mesh/deploy-an-opentelemetry-collector/
@@ -43,7 +43,7 @@ next_steps:
 
 tldr:
   q: How do I deploy an OpenTelemetry collector for {{site.mesh_product_name}}?
-  a: Run a single OpenTelemetry collector that receives metrics, traces, and access logs from sidecars over OTLP, and pick between a Deployment or per-node DaemonSet topology.
+  a: Run a per-node OpenTelemetry collector DaemonSet that receives metrics, traces, and access logs from sidecars over OTLP, then point the mesh policies at it.
 
 prereqs:
   inline:
@@ -63,34 +63,19 @@ prereqs:
 
 ---
 
-This guide deploys a single OpenTelemetry collector that receives all three telemetry signals from {{site.mesh_product_name}}: metrics from [MeshMetric](/mesh/policies/meshmetric/), traces from [MeshTrace](/mesh/policies/meshtrace/), and access logs from [MeshAccessLog](/mesh/policies/meshaccesslog/). It covers two production topologies, how the collector fits with sidecar injection, and what changes when mesh passthrough is off.
+This guide deploys an OpenTelemetry collector that receives all three telemetry signals from {{site.mesh_product_name}}: metrics from [MeshMetric](/mesh/policies/meshmetric/), traces from [MeshTrace](/mesh/policies/meshtrace/), and access logs from [MeshAccessLog](/mesh/policies/meshaccesslog/). It runs a per-node DaemonSet so sidecar traffic stays node-local, and explains what changes when mesh passthrough is off.
 
 ## How {{site.mesh_product_name}} talks to the collector
 
 Sidecars push telemetry to the collector over OTLP gRPC on port 4317. The collector receives, batches, and exports it to whatever backends you configure.
 
-This is a push model. Each sidecar opens an outbound connection to one collector pod and writes its own telemetry. Compare that to a pull model, where a collector scrapes Prometheus endpoints from every workload it can reach.
+This is a push model. Each sidecar opens an outbound connection to one collector pod and writes its own telemetry. With `internalTrafficPolicy: Local` on the collector service, kube-proxy on each node only forwards to the collector pod on that same node, so the hop never leaves the node.
 
-The distinction matters when you pick a topology. A [CNCF post](https://www.cncf.io/blog/2025/12/16/how-to-build-a-cost-effective-observability-platform-with-opentelemetry/) warns about 20-40x metric explosion when DaemonSet collectors all scrape the same Prometheus targets. That problem is specific to the pull model. {{site.mesh_product_name}} pushes, so each metric reaches one collector instance regardless of how many collector pods exist.
-
-## Pick a topology
-
-Two patterns work for the OTLP receiver. Pick one before you write the manifests.
-
-### Deployment + ClusterIP service
-
-Run two or three collector replicas behind a `ClusterIP` service. Sidecars resolve `otel-collector.observability:4317` to whichever replica kube-proxy picks.
-
-This is the default recommendation. It's simple, the failure domain is the whole replica set, and a rolling update of the collector doesn't drop telemetry from any specific node. Use this for small and medium clusters, or any cluster where collector throughput isn't a bottleneck.
-
-### Per-node DaemonSet
-
-Run one collector pod per node and route traffic node-locally. With `internalTrafficPolicy: Local` on the service, kube-proxy on each node only forwards to the collector pod on that same node. Sidecars still resolve the same DNS name (`otel-collector.observability:4317`), but the hop never leaves the node.
-
-Pick this for large clusters or workloads where the extra network hop matters. It improves locality, distributes load across nodes, and isolates collector failure to a single node's telemetry.
+{:.info}
+> A DaemonSet fits most clusters. You can also run the collector as a `Deployment` behind a `ClusterIP` service, as a [sidecar agent](https://opentelemetry.io/docs/collector/deployment/agent/) on the workload pod, or as a [gateway tier](https://opentelemetry.io/docs/collector/deployment/gateway/) in front of your backends. The config, policies, and external-service setup later in this guide apply to any of these.
 
 {:.warning}
-> The trade-off is silent loss. If the collector pod on a node crashes or is being rescheduled, sidecars on that node have no fallback. Their telemetry drops on the floor until the pod is back. There is no cross-node failover with `Local` traffic policy.
+> The trade-off of `internalTrafficPolicy: Local` is silent loss. If the collector pod on a node crashes or is being rescheduled, sidecars on that node have no fallback. Their telemetry drops on the floor until the pod is back. There is no cross-node failover with `Local` traffic policy.
 
 ## Deploy the collector
 
@@ -170,76 +155,7 @@ Pick this for large clusters or workloads where the extra network hop matters. I
    - `otlp_grpc/tempo`, `otlp_http/loki`, and `prometheus` are examples. The trace and log exporters send OTLP to a backend; the `prometheus` exporter exposes a `/metrics` endpoint on port 8889 for Prometheus to scrape. Swap the addresses to match your own backends.
    - `tls.insecure: true` on the Tempo exporter disables certificate verification for the in-cluster example. In production, point the exporter at a TLS endpoint with a trusted CA and remove the `insecure` flag.
 
-1. Apply the workload and service. Both topologies share the same collector configuration. Only the workload kind and the service traffic policy change.
-
-   {% navtabs "topology" %}
-   {% navtab "Deployment" %}
-
-   ```sh
-   echo "apiVersion: apps/v1
-   kind: Deployment
-   metadata:
-     name: otel-collector
-     namespace: observability
-   spec:
-     replicas: 2
-     selector:
-       matchLabels:
-         app: otel-collector
-     template:
-       metadata:
-         labels:
-           app: otel-collector
-       spec:
-         containers:
-           - name: otel-collector
-             image: otel/opentelemetry-collector-contrib:0.141.0
-             args: ['--config=/conf/config.yaml']
-             ports:
-               - name: otlp-grpc
-                 containerPort: 4317
-               - name: otlp-http
-                 containerPort: 4318
-               - name: prometheus
-                 containerPort: 8889
-             resources:
-               requests:
-                 cpu: 100m
-                 memory: 256Mi
-               limits:
-                 cpu: 500m
-                 memory: 512Mi
-             volumeMounts:
-               - name: config
-                 mountPath: /conf
-         volumes:
-           - name: config
-             configMap:
-               name: otel-collector-config
-   ---
-   apiVersion: v1
-   kind: Service
-   metadata:
-     name: otel-collector
-     namespace: observability
-   spec:
-     selector:
-       app: otel-collector
-     ports:
-       - name: otlp-grpc
-         port: 4317
-         targetPort: otlp-grpc
-         appProtocol: grpc
-       - name: otlp-http
-         port: 4318
-         targetPort: otlp-http
-       - name: prometheus
-         port: 8889
-         targetPort: prometheus" | kubectl apply -f -
-   ```
-
-   {% endnavtab %}
-   {% navtab "DaemonSet" %}
+1. Apply the DaemonSet and node-local service:
 
    ```sh
    echo "apiVersion: apps/v1
@@ -304,10 +220,7 @@ Pick this for large clusters or workloads where the extra network hop matters. I
          targetPort: prometheus" | kubectl apply -f -
    ```
 
-   {% endnavtab %}
-   {% endnavtabs %}
-
-   The DNS name `otel-collector.observability:4317` works the same way in both options. With `internalTrafficPolicy: Local`, kube-proxy resolves it to the node-local pod transparently.
+   Sidecars resolve `otel-collector.observability:4317` to whichever collector pod runs on their node.
 
 1. Wait for the collector to be ready:
 
@@ -414,7 +327,7 @@ The hostname generator publishes the service under `otel-collector.extsvc.mesh.l
 
    With the `debug` exporter at `verbosity: basic`, each batch shows up as one line per signal. If you see nothing, walk back: is the policy applied to the right `Mesh`, does the collector pod's address match the policy `endpoint`, can a debug pod in a mesh namespace reach `otel-collector.observability:4317` on TCP?
 
-1. For the DaemonSet topology, list the collector pods with their node assignments:
+1. List the collector pods with their node assignments:
 
    ```sh
    kubectl get pod -n observability -o wide -l app=otel-collector

--- a/app/_how-tos/mesh/deploy-an-opentelemetry-collector.md
+++ b/app/_how-tos/mesh/deploy-an-opentelemetry-collector.md
@@ -38,6 +38,8 @@ next_steps:
     url: /mesh/policies/meshtrace/
   - text: MeshAccessLog policy
     url: /mesh/policies/meshaccesslog/
+  - text: OpenTelemetry collector deployment patterns
+    url: https://opentelemetry.io/docs/collector/deploy/
   - text: OpenTelemetry collector processors
     url: https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor
 
@@ -63,23 +65,11 @@ prereqs:
 
 ---
 
-This guide deploys an OpenTelemetry collector that receives all three telemetry signals from {{site.mesh_product_name}}: metrics from [MeshMetric](/mesh/policies/meshmetric/), traces from [MeshTrace](/mesh/policies/meshtrace/), and access logs from [MeshAccessLog](/mesh/policies/meshaccesslog/). It runs a per-node DaemonSet so sidecar traffic stays node-local, and explains what changes when mesh passthrough is off.
-
-## How {{site.mesh_product_name}} talks to the collector
-
-Sidecars push telemetry to the collector over OTLP gRPC on port 4317. The collector receives, batches, and exports it to whatever backends you configure.
-
-This is a push model. Each sidecar opens an outbound connection to one collector pod and writes its own telemetry. With `internalTrafficPolicy: Local` on the collector service, kube-proxy on each node only forwards to the collector pod on that same node, so the hop never leaves the node.
-
-{:.info}
-> A DaemonSet is one form of the OpenTelemetry [agent](https://opentelemetry.io/docs/collector/deploy/agent/) pattern. You can also run the agent as a centralized `Deployment` behind a `ClusterIP` service, as a per-pod sidecar container, or front your backends with a [gateway](https://opentelemetry.io/docs/collector/deploy/gateway/) tier. The ConfigMap below carries over, but the `Service`, the `endpoint` in each mesh policy, and the `MeshExternalService` step may need to change for those shapes. For example, a sidecar collector receives on `localhost:4317` and doesn't live in a separate namespace.
-
-{:.warning}
-> The trade-off of `internalTrafficPolicy: Local` is silent loss. If the collector pod on a node crashes or is being rescheduled, sidecars on that node have no fallback. Their telemetry drops on the floor until the pod is back. There is no cross-node failover with `Local` traffic policy.
+This guide deploys an OpenTelemetry collector that receives all three telemetry signals from {{site.mesh_product_name}}: metrics from [MeshMetric](/mesh/policies/meshmetric/), traces from [MeshTrace](/mesh/policies/meshtrace/), and access logs from [MeshAccessLog](/mesh/policies/meshaccesslog/). The collector runs as a per-node DaemonSet, and sidecars push to it over OTLP gRPC on port 4317. It also covers what to change when mesh passthrough is off.
 
 ## Deploy the collector
 
-1. Create a dedicated namespace for the collector. The collector pod must not run a sidecar that pushes its own telemetry through itself, which would create a circular dependency.
+1. Create a dedicated namespace for the collector. A sidecar in the collector's own pod would push telemetry through the collector itself, creating a loop.
 
    ```sh
    kubectl create namespace observability
@@ -91,7 +81,7 @@ This is a push model. Each sidecar opens an outbound connection to one collector
    kubectl label namespace observability kuma.io/sidecar-injection=disabled
    ```
 
-1. Apply the collector configuration. It defines three pipelines, a memory limiter as the first processor, a tuned batch processor, and a debug exporter on every pipeline so you can see what's flowing through during testing.
+1. Apply the collector configuration. It defines three pipelines that share a `memory_limiter` ahead of `batch` (so the collector sheds load before allocating) and a `debug` exporter on every pipeline for verification. Swap `tempo`, `loki`, and `prometheus` for your own backends, and drop `debug` and `tls.insecure: true` for production.
 
    ```sh
    echo "apiVersion: v1
@@ -146,14 +136,6 @@ This is a push model. Each sidecar opens an outbound connection to one collector
              processors: [memory_limiter, batch]
              exporters: [otlp_http/loki, debug]" | kubectl apply -f -
    ```
-
-   A few things worth flagging:
-
-   - `memory_limiter` runs first. The OpenTelemetry project recommends this so the collector can shed load before later processors allocate. If batching ran first, a burst could OOM the pod before the limiter ever saw it.
-   - `batch` reduces export overhead. `send_batch_size: 4096` is a reasonable starting point. Tune up if your backend complains about request rate, down if it complains about batch size.
-   - The `debug` exporter is enabled in every pipeline at `verbosity: basic` so each batch shows up as one log line. Drop it from the pipelines once you've verified the setup, or bump to `verbosity: detailed` when you need to see individual records.
-   - `otlp_grpc/tempo`, `otlp_http/loki`, and `prometheus` are examples. The trace and log exporters send OTLP to a backend; the `prometheus` exporter exposes a `/metrics` endpoint on port 8889 for Prometheus to scrape. Swap the addresses to match your own backends.
-   - `tls.insecure: true` on the Tempo exporter disables certificate verification for the in-cluster example. In production, point the exporter at a TLS endpoint with a trusted CA and remove the `insecure` flag.
 
 1. Apply the DaemonSet and node-local service:
 
@@ -221,6 +203,9 @@ This is a push model. Each sidecar opens an outbound connection to one collector
    ```
 
    Sidecars resolve `otel-collector.observability:4317` to whichever collector pod runs on their node.
+
+   {:.warning}
+   > `internalTrafficPolicy: Local` keeps the hop node-local but doesn't fail over to another node. If the collector pod on a node restarts, that node's telemetry drops until it's back.
 
 1. Wait for the collector to be ready:
 
@@ -290,12 +275,10 @@ spec:
 
 ## Reach the collector when passthrough is off
 
-By default, sidecars can reach addresses outside the mesh through [passthrough mode](/mesh/policies/meshpassthrough/). The collector lives outside the mesh, so passthrough is what gets sidecar telemetry to it.
-
-If you disable passthrough at the `Mesh` level, sidecars can't reach the collector anymore and telemetry stops. To restore that path, declare the collector with a [MeshExternalService](/mesh/meshexternalservice/).
+By default, sidecars reach the collector through [passthrough mode](/mesh/policies/meshpassthrough/). If you've disabled passthrough on the `Mesh`, declare the collector with a [MeshExternalService](/mesh/meshexternalservice/) so sidecars can still reach it:
 
 {:.info}
-> `MeshExternalService` requires [ZoneEgress](/mesh/zone-egress/) and [mutual TLS](/mesh/policies/mutual-tls/) on the mesh. If you already disabled passthrough, you likely have mTLS on already.
+> `MeshExternalService` requires [ZoneEgress](/mesh/zone-egress/) and [mutual TLS](/mesh/policies/mutual-tls/) on the mesh. If you already disabled passthrough, you likely already have mTLS enabled.
 
 ```sh
 echo "apiVersion: kuma.io/v1alpha1
@@ -325,7 +308,7 @@ The hostname generator publishes the service under `otel-collector.extsvc.mesh.l
    kubectl logs -n observability -l app=otel-collector --tail=20
    ```
 
-   With the `debug` exporter at `verbosity: basic`, each batch shows up as one line per signal. If you see nothing, walk back: is the policy applied to the right `Mesh`, does the collector pod's address match the policy `endpoint`, can a debug pod in a mesh namespace reach `otel-collector.observability:4317` on TCP?
+   With the `debug` exporter at `verbosity: basic`, each batch shows up as one line per signal. If you see nothing, check that the policy targets the right `Mesh`, the policy `endpoint` matches the collector's service DNS, and a debug pod in a mesh namespace can reach `otel-collector.observability:4317` on TCP.
 
 1. List the collector pods with their node assignments:
 

--- a/app/_how-tos/mesh/deploy-an-opentelemetry-collector.md
+++ b/app/_how-tos/mesh/deploy-an-opentelemetry-collector.md
@@ -72,7 +72,7 @@ Sidecars push telemetry to the collector over OTLP gRPC on port 4317. The collec
 This is a push model. Each sidecar opens an outbound connection to one collector pod and writes its own telemetry. With `internalTrafficPolicy: Local` on the collector service, kube-proxy on each node only forwards to the collector pod on that same node, so the hop never leaves the node.
 
 {:.info}
-> A DaemonSet fits most clusters. You can also run the collector as a `Deployment` behind a `ClusterIP` service, as a [sidecar agent](https://opentelemetry.io/docs/collector/deployment/agent/) on the workload pod, or as a [gateway tier](https://opentelemetry.io/docs/collector/deployment/gateway/) in front of your backends. The config, policies, and external-service setup later in this guide apply to any of these.
+> A DaemonSet is one form of the OpenTelemetry [agent](https://opentelemetry.io/docs/collector/deploy/agent/) pattern. You can also run the agent as a centralized `Deployment` behind a `ClusterIP` service, as a per-pod sidecar container, or front your backends with a [gateway](https://opentelemetry.io/docs/collector/deploy/gateway/) tier. The ConfigMap below carries over, but the `Service`, the `endpoint` in each mesh policy, and the `MeshExternalService` step may need to change for those shapes. For example, a sidecar collector receives on `localhost:4317` and doesn't live in a separate namespace.
 
 {:.warning}
 > The trade-off of `internalTrafficPolicy: Local` is silent loss. If the collector pod on a node crashes or is being rescheduled, sidecars on that node have no fallback. Their telemetry drops on the floor until the pod is back. There is no cross-node failover with `Local` traffic policy.

--- a/app/_how-tos/mesh/deploy-an-opentelemetry-collector.md
+++ b/app/_how-tos/mesh/deploy-an-opentelemetry-collector.md
@@ -1,6 +1,6 @@
 ---
 title: Deploy an OpenTelemetry collector for metrics, traces, and logs
-description: Run a per-node OpenTelemetry collector to receive metrics, traces, and access logs from {{site.mesh_product_name}} sidecars.
+description: Run a per-node OpenTelemetry collector DaemonSet that receives metrics, traces, and access logs from {{site.mesh_product_name}} sidecars and forwards them to your backends.
 
 content_type: how_to
 permalink: /mesh/deploy-an-opentelemetry-collector/
@@ -45,35 +45,199 @@ next_steps:
 
 tldr:
   q: How do I deploy an OpenTelemetry collector for {{site.mesh_product_name}}?
-  a: Run a per-node OpenTelemetry collector DaemonSet that receives metrics, traces, and access logs from sidecars over OTLP, then point the mesh policies at it.
+  a: Run an OpenTelemetry collector as a per-node Kubernetes `DaemonSet` that receives metrics, traces, and access logs from sidecars over OTLP and forwards them to your backends.
+
+faqs:
+  - q: What should I check if no telemetry reaches the collector?
+    a: |
+      Walk back through these checks:
+
+      - Did you apply the policy to the right `Mesh`?
+      - Does the collector Pod's address match the policy `endpoint`?
+      - Can a debug Pod in a mesh namespace reach `otel-collector.observability:4317` on TCP?
+  - q: How do I run the collector as a Deployment instead?
+    a: |
+      Use a Deployment for small and medium clusters, or any cluster where collector throughput isn't a bottleneck. See [OpenTelemetry collector topologies](/mesh/observability/#topologies) for the trade-offs.
+
+      Replace the DaemonSet workload and service in [Deploy the collector](#deploy-the-collector) with a Deployment behind a `ClusterIP` service:
+
+      ```sh
+      echo "apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: otel-collector
+        namespace: observability
+      spec:
+        replicas: 2
+        selector:
+          matchLabels:
+            app: otel-collector
+        template:
+          metadata:
+            labels:
+              app: otel-collector
+          spec:
+            containers:
+              - name: otel-collector
+                image: otel/opentelemetry-collector-contrib:0.141.0
+                args: ['--config=/conf/config.yaml']
+                ports:
+                  - name: otlp-grpc
+                    containerPort: 4317
+                  - name: otlp-http
+                    containerPort: 4318
+                  - name: prometheus
+                    containerPort: 8889
+                resources:
+                  requests:
+                    cpu: 100m
+                    memory: 256Mi
+                  limits:
+                    cpu: 500m
+                    memory: 512Mi
+                volumeMounts:
+                  - name: config
+                    mountPath: /conf
+            volumes:
+              - name: config
+                configMap:
+                  name: otel-collector-config
+      ---
+      apiVersion: v1
+      kind: Service
+      metadata:
+        name: otel-collector
+        namespace: observability
+      spec:
+        selector:
+          app: otel-collector
+        ports:
+          - name: otlp-grpc
+            port: 4317
+            targetPort: otlp-grpc
+            appProtocol: grpc
+          - name: otlp-http
+            port: 4318
+            targetPort: otlp-http
+          - name: prometheus
+            port: 8889
+            targetPort: prometheus" | kubectl apply -f -
+      ```
+
+      Sidecars resolve `otel-collector.observability:4317` to whichever replica kube-proxy picks. With a Deployment, you can skip the node-local checks (Pod node assignments and endpoint slice) in [Verify the collector](#verify-the-collector).
 
 prereqs:
   inline:
     - title: A running Kubernetes cluster
       include_content: prereqs/kubernetes/mesh-cluster
+    - title: Helm
+      include_content: prereqs/helm
     - title: Install {{site.mesh_product_name}} with demo configuration
       include_content: prereqs/kubernetes/mesh-quickstart
-    - title: Observability backends
+    - title: Tempo
       content: |
-        Bring your own backends for the three signals the collector forwards. The examples in this guide assume:
+        Install [Grafana Tempo](https://grafana.com/docs/tempo/latest/setup/helm-chart/) as the trace backend. The collector config in this guide pushes traces to `tempo.observability:4317`:
 
-        - A trace backend that accepts OTLP gRPC (for example, Tempo or Jaeger)
-        - A log backend that accepts OTLP HTTP (for example, Loki)
-        - Prometheus scraping the collector's `/metrics` endpoint
+        ```sh
+        helm repo add grafana https://grafana.github.io/helm-charts
+        helm repo update
 
-        Adjust the exporter section of the collector config to match the addresses of your backends.
+        echo "
+        tempo:
+          receivers:
+            otlp:
+              protocols:
+                grpc:
+                  endpoint: 0.0.0.0:4317
+                http:
+                  endpoint: 0.0.0.0:4318
+        " > values-tempo.yaml
+
+        helm install tempo grafana/tempo \
+          --namespace observability --create-namespace \
+          -f values-tempo.yaml
+        ```
+      icon_url: /assets/icons/third-party/grafana.svg
+    - title: Loki
+      content: |
+        Install [Grafana Loki](https://grafana.com/docs/loki/latest/setup/install/helm/) as the log backend. The collector config in this guide pushes logs to `http://loki.observability:3100/otlp`:
+
+        ```sh
+        helm repo add grafana https://grafana.github.io/helm-charts
+        helm repo update
+
+        echo "
+        deploymentMode: SingleBinary
+        loki:
+          auth_enabled: false
+          commonConfig:
+            replication_factor: 1
+          storage:
+            type: filesystem
+          schemaConfig:
+            configs:
+              - from: '2024-01-01'
+                store: tsdb
+                object_store: filesystem
+                schema: v13
+                index:
+                  prefix: loki_index_
+                  period: 24h
+        singleBinary:
+          replicas: 1
+        read:
+          replicas: 0
+        write:
+          replicas: 0
+        backend:
+          replicas: 0
+        chunksCache:
+          enabled: false
+        resultsCache:
+          enabled: false
+        " > values-loki.yaml
+
+        helm install loki grafana/loki \
+          --namespace observability --create-namespace \
+          -f values-loki.yaml
+        ```
+      icon_url: /assets/icons/third-party/grafana.svg
+    - title: Prometheus
+      content: |
+        Install [Prometheus](https://prometheus.io/docs/prometheus/latest/installation/) with a scrape job for the collector's `/metrics` endpoint at `otel-collector.observability:8889`:
+
+        ```sh
+        helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+        helm repo update
+
+        echo "
+        extraScrapeConfigs: |
+          - job_name: otel-collector
+            static_configs:
+              - targets: ['otel-collector.observability:8889']
+        " > values-prometheus.yaml
+
+        helm install prometheus prometheus-community/prometheus \
+          --namespace observability --create-namespace \
+          -f values-prometheus.yaml
+        ```
+      icon_url: /assets/icons/prometheus.svg
 
 ---
 
-This guide deploys an OpenTelemetry collector that receives all three telemetry signals from {{site.mesh_product_name}}: metrics from [MeshMetric](/mesh/policies/meshmetric/), traces from [MeshTrace](/mesh/policies/meshtrace/), and access logs from [MeshAccessLog](/mesh/policies/meshaccesslog/). The collector runs as a per-node DaemonSet, and sidecars push to it over OTLP gRPC on port 4317. It also covers what to change when mesh passthrough is off.
+This guide deploys an OpenTelemetry collector as a per-node Kubernetes `DaemonSet` that receives all three telemetry signals from {{site.mesh_product_name}}: metrics from [MeshMetric](/mesh/policies/meshmetric/), traces from [MeshTrace](/mesh/policies/meshtrace/), and access logs from [MeshAccessLog](/mesh/policies/meshaccesslog/). Sidecars push to it over OTLP gRPC on port 4317. It also covers what to change when mesh passthrough is off.
+
+For background on the push model and topology trade-offs, see [OpenTelemetry collector](/mesh/observability/#opentelemetry-collector) in the observability reference docs.
 
 ## Deploy the collector
 
-1. Create a dedicated namespace for the collector. A sidecar in the collector's own pod would push telemetry through the collector itself, creating a loop.
+1. Create a dedicated namespace for the collector:
 
    ```sh
-   kubectl create namespace observability
+   kubectl create namespace observability --dry-run=client -o yaml | kubectl apply -f -
    ```
+
+   The collector Pod must run without a sidecar, otherwise the sidecar would push telemetry back through the collector it runs alongside, creating a circular dependency.
 
 1. Exclude the namespace from sidecar injection:
 
@@ -81,7 +245,7 @@ This guide deploys an OpenTelemetry collector that receives all three telemetry 
    kubectl label namespace observability kuma.io/sidecar-injection=disabled
    ```
 
-1. Apply the collector configuration. It defines three pipelines that share a `memory_limiter` ahead of `batch` (so the collector sheds load before allocating) and a `debug` exporter on every pipeline for verification. Swap `tempo`, `loki`, and `prometheus` for your own backends, and drop `debug` and `tls.insecure: true` for production.
+1. Apply the collector configuration:
 
    ```sh
    echo "apiVersion: v1
@@ -112,13 +276,13 @@ This guide deploys an OpenTelemetry collector that receives all three telemetry 
        exporters:
          debug:
            verbosity: basic
-         otlp_grpc/tempo:
+         otlp/tempo:
            endpoint: tempo.observability:4317
            tls:
              insecure: true
          prometheus:
            endpoint: 0.0.0.0:8889
-         otlp_http/loki:
+         otlphttp/loki:
            endpoint: http://loki.observability:3100/otlp
 
        service:
@@ -126,7 +290,7 @@ This guide deploys an OpenTelemetry collector that receives all three telemetry 
            traces:
              receivers: [otlp]
              processors: [memory_limiter, batch]
-             exporters: [otlp_grpc/tempo, debug]
+             exporters: [otlp/tempo, debug]
            metrics:
              receivers: [otlp]
              processors: [memory_limiter, batch]
@@ -134,8 +298,17 @@ This guide deploys an OpenTelemetry collector that receives all three telemetry 
            logs:
              receivers: [otlp]
              processors: [memory_limiter, batch]
-             exporters: [otlp_http/loki, debug]" | kubectl apply -f -
+             exporters: [otlphttp/loki, debug]" | kubectl apply -f -
    ```
+   The configuration defines three pipelines: traces, metrics, and logs. It also runs a memory limiter, a tuned batch processor, and a debug exporter on every pipeline so you can see telemetry flowing during testing.
+
+   Notes on this configuration:
+
+   - `memory_limiter` runs first. The OpenTelemetry project recommends this order so the collector can shed load before later processors allocate memory. If batching ran first, a burst could OOM the pod before the limiter ever saw it.
+   - `batch` reduces export overhead. `send_batch_size: 4096` is a reasonable starting point. Tune up if your backend complains about request rate, down if it complains about batch size.
+   - The `debug` exporter runs in every pipeline at `verbosity: basic` so each batch shows up as one log line. Drop it from the pipelines once you've verified the setup, or raise it to `verbosity: detailed` when you need to see individual records.
+   - `otlp/tempo`, `otlphttp/loki`, and `prometheus` are examples. The trace and log exporters send OTLP to a backend; the `prometheus` exporter exposes a `/metrics` endpoint on port 8889 for Prometheus to scrape. Swap the addresses to match your own backends if needed.
+   - `tls.insecure: true` on the Tempo exporter disables certificate verification for the in-cluster example. In production, point the exporter at a TLS endpoint with a trusted CA and remove the `insecure` flag.
 
 1. Apply the DaemonSet and node-local service:
 
@@ -202,10 +375,10 @@ This guide deploys an OpenTelemetry collector that receives all three telemetry 
          targetPort: prometheus" | kubectl apply -f -
    ```
 
-   Sidecars resolve `otel-collector.observability:4317` to whichever collector pod runs on their node.
+   Sidecars resolve `otel-collector.observability:4317` to whichever collector Pod runs on their node.
 
    {:.warning}
-   > `internalTrafficPolicy: Local` keeps the hop node-local but doesn't fail over to another node. If the collector pod on a node restarts, that node's telemetry drops until it's back.
+   > `internalTrafficPolicy: Local` keeps the hop node-local but does not fail over to another node. If the collector Pod on a node restarts, that node's telemetry drops until the Pod is ready.
 
 1. Wait for the collector to be ready:
 
@@ -271,7 +444,7 @@ spec:
 ```
 
 {:.info}
-> Trace sampling is set to 100% so you see something during testing. Drop it to single digits in production.
+> The `MeshTrace` policy samples 100% of traces so you see something during testing. Drop the rate to single digits in production.
 
 ## Reach the collector when passthrough is off
 
@@ -302,15 +475,15 @@ The hostname generator publishes the service under `otel-collector.extsvc.mesh.l
 
 ## Verify the collector
 
-1. Check that the collector is receiving data:
+1. Check that the collector is receiving metrics:
 
    ```sh
    kubectl logs -n observability -l app=otel-collector --tail=20
    ```
 
-   With the `debug` exporter at `verbosity: basic`, each batch shows up as one line per signal. If you see nothing, check that the policy targets the right `Mesh`, the policy `endpoint` matches the collector's service DNS, and a debug pod in a mesh namespace can reach `otel-collector.observability:4317` on TCP.
+   With the `debug` exporter at `verbosity: basic`, each batch shows up as one line per signal. Metrics flow continuously from Envoy stats, so you should see `Metrics` lines within a minute or so.
 
-1. List the collector pods with their node assignments:
+1. List the collector Pods with their node assignments:
 
    ```sh
    kubectl get pod -n observability -o wide -l app=otel-collector
@@ -322,4 +495,26 @@ The hostname generator publishes the service under `otel-collector.extsvc.mesh.l
    kubectl get endpointslice -n observability -l kubernetes.io/service-name=otel-collector -o yaml
    ```
 
-   The endpoint slice will list one collector pod per node. With `Local` traffic policy, each node's kube-proxy only routes to its own entry.
+   The endpoint slice lists one collector Pod per node, and each node's kube-proxy only routes to its own entry.
+
+## Generate traffic
+
+1. Port-forward the demo app service on port `5050`:
+
+   ```sh
+   kubectl port-forward svc/demo-app -n kong-mesh-demo 5050:5050
+   ```
+
+1. Go to <http://127.0.0.1:5050> to open the demo app UI.
+
+1. Enable **Auto-increment** to generate traffic.
+
+## Validate
+
+In a new terminal, re-check the collector logs and confirm all three signals appear:
+
+```sh
+kubectl logs -n observability -l app=otel-collector --tail=20
+```
+
+You should now see `Traces` and `Logs` lines alongside `Metrics`. If `Metrics` appears but one of the others is missing, the corresponding `MeshTrace` or `MeshAccessLog` policy isn't matching. In that case, verify the `targetRef`.

--- a/app/_indices/mesh.yaml
+++ b/app/_indices/mesh.yaml
@@ -119,7 +119,7 @@ sections:
   - title: Observability
     items:
       - path: /mesh/observability/
-      - path: /mesh/collect-metrics-with-opentelemetry/
+      - path: /mesh/deploy-an-opentelemetry-collector/
       - path: /mesh/dataplane-health/
 
   - title: References

--- a/app/_landing_pages/mesh.yaml
+++ b/app/_landing_pages/mesh.yaml
@@ -176,8 +176,8 @@ rows:
               ctas:
                 - text: Introduction 
                   url: /mesh/observability/
-                - text: OpenTelemetry configuration 
-                  url: /mesh/collect-metrics-with-opentelemetry/
+                - text: Deploy an OpenTelemetry collector
+                  url: /mesh/deploy-an-opentelemetry-collector/
       - blocks:
           - type: card
             config:

--- a/app/_mesh_policies/meshaccesslog/index.md
+++ b/app/_mesh_policies/meshaccesslog/index.md
@@ -7,6 +7,10 @@ products:
 description: 'Set up access logs on every data plane proxy in a mesh.'
 content_type: plugin
 icon: meshaccesslog.png
+
+related_resources:
+  - text: Deploy an OpenTelemetry collector
+    url: /mesh/deploy-an-opentelemetry-collector/
 ---
 
 

--- a/app/_mesh_policies/meshmetric/index.md
+++ b/app/_mesh_policies/meshmetric/index.md
@@ -10,6 +10,10 @@ min_version:
   mesh: '2.6'
 
 icon: meshmetric.png
+
+related_resources:
+  - text: Deploy an OpenTelemetry collector
+    url: /mesh/deploy-an-opentelemetry-collector/
 ---
 {{site.mesh_product_name}} facilitates consistent traffic metrics across all data plane proxies in your mesh.
 

--- a/app/_mesh_policies/meshtrace/index.md
+++ b/app/_mesh_policies/meshtrace/index.md
@@ -7,6 +7,10 @@ description: 'Publish traces to a third party tracing solution.'
 content_type: plugin
 type: policy
 icon: meshtrace.png
+
+related_resources:
+  - text: Deploy an OpenTelemetry collector
+    url: /mesh/deploy-an-opentelemetry-collector/
 ---
 
 {% warning %}

--- a/app/_redirects
+++ b/app/_redirects
@@ -60,6 +60,7 @@
 
 # Mesh redirects
 /mesh/meshidentity-spire/   /mesh/issue-identity-with-meshidentity-spire/
+/mesh/collect-metrics-with-opentelemetry/   /mesh/deploy-an-opentelemetry-collector/
 /how-to/deploy-mesh-on-kubernetes/ /mesh/#get-started
 /mesh/policies/introduction    /mesh/policies-introduction/
 /mesh/quickstart/kubernetes-demo    /mesh/kubernetes/

--- a/app/mesh/observability.md
+++ b/app/mesh/observability.md
@@ -236,7 +236,7 @@ spec:
       targetPort: 8126
 ```
 
-Check that the label of the installed Datadog pod hasn't changed (`app.kubernetes.io/name: datadog-agent-deployment`).
+Check that the label of the installed Datadog Pod hasn't changed (`app.kubernetes.io/name: datadog-agent-deployment`).
 If it changed, adjust accordingly.
 
 Once the agent is configured to ingest traces, you must configure a [MeshTrace policy](/mesh/policies/meshtrace).
@@ -246,6 +246,37 @@ Once the agent is configured to ingest traces, you must configure a [MeshTrace p
 The best way to have {{site.mesh_product_name}} and Datadog work together is with [TCP ingest](https://docs.datadoghq.com/agent/logs/?tab=tcpudp#custom-log-collection).
 
 Once your agent is configured with TCP ingest, you can configure a [`MeshAccessLog` policy](/mesh/policies/meshaccesslog) for data plane proxies to send logs.
+
+## OpenTelemetry collector
+
+You can run an [OpenTelemetry collector](https://opentelemetry.io/docs/collector/) to receive metrics, traces, and access logs from {{site.mesh_product_name}} sidecars and forward them to one or more backends. For step-by-step setup, see [Deploy an OpenTelemetry collector](/mesh/deploy-an-opentelemetry-collector/).
+
+### How {{site.mesh_product_name}} talks to the collector
+
+Sidecars push telemetry to the collector over OTLP gRPC on port 4317. The collector receives the telemetry, batches it, and exports it to whatever backends you configure.
+
+{{site.mesh_product_name}} uses a push model: each sidecar opens an outbound connection to one collector Pod and writes its own telemetry. In a pull model, by contrast, a collector scrapes Prometheus endpoints from every workload it can reach.
+
+The distinction matters when you pick a topology. A [CNCF post](https://www.cncf.io/blog/2025/12/16/how-to-build-a-cost-effective-observability-platform-with-opentelemetry/) warns about 20-40x metric explosion when DaemonSet collectors all scrape the same Prometheus targets which is a problem specific to the pull model. Because {{site.mesh_product_name}} pushes, each metric reaches one collector instance regardless of how many collector Pods exist.
+
+### Topologies
+
+Two patterns work for the OTLP receiver.
+
+#### Deployment + ClusterIP service
+
+Run two or three collector replicas behind a `ClusterIP` service. Sidecars resolve `otel-collector.observability:4317` to whichever replica kube-proxy picks.
+
+We recommend this topology because it's simple, the failure domain is the whole replica set, and a rolling update of the collector doesn't drop telemetry from any specific node. Use a Deployment for small and medium clusters, or any cluster where collector throughput isn't a bottleneck.
+
+#### Per-node DaemonSet
+
+Run one collector Pod per node and route traffic node-locally. With `internalTrafficPolicy: Local` on the service, kube-proxy on each node only forwards to the collector Pod on that same node. Sidecars still resolve the same DNS name (`otel-collector.observability:4317`), but the hop never leaves the node.
+
+Pick a DaemonSet for large clusters or workloads where the extra network hop matters. A DaemonSet improves locality, distributes load across nodes, and isolates collector failure to a single node's telemetry.
+
+{:.warning}
+> The trade-off is silent loss. If the collector Pod on a node crashes or is restarting, sidecars on that node have no fallback and drop their telemetry until the Pod is ready. The `Local` traffic policy does not fail over to other nodes.
 
 ## Observability in multi-zone
 

--- a/app/mesh/observability.md
+++ b/app/mesh/observability.md
@@ -267,7 +267,7 @@ Two patterns work for the OTLP receiver.
 
 #### Deployment + ClusterIP service
 
-Run two or three collector replicas behind a `ClusterIP` service. Sidecars resolve `otel-collector.observability:4317` to whichever replica kube-proxy picks.
+Run two or three collector replicas behind a `ClusterIP` service. Sidecars resolve `otel-collector.observability:4317` to the Service IP, and kube-proxy load-balances each connection to a collector Pod.
 
 We recommend this topology because it's simple, the failure domain is the whole replica set, and a rolling update of the collector doesn't drop telemetry from any specific node. Use a Deployment for small and medium clusters, or any cluster where collector throughput isn't a bottleneck.
 

--- a/app/mesh/observability.md
+++ b/app/mesh/observability.md
@@ -26,6 +26,8 @@ related_resources:
     url: /mesh/cli/
   - text: Data plane health
     url: /mesh/dataplane-health/
+  - text: Deploy an OpenTelemetry collector
+    url: /mesh/deploy-an-opentelemetry-collector/
 ---
 
 This page describes how to configure different observability tools to work with {{site.mesh_product_name}}.


### PR DESCRIPTION
## Motivation

Kong Mesh users running MeshMetric, MeshTrace, and MeshAccessLog policies need to point them at an OpenTelemetry collector, but there was no how-to covering the collector deployment itself, the Deployment vs DaemonSet trade-off, or what to do when mesh passthrough is disabled.

## Summary

- New how-to at `/mesh/deploy-an-opentelemetry-collector/` that deploys a single OTel collector receiving all three signals over OTLP.
- Navtabs switch between Deployment + ClusterIP and per-node DaemonSet manifests.
- Covers the `MeshExternalService` path when mesh passthrough is off.

## Implementation information

- Follows Kong Mesh how-to conventions: numbered substeps under each `## H2`, `echo … | kubectl apply -f -` inlines, `{:.info}` and `{:.warning}` callouts.
- Frontmatter uses `mesh-cluster` + `mesh-quickstart` `include_content` prereqs, an inline `kumactl install observability` prereq, and `next_steps:` instead of a body section.