### PR TITLE
chore(gateway): nginx duplicate headers breaking change

### DIFF
--- a/app/_includes/upgrade/lts-changes-34-310.md
+++ b/app/_includes/upgrade/lts-changes-34-310.md
@@ -195,10 +195,11 @@ rows:
       Review all regexes in your entity configuration and adjust based on the [PCRE2 syntax reference](https://www.pcre.org/current/doc/html/pcre2syntax.html).
   - category: Dependencies
     description: |
-      OpenResty was bumped from 1.21.4.2 to 1.25.3.1, picking up header enforcement changes from Nginx. 
-      Starting from 1.23.2, Nginx strictly enforces [RFC 9112](https://datatracker.ietf.org/doc/html/rfc9112), treating duplicate `Content-Length` and `Transfer-Encoding` headers as errors and throwing a `502 Bad Gateway` if both exist.
+      OpenResty was bumped from 1.21.4.2 to 1.25.3.1, picking up stricter header validation from Nginx.
+       Starting from 1.23.2, Nginx strictly enforces [RFC 9112](https://datatracker.ietf.org/doc/html/rfc9112) and treats upstream responses that contain duplicate `Content-Length` headers, duplicate `Transfer-Encoding` headers, or both headers as invalid, returning a `502 Bad Gateway`.
     action: |
-      Ensure that incoming requests don't send both headers, and remove the redundant `Transfer-Encoding` header from incoming requests if they do.
+      Ensure that your upstream services don't emit duplicate `Content-Length`/`Transfer-Encoding` headers or both headers in the same response. 
+      If both headers exist in the response, remove the redundant `Transfer-Encoding` header.
 {% endtable %}
 
 

--- a/app/_includes/upgrade/lts-changes-34-310.md
+++ b/app/_includes/upgrade/lts-changes-34-310.md
@@ -193,6 +193,12 @@ rows:
       This upgrade changes the expected regex syntax, and any incompatible regular expressions will prevent {{site.base_gateway}} from applying configuration.
     action: |
       Review all regexes in your entity configuration and adjust based on the [PCRE2 syntax reference](https://www.pcre.org/current/doc/html/pcre2syntax.html).
+  - category: Dependencies
+    description: |
+      OpenResty was bumped from 1.21.4.2 to 1.25.3.1, picking up header enforcement changes from Nginx. 
+      Starting from 1.23.2, Nginx strictly enforces [RFC 9112](https://datatracker.ietf.org/doc/html/rfc9112), treating duplicate `Content-Length` and `Transfer-Encoding` headers as errors and throwing a `502 Bad Gateway` if both exist.
+    action: |
+      Ensure that incoming requests don't send both headers, and remove the redundant `Transfer-Encoding` header from incoming requests if they do.
 {% endtable %}
 
 

--- a/app/gateway/breaking-changes.md
+++ b/app/gateway/breaking-changes.md
@@ -758,6 +758,11 @@ As a result, the following are prohibited:
 * SSL version 3
 Additionally, compression is disabled.
 
+#### OpenResty header enforcement
+
+OpenResty was bumped from 1.21.4.2 to 1.25.3.1, picking up header enforcement changes from Nginx. 
+Starting from 1.23.2, Nginx strictly enforces [RFC 9112](https://datatracker.ietf.org/doc/html/rfc9112), treating duplicate `Content-Length` and `Transfer-Encoding` headers as errors and throwing a `502 Bad Gateway` if both exist.
+
 #### Kong Manager Enterprise
 
 As of {{site.base_gateway}} 3.6, Kong Manager uses the session management mechanism in the OpenID Connect plugin.

--- a/app/gateway/breaking-changes.md
+++ b/app/gateway/breaking-changes.md
@@ -760,8 +760,8 @@ Additionally, compression is disabled.
 
 #### OpenResty header enforcement
 
-OpenResty was bumped from 1.21.4.2 to 1.25.3.1, picking up header enforcement changes from Nginx. 
-Starting from 1.23.2, Nginx strictly enforces [RFC 9112](https://datatracker.ietf.org/doc/html/rfc9112), treating duplicate `Content-Length` and `Transfer-Encoding` headers as errors and throwing a `502 Bad Gateway` if both exist.
+OpenResty was bumped from 1.21.4.2 to 1.25.3.1, picking up stricter header validation from Nginx.
+Starting from 1.23.2, Nginx strictly enforces [RFC 9112](https://datatracker.ietf.org/doc/html/rfc9112) and treats upstream responses that contain duplicate `Content-Length` headers, duplicate `Transfer-Encoding` headers, or both headers as invalid, returning a `502 Bad Gateway`.
 
 #### Kong Manager Enterprise
 


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

The OpenResty bump that occured in 3.6.0.0 picked up a breaking change from nginx. 

Related to https://konghq.atlassian.net/browse/FTI-7561.
See [slack convo](https://kongstrong.slack.com/archives/C03CTMSHP6C/p1779352124620969) for explanation.

There is no workaround in Kong.

## Preview Links
https://deploy-preview-5442--kongdeveloper.netlify.app/gateway/breaking-changes/#openresty-header-enforcement
https://deploy-preview-5442--kongdeveloper.netlify.app/gateway/upgrade/lts-upgrade-34-310/#preparation-review-gateway-changes
