### PR TITLE
feat(Platform): Multiple products entities

### DIFF
--- a/app/_data/schemas/frontmatter/base.json
+++ b/app/_data/schemas/frontmatter/base.json
@@ -73,6 +73,18 @@
     "tags": {
       "type": "array",
       "items": { "$ref": "schema:tags" }
+    },
+    "tier": {
+      "type": "string"
+    },
+    "tiers": {
+      "type": "object",
+      "patternProperties": {
+        "^[a-z][a-z0-9-]*$": {
+          "type": "string"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "if": {

--- a/app/_data/schemas/frontmatter/base.json
+++ b/app/_data/schemas/frontmatter/base.json
@@ -87,6 +87,9 @@
       "additionalProperties": false
     }
   },
+  "not": {
+    "required": ["tier", "tiers"]
+  },
   "if": {
     "properties": {
       "products": {

--- a/app/_includes/components/prereqs.html
+++ b/app/_includes/components/prereqs.html
@@ -124,9 +124,8 @@
   {% endif %}
 
   {% if prereqs.entities? %}
-    {% if product == 'operator' %}{% assign product='kic' %}{% endif %}
     <div class="flex flex-col gap-1.5 border-b border-primary/5 accordion-item last:border-b-0">
-      {% assign prereq_path = "prereqs/entities/" | append: product | append: ".md" %}
+      {% assign prereq_path = "prereqs/entities/" | append: prereqs.entities_product | append: ".md" %}
       {% include {{ prereq_path }} data=prereqs.data %}
     </div>
   {% endif %}

--- a/app/_includes/components/prereqs.md
+++ b/app/_includes/components/prereqs.md
@@ -71,8 +71,7 @@
 {% include prereqs/operator/konnect_network.md config=prereqs.operator.konnect %}
 {%- endif -%}
 {%- if prereqs.entities? -%}
-{%- if product == 'operator' %}{% assign product='kic' %}{% endif %}
-{%- assign prereq_path = "prereqs/entities/" | append: product | append: ".md" -%}
+{%- assign prereq_path = "prereqs/entities/" | append: prereqs.entities_product | append: ".md" -%}
 {% include {{ prereq_path }} data=prereqs.data %}
 {%- endif -%}
 {%- for prereq in prereqs.inline_without_position %}

--- a/app/_includes/landing_pages/header.md
+++ b/app/_includes/landing_pages/header.md
@@ -13,6 +13,9 @@
         {% if page.tier %}
             {% include tier.html products=page.products tier=page.tier %}
         {% endif %}
+        {% if page.tiers %}
+            {% include tier.html products=page.products tiers=page.tiers %}
+        {% endif %}
          {%- if page.beta == true or page.tech_preview == true -%}
             {%- include_cached badges/stage.html beta=page.beta tech_preview=page.tech_preview -%}
          {% endif %}

--- a/app/_includes/layouts/main.html
+++ b/app/_includes/layouts/main.html
@@ -2,6 +2,7 @@
 {%- if layout.uses == false and page.beta == true -%}{%- assign show_badges = true -%}{%- endif -%}
 {%- if layout.uses == false and page.tech_preview == true -%}{%- assign show_badges = true -%}{%- endif -%}
 {%- if layout.tier_inline == true and page.tier -%}{%- assign show_badges = true -%}{%- endif -%}
+{%- if layout.tier_inline == true and page.tiers -%}{%- assign show_badges = true -%}{%- endif -%}
 {%- if page.premium_partner or page.third_party -%}{%- assign show_badges = true -%}{%- endif %}
 <main {% if page.topology_switcher %}data-topology-switcher="{{ page.topology_switcher }}" {% endif %}id="main" class="flex flex-col pb-12 gap-12 w-full {{ page.content_type | slugify }} {{include.class}}">
     <div class="flex flex-col gap-3">
@@ -16,6 +17,9 @@
             <div class="flex gap-3 items-center">
             {% if layout.tier_inline == true and page.tier %}
                 {% include tier.html products=page.products tier=page.tier %}
+            {% endif %}
+            {% if layout.tier_inline == true and page.tiers %}
+                {% include tier.html products=page.products tiers=page.tiers %}
             {% endif %}
 
             {% if layout.uses == false %}
@@ -43,7 +47,7 @@
         {% endif %}
 
         {% if layout.uses != false %}
-        {% include_cached uses.html products=page.products tools=page.tools tier=page.tier beta=page.beta tech_preview=page.tech_preview %}
+        {% include_cached uses.html products=page.products tools=page.tools tier=page.tier tiers=page.tiers beta=page.beta tech_preview=page.tech_preview %}
         {% endif %}
 
         {% ifhascontent nav_header %}

--- a/app/_includes/tier.html
+++ b/app/_includes/tier.html
@@ -1,20 +1,48 @@
 {% unless page.plugin? %}
-{% if include.products and include.products.size > 1 %}
-{% raise "tier.html include called with a tier and more than one product." %}
+{% if include.tier and include.tiers %}
+{% raise "tier.html: page `{{page.url}}` sets both `tier` and `tiers`. Use one or the other." %}
+{% endif %}
+{% if include.tier and include.products and include.products.size > 1 %}
+{% raise "tier.html: page `{{page.url}}` sets `tier` with more than one product. Use `tiers:` to map each product to its tier." %}
 {% endif %}
 {% endunless %}
 
-{% assign product = include.products.first %}
-{% assign tier = site.data.products[product].tiers[include.tier] %}
-{% unless tier %}
-    {%- capture available_tiers -%}
-        {%- for tier in site.data.products[product].tiers -%}{{tier[0]}}{% unless forloop.last %}, {% endunless %}{%- endfor -%}
-    {%- endcapture -%}
-    {% raise "tier.html: invalid tier `{{include.tier}}` for product: `{{product}}`. Available tiers: {{available_tiers}}" %}
-{% endunless %}
+{% if include.tier %}
+    {% assign product = include.products.first %}
+    {% assign tier_data = site.data.products[product].tiers[include.tier] %}
+    {% unless tier_data %}
+        {%- capture available_tiers -%}
+            {%- for t in site.data.products[product].tiers -%}{{t[0]}}{% unless forloop.last %}, {% endunless %}{%- endfor -%}
+        {%- endcapture -%}
+        {% raise "tier.html: invalid tier `{{include.tier}}` for product: `{{product}}`. Available tiers: {{available_tiers}}" %}
+    {% endunless %}
 
-{% if include.url %}
-{% include badge.html url=tier.url text=tier.text css_class=include.tier %}
-{% else %}
-{% include badge.html text=tier.text css_class=include.tier %}
+    {% if include.url %}
+    {% include badge.html url=tier_data.url text=tier_data.text css_class=include.tier %}
+    {% else %}
+    {% include badge.html text=tier_data.text css_class=include.tier %}
+    {% endif %}
+{% elsif include.tiers %}
+    {% for pair in include.tiers %}
+        {% assign tier_product = pair[0] %}
+        {% assign tier_name = pair[1] %}
+
+        {% unless include.products contains tier_product %}
+            {% raise "tier.html: product `{{tier_product}}` listed in `tiers` is not present in `products` for page `{{page.url}}`." %}
+        {% endunless %}
+
+        {% assign tier_data = site.data.products[tier_product].tiers[tier_name] %}
+        {% unless tier_data %}
+            {%- capture available_tiers -%}
+                {%- for t in site.data.products[tier_product].tiers -%}{{t[0]}}{% unless forloop.last %}, {% endunless %}{%- endfor -%}
+            {%- endcapture -%}
+            {% raise "tier.html: invalid tier `{{tier_name}}` for product: `{{tier_product}}`. Available tiers: {{available_tiers}}" %}
+        {% endunless %}
+
+        {% if include.url %}
+        {% include badge.html url=tier_data.url text=tier_data.text css_class=tier_name %}
+        {% else %}
+        {% include badge.html text=tier_data.text css_class=tier_name %}
+        {% endif %}
+    {% endfor %}
 {% endif %}

--- a/app/_includes/uses.html
+++ b/app/_includes/uses.html
@@ -1,4 +1,4 @@
-{% if include.products or include.tools or include.tier or include.beta == true or include.tech_preview == true %}
+{% if include.products or include.tools or include.tier or include.tiers or include.beta == true or include.tech_preview == true %}
 <div class="flex gap-2 items-center flex-wrap">
     {%- if include.beta == true or include.tech_preview == true -%}
         {%- include_cached badges/stage.html beta=include.beta tech_preview=include.tech_preview -%}
@@ -7,8 +7,11 @@
     {% if include.tier %}
         {% include tier.html products=include.products tier=include.tier %}
     {% endif %}
+    {% if include.tiers %}
+        {% include tier.html products=include.products tiers=include.tiers %}
+    {% endif %}
 
-    {% if include.tier or include.beta == true or include.tech_preview == true %}
+    {% if include.tier or include.tiers or include.beta == true or include.tech_preview == true %}
         {% if include.products or include.tools %}
         <span class="text-sm"> and uses: </span>
         {% endif %}

--- a/app/_plugins/drops/prereqs.rb
+++ b/app/_plugins/drops/prereqs.rb
@@ -68,11 +68,16 @@ module Jekyll
         @inline ||= prereqs.fetch('inline', [])
       end
 
-      def data
-        product = @page.data.fetch('products', [])[0]
+      def entities_product
+        @entities_product ||= begin
+          product = prereqs['entities_product'] || @page.data.fetch('products', [])[0]
+          product = 'kic' if product == 'operator'
+          product
+        end
+      end
 
-        # Use KIC rendering for Operator for now
-        product = 'kic' if product == 'operator'
+      def data
+        product = entities_product
 
         yaml = {}
         yaml = { '_format_version' => '3.0' } if product == 'gateway'

--- a/app/_plugins/generators/data/llm_metadata.rb
+++ b/app/_plugins/generators/data/llm_metadata.rb
@@ -37,6 +37,7 @@ module Jekyll
           'ai_gateway_enterprise' => @page.data['ai_gateway_enterprise'],
           'min_version' => @page.data['min_version'],
           'tier' => @page.data['tier'],
+          'tiers' => resolve_tiers(@page.data['tiers']),
           'products' => resolve_names(@page.data['products'], 'products'),
           'tools' => resolve_names(@page.data['tools'], 'tools'),
           'beta' => @page.data['beta']
@@ -54,6 +55,15 @@ module Jekyll
         return if Array(slugs).empty?
 
         Array(slugs).map { |slug| @site.data.dig(data_key, slug, 'name') || slug }
+      end
+
+      def resolve_tiers(tiers)
+        return if tiers.nil? || tiers.empty?
+
+        tiers.each_with_object({}) do |(product, tier_name), out|
+          name = @site.data.dig('products', product, 'name') || product
+          out[name] = @site.data.dig('products', product, 'tiers', tier_name, 'text') || tier_name
+        end
       end
 
       def plugin_metadata


### PR DESCRIPTION
Fixes issues detailed in https://github.com/Kong/developer.konghq.com/pull/5377

@fabianrbz added changes that fix this issue and fit the platform. Now we can add: 

- prerequisites from different products on the same guide
- tier specification

Tested locally on [this PR](https://github.com/Kong/developer.konghq.com/pull/5288) (that doesn't contain the changes, it works as intended). 

## How to test it

Add this to any insomnia guide for example (`app/_how-tos/insomnia/azure-saml-sso-insomnia.md`): 

```yaml

products:
    - gateway
    - insomnia
works_on:
  - konnect 
tools:
  - deck  

tiers:
  insomnia: enterprise

prereqs:
  entities:
    services:
      - example-service
    routes:
      - example-route

 ```
 
 The guide should now display:
 
 - The enterprise badge
 - Prereqs for:
    - Konnect
    - deck
    - Insomnia
    - Gateway
 
The page should display 
## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
