### PR TITLE
feat(gateway): Streaming and cloning plugins

### DIFF
--- a/app/_gateway_entities/plugin.md
+++ b/app/_gateway_entities/plugin.md
@@ -250,12 +250,12 @@ Cloning a plugin creates a custom instance of an existing plugin, letting you ap
 A cloned plugin has a distinct name and is subject to its own precedence rules. 
 The priority of the cloned plugin can also be changed.
 
-Cloned plugins are useful in many situations:
+Cloned plugins are useful in many situations. For example:
 
 * Running the same plugin on different attributes of a request. For example, you may want to validate two different JWTs in two separate headers.
 * Allowing different teams who want to use the same plugin logic to apply different business rules. 
 For example, a platform team may want to add a global IP deny list to a Gateway to enforce a global security policy, while an engineering team may also want to block IPs from a particular problematic customer on a single Route.
-* Running multiple instances of the Datakit plugin where different teams want to implement independently manage their own distinct flows on the same Gateway.
+* Running multiple instances of the Datakit plugin where different teams want to independently manage their own distinct flows on the same Gateway.
 * In conjunction with [conditional plugins](/gateway/plugins/expressions/), running different configurations of the plugin based on different environmental conditions.
 
 {:.info}
@@ -289,7 +289,7 @@ To create a plugin clone, use the `cloned_plugins` key to define a new plugin, t
 cloned_plugins:
 # Create a clone of request transformer to use for global configuration
  - name: request-transformer-global
-   ref: request-transformer-advanced
+   ref: request-transformer
    priority: 999
 
 # Define an entry for the new plugin under the global plugins key

--- a/app/_gateway_entities/plugin.md
+++ b/app/_gateway_entities/plugin.md
@@ -246,7 +246,7 @@ For more information, see:
 ## Cloning plugins {% new_in 3.15 %}
 
 You can run multiple instances of a plugin by cloning it.
-Cloning a plugin creates a custom instance of an existing plugin, letting you apply different configurations to your prefered scopes.
+Cloning a plugin creates a custom instance of an existing plugin, letting you apply different configurations to your preferred scopes.
 A cloned plugin shares its code and logic with the source plugin, but is treated as a separate plugin instance.
 
 The priority of the cloned plugin can also be changed.

--- a/app/_gateway_entities/plugin.md
+++ b/app/_gateway_entities/plugin.md
@@ -259,7 +259,8 @@ For example, a platform team may want to add a global IP deny list to a Gateway 
 * In conjunction with [conditional plugins](/gateway/plugins/expressions/), running different configurations of the plugin based on different environmental conditions.
 
 {:.info}
