### PR TITLE
docs(mesh): add MeshOpenTelemetryBackend doc

### DIFF
--- a/app/_indices/mesh.yaml
+++ b/app/_indices/mesh.yaml
@@ -68,6 +68,7 @@ sections:
       - path: /mesh/workload/
       - path: /mesh/meshexternalservice/
       - path: /mesh/meshmultizoneservice/
+      - path: /mesh/meshopentelemetrybackend/
       - path: /mesh/meshservice/
 
   - title: Policies

--- a/app/_mesh_policies/meshaccesslog/index.md
+++ b/app/_mesh_policies/meshaccesslog/index.md
@@ -11,6 +11,8 @@ icon: meshaccesslog.png
 related_resources:
   - text: Deploy an OpenTelemetry collector
     url: /mesh/deploy-an-opentelemetry-collector/
+  - text: MeshOpenTelemetryBackend
+    url: /mesh/meshopentelemetrybackend/
 ---
 
 

--- a/app/_mesh_policies/meshmetric/index.md
+++ b/app/_mesh_policies/meshmetric/index.md
@@ -14,6 +14,8 @@ icon: meshmetric.png
 related_resources:
   - text: Deploy an OpenTelemetry collector
     url: /mesh/deploy-an-opentelemetry-collector/
+  - text: MeshOpenTelemetryBackend
+    url: /mesh/meshopentelemetrybackend/
 ---
 {{site.mesh_product_name}} facilitates consistent traffic metrics across all data plane proxies in your mesh.
 

--- a/app/_mesh_policies/meshtrace/index.md
+++ b/app/_mesh_policies/meshtrace/index.md
@@ -11,6 +11,8 @@ icon: meshtrace.png
 related_resources:
   - text: Deploy an OpenTelemetry collector
     url: /mesh/deploy-an-opentelemetry-collector/
+  - text: MeshOpenTelemetryBackend
+    url: /mesh/meshopentelemetrybackend/
 ---
 
 {% warning %}

--- a/app/mesh/meshopentelemetrybackend.md
+++ b/app/mesh/meshopentelemetrybackend.md
@@ -31,26 +31,42 @@ tags:
   - metrics
   - tracing
   - logging
-
-no_wrap: true
 ---
 
-{% navtabs "meshopentelemetrybackend" heading_level=2 %}
-{% navtab "Overview" %}
+`MeshOpenTelemetryBackend` defines an OpenTelemetry collector endpoint that observability policies reference through a `backendRef`. Without it, every [`MeshMetric`](/mesh/policies/meshmetric/), [`MeshTrace`](/mesh/policies/meshtrace/), and [`MeshAccessLog`](/mesh/policies/meshaccesslog/) policies carry their own copy of the collector address. With it, the address lives in one place and the policies point at it by name.
 
-`MeshOpenTelemetryBackend` defines an OpenTelemetry collector endpoint that observability policies reference through a `backendRef`. Without it, every [`MeshMetric`](/mesh/policies/meshmetric/), [`MeshTrace`](/mesh/policies/meshtrace/), and [`MeshAccessLog`](/mesh/policies/meshaccesslog/) policy carries its own copy of the collector address. With it, the address lives in one place and the policies point at it by name.
+{:.warning}
+> Inline `endpoint` fields on those three policies still work in 2.14 but are deprecated and will be removed in 3.0. New deployments should use `backendRef`.
 
-Inline `endpoint` fields on those three policies still work in 2.14 but are deprecated and will be removed in 3.0. New deployments should use `backendRef`.
+On Kubernetes, the `MeshOpenTelemetryBackend` resource must be created in the system namespace (`kong-mesh-system`). On Universal, it lives in the global control plane store.
 
-`MeshOpenTelemetryBackend` must be created in the system namespace (`kuma-system` on Kubernetes). On Universal, it lives in the Global CP store with no namespace concept.
+## Migrate from inline endpoint
 
-## Migrate from inline `endpoint`
+1. Create one `MeshOpenTelemetryBackend` with OpenTelemetry collector endpoint. For example:
+   ```yaml
+   apiVersion: kuma.io/v1alpha1
+   kind: MeshOpenTelemetryBackend
+   metadata:
+     name: main-collector
+     namespace: kong-mesh-system
+     labels:
+       kuma.io/mesh: default
+   spec:
+     endpoint:
+       address: otel-collector.observability
+       port: 4317
+     protocol: grpc
+   ```
+1. On each policy, replace the inline `endpoint` with the following configuration:
+   ```yaml
+   backendRef: 
+    kind: MeshOpenTelemetryBackend, 
+    name: main-collector
+   ```
 
-1. Create one `MeshOpenTelemetryBackend` carrying the address that was inline on the policy.
-2. On each policy, replace the inline `endpoint` with `backendRef: {kind: MeshOpenTelemetryBackend, name: BACKEND_NAME}`.
-3. Signal-specific fields (`refreshInterval`, `attributes`, `body`, `sampling`) stay on the policy.
+1. Keep signal-specific fields (`refreshInterval`, `attributes`, `body`, `sampling`) on the policy.
 
-To move the collector later, edit the backend - the policies stay untouched.
+If the collector endpoint changes, you'll only need to edit the `MeshOpenTelemetryBackend` and the change will automatically apply to the policies that use it.
 
 ## Reference a backend from a policy
 
@@ -66,12 +82,16 @@ rows:
   - field: '`backendRef.kind`'
     description: 'Must be `MeshOpenTelemetryBackend`.'
   - field: '`backendRef.name`'
-    description: '`metadata.name` of the backend, for same-cluster references.'
+    description: |
+      `metadata.name` of the backend. Use this when the `MeshOpenTelemetryBackend` and the policy are in the same zone. 
+      
+      If `name` doesn't resolve, the policy carries a `BackendRefsResolved: False` status condition with the reason `UnresolvedBackendRefs`.'
   - field: '`backendRef.labels`'
-    description: 'Label selector. Required for cross-zone references because [KDS](/mesh/mesh-multizone-service-deployment/) appends a hash suffix to `metadata.name` on synced resources.'
+    description: |
+      Label selector. Required for cross-zone references because [KDS](/mesh/mesh-multizone-service-deployment/) appends a hash suffix to `metadata.name` on synced resources. 
+      
+      When the `labels` match more than one backend, the oldest by creation time is used. In this case, the control plane doesn't emit a warning, so check creation timestamps if a policy resolves to an unexpected backend.
 {% endtable %}
-
-Exactly one of `name` or `labels` must be set. When `labels` matches more than one backend, the oldest by creation time wins - no warning is emitted, so check creation timestamps if a policy resolves to an unexpected backend. When `name` does not resolve at all, the policy carries a `BackendRefsResolved: False` status condition with reason `UnresolvedBackendRefs`.
 
 For cross-zone references, match on `kuma.io/display-name` so the resource resolves regardless of the hashed name added during sync:
 
