### PR TITLE
chore(docs-improvements): Comment out the PR title section of the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-## PR Title
+<!-- ## PR Title
 
 Use the format `feat/fix/chore(Product): Title`, for example:
 - `feat(mesh): Add transparent proxy upgrade guide`
@@ -6,6 +6,7 @@ Use the format `feat/fix/chore(Product): Title`, for example:
 - `chore(ai-gateway): Bump plugin schema`
 - `chore(platform): Fix issue template`
 - `release: Kong Gateway 3.14`
+-->
 
 ## Description
 


### PR DESCRIPTION
## Description

Commenting out the `PR Title` section, because otherwise you have to delete it every time you open a PR, or it clogs up the description. With it commented out, it'll still be visible when opening a PR, but not on the rendered description.

## Preview Links


