### PR TITLE
feat(tests): Update Dockerfile to use deck version 1.62.1 + oidc how-tos

### DIFF
--- a/.github/styles/base/Dictionary.txt
+++ b/.github/styles/base/Dictionary.txt
@@ -555,7 +555,7 @@ openai
 openid
 openresty
 openshift
-OpenSSL
+openssl
 opentelemetry
 Openwhisk
 optum

--- a/app/_how-tos/gateway/configure-oidc-with-acl-auth.md
+++ b/app/_how-tos/gateway/configure-oidc-with-acl-auth.md
@@ -75,6 +75,8 @@ cleanup:
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin. In this example, we're using the simple password grant with authenticated groups.
 
+{% include how-tos/steps/deck-salt-token.md %}
+
 Enable the OpenID Connect plugin on the `example-service` Service:
 
 {% entity_examples %}
@@ -94,6 +96,7 @@ entities:
         - password
         authenticated_groups_claim:
         - scope
+        cache_tokens_salt: ${salt-token}
 variables:
   issuer:
     value: $ISSUER
@@ -101,6 +104,8 @@ variables:
     value: $CLIENT_ID
   client-secret:
     value: $CLIENT_SECRET
+  salt-token:
+    value: $TOKEN_SALT
 {% endentity_examples %}
 
 In this example:

--- a/app/_how-tos/gateway/configure-oidc-with-acl-auth.md
+++ b/app/_how-tos/gateway/configure-oidc-with-acl-auth.md
@@ -70,12 +70,14 @@ cleanup:
       icon_url: /assets/icons/gateway.svg
 ---
 
+## Generate salt token
+
+{% include how-tos/steps/deck-salt-token.md %}
+
 ## Enable the OpenID Connect plugin
 
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin. In this example, we're using the simple password grant with authenticated groups.
-
-{% include how-tos/steps/deck-salt-token.md %}
 
 Enable the OpenID Connect plugin on the `example-service` Service:
 

--- a/app/_how-tos/gateway/configure-oidc-with-auth-code-flow.md
+++ b/app/_how-tos/gateway/configure-oidc-with-auth-code-flow.md
@@ -85,6 +85,8 @@ cleanup:
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin with the auth code flow and session authentication.
 
+{% include how-tos/steps/deck-salt-token.md %}
+
 Enable the OpenID Connect plugin on the `example-service` Service:
 
 {% entity_examples %}
@@ -108,6 +110,7 @@ entities:
         login_action: redirect
         login_tokens: null
         authorization_endpoint: http://localhost:8080
+        cache_tokens_salt: ${salt-token}
 variables:
   issuer:
     value: $ISSUER
@@ -115,6 +118,8 @@ variables:
     value: $CLIENT_ID
   client-secret:
     value: $CLIENT_SECRET
+  salt-token:
+    value: $TOKEN_SALT
 {% endentity_examples %}
 
 In this example:

--- a/app/_how-tos/gateway/configure-oidc-with-auth-code-flow.md
+++ b/app/_how-tos/gateway/configure-oidc-with-auth-code-flow.md
@@ -80,12 +80,14 @@ cleanup:
 
 ---
 
+## Generate salt token
+
+{% include how-tos/steps/deck-salt-token.md %}
+
 ## Enable the OpenID Connect plugin with the auth code flow
 
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin with the auth code flow and session authentication.
-
-{% include how-tos/steps/deck-salt-token.md %}
 
 Enable the OpenID Connect plugin on the `example-service` Service:
 

--- a/app/_how-tos/gateway/configure-oidc-with-claims-based-auth.md
+++ b/app/_how-tos/gateway/configure-oidc-with-claims-based-auth.md
@@ -102,12 +102,14 @@ cleanup:
 
 ---
 
+## Generate salt token
+
+{% include how-tos/steps/deck-salt-token.md %}
+
 ## Enable the OpenID Connect plugin with claims-based authorization
 
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin. In this example, we're using the simple password grant with the `scopes_claim` and `scopes_required` claims pair.
-
-{% include how-tos/steps/deck-salt-token.md %}
 
 Enable the OpenID Connect plugin on the `example-service` Service:
 

--- a/app/_how-tos/gateway/configure-oidc-with-claims-based-auth.md
+++ b/app/_how-tos/gateway/configure-oidc-with-claims-based-auth.md
@@ -107,6 +107,8 @@ cleanup:
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin. In this example, we're using the simple password grant with the `scopes_claim` and `scopes_required` claims pair.
 
