### PR TITLE
refactor(tests): check keycloak's readiness by checking the

### DIFF
--- a/app/_how-tos/gateway/configure-oidc-with-consumer-groups.md
+++ b/app/_how-tos/gateway/configure-oidc-with-consumer-groups.md
@@ -71,8 +71,6 @@ cleanup:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg
-
-automated_tests: false
 ---
 
 ## Enable the OpenID Connect plugin

--- a/app/_how-tos/gateway/configure-oidc-with-introspection.md
+++ b/app/_how-tos/gateway/configure-oidc-with-introspection.md
@@ -122,7 +122,7 @@ method: GET
 status_code: 200
 user: "alex:doe"
 display_headers: true
-debug: true
+retry: true
 extract_body:
   - name: 'headers.Authorization'
     variable: TOKEN
@@ -147,7 +147,6 @@ url: /anything
 method: GET
 status_code: 200
 display_headers: true
-debug: true
 headers:
   - "Authorization: $TOKEN"
 {% endvalidation %}

--- a/app/_how-tos/gateway/configure-oidc-with-introspection.md
+++ b/app/_how-tos/gateway/configure-oidc-with-introspection.md
@@ -122,6 +122,7 @@ method: GET
 status_code: 200
 user: "alex:doe"
 display_headers: true
+debug: true
 extract_body:
   - name: 'headers.Authorization'
     variable: TOKEN
@@ -146,6 +147,7 @@ url: /anything
 method: GET
 status_code: 200
 display_headers: true
+debug: true
 headers:
   - "Authorization: $TOKEN"
 {% endvalidation %}

--- a/app/_how-tos/gateway/configure-oidc-with-introspection.md
+++ b/app/_how-tos/gateway/configure-oidc-with-introspection.md
@@ -44,7 +44,7 @@ prereqs:
       - example-route
   inline:
     - title: Set up Keycloak
-      include_content: prereqs/auth/oidc/keycloak-password
+      include_content: prereqs/auth/oidc/keycloak-password-with-introspection
       icon_url: /assets/icons/keycloak.svg
 
 tags:
@@ -67,8 +67,6 @@ cleanup:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg
-
-automated_tests: false
 ---
 
 ## Enable the OpenID Connect plugin with introspection

--- a/app/_how-tos/gateway/configure-oidc-with-introspection.md
+++ b/app/_how-tos/gateway/configure-oidc-with-introspection.md
@@ -67,6 +67,8 @@ cleanup:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg
+
+automated_tests: false
 ---
 
 ## Enable the OpenID Connect plugin with introspection

--- a/app/_how-tos/gateway/configure-oidc-with-jwt-auth.md
+++ b/app/_how-tos/gateway/configure-oidc-with-jwt-auth.md
@@ -69,8 +69,6 @@ cleanup:
 
 search_aliases:
   - oidc
-
-automated_tests: false
 ---
 
 ## Enable the OpenID Connect plugin with JWT authentication

--- a/app/_how-tos/gateway/configure-oidc-with-password-grant.md
+++ b/app/_how-tos/gateway/configure-oidc-with-password-grant.md
@@ -67,8 +67,6 @@ cleanup:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg
-
-automated_tests: false
 ---
 
 ## Enable the OpenID Connect plugin with the password grant

--- a/app/_how-tos/gateway/configure-oidc-with-user-info-auth.md
+++ b/app/_how-tos/gateway/configure-oidc-with-user-info-auth.md
@@ -123,6 +123,7 @@ method: GET
 status_code: 200
 user: "alex:doe"
 display_headers: true
+retry: true
 extract_body:
   - name: 'headers.Authorization'
     variable: TOKEN

--- a/app/_includes/prereqs/auth/oidc/keycloak-password-with-introspection.md
+++ b/app/_includes/prereqs/auth/oidc/keycloak-password-with-introspection.md
@@ -1,0 +1,1 @@
+{% include prereqs/auth/oidc/keycloak-password.md with_introspection=true %}

--- a/app/_includes/prereqs/auth/oidc/keycloak-password.md
+++ b/app/_includes/prereqs/auth/oidc/keycloak-password.md
@@ -40,6 +40,42 @@ rows:
 {% endtable %}
 <!--vale on-->
 
+{% if include.with_introspection %}
+#### Configure the client for introspection
+
+Keycloak 26.6.2 and later requires the introspecting client to be present in the token's `aud` claim.
+Add an audience mapper to the `kong` client so that tokens it issues include `kong` in the audience:
+
+1. In the Keycloak admin console sidebar, open **Clients** and click the `kong` client.
+1. Open the **Client scopes** tab.
+1. Click **kong-dedicated**.
+1. Click **Add mapper** > **Configure a new mapper**.
+1. Select **Audience**.
+1. Configure the mapper:
+{% capture instructions %}
+<!--vale off-->
+{% table %}
+columns:
+  - title: Field
+    key: field
+  - title: Value
+    key: value
+rows:
+  - field: "**Name**"
+    value: "`kong-audience`"
+  - field: "**Included Client Audience**"
+    value: "`kong`"
+  - field: "**Add to access token**"
+    value: "On"
+  - field: "**Add to introspection token**"
+    value: "On"
+{% endtable %}
+<!--vale on-->
+{% endcapture %}
+{{instructions | indent: 3}}
+1. Click **Save**.
+{% endif %}
+
 #### Set up keys and credentials
 1. In your client, open the **Credentials** tab.
 1. Set **Client Authenticator** to **Client ID and Secret**.

