### PR TITLE
Add guide for using `TLSRoute` in operator

### DIFF
--- a/.github/styles/base/Dictionary.txt
+++ b/.github/styles/base/Dictionary.txt
@@ -556,6 +556,7 @@ openid
 openresty
 openshift
 openssl
+OpenSSL
 opentelemetry
 Openwhisk
 optum

--- a/app/_how-tos/operator/operator-get-started-gateway-api-4-tlsroute.md
+++ b/app/_how-tos/operator/operator-get-started-gateway-api-4-tlsroute.md
@@ -176,8 +176,6 @@ In real-world usage, you would create a DNS record for `tls9443.kong.example` po
 echo "hello" | openssl s_client -connect $PROXY_IP:9443 -servername tls9443.kong.example -quiet 2>/dev/null
 ```
 
-Press Ctrl+C to exit.
-
 The results should look like this:
 
 ```text
@@ -271,6 +269,6 @@ Reuse the `$PROXY_IP` you exported earlier and connect to the new listener:
 echo "hello" | openssl s_client -connect $PROXY_IP:9444 -servername tls9444.kong.example -quiet 2>/dev/null
 ```
 
-Press Ctrl+C to exit.
+You should see similar output as previously shown in the example using `Passthrough` TLS mode.
 
 Unlike the Passthrough case, the TLS handshake terminates at {{ site.base_gateway }}: the certificate presented to the client is the one stored in the labeled Secret, not a certificate served by the `echo` backend. You can confirm this by dropping the `-quiet` flag and inspecting the `subject=` line in the openssl output — it should match `CN=tls9444.kong.example`.

--- a/app/_how-tos/operator/operator-get-started-gateway-api-4-tlsroute.md
+++ b/app/_how-tos/operator/operator-get-started-gateway-api-4-tlsroute.md
@@ -1,5 +1,5 @@
 ---
-title: Proxy TCP traffic over TLS by SNI
+title: Proxy TLS traffic by SNI using TLSRoute
 description: "Use TLSRoute with {{ site.operator_product_name }} to route TCP traffic secured by TLS."
 content_type: how_to
 
@@ -41,7 +41,7 @@ next_steps:
 ---
 
 {:.info}
-> **Note**: {{ site.operator_product_name }} only reconciles `TLSRoute` resources using the `gateway.networking.k8s.io/v1` API, which is available in [Gateway API](https://gateway-api.sigs.k8s.io/) 1.5 or later (standard channel). If you installed the CRDs from an earlier release while following [step 1 of this series](/operator/get-started/gateway-api/install/), you should upgrade {{ site.operator_product_name }} to the version that supports `TLSRoute`. It will install or upgrade gateway API CRDs to appropriate version. If you did not install gateway API CRDs by the {{ site.operator_product_name }} helm release, please upgrade them manually:
+> **Note**: {{ site.operator_product_name }} only reconciles `TLSRoute` resources using the `gateway.networking.k8s.io/v1` API, which is available in [Gateway API](https://gateway-api.sigs.k8s.io/) 1.5 or later (standard channel). If you installed the CRDs from an earlier release while following [step 1 of this series](/operator/get-started/gateway-api/install/), you should upgrade {{ site.operator_product_name }} to the version that supports `TLSRoute`. It will install or upgrade gateway API CRDs with the appropriate version. If you did not install gateway API CRDs by the {{ site.operator_product_name }} helm release, please install or upgrade them manually:
 
 ```shell
 kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml --server-side

--- a/app/_how-tos/operator/operator-get-started-gateway-api-4-tlsroute.md
+++ b/app/_how-tos/operator/operator-get-started-gateway-api-4-tlsroute.md
@@ -110,31 +110,31 @@ kubectl patch -n kong --type=json deployment echo -p='[
 ]'
 ```
 
-## Route TCP traffic
+## Route TCP traffic with TLS
 
-To reconcile the `TLSRoute`, add a TLS listener to your `Gateway` resource:
+Re-apply the `kong` Gateway with the additional `stream9443` TLS listener in `Passthrough` mode:
 
 ```bash
