### PR TITLE
fix(docs-platform) Trim newlines from codeblock copy function

### DIFF
--- a/app/_assets/javascripts/clipboard_copy.js
+++ b/app/_assets/javascripts/clipboard_copy.js
@@ -1,4 +1,12 @@
 document.addEventListener("clipboard-copy", function (event) {
+  const targetId = event.target.getAttribute("for");
+  if (targetId) {
+    const targetEl = document.getElementById(targetId);
+    if (targetEl) {
+      navigator.clipboard.writeText(targetEl.textContent.trim());
+    }
+  }
+
   const button = event.target;
   const tooltip = event.target.previousElementSibling;
   const defaultAriaLabel = button.getAttribute("aria-label");

--- a/app/_assets/javascripts/clipboard_copy.js
+++ b/app/_assets/javascripts/clipboard_copy.js
@@ -1,12 +1,4 @@
 document.addEventListener("clipboard-copy", function (event) {
-  const targetId = event.target.getAttribute("for");
-  if (targetId) {
-    const targetEl = document.getElementById(targetId);
-    if (targetEl) {
-      navigator.clipboard.writeText(targetEl.textContent.trim());
-    }
-  }
-
   const button = event.target;
   const tooltip = event.target.previousElementSibling;
   const defaultAriaLabel = button.getAttribute("aria-label");

--- a/app/_plugins/converters/shiki.rb
+++ b/app/_plugins/converters/shiki.rb
@@ -54,6 +54,12 @@ class CodeHighlighter < Nodo::Core # rubocop:disable Style/Documentation
         },
         transformers: [
           {
+            preprocess(snippet) {
+              if (snippet.endsWith("\\n")) {
+                snippet = snippet.slice(0, -1);
+              }
+              return snippet;
+            },
             code(node) {
               node.properties.id = id;
             },


### PR DESCRIPTION
## Description

Removes the extra newline that gets added on codeblocks with the copy button.

Now, instead of this:

```
kongctl get portals

```
The pasted text will look like this:

```
kongctl get portals
```

Issue reported by Rick on Slack.

## Preview Links
Use the copy button on any page with codeblocks, eg https://deploy-preview-5294--kongdeveloper.netlify.app/gateway/get-started/
