### PR TITLE
feat(dcgw): Azure VWAN Terraform resource example

### DIFF
--- a/app/_how-tos/dedicated-cloud-gateways/azure-virtual-wan.md
+++ b/app/_how-tos/dedicated-cloud-gateways/azure-virtual-wan.md
@@ -51,6 +51,13 @@ faqs:
 
       <!--vale off-->
       ```hcl
+      echo '
+      variable "network_id" {}
+      variable "tenant_id" {}
+      variable "resource_group_name" {}
+      variable "vhub_name" {}
+      variable "subscription_id" {}
+
       resource "konnect_cloud_gateway_transit_gateway" "my_vhub_peering" {
         network_id = var.network_id
 
@@ -66,6 +73,7 @@ faqs:
           }
         }
       }
+      ' >> main.tf
       ```
       <!--vale on-->
 next_steps:

--- a/app/_how-tos/dedicated-cloud-gateways/azure-virtual-wan.md
+++ b/app/_how-tos/dedicated-cloud-gateways/azure-virtual-wan.md
@@ -42,6 +42,32 @@ prereqs:
     - title: Azure virtual WAN
       include_content: prereqs/dcgw-azure-vwan
       icon_url: /assets/icons/azure.svg
+faqs:
+  - q: "How do I manage my Azure virtual WAN peering with Terraform?"
+    a: |
+      Because configuring virtual hub peering requires approving the {{site.konnect_short_name}} app in Microsoft Entra (a step that generates a link only available in the {{site.konnect_short_name}} UI), you must complete the initial setup using the UI before managing the resource in Terraform.
+
+      After the peering is `Ready`, you can import or reference the `konnect_cloud_gateway_transit_gateway` resource in Terraform. The following example shows what the resource block looks like:
+
+      <!--vale off-->
+      ```hcl
+      resource "konnect_cloud_gateway_transit_gateway" "my_vhub_peering" {
+        network_id = var.network_id
+
+        azure_vhub_peering_gateway = {
+          name = "azure virtual hub peering"
+
+          transit_gateway_attachment_config = {
+            kind                = "azure-vhub-peering-attachment"
+            tenant_id           = var.tenant_id
+            subscription_id     = var.subscription_id
+            resource_group_name = var.resource_group_name
+            vhub_name           = var.vhub_name
+          }
+        }
+      }
+      ```
+      <!--vale on-->
 next_steps:
   - text: Dedicated Cloud Gateways production readiness checklist
     url: /dedicated-cloud-gateways/production-readiness/

--- a/app/_how-tos/dedicated-cloud-gateways/azure-virtual-wan.md
+++ b/app/_how-tos/dedicated-cloud-gateways/azure-virtual-wan.md
@@ -47,17 +47,9 @@ faqs:
     a: |
       Because configuring virtual hub peering requires approving the {{site.konnect_short_name}} app in Microsoft Entra (a step that generates a link only available in the {{site.konnect_short_name}} UI), you must complete the initial setup using the UI before managing the resource in Terraform.
 
-      After the peering is `Ready`, you can import or reference the `konnect_cloud_gateway_transit_gateway` resource in Terraform. The following example shows what the resource block looks like:
-
+      After the peering is `Ready`, you can manage it with Terraform by importing the existing `konnect_cloud_gateway_transit_gateway` into your Terraform state. For a complete example, see [`cloud-gateways.tf`](https://github.com/Kong/terraform-provider-konnect/blob/main/examples/scenarios/cloud-gateways.tf). The following example shows what the resource block looks like:
       <!--vale off-->
       ```hcl
-      echo '
-      variable "network_id" {}
-      variable "tenant_id" {}
-      variable "resource_group_name" {}
-      variable "vhub_name" {}
-      variable "subscription_id" {}
-
       resource "konnect_cloud_gateway_transit_gateway" "my_vhub_peering" {
         network_id = var.network_id
 
@@ -73,7 +65,6 @@ faqs:
           }
         }
       }
-      ' >> main.tf
       ```
       <!--vale on-->
 next_steps:


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes #4915 
## Preview Links
https://deploy-preview-5583--kongdeveloper.netlify.app/dedicated-cloud-gateways/azure-virtual-wan/#faqs
**Testing info** The TF resource will apply, but getting an "Error" status in the Konnect UI is expected since we're not approving the connection/Entra app as that can only be done in the UI setup. This is just providing the resource example so they can manage their config with Terraform post UI setup.

TODO:

- [x] Test

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
