### PR TITLE
feat(gateway): File system vault

### DIFF
--- a/app/_gateway_entities/vault.md
+++ b/app/_gateway_entities/vault.md
@@ -222,48 +222,72 @@ columns:
     key: enterprise
   - title: {{site.konnect_short_name}} supported
     key: supports_konnect
+  - title: How-to guide
+    key: how_to
 
 features:
   - title: Environment variable
-    url: /gateway/entities/vault/#store-secrets-as-environment-variables
+    url: '?tab=environment-variable#vault-provider-specific-configuration-parameters'
     oss: true
     enterprise: true
     supports_konnect: true
+    how_to: "--"
   - title: Konnect (Konnect Config Store)
-    url: /how-to/configure-the-konnect-config-store/
     oss: false
     enterprise: false
     supports_konnect: true
+    how_to: |
+      * [Basic setup](/how-to/configure-the-konnect-config-store/)
+      * [Store Mistral keys in a Konnect Config Store](/how-to/store-a-mistral-api-key-as-a-secret-in-konnect-config-store/)
   - title: AWS Secrets Manager
-    url: /how-to/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity/
+    url: '?tab=aws#vault-provider-specific-configuration-parameters'
     oss: false
     enterprise: true
     supports_konnect: true
+    how_to: |
+      * [Basic setup](/how-to/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity/)
   - title: Azure Key Vaults
-    <!--url: /how-to/configure-azure-key-vaults-as-a-vault-backend-with-vault-entity/-->
+    url: '?tab=azure#vault-provider-specific-configuration-parameters'
     oss: false
     enterprise: true
     supports_konnect: true
+    how_to: "--"
   - title: Azure Key Vaults (Certificates)
     oss: false
     enterprise: true
     supports_konnect: true
+    how_to: "--"
   - title: Google Cloud Secret
-    url: /how-to/configure-google-cloud-secret-as-a-vault-backend/
+    url: '?tab=google#vault-provider-specific-configuration-parameters'
     oss: false
     enterprise: true
     supports_konnect: true
+    how_to: |
+      * [Basic setup](/how-to/configure-google-cloud-secret-as-a-vault-backend/)
   - title: HashiCorp Vault
-    url: /how-to/configure-hashicorp-vault-as-a-vault-backend/
+    url: '?tab=hashicorp#vault-provider-specific-configuration-parameters'
     oss: false
     enterprise: true
     supports_konnect: true
+    how_to: |
+      * [Basic setup](/how-to/configure-hashicorp-vault-as-a-vault-backend/)
+      * [All how-to guides](/how-to/?tags=hashicorp-vault)
   - title: |
       CyberArk Secrets Manager (Conjur)  {% new_in 3.11 %}
-    url: /how-to/configure-cyberark-as-a-vault-backend/
+    url: '?tab=cyberark-secrets-manager#vault-provider-specific-configuration-parameters'
     oss: false
     enterprise: true
     supports_konnect: true
+    how_to: |
+      * [Basic setup](/how-to/configure-cyberark-as-a-vault-backend/)
+  - title: |
+      File system {% new_in 3.15 %}
+    url: '?tab=file-system#vault-provider-specific-configuration-parameters'
+    oss: false
+    enterprise: true
+    supports_konnect: true
+    how_to: |
+      * [Basic setup](/how-to/configure-file-system-as-a-vault-backend/)
 {% endfeature_table %}
 
 ## How do I reference secrets stored in a Vault?
@@ -1172,6 +1196,67 @@ rows:
       Duration (in seconds) that secrets remain usable after expiration (`config.ttl` is over). 
       Useful when the vault is unreachable or a secret is deleted but not yet replaced. 
       Kong continues retrying for `resurrect_ttl` seconds, then stops. The default is 1e8 seconds (~3 years).
