### PR TITLE
docs(Support KB): Fix JWT Signer plugin keyset field warning on Konnect.

### DIFF
--- a/app/_support/jwt_signer_keyset_field_on_konnect.md
+++ b/app/_support/jwt_signer_keyset_field_on_konnect.md
@@ -1,0 +1,47 @@
+---
+title: Fix JWT Signer plugin keyset field warning on Konnect
+content_type: support
+description: How to fix the JWT Signer plugin keyset field warning when running on {{site.konnect_short_name}}.
+products:
+  - gateway
+works_on:
+  - konnect
+tldr:
+  q: How do I fix the JWT Signer plugin keyset field warning on Konnect?
+  a: |
+    Set the `access_token_keyset` or `channel_token_keyset` field to a URL that points to a valid JWKS endpoint. On {{site.konnect_short_name}}, JWKS must be managed externally.
+---
+
+## Understanding the warning
+
+When using the JWT Signer plugin on {{site.konnect_short_name}}, you may see the following warning in your data plane logs:
+
+```
+*_token_keyset should be a valid URL when kong is running in Konnect mode, *_token_signing is true and *_token_upstream_header is set.
+```
+
+This warning appears when all of the following conditions are true:
+- `access_token_signing` or `channel_token_signing` is set to `true`
+- `access_token_upstream_header` or `channel_token_upstream_header` is set to a non-empty value
+- `access_token_keyset` or `channel_token_keyset` is left empty
+
+On {{site.konnect_short_name}}, all JWKS for the JWT Signer plugin must be managed externally. You must provide a URL that points to a valid JWKS endpoint for re-signing requests.
+
+## Fixing the warning
+
+Set the corresponding `*_token_keyset` field to the URL of the JWKS you want to use for re-signing:
+
+```yaml
+access_token_keyset: https://example.com/.well-known/jwks.json
+```
+
+Or for the channel token:
+
+```yaml
+channel_token_keyset: https://example.com/.well-known/jwks.json
+```
+
+## Validation
+
+After updating the configuration, check the data plane logs. The warning should no longer appear.
+

--- a/app/_support/jwt_signer_keyset_field_on_konnect.md
+++ b/app/_support/jwt_signer_keyset_field_on_konnect.md
@@ -7,35 +7,45 @@ products:
 works_on:
   - konnect
 tldr:
-  q: How do I fix the JWT Signer plugin keyset field warning on Konnect?
+  q: How do I fix the JWT Signer plugin keyset field warning on {{site.konnect_short_name}}?
   a: |
     Set the `access_token_keyset` or `channel_token_keyset` field to a URL that points to a valid JWKS endpoint. On {{site.konnect_short_name}}, JWKS must be managed externally.
 ---
 
 ## Understanding the warning
 
-When using the JWT Signer plugin on {{site.konnect_short_name}}, you may see the following warning in your data plane logs:
+The JWT Signer plugin on {{site.konnect_short_name}} writes one or both of the following warnings to the data plane logs when it detects a missing keyset URL:
 
 ```
-*_token_keyset should be a valid URL when kong is running in Konnect mode, *_token_signing is true and *_token_upstream_header is set.
+access_token_keyset should be a valid URL when kong is running in Konnect mode, access_token_signing is true and access_token_upstream_header is set.
 ```
+{:.no-copy-code}
 
-This warning appears when all of the following conditions are true:
-- `access_token_signing` or `channel_token_signing` is set to `true`
-- `access_token_upstream_header` or `channel_token_upstream_header` is set to a non-empty value
-- `access_token_keyset` or `channel_token_keyset` is left empty
+```
+channel_token_keyset should be a valid URL when kong is running in Konnect mode, channel_token_signing is true and channel_token_upstream_header is set.
+```
+{:.no-copy-code}
 
-On {{site.konnect_short_name}}, all JWKS for the JWT Signer plugin must be managed externally. You must provide a URL that points to a valid JWKS endpoint for re-signing requests.
+The warning appears when either of the following sets of conditions is true:
+
+- `access_token_signing` is `true`, `access_token_upstream_header` is non-empty, and `access_token_keyset` is empty
+- `channel_token_signing` is `true`, `channel_token_upstream_header` is non-empty, and `channel_token_keyset` is empty
+
+{{site.konnect_short_name}} requires all JWKS for the JWT Signer plugin to be managed externally. Provide a URL that points to a valid JWKS endpoint for re-signing requests.
+
+Without a configured `access_token_keyset` or `channel_token_keyset` value, `NULL` is sent to the data plane. Each data plane node then generates its own JWKS independently, making consistent downstream verification of re-signed tokens impossible.
 
 ## Fixing the warning
 
-Set the corresponding `*_token_keyset` field to the URL of the JWKS you want to use for re-signing:
+Set the corresponding `access_token_keyset` or `channel_token_keyset` field to the URL of the JWKS you want to use for re-signing.
+
+For the access token:
 
 ```yaml
 access_token_keyset: https://example.com/.well-known/jwks.json
 ```
 
-Or for the channel token:
+For the channel token:
 
 ```yaml
 channel_token_keyset: https://example.com/.well-known/jwks.json
@@ -43,5 +53,5 @@ channel_token_keyset: https://example.com/.well-known/jwks.json
 
 ## Validation
 
-After updating the configuration, check the data plane logs. The warning should no longer appear.
+Restart or wait for the data plane to reload the updated configuration, then review the data plane logs. The keyset warning no longer appears.
 

--- a/app/_support/jwt_signer_keyset_field_on_konnect.md
+++ b/app/_support/jwt_signer_keyset_field_on_konnect.md
@@ -10,9 +10,13 @@ tldr:
   q: How do I fix the JWT Signer plugin keyset field warning on {{site.konnect_short_name}}?
   a: |
     Set the `access_token_keyset` or `channel_token_keyset` field to a URL that points to a valid JWKS endpoint. On {{site.konnect_short_name}}, JWKS must be managed externally.
+
+related_resources:
+  - text: JWT Signer plugin
+    url: /plugins/jwt-signer/
 ---
 
-## Understanding the warning
+## Problem
 
 The JWT Signer plugin on {{site.konnect_short_name}} writes one or both of the following warnings to the data plane logs when it detects a missing keyset URL:
 
@@ -35,7 +39,7 @@ The warning appears when either of the following sets of conditions is true:
 
 Without a configured `access_token_keyset` or `channel_token_keyset` value, `NULL` is sent to the data plane. Each data plane node then generates its own JWKS independently, making consistent downstream verification of re-signed tokens impossible.
 
-## Fixing the warning
+## Solution
 
 Set the corresponding `access_token_keyset` or `channel_token_keyset` field to the URL of the JWKS you want to use for re-signing.
 


### PR DESCRIPTION
## Description

First KB article to fix JWT Signer plugin keyset field warning on Konnect.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