@@ -82,48 +102,61 @@ backendRef:
     kuma.io/display-name: main-collector
 ```
 
-### Per-zone collectors in multi-zone
+### Per-zone collectors in multi-zone deployments
 
-When zones run separate collectors, create one backend per zone on the Global CP and scope each policy to the matching zone. Because both the backend and the policy live on Global, the CP resolves `backendRef.name` before KDS sync - the hashed name that appears on zones never matters.
+When zones run separate collectors, create one backend per zone on the global control plane and scope each policy to the matching zone. Because both the backend and the policy live on the global control plane, the control plane resolves `backendRef.name` before KDS sync, so the hashed name that appears on zones never matters.
 
-If the policy is created on a zone CP and references a backend synced from Global, use `backendRef.labels` instead - the synced backend's `metadata.name` carries a hash suffix that does not match a plain `name:`.
+If the policy is created on a zone control plane and references a backend synced from the global control plane, use `backendRef.labels` instead, because the synced backend's `metadata.name` carries a hash suffix that doesn't match a plain `name`.
 
-When all zones can share the same collector service name, one backend on the Global CP is enough - DNS resolves to the local collector in each zone.
+When all zones can share the same collector service name, one backend on the global control plane is enough, and DNS resolves to the local collector in each zone.
 
 ## Environment-variable resolution
 
 `kuma-dp` reads `OTEL_EXPORTER_OTLP_*` environment variables locally at startup and merges them with the backend config. Secret-bearing values (headers, client keys, certificates) stay local to `kuma-dp`. During startup, `kuma-dp` reports only which environment variable keys are present to the control plane, never the values.
 
-Recognized variable families:
+Here are the variable used:
+* Shared: 
+  * `OTEL_EXPORTER_OTLP_ENDPOINT`
+  * `OTEL_EXPORTER_OTLP_PROTOCOL`
+  * `OTEL_EXPORTER_OTLP_HEADERS`
+  * `OTEL_EXPORTER_OTLP_INSECURE`
+  * `OTEL_EXPORTER_OTLP_TIMEOUT`
+  * `OTEL_EXPORTER_OTLP_COMPRESSION`
+  * `OTEL_EXPORTER_OTLP_CERTIFICATE`
+  * `OTEL_EXPORTER_OTLP_CLIENT_KEY`
+  * `OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE`
+* Per-signal (override shared per signal): 
+  * `OTEL_EXPORTER_OTLP_TRACES_*`
+  * `OTEL_EXPORTER_OTLP_LOGS_*`
+  * `OTEL_EXPORTER_OTLP_METRICS_*`
 
-- shared: `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_INSECURE`, `OTEL_EXPORTER_OTLP_TIMEOUT`, `OTEL_EXPORTER_OTLP_COMPRESSION`, `OTEL_EXPORTER_OTLP_CERTIFICATE`, `OTEL_EXPORTER_OTLP_CLIENT_KEY`, `OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE`
-- per-signal (override shared per signal): `OTEL_EXPORTER_OTLP_TRACES_*`, `OTEL_EXPORTER_OTLP_LOGS_*`, `OTEL_EXPORTER_OTLP_METRICS_*`
+For each field, `kuma-dp` resolves the first available source. By default, environment variables take precedence:
 
-For each field, `kuma-dp` resolves the first available source. With default `precedence: EnvFirst`:
+1. Signal-specific environment variable (when `allowSignalOverrides: true`)
+1. Shared environment variable
+1. Explicit field on the backend
+1. Built-in default
 
-1. signal-specific environment variable (when `allowSignalOverrides: true`)
-2. shared environment variable
-3. explicit field on the backend
-4. built-in default
+You can customize this behavior:
+* Set [`env.precedence`](#schema--env-precedence) to `ExplicitFirst` to use the explicit backend field first.
 
-With `precedence: ExplicitFirst`, the explicit backend field moves from position 3 to 1.
+* Set [`env.mode`](/#schema--env-mode) to `Disabled` to skip environment variables entirely.
 
-When `mode: Disabled`, environment variables are skipped entirely (points 1 and 2).
+* Set [`env.mode`](/#schema--env-mode) to `Required` to block the signal when input blocks are missing or invalid, even if the explicit configuration or defaults could otherwise fill the gap. Use `Required` when missing input should fail loudly. The signal blocks, `RequiredEnvMissing` appears in `DataplaneInsight`, and you can alert on the absence of exported data.
 
-When `mode: Required`, missing or invalid input blocks the signal even if explicit config or defaults could otherwise fill the gap. Use `Required` when missing input should fail loudly - the signal blocks, `RequiredEnvMissing` shows up in `DataplaneInsight`, and you can alert on the absence of exported data.
-
-Environment-variable values change only when `kuma-dp` restarts and re-bootstraps. Status updates pick them up at the same time.
+Environment variable values change only when `kuma-dp` restarts and re-bootstraps. Status updates pick them up at the same time.
 
 ### Ambiguity rule
 
-OpenTelemetry environment variables are process-global. If one data plane resolves more than one backend for the same signal and both backends allow environment input, the control plane cannot tell which backend the values belong to. The signal is marked `ambiguous` and environment input is dropped for it. Explicit config still applies. Plan one backend per signal per data plane, or set `mode: Disabled` on backends that should never receive environment input.
+OpenTelemetry environment variables are process-global. If one data plane resolves more than one backend for the same signal and both backends allow environment input, the control plane can't tell which backend the values belong to. The control plane marks the signal `ambiguous` and drops environment input for it. Explicit configuration still applies. Plan one backend per signal per data plane, or set `mode: Disabled` on backends that should never receive environment input.
 
-{% endnavtab %}
-{% navtab "Examples" %}
+## Examples
 
-## Single collector for all three signals
+The following examples show how to configure `MeshOpenTelemetryBackend` for different use cases.
 
-The most common shape: one backend resource, three policies pointing at it.
+### Single collector for all three signals
+
+This is the most common configuration: one backend resource carries the collector address and three policies point at it by name.
 
 {% navtabs "environment" %}
 {% navtab "Kubernetes" %}
@@ -133,7 +166,7 @@ apiVersion: kuma.io/v1alpha1
 kind: MeshOpenTelemetryBackend
 metadata:
   name: main-collector
-  namespace: kuma-system
+  namespace: kong-mesh-system
   labels:
     kuma.io/mesh: default
 spec:
@@ -146,7 +179,7 @@ apiVersion: kuma.io/v1alpha1
 kind: MeshMetric
 metadata:
   name: all-metrics
-  namespace: kuma-system
+  namespace: kong-mesh-system
   labels:
     kuma.io/mesh: default
 spec:
@@ -165,7 +198,7 @@ apiVersion: kuma.io/v1alpha1
 kind: MeshTrace
 metadata:
   name: all-traces
-  namespace: kuma-system
+  namespace: kong-mesh-system
   labels:
     kuma.io/mesh: default
 spec:
@@ -185,7 +218,7 @@ apiVersion: kuma.io/v1alpha1
 kind: MeshAccessLog
 metadata:
   name: all-access-logs
-  namespace: kuma-system
+  namespace: kong-mesh-system
   labels:
     kuma.io/mesh: default
 spec:
@@ -262,9 +295,9 @@ spec:
 {% endnavtab %}
 {% endnavtabs %}
 
-## Node-local collector
+### Node-local collector
 
-If the collector runs as a DaemonSet with `hostPort`, an empty backend is enough. `kuma-dp` resolves `HOST_IP:4317` on Kubernetes (Downward API) and `127.0.0.1:4317` on Universal and VMs.
+If the collector runs as a DaemonSet with `hostPort`, an empty backend is enough. `kuma-dp` uses the default `grpc` protocol and resolves `HOST_IP:4317` on Kubernetes (Downward API) and `127.0.0.1:4317` on Universal and VMs.
 
 {% navtabs "environment" %}
 {% navtab "Kubernetes" %}
@@ -274,10 +307,9 @@ apiVersion: kuma.io/v1alpha1
 kind: MeshOpenTelemetryBackend
 metadata:
   name: node-collector
-  namespace: kuma-system
+  namespace: kong-mesh-system
   labels:
     kuma.io/mesh: default
-# No spec - defaults apply: protocol grpc, port 4317, address resolved at runtime.
 ```
 
 {% endnavtab %}
