### PR TITLE
chore(gateway): Remove Amazon Linux 2 from distros list for 3.15

### DIFF
--- a/app/_data/products/gateway.yml
+++ b/app/_data/products/gateway.yml
@@ -1710,16 +1710,6 @@ releases:
     ee-version: "3.15.0.0"
     eol: TBA
     distributions:
-      - amazonlinux2:
-          package: true
-          package_support:
-            fips: false
-            arm: true
-            graviton: true
-          docker: true
-          docker_support:
-            arm: true
-          eol: 2026-06-30
       - amazonlinux2023:
           package: true
           package_support:


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

AL2 reaches EOL on June 30th. We are most likely not publishing images for this for 3.15 to avoid having to support it for two weeks.

~Don't merge yet, in case this decision is reversed.~ Verified.

## Preview Links
https://deploy-preview-5592--kongdeveloper.netlify.app/gateway/version-support-policy/
