### PR TITLE
Try profound

### DIFF
--- a/netlify/edge-functions/serve-markdown.ts
+++ b/netlify/edge-functions/serve-markdown.ts
@@ -1,26 +1,53 @@
-import type { Config } from "@netlify/edge-functions";
+import type { Config, Context } from "@netlify/edge-functions";
 
-export default async (request: Request) => {
+export default async (request: Request, context: Context) => {
   const acceptHeader = request.headers.get("Accept") || "";
-
-  if (!acceptHeader.includes("text/markdown")) {
-    return;
-  }
-
   const url = new URL(request.url);
   const { pathname } = url;
 
-  if (pathname.endsWith(".md")) {
-    return;
+  let response: URL | undefined;
+
+  if (acceptHeader.includes("text/markdown") && !pathname.endsWith(".md")) {
+    if (pathname === "/") {
+      url.pathname = "/index.md";
+    } else {
+      url.pathname = pathname.replace(/\/?$/, ".md").replace(/\.html\.md$/, ".md");
+    }
+    response = url;
   }
 
-  if (pathname === "/") {
-    url.pathname = "/index.md";
-  } else {
-    url.pathname = pathname.replace(/\/?$/, ".md").replace(/\.html\.md$/, ".md");
+  const apiKey = Netlify.env.get("PROFOUND_API_KEY");
+  const loggingEnabled = Netlify.env.get("LOG_TO_PROFOUND") === "true";
+
+  if (apiKey && loggingEnabled) {
+    const params: Record<string, string> = {};
+    url.searchParams.forEach((value, key) => {
+      params[key] = value;
+    });
+
+    context.waitUntil(
+      fetch("https://artemis.api.tryprofound.com/v1/logs/custom", {
+        method: "POST",
+        headers: {
+          'x-api-key': apiKey,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify([{
+          timestamp: new Date().toISOString(),
+          method: request.method,
+          host: request.headers.get("host"),
+          path: pathname,
+          status_code: 200, // hardcoded, we don't want to add extra overhead
+          ip: context.ip,
+          user_agent: request.headers.get("user-agent"),
+          query_params: params,
+          referer: request.headers.get("referer"),
+        }]),
+      })
+    );
   }
 
-  return url;
+  return response;
 };
 
 export const config: Config = {
@@ -29,7 +56,7 @@ export const config: Config = {
     "/**/*.css", "/**/*.js", "/**/*.png", "/**/*.jpg", "/**/*.jpeg",
     "/**/*.gif", "/**/*.svg", "/**/*.ico", "/**/*.webp",
     "/**/*.woff", "/**/*.woff2", "/**/*.ttf", "/**/*.eot",
-    "/**/*.json", "/**/*.xml", "/**/*.map",
+    "/**/*.json", "/**/*.xml", "/**/*.map"
   ],
   onError: "bypass",
 };

--- a/netlify/edge-functions/serve-markdown.ts
+++ b/netlify/edge-functions/serve-markdown.ts
@@ -53,6 +53,8 @@ export default async (request: Request, context: Context) => {
 export const config: Config = {
   path: "/*",
   excludedPath: [
+    "/assets/*",
+    "/vite/assets/*",
     "/**/*.css", "/**/*.js", "/**/*.png", "/**/*.jpg", "/**/*.jpeg",
     "/**/*.gif", "/**/*.svg", "/**/*.ico", "/**/*.webp",
     "/**/*.woff", "/**/*.woff2", "/**/*.ttf", "/**/*.eot",

--- a/netlify/edge-functions/serve-markdown.ts
+++ b/netlify/edge-functions/serve-markdown.ts
@@ -5,16 +5,16 @@ export default async (request: Request, context: Context) => {
   const url = new URL(request.url);
   const { pathname } = url;
 
-  let response: URL | undefined;
-
+  let nextRequest: Request = request;
   if (acceptHeader.includes("text/markdown") && !pathname.endsWith(".md")) {
-    if (pathname === "/") {
-      url.pathname = "/index.md";
-    } else {
-      url.pathname = pathname.replace(/\/?$/, ".md").replace(/\.html\.md$/, ".md");
-    }
-    response = url;
+    url.pathname =
+      pathname === "/"
+        ? "/index.md"
+        : pathname.replace(/\/?$/, ".md").replace(/\.html\.md$/, ".md");
+    nextRequest = new Request(url, request);
   }
+
+  const response = await context.next(nextRequest);
 
   const apiKey = Netlify.env.get("PROFOUND_API_KEY");
   const loggingEnabled = Netlify.env.get("LOG_TO_PROFOUND") === "true";
@@ -37,7 +37,7 @@ export default async (request: Request, context: Context) => {
           method: request.method,
           host: request.headers.get("host"),
           path: pathname,
-          status_code: 200, // hardcoded, we don't want to add extra overhead
+          status_code: response.status,
           ip: context.ip,
           user_agent: request.headers.get("user-agent"),
           query_params: params,


### PR DESCRIPTION
## feat: Add logging to the edge-function

## Description

Test if we can use the edge function to log the requests to profound after the response is sent to the user.
NOTE: I had to hardcode the http status code to 200 to avoid extra overhead of doing an extra request to get the actual status code.

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