+{% include how-tos/steps/deck-salt-token.md %}
+
 Enable the OpenID Connect plugin on the `example-service` Service:
 
 {% entity_examples %}
@@ -129,6 +131,7 @@ entities:
         - scope
         scopes_required:
         - openid
+        cache_tokens_salt: ${salt-token}
 variables:
   issuer:
     value: $ISSUER
@@ -136,6 +139,8 @@ variables:
     value: $CLIENT_ID
   client-secret:
     value: $CLIENT_SECRET
+  salt-token:
+    value: $TOKEN_SALT
 {% endentity_examples %}
 
 In this example:

--- a/app/_how-tos/gateway/configure-oidc-with-client-credentials.md
+++ b/app/_how-tos/gateway/configure-oidc-with-client-credentials.md
@@ -82,6 +82,8 @@ cleanup:
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin with the client credentials grant.
 
+{% include how-tos/steps/deck-salt-token.md %}
+
 Enable the OpenID Connect plugin on the `example-service` Service:
 
 {% entity_examples %}
@@ -101,6 +103,7 @@ entities:
         - client_credentials
         client_credentials_param_type:
         - header
+        cache_tokens_salt: ${salt-token}
 variables:
   issuer:
     value: $ISSUER
@@ -108,6 +111,8 @@ variables:
     value: $CLIENT_ID
   client-secret:
     value: $CLIENT_SECRET
+  salt-token:
+    value: $TOKEN_SALT
 {% endentity_examples %}
 
 In this example:

--- a/app/_how-tos/gateway/configure-oidc-with-client-credentials.md
+++ b/app/_how-tos/gateway/configure-oidc-with-client-credentials.md
@@ -77,12 +77,14 @@ cleanup:
 
 ---
 
+## Generate salt token
+
+{% include how-tos/steps/deck-salt-token.md %}
+
 ## Enable the OpenID Connect plugin with the client credentials grant
 
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin with the client credentials grant.
-
-{% include how-tos/steps/deck-salt-token.md %}
 
 Enable the OpenID Connect plugin on the `example-service` Service:
 

--- a/app/_how-tos/gateway/configure-oidc-with-consumer-groups.md
+++ b/app/_how-tos/gateway/configure-oidc-with-consumer-groups.md
@@ -78,6 +78,8 @@ cleanup:
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin. In this example, we're using the `client_credentials` grant with the `tier` Consumer Group claim.
 
+{% include how-tos/steps/deck-salt-token.md %}
+
 Enable the OpenID Connect plugin on the `example-service` Service:
 
 {% entity_examples %}
@@ -91,9 +93,12 @@ entities:
         - client_credentials
         consumer_groups_claim:
         - tier
+        cache_tokens_salt: ${salt-token}
 variables:
   issuer:
     value: $ISSUER
+  salt-token:
+    value: $TOKEN_SALT
 {% endentity_examples %}
 
 In this example:

--- a/app/_how-tos/gateway/configure-oidc-with-consumer-groups.md
+++ b/app/_how-tos/gateway/configure-oidc-with-consumer-groups.md
@@ -73,12 +73,14 @@ cleanup:
       icon_url: /assets/icons/gateway.svg
 ---
 
+## Generate salt token
+
+{% include how-tos/steps/deck-salt-token.md %}
+
 ## Enable the OpenID Connect plugin
 
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin. In this example, we're using the `client_credentials` grant with the `tier` Consumer Group claim.
-
-{% include how-tos/steps/deck-salt-token.md %}
 
 Enable the OpenID Connect plugin on the `example-service` Service:
 

--- a/app/_how-tos/gateway/configure-oidc-with-consumers.md
+++ b/app/_how-tos/gateway/configure-oidc-with-consumers.md
@@ -80,12 +80,14 @@ cleanup:
       icon_url: /assets/icons/gateway.svg
 ---
 
+## Generate salt token
+
+{% include how-tos/steps/deck-salt-token.md %}
+
 ## Enable the OpenID Connect plugin
 
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin. In this example, we're using the simple password grant with the `preferred_username` Consumer claim.
-
-{% include how-tos/steps/deck-salt-token.md %}
 
 Enable the OpenID Connect plugin on the `example-service` Service:
 

--- a/app/_how-tos/gateway/configure-oidc-with-consumers.md
+++ b/app/_how-tos/gateway/configure-oidc-with-consumers.md
@@ -85,6 +85,8 @@ cleanup:
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin. In this example, we're using the simple password grant with the `preferred_username` Consumer claim.
 
