### PR TITLE
feat(gateway): Datakit property node non_nil support

### DIFF
--- a/app/_kong_plugins/datakit/index.md
+++ b/app/_kong_plugins/datakit/index.md
@@ -1219,6 +1219,7 @@ If the retrieved value is `nil` or `null`, the plugin errors instead of continui
 - name: GET_SRC
   type: property
   property: kong.ctx.shared.src
+  non_nil: true
 - name: SET_API_KEY
   type: property
   property: kong.ctx.shared.api_key

--- a/app/_kong_plugins/datakit/index.md
+++ b/app/_kong_plugins/datakit/index.md
@@ -1223,7 +1223,7 @@ If the retrieved value is `nil` or `null`, the plugin errors instead of continui
   type: property
   property: kong.ctx.shared.api_key
   non_nil: true
-  input: get_src
+  input: GET_SRC
 ```
 
 #### Supported properties

--- a/app/_kong_plugins/datakit/index.md
+++ b/app/_kong_plugins/datakit/index.md
@@ -1202,6 +1202,30 @@ Field-level output connections are not supported, even if the output data has kn
     id: response.body
 ```
 
+#### Requiring non-nil property values {% new_in 3.15 %}
+
+You can require the result of any operation in a property node to contain a real value by setting `non_nil: true`.
+When set to `true`:
+
+* `get` operations trigger an error instead of sending `nil`/`null` as output
+* `set` operations trigger an error instead of accepting `nil`/`null` as input
+
+This enables you to create configurations with explicit intent and behavior.
+
+For example, you could use a property node to retrieve an API key from `kong.ctx.shared.src`.
+If the retrieved value is `nil` or `null`, the plugin errors instead of continuing:
+
+```yaml
+- name: GET_SRC
+  type: property
+  property: kong.ctx.shared.src
+- name: SET_API_KEY
+  type: property
+  property: kong.ctx.shared.api_key
+  non_nil: true
+  input: get_src
+```
+
 #### Supported properties
 
 The following properties support **get** operations:


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

The Datakit property node now supports setting `non_nil` for any get/set operation to require values to exist and not be nil/null.

Fixes https://konghq.atlassian.net/browse/KAG-9091

## Preview Links
https://deploy-preview-5455--kongdeveloper.netlify.app/plugins/datakit/#requiring-non-nil-property-values