@@ -287,7 +319,6 @@ metadata:
 type: MeshOpenTelemetryBackend
 name: node-collector
 mesh: default
-# No spec - defaults apply: protocol grpc, port 4317, address 127.0.0.1 resolved at runtime.
 ```
 
 {% endnavtab %}
@@ -303,9 +334,24 @@ spec:
   protocol: http
 ```
 
-## Reuse OpenTelemetry environment variables from the sidecar
+### Reuse OpenTelemetry environment variables from the sidecar
 
-Many setups already inject standard `OTEL_EXPORTER_OTLP_*` environment variables into the sidecar (OpenTelemetry Operator on Kubernetes, systemd unit on Universal, container runtime, wrapper script). The default `env` policy is `mode: Optional` plus `precedence: EnvFirst` plus `allowSignalOverrides: true`, so an empty backend reuses those values. With per-signal variables, traces can target a different collector while logs and metrics share the default.
+Many setups already inject standard `OTEL_EXPORTER_OTLP_*` environment variables into the sidecar (OpenTelemetry Operator on Kubernetes, systemd unit on Universal, container runtime, wrapper script). An empty backend reuses the default `env` configuration:
+
+```yaml
+env:
+  mode: Optional
+  precedence: EnvFirst
+  allowSignalOverrides: true
+```
+
+With per-signal variables, traces can target a different collector while logs and metrics share the default. For example, if the sidecar has the following environment variables:
+
+* OTEL_EXPORTER_OTLP_ENDPOINT=https://otel-gateway.observability:4318
+* OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+* OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://tempo.observability:4318
+
+{{site.mesh_product_name}} will use the specific `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` value for traces, and the default `OTEL_EXPORTER_OTLP_ENDPOINT` value for logs and metrics.
 
 {% navtabs "environment" %}
 {% navtab "Kubernetes" %}
@@ -315,15 +361,9 @@ apiVersion: kuma.io/v1alpha1
 kind: MeshOpenTelemetryBackend
 metadata:
   name: from-env
-  namespace: kuma-system
+  namespace: kong-mesh-system
   labels:
     kuma.io/mesh: default
-# No spec - sidecar environment variables drive the configuration.
-# Example sidecar environment:
-#   OTEL_EXPORTER_OTLP_ENDPOINT=https://otel-gateway.observability:4318
-#   OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-#   OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://tempo.observability:4318
-# Result: traces -> tempo, logs and metrics -> otel-gateway.
 ```
 
 {% endnavtab %}
@@ -333,20 +373,16 @@ metadata:
 type: MeshOpenTelemetryBackend
 name: from-env
 mesh: default
-# No spec - sidecar environment variables drive the configuration.
-# Example sidecar environment:
-#   OTEL_EXPORTER_OTLP_ENDPOINT=https://otel-gateway.observability:4318
-#   OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-#   OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://tempo.observability:4318
-# Result: traces -> tempo, logs and metrics -> otel-gateway.
 ```
 
 {% endnavtab %}
 {% endnavtabs %}
 
-When environment input must be ignored (regulated backends), set `mode: Disabled`. When the backend is meaningless without environment input (per-tenant headers, mTLS client keys), set `mode: Required` - the signal stays `missing` until the keys are present.
+When environment input must be ignored, set `mode: Disabled`. When the backend is meaningless without environment input (per-tenant headers, mTLS client keys), set `mode: Required`. In this case, the signal stays `missing` until the keys are present.
 
-## Per-zone collector example
+### Per-zone collector
+
+When each zone runs its own collector, create one backend per zone on the global control plane and scope each policy to the matching zone with `MeshSubset` and the `kuma.io/zone` tag.
 
 {% navtabs "environment" %}
 {% navtab "Kubernetes" %}
@@ -356,7 +392,7 @@ apiVersion: kuma.io/v1alpha1
 kind: MeshOpenTelemetryBackend
 metadata:
   name: collector-us-east
-  namespace: kuma-system
+  namespace: kong-mesh-system
   labels:
     kuma.io/mesh: default
 spec:
@@ -368,7 +404,7 @@ apiVersion: kuma.io/v1alpha1
 kind: MeshMetric
 metadata:
   name: metrics-us-east
-  namespace: kuma-system
+  namespace: kong-mesh-system
   labels:
     kuma.io/mesh: default
 spec:
@@ -419,34 +455,28 @@ spec:
 {% endnavtab %}
 {% endnavtabs %}
 
-{% endnavtab %}
-{% navtab "Configuration reference" %}
+## Troubleshooting
 
-{% json_schema MeshOpenTelemetryBackends %}
-
-{% endnavtab %}
-{% navtab "Troubleshooting" %}
-
-The control plane writes runtime status per backend and signal to each [DataplaneInsight](/mesh/dataplane/) under `status.openTelemetry`. Read it with:
+The control plane writes runtime status per backend and signal to each [`DataplaneInsight`](/mesh/dataplane/) under `status.openTelemetry`. Run the following commands to read it:
 
 {% navtabs "environment" %}
 {% navtab "Kubernetes" %}
 
 ```sh
-kubectl get dataplaneinsight DATAPLANE_NAME -o yaml
+kubectl get dataplaneinsight $DATAPLANE_NAME -o yaml
 ```
 
 {% endnavtab %}
 {% navtab "Universal" %}
 
 ```sh
-kumactl inspect dataplane DATAPLANE_NAME
+kumactl inspect dataplane $DATAPLANE_NAME
 ```
 
 {% endnavtab %}
 {% endnavtabs %}
 