+{% include how-tos/steps/deck-salt-token.md %}
+
 Enable the OpenID Connect plugin on the `example-service` Service:
 
 {% entity_examples %}
@@ -106,6 +108,7 @@ entities:
         - [preferred_username]
         consumer_by:
         - username
+        cache_tokens_salt: ${salt-token}
 variables:
   issuer:
     value: $ISSUER
@@ -113,6 +116,8 @@ variables:
     value: $CLIENT_ID
   client-secret:
     value: $CLIENT_SECRET
+  salt-token:
+    value: $TOKEN_SALT
 {% endentity_examples %}
 
 In this example:

--- a/app/_how-tos/gateway/configure-oidc-with-introspection.md
+++ b/app/_how-tos/gateway/configure-oidc-with-introspection.md
@@ -75,6 +75,8 @@ Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisit
 set up an instance of the OpenID Connect plugin with introspection authentication.
 We're also enabling the password grant so that you can test retrieving the auth token for introspection.
 
+{% include how-tos/steps/deck-salt-token.md %}
+
 Enable the OpenID Connect plugin on the `example-service` Service:
 
 {% entity_examples %}
@@ -95,6 +97,7 @@ entities:
         - password
         bearer_token_param_type:
         - header
+        cache_tokens_salt: ${salt-token}
 variables:
   issuer:
     value: $ISSUER
@@ -102,6 +105,8 @@ variables:
     value: $CLIENT_ID
   client-secret:
     value: $CLIENT_SECRET
+  salt-token:
+    value: $TOKEN_SALT
 {% endentity_examples %}
 
 In this example:

--- a/app/_how-tos/gateway/configure-oidc-with-introspection.md
+++ b/app/_how-tos/gateway/configure-oidc-with-introspection.md
@@ -69,13 +69,15 @@ cleanup:
       icon_url: /assets/icons/gateway.svg
 ---
 
+## Generate salt token
+
+{% include how-tos/steps/deck-salt-token.md %}
+
 ## Enable the OpenID Connect plugin with introspection
 
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin with introspection authentication.
 We're also enabling the password grant so that you can test retrieving the auth token for introspection.
-
-{% include how-tos/steps/deck-salt-token.md %}
 
 Enable the OpenID Connect plugin on the `example-service` Service:
 

--- a/app/_how-tos/gateway/configure-oidc-with-jwt-auth.md
+++ b/app/_how-tos/gateway/configure-oidc-with-jwt-auth.md
@@ -71,15 +71,16 @@ search_aliases:
   - oidc
 ---
 
+## Generate salt token
+
+{% include how-tos/steps/deck-salt-token.md %}
+
 ## Enable the OpenID Connect plugin with JWT authentication
 
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin with bearer authentication. The stateless JWT Access Token authentication is named `bearer` in the OpenID Connect plugin.
 
 We're also enabling the password grant so that you can test retrieving the bearer auth token. 
-
-{% include how-tos/steps/deck-salt-token.md %}
-
 
 Enable the OpenID Connect plugin on the `example-service` Service:
 

--- a/app/_how-tos/gateway/configure-oidc-with-jwt-auth.md
+++ b/app/_how-tos/gateway/configure-oidc-with-jwt-auth.md
@@ -78,6 +78,9 @@ set up an instance of the OpenID Connect plugin with bearer authentication. The 
 
 We're also enabling the password grant so that you can test retrieving the bearer auth token. 
 
+{% include how-tos/steps/deck-salt-token.md %}
+
+
 Enable the OpenID Connect plugin on the `example-service` Service:
 
 {% entity_examples %}
@@ -98,6 +101,7 @@ entities:
         - password
         bearer_token_param_type:
         - query
+        cache_tokens_salt: ${salt-token}
 variables:
   issuer:
     value: $ISSUER
@@ -105,6 +109,8 @@ variables:
     value: $CLIENT_ID
   client-secret:
     value: $CLIENT_SECRET
+  salt-token:
+    value: $TOKEN_SALT
 {% endentity_examples %}
 
 In this example:

--- a/app/_how-tos/gateway/configure-oidc-with-kong-oauth2.md
+++ b/app/_how-tos/gateway/configure-oidc-with-kong-oauth2.md
@@ -119,6 +119,8 @@ variables:
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin with Kong OAuth token authentication.
 
+{% include how-tos/steps/deck-salt-token.md %}
+
 Enable the OpenID Connect plugin on the `example-service` Service:
 
 {% entity_examples %}
