### PR TITLE
docs(sandox): change the sandbox changelog type from feature to break…

### DIFF
--- a/app/_data/changelogs/gateway.json
+++ b/app/_data/changelogs/gateway.json
@@ -20792,7 +20792,7 @@
       },
       {
         "message": "**sandbox**: Added `strict` and `lax` modes for `untrusted_lua`. The default mode changed from `sandbox` to `strict`.\n",
-        "type": "feature",
+        "type": "Breaking Change",
         "scope": "Core"
       },
       {


### PR DESCRIPTION


<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes https://konghq.atlassian.net/browse/FTI-7535

The changelog type of `sandbox` released in `3.14.0.0` should be breaking change instead of feature.

**DO NOT MERGE THIS PR UNTIL MANAGERS APPROVED IT**.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