-Per signal (one block each for `traces`, `metrics`, `logs`):
+The following fields are available for each signal:
 
 {% table %}
 columns:
@@ -456,26 +486,50 @@ columns:
     key: description
 rows:
   - field: '`enabled`'
-    description: 'Whether a policy targets this signal on this backend - `false` means no policy asked for it, distinct from `state: missing` (asked for but unresolved).'
+    description: 'Whether a policy targets this signal on this backend. `false` means no policy asked for it, distinct from `state: missing` (asked for but unresolved).'
   - field: '`state`'
-    description: '`ready`, `blocked`, `missing`, or `ambiguous`.'
+    description: |
+      The state of the signal. The value can be:
+      * `ready`
+      * `blocked`
+      * `missing`
+      * `ambiguous`
   - field: '`envAllowed`'
     description: 'Whether `env.mode` permits environment input for this backend.'
   - field: '`envInputPresent`'
-    description: 'Whether `kuma-dp` reported any matching environment-variable keys at bootstrap.'
+    description: 'Whether `kuma-dp` reported any matching environment variable keys at bootstrap.'
   - field: '`overrideKinds`'
-    description: 'OTLP fields where a per-signal variable overrides the shared layer (sorted), such as `endpoint`, `protocol`, `headers`, `timeout`.'
+    description: |
+      OTLP fields where a per-signal variable overrides the shared layer. For example:
+      * `endpoint`
+      * `protocol`
+      * `headers`
+      * `timeout`
   - field: '`missingFields`'
-    description: 'Fields the merge could not produce, such as `endpoint`, `protocol`, `headers`, `client_key`.'
+    description: |
+      Fields the merge could not produce. For example:
+      * `endpoint`
+      * `protocol`
+      * `headers`
+      * `client_key`
   - field: '`blockedReasons`'
-    description: 'One or more of `EnvDisabledByPolicy`, `RequiredEnvMissing`, `SignalOverridesDisallowed`, `MultipleBackendsForSignal`.'
+    description: |
+      The reason the signal was blocked. The value can be one or more of the following:
+      * `EnvDisabledByPolicy`
+      * `RequiredEnvMissing`
+      * `SignalOverridesDisallowed`
+      * `MultipleBackendsForSignal`
 {% endtable %}
 
 A signal is `ready` when the merge produces an `endpoint`. Other fields fall back to OpenTelemetry SDK defaults.
 
-**Soft blocks** (`EnvDisabledByPolicy`, `SignalOverridesDisallowed`) mean environment input was ignored but export still works. **Hard blocks** (`RequiredEnvMissing`, `MultipleBackendsForSignal`) prevent export entirely and move the state out of `ready`.
+There are two types of blocks:
+* Soft blocks (`EnvDisabledByPolicy` and `SignalOverridesDisallowed`) mean that the control plane ignored the environment input but the export still works. 
+* Hard blocks (`RequiredEnvMissing` and `MultipleBackendsForSignal`) prevent export entirely and move the state out of `ready`.
 
-## Signal missing: no endpoint resolved
+### Signal missing: no endpoint resolved
+
+A `state: missing` entry means a policy asked for the signal but the merge couldn't produce an `endpoint`. For example:
 
 ```yaml
 openTelemetry:
@@ -489,10 +543,13 @@ openTelemetry:
       missingFields:
       - endpoint
 ```
+{:.no-copy-code}
 
 The backend has no explicit address and no environment input was found. Either set `endpoint.address` on the backend or check the sidecar environment for `OTEL_EXPORTER_OTLP_ENDPOINT` or `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`.
 
-## Signal blocked: required input missing
+### Signal blocked: required input missing
+
+A backend configured with `mode: Required` reports `state: blocked` and `RequiredEnvMissing` when `kuma-dp` doesn't report the expected environment keys. For example:
 
 ```yaml
 openTelemetry:
@@ -506,10 +563,13 @@ openTelemetry:
       blockedReasons:
       - RequiredEnvMissing
 ```
+{:.no-copy-code}
 
-The backend has `mode: Required` but `kuma-dp` did not report the expected environment keys. Inject them on the sidecar and restart the data plane so the keys reach the control plane through bootstrap.
+The backend has `mode: Required` but `kuma-dp` didn't report the expected environment keys. Inject them on the sidecar and restart the data plane so the keys reach the control plane through bootstrap.
 
-## Signal ambiguous: more than one backend competing for input
+### Signal ambiguous: more than one backend competing for input
+
+When two backends resolve to the same data plane for the same signal and both allow environment input, every competing backend reports `state: ambiguous` with `MultipleBackendsForSignal`. For example:
 
 ```yaml
 openTelemetry:
@@ -531,24 +591,29 @@ openTelemetry:
       blockedReasons:
       - MultipleBackendsForSignal
 ```
+{:.no-copy-code}
 
-Two backends resolve to the same data plane and both allow environment input. Set `mode: Disabled` on every backend that should not receive environment input, or scope policies so only one backend reaches each data plane.
+Set `mode: Disabled` on every backend that should not receive environment input, or scope policies so only one backend reaches each data plane.
 
-## Backend reference does not resolve
+### Backend reference doesn't resolve
 
-`MeshOpenTelemetryBackend` carries a `ReferencedByPolicies` condition with reason `Referenced` while at least one policy points at it, otherwise reason `NotReferenced`. When a policy points at a backend that does not exist, the control plane logs through the `otel-backend-resolution` logger and skips the OTel export for that signal:
+`MeshOpenTelemetryBackend` carries a `ReferencedByPolicies` condition with reason `Referenced` while at least one policy points at it. Otherwise the reason is `NotReferenced`. When a policy points at a backend that doesn't exist, the control plane logs through the `otel-backend-resolution` logger and skips the OTel export for that signal:
 
 ```text
 MeshOpenTelemetryBackend not found, skipping backend  name=main-collector  labels=null
 ```
+{:.no-copy-code}
 
-In multi-zone, the most common cause is a zone-authored policy referencing a Global-synced backend by `name:` instead of `labels:`. Switch to `labels: {kuma.io/display-name: <name>}`. A backend just applied on the Global control plane can also take a few seconds to reach Zone control planes through KDS - expect short-lived `NotReferenced` and "not found" log lines while sync catches up.
+In multi-zone, the most common cause is a zone-authored policy referencing a backend synced from the global control plane by `name` instead of `labels`. Switch to `labels` with the `kuma.io/display-name` label. A backend only applied on the global control plane can also take a few seconds to reach zone control planes through KDS, so expect short-lived `NotReferenced` and `not found` log lines while sync catches up.
 
-## Mixed-version data planes during upgrade
+### Mixed-version data planes during upgrade
 
