### PR TITLE
feat(identity): authenticate principals with Basic Auth

### DIFF
--- a/app/_how-tos/gateway/authenticate-principals-with-basic-authentication.md
+++ b/app/_how-tos/gateway/authenticate-principals-with-basic-authentication.md
@@ -77,6 +77,9 @@ status_code: 201
 method: POST
 body:
   username: example-user
+capture:
+  - variable: BASIC_AUTH_ID
+    jq: ".id"
 {% endkonnect_api_request %}
 <!--vale on-->
 

--- a/app/_how-tos/gateway/authenticate-principals-with-basic-authentication.md
+++ b/app/_how-tos/gateway/authenticate-principals-with-basic-authentication.md
@@ -1,0 +1,155 @@
+---
+title: Authenticate Principals with basic authentication
+permalink: /how-to/authenticate-principals-with-basic-authentication/
+content_type: how_to
+related_resources:
+  - text: Authentication
+    url: /gateway/authentication/
+
+description: Use the Basic Authentication plugin to allow Principals to authenticate with a username and password.
+products:
+    - gateway
+
+plugins:
+  - basic-auth
+
+works_on:
+    - on-prem
+    - konnect
+
+min_version:
+  gateway: '3.4'
+
+entities: 
+  - plugin
+  - service
+  - route
+  - principal
+
+tags:
+    - authentication
+
+tldr:
+  q: How do I authenticate Principals with basic authentication?
+  a: |
+    Create a Principal and enable the Basic Authentication plugin globally with `principals.enabled: true`. Set `principals.directory` to your directory ID, then authenticate with the base64-encoded Principal credentials.
+tools:
+    - deck
+
+prereqs:
+  entities:
+    services:
+        - example-service
+    routes:
+        - example-route
+  inline:
+    - title: Kong Identity directory
+      include_content: prereqs/kong-identity-directory
+      icon_url: /assets/icons/identity.svg
+
+cleanup:
+  inline:
+    - title: Clean up Konnect environment
+      include_content: cleanup/platform/konnect
+      icon_url: /assets/icons/gateway.svg
+    - title: Destroy the {{site.base_gateway}} container
+      include_content: cleanup/products/gateway
+      icon_url: /assets/icons/gateway.svg
+---
+
+## Create a Principal
+
+{% include /how-tos/steps/principal.md %}
+
+## Add basic auth credentials
+
+Create basic auth credentials for the Principal in two steps:
+
+Create the username `example-user`:
+
+<!--vale off-->
+{% konnect_api_request %}
+url: /v2/directories/$DIRECTORY_ID/principals/$PRINCIPAL_ID/basic-auths
+status_code: 201
+method: POST
+body:
+  username: example-user
+{% endkonnect_api_request %}
+<!--vale on-->
+
+Then, set the password to: `example-password`
+
+<!--vale off-->
+{% konnect_api_request %}
+url: /v2/directories/$DIRECTORY_ID/principals/$PRINCIPAL_ID/basic-auths/$BASIC_AUTH_ID/passwords
+status_code: 201
+method: POST
+body:
+  secret: example-password
+{% endkonnect_api_request %}
+<!--vale on-->
+
+This sets the following credentials for the Principal:
+
+- Username: `example-user`
+- Password: `example-password`
+
+## Get the directory name
+
+To configure the Basic Auth plugin, you'll need the name of the directory you created. Store it as `DECK_DIRECTORY-NAME` with this script:
+
+{% include /how-tos/steps/get-directory-name.md %}
+
+## Configure the Basic Auth plugin via decK
+
+Enable the [Basic Authentication plugin](/plugins/basic-auth/) to allow users to authenticate with a username and password when they make a request.
+
+{% entity_examples %}
+entities:
+  plugins:
+  - config:
+      hide_credentials: true
+      principals:
+        directory: ${directory_name}
+        enabled: true
+    enabled: true
+    name: basic-auth
+    protocols:
+    - http
+    - https
+    route: example-route
+variables:
+  directory_name:
+    value: $DIRECTORY_NAME
+formats:
+  - deck
+{% endentity_examples %}
+
+This configuration:
+
+- Applies the plugin to `example-route`
+- Sets the authentication method with Principals in the `example-directory` Directory
+
+## Validate
+
+When a Principal authenticates with basic auth, the authorization header must be base64-encoded. For example, since we are using `example-user` as the username and `example-password` as the password, then the field’s value is the base64 encoding of `example-user:example-password`, or `ZXhhbXBsZS11c2VyOmV4YW1wbGUtcGFzc3dvcmQ=`.
+
+First, run the following to verify that unauthorized requests return an error:
+
+<!--vale off-->
+{% validation unauthorized-check %}
+url: /anything
+headers:
+  - 'authorization: Basic wrongpassword'
+{% endvalidation %}
+<!--vale on-->
+
+Then, run the following command to test Principal authentication:
+
+{% validation request-check %}
+url: '/anything'
+display_headers: true
+headers:
+  - 'authorization: Basic ZXhhbXBsZS11c2VyOmV4YW1wbGUtcGFzc3dvcmQ='
+status_code: 200
+{% endvalidation %}

