### PR TITLE
fix(inso-cli): Add step to install node-libcurl for Inso

### DIFF
--- a/.github/workflows/generate-inso-cli-docs.yaml
+++ b/.github/workflows/generate-inso-cli-docs.yaml
@@ -61,6 +61,9 @@ jobs:
         working-directory: insomnia
         run: npm ci --ignore-scripts
 
+      - name: Install node version of node-libcurl for inso
+        run: npm run install-libcurl-node
+
       - name: Generate Inso CLI reference docs
         working-directory: insomnia
         run: npm run build -w insomnia-inso && $PWD/packages/insomnia-inso/bin/inso generate-docs || true

--- a/.github/workflows/generate-inso-cli-docs.yaml
+++ b/.github/workflows/generate-inso-cli-docs.yaml
@@ -62,8 +62,8 @@ jobs:
         run: npm ci --ignore-scripts
 
       - name: Install node version of node-libcurl for inso
+        working-directory: insomnia
         run: npm run install-libcurl-node
-
       - name: Generate Inso CLI reference docs
         working-directory: insomnia
         run: npm run build -w insomnia-inso && $PWD/packages/insomnia-inso/bin/inso generate-docs || true


### PR DESCRIPTION
## Description

Install missing dep for inso-cli docs

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