-> If running {{site.base_gateway}} in hybrid mode or in {{site.konnect_short_name}}, set `KONG_CUSTOM_PLUGINS_ENABLED=on` in {{site.base_gateway}} configuration for both the DP and the CP to use cloned plugins.
+> To use cloned plugins, you must set [`custom_plugin_streaming_enabled`](/gateway/configuration/#custom-plugin-streaming-enabled) to `on` in {{site.base_gateway}} configuration. 
+> If running in hybrid mode, both the data plane and the control plane require this setting.
 
 ### Supported plugins
 

--- a/app/_gateway_entities/plugin.md
+++ b/app/_gateway_entities/plugin.md
@@ -245,9 +245,10 @@ For more information, see:
 
 ## Cloning plugins {% new_in 3.15 %}
 
-You can run multiple instances of a plugin by cloning it. 
-Cloning a plugin creates a custom instance of an existing plugin, letting you apply different configurations to different scopes. 
-A cloned plugin has a distinct name and is subject to its own precedence rules. 
+You can run multiple instances of a plugin by cloning it.
+Cloning a plugin creates a custom instance of an existing plugin, letting you apply different configurations to your prefered scopes.
+A cloned plugin shares its code and logic with the source plugin, but is treated as a separate plugin instance.
+
 The priority of the cloned plugin can also be changed.
 
 Cloned plugins are useful in many situations. For example:
@@ -258,29 +259,32 @@ For example, a platform team may want to add a global IP deny list to a Gateway 
 * Running multiple instances of the Datakit plugin where different teams want to independently manage their own distinct flows on the same Gateway.
 * In conjunction with [conditional plugins](/gateway/plugins/expressions/), running different configurations of the plugin based on different environmental conditions.
 
-{:.info}
-> To use cloned plugins, you must set [`custom_plugin_streaming_enabled`](/gateway/configuration/#custom-plugin-streaming-enabled) to `on` in {{site.base_gateway}} configuration. 
-> If running in hybrid mode, both the data plane and the control plane require this setting.
+### Permissions required
+
+To create cloned plugins, you must have the following permissions:
+* {{site.konnect_short_name}}: One of the following [control plane roles](/konnect-platform/teams-and-roles/#control-planes): `ServiceAdmin`, `RouteAdmin`, `PluginAdmin`, `CPAdmin`, or `Deployer`.
+* Self-managed {{site.base_gateway}}: `super-admin` or `admin` role.
 
 ### Supported plugins
 
 The following plugins support cloning:
 
-* [OpenID Connect](/plugins/openid-connect/)
 * [ACL](/plugins/acl/)
+* [Datakit](/plugins/datakit/)
+* [File Log](/plugins/file-log/)
+* [HTTP Log](/plugins/http-log/)
+* [IP Restriction](/plugins/ip-restriction/)
+* [Key Authentication](/plugins/key-auth/)
+* [OPA](/plugins/opa/)
+* [OpenID Connect](/plugins/openid-connect/)
 * [Pre-function](/plugins/pre-function/)
 * [Post-function](/plugins/post-function/)
 * [Request Transformer Advanced](/plugins/request-transformer-advanced/)
 * [Request Transformer](/plugins/request-transformer/)
 * [Response Transformer Advanced](/plugins/response-transformer-advanced/)
 * [Response Transformer](/plugins/response-transformer/)
-* [Key Authentication](/plugins/key-auth/)
-* [File Log](/plugins/file-log/)
-* [HTTP Log](/plugins/http-log/)
-* [TCP Log](/plugins/tcp-log/)
-* [IP Restriction](/plugins/ip-restriction/)
 * [Route by Header](/plugins/route-by-header/)
-* [OPA](/plugins/opa/)
+* [TCP Log](/plugins/tcp-log/)
 
 ### Example of cloned plugin
 
@@ -304,10 +308,28 @@ plugins:
 
 Where:
 * `cloned_plugins.name`: The name of your new plugin. This can be any unique name that doesn't conflict with an existing plugin.
-* `cloned_plugins.ref`: The source plugin that this clone will be based on.
-* `cloned_plugins.priority`: The order in which the plugin will run relative to other plugins (see [plugins priorities](#plugin-priority)). This is an optional setting; if not set, the plugin will fall back to [plugin precedence rules](#plugin-precedence). 
+  We recommend making this name distinct so that it doesn't conflict with future plugins (for example, `ACME-request-transformer-global`).
+* `cloned_plugins.ref`: The source plugin that this clone is based on.
+* `cloned_plugins.priority`: The order in which the plugin runs relative to other plugins (see [plugins priorities](#plugin-priority)). This is an optional setting; 
+  If not set, the plugin inherits the priority of the source plugin. 
+  For plugins with the same priority, the order depends on their names in reverse alphabetical order: plugins with alphabetically greater names run earlier (for example, `my-plugin-b` runs before `my-plugin-a`).
+
+{:.info}
+> **Note:** Each plugin ref (for example, `ref: request-transformer`) can have a maximum of five clones.
 
 For more information, see the tutorial on [Cloning a {{site.base_gateway}} plugin](/how-to/clone-gateway-plugin/).
+
+### Deleting or updating cloned plugins
+
+To delete a cloned plugin, remove all configurations that reference it first, then delete its entry under `cloned_plugins`. 
+
+If you need to make any changes to the configuration of the cloned plugin (for example, with a new name or priority, or to point to a different ref), we recommend the following approach for safe migration:
+
+1. Start a migration/maintenance window.
+1. Create a new cloned plugin.
+1. Update the configuration for all the plugin instances of the old cloned plugin to comply with the new cloned plugin.
+1. Remove the cloned plugin.
+1. Stop the migration/maintenance window.
 
 ## Protocols
 

--- a/app/_gateway_entities/plugin.md
+++ b/app/_gateway_entities/plugin.md
@@ -256,7 +256,7 @@ Cloned plugins are useful in many situations. For example:
 * Running the same plugin on different attributes of a request. For example, you may want to validate two different JWTs in two separate headers.
 * Allowing different teams who want to use the same plugin logic to apply different business rules. 
 For example, a platform team may want to add a global IP deny list to a Gateway to enforce a global security policy, while an engineering team may also want to block IPs from a particular problematic customer on a single Route.
-* Running multiple instances of the Datakit plugin where different teams want to independently manage their own distinct flows on the same Gateway.
+* Running multiple instances of the [Datakit](/plugins/datakit/) plugin where different teams want to independently manage their own distinct flows on the same Gateway.
 * In conjunction with [conditional plugins](/gateway/plugins/expressions/), running different configurations of the plugin based on different environmental conditions.
 
 ### Permissions required
@@ -306,18 +306,17 @@ plugins:
           - "X-Global-Header:isSetGlobally"
 ```
 
-Where:
-* `cloned_plugins.name`: The name of your new plugin. This can be any unique name that doesn't conflict with an existing plugin.
-  We recommend making this name distinct so that it doesn't conflict with future plugins (for example, `ACME-request-transformer-global`).
+* `cloned_plugins.name`: The name of your new plugin. This must be a unique name that doesn't conflict with an existing plugin.
+  We recommend making this name distinct so that it doesn't conflict with future plugins. For example, `acme-request-transformer-global`.
 * `cloned_plugins.ref`: The source plugin that this clone is based on.
-* `cloned_plugins.priority`: The order in which the plugin runs relative to other plugins (see [plugins priorities](#plugin-priority)). This is an optional setting; 
+* `cloned_plugins.priority`: The order in which the plugin runs relative to other plugins (see [plugins priorities](#plugin-priority)). This is an optional setting.
   If not set, the plugin inherits the priority of the source plugin. 
   For plugins with the same priority, the order depends on their names in reverse alphabetical order: plugins with alphabetically greater names run earlier (for example, `my-plugin-b` runs before `my-plugin-a`).
 
 {:.info}
 > **Note:** Each plugin ref (for example, `ref: request-transformer`) can have a maximum of five clones.
 
-For more information, see the tutorial on [Cloning a {{site.base_gateway}} plugin](/how-to/clone-gateway-plugin/).
+For more information, see the guide on [Cloning a {{site.base_gateway}} plugin](/how-to/clone-gateway-plugin/).
 
 ### Deleting or updating cloned plugins
 

--- a/app/_gateway_entities/plugin.md
+++ b/app/_gateway_entities/plugin.md
@@ -254,7 +254,7 @@ Cloned plugins are useful in many situations:
 
 * Running the same plugin on different attributes of a request. For example, you may want to validate two different JWTs in two separate headers.
 * Allowing different teams who want to use the same plugin logic to apply different business rules. 
-For example, a platform team may want to add a global IP blacklist to a Gateway to enforce a global security polic, while an engineering team may also want to block IPs from a particular problematic customer on a single Route.
+For example, a platform team may want to add a global IP deny list to a Gateway to enforce a global security policy, while an engineering team may also want to block IPs from a particular problematic customer on a single Route.
 * Running multiple instances of the Datakit plugin where different teams want to implement independently manage their own distinct flows on the same Gateway.
 * In conjunction with [conditional plugins](/gateway/plugins/expressions/), running different configurations of the plugin based on different environmental conditions.
 

--- a/app/_gateway_entities/plugin.md
+++ b/app/_gateway_entities/plugin.md
@@ -243,6 +243,71 @@ For more information, see:
 * [Plugin expressions reference](/gateway/plugins/expressions/)
 * [How to: Configure conditional plugin execution in {{site.base_gateway}}](/gateway/configure-conditional-plugin-execution/)
 
+## Cloning plugins {% new_in 3.15 %}
+
+You can run multiple instances of a plugin by cloning it. 
+Cloning a plugin creates a custom instance of an existing plugin, letting you apply different configurations to different scopes. 
+A cloned plugin has a distinct name and is subject to its own precedence rules. 
+The priority of the cloned plugin can also be changed.
+
+Cloned plugins are useful in many situations:
+
+* Running the same plugin on different attributes of a request. For example, you may want to validate two different JWTs in two separate headers.
+* Allowing different teams who want to use the same plugin logic to apply different business rules. 
+For example, a platform team may want to add a global IP blacklist to a Gateway to enforce a global security polic, while an engineering team may also want to block IPs from a particular problematic customer on a single Route.
+* Running multiple instances of the Datakit plugin where different teams want to implement independently manage their own distinct flows on the same Gateway.
+* In conjunction with [conditional plugins](/gateway/plugins/expressions/), running different configurations of the plugin based on different environmental conditions.
+
+{:.info}
+> If running {{site.base_gateway}} in hybrid mode or in {{site.konnect_short_name}}, set `KONG_CUSTOM_PLUGINS_ENABLED=on` in {{site.base_gateway}} configuration for both the DP and the CP to use cloned plugins.
+
+### Supported plugins
+
+The following plugins support cloning:
+
+* [OpenID Connect](/plugins/openid-connect/)
+* [ACL](/plugins/acl/)
+* [Pre-function](/plugins/pre-function/)
+* [Post-function](/plugins/post-function/)
+* [Request Transformer Advanced](/plugins/request-transformer-advanced/)
+* [Request Transformer](/plugins/request-transformer/)
+* [Response Transformer Advanced](/plugins/response-transformer-advanced/)
+* [Response Transformer](/plugins/response-transformer/)
+* [Key Authentication](/plugins/key-auth/)
+* [File Log](/plugins/file-log/)
+* [HTTP Log](/plugins/http-log/)
+* [TCP Log](/plugins/tcp-log/)
+* [IP Restriction](/plugins/ip-restriction/)
+* [Route by Header](/plugins/route-by-header/)
+* [OPA](/plugins/opa/)
+
+### Example of cloned plugin
+
+To create a plugin clone, use the `cloned_plugins` key to define a new plugin, then configure the clone the same as any other plugin through `plugins`:
+
+```yaml
+cloned_plugins:
+# Create a clone of request transformer to use for global configuration
+ - name: request-transformer-global
+   ref: request-transformer-advanced
+   priority: 999
+
+# Define an entry for the new plugin under the global plugins key
+plugins:
+  - name: request-transformer-global
+    config:
+      add:
+        headers:
+          - "X-Global-Header:isSetGlobally"
+```
+
+Where:
+* `cloned_plugins.name`: The name of your new plugin. This can be any unique name that doesn't conflict with an existing plugin.
+* `cloned_plugins.ref`: The source plugin that this clone will be based on.
+* `cloned_plugins.priority`: The order in which the plugin will run relative to other plugins (see [plugins priorities](#plugin-priority)). This is an optional setting; if not set, the plugin will fall back to [plugin precedence rules](#plugin-precedence). 
+
+For more information, see the tutorial on [Cloning a {{site.base_gateway}} plugin](/how-to/clone-gateway-plugin/).
+
 ## Protocols
 
 Plugins support different protocols.

--- a/app/_how-tos/gateway/clone-gateway-plugin.md
+++ b/app/_how-tos/gateway/clone-gateway-plugin.md
@@ -19,15 +19,16 @@ tools:
     - deck
 
 prereqs:
+  inline:
+    - title: Set up Konnect permissions
+      include_content: prereqs/custom-plugin-permissions
+      icon_url: /assets/icons/kogo-white.svg
+
   entities:
     services:
         - example-service
     routes:
         - example-route
-  gateway:
-    - name: "KONG_CUSTOM_PLUGIN_STREAMING_ENABLED=on"
-  konnect:
-    - name: "KONG_CUSTOM_PLUGIN_STREAMING_ENABLED=on"
 
 min_version:
   gateway: '3.15'
@@ -46,9 +47,6 @@ faqs:
   - q: Do all {{site.base_gateway}} plugins support cloning?
     a: |
       No, only a subset of plugins can be cloned. See the list of [supported plugins](/gateway/entities/plugin/#supported-plugins).
-  - q: I'm running {{site.base_gateway}} in hybrid mode and I can't set up a cloned plugin.
-    a: |
-      If you're running {{site.base_gateway}} in hybrid mode, both the control plane and data plane need to be launched with the [`custom_plugin_streaming_enabled=on`](/gateway/configuration/#custom-plugin-streaming-enabled) setting.
 
 cleanup:
   inline:
@@ -69,18 +67,19 @@ This lets two separate teams use the same plugin logic with independent configur
 
 ## Create a clone of the Request Transformer plugin
 
-Use the `cloned_plugins` key to define a new plugin named `request-transformer-global` that is based on `request-transformer`:
+Use the `cloned_plugins` key to define a new plugin named `ACME-request-transformer-global` that is based on `request-transformer`:
 
 {% entity_examples %}
 entities:
   cloned_plugins:
-    - name: request-transformer-global
+    - name: ACME-request-transformer-global
       ref: request-transformer
       priority: 802
 {% endentity_examples %}
 
 Where:
 * `cloned_plugins.name`: A unique name for the clone. This can be any name that doesn't conflict with an existing plugin.
+  We recommend making this name distinct so that it doesn't conflict with future plugins (for example, `ACME-request-transformer-global`).
 * `cloned_plugins.ref`: The source plugin that this clone is based on.
 * `cloned_plugins.priority`: The order in which the cloned plugin runs relative to other plugins. The base Request Transformer plugin has a priority of 801, so setting 802 makes the clone run first. This isn't required for this example since the clone runs globally, but it shows how you can control plugin ordering independently from the source plugin.
 
@@ -91,7 +90,7 @@ Configure the cloned plugin globally so it adds a header to every request:
 {% entity_examples %}
 entities:
   plugins:
-    - name: request-transformer-global
+    - name: ACME-request-transformer-global
       config:
         add:
           headers:

--- a/app/_how-tos/gateway/clone-gateway-plugin.md
+++ b/app/_how-tos/gateway/clone-gateway-plugin.md
@@ -1,5 +1,5 @@
 ---
-title: Clone a {{site.base_gateway}} plugin
+title: Run multiple instances of a {{site.base_gateway}} plugin
 permalink: /how-to/clone-gateway-plugin/
 content_type: how_to
 related_resources:
@@ -25,9 +25,9 @@ prereqs:
     routes:
         - example-route
   gateway:
-    - name: "KONG_CUSTOM_PLUGINS_ENABLED=on"
+    - name: "KONG_CUSTOM_PLUGIN_STREAMING_ENABLED=on"
   konnect:
-    - name: "KONG_CUSTOM_PLUGINS_ENABLED=on"
+    - name: "KONG_CUSTOM_PLUGIN_STREAMING_ENABLED=on"
 
 min_version:
   gateway: '3.15'

--- a/app/_how-tos/gateway/clone-gateway-plugin.md
+++ b/app/_how-tos/gateway/clone-gateway-plugin.md
@@ -25,9 +25,9 @@ prereqs:
     routes:
         - example-route
   gateway:
-    - name: "KONG_CUSTOM_PLUGINS_ENABLED=true"
+    - name: "KONG_CUSTOM_PLUGINS_ENABLED=on"
   konnect:
-    - name: "KONG_CUSTOM_PLUGINS_ENABLED=true"
+    - name: "KONG_CUSTOM_PLUGINS_ENABLED=on"
 
 min_version:
   gateway: '3.15'

--- a/app/_how-tos/gateway/clone-gateway-plugin.md
+++ b/app/_how-tos/gateway/clone-gateway-plugin.md
@@ -67,19 +67,21 @@ This lets two separate teams use the same plugin logic with independent configur
 
 ## Create a clone of the Request Transformer plugin
 
-Use the `cloned_plugins` key to define a new plugin named `ACME-request-transformer-global` that is based on `request-transformer`:
+Use the `cloned_plugins` key to define a new plugin named `acme-request-transformer-global` that is based on `request-transformer`:
 
 {% entity_examples %}
 entities:
   cloned_plugins:
-    - name: ACME-request-transformer-global
+    - name: acme-request-transformer-global
       ref: request-transformer
       priority: 802
+deck_flags:
+  - "--include-plugin-definitions"
 {% endentity_examples %}
 
 Where:
 * `cloned_plugins.name`: A unique name for the clone. This can be any name that doesn't conflict with an existing plugin.
-  We recommend making this name distinct so that it doesn't conflict with future plugins (for example, `ACME-request-transformer-global`).
+  We recommend making this name distinct so that it doesn't conflict with future plugins (for example, `acme-request-transformer-global`).
 * `cloned_plugins.ref`: The source plugin that this clone is based on.
 * `cloned_plugins.priority`: The order in which the cloned plugin runs relative to other plugins. The base Request Transformer plugin has a priority of 801, so setting 802 makes the clone run first. This isn't required for this example since the clone runs globally, but it shows how you can control plugin ordering independently from the source plugin.
 
@@ -90,11 +92,13 @@ Configure the cloned plugin globally so it adds a header to every request:
 {% entity_examples %}
 entities:
   plugins:
-    - name: ACME-request-transformer-global
+    - name: acme-request-transformer-global
       config:
         add:
           headers:
             - "X-Global-Header:isSetGlobally"
+deck_flags:
+  - "--include-plugin-definitions"
 {% endentity_examples %}
 
 ## Apply the source plugin to a Route

--- a/app/_how-tos/gateway/clone-gateway-plugin.md
+++ b/app/_how-tos/gateway/clone-gateway-plugin.md
@@ -1,0 +1,175 @@
+---
+title: Clone a {{site.base_gateway}} plugin
+permalink: /how-to/clone-gateway-plugin/
+content_type: how_to
+related_resources:
+  - text: Plugin cloning reference
+    url: /gateway/entities/plugin/#cloning-plugins
+
+description: "Create a duplicate of an existing {{site.base_gateway}} plugin so that you can run multiple instances of the same plugin with different configurations or in different scopes."
+
+products:
+    - gateway
+
+works_on:
+    - on-prem
+    - konnect
+
+tools:
+    - deck
+
+prereqs:
+  entities:
+    services:
+        - example-service
+    routes:
+        - example-route
+  gateway:
+    - name: "KONG_CUSTOM_PLUGINS_ENABLED=true"
+  konnect:
+    - name: "KONG_CUSTOM_PLUGINS_ENABLED=true"
+
+min_version:
+  gateway: '3.15'
+
+entities:
+  - service
+  - route
+  - plugin
+
+tldr:
+  q: How do I apply a plugin multiple times with different configurations?
+  a: |
+    To apply a plugin multiple times with different configurations, clone the plugin using the `cloned_plugins` key, then configure the clone the same as any other plugin through `plugins`.
+
+faqs:
+  - q: Do all {{site.base_gateway}} plugins support cloning?
+    a: |
+      No, only a subset of plugins can be cloned. See the list of [supported plugins](/gateway/entities/plugin/#supported-plugins).
+  - q: I'm running {{site.base_gateway}} in hybrid mode and I can't set up a cloned plugin.
+    a: |
+      If you're running {{site.base_gateway}} in hybrid mode, both the control plane and data plane need to be launched with the [`custom_plugins_enabled=on`](/gateway/configuration/#custom-plugins-enabled) setting.
+
+cleanup:
+  inline:
+    - title: Clean up Konnect environment
+      include_content: cleanup/platform/konnect
+      icon_url: /assets/icons/gateway.svg
+    - title: Destroy the {{site.base_gateway}} container
+      include_content: cleanup/products/gateway
+      icon_url: /assets/icons/gateway.svg
+---
+
+In this guide, you'll clone the [Request Transformer](/plugins/request-transformer/) plugin to run two independent instances with different configurations:
+
+* A global clone that adds a header to every request passing through the gateway.
+* The original plugin applied to a specific Route that adds a different header.
+
+This lets two separate teams use the same plugin logic with independent configuration and precedence.
+
+## Create a clone of the Request Transformer plugin
+
+Use the `cloned_plugins` key to define a new plugin named `request-transformer-global` that is based on `request-transformer`:
+
+{% entity_examples %}
+entities:
+  cloned_plugins:
+    - name: request-transformer-global
+      ref: request-transformer
+      priority: 802
+{% endentity_examples %}
+
+Where:
+* `cloned_plugins.name`: A unique name for the clone. This can be any name that doesn't conflict with an existing plugin.
+* `cloned_plugins.ref`: The source plugin that this clone is based on.
+* `cloned_plugins.priority`: The order in which the cloned plugin runs relative to other plugins. The base Request Transformer plugin has a priority of 801, so setting 802 makes the clone run first. This isn't required for this example since the clone runs globally, but it shows how you can control plugin ordering independently from the source plugin.
+
+## Apply the cloned plugin globally
+
+Configure the cloned plugin globally so it adds a header to every request:
+
+{% entity_examples %}
+entities:
+  plugins:
+    - name: request-transformer-global
+      config:
+        add:
+          headers:
+            - "X-Global-Header:isSetGlobally"
+{% endentity_examples %}
+
+## Apply the source plugin to a Route
+
+Configure the original Request Transformer plugin on `example-route` to add a Route-specific header. This runs as a separate, independent instance from the global clone:
+
+{% entity_examples %}
+entities:
+  plugins:
+    - name: request-transformer
+      route: example-route
+      config:
+        add:
+          headers:
+            - "X-Route-Header:isSetOnRoute"
+{% endentity_examples %}
+
+## Create a second route
+
+Create a second Route on `example-service` to use in validation. Requests to this Route will only be handled by the global clone, not the route-scoped plugin:
+
+{% entity_examples %}
+entities:
+  routes:
+    - name: example-route-2
+      service:
+        name: example-service
+      paths:
+        - /global
+      protocols:
+        - http
+        - https
+{% endentity_examples %}
+
+## Validate
+
+First, send a request to `example-route`, which triggers both plugins.
+The global clone adds `X-Global-Header` and the route-scoped plugin adds `X-Route-Header`:
+
+{% validation request-check %}
+url: '/anything'
+status_code: 200
+display_headers: true
+{% endvalidation %}
+
+In the response from `httpbin`, look for both headers in the `headers` object:
+
+```json
+{
+  "headers": {
+    "X-Global-Header": "isSetGlobally",
+    "X-Route-Header": "isSetOnRoute"
+  }
+}
+```
+{:.no-copy-code}
+
+Now send a request to `example-route-2`:
+
+{% validation request-check %}
+url: '/global'
+status_code: 200
+display_headers: true
+{% endvalidation %}
+
+Only the global clone should run, so you should only see `X-Global-Header`:
+
+```json
+{
+  "headers": {
+    "X-Global-Header": "isSetGlobally"
+  }
+}
+```
+{:.no-copy-code}
+
+The global clone runs on both Routes, while `request-transformer` only runs on `example-route`, confirming that the two instances are fully independent.

--- a/app/_how-tos/gateway/clone-gateway-plugin.md
+++ b/app/_how-tos/gateway/clone-gateway-plugin.md
@@ -48,7 +48,7 @@ faqs:
       No, only a subset of plugins can be cloned. See the list of [supported plugins](/gateway/entities/plugin/#supported-plugins).
   - q: I'm running {{site.base_gateway}} in hybrid mode and I can't set up a cloned plugin.
     a: |
-      If you're running {{site.base_gateway}} in hybrid mode, both the control plane and data plane need to be launched with the [`custom_plugins_enabled=on`](/gateway/configuration/#custom-plugins-enabled) setting.
+      If you're running {{site.base_gateway}} in hybrid mode, both the control plane and data plane need to be launched with the [`custom_plugin_streaming_enabled=on`](/gateway/configuration/#custom-plugin-streaming-enabled) setting.
 
 cleanup:
   inline:

--- a/app/_how-tos/gateway/stream-custom-plugins.md
+++ b/app/_how-tos/gateway/stream-custom-plugins.md
@@ -48,7 +48,7 @@ tldr:
 faqs:
   - q: Can I define any custom plugin as a streaming plugin?
     a: |
-      No, there are some limitations. The plugin must have only one `handler` and one `schema`, cannot run in the `init_worker` phase or create timers, and must be written in Lua. See the [custom plugin streaming reference](/custom-plugins/streaming-plugins/) for more detail.
+      No, there are some limitations. The plugin must have only one `handler` and one `schema`, can't run in the `init_worker` phase or create timers, and must be written in Lua. See the [custom plugin streaming reference](/custom-plugins/streaming-plugins/) for more detail.
 
 cleanup:
   inline:
@@ -167,7 +167,7 @@ Apply `replaceme` with a [condition](/gateway/plugins/expressions/) so it only r
 entities:
   plugins:
     - name: replaceme
-      condition: '!http.path.contains("skip")'
+      condition: "!http.path.contains(\"skip\")"
       config:
         target_word: sea
         replacement_word: pelican

--- a/app/_how-tos/gateway/stream-custom-plugins.md
+++ b/app/_how-tos/gateway/stream-custom-plugins.md
@@ -1,0 +1,201 @@
+---
+title: Stream {{site.base_gateway}} plugins
+permalink: /how-to/stream-custom-plugins/
+content_type: how_to
+related_resources:
+  - text: Plugin streaming reference
+    url: /custom-plugins/streaming-plugins/
+
+description: "Define custom plugins directly in {{site.base_gateway}} entity configuration and distribute them to all data planes automatically."
+
+products:
+    - gateway
+
+works_on:
+    - on-prem
+    - konnect
+
+tools:
+    - deck
+
+prereqs:
+  gateway:
+    - name: "KONG_CUSTOM_PLUGINS_ENABLED=true"
+  konnect:
+    - name: "KONG_CUSTOM_PLUGINS_ENABLED=true"
+  entities:
+    services:
+        - example-service
+    routes:
+        - example-route
+
+min_version:
+  gateway: '3.15'
+
+entities:
+  - plugin
+
+tldr:
+  q: How can I define a custom plugin without having to upload any files?
+  a: |
+    Use the `custom_plugins` key in your decK configuration to embed the plugin schema and handler directly in {{site.base_gateway}} entity configuration. 
+    If you're running in hybrid mode, the control plane streams the plugin to all connected data planes automatically.
+
+faqs:
+  - q: Can I define any custom plugin as a streaming plugin?
+    a: |
+      No, there are some limitations. The plugin must have only one `handler` and one `schema`, cannot run in the `init_worker` phase or create timers, and must be written in Lua. See the [custom plugin streaming reference](/custom-plugins/streaming-plugins/) for more detail.
+
+cleanup:
+  inline:
+    - title: Clean up Konnect environment
+      include_content: cleanup/platform/konnect
+      icon_url: /assets/icons/gateway.svg
+    - title: Destroy the {{site.base_gateway}} container
+      include_content: cleanup/products/gateway
+      icon_url: /assets/icons/gateway.svg
+---
+
+Normally, deploying a custom plugin requires uploading Lua files to every data plane and restarting {{site.base_gateway}}. 
+With streaming plugins, you define the plugin schema and handler directly in your {{site.base_gateway}} entity configuration. 
+The control plane becomes the single source of truth and distributes the plugin to all connected data planes automatically, with no file management or restarts needed.
+
+In this guide, you'll define two plugins inline to demonstrate how streaming works:
+
+* `replaceme`: Substitutes a target word in the request body with a replacement word before forwarding to the upstream.
+* `reflector`: Returns the request body directly to the caller, bypassing the upstream. This lets you inspect the modified body without needing an external service.
+
+You'll apply `replaceme` globally with a condition so it only runs when the request path does not contain the word `skip`, then validate both cases.
+
+## Create the first plugin
+
+The `replaceme` plugin reads the raw request body, performs a global text substitution, and writes the modified body back before the request is proxied upstream.
+
+```bash
+cat <<'EOF' | deck gateway apply -
+_format_version: "3.0"
+_transform: true
+
+custom_plugins:
+  - name: replaceme
+    schema: |
+      return {
+        name = "replaceme",
+        fields = {
+          {
+            config = {
+              type = "record",
+              fields = {
+                { target_word = { type = "string", required = true } },
+                { replacement_word = { type = "string", required = true } },
+              },
+            },
+          },
+        },
+      }
+    handler: |
+      local WordReplacerHandler = {
+        PRIORITY = 800,
+        VERSION = "1.0.0",
+      }
+      function WordReplacerHandler:access(config)
+        local raw_body, err = kong.request.get_raw_body()
+        if err then
+          kong.log.err("Failed to read request body: ", err)
+          return
+        end
+        if raw_body and raw_body ~= "" then
+          local escaped_target = config.target_word:gsub("([^%w])", "%%%1")
+          local modified_body, count = string.gsub(raw_body, escaped_target, config.replacement_word)
+          if count > 0 then
+            kong.service.request.set_raw_body(modified_body)
+          end
+        end
+      end
+      return WordReplacerHandler
+EOF
+```
+
+Where:
+* `custom_plugins.name`: A unique name for the plugin.
+* `custom_plugins.schema`: The Lua schema definition, which declares the plugin's configuration fields.
+* `custom_plugins.handler`: The Lua handler that contains the plugin logic.
+
+## Create the second plugin
+
+The `reflector` plugin returns the request body directly to the caller with a `200` response, bypassing the upstream entirely. 
+This makes it useful for testing what the request body looks like after earlier plugins have modified it.
+
+The `reflector` plugin has an empty schema because it takes no configuration.
+Its `PRIORITY` is set to `-10` so it runs after `replaceme` (priority `800`), ensuring `replaceme` modifies the body first.
+
+```bash
+cat <<'EOF' | deck gateway apply -
+_format_version: "3.0"
+_transform: true
+
+custom_plugins:
+  - name: reflector
+    schema: 'return { name = "reflector", fields = { { config = { type = "record", fields = {} } } } }'
+    handler: |
+      local ReflectorHandler = {
+        PRIORITY = -10,
+        VERSION = "1.0.0",
+      }
+      function ReflectorHandler:access(config)
+        local body = kong.request.get_raw_body()
+        local headers = kong.request.get_headers()
+        local content_type = headers["content-type"] or "text/plain"
+        return kong.response.exit(200, body, {
+          ["Content-Type"] = content_type
+        })
+      end
+      return ReflectorHandler
+EOF
+```
+
+## Configure the plugins
+
+Now that both plugins are defined, apply them globally.
+Apply `replaceme` with a [condition](/gateway/plugins/expressions/) so it only runs when the request path doesn't contain `skip`:
+
+{% entity_examples %}
+entities:
+  plugins:
+    - name: replaceme
+      condition: '!http.path.contains("skip")'
+      config:
+        target_word: sea
+        replacement_word: pelican
+    - name: reflector
+{% endentity_examples %}
+
+## Validate
+
+Send a request with the word `sea` in the body.
+The `replaceme` plugin substitutes every occurrence of `sea` with `pelican`, and `reflector` returns the modified body directly:
+
+```bash
+curl http://localhost:8000/anything -d 'She sells sea shells by the sea shore.'
+```
+
+You should see the following response:
+
+```text
+She sells pelican shells by the pelican shore.
+```
+{:.no-copy-code}
+
+Now send the same request, but include `skip` somewhere in the path.
+The condition `!http.path.contains("skip")` prevents `replaceme` from running, so the body passes through unchanged:
+
+```bash
+curl http://localhost:8000/anything/skip -d 'She sells sea shells by the sea shore.'
+```
+
+You should see the following response:
+
+```text
+She sells sea shells by the sea shore.
+```
+{:.no-copy-code}

--- a/app/_how-tos/gateway/stream-custom-plugins.md
+++ b/app/_how-tos/gateway/stream-custom-plugins.md
@@ -20,9 +20,9 @@ tools:
 
 prereqs:
   gateway:
-    - name: "KONG_CUSTOM_PLUGINS_ENABLED=true"
+    - name: "KONG_CUSTOM_PLUGINS_ENABLED=on"
   konnect:
-    - name: "KONG_CUSTOM_PLUGINS_ENABLED=true"
+    - name: "KONG_CUSTOM_PLUGINS_ENABLED=on"
   entities:
     services:
         - example-service

--- a/app/_how-tos/gateway/stream-custom-plugins.md
+++ b/app/_how-tos/gateway/stream-custom-plugins.md
@@ -20,9 +20,9 @@ tools:
 
 prereqs:
   gateway:
-    - name: "KONG_CUSTOM_PLUGINS_ENABLED=on"
+    - name: "KONG_CUSTOM_PLUGIN_STREAMING_ENABLED=on"
   konnect:
-    - name: "KONG_CUSTOM_PLUGINS_ENABLED=on"
+    - name: "KONG_CUSTOM_PLUGIN_STREAMING_ENABLED=on"
   entities:
     services:
         - example-service

--- a/app/_how-tos/gateway/stream-custom-plugins.md
+++ b/app/_how-tos/gateway/stream-custom-plugins.md
@@ -19,6 +19,10 @@ tools:
     - deck
 
 prereqs:
+  inline:
+    - title: Set up permissions
+      include_content: prereqs/custom-plugin-permissions
+      icon_url: /assets/icons/kogo-white.svg
   gateway:
     - name: "KONG_CUSTOM_PLUGIN_STREAMING_ENABLED=on"
   konnect:

--- a/app/_how-tos/gateway/stream-custom-plugins.md
+++ b/app/_how-tos/gateway/stream-custom-plugins.md
@@ -76,7 +76,7 @@ You'll apply `replaceme` globally with a condition so it only runs when the requ
 The `replaceme` plugin reads the raw request body, performs a global text substitution, and writes the modified body back before the request is proxied upstream.
 
 ```bash
-cat <<'EOF' | deck gateway apply -
+cat <<'EOF' | deck gateway apply --include-plugin-definitions -
 _format_version: "3.0"
 _transform: true
 
@@ -134,7 +134,7 @@ The `reflector` plugin has an empty schema because it takes no configuration.
 Its `PRIORITY` is set to `-10` so it runs after `replaceme` (priority `800`), ensuring `replaceme` modifies the body first.
 
 ```bash
-cat <<'EOF' | deck gateway apply -
+cat <<'EOF' | deck gateway apply --include-plugin-definitions -
 _format_version: "3.0"
 _transform: true
 
@@ -172,6 +172,8 @@ entities:
         target_word: sea
         replacement_word: pelican
     - name: reflector
+deck_flags:
+  - "--include-plugin-definitions"
 {% endentity_examples %}
 
 ## Validate

--- a/app/_includes/components/entity_examples.html
+++ b/app/_includes/components/entity_examples.html
@@ -2,6 +2,6 @@
 echo '
 _format_version: "3.0"
 {{ entity_examples.data }}
-' | deck gateway apply -
+' | deck gateway apply{% if entity_examples.deck_flags != empty %} {{ entity_examples.deck_flags | join: " " }}{%- endif %} -
 ```
 {:  data-test-step="block" }

--- a/app/_includes/prereqs/custom-plugin-permissions.md
+++ b/app/_includes/prereqs/custom-plugin-permissions.md
@@ -1,0 +1,6 @@
+If you're not using the Gateway quickstart, make sure your Gateway user has `super-admin` or `admin` permissions (not `workspace-super-admin` or `workspace-admin`.)
+The quickstart demo user has these permissions by default.
+{: data-deployment-topology="on-prem" }
+
+Ensure your {{site.konnect_short_name}} account has one of the following [control plane roles](/konnect-platform/teams-and-roles/#control-planes): `ServiceAdmin`, `RouteAdmin`, `PluginAdmin`, `CPAdmin`, or `Deployer`.
+{: data-deployment-topology="konnect" }

--- a/app/_includes/prereqs/products/konnect.md
+++ b/app/_includes/prereqs/products/konnect.md
@@ -16,7 +16,7 @@ This is a Konnect tutorial and requires a Konnect personal access token.
 
    ```bash
    curl -Ls https://get.konghq.com/quickstart | bash -s -- -k $KONNECT_TOKEN \{% for variable in include.env_variables %}
-        -e {{ variable.name }}{% if variable.value %}={{ variable.value }}{% endif %}{% endfor %}{% if include.ports %}{% for port in include.ports %} -p {{ port }}{% endfor %}{% endif %} \
+        -e {{ variable.name }}{% if variable.value %}={{ variable.value }}{% endif %}{% endfor %}{% if include.ports %}{% for port in include.ports %} -p {{ port }}{% endfor %} \{% endif %}
         --deck-output
    ```
 

--- a/app/_includes/prereqs/products/konnect.md
+++ b/app/_includes/prereqs/products/konnect.md
@@ -15,7 +15,9 @@ This is a Konnect tutorial and requires a Konnect personal access token.
 1. Run the [quickstart script](https://get.konghq.com/quickstart) to automatically provision a Control Plane and Data Plane, and configure your environment:
 
    ```bash
-   curl -Ls https://get.konghq.com/quickstart | bash -s -- -k $KONNECT_TOKEN{% for variable in include.env_variables %} -e {{ variable.name }}{% if variable.value %}={{ variable.value }}{% endif %}{% endfor %}{% if include.ports %}{% for port in include.ports %} -p {{ port }}{% endfor %}{% endif %} --deck-output
+   curl -Ls https://get.konghq.com/quickstart | bash -s -- -k $KONNECT_TOKEN \{% for variable in include.env_variables %}
+        -e {{ variable.name }}{% if variable.value %}={{ variable.value }}{% endif %}{% endfor %}{% if include.ports %}{% for port in include.ports %} -p {{ port }}{% endfor %}{% endif %} \
+        --deck-output
    ```
 
    This sets up a Konnect Control Plane named `quickstart`, provisions a local Data Plane, and prints out the following environment variable exports:

--- a/app/_plugins/drops/entity_examples.rb
+++ b/app/_plugins/drops/entity_examples.rb
@@ -24,6 +24,10 @@ module Jekyll
         @template ||= File.expand_path('app/_includes/components/entity_examples.html')
       end
 
+      def deck_flags
+        @deck_flags ||= @config.fetch('deck_flags', [])
+      end
+
       def variables
         @variables ||= @config.fetch('variables', {})
       end

--- a/app/custom-plugins/konnect-hybrid-mode.md
+++ b/app/custom-plugins/konnect-hybrid-mode.md
@@ -258,6 +258,17 @@ Based on your specific use case, you have to take one of the following paths:
 {% endnavtab %}
 {% endnavtabs %}
 
+## Streaming plugins {% new_in 3.15 %}
+
+Instead of uploading plugin files to each data plane manually, you can define the plugin schema and handler directly in {{site.base_gateway}} entity configuration.
+The control plane streams the plugin to all connected data planes automatically, with no file management or node restarts needed.
+
+Streaming plugins have some additional constraints compared to file-based plugins:
+they must be written in Lua, can only use a single `handler` and `schema`, and cannot run in the `init_worker` phase or create timers.
+
+For the full list of requirements and limitations, see [Streaming custom plugins](/custom-plugins/streaming-plugins/).
+For a step-by-step example, see [Stream {{site.base_gateway}} plugins](/how-to/stream-custom-plugins/).
+
 ## Troubleshooting custom plugins in {{site.konnect_short_name}}
 
 Common issues that you might encounter when working with custom plugins in {{site.konnect_short_name}}.

--- a/app/custom-plugins/reference.md
+++ b/app/custom-plugins/reference.md
@@ -40,6 +40,8 @@ related_resources:
     url: /custom-plugins/deployment-options/
   - text: Installation and distribution
     url: /custom-plugins/installation-and-distribution/
+  - text: Streaming custom plugins
+    url: /custom-plugins/streaming-plugins/
 ---
 
 Kong allows you to develop and deploy custom plugins.

--- a/app/custom-plugins/streaming-plugins.md
+++ b/app/custom-plugins/streaming-plugins.md
@@ -57,6 +57,12 @@ Keep the following custom plugin limitations in mind for streaming plugins:
 * Custom validation must be implemented in `handler.lua`, not `schema.lua`. In `handler.lua`, it can be logged and handled as part of plugin business logic.
 * Plugins can't read/write to the {{site.base_gateway}} filesystem.
 
+## Permissions required
+
+To create streaming plugins, you must have the following permissions:
+* {{site.konnect_short_name}}: One of the following [control plane roles](/konnect-platform/teams-and-roles/#control-planes): `ServiceAdmin`, `RouteAdmin`, `PluginAdmin`, `CPAdmin`, or `Deployer`.
+* Self-managed {{site.base_gateway}}: `super-admin` or `admin` role.
+
 ## How do I add a streamed plugin?
 
 {% navtabs 'streaming' %}
@@ -153,3 +159,13 @@ plugins:
 ```
 
 For a complete end-to-end tutorial, see [Stream {{site.base_gateway}} plugins](/how-to/stream-custom-plugins/).
+
+## Streaming plugin update path
+
+If you need to make any changes to the handler or schema of the streaming plugin, we recommend the following approach for safe migration:
+
+1. Start a migration/maintenance window.
+1. Create a new version of the custom plugin.
+1. Update all the instances of the custom plugin to comply with the new version's schema.
+1. Remove the old version of the custom plugin.
+1. Stop the migration/maintenance window.

--- a/app/custom-plugins/streaming-plugins.md
+++ b/app/custom-plugins/streaming-plugins.md
@@ -52,7 +52,7 @@ In these modes, the plugin is defined in the entity configuration directly, and 
 Keep the following custom plugin limitations in mind for streaming plugins:
 
 * Only `schema.lua` and `handler.lua` are supported. Plugin logic must be self-contained in these two modules.
-You can't use DAOs, custom APIs, migrations, or multiple Lua modules.
+  You can't use DAOs, custom APIs, migrations, or multiple Lua modules.
 * Custom modules cannot be required when plugin sandboxing is enabled. External Lua files or shared libraries can't be loaded.
 * Custom validation must be implemented in `handler.lua`, not `schema.lua`. In `handler.lua`, it can be logged and handled as part of plugin business logic.
 * Plugins can't read/write to the {{site.base_gateway}} filesystem.

--- a/app/custom-plugins/streaming-plugins.md
+++ b/app/custom-plugins/streaming-plugins.md
@@ -158,7 +158,7 @@ plugins:
       another_example_field: bar
 ```
 
-For a complete end-to-end tutorial, see [Stream {{site.base_gateway}} plugins](/how-to/stream-custom-plugins/).
+For a complete end-to-end example, see [Stream {{site.base_gateway}} plugins](/how-to/stream-custom-plugins/).
 
 ## Streaming plugin update path
 

--- a/app/custom-plugins/streaming-plugins.md
+++ b/app/custom-plugins/streaming-plugins.md
@@ -1,0 +1,155 @@
+---
+title: Streaming custom plugins
+content_type: reference
+layout: reference
+
+breadcrumbs:
+  - /custom-plugins/
+
+products:
+    - gateway
+
+works_on:
+    - konnect
+    - on-prem
+
+description: "Define custom plugin logic directly in {{site.base_gateway}} configuration and have it distributed to all data planes automatically."
+tags:
+  - custom-plugins
+
+min_version:
+  gateway: '3.15'
+
+related_resources:
+  - text: Custom plugins
+    url: /custom-plugins/
+  - text: Custom plugins reference
+    url: /custom-plugins/reference/
+  - text: Installation and distribution
+    url: /custom-plugins/installation-and-distribution/
+  - text: Deployment options
+    url: /custom-plugins/deployment-options/
+---
+
+You can define a custom plugin directly in Kong entity configuration.
+
+## How does custom plugin streaming work? 
+
+{{site.base_gateway}} can stream custom plugins from the control plane to the data plane. 
+The control plane becomes the single source of truth for plugin versions. You only need to define the plugin once, and {{site.base_gateway}} handles distribution to all data planes in the same control plane.
+
+A streamed custom plugin must meet the following requirements: 
+* Unique name per plugin
+* One plugin `handler` and one `schema`
+* Cannot run in the `init_worker` phase or create timers
+* Must be written in Lua
+
+You can also define streaming plugins in traditional or DB-less mode.
+In these modes, the plugin is defined in the entity configuration directly, and no separate files are needed.
+
+## Streaming plugin limitations
+
+Keep the following custom plugin limitations in mind for streaming plugins:
+
+* Only `schema.lua` and `handler.lua` are supported. Plugin logic must be self-contained in these two modules.
+You can't use DAOs, custom APIs, migrations, or multiple Lua modules.
+* Custom modules cannot be required when plugin sandboxing is enabled. External Lua files or shared libraries can't be loaded.
+* Custom validation must be implemented in `handler.lua`, not `schema.lua`. In `handler.lua`, it can be logged and handled as part of plugin business logic.
+* Plugins can't read/write to the {{site.base_gateway}} filesystem.
+
+## How do I add a streamed plugin?
+
+{% navtabs 'streaming' %}
+{% navtab "Admin API" %}
+
+You can add custom plugins using the `/custom-plugins` Admin API endpoint.
+If your schema and handler are in separate files, you can use [jq](https://jqlang.org/) to build the request:
+
+```bash
+curl -X POST http://localhost:8001/custom-plugins \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n \
+      --arg name "my-example-plugin" \
+      --arg handler "$(cat handler.lua)" \
+      --arg schema "$(cat schema.lua)" \
+      '{"name":$name,"handler":$handler,"schema":$schema}')"
+```
+
+Or pass the schema and handler inline:
+
+```bash
+curl -X POST http://localhost:8001/custom-plugins \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "my-example-plugin",
+    "schema": "SCHEMA_LUA",
+    "handler": "HANDLER_LUA"
+  }'
+```
+
+{% endnavtab %}
+{% navtab "Konnect API" %}
+
+You can use [jq](https://jqlang.org/) with the following request template to add the plugin using the `/custom-plugins` Control Plane Config API endpoint:
+
+```bash
+curl -X POST $KONNECT_CONTROL_PLANE_URL/v2/control-planes/$CONTROL_PLANE_ID/core-entities/custom-plugins \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $KONNECT_TOKEN" \
+  -d "$(jq -n \
+      --arg name "my-example-plugin" \
+      --arg handler "$(cat handler.lua)" \
+      --arg schema "$(cat schema.lua)" \
+      '{"name":$name,"handler":$handler,"schema":$schema}')" \
+    | jq
+```
+
+{% endnavtab %}
+{% navtab "decK" %}
+```yaml
+_format_version: "3.0"
+custom_plugins:
+ - name: my-example-plugin
+   schema: |
+    return {
+      name = "my-example-plugin",
+      fields = {
+        {
+          config = {
+            type = "record",
+            fields = {
+              { example_field = { type = "string", required = true } },
+              { another_example_field = { type = "string", required = true } },
+            },
+          },
+        },
+      },
+    }
+   handler: |
+    local MyPluginHandler = {
+      PRIORITY = 1000,
+      VERSION = "0.0.1",
+    }
+
+    return MyPluginHandler
+```
+{% endnavtab %}
+{% endnavtabs %}
+
+Once added to configuration, you can manage custom plugins using any of the following methods:
+* [decK](/deck/)
+* [Control Plane Config API](/api/konnect/control-planes-config/v2/)
+* [{{site.konnect_short_name}} UI](https://cloud.konghq.com/)
+
+For example:
+
+```yaml
+plugins:
+  - name: my-example-plugin
+    condition: '!http.path.contains("something")'
+    config:
+      example_field: foo
+      another_example_field: bar
+```
+
+For a complete end-to-end tutorial, see [Stream {{site.base_gateway}} plugins](/how-to/stream-custom-plugins/).


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

References and how-to guides for streaming and cloning plugins.
These were logged as one ticket by product but are actually two separate features that use the same env variable to enable them.

Includes a small fix to the Konnect prereq include to add linebreaks when using env variables.

Fixes #5401 

To do: check when rc2 comes out, but the config parameter looks like it's changing to `custom_plugin_streaming_enabled`.

## Preview Links
How-to guides:
https://deploy-preview-5445--kongdeveloper.netlify.app/how-to/clone-gateway-plugin/
https://deploy-preview-5445--kongdeveloper.netlify.app/how-to/stream-custom-plugins/

References:
https://deploy-preview-5445--kongdeveloper.netlify.app/custom-plugins/streaming-plugins/
https://deploy-preview-5445--kongdeveloper.netlify.app/gateway/entities/plugin/#cloning-plugins
https://deploy-preview-5445--kongdeveloper.netlify.app/custom-plugins/konnect-hybrid-mode/#streaming-plugins