-kubectl patch -n kong --type=json gateway kong -p='[
-    {
-        "op":"add",
-        "path":"/spec/listeners/-",
-        "value":{
-            "name":"stream9443",
-            "port":9443,
-            "protocol":"TLS",
-            "hostname":"tls9443.kong.example",
-            "allowedRoutes": {
-              "namespaces": {
-                "from": "All"
-              }
-            },
-            "tls": {
-              "mode": "Passthrough"
-            }
-        }
-    }
-]'
+echo 'apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: kong
+  namespace: kong
+spec:
+  gatewayClassName: kong
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+    - name: stream9443
+      port: 9443
+      protocol: TLS
+      hostname: tls9443.kong.example
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Passthrough' | kubectl apply -f -
 ```
 
 Next, create a `TLSRoute`:
@@ -208,34 +208,36 @@ For more information about how {{ site.operator_product_name }} handles secrets,
 
 ### Add a Terminate TLS listener to the Gateway
 
-Patch the existing `kong` Gateway to append a second TLS listener on port `9444` in `Terminate` mode, referencing the labeled Secret:
+Reapply the `kong` Gateway with a `stream9444` TLS listener in `Terminate` mode, referencing the labeled Secret:
+
+{:.warning}
+> **Warning**: Applying this Gateway replaces the listener list. If you completed the Passthrough walkthrough above, the `stream9443` listener will be removed and the `echo-tls` `TLSRoute` will no longer attach to a parent. Run `kubectl delete tlsroute echo-tls -n kong` to remove the leftover route if you only want the Terminate demo running.
 
 ```bash
-kubectl patch -n kong --type=json gateway kong -p='[
-    {
-        "op":"add",
-        "path":"/spec/listeners/-",
-        "value":{
-            "name":"stream9444",
-            "port":9444,
-            "protocol":"TLS",
-            "hostname":"tls9444.kong.example",
-            "allowedRoutes": {
-              "namespaces": {
-                "from": "All"
-              }
-            },
-            "tls": {
-              "mode": "Terminate",
-              "certificateRefs":[{
-                "group":"",
-                "kind":"Secret",
-                "name":"tls9444.kong.example"
-              }]
-            }
-        }
-    }
-]'
+echo 'apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: kong
+  namespace: kong
+spec:
+  gatewayClassName: kong
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+    - name: stream9444
+      port: 9444
+      protocol: TLS
+      hostname: tls9444.kong.example
+      allowedRoutes:
+        namespaces:
+          from: All
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - group: ""
+            kind: Secret
+            name: tls9444.kong.example' | kubectl apply -f -
 ```
 
 ### Create a TLSRoute for the Terminate listener

--- a/app/_how-tos/operator/operator-get-started-gateway-api-4-tlsroute.md
+++ b/app/_how-tos/operator/operator-get-started-gateway-api-4-tlsroute.md
@@ -23,6 +23,9 @@ works_on:
   - on-prem
   - konnect
 
+min_version:
+  operator: '2.2.0'
+
 entities: []
 
 tldr:
@@ -36,6 +39,13 @@ next_steps:
   - text: Learn about Custom resource definitions (CRDs)
     url: /operator/reference/custom-resources/
 ---
+
+{:.note}
+> **Note**: {{ site.operator_product_name }} only reconciles `TLSRoute` resources using the `gateway.networking.k8s.io/v1` API, which is available in [Gateway API](https://gateway-api.sigs.k8s.io/) 1.5 or later (standard channel). If you installed the CRDs from an earlier release while following [step 1 of this series](/operator/get-started/gateway-api/install/), you should upgrade {{ site.operator_product_name }} to the version that supports `TLSRoute`. It will install or upgrade gateway API CRDs to appropriate version. If you did not install gateway API CRDs by the {{ site.operator_product_name }} helm release, please upgrade them manually:
+
+```shell
+kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml --server-side
+```
 
 ## Generate a TLS certificate
 
@@ -135,7 +145,7 @@ kubectl patch -n kong --type=json gateway kong -p='[
 Next, create a `TLSRoute`:
 
 ```bash
