### PR TITLE
docs(realm): key-auth centrally-managed consumers require network con…

### DIFF
--- a/app/_kong_plugins/key-auth/examples/identity-realms.yaml
+++ b/app/_kong_plugins/key-auth/examples/identity-realms.yaml
@@ -1,8 +1,8 @@
 description: Authenticate centrally-managed Consumers in {{site.konnect_short_name}} by configuring the `identity_realms` field in the Key Auth plugin.
 extended_description: |
   You can authenticate [consumers that are managed centrally](/gateway/entities/consumer/#centrally-managed-consumers) in {{site.konnect_short_name}} by configuring the `identity_realms` field in the Key Auth plugin. A Data Plane can only reach out to realms in the same region as they are deployed.
-  
-  `identity_realms` are scoped to the Control Plane by default (`scope: cp`). 
+
+  `identity_realms` are scoped to the Control Plane by default (`scope: cp`).
   The order in which you configure the `identity_realms` dictates the priority in which the Data Plane attempts to authenticate the provided API keys.
   See the [realm priority reference](/plugins/key-auth/#identity-realms) for details.
 
@@ -12,8 +12,11 @@ title: 'Realms for external Consumers in Konnect'
 
 requirements:
   - |
-    You have a realm configured with an associated Control Plane in {{site.konnect_short_name}}. 
+    You have a realm configured with an associated Control Plane in {{site.konnect_short_name}}.
     You can do this with the [`/realms`](/api/konnect/consumers/#/operations/list-realms) endpoint.
+  - |
+    The Data Plane has network connectivity to {{site.konnect_short_name}} to reach the identity endpoint `https://%s.identity.konghq.com`, where `%s` is the region.
+    A Data Plane can only reach out to realms in the same region as they are deployed.
 weight: 899
 
 min_version:
@@ -25,10 +28,10 @@ variables:
     description: Region for your {{site.konnect_short_name}} instance.
   realm-id:
     value: $REALM_ID
-    description: The ID of the realm you created in the prerequisites. 
+    description: The ID of the realm you created in the prerequisites.
 
-config: 
-  key_names: 
+config:
+  key_names:
     - apikey
   identity_realms:
     - scope: realm

--- a/app/_kong_plugins/key-auth/examples/identity-realms.yaml
+++ b/app/_kong_plugins/key-auth/examples/identity-realms.yaml
@@ -15,7 +15,7 @@ requirements:
     You have a realm configured with an associated Control Plane in {{site.konnect_short_name}}.
     You can do this with the [`/realms`](/api/konnect/consumers/#/operations/list-realms) endpoint.
   - |
-    The Data Plane has network connectivity to {{site.konnect_short_name}} to reach the identity endpoint `https://%s.identity.konghq.com`, where `%s` is the region.
+    The Data Plane has network connectivity to {{site.konnect_short_name}} to reach the identity endpoint `https://{region}.identity.konghq.com`.
     A Data Plane can only reach out to realms in the same region as they are deployed.
 weight: 899
 

--- a/app/_kong_plugins/key-auth/index.md
+++ b/app/_kong_plugins/key-auth/index.md
@@ -77,7 +77,10 @@ The advanced version of this plugin, [Key Authentication Encrypted](/plugins/key
 You can authenticate [centrally-managed Consumers](/gateway/entities/consumer/#centrally-managed-consumers) in {{site.konnect_short_name}} by configuring the [`config.identity_realms`](./reference/#schema--config-identity-realms) field.
 See [Realms for external Consumers in {{site.konnect_short_name}}](/plugins/key-auth/examples/identity-realms/) for an example configuration.
 
-Identity realms are scoped to the Control Plane by default (`scope: cp`). 
+{:.info}
+> **Note:** Identity realms require the Data Plane to have network connectivity to {{site.konnect_short_name}} to look up centrally-managed Consumers. The Data Plane reaches the realm at the identity endpoint `https://%s.identity.konghq.com`, where `%s` is the region. If the Data Plane can't reach {{site.konnect_short_name}}, realm-scoped authentication won't work.
+
+Identity realms are scoped to the Control Plane by default (`scope: cp`).
 The order in which you configure the identity realm dictates the priority in which the Data Plane attempts to authenticate the provided API keys:
 
 {% table %}
@@ -89,18 +92,18 @@ columns:
 rows:
   - condition: Realm is listed first
     description: |
-      The Data Plane will first reach out to the realm. If the API key is not found in the realm, the Data Plane will look for the API key in the Control Plane config. 
+      The Data Plane will first reach out to the realm. If the API key is not found in the realm, the Data Plane will look for the API key in the Control Plane config.
   - condition: Control plane scope listed first
     description: |
       The Data Plane will initially check the Control Plane configuration (LMDB) for the API key before looking up the API key in the realm.
   - condition: Realm only
     description: |
-      You can configure a single identity realm by removing `cp` from `config.identity_realms.scope`. In this case, the Data Plane will only attempt to authenticate API keys against the realm. 
-      
+      You can configure a single identity realm by removing `cp` from `config.identity_realms.scope`. In this case, the Data Plane will only attempt to authenticate API keys against the realm.
+
       If the API key isn't found, the request will be blocked.
   - condition: Control plane only
     description: |
-      You can configure a lookup only in the Control Plane config by specifying `cp` in `config.identity_realms.scope` and no other identity realm parameters. In this scenario, the Data Plane will only check the Control Plane configuration (LMDB) for API key authentication. 
-      
+      You can configure a lookup only in the Control Plane config by specifying `cp` in `config.identity_realms.scope` and no other identity realm parameters. In this scenario, the Data Plane will only check the Control Plane configuration (LMDB) for API key authentication.
+
       If the API key isn't found, the request will be blocked.
 {% endtable %}

--- a/app/_kong_plugins/key-auth/index.md
+++ b/app/_kong_plugins/key-auth/index.md
@@ -78,7 +78,7 @@ You can authenticate [centrally-managed Consumers](/gateway/entities/consumer/#c
 See [Realms for external Consumers in {{site.konnect_short_name}}](/plugins/key-auth/examples/identity-realms/) for an example configuration.
 
 {:.info}
-> **Note:** Identity realms require the Data Plane to have network connectivity to {{site.konnect_short_name}} to look up centrally-managed Consumers. The Data Plane reaches the realm at the identity endpoint `https://%s.identity.konghq.com`, where `%s` is the region. If the Data Plane can't reach {{site.konnect_short_name}}, realm-scoped authentication won't work.
+> **Note:** Identity realms require the Data Plane to have network connectivity to {{site.konnect_short_name}} to look up centrally-managed Consumers. The Data Plane reaches the realm at the identity endpoint `https:/{region}.identity.konghq.com`. If the Data Plane can't reach {{site.konnect_short_name}}, realm-scoped authentication won't work.
 
 Identity realms are scoped to the Control Plane by default (`scope: cp`).
 The order in which you configure the identity realm dictates the priority in which the Data Plane attempts to authenticate the provided API keys:


### PR DESCRIPTION


<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

FTI: https://konghq.atlassian.net/browse/FTI-7542

Explicitly stating the centrally-managed consumers require network connectivity to the Konnect identity service to validate requests. Some DPs may not have public network connectivity, and hence they do not have access to this feature.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
