### PR TITLE
feat(gateway): Datakit spans and tracing in Debugger

### DIFF
--- a/app/_how-tos/gateway/get-started-with-datakit.md
+++ b/app/_how-tos/gateway/get-started-with-datakit.md
@@ -52,7 +52,10 @@ min_version:
 related_resources:
   - text: Datakit plugin
     url: /plugins/datakit/
-
+  - text: Datakit in {{site.base_gateway}}
+    url: /gateway/datakit/
+  - text: Using Debugger for Datakit
+    url: /observability/datakit-debugger/
 ---
 
 ## Enable Datakit

--- a/app/_kong_plugins/datakit/index.md
+++ b/app/_kong_plugins/datakit/index.md
@@ -32,6 +32,8 @@ related_resources:
     url: /gateway/datakit/
   - text: Get started with Datakit
     url: /how-to/get-started-with-datakit/
+  - text: Using Debugger for Datakit
+    url: /observability/datakit-debugger/
 
 min_version:
   gateway: '3.11'
@@ -1838,6 +1840,7 @@ Refer to the [Vault node](#vault-node) for more details on how to use vault refe
 ## Debugging
 
 Datakit includes support for debugging your configuration.
+For deeper tracing in production, you can also use the [{{site.konnect_short_name}} Debugger](/observability/datakit-debugger/), which captures Datakit node spans and I/O values per lifecycle event without exposing data in client responses.
 
 {:.warning}
 > Enabling the `debug` option in Datakit is considered unsafe for production

--- a/app/_landing_pages/gateway/datakit.yaml
+++ b/app/_landing_pages/gateway/datakit.yaml
@@ -216,7 +216,7 @@ rows:
                     - Add the `X-DataKit-Debug-Trace` header to get a full node execution trace, including timing, dependencies, and failures.
                     - Trace reports include node status (`NODE_ERROR`, `NODE_COMPLETE`, etc.) and dependency chains for in-depth analysis.
 
-                    For production tracing, you can also use the Konnect Debugger to capture Datakit node spans and I/O values without exposing data in client responses.
+                    For production tracing, you can also use the {{site.konnect_short_name}} Debugger to capture Datakit node spans and I/O values without exposing data in client responses.
 
       - blocks:
           - type: card
@@ -231,7 +231,7 @@ rows:
           - type: card
             config:
               title: Datakit tracing in Debugger
-              description: Use the Konnect Debugger to inspect Datakit node spans, trace I/O values per lifecycle event, and understand sanitization behavior.
+              description: Use the {{site.konnect_short_name}} Debugger to inspect Datakit node spans, trace I/O values per lifecycle event, and understand sanitization behavior.
               icon: /assets/icons/monitor.svg
               cta:
                 text: See reference

--- a/app/_landing_pages/gateway/datakit.yaml
+++ b/app/_landing_pages/gateway/datakit.yaml
@@ -215,12 +215,24 @@ rows:
                     - Enable the `debug` option to expose node execution errors in responses.
                     - Add the `X-DataKit-Debug-Trace` header to get a full node execution trace, including timing, dependencies, and failures.
                     - Trace reports include node status (`NODE_ERROR`, `NODE_COMPLETE`, etc.) and dependency chains for in-depth analysis.
+
+                    For production tracing, you can also use the Konnect Debugger to capture Datakit node spans and I/O values without exposing data in client responses.
+
       - blocks:
           - type: card
             config:
-              title: Debugging
+              title: Built-in configuration debugging
               description: Learn more about Datakit's debug and tracing modes.
               icon: /assets/icons/monitor.svg
               cta:
                 text: See debugging section
                 url: /plugins/datakit/#debugging
+      - blocks:
+          - type: card
+            config:
+              title: Datakit tracing in Debugger
+              description: Use the Konnect Debugger to inspect Datakit node spans, trace I/O values per lifecycle event, and understand sanitization behavior.
+              icon: /assets/icons/monitor.svg
+              cta:
+                text: See reference
+                url: /observability/datakit-debugger/

--- a/app/observability/datakit-debugger.md
+++ b/app/observability/datakit-debugger.md
@@ -1,6 +1,6 @@
 ---
 title: Using Debugger for Datakit
-description: 'Use the {{site.konnect_short_name}} Debugger to inspect Datakit node execution: trace node spans, view I/O values per node lifecycle event, and understand how sanitization rules apply to Datakit tracing data.'
+description: 'Use {{site.konnect_short_name}} Debugger to inspect Datakit node execution: trace node spans, view I/O values per node lifecycle event, and understand how sanitization rules apply to Datakit tracing data.'
 breadcrumbs:
   - /observability/
   - /observability/debugger/
@@ -20,7 +20,7 @@ tags:
   - debugger
 
 related_resources:
-  - text: The {{site.konnect_short_name}} Debugger
+  - text: "{{site.konnect_short_name}} Debugger"
     url: /observability/debugger/
   - text: Datakit plugin
     url: /plugins/datakit/
@@ -31,19 +31,27 @@ min_version:
   gateway: '3.15'
 ---
 
-When you run a Debugger session on a gateway that uses the Datakit plugin, the Debugger captures tracing data for each Datakit node in the pipeline.
-This gives you visibility into how data flows through your Datakit configuration: which nodes ran, what values they received and produced, and where errors or skips occurred.
+When you run a [Debugger session](/observability/debugger/) on a {{site.base_gateway}} instance that uses the [Datakit plugin](/plugins/datakit/), Debugger captures tracing data for each Datakit node in the pipeline.
+This gives you visibility into how data flows through your Datakit configuration.
+You can see which nodes ran, what values they received and produced, and where errors or skips occurred.
 
-## Prerequisites
+Datakit tracing provides debugging detail without exposing sensitive data.
+{{site.base_gateway}} tracks values as they move through the Datakit workflow and applies redaction and sanitization rules before sending trace data to {{site.konnect_short_name}}.
 
-To collect Datakit tracing events, body payload capture must be enabled for your Debugger session.
-Header-only capture records node spans but does not upload tracing events with I/O values.
+## Enable tracing event collection
+
+To collect Datakit tracing events, start a {{site.konnect_short_name}} Debugger session with body payload capture.
+If header-only payload capture is enabled, node spans will be recorded but tracing events won't be uploaded.
 
 ## Datakit node spans
 
-For each Datakit node that executes, the Debugger creates a span named `kong.datakit.node.<node_name>`, where `<node_name>` is the name you assigned to the node in your Datakit configuration.
-Spans capture metadata about node execution but do not include input or output values.
-Nodes that are skipped due to branch routing typically do not create a span.
+For each Datakit node that executes, Debugger creates a span named `kong.datakit.node.NODE_NAME`, where `NODE_NAME` is the name you assigned to the node in your Datakit configuration.
+
+Node spans capture metadata about node execution but don't contain node input or output values.
+Values are only captured in the separate Datakit tracing event payload.
+
+If a node is skipped due to branch routing rules, it normally won't create a span because execution hasn't started.
+Information about skipped nodes is available in Datakit tracing events.
 
 Each span includes the following attributes:
 
@@ -59,20 +67,22 @@ columns:
 rows:
   - attribute: "`proxy.kong.datakit.node.type`"
     description: The type of the Datakit node.
-    values: "`jq`, `call`, `jwt_decode`, `jwt_verify`, `jwt_sign`, `cache`, `branch`, `static`, `request`, `response`, `service_request`, `service_response`, `property`, `exit`, `vault`"
+    values: |
+      Depends on the node, for example, `jq`, `call`, or `jwt_decode`. 
+      See the [Datakit nodes reference](/plugins/datakit/#node-types) for all supported node types.
   - attribute: "`proxy.kong.datakit.node.status`"
-    description: The terminal status of the node after execution.
-    values: "`complete`, `fail`, `cancel`"
+    description: The final status of the node after execution.
+    values: "`complete`, `fail`, or `cancel`"
 {% endtable %}
 <!--vale on-->
 
 ## Tracing events
 
 Tracing events capture the full lifecycle of each node, including input and output values.
-Each event corresponds to a specific point in a node's execution and includes the data the node was working with at that moment.
+Each event corresponds to a specific point in a node's execution and includes the data the node was working with at that point.
 
 {:.info}
-> Large values may be omitted from tracing events if they exceed the capture size limit.
+> **Note**: Large values may be omitted from tracing events if they exceed the capture size limit.
 
 Each tracing event includes the following fields:
 
@@ -87,15 +97,21 @@ rows:
   - field: "`name`"
     description: The name of the Datakit node.
   - field: "`type`"
-    description: The type of the Datakit node (for example, `jq`, `call`, `jwt_decode`).
+    description: |
+      The type of the Datakit node (for example, `jq`, `call`, `jwt_decode`).
   - field: "`action`"
-    description: The lifecycle action that generated this event. See [Actions](#actions).
+    description: |
+      The lifecycle action that generated this event. See [Actions](#actions).
   - field: "`timestamp`"
     description: The time the event occurred.
   - field: "`value`"
-    description: The input or output value associated with this action. Present for `run`, `complete`, and `fail` actions. May be absent for large values that exceed capture limits.
+    description: |
+      The input or output value associated with this action.
+      <br><br>
+      The `run` action maps to input values, while the `complete`, `fail`, `cancel` actions map to output values.
   - field: "`error`"
-    description: The error message, if the action is `fail`.
+    description: |
+      The error message, if the action is `fail`.
 {% endtable %}
 <!--vale on-->
 
@@ -115,19 +131,19 @@ columns:
 rows:
   - action: "`run`"
     value: Input value
-    description: The node started executing. The event includes the input value the node received.
+    description: The node started running. The event includes the input value the node received.
   - action: "`complete`"
     value: Output value
     description: The node finished successfully. The event includes the output value the node produced.
   - action: "`fail`"
-    value: Partial output value (if any)
+    value: "Partial output value (if any)"
     description: The node encountered an error. The event includes an error message and any partial output.
   - action: "`skip`"
     value: Routing value
     description: The node was skipped due to branch routing. The event shows the routing value that caused the skip.
   - action: "`cancel`"
     value: None
-    description: The node was canceled before it completed, typically because an upstream node failed.
+    description: The node was canceled before it completed.
   - action: "`schedule`"
     value: Input value
     description: "`call` nodes only. The node was scheduled for an async HTTP request."
@@ -142,17 +158,20 @@ rows:
 
 ## Redaction and sanitization
 
-Datakit tracing values are sanitized on the data plane before being transmitted to {{site.konnect_short_name}}.
+Datakit values can carry arbitrary content, including Vault secrets, authentication headers, personally identifiable information (PII), response bodies, and transformed values.
+Datakit applies redaction and sanitization rules based on the source of the node's input.
+Tracing values are sanitized on the data plane before being transmitted to {{site.konnect_short_name}}.
+
 The same [custom masking rules](/observability/debugger/#payload-collection-and-sanitization) you configure for general Debugger payload capture also apply to Datakit tracing events.
 
 ### Vault-derived values
 
-Any value that originates from a vault secret is always replaced with `********`, regardless of other sanitization rules.
-If a node's output is derived from a vault-resolved value, the entire output is redacted.
+Any value that comes from a Vault secret is always replaced with `********`, regardless of other sanitization rules.
+If a node's output is derived from a Vault-resolved value, the entire output is redacted.
 
 ### Header sanitization
 
-When a Datakit value is a headers map (a structured map of header name-value pairs), it is sanitized using header-name rules.
+When a Datakit value is a headers map (a structured map of header name-value pairs), it's sanitized using header-name rules.
 The following headers are masked by default:
 
 * `authorization`
@@ -169,12 +188,17 @@ After transformation, the value no longer carries header context and is sanitize
 ### Body and structured value sanitization
 
 String values are sanitized using body rules (regex or JSONPath).
-Structured values (maps and objects) are sanitized using body rules plus JSONPath expressions applied to the structure.
+Structured values (maps and objects) are sanitized using body rules with JSONPath expressions applied to the structure.
 When a node's output is assembled from individual field-level inputs, each field is sanitized independently according to the rules that apply to its source.
 
 ### Node-specific sanitization behavior
 
-The sanitization applied to a node's tracing event values depends on the node type and the source of its inputs.
+The sanitization applied to a node's tracing event values depends on the node type and the source of its inputs. In summary:
+* Values that come from request data use sanitizer rules configured for request data.
+* Values that come from response data use sanitizer rules configured for response data.
+* Values that combine request and response data can use both request and response sanitizer rules.
+
+The following table breaks down sanitization behavior by node:
 
 <!--vale off-->
 {% table %}
@@ -203,7 +227,7 @@ rows:
     sanitization: Based on connected inputs
   - node: "`vault`"
     io: Output
-    sanitization: Always `********` (vault-derived)
+    sanitization: "Always `********` (vault-derived)"
   - node: "`call`"
     io: Output headers
     sanitization: Response header-name rules
@@ -221,13 +245,13 @@ rows:
     sanitization: Based on input values
   - node: "`jq`"
     io: Output
-    sanitization: Body rules (header context lost after transformation)
+    sanitization: "Body rules (header context lost after transformation)"
   - node: "`json_to_xml`"
     io: Output
-    sanitization: Body rules (header context lost after transformation)
+    sanitization: "Body rules (header context lost after transformation)"
   - node: "`xml_to_json`"
     io: Output
-    sanitization: Body rules (header context lost after transformation)
+    sanitization: "Body rules (header context lost after transformation)"
   - node: "`jwt_decode`"
     io: Input JWT
     sanitization: Always redacted
@@ -275,11 +299,33 @@ rows:
 
 ## Custom sanitization rules
 
-Custom sanitization rules you define in the Debugger apply to Datakit tracing event values.
-Body rules can be regex patterns (PCRE) or JSONPath expressions ([RFC 9535](https://www.rfc-editor.org/rfc/rfc9535)).
+Custom payload sanitization rules configured for Debugger also apply to Datakit tracing values.
+Custom body rules can use regex or JSONPath expressions ([RFC 9535](https://www.rfc-editor.org/rfc/rfc9535)).
 
-When writing JSONPath rules for `jwt_decode` output, use paths relative to the decoded output structure.
-For example, if the `jwt_decode` node outputs `{"header": {...}, "payload": {"sub": "user123"}}`, use `$.payload.sub` to target the `sub` field.
-If you then pass that output through a `jq` node that reshapes it to `{"sub": "user123"}`, use `$.sub` instead, because the `jq` transformation changed the structure.
+For object inputs and outputs, each field is sanitized independently.
+When a node's output is assembled from field-level inputs (for example, `request.headers` connected to `jq.headers`), Datakit preserves per-field sanitization for that output.
+Transformed `$self` outputs, like the full output of a `jq` node, are sanitized as a single value.
 
-To redact a field regardless of its position in a nested structure, use a recursive descent expression like `$..sub`, which matches any field named `sub` at any depth.
+Write JSONPath rules relative to the value as it appears in the tracing event.
+For example, `jwt_decode` output is an object with `header`, `payload`, and `signature` fields:
+
+```json
+{
+  "header": {
+    "typ": "JWT",
+    "alg": "HS256"
+  },
+  "payload": {
+    "sub": "user-123",
+    "email": "alice@example.com"
+  },
+  "signature": "..."
+}
+```
+
+* To redact `payload.sub`, use `$.payload.sub`.
+* To redact `header.typ`, use `$.header.typ`.
+
+If the `jwt_decode` output is then passed through a `jq` node that reshapes it, write your JSONPath rule relative to the `jq` output structure instead.
+
+To redact any field named `sub` regardless of its position in the structure, use the resursive deep-scan JSONPath rule `$..sub`.

--- a/app/observability/datakit-debugger.md
+++ b/app/observability/datakit-debugger.md
@@ -328,4 +328,4 @@ For example, `jwt_decode` output is an object with `header`, `payload`, and `sig
 
 If the `jwt_decode` output is then passed through a `jq` node that reshapes it, write your JSONPath rule relative to the `jq` output structure instead.
 
-To redact any field named `sub` regardless of its position in the structure, use the resursive deep-scan JSONPath rule `$..sub`.
+To redact any field named `sub` regardless of its position in the structure, use the recursive deep-scan JSONPath rule `$..sub`.

--- a/app/observability/datakit-debugger.md
+++ b/app/observability/datakit-debugger.md
@@ -32,15 +32,14 @@ min_version:
 ---
 
 When you run a [Debugger session](/observability/debugger/) on a {{site.base_gateway}} instance that uses the [Datakit plugin](/plugins/datakit/), Debugger captures tracing data for each Datakit node in the pipeline.
-This gives you visibility into how data flows through your Datakit configuration.
-You can see which nodes ran, what values they received and produced, and where errors or skips occurred.
+This gives you visibility into how data flows through your Datakit configuration, which nodes ran, what values they received and produced, and where errors or skips occurred.
 
 Datakit tracing provides debugging detail without exposing sensitive data.
 {{site.base_gateway}} tracks values as they move through the Datakit workflow and applies redaction and sanitization rules before sending trace data to {{site.konnect_short_name}}.
 
 ## Enable tracing event collection
 
-To collect Datakit tracing events, start a {{site.konnect_short_name}} Debugger session with body payload capture.
+To collect Datakit tracing events, start a {{site.konnect_short_name}} Debugger session with body payload capture enabled.
 If header-only payload capture is enabled, node spans will be recorded but tracing events won't be uploaded.
 
 ## Datakit node spans
@@ -50,7 +49,7 @@ For each Datakit node that executes, Debugger creates a span named `kong.datakit
 Node spans capture metadata about node execution but don't contain node input or output values.
 Values are only captured in the separate Datakit tracing event payload.
 
-If a node is skipped due to branch routing rules, it normally won't create a span because execution hasn't started.
+If a node is skipped due to branch routing rules, it won't create a span because execution hasn't started.
 Information about skipped nodes is available in Datakit tracing events.
 
 Each span includes the following attributes:

--- a/app/observability/datakit-debugger.md
+++ b/app/observability/datakit-debugger.md
@@ -1,0 +1,285 @@
+---
+title: Using Debugger for Datakit
+description: 'Use the {{site.konnect_short_name}} Debugger to inspect Datakit node execution: trace node spans, view I/O values per node lifecycle event, and understand how sanitization rules apply to Datakit tracing data.'
+breadcrumbs:
+  - /observability/
+  - /observability/debugger/
+content_type: reference
+layout: reference
+search_aliases:
+  - active tracing
+  - debugger
+products:
+    - observability
+    - konnect
+    - gateway
+works_on:
+    - konnect
+tags:
+  - tracing
+  - debugger
+
+related_resources:
+  - text: The {{site.konnect_short_name}} Debugger
+    url: /observability/debugger/
+  - text: Datakit plugin
+    url: /plugins/datakit/
+  - text: Datakit in {{site.base_gateway}}
+    url: /gateway/datakit/
+
+min_version:
+  gateway: '3.15'
+---
+
+When you run a Debugger session on a gateway that uses the Datakit plugin, the Debugger captures tracing data for each Datakit node in the pipeline.
+This gives you visibility into how data flows through your Datakit configuration: which nodes ran, what values they received and produced, and where errors or skips occurred.
+
+## Prerequisites
+
+To collect Datakit tracing events, body payload capture must be enabled for your Debugger session.
+Header-only capture records node spans but does not upload tracing events with I/O values.
+
+## Datakit node spans
+
+For each Datakit node that executes, the Debugger creates a span named `kong.datakit.node.<node_name>`, where `<node_name>` is the name you assigned to the node in your Datakit configuration.
+Spans capture metadata about node execution but do not include input or output values.
+Nodes that are skipped due to branch routing typically do not create a span.
+
+Each span includes the following attributes:
+
+<!--vale off-->
+{% table %}
+columns:
+  - title: Attribute
+    key: attribute
+  - title: Description
+    key: description
+  - title: Values
+    key: values
+rows:
+  - attribute: "`proxy.kong.datakit.node.type`"
+    description: The type of the Datakit node.
+    values: "`jq`, `call`, `jwt_decode`, `jwt_verify`, `jwt_sign`, `cache`, `branch`, `static`, `request`, `response`, `service_request`, `service_response`, `property`, `exit`, `vault`"
+  - attribute: "`proxy.kong.datakit.node.status`"
+    description: The terminal status of the node after execution.
+    values: "`complete`, `fail`, `cancel`"
+{% endtable %}
+<!--vale on-->
+
+## Tracing events
+
+Tracing events capture the full lifecycle of each node, including input and output values.
+Each event corresponds to a specific point in a node's execution and includes the data the node was working with at that moment.
+
+{:.info}
+> Large values may be omitted from tracing events if they exceed the capture size limit.
+
+Each tracing event includes the following fields:
+
+<!--vale off-->
+{% table %}
+columns:
+  - title: Field
+    key: field
+  - title: Description
+    key: description
+rows:
+  - field: "`name`"
+    description: The name of the Datakit node.
+  - field: "`type`"
+    description: The type of the Datakit node (for example, `jq`, `call`, `jwt_decode`).
+  - field: "`action`"
+    description: The lifecycle action that generated this event. See [Actions](#actions).
+  - field: "`timestamp`"
+    description: The time the event occurred.
+  - field: "`value`"
+    description: The input or output value associated with this action. Present for `run`, `complete`, and `fail` actions. May be absent for large values that exceed capture limits.
+  - field: "`error`"
+    description: The error message, if the action is `fail`.
+{% endtable %}
+<!--vale on-->
+
+### Actions
+
+The `action` field describes what happened to the node at the moment the event was recorded.
+
+<!--vale off-->
+{% table %}
+columns:
+  - title: Action
+    key: action
+  - title: Value captured
+    key: value
+  - title: Description
+    key: description
+rows:
+  - action: "`run`"
+    value: Input value
+    description: The node started executing. The event includes the input value the node received.
+  - action: "`complete`"
+    value: Output value
+    description: The node finished successfully. The event includes the output value the node produced.
+  - action: "`fail`"
+    value: Partial output value (if any)
+    description: The node encountered an error. The event includes an error message and any partial output.
+  - action: "`skip`"
+    value: Routing value
+    description: The node was skipped due to branch routing. The event shows the routing value that caused the skip.
+  - action: "`cancel`"
+    value: None
+    description: The node was canceled before it completed, typically because an upstream node failed.
+  - action: "`schedule`"
+    value: Input value
+    description: "`call` nodes only. The node was scheduled for an async HTTP request."
+  - action: "`dispatch`"
+    value: Request data
+    description: "`call` nodes only. The async HTTP request was dispatched."
+  - action: "`resume`"
+    value: Response data
+    description: "`call` nodes only. The async HTTP response was received and the node resumed execution."
+{% endtable %}
+<!--vale on-->
+
+## Redaction and sanitization
+
+Datakit tracing values are sanitized on the data plane before being transmitted to {{site.konnect_short_name}}.
+The same [custom masking rules](/observability/debugger/#payload-collection-and-sanitization) you configure for general Debugger payload capture also apply to Datakit tracing events.
+
+### Vault-derived values
+
+Any value that originates from a vault secret is always replaced with `********`, regardless of other sanitization rules.
+If a node's output is derived from a vault-resolved value, the entire output is redacted.
+
+### Header sanitization
+
+When a Datakit value is a headers map (a structured map of header name-value pairs), it is sanitized using header-name rules.
+The following headers are masked by default:
+
+* `authorization`
+* `api-key`
+* `x-api-key`
+* `x-consumer-username`
+* `x-consumer-custom-id`
+* `x-consumer-id`
+* `x-credential-identifier`
+
+Header context is lost when a value passes through a transformation node like `jq`, `json_to_xml`, or `xml_to_json`.
+After transformation, the value no longer carries header context and is sanitized using body rules instead.
+
+### Body and structured value sanitization
+
+String values are sanitized using body rules (regex or JSONPath).
+Structured values (maps and objects) are sanitized using body rules plus JSONPath expressions applied to the structure.
+When a node's output is assembled from individual field-level inputs, each field is sanitized independently according to the rules that apply to its source.
+
+### Node-specific sanitization behavior
+
+The sanitization applied to a node's tracing event values depends on the node type and the source of its inputs.
+
+<!--vale off-->
+{% table %}
+columns:
+  - title: Node type
+    key: node
+  - title: Input or output
+    key: io
+  - title: Sanitization applied
+    key: sanitization
+rows:
+  - node: "`request`"
+    io: Headers
+    sanitization: Header-name rules
+  - node: "`request`"
+    io: Body, query parameters
+    sanitization: Body rules
+  - node: "`response`"
+    io: All values
+    sanitization: Based on connected inputs
+  - node: "`service_request`"
+    io: All values
+    sanitization: Based on connected inputs
+  - node: "`service_response`"
+    io: All values
+    sanitization: Based on connected inputs
+  - node: "`vault`"
+    io: Output
+    sanitization: Always `********` (vault-derived)
+  - node: "`call`"
+    io: Output headers
+    sanitization: Response header-name rules
+  - node: "`call`"
+    io: Output body
+    sanitization: Response body rules
+  - node: "`static`"
+    io: Output
+    sanitization: Only if the value matches a configured rule
+  - node: "`property GET`"
+    io: Output
+    sanitization: Only if the value matches a configured rule
+  - node: "`property SET`"
+    io: Output
+    sanitization: Based on input values
+  - node: "`jq`"
+    io: Output
+    sanitization: Body rules (header context lost after transformation)
+  - node: "`json_to_xml`"
+    io: Output
+    sanitization: Body rules (header context lost after transformation)
+  - node: "`xml_to_json`"
+    io: Output
+    sanitization: Body rules (header context lost after transformation)
+  - node: "`jwt_decode`"
+    io: Input JWT
+    sanitization: Always redacted
+  - node: "`jwt_decode`"
+    io: JWT signature
+    sanitization: Always redacted
+  - node: "`jwt_decode`"
+    io: JWT header and payload claims
+    sanitization: Body rules
+  - node: "`jwt_verify`"
+    io: Input token and key
+    sanitization: Always redacted
+  - node: "`jwt_verify`"
+    io: Output claims and header
+    sanitization: Body rules
+  - node: "`jwt_sign`"
+    io: Input key
+    sanitization: Always redacted
+  - node: "`jwt_sign`"
+    io: Output token
+    sanitization: Always redacted
+  - node: "`jwt_sign`"
+    io: Input claims and headers
+    sanitization: Body rules
+  - node: "`cache GET`"
+    io: Output
+    sanitization: Only if the value matches a configured rule
+  - node: "`cache SET`"
+    io: Cached data
+    sanitization: Based on input data source
+  - node: "`cache SET`"
+    io: Generated values
+    sanitization: Body rules
+  - node: "`branch`"
+    io: Routing values
+    sanitization: Body rules
+  - node: "`exit`"
+    io: Response body
+    sanitization: Based on input sources
+  - node: "`exit`"
+    io: Response headers
+    sanitization: Based on input sources
+{% endtable %}
+<!--vale on-->
+
+## Custom sanitization rules
+
+Custom sanitization rules you define in the Debugger apply to Datakit tracing event values.
+Body rules can be regex patterns (PCRE) or JSONPath expressions ([RFC 9535](https://www.rfc-editor.org/rfc/rfc9535)).
+
+When writing JSONPath rules for `jwt_decode` output, use paths relative to the decoded output structure.
+For example, if the `jwt_decode` node outputs `{"header": {...}, "payload": {"sub": "user123"}}`, use `$.payload.sub` to target the `sub` field.
+If you then pass that output through a `jq` node that reshapes it to `{"sub": "user123"}`, use `$.sub` instead, because the `jq` transformation changed the structure.
+
+To redact a field regardless of its position in a nested structure, use a recursive descent expression like `$..sub`, which matches any field named `sub` at any depth.

--- a/app/observability/debugger-spans.md
+++ b/app/observability/debugger-spans.md
@@ -20,6 +20,8 @@ tags:
 related_resources:
   - text: The {{site.konnect_short_name}} Debugger
     url: /observability/debugger/
+  - text: Using Debugger for Datakit
+    url: /observability/datakit-debugger/
 ---
 
 

--- a/app/observability/debugger.md
+++ b/app/observability/debugger.md
@@ -30,6 +30,8 @@ related_resources:
     url: /konnect-platform/cmek/
   - text: "{{site.base_gateway}} tracing reference"
     url: /gateway/tracing/
+  - text: Using Debugger for Datakit
+    url: /observability/datakit-debugger/
 ---
 
 {{site.konnect_short_name}} Debugger provides a connected debugging experience and real-time trace-level visibility into API traffic, enabling you to:


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Adds a reference doc for using Debugger for debugging Datakit.

This is a continuation of an earlier ticket that was already merged into 3.15 - SME provided more information.

## Preview Links

https://deploy-preview-5590--kongdeveloper.netlify.app/observability/datakit-debugger/
https://deploy-preview-5590--kongdeveloper.netlify.app/plugins/datakit/#debugging
https://deploy-preview-5590--kongdeveloper.netlify.app/gateway/datakit/#debugging-and-development
