### PR TITLE
feat(plugin): add sample on array field indices

### DIFF
--- a/app/_includes/plugins/logging/log-custom-fields-by-lua.md
+++ b/app/_includes/plugins/logging/log-custom-fields-by-lua.md
@@ -3,7 +3,7 @@
 {% assign custom_fields_by_lua_slug = include.custom_fields_by_lua_slug %}
 
 The [`{{custom_fields_by_lua_name}}`](./reference/#schema--{{custom_fields_by_lua_slug}}) configuration allows for the dynamic modification of
-log fields using Lua code. Below is a snippet of an example configuration that 
+log fields using Lua code. Below is a snippet of an example configuration that
 removes the `route` field from the logs:
 
 ```sh
@@ -18,6 +18,23 @@ Similarly, new fields can be added:
 curl -i -X POST http://localhost:8001/plugins \
   --data config.name={{include.slug}} \
   --data {{custom_fields_by_lua}}.header="return kong.request.get_header('h1')"
+```
+
+Array indices should be enclosed within square brackets:
+
+```sh
+curl -i -X POST http://localhost:8001/plugins \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "name": "file-log",
+  "config": {
+    "path": "/tmp/test.log",
+    "custom_fields_by_lua": {
+      "foo[1].bar[2].woo": "return 456"
+    }
+  }
+}'
 ```
 
 ### Special characters {% unless page.name =="Solace Log"%}{% new_in 3.10 %}{% endunless %}
@@ -41,13 +58,13 @@ The field will look like this in the log:
 
 ### Plugin precedence and managing fields
 
-All logging plugins use the same table for logging. 
-If you set `{{custom_fields_by_lua_name}}` in one plugin, all logging plugins that execute after that plugin will also use the same configuration. 
+All logging plugins use the same table for logging.
+If you set `{{custom_fields_by_lua_name}}` in one plugin, all logging plugins that execute after that plugin will also use the same configuration.
 For example, if you configure fields via `{{custom_fields_by_lua_name}}` in File Log, those same fields will appear in [Syslog](/plugins/syslog/), since {{page.name}} executes first.
 
 * If you want all logging plugins to use the same configuration, we recommend using the [Pre-function](/plugins/pre-function/) plugin to call [kong.log.set_serialize_value](/gateway/pdk/reference/kong.log/#kong-log-set-serialize-value-key-value-options) so that the function is applied predictably and is easier to manage.
 
-* If you **don't** want all logging plugins to use the same configuration, you need to manually disable the relevant fields in each plugin. 
+* If you **don't** want all logging plugins to use the same configuration, you need to manually disable the relevant fields in each plugin.
 
    For example, if you configure a field in File Log that you don't want appearing in Syslog, set that field to `return nil` in the File Log plugin:
 

--- a/app/_includes/plugins/logging/log-custom-fields-by-lua.md
+++ b/app/_includes/plugins/logging/log-custom-fields-by-lua.md
@@ -27,10 +27,9 @@ curl -i -X POST http://localhost:8001/plugins \
   --header 'Accept: application/json' \
   --header 'Content-Type: application/json' \
   --data '{
-  "name": "file-log",
+  "name": "{{include.slug}}",
   "config": {
-    "path": "/tmp/test.log",
-    "custom_fields_by_lua": {
+    "{{custom_fields_by_lua_name}}": {
       "foo[1].bar[2].woo": "return 456"
     }
   }

--- a/app/_includes/plugins/logging/log-custom-fields-by-lua.md
+++ b/app/_includes/plugins/logging/log-custom-fields-by-lua.md
@@ -20,7 +20,9 @@ curl -i -X POST http://localhost:8001/plugins \
   --data {{custom_fields_by_lua}}.header="return kong.request.get_header('h1')"
 ```
 
-Array indices should be enclosed within square brackets:
+### Array indices {% new_in 3.15 %}
+
+Array indices should be enclosed within square brackets. For example:
 
 ```sh
 curl -i -X POST http://localhost:8001/plugins \
@@ -35,6 +37,8 @@ curl -i -X POST http://localhost:8001/plugins \
   }
 }'
 ```
+
+Array indices only support positive integers.
 
 ### Special characters {% unless page.name =="Solace Log"%}{% new_in 3.10 %}{% endunless %}
 


### PR DESCRIPTION
## PR Title

fix(plugin): add sample on array field indices

## Description

Log plugins now support array indices within square brackets like `hello[1].world[2].foo`.

It is added in `3.15.0.0`.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