-`backendRef` requires the data plane to advertise the `feature-otel-via-kuma-dp` feature. All 2.14 data planes do by default. During an upgrade where some proxies are still on 2.13, the control plane silently skips the OTel pipe route for those proxies - **no log entry is emitted**. The signal does not export through the backend. Confirm by reading `status.openTelemetry` on the affected proxies: no signal status entries are written for `backendRef`-based backends until the proxy advertises the feature.
+`backendRef` requires the data plane to advertise the `feature-otel-via-kuma-dp` feature. All 2.14 data planes do by default. During an upgrade where some proxies are still on 2.13, the control plane silently skips the OTel pipe route for those proxies and emits no log entry. The signal doesn't export through the backend. Read `status.openTelemetry` on the affected proxies and confirm that the control plane writes no signal status entries for backends referenced with `backendRef` until the proxy advertises the feature.
 
 Inline `endpoint` configurations stay on the direct Envoy export path and keep working through the upgrade.
 
-{% endnavtab %}
-{% endnavtabs %}
+## Schema
+
+The full schema for the `MeshOpenTelemetryBackend` resource:
+
+{% json_schema MeshOpenTelemetryBackends %}

--- a/app/mesh/meshopentelemetrybackend.md
+++ b/app/mesh/meshopentelemetrybackend.md
@@ -614,6 +614,4 @@ Inline `endpoint` configurations stay on the direct Envoy export path and keep w
 
 ## Schema
 
-The full schema for the `MeshOpenTelemetryBackend` resource:
-
 {% json_schema MeshOpenTelemetryBackends %}

