### PR TITLE
Perf/improve hooks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem 'kramdown-parser-gfm'
 gem 'liquid-c'
 gem 'nodo'
 gem 'nokogiri'
+gem 'nokolexbor'
 gem 'rouge', '~> 4.3'
 # XXX: bundler isn't installing mini_portile as a dependency of nokogiri
 # installing it manually fixes the issue

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,7 @@ GEM
     nokogiri (1.19.3)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
+    nokolexbor (0.7.0)
     parallel (1.28.0)
     parser (3.3.11.1)
       ast (~> 2.4.1)
@@ -180,6 +181,7 @@ DEPENDENCIES
   mini_portile2 (~> 2.8)
   nodo
   nokogiri
+  nokolexbor
   pry
   puma
   rouge (~> 4.3)

--- a/app/_includes/install/konnect-cta.html
+++ b/app/_includes/install/konnect-cta.html
@@ -1,5 +1,5 @@
 {% unless page.output_format == 'markdown' %}
-<div class="flex shadow-primary relative border rounded-lg border-transparent background-gradient heading-section">
+<div class="flex shadow-primary relative border rounded-lg border-transparent background-gradient">
     <div class="flex flex-col gap-4 p-5 rounded-md bg-primary">
         <div class="flex items-center gap-3">
             <svg xmlns="http://www.w3.org/2000/svg" height="26" viewBox="0 0 45 40" fill="none">

--- a/app/_plugins/hooks/post_process_html.rb
+++ b/app/_plugins/hooks/post_process_html.rb
@@ -108,7 +108,7 @@ class KongPluginsMetaInjector
   def process
     return unless should_inject?
 
-    inject_meta_tag(build_meta_tag)
+    @page_or_doc.output = @page_or_doc.output.sub('</head>', "  #{build_meta_tag}\n</head>")
   end
 
   private
@@ -123,21 +123,6 @@ class KongPluginsMetaInjector
 
   def build_meta_tag
     %(<meta name="algolia:kong_plugins" content="#{kong_plugins.join(', ')}">)
-  end
-
-  def inject_meta_tag(meta_tag)
-    doc = Nokogiri::HTML(@page_or_doc.output)
-    head = doc.at_css('head')
-
-    last_meta = head.css('meta').last
-
-    if last_meta
-      last_meta.add_next_sibling("\n  #{meta_tag}")
-    else
-      head.prepend_child("#{meta_tag}\n  ")
-    end
-
-    @page_or_doc.output = doc.to_html
   end
 end
 

--- a/app/_plugins/hooks/post_process_html.rb
+++ b/app/_plugins/hooks/post_process_html.rb
@@ -21,14 +21,14 @@ class AddLinksToHeadings # rubocop:disable Style/Documentation
       next if heading.ancestors('.accordion-trigger').any?
       next unless heading['id']
 
-      # handle new-in badge
+      # Use the heading's text content, excluding any new-in badge.
       text = if ['/mesh/changelog/', '/mesh/version-specific-upgrade-notes/'].include?(@page_or_doc.url)
                # special case, it has links in the headings
                heading.content.strip
              else
-               text = heading.children.find(&:text?)&.text&.strip
-               text = heading.content.strip if text.nil? || text.empty?
-               text
+               heading_without_badge = heading.dup
+               heading_without_badge.css('.new-in').each(&:remove)
+               heading_without_badge.content.strip
              end
       old_id = heading['id']
 

--- a/app/_plugins/hooks/sections/base.rb
+++ b/app/_plugins/hooks/sections/base.rb
@@ -25,15 +25,51 @@ module SectionWrapper
     # Build the output as a string instead of mutating the parsed doc.
     # Cross-fragment node moves trigger a use-after-free in Nokolexbor; this
     # avoids the issue entirely by only reading from the parsed tree.