@@ -138,6 +140,7 @@ entities:
         - kong_oauth2
         bearer_token_param_type:
         - header
+        cache_tokens_salt: ${salt-token}
 variables:
   issuer:
     value: $ISSUER
@@ -145,6 +148,8 @@ variables:
     value: $CLIENT_ID
   client-secret:
     value: $CLIENT_SECRET
+  salt-token:
+    value: $TOKEN_SALT
 {% endentity_examples %}
 
 In this example:

--- a/app/_how-tos/gateway/configure-oidc-with-kong-oauth2.md
+++ b/app/_how-tos/gateway/configure-oidc-with-kong-oauth2.md
@@ -114,12 +114,14 @@ variables:
     value: $PROVISION_KEY
 {% endentity_examples %}
 
+## Generate salt token
+
+{% include how-tos/steps/deck-salt-token.md %}
+
 ## Enable the OpenID Connect plugin with Kong OAuth token authentication
 
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin with Kong OAuth token authentication.
-
-{% include how-tos/steps/deck-salt-token.md %}
 
 Enable the OpenID Connect plugin on the `example-service` Service:
 

--- a/app/_how-tos/gateway/configure-oidc-with-password-grant.md
+++ b/app/_how-tos/gateway/configure-oidc-with-password-grant.md
@@ -74,6 +74,8 @@ cleanup:
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin with the password grant.
 
+{% include how-tos/steps/deck-salt-token.md %}
+
 Enable the OpenID Connect plugin on the `example-service` Service:
 
 {% entity_examples %}
@@ -93,6 +95,7 @@ entities:
         - password
         password_param_type:
         - header
+        cache_tokens_salt: ${salt-token}
 variables:
   issuer:
     value: $ISSUER
@@ -100,6 +103,8 @@ variables:
     value: $CLIENT_ID
   client-secret:
     value: $CLIENT_SECRET
+  salt-token:
+    value: $TOKEN_SALT
 {% endentity_examples %}
 
 In this example:

--- a/app/_how-tos/gateway/configure-oidc-with-password-grant.md
+++ b/app/_how-tos/gateway/configure-oidc-with-password-grant.md
@@ -69,12 +69,14 @@ cleanup:
       icon_url: /assets/icons/gateway.svg
 ---
 
+## Generate salt token
+
+{% include how-tos/steps/deck-salt-token.md %}
+
 ## Enable the OpenID Connect plugin with the password grant
 
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin with the password grant.
-
-{% include how-tos/steps/deck-salt-token.md %}
 
 Enable the OpenID Connect plugin on the `example-service` Service:
 

--- a/app/_how-tos/gateway/configure-oidc-with-refresh-token.md
+++ b/app/_how-tos/gateway/configure-oidc-with-refresh-token.md
@@ -76,6 +76,8 @@ set up an instance of the [OpenID Connect plugin](/plugins/openid-connect/) with
 
 We're also enabling the password grant, as well as a refresh token header, so that we can test retrieving the token.
 
+{% include how-tos/steps/deck-salt-token.md %}
+
 Enable the OpenID Connect plugin on the `example-service` Service:
 
 {% entity_examples %}
@@ -98,6 +100,7 @@ entities:
         - header
         refresh_token_param_name: refresh_token
         upstream_refresh_token_header: refresh_token
+        cache_tokens_salt: ${salt-token}
 variables:
   issuer:
     value: $ISSUER
@@ -105,6 +108,8 @@ variables:
     value: $CLIENT_ID
   client-secret:
     value: $CLIENT_SECRET
+  salt-token:
+    value: $TOKEN_SALT
 {% endentity_examples %}
 
 In this example:

--- a/app/_how-tos/gateway/configure-oidc-with-refresh-token.md
+++ b/app/_how-tos/gateway/configure-oidc-with-refresh-token.md
@@ -69,14 +69,16 @@ cleanup:
       icon_url: /assets/icons/gateway.svg
 ---
 
+## Generate salt token
+
+{% include how-tos/steps/deck-salt-token.md %}
+
 ## Enable the OpenID Connect plugin with refresh tokens
 
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the [OpenID Connect plugin](/plugins/openid-connect/) with the refresh token grant.
 
 We're also enabling the password grant, as well as a refresh token header, so that we can test retrieving the token.
-
-{% include how-tos/steps/deck-salt-token.md %}
 
 Enable the OpenID Connect plugin on the `example-service` Service:
 

