### PR TITLE
fix: vault how-tos

### DIFF
--- a/app/_how-tos/gateway/configure-hashicorp-vault-as-a-vault-backend.md
+++ b/app/_how-tos/gateway/configure-hashicorp-vault-as-a-vault-backend.md
@@ -107,7 +107,7 @@ command: |
   curl -X POST http://localhost:8200/v1/secret/data/customer/acme \
        -H "X-Vault-Token: $VAULT_TOKEN" \
        -H "Content-Type: application/json" \
-       -d '{"data":{"name":"ACME Inc."}}' \
+       -d '{"data":{"name":"ACME Inc."}}'
 expected:
   return_code: 0
 render_output: false

--- a/app/_includes/prereqs/hashicorp.md
+++ b/app/_includes/prereqs/hashicorp.md
@@ -8,8 +8,10 @@ This how-to requires you to have a dev mode or self-managed HashiCorp Vault. The
    ```sh
    docker run -d \
       --name vault \
+      --cap-add=IPC_LOCK \
       -p 8200:8200 \
       -e SKIP_SETCAP=1 \
+      -e SKIP_CHOWN=1 \
       -e VAULT_DEV_ROOT_TOKEN_ID=root \
       hashicorp/vault
    ```

--- a/tools/automated-tests/config/tests.yaml
+++ b/tools/automated-tests/config/tests.yaml
@@ -11,7 +11,7 @@ products:
         - docker network create kong-quickstart-net >/dev/null 2>&1 || true
         - docker run -d --name automated-tests-keycloak -p 127.0.0.1:8080:8080 --network kong-quickstart-net -e KC_DB_USERNAME=keycloak -e KC_DB_PASSWORD=password -e KC_DB_DATABASE=keycloak -v $REALM_PATH:/opt/keycloak/data/import quay.io/keycloak/keycloak  start-dev --import-realm
         - docker run -d --name redis-stack-server -p 6379:6379  --network kong-quickstart-net redis/redis-stack-server:latest
-        - docker run -d --name vault -p 8200:8200 --network kong-quickstart-net -e SKIP_SETCAP=1 -e VAULT_DEV_ROOT_TOKEN_ID=root hashicorp/vault
+        - docker run -d --name vault -p 8200:8200 --network kong-quickstart-net -e SKIP_SETCAP=1 -e VAULT_DEV_ROOT_TOKEN_ID=root -e SKIP_CHOWN=1 --cap-add=IPC_LOCK hashicorp/vault
         - sleep 10
 
     after: &gateway-after


### PR DESCRIPTION
## Description

Pass `SKIP_CHOWN and cap-add` to vault when running it in dev mode

See https://github.com/hashicorp/vault/issues/31919



## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
