### PR TITLE
feat(debugger/gateway): Datakit debugger support

### DIFF
--- a/app/observability/debugger-spans.md
+++ b/app/observability/debugger-spans.md
@@ -238,37 +238,6 @@ A span capturing the execution of a plugin configured to run in the `access` pha
 This span has the following attributes:
 {{instance_id}}
 
-### kong.datakit.node.node_name {% new_in 3.15 %}
-
-A span that captures the execution of a single node in the Datakit plugin execution plan.
-One span is created per node, and each span appears as a child of `kong.access.plugin.datakit`.
-
-This span has the following attributes:
-{% table %}
-columns:
-  - title: Name
-    key: name
-  - title: Description
-    key: description
-rows:
-  - name: "`proxy.kong.datakit.node.type`"
-    description: |
-        The type of the node, such as `branch` or `call`. 
-        See the [Datakit nodes reference](/plugins/datakit/#node-types) for all possible node types.
-  - name: "`proxy.kong.datakit.node.status`"
-    description: |
-        Final execution status of the node.
-        <br><br>
-        One of: 
-        * `complete`: node finished successfully
-        * `fail`: node encountered a fatal error
-        * `skip`: node was not executed
-        * `cancel`: execution was halted before completion
-        <br><br>
-        
-        When the status is `fail`, the span also records the error message.
-{% endtable %}
-
 ### kong.dns
 A span capturing the time spent in looking up DNS.
 
@@ -384,3 +353,33 @@ This span has the following attributes:
 
 ### kong.wait_for_client_read
 A span that measures the time Kong spends finishing the response write to the client. This duration may be extended for slow-reading clients, resulting in a longer span.
+
+### kong.datakit.node.node_name {% new_in 3.15 %}
+
+A span that captures the execution of a single node in the Datakit plugin execution plan.
+One span is created for each Datakit node that starts execution, and each span appears as a child of [`kong.access.plugin.datakit`](#kongaccesspluginplugin_name) or [`kong.response.plugin.datakit`](#kongresponsepluginplugin_name).
+
+This span has the following attributes:
+{% table %}
+columns:
+  - title: Name
+    key: name
+  - title: Description
+    key: description
+rows:
+  - name: "`proxy.kong.datakit.node.type`"
+    description: |
+        The type of the node, such as `branch` or `call`. 
+        See the [Datakit nodes reference](/plugins/datakit/#node-types) for all possible node types.
+  - name: "`proxy.kong.datakit.node.status`"
+    description: |
+        Final execution status of the node.
+        <br><br>
+        One of: 
+        * `complete`: node finished successfully
+        * `fail`: node encountered a fatal error
+        * `cancel`: execution was halted before completion
+        <br><br>
+        
+        When the status is `fail`, the span also records the error message.
+{% endtable %}

--- a/app/observability/debugger-spans.md
+++ b/app/observability/debugger-spans.md
@@ -238,6 +238,37 @@ A span capturing the execution of a plugin configured to run in the `access` pha
 This span has the following attributes:
 {{instance_id}}
 
+### kong.datakit.node.node_name {% new_in 3.15 %}
+
+A span that captures the execution of a single node in the Datakit plugin execution plan.
+One span is created per node, and each span appears as a child of `kong.access.plugin.datakit`.
+
+This span has the following attributes:
+{% table %}
+columns:
+  - title: Name
+    key: name
+  - title: Description
+    key: description
+rows:
+  - name: "`proxy.kong.datakit.node.type`"
+    description: |
+        The type of the node, such as `branch` or `call`. 
+        See the [Datakit nodes reference](/plugins/datakit/#node-types) for all possible node types.
+  - name: "`proxy.kong.datakit.node.status`"
+    description: |
+        Final execution status of the node.
+        <br><br>
+        One of: 
+        * `complete`: node finished successfully
+        * `fail`: node encountered a fatal error
+        * `skip`: node was not executed
+        * `cancel`: execution was halted before completion
+        <br><br>
+        
+        When the status is `fail`, the span also records the error message.
+{% endtable %}
+
 ### kong.dns
 A span capturing the time spent in looking up DNS.
 
@@ -353,34 +384,3 @@ This span has the following attributes:
 
 ### kong.wait_for_client_read
 A span that measures the time Kong spends finishing the response write to the client. This duration may be extended for slow-reading clients, resulting in a longer span.
-
-### kong.datakit.node.node_name {% new_in 3.15 %}
-
-A span that captures the execution of a single node in the Datakit plugin execution plan.
-One span is created per node, and each span appears as a child of `kong.access.plugin.datakit`.
-
-This span has the following attributes:
-{% table %}
-columns:
-  - title: Name
-    key: name
-  - title: Description
-    key: description
-rows:
-  - name: "`proxy.kong.datakit.node.type`"
-    description: |
-        The type of the node, such as `branch` or `call`. 
-        See the [Datakit nodes reference](/plugins/datakit/#node-types) for all possible node types.
-  - name: "`proxy.kong.datakit.node.status`"
-    description: |
-        Final execution status of the node.
-        <br><br>
-        One of: 
-        * `complete`: node finished successfully
-        * `fail`: node encountered a fatal error
-        * `skip`: node was not executed
-        * `cancel`: execution was halted before completion
-        <br><br>
-        
-        When the status is `fail`, the span also records the error message.
-{% endtable %}

--- a/app/observability/debugger-spans.md
+++ b/app/observability/debugger-spans.md
@@ -238,7 +238,6 @@ A span capturing the execution of a plugin configured to run in the `access` pha
 This span has the following attributes:
 {{instance_id}}
 
-
 ### kong.dns
 A span capturing the time spent in looking up DNS.
 
@@ -354,3 +353,34 @@ This span has the following attributes:
 
 ### kong.wait_for_client_read
 A span that measures the time Kong spends finishing the response write to the client. This duration may be extended for slow-reading clients, resulting in a longer span.
+
+### kong.datakit.node.node_name {% new_in 3.15 %}
+
+A span that captures the execution of a single node in the Datakit plugin execution plan.
+One span is created per node, and each span appears as a child of `kong.access.plugin.datakit`.
+
+This span has the following attributes:
+{% table %}
+columns:
+  - title: Name
+    key: name
+  - title: Description
+    key: description
+rows:
+  - name: "`proxy.kong.datakit.node.type`"
+    description: |
+        The type of the node, such as `branch` or `call`. 
+        See the [Datakit nodes reference](/plugins/datakit/#node-types) for all possible node types.
+  - name: "`proxy.kong.datakit.node.status`"
+    description: |
+        Final execution status of the node.
+        <br><br>
+        One of: 
+        * `complete`: node finished successfully
+        * `fail`: node encountered a fatal error
+        * `skip`: node was not executed
+        * `cancel`: execution was halted before completion
+        <br><br>
+        
+        When the status is `fail`, the span also records the error message.
+{% endtable %}


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Add Datakit spans to debugger spans reference for 3.15.

Docs for https://konghq.atlassian.net/browse/KAG-9092

## Preview Links

https://deploy-preview-5456--kongdeveloper.netlify.app/observability/debugger-spans/#kong-datakit-node-node-name