--- a/app/_how-tos/gateway/configure-oidc-with-session-auth.md
+++ b/app/_how-tos/gateway/configure-oidc-with-session-auth.md
@@ -73,14 +73,16 @@ cleanup:
       icon_url: /assets/icons/gateway.svg
 ---
 
+## Generate salt token
+
+{% include how-tos/steps/deck-salt-token.md %}
+
 ## Enable the OpenID Connect plugin with session auth
 
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin with the session auth flow.
 
 We're also enabling the password grant so that we can test retrieving the session cookie.
-
-{% include how-tos/steps/deck-salt-token.md %}
 
 Enable the OpenID Connect plugin on the `example-service` Service:
 

--- a/app/_how-tos/gateway/configure-oidc-with-session-auth.md
+++ b/app/_how-tos/gateway/configure-oidc-with-session-auth.md
@@ -80,6 +80,8 @@ set up an instance of the OpenID Connect plugin with the session auth flow.
 
 We're also enabling the password grant so that we can test retrieving the session cookie.
 
+{% include how-tos/steps/deck-salt-token.md %}
+
 Enable the OpenID Connect plugin on the `example-service` Service:
 
 {% entity_examples %}
@@ -98,6 +100,7 @@ entities:
         auth_methods:
         - session
         - password
+        cache_tokens_salt: ${salt-token}
 variables:
   issuer:
     value: $ISSUER
@@ -105,6 +108,8 @@ variables:
     value: $CLIENT_ID
   client-secret:
     value: $CLIENT_SECRET
+  salt-token:
+    value: $TOKEN_SALT
 {% endentity_examples %}
 
 In this example:

--- a/app/_how-tos/gateway/configure-oidc-with-user-info-auth.md
+++ b/app/_how-tos/gateway/configure-oidc-with-user-info-auth.md
@@ -76,6 +76,8 @@ set up an instance of the OpenID Connect plugin with the user info grant.
 
 We're also enabling the password grant so that you can test retrieving the token.
 
+{% include how-tos/steps/deck-salt-token.md %}
+
 Enable the OpenID Connect plugin on the `example-service` Service:
 
 {% entity_examples %}
@@ -96,6 +98,7 @@ entities:
         - password
         bearer_token_param_type:
         - header
+        cache_tokens_salt: ${salt-token}
 variables:
   issuer:
     value: $ISSUER
@@ -103,6 +106,8 @@ variables:
     value: $CLIENT_ID
   client-secret:
     value: $CLIENT_SECRET
+  salt-token:
+    value: $TOKEN_SALT
 {% endentity_examples %}
 
 In this example:

--- a/app/_how-tos/gateway/configure-oidc-with-user-info-auth.md
+++ b/app/_how-tos/gateway/configure-oidc-with-user-info-auth.md
@@ -69,14 +69,16 @@ cleanup:
 
 ---
 
