### PR TITLE
feat(platform): Add tech-preview banner on landing pages

### DIFF
--- a/app/_includes/card.html
+++ b/app/_includes/card.html
@@ -43,15 +43,9 @@
     Recommended
     {% endif %}
     </div>
-    {% endif %}
-
-    {% if include.tech_preview %}
+    {% elsif include.tech_preview %}
     <div class="text-xs absolute transform rotate-45 bg-semantic-yellow-secondary text-center text-semantic-yellow-primary font-semibold py-1 right-[-35px] top-[32px] w-[170px]">
-    {% if include.tech_preview != true %}
-    {{ include.tech_preview }}
-    {% else %}
     Tech Preview
-    {% endif %}
     </div>
     {% endif %}
 

--- a/app/_includes/card.html
+++ b/app/_includes/card.html
@@ -34,13 +34,23 @@
 {% endif %}
 {% endcapture %}
 
-<div {% if include.id %}id="{{ include.id }}"{% endif %} class="card {% if include.featured %}card__featured{% else %}card__bordered{% endif %} {{ include.css_class}} ">
+<div {% if include.id %}id="{{ include.id }}"{% endif %} class="card {% if include.featured %}card__featured{% else %}card__bordered{% endif %} {% if include.tech_preview %}relative overflow-hidden{% endif %} {{ include.css_class}} ">
     {% if include.featured %}
     <div class="text-xs absolute transform rotate-45 bg-brand-saturated dark:bg-terciary text-center text-white font-semibold py-1 right-[-35px] top-[32px] w-[170px]">
     {% if include.featured != true %}
     {{ include.featured }}
     {% else %}
     Recommended
+    {% endif %}
+    </div>
+    {% endif %}
+
+    {% if include.tech_preview %}
+    <div class="text-xs absolute transform rotate-45 bg-brand-saturated dark:bg-terciary text-center text-white font-semibold py-1 right-[-35px] top-[32px] w-[170px]">
+    {% if include.tech_preview != true %}
+    {{ include.tech_preview }}
+    {% else %}
+    Tech Preview
     {% endif %}
     </div>
     {% endif %}

--- a/app/_includes/card.html
+++ b/app/_includes/card.html
@@ -46,7 +46,7 @@
     {% endif %}
 
     {% if include.tech_preview %}
-    <div class="text-xs absolute transform rotate-45 bg-semantic-yellow-primary text-center text-white font-semibold py-1 right-[-35px] top-[32px] w-[170px]">
+    <div class="text-xs absolute transform rotate-45 bg-semantic-yellow-secondary text-center text-semantic-yellow-primary font-semibold py-1 right-[-35px] top-[32px] w-[170px]">
     {% if include.tech_preview != true %}
     {{ include.tech_preview }}
     {% else %}

--- a/app/_includes/card.html
+++ b/app/_includes/card.html
@@ -46,7 +46,7 @@
     {% endif %}
 
     {% if include.tech_preview %}
-    <div class="text-xs absolute transform rotate-45 bg-brand-saturated dark:bg-terciary text-center text-white font-semibold py-1 right-[-35px] top-[32px] w-[170px]">
+    <div class="text-xs absolute transform rotate-45 bg-semantic-yellow-primary text-center text-white font-semibold py-1 right-[-35px] top-[32px] w-[170px]">
     {% if include.tech_preview != true %}
     {{ include.tech_preview }}
     {% else %}

--- a/app/_includes/card.html
+++ b/app/_includes/card.html
@@ -37,16 +37,10 @@
 <div {% if include.id %}id="{{ include.id }}"{% endif %} class="card {% if include.featured %}card__featured{% else %}card__bordered{% endif %} {% if include.tech_preview %}relative overflow-hidden{% endif %} {{ include.css_class}} ">
     {% if include.featured %}
     <div class="text-xs absolute transform rotate-45 bg-brand-saturated dark:bg-terciary text-center text-white font-semibold py-1 right-[-35px] top-[32px] w-[170px]">
-    {% if include.featured != true %}
-    {{ include.featured }}
-    {% else %}
-    Recommended
-    {% endif %}
+    {% if include.featured != true %}{{ include.featured }}{% else %}Recommended{% endif %}
     </div>
     {% elsif include.tech_preview %}
-    <div class="text-xs absolute transform rotate-45 bg-semantic-yellow-secondary text-center text-semantic-yellow-primary font-semibold py-1 right-[-35px] top-[32px] w-[170px]">
-    Tech Preview
-    </div>
+    <div class="text-xs absolute transform rotate-45 bg-semantic-yellow-secondary text-center text-semantic-yellow-primary font-semibold py-1 right-[-35px] top-[32px] w-[170px]">Tech Preview</div>
     {% endif %}
 
     {% if include.cta_url %}

--- a/app/_includes/landing_pages/card.md
+++ b/app/_includes/landing_pages/card.md
@@ -1,5 +1,5 @@
 {% if page.output_format == 'markdown' %}
 {% include card.md icon=include.config.icon title=include.config.title description=include.config.description cta_url=include.config.cta.url cta_text=include.config.cta.text featured=include.config.featured ctas=include.config.ctas id=include.config.id heading_level=include.heading_level%}
 {%- else -%}
-{% include card.html icon=include.config.icon title=include.config.title description=include.config.description cta_url=include.config.cta.url cta_text=include.config.cta.text featured=include.config.featured ctas=include.config.ctas id=include.config.id %}
+{% include card.html icon=include.config.icon title=include.config.title description=include.config.description cta_url=include.config.cta.url cta_text=include.config.cta.text featured=include.config.featured tech_preview=include.config.tech_preview ctas=include.config.ctas id=include.config.id %}
 {% endif %}


### PR DESCRIPTION

Here is an example of what this would look like, change isn't actually included in the PR only functionality: 
<img width="1416" height="461" alt="image" src="https://github.com/user-attachments/assets/557a060d-0c2c-4137-b90c-a6456162295d" />


```
    columns:
      - blocks:
        - type: card
          config:
            icon: /assets/icons/kubernetes.svg
            title: "Manage {{ site.base_gateway }} in Kubernetes through the Gateway API"
            tech_preview: true
            description: |
              Deploy and configure {{ site.base_gateway }} in Kubernetes using Gateway API resources.
            cta:
              text: Deploy {{ site.base_gateway }} in Kubernetes using Gateway API
              url: /operator/get-started/gateway-api/install/ 

```