+    #
+    # Boundaries: an h2 starts a new section; a pre-wrapped `.heading-section`
+    # element (e.g. an `{% entity_example %}` block) is emitted as-is and
+    # flushes any open section. Otherwise content accumulates into the
+    # current h2 section, or into the pre-h2 bucket if no h2 is open yet.
     def wrap_sections(content)
       doc = Nokolexbor::DocumentFragment.parse(content)
-      return build_wrapper_string('', '', doc.inner_html) unless doc.at_css('h2')
+      return build_wrapper_string('', '', doc.inner_html) unless any_boundary?(doc.children)
 
-      pre, sections = split_by_heading(doc.children, 'h2')
-      out = +''
-      out << build_wrapper_string('', '', nodes_to_html(pre)) unless pre.empty?
-      sections.each { |h2, body| out << build_section_string(h2, body) }
+      out, pre, h2, body = +'', [], nil, nil
+      doc.children.each do |node|
+        next if whitespace_only_text?(node)
+        if heading?(node, 'h2')
+          out << flush_pending(pre, h2, body); pre = []; h2 = node; body = []
+        elsif pre_wrapped_section?(node)
+          out << flush_pending(pre, h2, body); out << node.to_html
+          pre = []; h2 = nil; body = nil
+        elsif h2
+          body << node
+        else
+          pre << node
+        end
+      end
+      out << flush_pending(pre, h2, body)
       out
+    end
+
+    def flush_pending(pre, h2, body)
+      return build_section_string(h2, body) if h2
+      return build_wrapper_string('', '', nodes_to_html(pre)) if pre.any?
+      ''
+    end
+
+    def any_boundary?(nodes)
+      nodes.any? { |n| heading?(n, 'h2') || pre_wrapped_section?(n) }
+    end
+
+    def pre_wrapped_section?(node)
+      return false unless node.element?
+      (node['class'] || '').split(/\s+/).include?('heading-section')
+    end
+
+    def whitespace_only_text?(node)
+      return false if node.element?
+      node.to_html.strip.empty?
     end
 
     def split_by_heading(nodes, tag)

--- a/app/_plugins/hooks/sections/base.rb
+++ b/app/_plugins/hooks/sections/base.rb
@@ -1,4 +1,4 @@
-require 'nokogiri'
+require 'nokolexbor'
 
 module SectionWrapper
   class Base
@@ -22,70 +22,58 @@ module SectionWrapper
 
     private
 
+    # Build the output as a string instead of mutating the parsed doc.
+    # Cross-fragment node moves trigger a use-after-free in Nokolexbor; this
+    # avoids the issue entirely by only reading from the parsed tree.
     def wrap_sections(content)
-      doc = Nokogiri::HTML::DocumentFragment.parse(content)
+      doc = Nokolexbor::DocumentFragment.parse(content)
+      return build_wrapper_string('', '', doc.inner_html) unless doc.at_css('h2')
 
-      first_h2 = doc.at_css('h2')
-
-      if first_h2
-        # Wrap content before the first h2
-        content = wrap_content(doc, doc.children.take_while { |node| node != first_h2 })
-
-        doc.children.first.add_previous_sibling(content) if content && content.children.any?
-
-        doc.css('h2').each do |h2|
-          next if h2.ancestors('.heading-section').any?
-
-          title = h2.content
-          slug = h2['id']
-
-          wrapper = build_wrapper(section_title(h2, slug, title), h2['data-deployment-topology'])
-
-          # Move content between this h2 and the next one into the wrapper
-          move_sibling_content_into_wrapper(h2, wrapper)
-
-          # Replace the original h2 with the wrapper
-          h2.replace(wrapper)
-        end
-      else
-        wrapper = wrap_content(doc, doc.children)
-        doc.children = wrapper.children
-      end
-
-      # Return the modified HTML as a string
-      doc.to_html
+      pre, sections = split_by_heading(doc.children, 'h2')
+      out = +''
+      out << build_wrapper_string('', '', nodes_to_html(pre)) unless pre.empty?
+      sections.each { |h2, body| out << build_section_string(h2, body) }
+      out
     end
 
