### PR TITLE
feat(gateway): Distroless image

### DIFF
--- a/app/_data/products/gateway.yml
+++ b/app/_data/products/gateway.yml
@@ -1559,14 +1559,6 @@ releases:
           docker_support:
             arm: true
           default: true
-      - distroless:
-          package: false
-          docker: true
-          docker_support:
-            arm: true
-            fips: true
-            graviton: true
-          default: true
       - rhel8:
           package: true
           package_support:
@@ -1747,6 +1739,14 @@ releases:
           docker: true
           docker_support:
             arm: true
+          default: true
+      - distroless:
+          package: false
+          docker: true
+          docker_support:
+            arm: true
+            fips: true
+            graviton: true
           default: true
       - rhel8:
           package: true

--- a/app/_data/products/gateway.yml
+++ b/app/_data/products/gateway.yml
@@ -1565,6 +1565,7 @@ releases:
           docker_support:
             arm: true
             fips: true
+            graviton: true
           default: true
       - rhel8:
           package: true

--- a/app/_data/products/gateway.yml
+++ b/app/_data/products/gateway.yml
@@ -1559,6 +1559,13 @@ releases:
           docker_support:
             arm: true
           default: true
+      - distroless:
+          package: false
+          docker: true
+          docker_support:
+            arm: true
+            fips: true
+          default: true
       - rhel8:
           package: true
           package_support:

--- a/app/_data/support/packages.yml
+++ b/app/_data/support/packages.yml
@@ -39,6 +39,9 @@ debian12:
 debian-stable:
   os: Debian
   version: stable
+distroless:
+  os: Distroless
+  version: N/A
 rhel7:
   os: RHEL
   version: 7.x

