### PR TITLE
fix(ai-gateway) remove mentions of auto generation

### DIFF
--- a/app/_kong_plugins/ai-mcp-proxy/index.md
+++ b/app/_kong_plugins/ai-mcp-proxy/index.md
@@ -53,7 +53,7 @@ related_resources:
   - text: Create MCP tools from a RESTful API
     url: /mcp/map-api-to-mcp-tools/
   - text: Create MCP tools for Weather API
-    url: /mcp/weather-mcp-api/
+    url: /mcp/map-weather-api-to-mcp-tools/
   - text: Control MCP tool access with Consumer and Consumer Group ACLs
     url: /mcp/use-access-controls-for-mcp-tools/
   - text: Enforce ACLs on aggregated MCP servers

--- a/app/_kong_plugins/ai-mcp-proxy/index.md
+++ b/app/_kong_plugins/ai-mcp-proxy/index.md
@@ -50,9 +50,9 @@ related_resources:
   - text: Kong MCP traffic gateway
     url: /mcp/
     icon: /assets/icons/mcp.svg
-  - text: Autogenerate MCP tools from a RESTful API
+  - text: Create MCP tools from a RESTful API
     url: /mcp/map-api-to-mcp-tools/
-  - text: Autogenerate MCP tools for Weather API
+  - text: Create MCP tools for Weather API
     url: /mcp/weather-mcp-api/
   - text: Control MCP tool access with Consumer and Consumer Group ACLs
     url: /mcp/use-access-controls-for-mcp-tools/
@@ -103,9 +103,9 @@ next_steps:
     url: /mcp/
   - text: Learn about {{site.konnect_product_name}} MCP Server
     url: /mcp/kong-mcp/get-started/
-  - text: Autogenerate MCP tools from a RESTful API
+  - text: Create MCP tools from a RESTful API
     url: /mcp/map-api-to-mcp-tools/
-  - text: Autogenerate MCP tools for Weather API
+  - text: Create MCP tools for Weather API
     url: /mcp/map-weather-api-to-mcp-tools/
   - text: Control MCP tool access with Consumer and Consumer Group ACLs
     url: /mcp/use-access-controls-for-mcp-tools/

--- a/app/_landing_pages/mcp.yaml
+++ b/app/_landing_pages/mcp.yaml
@@ -30,7 +30,7 @@ rows:
               {{site.ai_gateway}} enables teams to manage remote MCP traffic with enterprise-grade security, performance, authentication, context propagation, load balancing, and observability.
 
               Learn how to:
-              - [Autogenerate and secure MCP tools from any API](#autogenerate-mcp-servers-using-ai-mcp-proxy)
+              - [Map APIs to secure MCP tools](#map-apis-to-mcp-servers-using-ai-mcp-proxy)
               - [Apply security, governance, and observability controls to MCP servers](#apply-security-governance-and-observability-controls-to-mcp-servers)
               - [Observe MCP traffic logs and metrics](#mcp-traffic-observability)
               - [Leverage {{site.base_gateway}} for MCP traffic using how-to guides](#mcp-how-to-guides)
@@ -91,11 +91,11 @@ rows:
             icon: /assets/icons/mcp.svg
             title: Create MCP tools from any API using AI MCP plugins
             description: |
-              Explore guides to auto-generate MCP servers and tools without custom code.
+              Explore guides to create MCP servers and tools without custom code.
             ctas:
               - text: Proxy MCP Traffic with the AI MCP Proxy plugin
                 url: "/plugins/ai-mcp-proxy/"
-              - text: Autogenerate a serverless MCP
+              - text: Map APIs to MCP servers using AI MCP Proxy
                 url: "/mcp/map-api-to-mcp-tools/"
               - text: Create MCP tools from any API schema
                 url: "/mcp/map-weather-api-to-mcp-tools/"

--- a/app/_landing_pages/mcp.yaml
+++ b/app/_landing_pages/mcp.yaml
@@ -46,7 +46,7 @@ rows:
           config:
             header:
               type: h2
-              text: "Autogenerate MCP servers using {{site.ai_gateway}}"
+              text: "Create MCP servers using {{site.ai_gateway}}"
             blocks:
               - type: text
                 text: |
@@ -59,7 +59,7 @@ rows:
           config:
             header:
               type: h2
-              text: "Autogenerate MCP servers using AI MCP Proxy"
+              text: "Map APIs to MCP servers using AI MCP Proxy"
             blocks:
               - type: text
                 text: |
@@ -89,7 +89,7 @@ rows:
         - type: card
           config:
             icon: /assets/icons/mcp.svg
-            title: Autogenerate MCP tools from any API using AI MCP plugins
+            title: Create MCP tools from any API using AI MCP plugins
             description: |
               Explore guides to auto-generate MCP servers and tools without custom code.
             ctas:
@@ -97,7 +97,7 @@ rows:
                 url: "/plugins/ai-mcp-proxy/"
               - text: Autogenerate a serverless MCP
                 url: "/mcp/map-api-to-mcp-tools/"
-              - text: Autogenerate MCP tools from any API schema
+              - text: Create MCP tools from any API schema
                 url: "/mcp/map-weather-api-to-mcp-tools/"
               - text: "Aggregate MCP tools from multiple AI MCP Proxy plugins"
                 url: /mcp/aggregate-mcp-tools/


### PR DESCRIPTION
## Description

Followup to [find ticket], some links like those on https://developer.konghq.com/mcp/#autogenerate-mcp-servers-using-ai-mcp-proxy still refer to autogeneration not mapping APIs to MCP


Fixes https://github.com/Kong/developer.konghq.com/issues/5156

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