-    def wrap_content(doc, nodes)
-      return if nodes.empty?
-
-      wrapper = build_wrapper
-      content = wrapper.at_css('.content')
-      nodes.each { |node| content.add_child(node) }
-      wrapper
+    def split_by_heading(nodes, tag)
+      groups = nodes.to_a.slice_when { |_, b| heading?(b, tag) }.to_a
+      pre = heading?(groups.first&.first, tag) ? [] : (groups.shift || [])
+      sections = groups.map { |g| [g.first, g.drop(1)] }
+      [pre, sections]
     end
 
-    def build_wrapper(section_title = '', _ = '')
-      Nokogiri::HTML::DocumentFragment.parse <<-HTML
+    def heading?(node, tag)
+      node&.element? && node.name == tag
+    end
+
+    def build_section_string(h2, body_nodes)
+      build_wrapper_string(
+        section_title(h2, h2['id'], h2.content),
+        h2['data-deployment-topology'],
+        wrap_section_body(body_nodes)
+      )
+    end
+
+    def wrap_section_body(nodes)
+      nodes_to_html(nodes)
+    end
+
+    def nodes_to_html(nodes)
+      nodes.map(&:to_html).join
+    end
+
+    def section_title(h2, _slug, _title)
+      h2.to_html
+    end
+
+    def build_wrapper_string(title_html, _topology, body_html)
+      <<~HTML
         <div class="flex flex-col gap-4 heading-section">
-            #{section_title}
-            <div class="content"></div>
+          #{title_html}
+          <div class="content">#{body_html}</div>
         </div>
       HTML
-    end
-
-    def move_sibling_content_into_wrapper(h2, wrapper)
-      current_node = h2.next_element
-
-      while current_node && current_node.name != 'h2' && !current_node.matches?('.heading-section')
-        next_node = current_node.next_element
-        wrapper.at_css('.content').add_child(current_node)
-        current_node = next_node
-      end
-    end
-
-    def section_title(h2, slug, title)
-      h2.to_html
     end
   end
 end

--- a/app/_plugins/hooks/sections/base.rb
+++ b/app/_plugins/hooks/sections/base.rb
@@ -72,13 +72,6 @@ module SectionWrapper
       node.to_html.strip.empty?
     end
 
-    def split_by_heading(nodes, tag)
-      groups = nodes.to_a.slice_when { |_, b| heading?(b, tag) }.to_a
-      pre = heading?(groups.first&.first, tag) ? [] : (groups.shift || [])
-      sections = groups.map { |g| [g.first, g.drop(1)] }
-      [pre, sections]
-    end
-
     def heading?(node, tag)
       node&.element? && node.name == tag
     end

--- a/app/_plugins/hooks/sections/base.rb
+++ b/app/_plugins/hooks/sections/base.rb
@@ -60,7 +60,8 @@ module SectionWrapper
       return if nodes.empty?
 
       wrapper = build_wrapper
-      nodes.each { |node| wrapper.at_css('.content').add_child(node) }
+      content = wrapper.at_css('.content')
+      nodes.each { |node| content.add_child(node) }
       wrapper
     end
 

--- a/app/_plugins/hooks/sections/cookbook.rb
+++ b/app/_plugins/hooks/sections/cookbook.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'cgi'
-require 'nokogiri'
 require_relative 'base'
 require_relative 'how-to'
 
@@ -9,42 +8,26 @@ module SectionWrapper
   class Cookbook < HowTo
     private
 
-    def wrap_sections(content)
-      html = super(content)
-      wrap_h4_sections(html)
+    # Hook into the section-body step so h4 wrapping happens in the same pass
+    # as h2 wrapping, with no re-parse and no cross-fragment node moves.
+    def wrap_section_body(nodes)
+      pre, sections = split_by_heading(nodes, 'h4')
+      out = +''
+      out << nodes_to_html(pre)
+      sections.each { |h4, body| out << build_h4_section_string(h4, body) }
+      out
     end
 