--- a/app/mesh/meshopentelemetrybackend.md
+++ b/app/mesh/meshopentelemetrybackend.md
@@ -1,0 +1,552 @@
+---
+title: MeshOpenTelemetryBackend
+description: Shared OpenTelemetry collector configuration that MeshMetric, MeshTrace, and MeshAccessLog can reference instead of duplicating endpoint settings.
+
+content_type: reference
+layout: reference
+products:
+  - mesh
+breadcrumbs:
+  - /mesh/
+
+related_resources:
+  - text: MeshMetric
+    url: /mesh/policies/meshmetric/
+  - text: MeshTrace
+    url: /mesh/policies/meshtrace/
+  - text: MeshAccessLog
+    url: /mesh/policies/meshaccesslog/
+  - text: Multi-zone deployment
+    url: /mesh/mesh-multizone-service-deployment/
+  - text: Deploy an OpenTelemetry collector
+    url: /mesh/deploy-an-opentelemetry-collector/
+
+min_version:
+  mesh: '2.14'
+
+tags:
+  - observability
+  - metrics
+  - tracing
+  - logging
+
+no_wrap: true
+---
+
+{% navtabs "meshopentelemetrybackend" heading_level=2 %}
+{% navtab "Overview" %}
+
+`MeshOpenTelemetryBackend` defines an OpenTelemetry collector endpoint that observability policies reference through a `backendRef`. Without it, every [`MeshMetric`](/mesh/policies/meshmetric/), [`MeshTrace`](/mesh/policies/meshtrace/), and [`MeshAccessLog`](/mesh/policies/meshaccesslog/) policy carries its own copy of the collector address. With it, the address lives in one place and the policies point at it by name.
+
+Inline `endpoint` fields on those three policies still work in 2.14 but are deprecated and will be removed in 3.0. New deployments should use `backendRef`.
+
+`MeshOpenTelemetryBackend` must be created in the system namespace (`kuma-system` on Kubernetes). On Universal, it lives in the Global CP store with no namespace concept.
+
+## Migrate from inline `endpoint`
+
+1. Create one `MeshOpenTelemetryBackend` carrying the address that was inline on the policy.
+2. On each policy, replace the inline `endpoint` with `backendRef: {kind: MeshOpenTelemetryBackend, name: <backend>}`.
+3. Signal-specific fields (`refreshInterval`, `attributes`, `body`, `sampling`) stay on the policy.
+
+To move the collector later, edit the backend - the policies stay untouched.
+
+## Reference a backend from a policy
+
+Every observability policy that supports OpenTelemetry has a `backendRef` field on its OTel backend block. The reference works the same way as `BackendRef` on `MeshHTTPRoute`: use `name` to reference a resource in the same cluster, use `labels` to reference a resource synced from another cluster.
+
+{% table %}
+columns:
+  - title: Field
+    key: field
+  - title: Description
+    key: description
+rows:
+  - field: '`backendRef.kind`'
+    description: 'Must be `MeshOpenTelemetryBackend`.'
+  - field: '`backendRef.name`'
+    description: '`metadata.name` of the backend, for same-cluster references.'
+  - field: '`backendRef.labels`'
+    description: 'Label selector. Required for cross-zone references because [KDS](/mesh/mesh-multizone-service-deployment/) appends a hash suffix to `metadata.name` on synced resources.'
+{% endtable %}
+
+Exactly one of `name` or `labels` must be set. When `labels` matches more than one backend, the oldest by creation time wins - no warning is emitted, so check creation timestamps if a policy resolves to an unexpected backend. When `name` does not resolve at all, the policy carries a `BackendRefsResolved: False` status condition with reason `UnresolvedBackendRefs`.
+
+For cross-zone references, match on `kuma.io/display-name` so the resource resolves regardless of the hashed name added during sync:
+
+```yaml
+backendRef:
+  kind: MeshOpenTelemetryBackend
+  labels:
+    kuma.io/display-name: main-collector
+```
+
+### Per-zone collectors in multi-zone
+
+When zones run separate collectors, create one backend per zone on the Global CP and scope each policy to the matching zone. Because both the backend and the policy live on Global, the CP resolves `backendRef.name` before KDS sync - the hashed name that appears on zones never matters.
+
+If the policy is created on a zone CP and references a backend synced from Global, use `backendRef.labels` instead - the synced backend's `metadata.name` carries a hash suffix that does not match a plain `name:`.
+
+When all zones can share the same collector service name, one backend on the Global CP is enough - DNS resolves to the local collector in each zone.
+
+## Environment-variable resolution
+
+`kuma-dp` reads `OTEL_EXPORTER_OTLP_*` environment variables locally at startup and merges them with the backend config. Secret-bearing values (headers, client keys, certificates) stay local to `kuma-dp`. During startup, `kuma-dp` reports only which environment variable keys are present to the control plane, never the values.
+
+Recognized variable families:
+
+- shared: `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_EXPORTER_OTLP_INSECURE`, `OTEL_EXPORTER_OTLP_TIMEOUT`, `OTEL_EXPORTER_OTLP_COMPRESSION`, `OTEL_EXPORTER_OTLP_CERTIFICATE`, `OTEL_EXPORTER_OTLP_CLIENT_KEY`, `OTEL_EXPORTER_OTLP_CLIENT_CERTIFICATE`
+- per-signal (override shared per signal): `OTEL_EXPORTER_OTLP_TRACES_*`, `OTEL_EXPORTER_OTLP_LOGS_*`, `OTEL_EXPORTER_OTLP_METRICS_*`
+
+For each field, `kuma-dp` resolves the first available source. With default `precedence: EnvFirst`:
+
+1. signal-specific environment variable (when `allowSignalOverrides: true`)
+2. shared environment variable
+3. explicit field on the backend
+4. built-in default
+
+With `precedence: ExplicitFirst`, the explicit backend field moves from position 3 to 1.
+
+When `mode: Disabled`, environment variables are skipped entirely (points 1 and 2).
+
+When `mode: Required`, missing or invalid input blocks the signal even if explicit config or defaults could otherwise fill the gap. Use `Required` when missing input should fail loud - the signal blocks, `RequiredEnvMissing` shows up in `DataplaneInsight`, and you can alert on the absence of exported data.
+
+Environment-variable values change only when `kuma-dp` restarts and re-bootstraps. Status updates pick them up at the same time.
+
+### Ambiguity rule
+
+OpenTelemetry environment variables are process-global. If one data plane resolves more than one backend for the same signal and both backends allow environment input, the control plane cannot tell which backend the values belong to. The signal is marked `ambiguous` and environment input is dropped for it. Explicit config still applies. Plan one backend per signal per data plane, or set `mode: Disabled` on backends that should never receive environment input.
+
+{% endnavtab %}
+{% navtab "Examples" %}
+
+## Single collector for all three signals
+
+The most common shape: one backend resource, three policies pointing at it.
+
+{% navtabs "environment" %}
+{% navtab "Kubernetes" %}
+
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshOpenTelemetryBackend
+metadata:
+  name: main-collector
+  namespace: kuma-system
+  labels:
+    kuma.io/mesh: default
+spec:
+  endpoint:
+    address: otel-collector.observability
+    port: 4317
+  protocol: grpc
+---
+apiVersion: kuma.io/v1alpha1
+kind: MeshMetric
+metadata:
+  name: all-metrics
+  namespace: kuma-system
+  labels:
+    kuma.io/mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    backends:
+      - type: OpenTelemetry
+        openTelemetry:
+          backendRef:
+            kind: MeshOpenTelemetryBackend
+            name: main-collector
+          refreshInterval: 30s
+---
+apiVersion: kuma.io/v1alpha1
+kind: MeshTrace
+metadata:
+  name: all-traces
+  namespace: kuma-system
+  labels:
+    kuma.io/mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    backends:
+      - type: OpenTelemetry
+        openTelemetry:
+          backendRef:
+            kind: MeshOpenTelemetryBackend
+            name: main-collector
+    sampling:
+      overall: 80
+---
+apiVersion: kuma.io/v1alpha1
+kind: MeshAccessLog
+metadata:
+  name: all-access-logs
+  namespace: kuma-system
+  labels:
+    kuma.io/mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    backends:
+      - type: OpenTelemetry
+        openTelemetry:
+          backendRef:
+            kind: MeshOpenTelemetryBackend
+            name: main-collector
+```
+
+{% endnavtab %}
+{% navtab "Universal" %}
+
+```yaml
+type: MeshOpenTelemetryBackend
+name: main-collector
+mesh: default
+spec:
+  endpoint:
+    address: otel-collector.observability
+    port: 4317
+  protocol: grpc
+---
+type: MeshMetric
+name: all-metrics
+mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    backends:
+      - type: OpenTelemetry
+        openTelemetry:
+          backendRef:
+            kind: MeshOpenTelemetryBackend
+            name: main-collector
+          refreshInterval: 30s
+---
+type: MeshTrace
+name: all-traces
+mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    backends:
+      - type: OpenTelemetry
+        openTelemetry:
+          backendRef:
+            kind: MeshOpenTelemetryBackend
+            name: main-collector
+    sampling:
+      overall: 80
+---
+type: MeshAccessLog
+name: all-access-logs
+mesh: default
+spec:
+  targetRef:
+    kind: Mesh
+  default:
+    backends:
+      - type: OpenTelemetry
+        openTelemetry:
+          backendRef:
+            kind: MeshOpenTelemetryBackend
+            name: main-collector
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+## Node-local collector
+
+If the collector runs as a DaemonSet with `hostPort`, an empty backend is enough. `kuma-dp` resolves `HOST_IP:4317` on Kubernetes (Downward API) and `127.0.0.1:4317` on Universal and VMs.
+
+{% navtabs "environment" %}
+{% navtab "Kubernetes" %}
+
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshOpenTelemetryBackend
+metadata:
+  name: node-collector
+  namespace: kuma-system
+  labels:
+    kuma.io/mesh: default
+# No spec - defaults apply: protocol grpc, port 4317, address resolved at runtime.
+```
+
+{% endnavtab %}
+{% navtab "Universal" %}
+
+```yaml
+type: MeshOpenTelemetryBackend
+name: node-collector
+mesh: default
+# No spec - defaults apply: protocol grpc, port 4317, address 127.0.0.1 resolved at runtime.
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+If the DaemonSet exposes OTLP/HTTP on a different port, override only the fields that change:
+
+```yaml
+spec:
+  endpoint:
+    port: 4318
+    path: /otlp
+  protocol: http
+```
+
+## Reuse OpenTelemetry environment variables from the sidecar
+
+Many setups already inject standard `OTEL_EXPORTER_OTLP_*` environment variables into the sidecar (OpenTelemetry Operator on Kubernetes, systemd unit on Universal, container runtime, wrapper script). The default `env` policy is `mode: Optional` plus `precedence: EnvFirst` plus `allowSignalOverrides: true`, so an empty backend reuses those values. With per-signal variables, traces can target a different collector while logs and metrics share the default.
+
+{% navtabs "environment" %}
+{% navtab "Kubernetes" %}
+
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshOpenTelemetryBackend
+metadata:
+  name: from-env
+  namespace: kuma-system
+  labels:
+    kuma.io/mesh: default
+# No spec - sidecar environment variables drive the configuration.
+# Example sidecar environment:
+#   OTEL_EXPORTER_OTLP_ENDPOINT=https://otel-gateway.observability:4318
+#   OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+#   OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://tempo.observability:4318
+# Result: traces -> tempo, logs and metrics -> otel-gateway.
+```
+
+{% endnavtab %}
+{% navtab "Universal" %}
+
+```yaml
+type: MeshOpenTelemetryBackend
+name: from-env
+mesh: default
+# No spec - sidecar environment variables drive the configuration.
+# Example sidecar environment:
+#   OTEL_EXPORTER_OTLP_ENDPOINT=https://otel-gateway.observability:4318
+#   OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+#   OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://tempo.observability:4318
+# Result: traces -> tempo, logs and metrics -> otel-gateway.
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+When environment input must be ignored (regulated backends), set `mode: Disabled`. When the backend is meaningless without environment input (per-tenant headers, mTLS client keys), set `mode: Required` - the signal stays `missing` until the keys are present.
+
+## Per-zone collector example
+
+{% navtabs "environment" %}
+{% navtab "Kubernetes" %}
+
+```yaml
+apiVersion: kuma.io/v1alpha1
+kind: MeshOpenTelemetryBackend
+metadata:
+  name: collector-us-east
+  namespace: kuma-system
+  labels:
+    kuma.io/mesh: default
+spec:
+  endpoint:
+    address: collector.us-east.internal
+    port: 4317
+---
+apiVersion: kuma.io/v1alpha1
+kind: MeshMetric
+metadata:
+  name: metrics-us-east
+  namespace: kuma-system
+  labels:
+    kuma.io/mesh: default
+spec:
+  targetRef:
+    kind: MeshSubset
+    tags:
+      kuma.io/zone: us-east
+  default:
+    backends:
+      - type: OpenTelemetry
+        openTelemetry:
+          backendRef:
+            kind: MeshOpenTelemetryBackend
+            name: collector-us-east
+          refreshInterval: 30s
+```
+
+{% endnavtab %}
+{% navtab "Universal" %}
+
+```yaml
+type: MeshOpenTelemetryBackend
+name: collector-us-east
+mesh: default
+spec:
+  endpoint:
+    address: collector.us-east.internal
+    port: 4317
+---
+type: MeshMetric
+name: metrics-us-east
+mesh: default
+spec:
+  targetRef:
+    kind: MeshSubset
+    tags:
+      kuma.io/zone: us-east
+  default:
+    backends:
+      - type: OpenTelemetry
+        openTelemetry:
+          backendRef:
+            kind: MeshOpenTelemetryBackend
+            name: collector-us-east
+          refreshInterval: 30s
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+{% endnavtab %}
+{% navtab "Configuration reference" %}
+
+{% json_schema MeshOpenTelemetryBackends %}
+
+{% endnavtab %}
+{% navtab "Troubleshooting" %}
+
+The control plane writes runtime status per backend and signal to each [DataplaneInsight](/mesh/dataplane/) under `spec.openTelemetry`. Read it with:
+
+{% navtabs "environment" %}
+{% navtab "Kubernetes" %}
+
+```sh
+kubectl get dataplaneinsight <name> -o yaml
+```
+
+{% endnavtab %}
+{% navtab "Universal" %}
+
+```sh
+kumactl inspect dataplane <name>
+```
+
+{% endnavtab %}
+{% endnavtabs %}
+
+Per signal (one block each for `traces`, `metrics`, `logs`):
+
+{% table %}
+columns:
+  - title: Field
+    key: field
+  - title: Description
+    key: description
+rows:
+  - field: '`enabled`'
+    description: 'Whether a policy targets this signal on this backend - `false` means no policy asked for it, distinct from `state: missing` (asked for but unresolved).'
+  - field: '`state`'
+    description: '`ready`, `blocked`, `missing`, or `ambiguous`.'
+  - field: '`envAllowed`'
+    description: 'Whether `env.mode` permits environment input for this backend.'
+  - field: '`envInputPresent`'
+    description: 'Whether `kuma-dp` reported any matching environment-variable keys at bootstrap.'
+  - field: '`overrideKinds`'
+    description: 'OTLP fields where a per-signal variable overrides the shared layer (sorted), such as `endpoint`, `protocol`, `headers`, `timeout`.'
+  - field: '`missingFields`'
+    description: 'Fields the merge could not produce, such as `endpoint`, `protocol`, `headers`, `client_key`.'
+  - field: '`blockedReasons`'
+    description: 'One or more of `EnvDisabledByPolicy`, `RequiredEnvMissing`, `SignalOverridesDisallowed`, `MultipleBackendsForSignal`.'
+{% endtable %}
+
+A signal is `ready` when the merge produces an `endpoint`. Other fields fall back to OpenTelemetry SDK defaults.
+
+**Soft blocks** (`EnvDisabledByPolicy`, `SignalOverridesDisallowed`) mean environment input was ignored but export still works. **Hard blocks** (`RequiredEnvMissing`, `MultipleBackendsForSignal`) prevent export entirely and move the state out of `ready`.
+
+## Signal missing: no endpoint resolved
+
+```yaml
+openTelemetry:
+  backends:
+  - name: from-env
+    metrics:
+      enabled: true
+      state: missing
+      envAllowed: true
+      envInputPresent: false
+      missingFields:
+      - endpoint
+```
+
+The backend has no explicit address and no environment input was found. Either set `endpoint.address` on the backend or check the sidecar environment for `OTEL_EXPORTER_OTLP_ENDPOINT` or `OTEL_EXPORTER_OTLP_METRICS_ENDPOINT`.
+
+## Signal blocked: required input missing
+
+```yaml
+openTelemetry:
+  backends:
+  - name: tenant-cloud
+    traces:
+      enabled: true
+      state: blocked
+      envAllowed: true
+      envInputPresent: false
+      blockedReasons:
+      - RequiredEnvMissing
+```
+
+The backend has `mode: Required` but `kuma-dp` did not report the expected environment keys. Inject them on the sidecar and restart the data plane so the keys reach the control plane through bootstrap.
+
+## Signal ambiguous: more than one backend competing for input
+
+```yaml
+openTelemetry:
+  backends:
+  - name: backend-a
+    traces:
+      enabled: true
+      state: ambiguous
+      envAllowed: true
+      envInputPresent: true
+      blockedReasons:
+      - MultipleBackendsForSignal
+  - name: backend-b
+    traces:
+      enabled: true
+      state: ambiguous
+      envAllowed: true
+      envInputPresent: true
+      blockedReasons:
+      - MultipleBackendsForSignal
+```
+
+Two backends resolve to the same data plane and both allow environment input. Set `mode: Disabled` on every backend that should not receive environment input, or scope policies so only one backend reaches each data plane.
+
+## Backend reference does not resolve
+
+`MeshOpenTelemetryBackend` carries a `ReferencedByPolicies` condition with reason `Referenced` while at least one policy points at it, otherwise reason `NotReferenced`. When a policy points at a backend that does not exist, the control plane logs through the `otel-backend-resolution` logger and skips the OTel export for that signal:
+
+```text
+MeshOpenTelemetryBackend not found, skipping backend  name=main-collector  labels=null
+```
+
+In multi-zone, the most common cause is a zone-authored policy referencing a Global-synced backend by `name:` instead of `labels:`. Switch to `labels: {kuma.io/display-name: <name>}`. A backend just applied on the Global control plane can also take a few seconds to reach Zone control planes through KDS - expect short-lived `NotReferenced` and "not found" log lines while sync catches up.
+
+## Mixed-version data planes during upgrade
+
+`backendRef` requires the data plane to advertise the `feature-otel-via-kuma-dp` feature. All 2.14 data planes do by default. During an upgrade where some proxies are still on 2.13, the control plane silently skips the OTel pipe route for those proxies - **no log entry is emitted**. The signal does not export through the backend. Confirm by reading `DataplaneInsight.openTelemetry` on the affected proxies: no signal status entries are written for `backendRef`-based backends until the proxy advertises the feature.
+
+Inline `endpoint` configurations stay on the direct Envoy export path and keep working through the upgrade.
+
+{% endnavtab %}
+{% endnavtabs %}

--- a/app/mesh/meshopentelemetrybackend.md
+++ b/app/mesh/meshopentelemetrybackend.md
@@ -114,7 +114,7 @@ When all zones can share the same collector service name, one backend on the glo
 
 `kuma-dp` reads `OTEL_EXPORTER_OTLP_*` environment variables locally at startup and merges them with the backend config. Secret-bearing values (headers, client keys, certificates) stay local to `kuma-dp`. During startup, `kuma-dp` reports only which environment variable keys are present to the control plane, never the values.
 
-Here are the variable used:
+Here are the variables used:
 * Shared: 
   * `OTEL_EXPORTER_OTLP_ENDPOINT`
   * `OTEL_EXPORTER_OTLP_PROTOCOL`

--- a/app/mesh/meshopentelemetrybackend.md
+++ b/app/mesh/meshopentelemetrybackend.md
@@ -24,6 +24,8 @@ related_resources:
 min_version:
   mesh: '2.14'
 
+tech_preview: true
+
 tags:
   - observability
   - metrics
@@ -45,7 +47,7 @@ Inline `endpoint` fields on those three policies still work in 2.14 but are depr
 ## Migrate from inline `endpoint`
 
 1. Create one `MeshOpenTelemetryBackend` carrying the address that was inline on the policy.
-2. On each policy, replace the inline `endpoint` with `backendRef: {kind: MeshOpenTelemetryBackend, name: <backend>}`.
+2. On each policy, replace the inline `endpoint` with `backendRef: {kind: MeshOpenTelemetryBackend, name: BACKEND_NAME}`.
 3. Signal-specific fields (`refreshInterval`, `attributes`, `body`, `sampling`) stay on the policy.
 
 To move the collector later, edit the backend - the policies stay untouched.
@@ -108,7 +110,7 @@ With `precedence: ExplicitFirst`, the explicit backend field moves from position
 
 When `mode: Disabled`, environment variables are skipped entirely (points 1 and 2).
 
-When `mode: Required`, missing or invalid input blocks the signal even if explicit config or defaults could otherwise fill the gap. Use `Required` when missing input should fail loud - the signal blocks, `RequiredEnvMissing` shows up in `DataplaneInsight`, and you can alert on the absence of exported data.
+When `mode: Required`, missing or invalid input blocks the signal even if explicit config or defaults could otherwise fill the gap. Use `Required` when missing input should fail loudly - the signal blocks, `RequiredEnvMissing` shows up in `DataplaneInsight`, and you can alert on the absence of exported data.
 
 Environment-variable values change only when `kuma-dp` restarts and re-bootstraps. Status updates pick them up at the same time.
 
@@ -425,20 +427,20 @@ spec:
 {% endnavtab %}
 {% navtab "Troubleshooting" %}
 
-The control plane writes runtime status per backend and signal to each [DataplaneInsight](/mesh/dataplane/) under `spec.openTelemetry`. Read it with:
+The control plane writes runtime status per backend and signal to each [DataplaneInsight](/mesh/dataplane/) under `status.openTelemetry`. Read it with:
 
 {% navtabs "environment" %}
 {% navtab "Kubernetes" %}
 
 ```sh