+{% endtable %}
+<!--vale on-->
+{% endnavtab %}
+{% navtab "File system" %}
+
+The file system vault reads secrets from files on the {{site.base_gateway}} data plane's local filesystem. 
+Secrets can be plain text files or JSON files. 
+The file system vault doesn't require any external services or credentials.
+
+For a complete tutorial, see [Configure the file system vault backend](/how-to/configure-file-system-as-a-vault-backend/).
+
+<!--vale off-->
+{% table %}
+columns:
+  - title: Field name
+    key: field
+  - title: Parameter format
+    key: parameter
+  - title: Description
+    key: description
+rows:
+  - field: |
+      Prefix <br>{% new_in 3.15 %}
+    parameter: |
+      * **Vault entity:** `vaults.config.prefix`
+      * **kong.conf parameter:** `vault_fs_prefix`
+      * **Environment variable:** `KONG_VAULT_FS_PREFIX`
+    description: |
+      **Required.** The path to the directory containing the secret files. For example, `/tmp/kong/secrets`. All secrets will be read from this directory.
+  - field: |
+      TTL <br>{% new_in 3.15 %}
+    parameter: |
+      * **Vault entity:** `vaults.config.ttl`
+      * **kong.conf parameter:** `vault_fs_ttl`
+      * **Environment variable:** `KONG_VAULT_FS_TTL`
+    description: |
+      The time-to-live (in seconds) for cached secrets. A value of 0 (default) disables rotation. If non-zero, use at least 60 seconds.
+  - field: |
+      Negative TTL<br>{% new_in 3.15 %}
+    parameter: |
+      * **Vault entity:** `vaults.config.neg_ttl`
+      * **kong.conf parameter:** `vault_fs_neg_ttl`
+      * **Environment variable:** `KONG_VAULT_FS_NEG_TTL`
+    description: |
+      The TTL (in seconds) for caching failed secret lookups (file not found or unreadable). If not set, uses the `ttl` value. A value of 0 disables negative caching.
+  - field: |
+      Resurrect TTL<br>{% new_in 3.15 %}
+    parameter: |
+      * **Vault entity:** `vaults.config.resurrect_ttl`
+      * **kong.conf parameter:** `vault_fs_resurrect_ttl`
+      * **Environment variable:** `KONG_VAULT_FS_RESURRECT_TTL`
+    description: |
+      The duration (in seconds) for which expired secrets will continue to be used if the file is unreadable or missing. After this time, Kong stops retrying. The default is 1e8 seconds (~3 years).
+  - field: |
+      Base64 Decode<br>{% new_in 3.15 %}
+    parameter: |
+      * **Vault entity:** `vaults.config.base64_decode`
+      * **kong.conf parameter:** `vault_fs_base64_decode`
+      * **Environment variable:** `KONG_VAULT_FS_BASE64_DECODE`
+    description: |
+      Decode all secrets in this vault as base64. Useful for binary data. If some of the secrets in the vault are not base64-encoded, an error will occur when using them. We recommend creating a separate vault for base64 secrets.
 {% endtable %}
 <!--vale on-->
 {% endnavtab %}

--- a/app/_gateway_entities/vault.md
+++ b/app/_gateway_entities/vault.md
@@ -1207,7 +1207,7 @@ rows:
 Secrets can be plain text files or JSON files. 
 The file system vault doesn't require any external services or credentials.
 
-If configuring via a Vault entity, set `vaults.name` to `fs`.
+If you're configuring via a Vault entity, set `vaults.name` to `fs`.
 
 For a complete tutorial, see [Configure the file system vault backend](/how-to/configure-file-system-as-a-vault-backend/).
 

--- a/app/_gateway_entities/vault.md
+++ b/app/_gateway_entities/vault.md
@@ -252,7 +252,9 @@ features:
     enterprise: true
     supports_konnect: true
     how_to: "--"
-  - title: Azure Key Vaults (Certificates)
+  - title: |
+      Azure Key Vaults (Certificates) {% new_in 3.15 %}
+    url: '?tab=azure-certs#vault-provider-specific-configuration-parameters'
     oss: false
     enterprise: true
     supports_konnect: true
@@ -1201,9 +1203,11 @@ rows:
 {% endnavtab %}
 {% navtab "File system" %}
 
-The file system vault reads secrets from files on the {{site.base_gateway}} data plane's local filesystem. 
+{% new_in 3.15 %} The file system vault reads secrets from files on the {{site.base_gateway}} data plane's local filesystem. 
 Secrets can be plain text files or JSON files. 
 The file system vault doesn't require any external services or credentials.
+
+If configuring via a Vault entity, set `vaults.name` to `fs`.
 
 For a complete tutorial, see [Configure the file system vault backend](/how-to/configure-file-system-as-a-vault-backend/).
 
@@ -1253,8 +1257,8 @@ rows:
       Base64 Decode<br>{% new_in 3.15 %}
     parameter: |
       * **Vault entity:** `vaults.config.base64_decode`
