### PR TITLE
 fix(ewg-conf): dereference json schemas before passing them to the spec-renderer

### DIFF
--- a/app/_assets/javascripts/apps/PluginSchema.vue
+++ b/app/_assets/javascripts/apps/PluginSchema.vue
@@ -34,6 +34,6 @@ const schema = window.schema;
 }
 
 :deep(.default-markdown ul) {
-  @apply ml-4;
+  @apply ml-4 !important;
 }
 </style>

--- a/app/_assets/javascripts/apps/PluginSchema.vue
+++ b/app/_assets/javascripts/apps/PluginSchema.vue
@@ -32,4 +32,8 @@ const schema = window.schema;
 :deep(.default-markdown a[href^="https://"]) {
   @apply bg-none pr-0 !important;
 }
+
+:deep(.default-markdown ul) {
+  @apply ml-4;
+}
 </style>

--- a/app/_plugins/tags/event_gateway_conf.rb
+++ b/app/_plugins/tags/event_gateway_conf.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 require_relative '../monkey_patch'
+require_relative '../utils/json_schema_deref'
 
 module Jekyll
   class EventGatewayConf < Liquid::Tag # rubocop:disable Style/Documentation
@@ -11,7 +12,8 @@ module Jekyll
       @page = context.environments.first['page']
 
       context.stack do
-        context['schema'] = @site.data.dig('event-gateway-bootstrap-schema', release(@site, @page).gsub('.', ''))
+        raw = @site.data.dig('event-gateway-bootstrap-schema', release(@site, @page).gsub('.', ''))
+        context['schema'] = Jekyll::Utils::JsonSchemaDeref.new(raw).resolve
         Liquid::Template.parse(template, { line_numbers: true }).render(context)
       end
     end

--- a/app/_plugins/utils/json_schema_deref.rb
+++ b/app/_plugins/utils/json_schema_deref.rb
@@ -29,9 +29,12 @@ module Jekyll
         return hash.transform_values { |v| resolve_node(v, in_progress) } unless ref
 
         m = INTERNAL_REF.match(ref)
-        return inline_ref(m[:name], ref, in_progress) if m
+        return hash.transform_values { |v| resolve_node(v, in_progress) } unless m
 
-        hash
+        deref = inline_ref(m[:name], ref, in_progress)
+        siblings = hash.except('$ref').transform_values { |v| resolve_node(v, in_progress) }
+
+        deref.is_a?(Hash) ? deref.merge(siblings) : deref
       end
 
       def inline_ref(name, ref, in_progress)

--- a/app/_plugins/utils/json_schema_deref.rb
+++ b/app/_plugins/utils/json_schema_deref.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Utils
+    class JsonSchemaDeref
+      INTERNAL_REF = /\A#\/\$defs\/(?<name>[^\/]+)\z/
+
+      def initialize(schema)
+        @schema = schema || {}
+        @defs = @schema.fetch('$defs', {})
+      end
+
+      def resolve
+        resolve_node(@schema.except('$defs'), Set.new)
+      end
+
+      private
+
+      def resolve_node(node, in_progress)
+        case node
+        when Hash  then resolve_hash(node, in_progress)
+        when Array then node.map { |v| resolve_node(v, in_progress) }
+        else            node
+        end
+      end
+
+      def resolve_hash(hash, in_progress)
+        ref = hash['$ref']
+        return hash.transform_values { |v| resolve_node(v, in_progress) } unless ref
+
+        m = INTERNAL_REF.match(ref)
+        return inline_ref(m[:name], ref, in_progress) if m
+
+        hash
+      end
+
+      def inline_ref(name, ref, in_progress)
+        # Cycle guard: if already resolving this def, leave the $ref as-is
+        return { '$ref' => ref } if in_progress.include?(name)
+
+        subtree = @defs[name]
+        return { '$ref' => ref } unless subtree
+
+        resolve_node(subtree, in_progress | Set[name])
+      end
+    end
+  end
+end

--- a/app/_plugins/utils/json_schema_deref.rb
+++ b/app/_plugins/utils/json_schema_deref.rb
@@ -34,7 +34,11 @@ module Jekyll
         deref = inline_ref(m[:name], ref, in_progress)
         siblings = hash.except('$ref').transform_values { |v| resolve_node(v, in_progress) }
 
-        deref.is_a?(Hash) ? deref.merge(siblings) : deref
+        return deref unless deref.is_a?(Hash)
+
+        merged = deref.merge(siblings)
+        merged['description'] = deref['description'] if deref.key?('description')
+        merged
       end
 
       def inline_ref(name, ref, in_progress)


### PR DESCRIPTION

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