--- a/app/_how-tos/gateway/authenticate-principals-with-basic-authentication.md
+++ b/app/_how-tos/gateway/authenticate-principals-with-basic-authentication.md
@@ -6,7 +6,7 @@ related_resources:
   - text: Authentication
     url: /gateway/authentication/
   - text: Principals and directories
-     url: /identity/principals/ 
+    url: /identity/principals/ 
   
 
 description: Use the Basic Authentication plugin to allow Principals to authenticate with a username and password.

--- a/app/_how-tos/gateway/authenticate-principals-with-basic-authentication.md
+++ b/app/_how-tos/gateway/authenticate-principals-with-basic-authentication.md
@@ -5,6 +5,9 @@ content_type: how_to
 related_resources:
   - text: Authentication
     url: /gateway/authentication/
+  - text: Principals and directories
+     url: /identity/principals/ 
+  
 
 description: Use the Basic Authentication plugin to allow Principals to authenticate with a username and password.
 products:

--- a/app/_how-tos/gateway/authenticate-principals-with-basic-authentication.md
+++ b/app/_how-tos/gateway/authenticate-principals-with-basic-authentication.md
@@ -21,7 +21,7 @@ works_on:
     - konnect
 
 min_version:
-  gateway: '3.4'
+  gateway: '3.15'
 
 entities: 
   - plugin

--- a/app/_how-tos/gateway/authenticate-principals-with-basic-authentication.md
+++ b/app/_how-tos/gateway/authenticate-principals-with-basic-authentication.md
@@ -35,7 +35,7 @@ tags:
 tldr:
   q: How do I authenticate Principals with basic authentication?
   a: |
-    Create a Principal and enable the Basic Authentication plugin globally with `principals.enabled: true`. Set `principals.directory` to your directory ID, then authenticate with the base64-encoded Principal credentials.
+    Create a [Principal](/identity/principals/) and enable the Basic Authentication plugin globally with `principals.enabled: true`. Set `principals.directory` to your directory ID, then authenticate with the base64-encoded Principal credentials.
 tools:
     - deck
 

--- a/app/_includes/how-tos/steps/get-directory-name.md
+++ b/app/_includes/how-tos/steps/get-directory-name.md
@@ -1,0 +1,17 @@
+
+<!--vale off-->
+{% konnect_api_request %}
+url: /v2/directories
+status_code: 200
+method: GET
+capture:
+  - variable: DECK_DIRECTORY_NAME
+    jq: ".data[0].name"
+{% endkonnect_api_request %}
+<!--vale on-->
+
+Export the directory name so decK can read it during sync:
+
+```bash
+export DECK_DIRECTORY_NAME
+```

