### PR TITLE
fix(ai-gw): Explicitly state not shown capabilities are not available

### DIFF
--- a/app/_includes/plugins/ai-proxy/providers/providers.md
+++ b/app/_includes/plugins/ai-proxy/providers/providers.md
@@ -109,7 +109,7 @@ rows:
 
 ## Supported capabilities
 
-The following tables show the AI capabilities supported by {{ provider.name }} provider when used with the [AI Proxy](/plugins/ai-proxy/) or the [AI Proxy Advanced](/plugins/ai-proxy-advanced/) plugin.
+The following tables show the AI capabilities supported by {{ provider.name }} provider when used with the [AI Proxy](/plugins/ai-proxy/) or the [AI Proxy Advanced](/plugins/ai-proxy-advanced/) plugin. Any upstream capabilities not listed are unavailable.
 
 {:.info}
 > Set the plugin's [`route_type`](/plugins/ai-proxy/reference/#schema--config-route-type) based on the capability you want to use. See the tables below for supported route types.


### PR DESCRIPTION
## Description

Following https://app.kapa.ai/93b55f65-cffb-4d0b-9da7-c8915a838dce/conversations/24a5140d-dac0-4ce0-aa75-42e9b768667f, https://app.kapa.ai/93b55f65-cffb-4d0b-9da7-c8915a838dce/conversations/9ea7d265-e851-47ea-a0c1-82d798b2fc6e adds stronger language to all plugin capability lists.

## Preview Links