-      * **kong.conf parameter:** `vault_fs_base64_decode`
-      * **Environment variable:** `KONG_VAULT_FS_BASE64_DECODE`
+      * **kong.conf parameter:** `vault_fs_decode_base64`
+      * **Environment variable:** `KONG_VAULT_FS_DECODE_BASE64`
     description: |
       Decode all secrets in this vault as base64. Useful for binary data. If some of the secrets in the vault are not base64-encoded, an error will occur when using them. We recommend creating a separate vault for base64 secrets.
 {% endtable %}

--- a/app/_how-tos/gateway/configure-file-system-as-a-vault-backend.md
+++ b/app/_how-tos/gateway/configure-file-system-as-a-vault-backend.md
@@ -47,23 +47,17 @@ prereqs:
         Create a directory for your secrets on the {{site.base_gateway}} data plane and add at least one secret file.
 
         For example, if using the quickstart Docker container:
-        
-        1. Exec into the container:
-
-           ```
-           docker exec -it kong-quickstart-gateway /bin/bash  
-           ```
 
         1. Create the directory:
 
            ```sh
-           mkdir -p /tmp/kong/secrets
+           docker exec kong-quickstart-gateway mkdir -p /tmp/kong/secrets
            ```
         
         1. Create a test secret:
 
            ```
-           echo -n "my-secret-value" > /tmp/kong/secrets/my-secret.txt
+           docker exec kong-quickstart-gateway /bin/sh -c 'echo -n "my-secret-value" > /tmp/kong/secrets/my-secret.txt'
            ```
 
         1. Export the directory path as an environment variable for use with decK:
@@ -76,13 +70,6 @@ prereqs:
 
 cleanup:
   inline:
-    - title: Remove secret files
-      content: |
-        Delete the secrets directory you created:
-        ```sh
-        rm -rf /tmp/kong/secrets
-        ```
-      icon_url: /assets/icons/file.svg
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
       icon_url: /assets/icons/gateway.svg