-kubectl get dataplaneinsight <name> -o yaml
+kubectl get dataplaneinsight DATAPLANE_NAME -o yaml
 ```
 
 {% endnavtab %}
 {% navtab "Universal" %}
 
 ```sh
-kumactl inspect dataplane <name>
+kumactl inspect dataplane DATAPLANE_NAME
 ```
 
 {% endnavtab %}
@@ -544,7 +546,7 @@ In multi-zone, the most common cause is a zone-authored policy referencing a Glo
 
 ## Mixed-version data planes during upgrade
 
-`backendRef` requires the data plane to advertise the `feature-otel-via-kuma-dp` feature. All 2.14 data planes do by default. During an upgrade where some proxies are still on 2.13, the control plane silently skips the OTel pipe route for those proxies - **no log entry is emitted**. The signal does not export through the backend. Confirm by reading `DataplaneInsight.openTelemetry` on the affected proxies: no signal status entries are written for `backendRef`-based backends until the proxy advertises the feature.
+`backendRef` requires the data plane to advertise the `feature-otel-via-kuma-dp` feature. All 2.14 data planes do by default. During an upgrade where some proxies are still on 2.13, the control plane silently skips the OTel pipe route for those proxies - **no log entry is emitted**. The signal does not export through the backend. Confirm by reading `status.openTelemetry` on the affected proxies: no signal status entries are written for `backendRef`-based backends until the proxy advertises the feature.
 
 Inline `endpoint` configurations stay on the direct Envoy export path and keep working through the upgrade.
 

--- a/app/mesh/observability.md
+++ b/app/mesh/observability.md
@@ -28,6 +28,8 @@ related_resources:
     url: /mesh/dataplane-health/
   - text: Deploy an OpenTelemetry collector
     url: /mesh/deploy-an-opentelemetry-collector/
+  - text: MeshOpenTelemetryBackend
+    url: /mesh/meshopentelemetrybackend/
 ---
 
 This page describes how to configure different observability tools to work with {{site.mesh_product_name}}.


### PR DESCRIPTION
## Motivation

MeshOpenTelemetryBackend lets MeshMetric, MeshTrace, and MeshAccessLog share one OTel collector endpoint via `backendRef` instead of duplicating it on each policy. Ships in 2.14 as preview and needs its own reference page.

## Implementation information

- Migrated `meshopentelemetrybackend.md` from kumahq/kuma-website to `app/mesh/`
- Wrapped the page in a top-level `{% navtabs %}` block with Overview, Examples, Configuration reference, and Troubleshooting tabs. Set `no_wrap: true` to skip section wrapping (the wrapper chokes when every `h2` lives inside a navtab)
- Inner Kubernetes/Universal sub-tabs share the `environment` group so picking once syncs every example on the page
- Added `related_resources` back-links from `meshmetric`, `meshtrace`, `meshaccesslog`, and `observability` so readers can find the backend from the policies that consume it
- Added the page under Resource References in `app/_indices/mesh.yaml`

https://deploy-preview-5310--kongdeveloper.netlify.app/mesh/meshopentelemetrybackend/dev/