### PR TITLE
Call out version to versionupgrade path

### DIFF
--- a/app/mesh/changelog.md
+++ b/app/mesh/changelog.md
@@ -17,4 +17,6 @@ search_aliases:
     - release notes
 ---
 
+Whilst the {{site.mesh_product_name}} change log documents the updates to each version.  Please also refer to the  [Version-specific upgrade notes](/mesh/version-specific-upgrade-notes/) which will give you step by step changes that would be needed to succesfully upgrade your minor versions.
+
 {% embed CHANGELOG.md %}

--- a/app/mesh/changelog.md
+++ b/app/mesh/changelog.md
@@ -17,6 +17,6 @@ search_aliases:
     - release notes
 ---
 
-Whilst the {{site.mesh_product_name}} change log documents the updates to each version.  Please also refer to the  [Version-specific upgrade notes](/mesh/version-specific-upgrade-notes/) which will give you step by step changes that would be needed to succesfully upgrade your minor versions.
+While the {{site.mesh_product_name}} changelog documents updates in each version, refer to the [Version-specific upgrade notes](/mesh/version-specific-upgrade-notes/) for step-by-step instructions to successfully upgrade between minor versions.
 
 {% embed CHANGELOG.md %}


### PR DESCRIPTION
Need to link out to the version to version upgrade methodology 

## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