-echo "apiVersion: gateway.networking.k8s.io/v1alpha2
+echo "apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: echo-tls
@@ -240,7 +250,7 @@ kubectl patch -n kong --type=json gateway kong -p='[
 Because Kong is now terminating TLS, the backend can receive plain TCP. Point the `TLSRoute` at the unmodified `echo` Service on its default plain TCP port `1027`:
 
 ```bash
-echo "apiVersion: gateway.networking.k8s.io/v1alpha2
+echo "apiVersion: gateway.networking.k8s.io/v1
 kind: TLSRoute
 metadata:
   name: echo-tls-terminate

--- a/app/_how-tos/operator/operator-get-started-gateway-api-4-tlsroute.md
+++ b/app/_how-tos/operator/operator-get-started-gateway-api-4-tlsroute.md
@@ -24,7 +24,7 @@ works_on:
   - konnect
 
 min_version:
-  operator: '2.2.0'
+  operator: '2.2'
 
 entities: []
 
@@ -41,11 +41,9 @@ next_steps:
 ---
 
 {:.info}
-> **Note**: {{ site.operator_product_name }} only reconciles `TLSRoute` resources using the `gateway.networking.k8s.io/v1` API, which is available in [Gateway API](https://gateway-api.sigs.k8s.io/) 1.5 or later (standard channel). If you installed the CRDs from an earlier release while following [step 1 of this series](/operator/get-started/gateway-api/install/), you should upgrade {{ site.operator_product_name }} to the version that supports `TLSRoute`. It will install or upgrade gateway API CRDs with the appropriate version. If you did not install gateway API CRDs by the {{ site.operator_product_name }} helm release, please install or upgrade them manually:
-
-```shell
-kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml --server-side
-```
+> {{ site.operator_product_name }} only reconciles `TLSRoute` resources using the `gateway.networking.k8s.io/v1` API, which is available in [Gateway API](https://gateway-api.sigs.k8s.io/) 1.5 or later (standard channel). If you installed the CRDs from an earlier release while following [step 1 of this series](/operator/get-started/gateway-api/install/), upgrade {{ site.operator_product_name }} to the version that supports `TLSRoute`. It will install or upgrade gateway API CRDs with the appropriate version. If you did not install gateway API CRDs by the {{ site.operator_product_name }} helm release, install or upgrade them manually:
+> 
+> 
 
 ## Generate a TLS certificate
 
@@ -53,13 +51,7 @@ kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/downloa
 
 ## Attach the TLS certificate to the echo Service
 
-If you haven't already deployed the `echo` Service, install it:
-
-```bash
-kubectl apply -f {{site.links.web}}/manifests/kic/echo-service.yaml -n kong
-```
-
-The `echo` Service does not listen on the TLS port by default as it requires a certificate stored in a Kubernetes Secret. Patch the `echo` Deployment to mount the Secret in the pod and set the `TLS_CERT_FILE` and `TLS_KEY_FILE` environment variables to allow the `echo` Service to terminate TLS:
+The `echo` Service we deployed in a [previous step](/operator/get-started/gateway-api/create-route/#create-a-backend-service) doesn't listen on the TLS port by default as it requires a certificate stored in a Kubernetes Secret. Patch the `echo` Deployment to mount the Secret in the pod and set the `TLS_CERT_FILE` and `TLS_KEY_FILE` environment variables to allow the `echo` Service to terminate TLS:
 
 ```bash
 kubectl patch -n kong --type=json deployment echo -p='[