-    def wrap_h4_sections(html)
-      doc = Nokogiri::HTML::DocumentFragment.parse(html)
-
-      doc.css('.accordion-panel').each do |panel|
-        h4s = panel.children.select { |n| n.element? && n.name == 'h4' }
-        next if h4s.empty?
-
-        h4s.each do |h4|
-          slug = h4['id']
-          title = h4.content
-
-          wrapper = build_h4_wrapper(h4_section_title(h4, slug, title))
-          content_div = wrapper.at_css('.content')
-
-          current_node = h4.next_element
-          while current_node && !%w[h1 h2 h3 h4].include?(current_node.name)
-            next_node = current_node.next_element
-            content_div.add_child(current_node)
-            current_node = next_node
-          end
-
-          h4.replace(wrapper)
-        end
-      end
-
-      doc.to_html
+    def build_h4_section_string(h4, body_nodes)
+      build_h4_wrapper_string(
+        h4_section_title(h4, h4['id'], h4.content),
+        nodes_to_html(body_nodes)
+      )
     end
 
     def h4_section_title(h4, slug, title)
       escaped_title = CGI.escapeHTML(title)
-      Nokogiri::HTML::DocumentFragment.parse <<-HTML
+      <<~HTML
         <a aria-label="Anchor" href="##{slug}" title="#{escaped_title}" class="link-anchor flex items-center justify-between hover:no-underline accordion-trigger">
           <div class="flex items-center gap-2 group w-full">
             #{h4.to_html}
@@ -59,12 +42,12 @@ module SectionWrapper
       HTML
     end
 
-    def build_h4_wrapper(section_title)
-      Nokogiri::HTML::DocumentFragment.parse <<-HTML
+    def build_h4_wrapper_string(title_html, body_html)
+      <<~HTML
         <div class="accordion">
           <div class="flex flex-col gap-4 border-b border-primary/5 accordion-item">
-            #{section_title}
-            <div class="content accordion-panel"></div>
+            #{title_html}
+            <div class="content accordion-panel">#{body_html}</div>
           </div>
         </div>
       HTML

--- a/app/_plugins/hooks/sections/cookbook.rb
+++ b/app/_plugins/hooks/sections/cookbook.rb
@@ -10,12 +10,37 @@ module SectionWrapper
 
     # Hook into the section-body step so h4 wrapping happens in the same pass
     # as h2 wrapping, with no re-parse and no cross-fragment node moves.
+    #
+    # h4 starts a new accordion-wrapped section; h1/h2/h3 boundaries flush the
+    # current h4 section and pass through as-is (matching the old behavior in
+    # which `move_sibling_content_into_wrapper` stopped at any h1-h4).
     def wrap_section_body(nodes)
-      pre, sections = split_by_heading(nodes, 'h4')
-      out = +''
-      out << nodes_to_html(pre)
-      sections.each { |h4, body| out << build_h4_section_string(h4, body) }
+      out, pre, h4, body = +'', [], nil, nil
+      nodes.each do |node|
+        next if whitespace_only_text?(node)
+        if heading?(node, 'h4')
+          out << flush_h4_pending(pre, h4, body); pre = []; h4 = node; body = []
+        elsif h4_boundary?(node)
+          out << flush_h4_pending(pre, h4, body); out << node.to_html
+          pre = []; h4 = nil; body = nil
+        elsif h4
+          body << node
+        else
+          pre << node
+        end
+      end
+      out << flush_h4_pending(pre, h4, body)
       out
+    end
+
+    def flush_h4_pending(pre, h4, body)
+      return build_h4_section_string(h4, body) if h4
+      return nodes_to_html(pre) if pre.any?
+      ''
+    end
+
+    def h4_boundary?(node)
+      node.element? && %w[h1 h2 h3].include?(node.name)
     end
 
     def build_h4_section_string(h4, body_nodes)

