### PR TITLE
feat(gateway): OAS validation structured errors

### DIFF
--- a/app/_kong_plugins/oas-validation/examples/structured-errors.yaml
+++ b/app/_kong_plugins/oas-validation/examples/structured-errors.yaml
@@ -20,6 +20,7 @@ config:
     contents of entire API spec go here
   structured_errors: true
   max_structured_errors: 10
+  verbose_response: true
 
 tools:
   - deck

--- a/app/_kong_plugins/oas-validation/examples/structured-errors.yaml
+++ b/app/_kong_plugins/oas-validation/examples/structured-errors.yaml
@@ -1,0 +1,29 @@
+title: 'Enable structured validation errors'
+
+description: |
+  Return validation errors as a structured list instead of a flat string.
+
+extended_description: |
+  By default, validation errors are returned as a single flat string.
+  Enable `structured_errors` to receive errors in [JSON Schema draft 2020-12 Output Structure](https://json-schema.org/draft/2020-12/json-schema-core#name-output-structure),
+  with `instanceLocation` and `keywordLocation` fields for each error.
+
+  Use `max_structured_errors` to cap the number of errors returned.
+  Any errors over the cap are discarded.
+
+min_version: '3.15'
+
+weight: 850
+
+config:
+  api_spec: |-
+    contents of entire API spec go here
+  structured_errors: true
+  max_structured_errors: 10
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform

--- a/app/_kong_plugins/oas-validation/examples/structured-errors.yaml
+++ b/app/_kong_plugins/oas-validation/examples/structured-errors.yaml
@@ -11,7 +11,8 @@ extended_description: |
   Use `max_structured_errors` to cap the number of errors returned.
   Any errors over the cap are discarded.
 
-min_version: '3.15'
+min_version:
+  gateway: '3.15'
 
 weight: 850
 

--- a/app/_kong_plugins/oas-validation/index.md
+++ b/app/_kong_plugins/oas-validation/index.md
@@ -153,7 +153,7 @@ columns:
     key: description
 rows:
   - param: |
-      `structured_errors` {% new_in 3.15 %}
+      [`structured_errors`](/plugins/oas-validation/reference/#schema--config-structured-errors) {% new_in 3.15 %}
     default: "`false`"
     description: |
       Enable `structured_errors` to receive validation errors as an `errors` array instead of a flat string, following [JSON Schema draft 2020-12 Output Structure](https://json-schema.org/draft/2020-12/json-schema-core#name-output-structure). Each error includes `instanceLocation` (the path in the request or response body where the violation occurred), `keywordLocation` (the path in the schema that triggered the error), and `error`.
@@ -162,18 +162,20 @@ rows:
       <br><br>
       When disabled, the plugin preserves the original non-structured error format.
   - param: |
-      `max_structured_errors` {% new_in 3.15 %}
+      [`max_structured_errors`](/plugins/oas-validation/reference/#schema--config-max-structured-errors) {% new_in 3.15 %}
     default: "unset (all errors returned)"
     description: |
-      Caps the number of structured validation errors returned in the response. Must be greater than 0. Requires `structured_errors` to be enabled. Any extra errors over the cap are discarded. 
-  - param: "`collect_all_errors`"
+      Caps the number of structured validation errors returned in the response. Must be greater than 0. `structured_errors` must also be enabled. Any extra errors over the cap are discarded. 
+  - param: "[`collect_all_errors`](/plugins/oas-validation/reference/#schema--config-collect-all-errors)"
     default: "`false`"
     description: |
       Collects all validation errors instead of stopping at the first error.
       Only takes effect when `structured_errors` is disabled.
       <br><br>
-      **Note:** Be careful when enabling this option, as it does affect performance.
-  - param: "`verbose_response`"
+      
+      {:.info}
+      > **Note:** Be careful when enabling this option, as it does affect performance.
+  - param: "[`verbose_response`](/plugins/oas-validation/reference/#schema--config-verbose-response)"
     default: "`false`"
     description: |
       If set to `true`, returns a detailed error message for invalid requests and responses. Useful while testing.

--- a/app/_kong_plugins/oas-validation/index.md
+++ b/app/_kong_plugins/oas-validation/index.md
@@ -156,7 +156,9 @@ rows:
       `structured_errors` {% new_in 3.15 %}
     default: "`false`"
     description: |
-      Enable `structured_errors` to receive validation errors as a structured list instead of a flat string, following [JSON Schema draft 2020-12 Output Structure](https://json-schema.org/draft/2020-12/json-schema-core#name-output-structure). Each error includes `instanceLocation` (the path in the request or response body where the violation occurred) and `keywordLocation` (the path in the schema that triggered the error). 
+      Enable `structured_errors` to receive validation errors as an `errors` array instead of a flat string, following [JSON Schema draft 2020-12 Output Structure](https://json-schema.org/draft/2020-12/json-schema-core#name-output-structure). Each error includes `instanceLocation` (the path in the request or response body where the violation occurred), `keywordLocation` (the path in the schema that triggered the error), and `error`.
+      <br><br>
+      Requires `verbose_response` to be set to `true`.
       <br><br>
       When disabled, the plugin preserves the original non-structured error format.
   - param: |

--- a/app/_kong_plugins/oas-validation/index.md
+++ b/app/_kong_plugins/oas-validation/index.md
@@ -134,3 +134,46 @@ If validation fails, the webhook URL receives a response with JSON payload, whic
 
 See the [Event Hooks](/gateway/entities/event-hook/) reference for details on how to configure an Event Hook.
 
+
+## Error handling
+
+By default, when the OAS Validation plugin reports schema violations, it embeds all errors into a single string inside the `message` field.
+This makes it difficult for client applications to parse, display, or log validation failures in a structured way.
+
+The following settings control how validation errors are reported:
+
+<!--vale off-->
+{% table %}
+columns:
+  - title: Parameter
+    key: param
+  - title: Default
+    key: default
+  - title: Description
+    key: description
+rows:
+  - param: |
+      `structured_errors` {% new_in 3.15 %}
+    default: "`false`"
+    description: |
+      Enable `structured_errors` to receive validation errors as a structured list instead of a flat string, following [JSON Schema draft 2020-12 Output Structure](https://json-schema.org/draft/2020-12/json-schema-core#name-output-structure). Each error includes `instanceLocation` (the path in the request or response body where the violation occurred) and `keywordLocation` (the path in the schema that triggered the error). 
+      <br><br>
+      When disabled, the plugin preserves the original non-structured error format.
+  - param: |
+      `max_structured_errors` {% new_in 3.15 %}
+    default: "unset (all errors returned)"
+    description: |
+      Caps the number of structured validation errors returned in the response. Must be greater than 0. Requires `structured_errors` to be enabled. Any extra errors over the cap are discarded. 
+  - param: "`collect_all_errors`"
+    default: "`false`"
+    description: |
+      Collects all validation errors instead of stopping at the first error.
+      Only takes effect when `structured_errors` is disabled.
+      <br><br>
+      **Note:** Be careful when enabling this option, as it does affect performance.
+  - param: "`verbose_response`"
+    default: "`false`"
+    description: |
+      If set to `true`, returns a detailed error message for invalid requests and responses. Useful while testing.
+{% endtable %}
+<!--vale on-->


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Adds a section on error handling in the OAS Validation plugin and logs the new params in 3.15.

You can test with the 3.15.0.0-rc.3 image and the following snippet:

```
curl -i -X POST http://localhost:8001/plugins/ \
    --header "Accept: application/json" \
    --header "Content-Type: application/json" \
    --data '
    {
      "name": "oas-validation",
      "config": {
        "api_spec": "openapi: 3.0.0\ninfo:\n  title: Sample API\n  version: 1.0.0\npaths:\n  /test:\n    get:\n      responses:\n        \"200\":\n          description: OK",
        "structured_errors": true,
        "max_structured_errors": 10,
        "verbose_response": true
      },
      "tags": []
    }
    '

```
Fixes #5414 

## Preview Links

https://deploy-preview-5553--kongdeveloper.netlify.app/plugins/oas-validation/#error-handling
https://deploy-preview-5553--kongdeveloper.netlify.app/plugins/oas-validation/examples/structured-errors/