@@ -185,6 +177,7 @@ In namespace default.
 With IP address 10.244.0.26.
 hello
 ```
+{:.no-copy-code}
 
 ## Terminate TLS at the listener
 

--- a/app/_how-tos/operator/operator-get-started-gateway-api-4-tlsroute.md
+++ b/app/_how-tos/operator/operator-get-started-gateway-api-4-tlsroute.md
@@ -43,7 +43,9 @@ next_steps:
 {:.info}
 > {{ site.operator_product_name }} only reconciles `TLSRoute` resources using the `gateway.networking.k8s.io/v1` API, which is available in [Gateway API](https://gateway-api.sigs.k8s.io/) 1.5 or later (standard channel). If you installed the CRDs from an earlier release while following [step 1 of this series](/operator/get-started/gateway-api/install/), upgrade {{ site.operator_product_name }} to the version that supports `TLSRoute`. It will install or upgrade gateway API CRDs with the appropriate version. If you did not install gateway API CRDs by the {{ site.operator_product_name }} helm release, install or upgrade them manually:
 > 
-> 
+> ```shell
+> kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.5.1/standard-install.yaml --server-side
+> ```
 
 ## Generate a TLS certificate
 

--- a/app/_how-tos/operator/operator-get-started-gateway-api-4-tlsroute.md
+++ b/app/_how-tos/operator/operator-get-started-gateway-api-4-tlsroute.md
@@ -242,7 +242,7 @@ spec:
 
 ### Create a TLSRoute for the Terminate listener
 
-Because Kong is now terminating TLS, the backend can receive plain TCP. Point the `TLSRoute` at the unmodified `echo` Service on its default plain TCP port `1027`:
+Because Kong is now terminating TLS, the backend can receive plain TCP. Point the `TLSRoute` at the unmodified `echo` Service on its default plain TCP port `1025`:
 
 ```bash
 echo "apiVersion: gateway.networking.k8s.io/v1
@@ -259,7 +259,7 @@ spec:
   rules:
     - backendRefs:
       - name: echo
-        port: 1027
+        port: 1025
 " | kubectl apply -f -
 ```
 

--- a/app/_how-tos/operator/operator-get-started-gateway-api-4-tlsroute.md
+++ b/app/_how-tos/operator/operator-get-started-gateway-api-4-tlsroute.md
@@ -3,7 +3,7 @@ title: Proxy TCP traffic over TLS by SNI
 description: "Use TLSRoute with {{ site.operator_product_name }} to route TCP traffic secured by TLS."
 content_type: how_to
 
-permalink: /operator/get-started/gateway-api/tlsroute/
+permalink: /operator/get-started/gateway-api/create-tlsroute/
 series:
   id: operator-get-started-gateway-api
   position: 4
@@ -36,8 +36,6 @@ next_steps:
   - text: Learn about Custom resource definitions (CRDs)
     url: /operator/reference/custom-resources/
 ---
-
-{{ site.operator_product_name }} reconciles the managed `DataPlane` from the `Gateway` listeners: when you add a `TLS` listener to your `Gateway`, Operator automatically sets the corresponding stream listener on the `DataPlane` and exposes the port on the proxy Service. The only Operator-specific step you need to take is updating the `Gateway`.
 
 ## Generate a TLS certificate
 

--- a/app/_how-tos/operator/operator-get-started-gateway-api-4-tlsroute.md
+++ b/app/_how-tos/operator/operator-get-started-gateway-api-4-tlsroute.md
@@ -40,7 +40,7 @@ next_steps:
     url: /operator/reference/custom-resources/
 ---
 
-{:.note}
+{:.info}
 > **Note**: {{ site.operator_product_name }} only reconciles `TLSRoute` resources using the `gateway.networking.k8s.io/v1` API, which is available in [Gateway API](https://gateway-api.sigs.k8s.io/) 1.5 or later (standard channel). If you installed the CRDs from an earlier release while following [step 1 of this series](/operator/get-started/gateway-api/install/), you should upgrade {{ site.operator_product_name }} to the version that supports `TLSRoute`. It will install or upgrade gateway API CRDs to appropriate version. If you did not install gateway API CRDs by the {{ site.operator_product_name }} helm release, please upgrade them manually:
 
 ```shell