--- a/app/_how-tos/gateway/configure-file-system-as-a-vault-backend.md
+++ b/app/_how-tos/gateway/configure-file-system-as-a-vault-backend.md
@@ -60,7 +60,7 @@ prereqs:
              docker exec kong-quickstart-gateway /bin/sh -c 'echo -n "my-secret-value" > /tmp/kong/secrets/my-secret.txt'
              ```
           1. Export the directory path as an environment variable for use with decK:
-        {% endon_prem%}
+        {% endon_prem %}
         {% konnect %}
         content: |
           1. Since {{site.konnect_short_name}} data plane container names can vary, set your container name as an environment variable:

--- a/app/_how-tos/gateway/configure-file-system-as-a-vault-backend.md
+++ b/app/_how-tos/gateway/configure-file-system-as-a-vault-backend.md
@@ -27,7 +27,6 @@ tags:
     - security
 
 search_aliases:
-  - fs vault
   - filesystem vault
   - file vault
 

--- a/app/_how-tos/gateway/configure-file-system-as-a-vault-backend.md
+++ b/app/_how-tos/gateway/configure-file-system-as-a-vault-backend.md
@@ -1,0 +1,146 @@
+---
+title: Configure the file system vault backend
+permalink: /how-to/configure-file-system-as-a-vault-backend/
+content_type: how_to
+description: "Learn how to store and reference secrets from local files using the {{site.base_gateway}} file system vault."
+products:
+    - gateway
+
+related_resources:
+  - text: Secrets management
+    url: /gateway/secrets-management/
+  - text: Configuration parameters for the file system vault
+    url: /gateway/entities/vault/?tab=file-system#vault-provider-specific-configuration-parameters
+
+works_on:
+    - on-prem
+    - konnect
+
+min_version:
+  gateway: '3.15'
+
+entities:
+  - vault
+
+tags:
+    - secrets-management
+    - security
+
+search_aliases:
+  - fs vault
+  - filesystem vault
+  - file vault
+
+tldr:
+    q: How can I store and reference secrets from local files in {{site.base_gateway}}?
+    a: |
+      Create a directory for your secret files on the data plane, then configure a Vault entity with `name: fs` and `config.prefix` set to that directory path. 
+      Reference secrets using `{vault://fs-vault/my-secret.txt}` for plain text files, or `{vault://fs-vault/creds.json/password}` to extract a specific key from a JSON file.
+
+tools:
+    - deck
+
+prereqs:
+  inline:
+    - title: Secret files
+      content: |
+        Create a directory for your secrets on the {{site.base_gateway}} data plane and add at least one secret file.
+
+        For example, if using the quickstart Docker container:
+        
+        1. Exec into the container:
+
+           ```
+           docker exec -it kong-quickstart-gateway /bin/bash  
+           ```
+
+        1. Create the directory:
+
+           ```sh
+           mkdir -p /tmp/kong/secrets
+           ```
+        
+        1. Create a test secret:
+
+           ```
+           echo -n "my-secret-value" > /tmp/kong/secrets/my-secret.txt
+           ```
+
+        1. Export the directory path as an environment variable for use with decK:
+
+           {% env_variables %}
+           DECK_FS_PREFIX: '/tmp/kong/secrets'
+           {% endenv_variables %}
+
+      icon_url: /assets/icons/gateway.svg
+
+cleanup:
+  inline:
+    - title: Remove secret files
+      content: |
+        Delete the secrets directory you created:
+        ```sh
+        rm -rf /tmp/kong/secrets
+        ```
+      icon_url: /assets/icons/file.svg
+    - title: Destroy the {{site.base_gateway}} container
+      include_content: cleanup/products/gateway
+      icon_url: /assets/icons/gateway.svg
+
+faqs:
+  - q: How do I rotate secrets in the file system vault, and how does {{site.base_gateway}} pick up the new values?
+    a: |
+      Update the file contents on disk. Configure the `ttl` setting in your {{site.base_gateway}} Vault entity so that {{site.base_gateway}} re-reads the file periodically.
+  - q: Can the file system vault read secrets from subdirectories?
+    a: |
+      Yes. Reference the path relative to `config.prefix`. 
+      For example, if your prefix is `/tmp/kong/secrets` and your secret is at `/tmp/kong/secrets/db/password.txt`, reference it as `{vault://fs-vault/db/password.txt}`.
+  - q: |
+      {% include /gateway/vaults-format-faq.md type='question' %}
+    a: |
+      {% include /gateway/vaults-format-faq.md type='answer' %}
+
+next_steps:
+  - text: Review the Vaults entity
+    url: /gateway/entities/vault/
+  - text: What can be stored as a secret?
+    url: /gateway/entities/vault/#what-can-be-stored-as-a-secret
+
+automated_tests: false
+---
+
+## Create a Vault entity for the file system vault
+
+Using decK, create a [Vault](/gateway/entities/vault/) entity that points to your secrets directory:
+
+<!--vale off-->
+{% entity_examples %}
+entities:
+  vaults:
+    - name: fs
+      prefix: fs-vault
+      description: Storing secrets in local files
+      config:
+        prefix: ${fs_prefix}
+variables:
+  fs_prefix:
+    value: $FS_PREFIX
+{% endentity_examples %}
+<!--vale on-->
+
+## Validate
+
+To validate that the Vault can read your secret, call it using the `kong vault get` command within the data plane container:
+
+{% validation vault-secret %}
+secret: '{vault://fs-vault/my-secret.txt}'
+value: 'my-secret-value'
+{% endvalidation %}
+
+If the vault was configured correctly, this command returns the contents of the file.
+
+You can now reference any file in the secrets directory from any referenceable field using `{vault://fs-vault/example-filename}`.
+
+For JSON files, you can extract a specific key by appending it to the path. For example, if `/tmp/kong/secrets/creds.json` contains `{"username":"user","password":"pass"}`, reference individual values like `{vault://fs-vault/creds.json/password}`.
+
+For more information about supported secret types, see [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret).

--- a/app/_how-tos/gateway/configure-file-system-as-a-vault-backend.md
+++ b/app/_how-tos/gateway/configure-file-system-as-a-vault-backend.md
@@ -45,25 +45,45 @@ prereqs:
       content: |
         Create a directory for your secrets on the {{site.base_gateway}} data plane and add at least one secret file.
 
-        For example, if using the quickstart Docker container:
+        {% on_prem %}
+        content: |
+          For example, if using the quickstart Docker container:
 
-        1. Create the directory:
+          1. Create the directory:
 
-           ```sh
-           docker exec kong-quickstart-gateway mkdir -p /tmp/kong/secrets
-           ```
+             ```sh
+             docker exec kong-quickstart-gateway mkdir -p /tmp/kong/secrets
+             ```
+          1. Create a test secret:
+
+             ```
+             docker exec kong-quickstart-gateway /bin/sh -c 'echo -n "my-secret-value" > /tmp/kong/secrets/my-secret.txt'
+             ```
+          1. Export the directory path as an environment variable for use with decK:
+        {% endon_prem%}
+        {% konnect %}
+        content: |
+          1. Since {{site.konnect_short_name}} data plane container names can vary, set your container name as an environment variable:
+
+             ```sh
+             export KONNECT_DP_CONTAINER='your-dp-container-name'
+             ```
+          1. Create the directory:
+
+             ```sh
+             docker exec $KONNECT_DP_CONTAINER mkdir -p /tmp/kong/secrets
+             ```
+          1. Create a test secret:
+
+             ```
+             docker exec $KONNECT_DP_CONTAINER /bin/sh -c 'echo -n "my-secret-value" > /tmp/kong/secrets/my-secret.txt'
+             ```
+          1. Export the directory path as an environment variable for use with decK:
+        {% endkonnect %}
         
-        1. Create a test secret:
-
-           ```
-           docker exec kong-quickstart-gateway /bin/sh -c 'echo -n "my-secret-value" > /tmp/kong/secrets/my-secret.txt'
-           ```
-
-        1. Export the directory path as an environment variable for use with decK:
-
-           {% env_variables %}
-           DECK_FS_PREFIX: '/tmp/kong/secrets'
-           {% endenv_variables %}
+          {% env_variables %}
+          DECK_FS_PREFIX: '/tmp/kong/secrets'
+          {% endenv_variables %}
 
       icon_url: /assets/icons/gateway.svg
 
@@ -71,6 +91,9 @@ cleanup:
   inline:
     - title: Destroy the {{site.base_gateway}} container
       include_content: cleanup/products/gateway
+      icon_url: /assets/icons/gateway.svg
+    - title: Clean up Konnect environment
+      include_content: cleanup/platform/konnect
       icon_url: /assets/icons/gateway.svg
 
 faqs:

--- a/app/_landing_pages/gateway/secrets-management.yaml
+++ b/app/_landing_pages/gateway/secrets-management.yaml
@@ -154,6 +154,19 @@ rows:
                 url: "/gateway/entities/vault/?tab=conjur#vault-provider-specific-configuration-parameters"
               - text: With {{ site.base_gateway }}
                 url: "/how-to/configure-cyberark-as-a-vault-backend/"
+      - blocks:
+        - type: card
+          config:
+            title: "File system {% new_in 3.15 %}"
+            description: |
+              Read secrets from files on the {{site.base_gateway}} data plane's local filesystem. 
+            icon: /assets/icons/file.svg
+            ctas:
+              - text: Configuration
+                url: "/gateway/entities/vault/?tab=file-system#vault-provider-specific-configuration-parameters"
+              - text: With {{ site.base_gateway }}
+                url: "/how-to/configure-file-system-as-a-vault-backend/"
+  - header:
   - header:
       text: Secrets rotation
       type: h2

--- a/app/_landing_pages/gateway/secrets-management.yaml
+++ b/app/_landing_pages/gateway/secrets-management.yaml
@@ -167,7 +167,6 @@ rows:
               - text: With {{ site.base_gateway }}
                 url: "/how-to/configure-file-system-as-a-vault-backend/"
   - header:
-  - header:
       text: Secrets rotation
       type: h2
     columns:


### PR DESCRIPTION
## Description

Documentation for the file system vault feature.
* how-to guide
* new entries in vault entity doc
* reworked the vault providers table a bit to add a column for how-to guides and have links to the config

Fixes https://github.com/Kong/developer.konghq.com/issues/5408

Note for reviewers: this currently only works on-prem, and only in curl. The doc has a decK command; you can use this to test:

```
curl -i -X POST http://localhost:8001/vaults \
  --header "Content-Type: application/json" \
  --data '{
    "name": "fs",
    "prefix": "fs-vault",
    "description": "Storing secrets in local files",
    "config": {
      "prefix": "'"$DECK_FS_PREFIX"'"
    }
  }'
```

## Preview Links
https://deploy-preview-5382--kongdeveloper.netlify.app/how-to/configure-file-system-as-a-vault-backend/
https://deploy-preview-5382--kongdeveloper.netlify.app/gateway/secrets-management/
https://deploy-preview-5382--kongdeveloper.netlify.app/gateway/entities/vault/?tab=file-system#supported-vault-backends
https://deploy-preview-5382--kongdeveloper.netlify.app/gateway/entities/vault/?tab=file-system#vault-provider-specific-configuration-parameters