### PR TITLE
Fixed duplicate client/Client entry in sequence diagram

### DIFF
--- a/app/_kong_plugins/ai-custom-guardrail/index.md
+++ b/app/_kong_plugins/ai-custom-guardrail/index.md
@@ -77,7 +77,7 @@ Here's how it works if you apply it to both requests and responses:
 {% mermaid %}
 sequenceDiagram
   autonumber
-  participant Client
+  participant client as Client
   participant custguardrail as AI Custom Guardrail plugin
   participant guardrail as Guardrail service
   participant proxy as AI Proxy/Advanced plugin


### PR DESCRIPTION
## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `fix(documentation/diagram): fixed duplicate and dangling entry for client/Client`

## Description
Diagram was broken and started right to left with client + having a dangling Client on the left side.


## Checklist 
- [ ] Tested diagram visualisation with mermaid