@@ -130,12 +130,7 @@ kubectl patch -n kong --type=json gateway kong -p='[
               }
             },
             "tls": {
-              "mode": "Passthrough",
-              "certificateRefs":[{
-                "group":"",
-                "kind":"Secret",
-                "name":"tls9443.kong.example"
-              }]
+              "mode": "Passthrough"
             }
         }
     }
@@ -215,7 +210,7 @@ For more information about how {{ site.operator_product_name }} handles secrets,
 
 ### Add a Terminate TLS listener to the Gateway
 
-Patch the existing `kong` Gateway to append a second TLS listener on port `9444` in `Terminate` mode, referencing the labelled Secret:
+Patch the existing `kong` Gateway to append a second TLS listener on port `9444` in `Terminate` mode, referencing the labeled Secret:
 
 ```bash
 kubectl patch -n kong --type=json gateway kong -p='[
@@ -278,4 +273,4 @@ echo "hello" | openssl s_client -connect $PROXY_IP:9444 -servername tls9444.kong
 
 Press Ctrl+C to exit.
 
-Unlike the Passthrough case, the TLS handshake terminates at {{ site.base_gateway }}: the certificate presented to the client is the one stored in the labelled Secret, not a certificate served by the `echo` backend. You can confirm this by dropping the `-quiet` flag and inspecting the `subject=` line in the openssl output — it should match `CN=tls9444.kong.example`.
+Unlike the Passthrough case, the TLS handshake terminates at {{ site.base_gateway }}: the certificate presented to the client is the one stored in the labeled Secret, not a certificate served by the `echo` backend. You can confirm this by dropping the `-quiet` flag and inspecting the `subject=` line in the openssl output — it should match `CN=tls9444.kong.example`.

--- a/app/_how-tos/operator/operator-get-started-gateway-api-4-tlsroute.md
+++ b/app/_how-tos/operator/operator-get-started-gateway-api-4-tlsroute.md
@@ -1,0 +1,273 @@
+---
+title: Proxy TCP traffic over TLS by SNI
+description: "Use TLSRoute with {{ site.operator_product_name }} to route TCP traffic secured by TLS."
+content_type: how_to
+
+permalink: /operator/get-started/gateway-api/tlsroute/
+series:
+  id: operator-get-started-gateway-api
+  position: 4
+
+breadcrumbs:
+  - /operator/
+  - index: operator
+    group: Gateway Deployment
+  - index: operator
+    group: Gateway Deployment
+    section: "Get Started"
+
+products:
+  - operator
+
+works_on:
+  - on-prem
+  - konnect
+
+entities: []
+
+tldr:
+  q: How do I route TCP traffic with {{ site.operator_product_name }}?
+  a: Add a `TLS` listener to your `Gateway` in either `Passthrough` or `Terminate` mode, then create a `TLSRoute` resource. {{ site.operator_product_name }} automatically reconciles the managed `DataPlane` stream listener and proxy Service port, and converts the `TLSRoute` into a {{ site.base_gateway }} [Service](/gateway/entities/service/) and [Route](/gateway/entities/route/).
+
+prereqs:
+  skip_product: true
+
+next_steps:
+  - text: Learn about Custom resource definitions (CRDs)
+    url: /operator/reference/custom-resources/
+---
+
+{{ site.operator_product_name }} reconciles the managed `DataPlane` from the `Gateway` listeners: when you add a `TLS` listener to your `Gateway`, Operator automatically sets the corresponding stream listener on the `DataPlane` and exposes the port on the proxy Service. The only Operator-specific step you need to take is updating the `Gateway`.
+
+## Generate a TLS certificate
+
+{% include /k8s/create-certificate.md namespace='kong' hostname='tls9443.kong.example' cert_required=true %}
+
+## Attach the TLS certificate to the echo Service
+
+If you haven't already deployed the `echo` Service, install it:
+
+```bash
+kubectl apply -f {{site.links.web}}/manifests/kic/echo-service.yaml -n kong
+```
+
+The `echo` Service does not listen on the TLS port by default as it requires a certificate stored in a Kubernetes Secret. Patch the `echo` Deployment to mount the Secret in the pod and set the `TLS_CERT_FILE` and `TLS_KEY_FILE` environment variables to allow the `echo` Service to terminate TLS:
+
+```bash
+kubectl patch -n kong --type=json deployment echo -p='[
+    {
+        "op":"add",
+        "path":"/spec/template/spec/containers/0/env/-",
+        "value":{
+            "name": "TLS_PORT",
+            "value": "1030"
+        }
+    },
+    {
+        "op":"add",
+        "path":"/spec/template/spec/containers/0/env/-",
+        "value":{
+            "name": "TLS_CERT_FILE",
+            "value": "/var/run/certs/tls.crt"
+        }
+    },
+    {
+        "op":"add",
+        "path":"/spec/template/spec/containers/0/env/-",
+        "value":{
+            "name": "TLS_KEY_FILE",
+            "value": "/var/run/certs/tls.key"
+        }
+    },
+    {
+        "op":"add",
+        "path":"/spec/template/spec/containers/0/volumeMounts",
+        "value":[{
+            "mountPath": "/var/run/certs",
+            "name": "secret-test",
+            "readOnly": true
+        }]
+    },
+    {
+        "op":"add",
+        "path":"/spec/template/spec/volumes",
+        "value":[{
+            "name": "secret-test",
+            "secret": {
+              "defaultMode": 420,
+              "secretName": "tls9443.kong.example"
+            }
+        }]
+    }
+]'
+```
+
+## Route TCP traffic
+
+To reconcile the `TLSRoute`, add a TLS listener to your `Gateway` resource:
+
+```bash
+kubectl patch -n kong --type=json gateway kong -p='[
+    {
+        "op":"add",
+        "path":"/spec/listeners/-",
+        "value":{
+            "name":"stream9443",
+            "port":9443,
+            "protocol":"TLS",
+            "hostname":"tls9443.kong.example",
+            "allowedRoutes": {
+              "namespaces": {
+                "from": "All"
+              }
+            },
+            "tls": {
+              "mode": "Passthrough",
+              "certificateRefs":[{
+                "group":"",
+                "kind":"Secret",
+                "name":"tls9443.kong.example"
+              }]
+            }
+        }
+    }
+]'
+```
+
+Next, create a `TLSRoute`:
+
+```bash
+echo "apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: echo-tls
+  namespace: kong
+spec:
+  parentRefs:
+    - name: kong
+      sectionName: stream9443
+  hostnames:
+    - tls9443.kong.example
+  rules:
+    - backendRefs:
+      - name: echo
+        port: 1030
+" | kubectl apply -f -
+```
+
+This configuration instructs {{ site.base_gateway }} to forward all traffic it receives on port `9443` to the `echo` Service on port `1030`.
+
+## Validate your configuration
+
+Export the Gateway's external address:
+
+```bash
+export PROXY_IP=$(kubectl get gateway kong -n kong -o jsonpath='{.status.addresses[0].value}')
+```
+
+You can now access the `echo` Service on port `9443` with SNI `tls9443.kong.example`.
+
+In real-world usage, you would create a DNS record for `tls9443.kong.example` pointing to your proxy Service's public IP address, which causes TLS clients to add an SNI automatically. For this demo, add it manually using the OpenSSL CLI:
+
+```bash
+echo "hello" | openssl s_client -connect $PROXY_IP:9443 -servername tls9443.kong.example -quiet 2>/dev/null
+```
+
+Press Ctrl+C to exit.
+
+The results should look like this:
+
+```text
+Welcome, you are connected to node kind-control-plane.
+Running on Pod echo-5f44d4c6f9-krnhk.
+In namespace default.
+With IP address 10.244.0.26.
+hello
+```
+
+## Terminate TLS at the listener
+
+The previous sections used `tls.mode: Passthrough`, which forwards encrypted TLS bytes through {{ site.base_gateway }} so the backend completes the handshake. {{ site.operator_product_name }} also supports `tls.mode: Terminate`: {{ site.base_gateway }} terminates the client's TLS connection at the listener using a certificate you provide, then forwards plain TCP to the backend. Use this mode when you want Kong to apply plugins, observe traffic, or enforce TLS policy on the connection. The tradeoff is that the connection is no longer end-to-end encrypted.
+
+The following sections walk through a second `TLSRoute` on a new listener (port `9444`) so it coexists with the Passthrough example above.
+
+### Generate a TLS certificate for the Terminate listener
+
+{% include /k8s/create-certificate.md namespace='kong' hostname='tls9444.kong.example' cert_required=true %}
+
+### Label the certificate Secret
+
+{{ site.operator_product_name }} only watches certificate Secrets that carry the `konghq.com/secret="true"` label. Add the label so Operator picks up the Secret you just created:
+
+```bash
+kubectl label secret tls9444.kong.example -n kong konghq.com/secret="true"
+```
+
+For more information about how {{ site.operator_product_name }} handles secrets, see the [Secrets reference](/operator/reference/secrets/).
+
+### Add a Terminate TLS listener to the Gateway
+
+Patch the existing `kong` Gateway to append a second TLS listener on port `9444` in `Terminate` mode, referencing the labelled Secret:
+
+```bash
+kubectl patch -n kong --type=json gateway kong -p='[
+    {
+        "op":"add",
+        "path":"/spec/listeners/-",
+        "value":{
+            "name":"stream9444",
+            "port":9444,
+            "protocol":"TLS",
+            "hostname":"tls9444.kong.example",
+            "allowedRoutes": {
+              "namespaces": {
+                "from": "All"
+              }
+            },
+            "tls": {
+              "mode": "Terminate",
+              "certificateRefs":[{
+                "group":"",
+                "kind":"Secret",
+                "name":"tls9444.kong.example"
+              }]
+            }
+        }
+    }
+]'
+```
+
+### Create a TLSRoute for the Terminate listener
+
+Because Kong is now terminating TLS, the backend can receive plain TCP. Point the `TLSRoute` at the unmodified `echo` Service on its default plain TCP port `1027`:
+
+```bash
+echo "apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: echo-tls-terminate
+  namespace: kong
+spec:
+  parentRefs:
+    - name: kong
+      sectionName: stream9444
+  hostnames:
+    - tls9444.kong.example
+  rules:
+    - backendRefs:
+      - name: echo
+        port: 1027
+" | kubectl apply -f -
+```
+
+### Validate the Terminate listener
+
+Reuse the `$PROXY_IP` you exported earlier and connect to the new listener:
+
+```bash
+echo "hello" | openssl s_client -connect $PROXY_IP:9444 -servername tls9444.kong.example -quiet 2>/dev/null
+```
+
+Press Ctrl+C to exit.
+
+Unlike the Passthrough case, the TLS handshake terminates at {{ site.base_gateway }}: the certificate presented to the client is the one stored in the labelled Secret, not a certificate served by the `echo` backend. You can confirm this by dropping the `-quiet` flag and inspecting the `subject=` line in the openssl output — it should match `CN=tls9444.kong.example`.


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

Add the guide page for using `TLSRoute` in Kong operator

## Description

Fixes [KO#3133](https://github.com/Kong/kong-operator/issues/3133)

## Preview Links

https://deploy-preview-5358--kongdeveloper.netlify.app/operator/get-started/gateway-api/create-tlsroute/

## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [x] Add new pages to the product documentation index (if applicable).