--- a/app/_plugins/hooks/sections/how-to.rb
+++ b/app/_plugins/hooks/sections/how-to.rb
@@ -1,10 +1,8 @@
-require 'nokogiri'
-
 module SectionWrapper
   class HowTo < Base
     def section_title(h2, slug, title)
       h2.add_class('how-to-step--title')
-      Nokogiri::HTML::DocumentFragment.parse <<-HTML
+      <<~HTML
         <a aria-label="Anchor" href="##{slug}" title="#{title}" class="link-anchor flex items-center justify-between hover:no-underline accordion-trigger">
           <div class="flex items-center gap-2 group w-full">
           #{h2.to_html}
@@ -19,23 +17,22 @@ module SectionWrapper
       HTML
     end
 
-    def build_wrapper(section_title = '', topology = '')
-      topology = "data-deployment-topology=\"#{topology}\"" if !topology.nil? && !topology.empty?
-      wrapper = if section_title != ''
-                  <<-HTML
-          <div #{topology} class="flex flex-col gap-4 border-b border-primary/5 pb-8 accordion-item">
-            #{section_title}
-            <div class="content accordion-panel"></div>
+    def build_wrapper_string(title_html, topology, body_html)
+      topology_attr = topology && !topology.empty? ? %( data-deployment-topology="#{topology}") : ''
+      if title_html.to_s.strip.empty?
+        <<~HTML
+          <div#{topology_attr} class="flex flex-col gap-4 border-b border-primary/5 pb-8">
+            <div class="content">#{body_html}</div>
           </div>
-                  HTML
-                else
-                  <<-HTML
-        <div #{topology} class="flex flex-col gap-4 border-b border-primary/5 pb-8">
-          <div class="content"></div>
-        </div>
-                  HTML
-                end
-      Nokogiri::HTML::DocumentFragment.parse(wrapper)
+        HTML
+      else
+        <<~HTML
+          <div#{topology_attr} class="flex flex-col gap-4 border-b border-primary/5 pb-8 accordion-item">
+            #{title_html}
+            <div class="content accordion-panel">#{body_html}</div>
+          </div>
+        HTML
+      end
     end
   end
 end

--- a/app/_plugins/hooks/split_into_sections.rb
+++ b/app/_plugins/hooks/split_into_sections.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'nokogiri'
-
 Jekyll::Hooks.register :documents, :post_convert do |doc, _payload|
   SectionWrapper::Base.make_for(doc).process
 end

--- a/app/_plugins/hooks/strip_release_from_links_in_canonicals.rb
+++ b/app/_plugins/hooks/strip_release_from_links_in_canonicals.rb
@@ -1,31 +1,24 @@
 # frozen_string_literal: true
 
-require 'nokogiri'
-
 class StripReleaseFromLinks
   def initialize(page_or_doc)
     @page_or_doc = page_or_doc
   end
 
-  def process # rubocop:disable Metrics/AbcSize,Metrics/MethodLength,Metrics/CyclomaticComplexity,Metrics/PerceivedComplexity
-    return unless @page_or_doc.data['content_type'] == 'reference' && @page_or_doc.url == @page_or_doc.data['base_url']
-    return unless @page_or_doc.data['versioned']
+  def process
+    return unless applicable?
 
-    doc = Nokogiri::HTML(@page_or_doc.output)
-    changes = false
     release = @page_or_doc.data['release']['release']
+    pattern = %r{href="(/[^"]*)/#{Regexp.escape(release)}/?"}
+    @page_or_doc.output = @page_or_doc.output.gsub(pattern, 'href="\1/"')
+  end
 
-    doc.css('a').each do |link|
-      href = link['href']
+  private
 
