### PR TITLE
fix(kic): Fix KIC image tag formatting in kic-konnect-install.md

### DIFF
--- a/app/_includes/k8s/kic-konnect-install.md
+++ b/app/_includes/k8s/kic-konnect-install.md
@@ -69,7 +69,7 @@ kubectl create secret tls konnect-client-tls -n kong --cert=./tls.crt --key=./tl
 echo 'controller:
   ingressController:
     image:
-      tag: {{ site.data.kic_latest.release }}
+      tag: "{{ site.data.kic_latest.release }}"
     env:
       feature_gates: "FillIDs=true"
     konnect:


### PR DESCRIPTION
## Description

Image tag must be within double quotes

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