--- a/app/_includes/how-tos/steps/principal.md
+++ b/app/_includes/how-tos/steps/principal.md
@@ -1,4 +1,4 @@
-Create the Principal by sending a POST request to the `/v2/directories/{directoryId}/principals` [endpoint](/api/konnect/kong-identity/v2/#/operations/createPrincipal):
+Create the Principal by sending a POST request to the `/v2/directories/{directoryId}/principals` endpoint:
 
 <!--vale off-->
 {% konnect_api_request %}

--- a/app/_includes/how-tos/steps/principal.md
+++ b/app/_includes/how-tos/steps/principal.md
@@ -1,0 +1,20 @@
+Create the Principal by sending a POST request to the `/v2/directories/{directoryId}/principals` [endpoint](/api/konnect/kong-identity/v2/#/operations/createPrincipal):
+
+<!--vale off-->
+{% konnect_api_request %}
+url: /v2/directories/$DIRECTORY_ID/principals
+status_code: 201
+method: POST
+body:
+  display_name: "example-principal"
+  description: "Example principal"
+capture:
+  - variable: PRINCIPAL_ID
+    jq: ".id"
+{% endkonnect_api_request %}
+<!--vale on-->
+
+This script:
+
+- Creates a Principal named `example-principal`
+- Saves the returned ID as `$PRINCIPAL_ID`

--- a/app/_indices/identity.yaml
+++ b/app/_indices/identity.yaml
@@ -12,3 +12,4 @@ sections:
       - path: /how-to/configure-kong-identity-oauth-introspection/
       - path: /how-to/configure-kong-identity-upstream-oauth/
       - path: /how-to/kong-identity-dcr/
+      - path: /how-to/authenticate-principals-with-basic-authentication/

--- a/app/_kong_plugins/basic-auth/examples/principal.yaml
+++ b/app/_kong_plugins/basic-auth/examples/principal.yaml
@@ -1,13 +1,13 @@
-description: Authenticate Principals {% new_in 3.15 %} managed by Kong Identity by configuring the `principals` field in the Basic Auth plugin.
+description: Authenticate principals managed by Kong Identity by configuring the `principals` field in the Basic Auth plugin.
 extended_description: |
   You can authenticate Principals managed by Kong Identity in {{site.konnect_short_name}} by configuring the `principals` field in the Baisc Auth plugin. Principals are grouped into regional directories.
 
 
-title: 'Authenticate Principals {% new_in 3.15 %}'
+title: 'Authenticate principals'
 
 requirements:
   - |
-    You have a Kong Identity directory containing Principals in {{site.konnect_short_name}}.
+    A Kong Identity directory with [principals](/identity/principals/) in {{site.konnect_short_name}}.
 
 weight: 898
 
@@ -17,12 +17,9 @@ min_version:
 variables:
   directory_name:
     value: $DIRECTORY_NAME
-    description: The name of the Kong Identity directory to look up Principals in.
+    description: The name of the Kong Identity directory to look up principals in.
 
 config:
-  key_names:
-    - apikey
-  identity_realms: []
   principals:
     enabled: true
     directory: ${directory_name}

--- a/app/_kong_plugins/basic-auth/examples/principal.yaml
+++ b/app/_kong_plugins/basic-auth/examples/principal.yaml
@@ -1,0 +1,35 @@
+description: Authenticate Principals {% new_in 3.15 %} managed by Kong Identity by configuring the `principals` field in the Basic Auth plugin.
+extended_description: |
+  You can authenticate Principals managed by Kong Identity in {{site.konnect_short_name}} by configuring the `principals` field in the Baisc Auth plugin. Principals are grouped into regional directories.
+
+  For a full tutorial of this example, see [Authenticate Principals with the Key Authentication plugin](/how-to/authenticate-principals-with-basic-auth/).
+
+title: 'Authenticate Principals {% new_in 3.15 %}'
+
+requirements:
+  - |
+    You have a Kong Identity directory containing Principals in {{site.konnect_short_name}}.
+
+weight: 898
+
+min_version:
+  gateway: '3.15'
+
+variables:
+  directory_name:
+    value: $DIRECTORY_NAME
+    description: The name of the Kong Identity directory to look up Principals in.
+
+config:
+  key_names:
+    - apikey
+  identity_realms: []
+  principals:
+    enabled: true
+    directory: ${directory_name}
+
+tools:
+  - deck
+  - konnect-api
+  - kic
+  - terraform

--- a/app/_kong_plugins/basic-auth/examples/principal.yaml
+++ b/app/_kong_plugins/basic-auth/examples/principal.yaml
@@ -2,7 +2,6 @@ description: Authenticate Principals {% new_in 3.15 %} managed by Kong Identity 
 extended_description: |
   You can authenticate Principals managed by Kong Identity in {{site.konnect_short_name}} by configuring the `principals` field in the Baisc Auth plugin. Principals are grouped into regional directories.
 
-  For a full tutorial of this example, see [Authenticate Principals with the Key Authentication plugin](/how-to/authenticate-principals-with-basic-auth/).
 
 title: 'Authenticate Principals {% new_in 3.15 %}'
 

--- a/app/_kong_plugins/basic-auth/index.md
+++ b/app/_kong_plugins/basic-auth/index.md
@@ -35,7 +35,7 @@ search_aliases:
   - username and password auth
 
 faqs:
-  - q: I updated my Consumer's username, why doesn't their password or basic authentication work anymore?
+  - q: I updated my Consumer/Principal's username, why doesn't their password or basic authentication work anymore?
     a: The basic auth password credential is encrypted in the database. {{site.base_gateway}} can only get the encrypted value of the password from the database. When you update the username or tag, {{site.base_gateway}} overwrites the password with its encrypted value. To fix this, enter the original password when you update the username or tag of the basic auth credential.
   - q: How do I delete a Consumer credential?
     a: You can delete a specific credential by sending a `DELETE` request to `/{workspace_id_or_name}/consumers/{consumer_id_or_name}/basic-auth/{credentials_id}`.
@@ -52,21 +52,21 @@ min_version:
   gateway: '1.0'
 ---
 
-The [Basic Authentication](https://datatracker.ietf.org/doc/html/rfc7617 ) plugin enforces username and password authentication for [Consumers](/gateway/entities/consumer/) when making a request to a [Gateway Service](/gateway/entities/service/) or [Route](/gateway/entities/route/). Consumers represent a developer or an application consuming the upstream service. 
+The [Basic Authentication](https://datatracker.ietf.org/doc/html/rfc7617 ) plugin enforces username and password authentication for [Consumers](/gateway/entities/consumer/) or [Principals](/identity/principals/) {% new_in 3.15 %} when making a request to a [Gateway Service](/gateway/entities/service/) or [Route](/gateway/entities/route/). Consumers and Principals represent a developer or an application consuming the upstream service. 
 
 Basic authentication can be used with both HTTP and HTTPS requests and is an effective way to add simple password protection to web applications.
 
 ## How it works
 
-The Basic Authentication plugin requires at least one Consumer to work. When you create the Consumer, you must specify a username and password, for example: `Ariel:Password`. The Consumer's password must be base64-encoded when it's used in the Authentication header. For example, `Ariel:Password` would become `QXJpZWw6UGFzc3dvcmQ=`.
+The Basic Authentication plugin requires at least one Consumer or a Principal {% new_in 3.15 %} to work. When you create the Consumer or the Principal, you must specify a username and password, for example: `Ariel:Password`. The credentials must be base64-encoded when it's used in the Authentication header. For example, `Ariel:Password` would become `QXJpZWw6UGFzc3dvcmQ=`.
 
-Then, you can enable the plugin on a Gateway Service, Route, or globally. When a Consumer makes a request to the associated Gateway Service or Route, the plugin checks for valid credentials in the `Proxy-Authorization` and `Authorization` headers (in that order). In {{site.base_gateway}} 3.13 or later, you can [protect against brute force attacks](#brute-force-protection) by enabling `config.brute_force_protection`. This will return an `429 Too Many Requests` error after the fourth failed login attempt.
+Then, you can enable the plugin on a Gateway Service, Route, or globally. When either a Consumer or a Principal {% new_in 3.15 %} makes a request to the associated Gateway Service or Route, the plugin checks for valid credentials in the `Proxy-Authorization` and `Authorization` headers (in that order). In {{site.base_gateway}} 3.13 or later, you can [protect against brute force attacks](#brute-force-protection) by enabling `config.brute_force_protection`. This will return an `429 Too Many Requests` error after the fourth failed login attempt.
 
 ### Using multiple authentication plugins
 
 You can use the Basic Authentication plugin along with other authentication plugins. This allows clients to use different authentication methods to access a given Gateway Service or Route. 
 
-The authentication plugins can be configured to always require authentication or only perform authentication if the Consumer wasn't already authenticated. For more information, see [Using multiple authentication methods](/gateway/authentication/#using-multiple-authentication-methods).
+The authentication plugins can be configured to always require authentication or only perform authentication if the Consumer or the Principal wasn't already authenticated. For more information, see [Using multiple authentication methods](/gateway/authentication/#using-multiple-authentication-methods).
 
 ## Use cases
 
@@ -83,9 +83,9 @@ rows:
   - use_case: "Allow or deny requests on a Gateway Service or Route"
     description: "Configure both the [ACL](/plugins/acl/) and Basic Authentication plugins to restrict access to a Service or a Route by adding Consumers to allowed or denied lists using arbitrary ACL groups."
   - use_case: "Authenticate on the upstream service"
-    description: "Configure the Basic Authentication plugin on a Route and then configure the Consumer credential in the `config.add.headers` property for the [Request Transformer](/plugins/request-transformer/) plugin."
+    description: "Configure the Basic Authentication plugin on a Route and then configure the  or the Principal credential in the `config.add.headers` property for the [Request Transformer](/plugins/request-transformer/) plugin."
   - use_case: "[Allow clients to choose their authentication method](/how-to/allow-multiple-authentication/)"
-    description: "Enable the Basic Authentication plugin and any other authentication plugins. Use the `config.anonymous` property on the plugins to determine if authentication is always performed or only when the Consumer wasn't already authenticated."
+    description: "Enable the Basic Authentication plugin and any other authentication plugins. Use the `config.anonymous` property on the plugins to determine if authentication is always performed or only when the Consumer or the Principals wasn't already authenticated."
   - use_case: "Check credentials per session"
     description: "When the [Session](/plugins/session/) plugin is enabled in conjunction with an authentication plugin, it runs before credential verification. If no session is found, then the authentication plugin runs again and credentials are checked normally. If the credential verification is successful, then the Session plugin creates a new session for usage with subsequent requests."
   - use_case: "Rate limit unauthenticated and authenticated users differently"

--- a/app/_kong_plugins/basic-auth/index.md
+++ b/app/_kong_plugins/basic-auth/index.md
@@ -35,7 +35,7 @@ search_aliases:
   - username and password auth
 
 faqs:
-  - q: I updated my Consumer/Principal's username, why doesn't their password or basic authentication work anymore?
+  - q: I updated my Consumer/principal's username, why doesn't their password or basic authentication work anymore?
     a: The basic auth password credential is encrypted in the database. {{site.base_gateway}} can only get the encrypted value of the password from the database. When you update the username or tag, {{site.base_gateway}} overwrites the password with its encrypted value. To fix this, enter the original password when you update the username or tag of the basic auth credential.
   - q: How do I delete a Consumer credential?
     a: You can delete a specific credential by sending a `DELETE` request to `/{workspace_id_or_name}/consumers/{consumer_id_or_name}/basic-auth/{credentials_id}`.
@@ -52,21 +52,21 @@ min_version:
   gateway: '1.0'
 ---
 
-The [Basic Authentication](https://datatracker.ietf.org/doc/html/rfc7617 ) plugin enforces username and password authentication for [Consumers](/gateway/entities/consumer/) or [Principals](/identity/principals/) {% new_in 3.15 %} when making a request to a [Gateway Service](/gateway/entities/service/) or [Route](/gateway/entities/route/). Consumers and Principals represent a developer or an application consuming the upstream service. 
+The [Basic Authentication](https://datatracker.ietf.org/doc/html/rfc7617 ) plugin enforces username and password authentication for [Consumers](/gateway/entities/consumer/) or [principals](/identity/principals/) {% new_in 3.15 %} when making a request to a [Gateway Service](/gateway/entities/service/) or [Route](/gateway/entities/route/). Consumers and principals represent a developer or an application consuming the upstream service. 
 
 Basic authentication can be used with both HTTP and HTTPS requests and is an effective way to add simple password protection to web applications.
 
 ## How it works
 
-The Basic Authentication plugin requires at least one Consumer or a Principal {% new_in 3.15 %} to work. When you create the Consumer or the Principal, you must specify a username and password, for example: `Ariel:Password`. The credentials must be base64-encoded when it's used in the Authentication header. For example, `Ariel:Password` would become `QXJpZWw6UGFzc3dvcmQ=`.
+The Basic Authentication plugin requires at least one Consumer or a principal {% new_in 3.15 %} to work. When you create the Consumer or the [principal](/identity/principals/), you must specify a username and password, for example: `Ariel:Password`. The credentials must be base64-encoded when it's used in the Authentication header. For example, `Ariel:Password` would become `QXJpZWw6UGFzc3dvcmQ=`.
 
-Then, you can enable the plugin on a Gateway Service, Route, or globally. When either a Consumer or a Principal {% new_in 3.15 %} makes a request to the associated Gateway Service or Route, the plugin checks for valid credentials in the `Proxy-Authorization` and `Authorization` headers (in that order). In {{site.base_gateway}} 3.13 or later, you can [protect against brute force attacks](#brute-force-protection) by enabling `config.brute_force_protection`. This will return an `429 Too Many Requests` error after the fourth failed login attempt.
+Then, you can enable the plugin on a Gateway Service, Route, or globally. When either a Consumer or a principal {% new_in 3.15 %} makes a request to the associated Gateway Service or Route, the plugin checks for valid credentials in the `Proxy-Authorization` and `Authorization` headers (in that order). In {{site.base_gateway}} 3.13 or later, you can [protect against brute force attacks](#brute-force-protection) by enabling `config.brute_force_protection`. This will return an `429 Too Many Requests` error after the fourth failed login attempt.
 
 ### Using multiple authentication plugins
 
 You can use the Basic Authentication plugin along with other authentication plugins. This allows clients to use different authentication methods to access a given Gateway Service or Route. 
 
-The authentication plugins can be configured to always require authentication or only perform authentication if the Consumer or the Principal wasn't already authenticated. For more information, see [Using multiple authentication methods](/gateway/authentication/#using-multiple-authentication-methods).
+The authentication plugins can be configured to always require authentication or only perform authentication if the Consumer or the principal wasn't already authenticated. For more information, see [Using multiple authentication methods](/gateway/authentication/#using-multiple-authentication-methods).
 
 ## Use cases
 
@@ -83,9 +83,9 @@ rows:
   - use_case: "Allow or deny requests on a Gateway Service or Route"
     description: "Configure both the [ACL](/plugins/acl/) and Basic Authentication plugins to restrict access to a Service or a Route by adding Consumers to allowed or denied lists using arbitrary ACL groups."
   - use_case: "Authenticate on the upstream service"
-    description: "Configure the Basic Authentication plugin on a Route and then configure the  or the Principal credential in the `config.add.headers` property for the [Request Transformer](/plugins/request-transformer/) plugin."
+    description: "Configure the Basic Authentication plugin on a Route and then configure the Consumer or the principal credential in the `config.add.headers` property for the [Request Transformer](/plugins/request-transformer/) plugin."
   - use_case: "[Allow clients to choose their authentication method](/how-to/allow-multiple-authentication/)"
-    description: "Enable the Basic Authentication plugin and any other authentication plugins. Use the `config.anonymous` property on the plugins to determine if authentication is always performed or only when the Consumer or the Principals wasn't already authenticated."
+    description: "Enable the Basic Authentication plugin and any other authentication plugins. Use the `config.anonymous` property on the plugins to determine if authentication is always performed or only when the Consumer or the principals wasn't already authenticated."
   - use_case: "Check credentials per session"
     description: "When the [Session](/plugins/session/) plugin is enabled in conjunction with an authentication plugin, it runs before credential verification. If no session is found, then the authentication plugin runs again and credentials are checked normally. If the credential verification is successful, then the Session plugin creates a new session for usage with subsequent requests."
   - use_case: "Rate limit unauthenticated and authenticated users differently"


### PR DESCRIPTION

## Description

closes #5037 

This PR contains a new guide for Kong Identity, using Principals and Basic Auth. It should be merged after https://github.com/Kong/developer.konghq.com/pull/5327
 
## Preview Links

- NEW: [how-to](https://deploy-preview-5451--kongdeveloper.netlify.app/how-to/authenticate-principals-with-basic-authentication/)
- [Plugin overview](https://deploy-preview-5451--kongdeveloper.netlify.apphttps://deploy-preview-5451--kongdeveloper.netlify.app/plugins/basic-auth/)
- [Plugin example config](https://deploy-preview-5451--kongdeveloper.netlify.app/plugins/basic-auth/examples/principal/)

## Test instructions

- Use a control plane from `.tech`, and when deploying the data plane, at the bottom of the script, replace `kong/kong-gateway:3.14` by `kong/kong-gateway-dev:3.15.0.0-rc.5`
- Use this environment variable: `export KONNECT_CONTROL_PLANE_URL=https://us.api.konghq.tech` 
- Replace the API endpoints: instead of `us.api.konghq.com`, use `us.api.konghq.tech`

## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [x] Add new pages to the product documentation index (if applicable).
