### PR TITLE
Fix(Platform): Incorrect footer link

### DIFF
--- a/app/_data/footer.yml
+++ b/app/_data/footer.yml
@@ -13,9 +13,9 @@ platform:
     service_mesh:
       text: Service Mesh
       url: https://konghq.com/products/kong-mesh
-    api_builder:
-      text: API Builder
-      url: https://konghq.com/products/kong-insomnia
+    dev_portal:
+      text: Dev Portal
+      url: https://konghq.com/products/kong-konnect/features/developer-portal
     pricing:
       text: Pricing
       url: https://konghq.com/pricing


### PR DESCRIPTION
Currently API builder points to the insomnia docs

I checked w/ Nathanel and he would like it to highlight Dev Portal