### PR TITLE
feat(kongctl): Add kongctl script install instructions

### DIFF
--- a/app/_includes/tools/kongctl/install/linux.md
+++ b/app/_includes/tools/kongctl/install/linux.md
@@ -1,4 +1,19 @@
-Download the latest kongctl binary for Linux from the [GitHub releases page](https://github.com/Kong/kongctl/releases).
+Install or update kongctl on Linux with the installation script:
+
+```sh
+curl -fsSL https://get.konghq.com/kongctl | sh
+```
+
+The script detects your platform, verifies release checksums, and installs the `kongctl` binary to a local bin directory such as `$HOME/.local/bin`.
+Make sure the installation directory is in your `PATH` before running `kongctl`.
+
+Verify the installation:
+
+```sh
+kongctl version --full
+```
+
+To install kongctl manually, download the latest Linux binary from the [GitHub releases page](https://github.com/Kong/kongctl/releases).
 
 1. Download the binary:
    ```sh
@@ -15,7 +30,7 @@ Download the latest kongctl binary for Linux from the [GitHub releases page](htt
    sudo mv kongctl /usr/local/bin/
    ```
 
-1. Verify the installation:
+1. Verify the manual installation:
    ```sh
    kongctl version --full
    ```


### PR DESCRIPTION
## Summary

- Add the `curl -fsSL https://get.konghq.com/kongctl | sh` installation path to the Linux kongctl install instructions on the kongctl landing page.
- Keep the existing manual GitHub release download steps as a fallback path.

## Validation

- `vale app/_includes/tools/kongctl/install/linux.md`
- `git diff --check`

`make build` was attempted, but the local toolchain resolved Ruby 3.4.8 while the repo requires Ruby 3.4.4, so the Makefile stopped before building.