### PR TITLE
fix: render md version of /cookbooks/

### DIFF
--- a/app/cookbooks/index.html
+++ b/app/cookbooks/index.html
@@ -1,11 +1,14 @@
 ---
-title: Kong AI Gateway Cookbook
+title: Kong AI Gateway Cookbooks
 cookbooks_index: true
 layout: default
 edit_and_issue_links: false
-llm: false
 description: A collection of production-ready recipes to build with Kong AI Gateway. LLM routing, guardrails, semantic caching, cost optimization, governance, and MCP integration.
 ---
+{% if page.output_format == 'markdown' %}
+{% for cookbook in site.cookbooks %}
+* [{{cookbook.title | liquify}}]({{cookbook.url}}){% endfor %}
+{% else %}
 {%- assign categories = site.data.cookbook_categories -%}
 {%- assign all_cookbooks = site.cookbooks | sort: "title" -%}
 {%- assign featured_cookbooks = all_cookbooks | where: "featured", true -%}
@@ -130,3 +133,4 @@ description: A collection of production-ready recipes to build with Kong AI Gate
   </div>
 
 </div>
+{% endif %}


### PR DESCRIPTION
## Description

Render md version of the page.

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