--- a/tools/automated-tests/config/keycloak-realms/master-realm.json
+++ b/tools/automated-tests/config/keycloak-realms/master-realm.json
@@ -794,6 +794,19 @@
             "claim.name": "client_id",
             "jsonType.label": "String"
           }
+        },
+        {
+          "id": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+          "name": "kong-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "included.client.audience": "kong",
+            "id.token.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true"
+          }
         }
       ],
       "defaultClientScopes": [

--- a/tools/automated-tests/config/keycloak-realms/master-realm.json
+++ b/tools/automated-tests/config/keycloak-realms/master-realm.json
@@ -807,6 +807,21 @@
             "access.token.claim": "true",
             "introspection.token.claim": "true"
           }
+        },
+        {
+          "id": "b3e2c1d4-9f8a-4b7e-a123-5c6d7e8f9a0b",
+          "name": "tier",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-hardcoded-claim-mapper",
+          "consentRequired": false,
+          "config": {
+            "claim.value": "gold",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "tier",
+            "jsonType.label": "String"
+          }
         }
       ],
       "defaultClientScopes": [

--- a/tools/automated-tests/config/tests.yaml
+++ b/tools/automated-tests/config/tests.yaml
@@ -12,7 +12,12 @@ products:
         - docker run -d --name automated-tests-keycloak -p 127.0.0.1:8080:8080 --network kong-quickstart-net -e KC_DB_USERNAME=keycloak -e KC_DB_PASSWORD=password -e KC_DB_DATABASE=keycloak -v $REALM_PATH:/opt/keycloak/data/import quay.io/keycloak/keycloak  start-dev --import-realm
         - docker run -d --name redis-stack-server -p 6379:6379  --network kong-quickstart-net redis/redis-stack-server:latest
         - docker run -d --name vault -p 8200:8200 --network kong-quickstart-net -e SKIP_SETCAP=1 -e VAULT_DEV_ROOT_TOKEN_ID=root -e SKIP_CHOWN=1 --cap-add=IPC_LOCK hashicorp/vault
-        - sleep 10
+        - |-
+          timeout 120 bash -c '
+            until curl -fsS http://localhost:8080/realms/master/.well-known/openid-configuration >/dev/null 2>&1; do
+              sleep 2
+            done
+          '
 
     after: &gateway-after
       commands:

--- a/tools/automated-tests/instructions/validations.js
+++ b/tools/automated-tests/instructions/validations.js
@@ -37,8 +37,8 @@ async function processHeaders(config, container) {
   let headers = {};
   if (config.headers) {
     config.headers.forEach((header) => {
-      const [key, value] = header.split(":");
-      headers[key] = replaceEnvVars(value, env);
+      const [key, ...rest] = header.split(":");
+      headers[key.trim()] = replaceEnvVars(rest.join(":").trim(), env);
     });
   }
   return headers;

--- a/tools/automated-tests/instructions/validations.js
+++ b/tools/automated-tests/instructions/validations.js
@@ -148,6 +148,12 @@ async function executeRequest(config, runtimeConfig, container, onResponse) {
 
     const url = replaceEnvVars(config.url, env);
 
+    if (config.debug) {
+      console.log(`[debug] request: ${options.method} ${url}`);
+      console.log(`[debug] request headers: ${JSON.stringify(headers)}`);
+      if (options.body) console.log(`[debug] request body: ${options.body}`);
+    }
+
     const response = await fetchWithOptionalJar(
       url,
       options,
@@ -162,6 +168,11 @@ async function executeRequest(config, runtimeConfig, container, onResponse) {
       } catch (e) {
         body = { message: text };
       }
+    }
+
+    if (config.debug) {
+      console.log(`[debug] response status: ${response.status}`);
+      console.log(`[debug] response body: ${JSON.stringify(body)}`);
     }
 
     // Extract headers and check if retry is needed
@@ -208,6 +219,9 @@ async function executeRequest(config, runtimeConfig, container, onResponse) {
         ) {
           shouldRetry = true;
         } else {
+          if (config.debug) {
+            console.log(`extracted body field ${field.name} into ${field.variable}: ${value}`);
+          }
           await setEnvVariable(container, field.variable, value);
         }
       }


### PR DESCRIPTION
## Description

check keycloak's readiness by checking the `/realms/master/.well-known/openid-configuration` endpoint

Update keycloak's realm and instructions after a breaking change was introduced in their latest version
https://www.keycloak.org/docs/26.6.2/upgrading/#migrating-to-26-6-2

    Token Introspection Audience Validation — The introspection endpoint
    now requires the authenticated client is present in the token's aud claim.
    Returns {"active": false} if not — which Kong treats as a 401.

    The fix is to add an audience protocol mapper to the kong client in the Keycloak
    realm so that kong is included in the aud claim of tokens it issues.

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
