### PR TITLE
fix(link-checker): monkey-patch http/https.request to use setTimeout

### DIFF
--- a/tools/broken-link-checker/full.js
+++ b/tools/broken-link-checker/full.js
@@ -1,3 +1,4 @@
+import "./lib/patch-http-timeout.js";
 import { promises as fs } from "fs";
 import minimist from "minimist";
 import checkSite from "./lib/check-site.js";

--- a/tools/broken-link-checker/lib/check-site.js
+++ b/tools/broken-link-checker/lib/check-site.js
@@ -16,7 +16,7 @@ export default function (options) {
       {
         honorRobotExclusions: false,
         excludedKeywords: options.excluded,
-        maxSocketsPerHost: 128,
+        maxSocketsPerHost: 16,
         cacheResponses: true,
       },
       {

--- a/tools/broken-link-checker/lib/check-url-list.js
+++ b/tools/broken-link-checker/lib/check-url-list.js
@@ -19,7 +19,7 @@ export default function (urls, opts) {
       {
         honorRobotExclusions: false,
         excludedKeywords: ignoredTargets,
-        maxSocketsPerHost: 64,
+        maxSocketsPerHost: 32,
         requestMethod: "get",
         cacheResponses: true,
       },
@@ -55,6 +55,7 @@ export default function (urls, opts) {
               text: result.html.text,
               target: result.url.resolved,
               reason: result.brokenReason,
+              message: result.http?.response?.message,
             };
 
             // Keep a separate list for links that failed with a status code other than 404

--- a/tools/broken-link-checker/lib/patch-http-timeout.js
+++ b/tools/broken-link-checker/lib/patch-http-timeout.js
@@ -1,0 +1,35 @@
+// Adds a default per-socket inactivity timeout to every outgoing http/https
+// request. The link checker uses broken-link-checker@0.7.8 → bhttp, which
+// does not pass a responseTimeout and has no way to configure one from its
+// public API. When the target server (typically a Netlify deploy preview
+// under load) opens the connection but never responds, the request hangs
+// forever and the SiteChecker / HtmlUrlChecker `end` event never fires —
+// stalling CI until GitHub kills the job at the workflow timeout.
+
+import http from "node:http";
+import https from "node:https";
+
+const TIMEOUT_MS = 30_000;
+
+function patch(mod) {
+  const orig = mod.request;
+  mod.request = function patchedRequest(...args) {
+    const req = orig.apply(this, args);
+    req.setTimeout(TIMEOUT_MS, () => {
+      // Skip if the request already finished — a late timer on a pooled
+      // keep-alive socket would otherwise emit 'error' on a ClientRequest
+      // whose listener bhttp has already detached, crashing the process.
+      if (req.destroyed || req.res?.complete) return;
+      const err = new Error(`socket inactivity timeout after ${TIMEOUT_MS}ms`);
+      // Set .code so broken-link-checker classifies this as ERRNO_ETIMEDOUT
+      // (see node_modules/broken-link-checker/lib/internal/checkUrl.js)
+      // rather than BLC_UNKNOWN / "Unknown Error".
+      err.code = "ETIMEDOUT";
+      req.destroy(err);
+    });
+    return req;
+  };
+}
+
+patch(http);
+patch(https);

--- a/tools/broken-link-checker/run.js
+++ b/tools/broken-link-checker/run.js
@@ -1,3 +1,4 @@
+import "./lib/patch-http-timeout.js";
 import { Octokit } from "@octokit/rest";
 import { context } from "@actions/github";
 import minimist from "minimist";
@@ -33,7 +34,8 @@ async function getPRFiles(options) {
 async function getSourceUrlsMappings(options) {
   if (options.type === "pr") {
     const response = await fetch(
-      `${options.baseUrl}/sources_urls_mapping.json`
+      `${options.baseUrl}/sources_urls_mapping.json`,
+      { signal: AbortSignal.timeout(30_000) }
     );
 
     let body = await response.json();


### PR DESCRIPTION
## Description

Monkey-patch #request so that the github action doesn't hang


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