+## Generate salt token
+
+{% include how-tos/steps/deck-salt-token.md %}
+
 ## Enable the OpenID Connect plugin with user info auth
 
 Using the Keycloak and {{site.base_gateway}} configuration from the [prerequisites](#prerequisites), 
 set up an instance of the OpenID Connect plugin with the user info grant.
 
 We're also enabling the password grant so that you can test retrieving the token.
-
-{% include how-tos/steps/deck-salt-token.md %}
 
 Enable the OpenID Connect plugin on the `example-service` Service:
 

--- a/app/_includes/how-tos/steps/deck-salt-token.md
+++ b/app/_includes/how-tos/steps/deck-salt-token.md
@@ -1,0 +1,5 @@
+Starting with decK {% new_in 1.59 %} in order to avoid regenerating session credentials during sync, you need to set [`cache_tokens_salt`](/plugins/openid-connect/reference/#schema--config-cache-tokens-salt). Generate a salt token:
+
+{% env_variables %}
+DECK_TOKEN_SALT: $(openssl rand -base64 16)
+{% endenv_variables %}

--- a/app/_includes/how-tos/steps/deck-salt-token.md
+++ b/app/_includes/how-tos/steps/deck-salt-token.md
@@ -1,4 +1,4 @@
-Starting with decK {% new_in 1.59 %} in order to avoid regenerating session credentials during sync, you need to set [`cache_tokens_salt`](/plugins/openid-connect/reference/#schema--config-cache-tokens-salt). Generate a salt token:
+Starting with decK {% new_in 1.59 %}, you need to set [`cache_tokens_salt`](/plugins/openid-connect/reference/#schema--config-cache-tokens-salt) to avoid regenerating session credentials during sync. Generate a salt token:
 
 {% env_variables %}
 DECK_TOKEN_SALT: $(openssl rand -base64 16)

--- a/app/_includes/prereqs/tools/deck.md
+++ b/app/_includes/prereqs/tools/deck.md
@@ -1,10 +1,11 @@
-{% capture summary %}decK &nbsp; {% new_in 1.43 %}{% endcapture %}
+{% assign deck_latest = site.data.tools.deck.releases | first %}
+{% capture summary %}decK &nbsp; {% new_in deck_latest.version %}{% endcapture %}
 {% capture details_content %}
-decK is a CLI tool for managing {{site.base_gateway}} declaratively with state files.
-To complete this tutorial, install [decK](/deck/) **version 1.43** or later.
 
+To complete this tutorial, install [decK](/deck/). We recommend keeping decK up to date with the latest version ({{deck_latest.version}}).
+
+decK is a CLI tool for managing {{site.base_gateway}} declaratively with state files.
 This guide uses `deck gateway apply`, which directly applies entity configuration to your Gateway instance.
-We recommend upgrading your decK installation to take advantage of this tool.
 
 You can check your current decK version with `deck version`.
 {% endcapture %}

--- a/tools/automated-tests/docker/Dockerfile
+++ b/tools/automated-tests/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN python3 -m venv /opt/myenv
 ENV PATH="/opt/myenv/bin:$PATH"
 
 RUN ARCH=$(dpkg --print-architecture) && \
-    curl -L -o deck_v1.deb https://github.com/Kong/deck/releases/download/v1.49.1/deck_v1.49.1_${ARCH}.deb && \
+    curl -L -o deck_v1.deb https://github.com/Kong/deck/releases/download/v1.62.1/deck_v1.62.1_${ARCH}.deb && \
     dpkg -i deck_v1.deb
 RUN apt-get update
 RUN apt-get install ca-certificates curl

--- a/tools/deck-versions/fetch-versions.js
+++ b/tools/deck-versions/fetch-versions.js
@@ -28,9 +28,9 @@ async function getLatestReleasess(releases) {
     .map((item) => item.obj);
 }
 
-async function fetchDeckReleaseNames() {
+async function main() {
   const response = await fetch(
-    "https://api.github.com/repos/kong/deck/releases"
+    "https://api.github.com/repos/kong/deck/releases",
   );
   if (!response.ok) {
     console.error("Failed to fetch releases:", response.statusText);
@@ -42,7 +42,7 @@ async function fetchDeckReleaseNames() {
 
   const deckDataPath = path.resolve(
     __dirname,
-    "../../app/_data/tools/deck.yml"
+    "../../app/_data/tools/deck.yml",
   );
 
   const seenReleases = {};
@@ -74,12 +74,25 @@ async function fetchDeckReleaseNames() {
       (r) =>
         `  - release: "${r.release}"\n    version: "${r.version}"\n${
           r.latest ? `    latest: true\n` : ""
-        }    released: ${r.published_at}`
+        }    released: ${r.published_at}`,
     )
     .join("\n")}`;
 
   fs.writeFileSync(deckDataPath, yamlContent, "utf8");
   console.log("Updated deck.yml successfully");
+
+  const latestVersion = releaseNames[0].name.replace(/^v/, "");
+  const dockerfilePath = path.resolve(
+    __dirname,
+    "../../tools/automated-tests/docker/Dockerfile",
+  );
+  const dockerfileContent = fs.readFileSync(dockerfilePath, "utf8");
+  const updatedDockerfile = dockerfileContent.replace(
+    /https:\/\/github\.com\/Kong\/deck\/releases\/download\/v[0-9]+\.[0-9]+\.[0-9]+\/deck_v[0-9]+\.[0-9]+\.[0-9]+_\$\{ARCH\}\.deb/,
+    `https://github.com/Kong/deck/releases/download/v${latestVersion}/deck_v${latestVersion}_\${ARCH}.deb`,
+  );
+  fs.writeFileSync(dockerfilePath, updatedDockerfile, "utf8");
+  console.log("Updated Dockerfile deck version successfully");
 }
 
-fetchDeckReleaseNames();
+main();


### PR DESCRIPTION
## Description

Automatically bump deck's version in automated test whenever it's released.
Bump deck version to latest in Dockerfile.

Fix how-tos that use the oidc plugin to set `cache_tokens_salt` to avoiding getting an error when applying the changes with deck. I added a placeholder include that generates a salt, exports it to an env variable + some exaplanation.


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
