### PR TITLE
feat(gateway): add AWS secret vault ref syntax

### DIFF
--- a/app/_how-tos/gateway/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity.md
+++ b/app/_how-tos/gateway/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity.md
@@ -114,4 +114,14 @@ value: 'secret'
 
 If the vault was configured correctly, this command should return the value of the secret. Then, you can use `{vault://aws-vault/my-aws-secret/token}` to reference the secret in any referenceable field.
 
+{:.info}
+> **Reference plaintext and key/value secrets**
+>
+> AWS secrets can be stored as **plaintext** and **key/value (JSON)**. How you reference a secret depends on its type:
+>
+> * If your secret is a **key/value (JSON)** secret, reference it by the secret name and the field key: `{vault://aws-vault/my-aws-secret/token}`
+> * If your secret is a **plaintext** secret, reference it by the secret name only: `{vault://aws-vault/my-aws-secret}`
+>
+> For key/value secrets, the secret must be a flat JSON object whose values are strings. Nested objects and non-string values aren't supported.
+
 For more information about supported secret types, see [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret). 

--- a/app/_how-tos/kubernetes-ingress-controller/kic-vault-aws.md
+++ b/app/_how-tos/kubernetes-ingress-controller/kic-vault-aws.md
@@ -88,4 +88,14 @@ command: kubectl exec -n kong -it deployment/kong-gateway -c proxy --
 
 If the vault was configured correctly, this command should return the value of the secret. You can use `{vault://aws-vault/my-aws-secret/token}` to reference the secret in any referenceable field.
 
+{:.info}
+> **Reference plaintext and key/value secrets**
+>
+> AWS secrets can be stored as **plaintext** and **key/value (JSON)**. How you reference a secret depends on its type:
+>
+> * If your secret is a **key/value (JSON)** secret, reference it by the secret name and the field key: `{vault://aws-vault/my-aws-secret/token}`
+> * If your secret is a **plaintext** secret, reference it by the secret name only: `{vault://aws-vault/my-aws-secret}`
+>
+> For key/value secrets, the secret must be a flat JSON object whose values are strings. Nested objects and non-string values aren't supported.
+
 For more information about supported secret types, see [What can be stored as a secret](/gateway/entities/vault/#what-can-be-stored-as-a-secret). 


### PR DESCRIPTION


<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Add an info callout to the Gateway and KIC AWS Secrets Manager vault guides explaining how the reference syntax differs by secret type.

Fixes [FTI-7221](https://konghq.atlassian.net/browse/FTI-7221)

## Preview Links

- https://deploy-preview-5594--kongdeveloper.netlify.app/how-to/configure-aws-secrets-manager-as-a-vault-backend-with-vault-entity/
- https://deploy-preview-5594--kongdeveloper.netlify.app/kubernetes-ingress-controller/vault/aws/

## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [x] Add new pages to the product documentation index (if applicable).


[FTI-7221]: https://konghq.atlassian.net/browse/FTI-7221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