--- a/app/_how-tos/gateway/install-gateway-distroless.md
+++ b/app/_how-tos/gateway/install-gateway-distroless.md
@@ -1,0 +1,156 @@
+---
+title: Install {{site.base_gateway}} using the distroless image
+description: Run {{site.base_gateway}} from the distroless Docker image, which contains only the {{site.base_gateway}} runtime and its dependencies with no shell or package manager.
+content_type: how_to
+breadcrumbs:
+  - /gateway/
+  - /gateway/install/
+permalink: /gateway/install/docker-distroless/
+related_resources:
+  - text: Install {{site.base_gateway}} on a supported platform
+    url: /gateway/install/
+  - text: Install {{site.base_gateway}} using Docker Compose
+    url: /gateway/install/docker/
+  - text: Install {{site.base_gateway}} in read-only mode
+    url: /gateway/install/docker-read-only/
+  - text: Build your own custom Docker image
+    url: /how-to/build-custom-docker-image/
+
+products:
+  - gateway
+
+works_on:
+  - on-prem
+min_version:
+  gateway: '3.15'
+
+tldr:
+  q: How do I run {{site.base_gateway}} using the distroless image?
+  a: |
+    Pull `kong/kong-gateway:{{site.data.gateway_latest.ee-version}}-distroless` and run it with configuration passed via environment variables.
+    The distroless image has no shell, so you must configure Gateway at container startup.
+
+prereqs:
+  skip_product: true
+  inline:
+    - title: Docker
+      content: |
+        This guide requires [Docker](https://docs.docker.com/get-started/get-docker/) installed on your system.
+    - title: Kong license
+      content: |
+        Set your {{site.base_gateway}} license as an environment variable:
+        ```sh
+        export KONG_LICENSE_DATA='<your-license-json>'
+        ```
+
+faqs:
+  - q: Why use the distroless image?
+    a: |
+      The distroless image contains only the {{site.base_gateway}} runtime and its dependencies.
+      It has no shell, package manager, or OS tooling, which reduces the image's attack surface and can simplify security scanning.
+  - q: Can I get a shell inside the distroless container?
+    a: |
+      No. The distroless image has no shell.
+      Use environment variables or mounted config files to configure {{site.base_gateway}} instead of running commands inside the container.
+  - q: Is there a FIPS-compliant distroless image?
+    a: |
+      Yes. Pull `kong/kong-gateway:{{site.data.gateway_latest.ee-version}}-distroless-fips` and set `KONG_FIPS=on`.
+      See [FIPS support](/gateway/fips-support/) for additional configuration requirements.
+
+  - q: Can I run the distroless image with a database?
+    a: |
+      Yes. The distroless image supports the same deployment modes as other {{site.base_gateway}} images.
+      This guide uses DB-less mode, which requires no separate database container.
+
+      If you need a database-backed deployment, start a Postgres container first and run `kong migrations bootstrap` before starting the Gateway.
+      See [Install {{site.base_gateway}} using Docker Compose](/gateway/install/docker/) for a database-backed example.
+
+tags:
+  - install
+  - docker
+
+automated_tests: false
+---
+
+## Pull the distroless image
+
+Pull the {{site.base_gateway}} distroless image from Docker Hub:
+
+```sh
+docker pull kong/kong-gateway:{{ site.data.gateway_latest.ee-version }}-distroless
+```
+
+The distroless image is available for `linux/amd64` and `linux/arm64`.
+Docker pulls the correct variant automatically based on your host architecture.
+
+## Create a Docker network
+
+Create a dedicated network for {{site.base_gateway}}:
+
+```sh
+docker network create kong-net
+```
+
+## Create a declarative configuration file
+
+In DB-less mode, you provide your Gateway configuration in a YAML file at startup.
+
+
+Create a directory for your Kong configuration:
+
+```sh
+mkdir -p declarative
+```
+
+Then, create a `kong.yml` file with your entire Gateway configuration. For example, the following file creates a Service and a Route:
+
+```sh
+cat <<EOF > declarative/kong.yml
+_format_version: "3.0"
+services:
+- name: example-service
+  url: http://httpbin.konghq.com
+  routes:
+  - name: example-route
+    paths:
+    - /anything
+EOF
+```
+
+## Start {{site.base_gateway}}
+
+Run the distroless container, mounting the declarative configuration file and passing all settings via environment variables:
+
+```sh
+docker run -d \
+  --name kong-distroless \
+  --network kong-net \
+  -v "$(pwd)/declarative:/kong/declarative" \
+  -e KONG_DATABASE=off \
+  -e KONG_DECLARATIVE_CONFIG=/kong/declarative/kong.yml \
+  -e KONG_PROXY_ACCESS_LOG=/dev/stdout \
+  -e KONG_PROXY_ERROR_LOG=/dev/stderr \
+  -e KONG_ADMIN_ACCESS_LOG=/dev/stdout \
+  -e KONG_ADMIN_ERROR_LOG=/dev/stderr \
+  -e KONG_ADMIN_LISTEN="0.0.0.0:8001" \
+  -e KONG_LICENSE_DATA="$KONG_LICENSE_DATA" \
+  -p 8000:8000 \
+  -p 8001:8001 \
+  kong/kong-gateway:{{ site.data.gateway_latest.ee-version }}-distroless
+```
+
+{:.info}
+> Because the distroless image has no shell, all {{site.base_gateway}} configuration must be passed as environment variables (`KONG_*`) or in a mounted `kong.conf` file.
+> You **cannot** run `kong` commands inside the container after it starts.
+
+## Validate
+
+Check that {{site.base_gateway}} is running by accessing the `example-route` Route:
+
+{% control_plane_request %}
+url: '/anything'
+method: GET
+status_code: 200
+{% endcontrol_plane_request %}
+
+This should return an `HTTP/1.1 200 OK` response.

--- a/app/_how-tos/gateway/install-gateway-distroless.md
+++ b/app/_how-tos/gateway/install-gateway-distroless.md
@@ -28,7 +28,7 @@ tldr:
   q: How do I run {{site.base_gateway}} using the distroless image?
   a: |
     Pull `kong/kong-gateway:{{site.data.gateway_latest.ee-version}}-distroless` and run it with configuration passed via environment variables.
-    The distroless image has no shell, so you must configure Gateway at container startup.
+    The distroless image has no shell, so you must configure {{site.base_gateway}} at container startup.
 
 prereqs:
   skip_product: true
@@ -60,7 +60,7 @@ faqs:
   - q: Can I run the distroless image with a database?
     a: |
       Yes. The distroless image supports the same deployment modes as other {{site.base_gateway}} images.
-      This guide uses DB-less mode, which requires no separate database container.
+      This guide uses [DB-less mode](/gateway/db-less-mode/), which requires no separate database container.
 
       If you need a database-backed deployment, start a Postgres container first and run `kong migrations bootstrap` before starting the Gateway.
       See [Install {{site.base_gateway}} using Docker Compose](/gateway/install/docker/) for a database-backed example.
@@ -93,7 +93,7 @@ docker network create kong-net
 
 ## Create a declarative configuration file
 
-In DB-less mode, you provide your Gateway configuration in a YAML file at startup.
+In [DB-less mode](/gateway/db-less-mode/), you provide your Gateway configuration in a YAML file at startup.
 
 
 Create a directory for your Kong configuration:
@@ -143,12 +143,12 @@ docker run -d \
 ```
 
 {:.info}
-> Because the distroless image has no shell, all {{site.base_gateway}} configuration must be passed as environment variables (`KONG_*`) or in a mounted `kong.conf` file.
+> Because the distroless image has no shell, all {{site.base_gateway}} configuration must be passed as [environment variables (`KONG_*`)](/gateway/manage-kong-conf/#environment-variables) or in a mounted `kong.conf` file.
 > You **cannot** run `kong` commands inside the container after it starts.
 
 ## Validate
 
-First, check that {{site.base_gateway}} is running by check port 8000:
+First, check that {{site.base_gateway}} is running by checking port 8000:
 
 <!--vale off-->
 {% control_plane_request %}

--- a/app/_how-tos/gateway/install-gateway-distroless.md
+++ b/app/_how-tos/gateway/install-gateway-distroless.md
@@ -104,7 +104,7 @@ mkdir -p declarative
 
 Then, create a `kong.yml` file with your entire Gateway configuration. For example, the following file creates a Service and a Route:
 
-```sh
+```yaml
 cat <<EOF > declarative/kong.yml
 _format_version: "3.0"
 services:
@@ -114,6 +114,9 @@ services:
   - name: example-route
     paths:
     - /anything
+    protocols:
+    - http
+    - https
 EOF
 ```
 
@@ -145,12 +148,23 @@ docker run -d \
 
 ## Validate
 
-Check that {{site.base_gateway}} is running by accessing the `example-route` Route:
+First, check that {{site.base_gateway}} is running by check port 8000:
 
+<!--vale off-->
 {% control_plane_request %}
-url: '/anything'
+url: '/services'
 method: GET
 status_code: 200
 {% endcontrol_plane_request %}
+<!--vale on-->
 
-This should return an `HTTP/1.1 200 OK` response.
+You should get a `200` response with a list of Gateway Services.
+
+Then, access a configured Route through the proxy URL on port 8001:
+
+{% validation request-check %}
+url: /anything
+status_code: 200
+{% endvalidation %}
+
+This should return an `200` response, this time with the results from your Route.

--- a/app/_how-tos/gateway/install-gateway-distroless.md
+++ b/app/_how-tos/gateway/install-gateway-distroless.md
@@ -21,6 +21,7 @@ products:
 
 works_on:
   - on-prem
+  - konnect
 min_version:
   gateway: '3.15'
 

--- a/app/_includes/install/gateway.html
+++ b/app/_includes/install/gateway.html
@@ -25,6 +25,13 @@
 - [Install via Docker](/gateway/install/docker/)
 - [Install via Docker in read-only mode](/gateway/install/docker-read-only/)
 
+### Distroless image
+
+The distroless image contains only the {{site.base_gateway}} runtime and its dependencies, with no shell, package manager, or OS tooling.
+It's available for `linux/amd64` and `linux/arm64`.
+
+- [Install via distroless image](/gateway/install/docker-distroless/)
+
 ### Build your own
 
 {{site.base_gateway}} is distributed as prebuilt `deb` and `rpm` packages, in addition to official Docker images hosted on [Docker Hub](https://hub.docker.com/r/kong).
@@ -101,6 +108,26 @@ Configure {{site.base_gateway}} using Kubernetes-native resources such as `httpr
     </div>
 
     <div class="border-t border-primary"></div>
+
+    <div class="flex flex-col gap-2">
+        <div class="flex gap-2">
+            <h3 class="font-semibold text-base leading-6">Distroless image</h3>
+        </div>
+
+        <div class="flex text-secondary">
+            <p>
+                The distroless image contains only the {{site.base_gateway}} runtime and its dependencies, with no shell, package manager, or OS tooling.
+                It's available for AMD64 and ARM64 architectures.
+            </p>
+        </div>
+
+        <a href="/gateway/install/docker-distroless/" class="flex w-full p-5 gap-4 rounded-md shadow-primary text-sm text-white font-semibold bg-terciary items-center justify-between hover:no-underline hover:bg-hover-component/100 hover:text-primary">
+            Install via distroless image
+            <span class="flex text-terciary h-5 w-5">&rarr;</span>
+        </a>
+    </div>
+
+    <div class="border-t border-primary/5"></div>
 
     <div class="flex flex-col gap-2">
         <div class="flex gap-2">

--- a/app/_includes/install/gateway.html
+++ b/app/_includes/install/gateway.html
@@ -121,7 +121,7 @@ Configure {{site.base_gateway}} using Kubernetes-native resources such as `httpr
             </p>
         </div>
 
-        <a href="/gateway/install/docker-distroless/" class="flex w-full p-5 gap-4 rounded-md shadow-primary text-sm text-white font-semibold bg-terciary items-center justify-between hover:no-underline hover:bg-hover-component/100 hover:text-primary">
+        <a href="/gateway/install/docker-distroless/" class="flex w-full p-5 gap-4 rounded-md shadow-primary text-sm text-primary font-semibold bg-terciary items-center justify-between hover:no-underline hover:bg-primary">
             Install via distroless image
             <span class="flex text-terciary h-5 w-5">&rarr;</span>
         </a>

--- a/app/_includes/support/gateway.html
+++ b/app/_includes/support/gateway.html
@@ -71,19 +71,19 @@ rows:
                 </td>
                 <td class="text-center px-0">
                     <div class="flex flex-col divide-y divide-primary/5 *:py-4 first:*:pt-0 last:*:pb-0">
-                        <span class="flex justify-center">{{ distro.package_support.arm | to_check }}</span>
+                        {% if distro.package %}<span class="flex justify-center">{{ distro.package_support.arm | to_check }}</span>{% endif %}
                         {% if distro.docker %}<span class="flex justify-center">{{ distro.docker_support.arm | to_check }}</span>{% endif %}
                     </div>
                 </td>
                 <td class="text-center px-0">
                     <div class="flex flex-col divide-y divide-primary/5 *:py-4 first:*:pt-0 last:*:pb-0">
-                        <span class="flex justify-center">{{ distro.package_support.fips | to_check }}</span>
+                        {% if distro.package %}<span class="flex justify-center">{{ distro.package_support.fips | to_check }}</span>{% endif %}
                         {% if distro.docker %}<span class="flex justify-center">{{ distro.docker_support.fips | to_check }}</span>{% endif %}
                     </div>
                 </td>
                 <td class="text-center px-0">
                     <div class="flex flex-col divide-y divide-primary/5 *:py-4 first:*:pt-0 last:*:pb-0">
-                        <span class="flex justify-center">{{ distro.package_support.graviton | to_check }}</span>
+                        {% if distro.package %}<span class="flex justify-center">{{ distro.package_support.graviton | to_check }}</span>{% endif %}
                         {% if distro.docker %}<span class="flex justify-center">{{ distro.docker_support.graviton | to_check }}</span>{% endif %}
                     </div>
                 </td>


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

* Adds the distroless image to the OS support table
  * Fixes the table to not display packages when there are none available
* Set up guide for distroless in DB-less mode as the simplest option, with all the FAQs and caveats

Outstanding questions:
* Is this supported with Konnect? - yes
* Does this actually support all deployment modes (traditional with DB, hybrid)?   - yes
* Does it support AWS Graviton? - yes

Fixes #5417 

## Preview Links
https://deploy-preview-5581--kongdeveloper.netlify.app/gateway/install/#docker
https://deploy-preview-5581--kongdeveloper.netlify.app/gateway/install/docker-distroless/
https://deploy-preview-5581--kongdeveloper.netlify.app/gateway/version-support-policy/#supported-versions - 3.15 tab