-      next unless href&.start_with?('/') && (href&.end_with?("/#{release}/") || href&.end_with?("/#{release}"))
-
-      changes = true
-      modified_href = href.sub(%r{/#{release}/?$}, '/')
-      link['href'] = modified_href
-    end
-
-    @page_or_doc.output = doc.to_html if changes
+  def applicable?
+    @page_or_doc.data['content_type'] == 'reference' &&
+      @page_or_doc.url == @page_or_doc.data['base_url'] &&
+      @page_or_doc.data['versioned']
   end
 end
 

--- a/app/kubernetes-ingress-controller/deployment-topologies/db-backed.md
+++ b/app/kubernetes-ingress-controller/deployment-topologies/db-backed.md
@@ -47,11 +47,11 @@ flowchart LR
 
 A[<img src="/assets/icons/kubernetes.svg" style="max-height:20px"> API Server]
 KIC1[<img src="/assets/icons/gateway.svg" style="max-height:20px"> KIC 
-&lpar;Active&rpar;]
+&amp;lpar;Active&amp;rpar;]
 KIC2[<img src="/assets/icons/gateway.svg" style="max-height:20px"> KIC
-&lpar;Standby&rpar;]
+&amp;lpar;Standby&amp;rpar;]
 KIC3[<img src="/assets/icons/gateway.svg" style="max-height:20px"> KIC
-&lpar;Standby&rpar;]
+&amp;lpar;Standby&amp;rpar;]
 DP1[<img src="/assets/icons/gateway.svg" style="max-height:20px"> Data Plane]
 DP2[<img src="/assets/icons/gateway.svg" style="max-height:20px"> Data Plane]
 DP3[<img src="/assets/icons/gateway.svg" style="max-height:20px"> Data Plane]
@@ -101,11 +101,11 @@ flowchart LR
 
 A[<img src="/assets/icons/kubernetes.svg" style="max-height:20px"> API Server]
 KIC1[<img src="/assets/icons/gateway.svg" style="max-height:20px"> KIC 
-&lpar;Active&rpar;]
+&amp;lpar;Active&amp;rpar;]
 KIC2[<img src="/assets/icons/gateway.svg" style="max-height:20px"> KIC
-&lpar;Standby&rpar;]
+&amp;lpar;Standby&amp;rpar;]
 KIC3[<img src="/assets/icons/gateway.svg" style="max-height:20px"> KIC
-&lpar;Standby&rpar;]
+&amp;lpar;Standby&amp;rpar;]
 CP[<img src="/assets/icons/gateway.svg" style="max-height:20px"> Control Plane]
 DP1[<img src="/assets/icons/gateway.svg" style="max-height:20px"> Data Plane]
 DP2[<img src="/assets/icons/gateway.svg" style="max-height:20px"> Data Plane]

--- a/app/kubernetes-ingress-controller/deployment-topologies/gateway-discovery.md
+++ b/app/kubernetes-ingress-controller/deployment-topologies/gateway-discovery.md
@@ -53,11 +53,11 @@ flowchart LR
 
 A[<img src="/assets/icons/kubernetes.svg" style="max-height:20px"> API Server]
 KIC1[<img src="/assets/icons/gateway.svg" style="max-height:20px"> KIC 
-&lpar;Active&rpar;]
+&amp;lpar;Active&amp;rpar;]
 KIC2[<img src="/assets/icons/gateway.svg" style="max-height:20px"> KIC
-&lpar;Standby&rpar;]
+&amp;lpar;Standby&amp;rpar;]
 KIC3[<img src="/assets/icons/gateway.svg" style="max-height:20px"> KIC
-&lpar;Standby&rpar;]
+&amp;lpar;Standby&amp;rpar;]
 DP1[<img src="/assets/icons/gateway.svg" style="max-height:20px"> Data Plane]
 DP2[<img src="/assets/icons/gateway.svg" style="max-height:20px"> Data Plane]
 DP3[<img src="/assets/icons/gateway.svg" style="max-height:20px"> Data Plane]


### PR DESCRIPTION
## Description

Several perf improvements to reduce the build time:

* use nokolexbor instead of nokogiri
* skip full doc parse + serialize when a simple gsub is enough
* cache some variables

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
