### PR TITLE
fix(plugins): List premium partner plugins before all other third-party plugins

### DIFF
--- a/app/plugins.html
+++ b/app/plugins.html
@@ -10,7 +10,7 @@ description: Extend Kong Gateway and Kong Konnect with powerful plugins and easy
 {%- assign kong_plugins = site.data.kong_plugins | where_exp: "plugin", "plugin.published != false" -%}
 {%- assign act_as_plugins = site.data.act_as_plugins | where_exp: "plugin", "plugin.published != false" -%}
 {%- assign plugins = kong_plugins | concat: act_as_plugins -%}
-{%- assign third_party_plugins = plugins | where: "third_party", true -%}
+{%- assign third_party_plugins = plugins | where: "third_party", true | sort: "premium_partner" | reverse -%}
 
 {% if page.output_format == 'markdown'%}
 {% for cat in categories %}


### PR DESCRIPTION
## Description

List all premium partner third-party plugins before other third-party plugins in the "3rd Party Plugins" category on the Gateway plugin hub.

Request from partner + rep.

