### PR TITLE
fix(docs-improvements): Plugin icon size

### DIFF
--- a/app/_includes/cards/plugin.html
+++ b/app/_includes/cards/plugin.html
@@ -17,7 +17,7 @@
   {% if plugin.tier %}data-tier="{{plugin.tier}}"{% endif %}
 >
     <a href="{{plugin.url}}" class="flex flex-col gap-5 hover:no-underline text-secondary w-full p-6">
-        <img src="{{ plugin.icon }}" class="card__icon"/>
+        <img src="{{ plugin.icon }}" class="card__icon w-8 h-8"/>
 
         <div class="flex flex-col gap-3 flex-grow">
             <h4>{{ name | liquify }}</h4>

--- a/app/_includes/cards/policy.html
+++ b/app/_includes/cards/policy.html
@@ -2,9 +2,9 @@
 <div class="card card__highlighted min-h-[260px]">
     <a href="{{policy.url}}" class="flex flex-col gap-5 hover:no-underline text-secondary w-full p-6">
         {% if policy.icon %}
-        <img src="{{ policy.icon }}" class="card__icon"/>
+        <img src="{{ policy.icon }}" class="card__icon w-8 h-8"/>
         {% else %}
-        <div class="card__icon"></div>
+        <div class="card__icon w-8 h-8"></div>
         {% endif %}
 
         <div class="flex flex-col gap-3 flex-grow">


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Post-rebrand, the plugin icons are now too small, and were not designed for that so the detail isn't visible:

<img width="1031" height="917" alt="Screenshot 2026-06-11 at 12 42 40 PM" src="https://github.com/user-attachments/assets/b88249ca-419f-4c33-b79e-5e0afc19b28a" />

This PR sets them to their previous size:
<img width="947" height="871" alt="Screenshot 2026-06-11 at 12 42 50 PM" src="https://github.com/user-attachments/assets/d1778e1b-e137-4790-bbc1-568fcef2ce66" />


## Preview Links
https://deploy-preview-5551--kongdeveloper.netlify.app/plugins/
https://deploy-preview-5551--kongdeveloper.netlify.app/mesh/policies/