### PR TITLE
chore(gateway): Regenerate latest changelogs

### DIFF
--- a/app/_data/changelogs/gateway.json
+++ b/app/_data/changelogs/gateway.json
@@ -1,794 +1,4 @@
 {
-  "3.10.0.0": {
-    "kong": [
-      {
-        "message": "**Prometheus**: Added gauge to expose connectivity state to the control plane.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added a new configuration parameter `admin_gui_csp_header` to Gateway, which controls the Content-Security-Policy (CSP) header served with Admin GUI (Kong Manager). This defaults to `\"off\"`, and you can opt-in by setting it to `\"on\"`.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "Backported the `balancer.set_upstream_tls` feature from the OpenResty upstream [openresty/lua-resty-core#460](https://github.com/openresty/lua-resty-core/pull/460).",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped atc-router from v1.6.2 to v1.7.1. This release contains upgraded dependencies and a new interface for validating expressions.\n",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped Kong Nginx Module from 0.15.0 to 0.15.1.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped libexpat from 2.6.2 to 2.6.4 to fix a crash in the XML_ResumeParser function caused by XML_StopParser stopping an uninitialized parser.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-kong-nginx-module from 0.13.0 to 0.14.0.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-resty-simdjson from 1.1.0 to 1.2.0.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped `ngx_wasm_module` to `a376e67ce02c916304cc9b9ef25a540865ee6740`",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped OpenResty from 1.25.3.2 to 1.27.1.1.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped PCRE2 from 10.44 to 10.45 (https://github.com/PCRE2Project/pcre2/blob/pcre2-10.45/NEWS).",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped Snappy Library from 1.2.0 to 1.2.1.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped OpenSSL to 3.4.1 in Core dependencies.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "**AI Plugins**: Deprecated `preserve` mode in `config.route_type`. Use `config.llm_format` instead. The `preserve` mode setting will be removed in a future release.",
-        "type": "deprecation",
-        "plugins": [
-          "ai-proxy",
-          "ai-proxy-advanced",
-          "ai-request-transformer",
-          "ai-response-transformer"
-        ],
-        "scope": "Plugin"
-      },
-      {
-        "message": "dynamic control upstream tls when kong.service.request.set_scheme was called",
-        "type": "feature",
-        "scope": "PDK"
-      },
-      {
-        "message": "**CORS**: Added an option to skip returning the Access-Control-Allow-Origin response header when requests don't have the Origin header.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added a new field `x5t` to the entity `keys`, letting you use a X.509 Certificate Thumbprint to identify the key.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "Added a patch for `kong.resty.set_next_upstream()` to control the next upstream retry logic on the Lua side. [Kong/lua-kong-nginx-module#98](https://github.com/Kong/lua-kong-nginx-module/pull/98)\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**Opentelemetry**: This plugin now supports variable resource attributes.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where a GET request to the Admin API root `/` path would return a 500 server error.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**AI Plugins**: Changed the serialized log key of AI metrics from `ai.ai-proxy` to `ai.proxy` to avoid conflicts with metrics generated from plugins other than AI Proxy and AI Proxy Advanced. If you are using logging plugins (for example, File Log, HTTP Log, etc.), you will have to update metrics pipeline configurations to reflect this change.\n",
-        "type": "Breaking Change",
-        "plugins": [
-          "ai-proxy",
-          "ai-proxy-advanced"
-        ],
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed a bug in the Azure provider where `model.options.upstream_path` overrides would always return a 404 response.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed a bug where Azure streaming responses would be missing individual tokens.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed a bug where response streaming in Gemini and Bedrock providers was returning whole chat responses in one chunk.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed a bug with the Gemini provider, where multimodal requests (in OpenAI format) would not transform properly.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Fixed an issue where AI upstream URL trailing would be empty.",
-        "type": "bugfix",
-        "plugins": [
-          "ai-proxy-advanced",
-          "ai-proxy",
-          "ai-rag-injector",
-          "ai-request-transformer",
-          "ai-response-transformer",
-          "ai-semantic-cache",
-          "ai-semantic-prompt-guard"
-        ],
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AWS-Lambda**: Fixed an issue that occurred when `is_proxy_integration` was enabled, where Kong's response could behave incorrectly when the response was changed after the execution of the AWS Lambda plugin. The Content-Length header in the lambda function response is now ignored by the AWS Lambda plugin.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where consistent hashing did not correctly handle hyphenated-Pascal-case headers, leading to uneven distribution of requests across upstream targets.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the `db_resurrect_ttl` configuration didn't take effect.",
-        "type": "bugfix",
-        "scope": "Configuration"
-      },
-      {
-        "message": "Fixed an issue where `POST /config?flatten_errors=1` could not return a proper response if the input contained duplicate consumer credentials.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where a valid declarative config with certificate or SNI entities couldn't be loaded in DB-less mode.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed error caused by duplicate `Content-Type`.\n",
-        "type": "bugfix",
-        "scope": "Admin API"
-      },
-      {
-        "message": "Fixed an issue where `POST /config?flatten_errors=1` could return a JSON object instead of an empty array.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the error reason wasn't thrown when parsing the certificate from vault.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Users can now use a backslash to escape dots in logging plugins' `custom_fields_by_lua`  key strings, preventing dots from creating nested tables.",
-        "type": "bugfix",
-        "scope": "PDK"
-      },
-      {
-        "message": "**grpc-web** and **grpc-gateway**: Fixed a bug where the `TE` (transfer-encoding) header would not be sent to the upstream gRPC servers when `grpc-web` or `grpc-gateweay` are in use.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the new DNS client did not correctly handle the timeout option in resolv.conf.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the schema library would error with a nil reference if an entity checker referred to a nonexistent field.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**authentications**: Improved the error message which occurred when an anonymous consumer was configured but did not exist.",
-        "type": "bugfix",
-        "plugins": [
-          "basic-auth",
-          "hmac-auth",
-          "jwt",
-          "key-auth",
-          "ldap-auth",
-          "oauth2"
-        ],
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kong.service.request.clear_query_arg**: Changed the encoding of spaces in query arguments from `+`\nto `%20` as a short-term solution to an issue that some users are reporting. While the `+` character is the correct\nencoding of space in querystrings, Kong uses `%20` in many other APIs (inherited from Nginx / OpenResty).\n",
-        "type": "Breaking Change",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed potential connection leaks when the data plane failed to connect to the control plane.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**response-ratelimiting**: Fixed an issue where usage headers that were supposed to be sent to the upstream were lost instead.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where `socket_path` permissions were not correctly set to `755` when the umask setting did not give enough permissions.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where targets couldn't be removed from the DNS query if they were deleted or updated via the Admin API.",
-        "scope": "Core",
-        "type": "bugfix"
-      },
-      {
-        "message": "Fixed an issue where the `tls_verify`, `tls_verify_depth`, and `ca_certificates` properties of a service were not included in the upstream keepalive pool name.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**file-log**: Fixed an issue where an error would occur when there were spaces at the beginning or end of a path.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**OpenTelemetry**: This plugin now supports instana headers in propagation.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Reduced the LMDB storage space by optimizing the key format.",
-        "type": "performance",
-        "scope": "Core"
-      },
-      {
-        "message": "Improved performance of trace ID size lookup.",
-        "type": "performance",
-        "scope": "Core"
-      },
-      {
-        "message": "**Prometheus**: Added the capability to enable or disable exporting of Proxy-Wasm metrics.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Refined PDK usage for better performance.",
-        "type": "performance",
-        "scope": "PDK"
-      },
-      {
-        "message": "**session**: Added two boolean configuration fields `hash_subject` (default `false`) and `store_metadata` (default `false`) to store the session's metadata in the database.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "The upstream URI variable is now refreshed when the proxy pass balancer is recreated.",
-        "type": "feature",
-        "scope": "Core"
-      }
-    ],
-    "kong-ee": [
-      {
-        "message": "**Confluent**: Added support for message manipulation with the new configuration field `message_by_lua_functions`.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Confluent**: Added support for sending messages to multiple topics with `topics_query_arg`, and enabled topic allowlisting with `allowed_topics`.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added external consumer support for Konnect.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**kafka-upstream**: Added support for sending messages to multiple topics with `topics_query_arg`, and enabled topic allowlisting with `allowed_topics`.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-upstream**: Added support for message manipulation with the new configuration field `message_by_lua_functions`.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-sanitizer**: Added a new plugin that can sanitize the PII information in requests before the requests are proxied by the AI Proxy or AI Proxy Advanced plugin.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai**: Added support for boto3 SDKs for Bedrock provider, and for Google GenAI SDKs for Gemini provider.\n",
-        "type": "feature",
-        "plugins": [
-          "ai-prompt-decorator",
-          "ai-prompt-guard",
-          "ai-proxy-advanced",
-          "ai-proxy",
-          "ai-rate-limiting-advanced",
-          "ai-semantic-cache",
-          "ai-semantic-prompt-guard"
-        ],
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai**: Added an AI Gateway sales counter for license reporting.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-rate-limiting-advanced**: Added support for allowing multiple rate limits for the same providers.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-consume**: Added the `kafka-consume` plugin, which adds Kafka consumption capabilities to Kong.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added a new core entity to Kong Gateway: partials. Partials enable users to define shared configuration for Redis.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai**: Added support for `pgvector` database in the `ai` related plugins.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Added new `priority` balancer algorithm, which allows setting apriority group for each upstream model.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-callout**: Added the `request-callout` plugin, which provides complex request augmentation and internal authentication.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Added the `failover_criteria` configuration option, which allows retrying requests to the next upstream server in case of failure.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added an optional configuration parameter `admin_gui_csp_header_value` to Gateway, which controls the value of the Content-Security-Policy (CSP) header served with Admin GUI (Kong Manager).",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped libxml2 from 2.12.9 to 2.12.10.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Updated included debug tools: `curl` to 8.12.1, the Mozilla CA Certificate Store to 2025-02-25, and `nghttp2` to 1.65.0.\n",
-        "type": "dependency",
-        "scope": "CLI Command"
-      },
-      {
-        "message": "**AI-RAG-Injector**: Added a new plugin which allows automatically injecting documents to simplify building RAG pipelines.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Proxy Advanced**: Added cost to `tokens_count_strategy` when using the lowest-usage load balancing strategy.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Added support for the `discriminator` keyword in OpenAPI specs.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Added the `huggingface`, `azure`, `vertex`, and `bedrock` providers to embeddings. They can be used by the ai-proxy-advanced, ai-semantic-cache, ai-semantic-prompt-guard, and ai-rag-injector plugins.\n",
-        "type": "feature",
-        "plugins": [
-          "ai-proxy-advanced",
-          "ai-semantic-cache",
-          "ai-semantic-prompt-guard",
-          "ai-rag-injector"
-        ],
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added support for incremental config sync for hybrid mode deployments. Instead of sending the entire entity config to data planes on each config update, incremental config sync lets you send only the changed configuration to data planes.\n",
-        "type": "feature",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**json-threat-protection**: Added the schema field `allow_duplicate_object_entry_name` to allow or disallow duplicate object keys in JSON payloads. When set to `false`, the plugin will reject JSON payloads with duplicate object keys. The default value is `true`, which is same as the previous behavior.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**jwe**: JWE now supports the following encryption algorithms: A128GCM, A192GCM, A128CBC-HS256, A192CBC-HS384, A256CBC-HS512.\n",
-        "type": "feature",
-        "scope": "PDK"
-      },
-      {
-        "message": "**AI Plugins**: Allow authentication to Bedrock services with assume roles in AWS.\n",
-        "type": "feature",
-        "plugins": [
-          "ai-proxy-advanced",
-          "ai-proxy",
-          "ai-rag-injector",
-          "ai-request-transformer",
-          "ai-response-transformer",
-          "ai-semantic-cache",
-          "ai-semantic-prompt-guard"
-        ],
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Added support for `oneOf`, `anyOf`, `allOf`, and `not` keywords.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Proxy Advanced**: Added the ability to set a catch-all target in semantic routing.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where the ai-proxy-advanced plugin failed to failover between providers of different formats.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**app-dynamics**: Fixed a segmentation fault caused by a missing destructor call on process exit.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where a certificate entity configured with a vault reference occasionally didn't get refreshed on time when initialized with an invalid string.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where a mismatch between If-Match in requests and ETag in responses would result in a bad case in the response phase.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where modifying x-forwarded header before access phase may not take effect\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**forward-proxy**: Fixed an issue where the `upstream_status` field was empty in logs when using the `forward-proxy` plugin.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**jq**: Fixed an issue where jq did not work properly with proxy-cache-advanced.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**jwt-signer**: Fixed an issue where the jwt-signer plugin failed to upsert jwks if the jwks contains extra custom fields.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ldap-auth-advanced**: Fixed an issue where binary string was truncated at the first null character.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where Admin API Enterprise-only entities were not writable when a license expired but was still in the grace period.",
-        "type": "bugfix",
-        "scope": "Admin API"
-      },
-      {
-        "message": "**mocking**: Fixed an issue where random delays were out of range.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where DNS answers with TTL=0 were incorrectly cached indefinitely in the new DNS client.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**rate-limiting-advanced**: Fixed an issue where the runtime failed due to `sync_rate` not being set if the `strategy` was `local`.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**service-protection**: Fixed an issue where the runtime failed due to `sync_rate` not being set if the `strategy` was `local`.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where query params without values caused an assertion failure.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Fixed an issue where forbidden requests were redirected to `unauthorized_redirect_uri` if configured. After the fix, forbidden requests will be redirected to `forbidden_redirect_uri` if configured.\n",
-        "type": "Breaking Change",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where Kong could have connection leaks when failing to connect to an upstream by websocket.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where a newly spawned worker couldn't use RDS IAM authentication when an old worker was decommissioned.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Created connection pools for each `host`, `port`, `username`, `ssl` combination to fix the following issues:\n\n  - Fixed a 401 error where multiple plugins (for example, Rate Limiting Advanced and OpenID Connect) were configured to use different Redis databases.\n  - Prevented malicious clients from gaining access to shared authenticated connections, thus protecting Redis servers.\n  - Restricted clients with limited ACL control to their granted scope.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**pre-function**: Fixed an issue where a duplicate `protocols` field was accidentally added to the `pre-function` schema.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-semantic-cache**: Fixed an issue where the Refresh header wasn't properly sent to the client.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Analytics**: Fixed an issue where `trace_id` did not honor the value extracted during tracing headers propagation.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**Vault**: Updated the AWS Vault supported regions list to the latest.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where Gemini streaming responses were getting truncated and/or missing tokens.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an incorrect error thrown when trying to log streaming responses.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: - Fixed an issue where templates weren't being resolved correctly.\n- The plugins now support nested fields.\n",
-        "type": "bugfix",
-        "scope": "Plugin",
-        "plugins": [
-          "ai-proxy",
-          "ai-request-transformer",
-          "ai-response-transformer"
-        ]
-      },
-      {
-        "message": "**ai-rate-limiting-advanced**: `window_size` and `limit` now require an array of numbers instead of a single number.\nIf you configured the plugin before 3.10 and use `kong migrations` to upgrade to 3.10, it will be automatically migrated to use the array.\n",
-        "type": "Breaking Change",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-semantic-cache**: Fixed issue where the SSE body may have extra trailing.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed tool calls not working in streaming mode for Bedrock and Gemini providers.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where Konnect analytics were missing for Kong AI Gateway.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Added support for the new Ollama streaming content type in the AI driver.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-proxy**: Fixed preserve mode.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-semantic-prompt-guard**: Fixed an issue where Kong Gateway was not able to reconfigure the plugin when using DB-less mode.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where a false error log was generated when a DELETE request with `Content-Type: application/json` and no body was made.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where event hooks sometimes ignored events, caused by the normalized table not including values of type number or boolean.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the PEM-formatted private keys in the keys entity were not encrypted when keyring was enabled.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**service-protection**: Enhanced robustness for user misconfigurations. The following use cases are now handled:\n  - RLA and service-protection are configured on the same service.\n  - There is no service but the service-protection plugin is enabled with global scope.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where the ai-proxy-advanced plugin identity running failed in retry scenarios.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added a new feature to invalidate the admin's or the developer's related session while changing the password.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**json-threat-protection**: This plugin now accurately supports proxying for non-`POST/PUT/PATCH` requests.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Improved performance on OpenAPI 3.0.",
-        "type": "performance",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**OpenID-Connect**: Removed issuer discovery from schema to improve performance upon plugin initialization or updating. The issuer discovery will only be triggerd by client requests.",
-        "type": "performance",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Free mode is deprecated and will be removed in a future 3.x version of Kong Gateway Enterprise. At that point, running Kong Gateway without a license will behave the same as running it with an expired license.",
-        "type": "Breaking Change",
-        "scope": "Core"
-      },
-      {
-        "message": "Added a feature to store the last sync time on the Data Plane side.\n",
-        "type": "feature",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Updated `/license/report` endpoint to include counts for Kafka consumption, Confluent Kafka consumption, and Confluent production.\n",
-        "type": "feature",
-        "scope": "Admin API"
-      },
-      {
-        "message": "Fixed an issue where the \"meta\" field was not validated when creating or updating a portal developer.",
-        "type": "bugfix",
-        "scope": "Admin API"
-      },
-      {
-        "message": "**AI Proxy**: Some active tracing latency values are incorrectly reported as having zero length when using the AI Proxy plugin.\n",
-        "type": "known-issues",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Kafka Consume**: Kong Gateway allows you to configure the Kafka Consume plugin without authentication settings, but authentication must be configured for the plugin to work.\n\nIf authentication is not configured, or if the authentication strategy is missing, the plugin will fail with a generic authentication error.\n",
-        "type": "known-issues",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Confluent Consume and Kafka Consume plugins**: An error message appears in the logs about a missing cluster name, even when the name is specified.\n",
-        "type": "known-issues",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Vault Auth**: The Vault Auth plugin doesn't clear its cache when incremental sync is turned on. This means that deleted secrets will remain in the cache, and can still be accessed by the plugin.\n",
-        "type": "known-issues",
-        "scope": "Plugin"
-      },
-      {
-        "message": "When running in incremental sync mode ([`incremental_sync=on`](/gateway/configuration/#incremental-sync)), Kong Gateway can't apply configuration deltas to the stream subsystem. \nThis issue affects versions 3.10.0.0 and above, where incremental sync is enabled alongside stream proxying ([`stream_listen`](/gateway/configuration/#stream-listen)).\nAs a workaround for this issue, set `incremental_sync=off` when using stream proxying.\n",
-        "type": "known-issues",
-        "scope": "Core"
-      },
-      {
-        "message": "The Brotli module is missing from all of the following ARM64 Kong Gateway Docker images:\n* RHEL 9\n* Debian 12\n* Amazon Linux 2\n* Amazon Linux 2023\n",
-        "type": "known-issues",
-        "scope": "Core"
-      },
-      {
-        "message": "A bug originating from the underlying OpenResty platform affects connection pooling in certain circumstances. \nThis issue impacts transaction handling and negatively impacts performance, resulting in reduced request rates and increased latencies. \nVersions 3.10.0.0 and 3.10.0.1 are both affected. To resolve this regression, please upgrade to Kong Gateway 3.10.0.2 or later.\n",
-        "type": "known-issues",
-        "scope": "Core"
-      }
-    ],
-    "kong-manager-ee": [
-      {
-        "message": "Fixed an issue where the lists in the UI would flicker under some circumstances.",
-        "type": "bugfix",
-        "githubs": [
-          3663
-        ],
-        "scope": "Core"
-      },
-      {
-        "message": "Add Redis shared configuration support in Plugins.",
-        "type": "feature",
-        "githubs": [
-          3701
-        ],
-        "scope": "Core"
-      },
-      {
-        "message": "Kong Manager now shows the scope option in gray when it can't be changed.",
-        "type": "feature",
-        "githubs": [
-          3664
-        ],
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the license expiration date was calculated incorrectly.",
-        "type": "bugfix",
-        "githubs": [
-          3675
-        ],
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where creating `jwt-credential` with special algorithms (`PS256`, `PS384`, `PS512`, and `EdDSA`) couldn't populate `rsa_public_key` in the Kong Manager.\n",
-        "type": "bugfix",
-        "githubs": [
-          3755
-        ],
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where editing an upstream would not remove the values of some fields (`client certificate`, `tags`, `timeouts`, and `host_header`, etc) in the Kong Manager.\n",
-        "type": "bugfix",
-        "githubs": [
-          3793
-        ],
-        "scope": "Core"
-      },
-      {
-        "message": "Kong Manager now returns to the previous page upon canceling plugin editing.",
-        "type": "feature",
-        "githubs": [
-          3690
-        ],
-        "scope": "Core"
-      }
-    ]
-  },
   "3.9.0.0": {
     "kong": [
       {
@@ -14461,966 +13671,6 @@
     ],
     "kong-manager-ee": []
   },
-  "3.11.0.0": {
-    "kong": [
-      {
-        "message": "**AWS-Lambda**: A warning message was added during schema validation on those plugins that contain a function name that does not comply with AWS Lambda's FunctionName pattern.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Bumped lua-kong-nginx-module from 0.15.1 to 0.15.2.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped OpenResty from 1.27.1.1 to 1.27.1.2.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "**Wasm**: removed ngx_wasm_module from default builds.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai**: Added support for transforming, introspecting, and collecting metrics for image and audio generation requests, Responses API, and Realtime API. Added support for proxying Files, Batches, and Assistants API.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Added new config field genai_category 'text/embeddings' and new route_type 'llm/v1/embeddings'",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where large request payload was not logged.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Fixed an issue where the Gemini provider could not use Anthropic 'rawPredict' endpoint models hosted in Vertex.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where latency metric was not implemented for streaming responses.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed several issues that `kong start` and `kong stop` command throw error when the configuration contains vault reference and a prefix directory exists.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**cors**: Fixed an issue where requests with empty `origin` headers would cause empty reply from server.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where upstream connection pooling failed when pool names exceeded 32 characters  by applying a patch from upstream OpenResty.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**jwt**: Fixed an issue where the WWW-Authenticate header used an incorrect delimiter, now using a comma as specified by RFC 7235.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where `ca_certificate` cache was not invalidated when incremental sync was enabled.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where SSE terminator may not have correct ending characters.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where the response body for observability may be larger than the real one because of the stale data.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Improved the performance of string splitting functions in Kong's core.",
-        "type": "performance",
-        "scope": "Core"
-      },
-      {
-        "message": "Reverted removal of `translate_backwards` from plugins' metaschema in order to maintain backward compatibility.",
-        "type": "bugfix",
-        "scope": "Core"
-      }
-    ],
-    "kong-ee": [
-      {
-        "message": "**ai**: Added support for the `cohere` LLM format in the ai related plugins. This allows users can directly use the `cohere` rerank API.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**graphql-rate-limiting-advanced**: Added support for passing all downstream headers to GraphQL upstream servers in introspection requests.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-log**: Added support for Kafka 4.0.\n**kafka-upstream**: Added support for Kafka 4.0.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-prompt-compressor**: Added a new plugin that compresses prompt information in requests before they are proxied by the AI Proxy or AI Proxy Advanced plugin.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**forward-proxy**: Marked the `auth_password` in the `forward_proxy` plugin as an `encrypted` field.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-callout**: Marked the `auth_password` as an `encrypted` field.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai**: add support for the `huggingface` LLM Native format in the ai related plugins.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where debug level logs for incremental sync were insufficient, making debugging more difficult.\n",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**ai-rate-limiting-advanced**: Added support for the `namespace` field in the AI Rate Limiting Advanced plugin. This allows users to specify a ratelimiting namespace for the plugin, Similar to the existing `namespace` field in the `rate-limiting-advanced` plugin.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Add `tried_targets` field in serialized analytics logs for record of all tried ai targets.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai**: added `model.options.bedrock.performance_config_latency` config parameter, to allow administrators to enforce performanceConfig 'latency' for all AWS Bedrock requests.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai**: maps performanceConfig 'latency' field from client requests, for AWS Bedrock requests.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Bumped lua-kong-nginx-module from 0.15.2 to 0.15.3.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped luarocks from 3.11.1 to 3.12.1. This fixes the error `main function has more than 65536 constants`, which was preventing rocks from being published or installed.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai**: changed a description for the max_request_body_size schema field to clarify relation to the request body size limit.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Bumped lua-resty-azure from 1.6.1 to 1.7.0.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "ai-proxy, ai-proxy-advanced: Deprecated the `preserve` route_type. You are encouraged to use new route_types added in version 3.11.x.x and onwards.",
-        "type": "deprecation",
-        "scope": "Plugin",
-        "plugins": [
-          "ai-proxy",
-          "ai-proxy-advanced"
-        ]
-      },
-      {
-        "message": "Added support for OpenTelemetry formatted logs to the (tech preview) Active\nTracing feature\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**prometheus**: added `consumer` label for ai metrics and added metrics for ai-rag-injector plugin.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**llm**: Added support for Bedrock agent SDK, including rerand, converse, converse-stream, retrieveAndGenerate, and retrieveAndGenerate-stream.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Solace Upstream (beta)**: Added a new plugin which allows to transform requests into Solace messages in a Solace queue or topic.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added an optional configuration parameter `admin_gui_hide_konnect_cta` that controls the visibility of the Konnect call-to-action in the Admin GUI.",
-        "type": "feature",
-        "scope": "Configuration"
-      },
-      {
-        "message": "Logged license model_hours exceeded warning when LLM model usage exceeded the limit.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai**: Change sales counter sync per hour instead of per week.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-aws-guardrails**: Added a new AI plugin that can protect requests and responses to/from AI LLM.\n",
-        "scope": "Plugin",
-        "type": "feature"
-      },
-      {
-        "message": "**confluent**: Added support for sending messages with dynamic keys to determine partitions.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Conjur Vault**: Added support for CyberArk Conjur Vault.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**datakit**: Added new datakit plugin",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the delta type was not being validated during incremental sync.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Added certificate-based authentication to the Hashicorp vault backend.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**jwe**: Supported more encryption algorithms for jwe, including A128KW, A192KW, A256KW, ECDH-ES+A128KW, ECDH-ES+A192KW, ECDH-ES+A256KW, A128GCMKW, A192GCMKW, A256GCMKW.",
-        "type": "feature",
-        "scope": "PDK"
-      },
-      {
-        "message": "**kafka-log**: Added support for sending messages with dynamic keys to determine partitions.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-upstream**: Added support for sending messages with dynamic keys to determine partitions.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Created internal JSON Object Signing and Encryption (JOSE) library to improve performance, features and security of several plugins.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where some logs are missing when incremental sync is enabled on the Data Plane side.\n",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**oas-validation**: Added support for validating `multipart/form-data` requests.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**opentelemetry**: Added a new configuration field `sampling_strategy` to the plugin. The field allowed you to specify the sampling strategies for OTLP `traces`.\nSet `parent_drop_probability_fallback` if you want parent-based sampling when the parent span contains a `false` sampled flag, and fallback to probability-based sampling otherwise.\nSet `parent_probability_fallback` if you want parent-based sampling when the parent span contains a valid sampled flag (`true` or `false`), and fallback to probability-based sampling otherwise.\nThe default value is `parent_drop_probability_fallback` and keeps the instrumentation, sampling and exporting behaviour as before.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added a new `kong.request.get_raw_forwarded_path()` function for returning non-normalized `forwarded_path`.\n",
-        "type": "feature",
-        "scope": "PDK"
-      },
-      {
-        "message": "Added support for reporting whether `new_dns_client` and `incremental_sync` were enabled in anonymous reports.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**request-callout**: The plugin now logs the request URL, response code, and request latency (in milliseconds).",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-callout**: The plugin now sends a custom User-Agent header if one isn't provided. The default value is `kong/<kong_version>/request-callout`.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-validator**: Added support for specifying JSON schema draft versions.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-log**: Added support for Schema Registry integration with Confluent Schema Registry for AVRO and JSON schemas.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added an optional configuration parameter `service.tls_sans`. This allows to specify additional entries (either DNS names or URIs) for Subject Alternative Names validation of a TLS-based upstream.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**Core**: Provided more granular and valuable latency metrics in Kong Gateway, aligning with our Active Tracing measurements.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "Added the sticky-sessions load-balancer algorithm.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**vault**: Added support to decode base64 secrets before using them.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**kafka-consume**: Added WebSocket support to the kafka-consume plugin for consuming Kafka messages.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the Active Tracing total time was not including connection and handshake times.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Added a new configuration, `route_match_calculation`, which included bug fixes for the `traditional_compatible` and the `expressions` router flavors.\nThe default value `original` retained the current `3.x` router matching behavior without changes. The value `strict` enforced the router matching behavior with corrected calculation as follows:\n1. The weight (priority point) of a route was incorrectly\n   downgraded.\n2. A route of HTTPS-only protocol with SNIs incorrectly captured\n   requests over HTTP routes.\n3. A route of TLS-only protocol with SNIs incorrectly captured\n   requests over TCP or UDP routes.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**AI plugins**: Fixed an issue where some of ai metrics was missed in analytics",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-aws-guardrails**: Fixed an issue where the plugin did not support inspecting responses in non-stream mode.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**prometheus**: Fixed an issue where AI latency histogram might miss some calculation.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where patterns using multiple capture groups (e.g., `$(group1)/$(group2)`) failed to extract expected matches.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-rate-limiting-advanced**: Fixed an issue where AI rate limiting advanced plugin might panic when use redis strategy and sync_rate is set to 0.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**request-callout**: Fix issue where a callout response would not be available to response `by_lua` code",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-callout**: Fixed an issue where caching options modified via `by_lua` would apply to all subsequent callouts.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-callout**: Fixed an issue where callouts with the same name would be accepted.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-callout**: Query parameters specified via `callout.request.query` will now correctly replace those in the callout URL.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the LMDB database file was created with incorrect permission when running kong cli command with root privileges.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where events mechanism of clustering might be initialized repeatedly.\n",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Fixed an issue where the delta coalescing logic on the CP side might work inefficiently.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Fixed an issue where modifying x-forwarded-for header before access phase may not take effect\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**degraphql**: Fixed an issue where the degraphql handle type Boolean was not being assigned correctly in the degraphql router.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where validation incorrectly passed for mis-matched deprecated and new fields if the new field value\nwas false. \n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the error logs generated during router rebuilding might be excessively noisy.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where with small chance DP might repeatedly full sync when incremental sync is enabled.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Fixed an issue where the RPC framework might handle connections incorrectly on the data plane.\n",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where model name did not escape when using AWS Bedrock inference profile.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where crud event was triggered multiple times by event_hooks.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**key-auth**: Fixed an issue where external consumers could not be used with traditional Kong deployments, such as with KIC.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where an external Python plugin cannot receive the updated value for its referenceable configuration fields.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-callout**: Fixed an issue where values in `custom` would not accept explicit null values for removal of fields",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the data plane (DP) may report healthy before it is actually ready to accept traffic.",
-        "type": "bugfix",
-        "scope": "Admin API"
-      },
-      {
-        "message": "Fixed an issue where sometimes the paginated sync incorrectly reports \"history lost\" and fails.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**jwt-signer**: Fixed an issue where data planes didn't use the keys passed from the control plane to sign/re-sign.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka**: Fixed an issue where the Kafka SCRAM authentication did not send the server nonce.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the log lines might be incorrectly logged.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**AI**: Fixed an issue where the password for the pgvector strategy was not being set correctly in the database.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where the plugin raises \"path not found error\" when include_base_path is set to true and the server url is \"/\".\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where the plugin throws an error for responses without a Content-Type header.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where query parameters with explode=false couldn't be validated.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**OpenID-Connect**: Fixed an issue where caused IdP to report invalid redirect_uri errors when `config.redirect_uri` was not configured and the uri path contained spaces.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Fixed an issue where the OIDC plugin caused the third-party IDP to throw an error during logout attempts if the session had already been invalidated.\nAdded the `client_id` to the logout URL to ensure the logout request is sent to the correct client, preventing such errors.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where new custom plugin creation during a full sync with incremental enabled would cause inconsistency. It now fails and reinitiating the sync in such case.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where a change to a Partial in a custom workspace caused a communication issue between CP and DP on Incremental Config Sync mode.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where Plugins were not exported correctly when using Partials in a custom workspace in Hybrid Mode.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where Pgvector index failed when using special characters in the name.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the /schemas/plugins/validate endpoint returned a validation error\nwhen a plugin was linked to a partial containing a vault key.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the IAM Authentication for RDS failed due to token not being refreshed under certain conditions.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**key-auth**: Fixed an issue where region was not permitted to be null for remote identity realms.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-callout**: Fixed an issue where callout and upstream request body customizations were not performed when an empty request body was provided; now, an empty JSON body is used and content-type JSON is added to the request.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-callout**: Fixed an issue where callout plugin failed with timeout when `callouts.request.body.custom` is null and `callouts.request.headers.forward` is true.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-callout**: Fixed an issue where the client request body is forwarded to upstream when `upstream.body.forward` is false.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-validator**: Fixed an issue where multipart/form-data content type was rejected.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where rate-limiting library could cause deadlock with Postgres.",
-        "type": "bugfix",
-        "scope": "Performance"
-      },
-      {
-        "message": "Fixed an issue where RPC calls miss the retry mechanism in the clustering system for resilience against transient network issues.\n",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Schema map values can now assume null values.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "Fix issue where schema library would fail with a nil reference if configurations are set via both deprecated and new names with diverging values",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-semantic-cache**: Fixed an issue where SSE terminator may not have correct ending characters.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the Lua VM memory size returned by status API is not accurate on the control plane.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where error logs were excessive when changing routes.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where dataplane nodes sometimes did not recover from sync failures, leading to recursive retries and failures.\n",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Fixed an issue where validation required all of `timeout` fields (`connect_timeout`, `read_timeout`, `send_timeout`)\nto have the same value. In reality only `connect_timeout` has to have the same value since that is the value used for\ngenerating the `timeout` field in the response if it is missing in the request.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where newly spawned workers used outdated router data because the `init` phase was skipped.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where updating an entity in a non-default workspace during incremental sync\nmay not have been applied correctly.\n",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Fixed an issue where the send request time was incorrectly calculated, now it should be more accurate.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**upstream-timeout**: Fixed an issue where `read_timeout`, `write_timeout`, and `connect_timeout` were set to 0, causing a runtime error.  After this release, any existing upstream-timeout plugin with these fields set to 0 will automatically update them to the default value of 60000.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where full configuration sync caused data plane to stop proxying when incremental config sync is enabled.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**ldap-auth-advanced**: Fixed an issue that caused browsers to automatically pop up dialog boxes when authentication failed while `ldap-auth-advanced` was enabled in the Kong Manager.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the Admin API returned a 500 error instead of a 401 error when an empty string was provided for the `Kong-Admin-Token` header.\n",
-        "type": "bugfix",
-        "scope": "Admin API"
-      },
-      {
-        "message": "AI Azure Content Safety: Fixed an issue where Blocklist breaches are not correctly parsed.\n",
-        "type": "bugfix",
-        "scope": "Plugin",
-        "plugins": [
-          "ai-azure-content-safety"
-        ]
-      },
-      {
-        "message": "**AI Plugins**: Fixed unable to use Titan Text Embeddings models.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Blocked plugins to execute retry logic. Also improve testing functions\n",
-        "type": "bugfix",
-        "scope": "Plugin",
-        "plugins": [
-          "ai-prompt-compressor",
-          "ai-sanitizer",
-          "ai-semantic-cache",
-          "ai-rag-injector"
-        ]
-      },
-      {
-        "message": "Fixed an issue where the `ai-prompt-decorator` plugin prompt field was too short.\n",
-        "type": "feature",
-        "scope": "Plugin",
-        "plugins": [
-          "ai-prompt-decorator"
-        ]
-      },
-      {
-        "message": "**ai-prompt-decorator**: Fixed an issue where the plugin would miss the model, temperature, and other user-defined fields.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Proxy Advanced**: Fixed an issue where AI Proxy Advanced can't failover from other provider to Bedrock.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fix consistent-hashing algorithm not using correct value to hash.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Proxy Advanced**: Fixed an issue where the stale semantic key vector may not be refreshed after the plugin config is updated.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where AI Proxy and AI Proxy Advanced would use corrupted plugin config.\n",
-        "type": "bugfix",
-        "scope": "Plugin",
-        "plugins": [
-          "ai-proxy",
-          "ai-proxy-advanced"
-        ]
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where AI Proxy returns 403 using gemini provider.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ollama**: Fixed an issue where 'tools' and 'RAG' decoration did not work for Ollama (llama2) provider.\n",
-        "type": "bugfix",
-        "scope": "Plugin",
-        "plugins": [
-          "ai-rag-injector"
-        ]
-      },
-      {
-        "message": "Fixed an issue where data plane (DP) might receive incorrect data if the control plane's (CP) configuration version was older than the DP's version.\n",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Fixed an issue where the CLI command `kong runner` crashes if using off strategy.\n",
-        "type": "bugfix",
-        "scope": "CLI Command"
-      },
-      {
-        "message": "Fixed an issue where the control plane might not send RPC calls to the data plane correctly in some corner cases.\n",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Fixed an issue where CP may send sync notifications too frequently when incremental sync is enabled.\n",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Fixed an issue where the field `user_token_ident` was not being disallowed for update in the Admin API.\n",
-        "type": "bugfix",
-        "scope": "Admin API"
-      },
-      {
-        "message": "Fixed an issue where the Control Plane (CP) would send duplicate sync notifications when configuration changes occurred.\n",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**header-cert-auth**: Fixed an issue where Header Cert Authentication plugin failed to validate revocation using OCSP when the downstream connection wasn't an SSL connection.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where users encountered duplicate key violation errors on `rbac_role_entities_pkey` while using the `deck sync` command.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where validation might not report error message correctly when incremental sync was enabled.\n",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**mocking**: Fixed an issue where an empty array set in the mocking plugin returned an object type instead of an array type in the response body.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**mtls-auth**: Fixed an issue where uselss interface is called when doing the OCSP client cert verification.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Prometheus**: Fixed an issue where the control plane failed to expose the `db_entities_total` metric.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**prometheus**: Fixed an issue where the metric `data_plane_config_hash` might not work correctly for incremental sync.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the rate limiting plugins can't handle decimal numbers when using Redis strategy.\n",
-        "type": "bugfix",
-        "scope": "Plugin",
-        "plugins": [
-          "rate-limiting",
-          "rate-limiting-advanced",
-          "graphql-rate-limiting-advanced",
-          "ai-rate-limiting-advanced"
-        ]
-      },
-      {
-        "message": "Fixed an issue where deleting an RBAC user would also delete a non-default role with the same name.\n",
-        "type": "bugfix",
-        "scope": "Admin API"
-      },
-      {
-        "message": "Fixed an issue where adding the `hash_subject` and `store_metadata` fields to the `portal_session_conf` in the Dev Portal was not working as expected.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the admin API might not fetch the workspace correctly during batch updates.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**Rate-Limiting-Advanced**: Limited the length of the bucket identifier to prevent using strings longer than 256 characters for cache indexing, which could lead to high memory consumption in high-traffic scenarios.",
-        "type": "performance",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Visiting kconfig.js from the Kong Manager UI no longer triggers warnings for vitals and portal deprecation.\n",
-        "type": "bugfix",
-        "scope": "Admin API"
-      },
-      {
-        "message": "Bumped page size for cluster sync to improve performance of full syncs.",
-        "type": "performance",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**JWT**: refactored plugin code to be more performant (measured to be at least three times faster).",
-        "type": "performance",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Improved performance for OpenAPI 3.1.",
-        "type": "performance",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: improved the performance of signature verification.",
-        "type": "performance",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Implemented a faster SSE parser.",
-        "type": "performance",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Improved performance by removing the n+1 query problem for plugins.\nPlugins are now fetched in bulk with plugins_partials and partials.\n",
-        "type": "performance",
-        "scope": "Core"
-      },
-      {
-        "message": "Improved RPC message queue responsiveness.",
-        "type": "performance",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Optimized query of the default workspace by directly accessing LMDB, improving performance.\n",
-        "type": "performance",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where LMDB operation failures during incremental sync were not reported.\n",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Added a configuration option `vault_secrets_lazy_load` to control how vault\nsecrets are loaded. When enabled, plugin options stored as vault secrets are\nloaded only when needed. This can save memory and reduce startup time but may\nincrease latency the first time a secret is accessed or after it expires. The\ndefault value is `off`, preserving the behavior of previous releases.\n",
-        "type": "feature",
-        "scope": "Configuration"
-      },
-      {
-        "message": "Fixed an issue where some of ai metrics was missed in analytics",
-        "scope": "Plugin",
-        "plugins": [
-          "ai-prompt-compressor",
-          "ai-rag-injector",
-          "ai-semantic-cache",
-          "ai-sanitizer"
-        ],
-        "type": "bugfix"
-      },
-      {
-        "message": "The Brotli module is missing from all of the following ARM64 Kong Gateway Docker images:\n* RHEL 9\n* Debian 12\n* Amazon Linux 2\n* Amazon Linux 2023\n",
-        "type": "known-issues",
-        "scope": "Core"
-      },
-      {
-        "message": "If any [AI Gateway plugin](/plugins/?category=ai) has been enabled in a self-managed Kong Gateway deployment for more than a week, upgrades from 3.10 versions to 3.11.0.0 will fail due to a license migration issue.\nThis does not affect Konnect deployments. A fix will be provided in 3.11.0.1.\n\nSee [breaking changes in 3.11](/gateway/breaking-changes/#known-issues-in-3-11-0-0) for a temporary workaround.\n",
-        "type": "known-issues",
-        "scope": "Plugin",
-        "plugins": [
-          "ai-proxy",
-          "ai-proxy-advanced",
-          "ai-azure-content-safety",
-          "ai-prompt-decorator",
-          "ai-prompt-guard",
-          "ai-prompt-template",
-          "ai-rag-injector",
-          "ai-rate-limiting-advanced",
-          "ai-request-transformer",
-          "ai-response-transformer",
-          "ai-sanitizer",
-          "ai-semantic-cache",
-          "ai-semantic-prompt-guard"
-        ]
-      }
-    ],
-    "kong-manager-ee": [
-      {
-        "message": "Added a feature to persist the configuration format preference.",
-        "type": "feature",
-        "githubs": [
-          3907
-        ],
-        "scope": "Core"
-      },
-      {
-        "message": "Added a new UI for the Request Callout plugin.",
-        "type": "feature",
-        "githubs": [
-          3839
-        ],
-        "scope": "Core"
-      },
-      {
-        "message": "Improved the Route configuration form for a better user experience.",
-        "type": "feature",
-        "githubs": [
-          3886
-        ],
-        "scope": "Core"
-      },
-      {
-        "message": "Improved the user experience in Kong Manager by fixing various UI-related issues.",
-        "type": "bugfix",
-        "githubs": [
-          3863,
-          3888,
-          3894,
-          3897,
-          3898,
-          3899,
-          3901,
-          3905,
-          3908,
-          3912,
-          3916
-        ],
-        "scope": "Core"
-      }
-    ]
-  },
   "3.8.1.2": {
     "kong": [],
     "kong-ee": [
@@ -16376,955 +14626,6 @@
     "kong-ee": [],
     "kong-manager-ee": []
   },
-  "3.12.0.0": {
-    "kong": [
-      {
-        "message": "**AI Plugins**: Support relative path for tool paths in MCP plugins.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Added `time_to_first_token` and `request_mode` for observability.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Fixed an issue where Bedrock (Converse API) didn't properly parse multiple `toolUse` tool calls in one turn, on some models.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where the Anthropic provider mapped the wrong `stop_reason` to Chat and Completions responses.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where the Anthropic provider failed to stream function call responses.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where the Anthropic provider could truncate tokens in streaming responses.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Fixed an issue where Structured Output did not work correctly with Anthropic Claude models.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where OpenAI chat completion's `tool_choice` was not converted to Anthropic's.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Fixed an issue where structured output did not work for the Bedrock provider when SSE streaming responses.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Fixed an issue where Structured Output did not work correctly with Bedrock (Converse API) models.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Fixed an issue where `id`, `created`, and/or `finish_reason` fields were missing from or incorrect in Gemini responses.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where the `model` field was incorrect in Gemini responses when a variable was used as the model name.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where the `model` field was missing in OpenAI-format Gemini responses in some situations.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where the Gemini provider did not properly handle multiple tool calls across different turns.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where an empty array was encoded as an empty object in structured output.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Fixed an issue where Structured-Output requests were ignored.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where AWS stream parser didn't parse correctly when the frame was incomplete.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where stream/proxy listeners could unexpectedly access the router from the control plane. Stream/proxy listeners are now disabled for the control plane.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**exit-transformer**: Fixed an issue where exit-transformer affected the Status API.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where JSON array data wasn't correctly parsed.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**prometheus**: Fixed an issue where WebSocket wasn't recorded in the Prometheus metrics.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      }
-    ],
-    "kong-ee": [
-      {
-        "message": "**ai-llm-as-judge**: Fix an issue where the ai-llm-as-judge plugin didn't work with non-OpenAI provider configuration.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-llm-as-judge**: Introduced the AI LLM as Judge plugin, enabling you to evaluate an LLM and use the score as a balancer.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp**: Introduced the AI MCP plugin, enabling you to export any API to AI applications via MCP.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**injection-protection**: Added the ability to allow users to check a request path or query.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ace**: Add the `ace` plugin.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-semantic-response-guard**: Introduced the AI Semantic Response Guard plugin, enabling you to guard LLM responses against semantic content.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Added a new `endpoint_id` field for GCP Gemini options to support Model Garden.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Bumped ca-certificates (debug tool) from 2025-02-25 to 2025-07-15.",
-        "type": "dependency",
-        "scope": "CLI Command"
-      },
-      {
-        "message": "Bumped curl (debug tool) from 8.12.1 to 8.15.0.",
-        "type": "dependency",
-        "scope": "CLI Command"
-      },
-      {
-        "message": "Bumped kong-redis-cluster from 1.5.5 to 1.5.6. This fixes an issue where Redis connections were not reused properly.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped libexpat from 2.6.4 to 2.7.1.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped libxslt from 1.1.42 to 1.1.43.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-muiltipart from 0.5.9 to 0.5.11",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-protobuf from 0.5.2 to 0.5.3.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-resty-aws from 1.5.4 to 1.6.0.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-resty-azure from 1.7.0 to 1.10.0.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-resty-cookie from 0.3.0 to 0.4.1.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-resty-gcp from 0.0.13 to 0.0.14.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-resty-jq from 0.1.0 to 0.2.0.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-resty-session from 4.0.5 to 4.1.4.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped LuaRocks from 3.11.1 to 3.12.2.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped multipart from 0.5.9 to 0.5.10.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped nghttp2 (debug tool) from 1.65.0 to 1.66.0.",
-        "type": "dependency",
-        "scope": "CLI Command"
-      },
-      {
-        "message": "Bumped PCRE2 from 10.45 to 10.46.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped snappy from 1.2.1 to 1.2.2.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped xmlua from 1.2.1 to 1.2.2.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-resty-websocket to version 0.4.0.2 to solve an issue with connecting to an HTTP/1.0 proxy, and to add an enhancement for status code return.\n",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "**postgres**: Improved error logging for PostgreSQL connection failures.\n**vault**: Log more details when vault callback execution fails.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-resty-lmdb to version 1.6.1.\n",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "The lua-resty-kafka module `resty.kafka` inside the Kong Gateway package is now deprecated. Developers can still use it, but it will no longer receive any updates.",
-        "scope": "Core",
-        "type": "deprecation"
-      },
-      {
-        "message": "**ai-mcp-oauth2**: Introduced the AI MCP OAuth2 plugin, which protects the MCP traffic with OAuth2.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**datakit**: Added caching support via a new `cache` node type.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added a feature to show the basic incremental sync information\non the Data Plane side.\n",
-        "type": "feature",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**ais**: Added the MemoryDB vector database strategy to LLM plugins.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Solace Consume** Added the `solace-consume` plugin, which adds Solace consumption capabilities to Kong.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added the new metric `target_id` (Target entity ID) to the Konnect Analytics to improve the observability.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "Added the `/status/timers` endpoint to the Status API for data planes, mirroring the Admin API `/timers` endpoint.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**kafka-consume**: Added `typedefs.no_service` to the `kafka-consume` plugin to prevent binding to a service, as it does not proxy to one. Note that this is a breaking change. If you previously attached a kafka-consume plugin to a service, it will no longer take effect. In such cases, requests will instead be proxied to the upstream configured in the service.\n",
-        "type": "Breaking Change",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**confluent-consume**: Added `websocket` mode to the `confluent-consume` plugin.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: GCP authentication order can now be configured using the `GCP_AUTH_METHOD_ORDER` environment variable.\nSetting it to `adc` allows the plugin to select Application Default Credentials (ADC) in precedence over Service Account.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Added latency and cost observability to realtime API.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-azure-content-safety**: Added response guard to filter AI responses for safety and compliance.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp**: The plugin now supports path parameters.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: The plugin now forwards client headers when calling the tool.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-oauth2**: Dropped the `enabled` field, as we already have one in plugin table.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp**: Added observability support for AI MCP traffic.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp**: The plugin now supports using multiple tools in the same plugin instance.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "AI MCP metrics are now reported to Konnect Analytics.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-sanitizer**: Added support for sanitizing LLM responses.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Analytics**: Added the `cache.status` field to collect the cache status of proxy-cache plugin.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**AWS-Lambda**: Added support for AWS API Gateway payload v2. A new configuration field `awsgateway_compatible_payload_version` has been added to control the version of the payload.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**datakit**: Added support for conditional execution via the `branch` node.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added vault support to the Datakit plugin. This unblocks common use cases such as storing secrets in Vault and retrieving them as tokens in Datakit.",
-        "type": "feature",
-        "scope": "Plugin",
-        "plugins": [
-          "datakit"
-        ]
-      },
-      {
-        "message": "**jwt-signer**: Added support for additional claim validations, including `notbefore`, `issuer`, `subject`, and `audience`.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**jwt-signer**: Added new options to support claim existence verification: `access_channel_token_(introspection_)required_claims.` The specified claims must be present in the token payload.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**jwt-signer**: Added new options to support optional claim verification: `access_channel_token_(introspection_)optional_claims.` The specified claims are verified only if they are present.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**jwt-signer**: Added new options `access_token_signing` and `channel_token_signing` to quickly turn on and off token signing or re-signing.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Kafka**: Supported sending failed messages to dead letter queue topics.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-consume, confluent-consume**: The plugin now supports modifying the returned content as needed.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added `$kong_upstream_*` Nginx variables to correctly log upstream information in `log_format`.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**openid-connect**: Added support for session binding (IP, scheme, and/or User-Agent header).\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Added support for claim to consumer groups mapping.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**opentelemetry**: Added the `peer.service` attribute to the balancer span to link multiple services together. This allows for better tracing of requests that span multiple services.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added a new `kong.client.get_aws_vpce_id()` function for returning the VPC ID of the endpoint in the PROXY protocol v2 header PP2_SUBTYPE_AWS_VPCE_ID.\n",
-        "type": "feature",
-        "scope": "PDK"
-      },
-      {
-        "message": "Kong now supports Azure authentication methods for connecting to Azure PostgreSQL databases. A new configuration option `pg_azure_auth` as well as corresponding configuration fields `pg_azure_client_id`, `pg_azure_client_secret`, and `pg_azure_tenant_id` have been added to the Kong configuration file. When `pg_azure_auth` is set to `on`, Kong will use Azure authentication methods to connect to Azure PostgreSQL databases.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**request-callout**: The plugin now supports dynamic request URLs in the form of Lua expressions `$(some_lua_expression)`.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Rate-Limiting-Advanced**: Added request throttling feature.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka**: Added support for OAuth 2.0 authorization for Confluent Schema Registry.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**session**: Added support for session binding (IP, scheme, and/or User-Agent header).\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**solace-log**: Added the `solace-log` plugin to support logging to Solace PubSub+ event broker.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**solace**: Added WebSocket transport support for `PERSISTENT` delivery mode.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-aws-guardrails**: Add support for AWS IAM role to the ai-aws-guardrails plugin.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added failover support for upstream targets, allowing load balancing to backup\ntargets when primary targets are offline.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-sanitizer**: Added a `block_if_detected` option to reject requests containing PII data instead of sanitizing them. When `block_if_detected` is enabled, requests with detected PII will be blocked with a 400 response containing details about the identified PII types and count.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where the AI Proxy Advanced plugin's lowest latency load balancer could fail to select a target when only one target was available, leading to 500 errors.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-driver**: Fixed an issue where AI Proxy and AI Proxy Advanced generated incorrect default ports for upstream schemes, leading to 400 errors.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ais**: Fixed an issue where the LLM license migration could fail if the license counter contained more than one week of data.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue with Azure Managed Identity credentials causing improper request balancing.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where the ai-retry phase was not correctly setting the namespace in the `kong.plugin.ctx`, causing the ai-proxy-advanced balancer to retry the first target more than once.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-semantic-cache**: Fixed an issue where the DELETE `/ai-semantic-cache` endpoint returned 500 errors for successful deletions when using pgvector as the vector database.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-semantic-cache**: Fixed an issue where the DELETE `/ai-semantic-cache` endpoint returned an incorrect 204 status for non-existent keys.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-semantic-cache**: Fixed an issue where AI inference requests to non-OpenAI providers in the stream mode were not supported.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**app-dynamics**: Fixed an issue where response time measurements to backend services were inaccurate. The plugin now captures the full request duration, including upstream.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**aws-lambda**: Fixed an issue where the AWS Gateway compatible payload generated by the plugin did not include the `resource` field in some cases.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where AWS Bedrock did not properly handle image editing requests through the `image/v1/images/edits` route.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where AWS Bedrock streaming requests would panic when the ai-semantic-cache plugin was enabled.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-callout**: Fixed an issue where `untrusted_lua_sandbox_requires` option was not respected.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**datakit**: Fixed plugin config validation to catch more invalid usage of the `property` node.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**datakit**: Fixed an issue where an invalid plugin instance could affect other plugins.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Semantic Plugins**: Fixed an issue where Gemini Vertex AI embeddings failed due to incorrect URL construction and response parsing.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the `/clustering/data-planes` endpoint returned an incorrect DP hostname when incremental sync was enabled.\n",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**konnect-application-auth - Konnect user only**: Changed the priority of konnect application auth plugin from 950 to 960. This change is to make sure the execution sequences of the konnect-application-auth plugin and the ACL plugin are as expected. If you're using the konnect-application-auth plugin and other custom plugins that have a dependency with the konnect-application-auth plugin and have a priority between 950 and 960, you may need to adjust the priorities of these custom plugins accordingly or use dynamic plugin ordering.",
-        "type": "Breaking Change",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-log, kafka-upstream, kafka-consume**: Added warnings when the strategy is SASL without a mechanism, or the mechanism is set without a SASL strategy.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-upstream**: Fixed an issue where `forward_body` dropped request bodies larger than Nginx's\ndefault buffer size (16 KB). It now reads up to 1 MB and returns an error if the body can't be fully read.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**keyring**: Fixed an issue where 'key not found' was incorrectly reported as a warning continuously.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**ldap-auth-advanced**: Fixed a group validation issue where LDAP group names containing asterisk (`*`) characters were incorrectly marked as invalid during Kong Manager RBAC authentication. Group names with asterisk characters (such as `*Dev - EXAMPLE - TOP`) now properly validate and allow role mapping.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy, ai-proxy-advanced**: Fixed an issue where AI Proxy and AI Proxy Advanced couldn't properly failover to a Bedrock target.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**analytics**: Fixed an issue where multi-model tokens usage metrics were not reported to Konnect.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-proxy, ai-proxy-advanced**: Fix panic in LLM observability when populating token usage for AI Proxy token usage details.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy, ai-proxy-advanced**: Fixed an issue where AI Proxy and AI Proxy Advanced could produce duplicate content in the response when the SSE event was truncated.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy, ai-proxy-advanced**: Fixed an issue where AI Proxy and AI Proxy Advanced could drop content in the response when the SSE event was truncated.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed redundant configuration exports when multiple data planes were connected concurrently by coalescing triggers and delegating export/broadcast operations to the background push loop.\n",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where certain query strings in URLs that did not conform to the configured OpenAPI specification could cause the plugin to throw an unexpected runtime error and respond with an HTTP 500 error.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oauth2-introspection**: Fixed a high memory usage issue caused by caching negative introspection responses.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Fixed an issue where `upstream_session_id_header` and `downstream_session_id_header` mistakenly required the `downstream_headers_claims` and `downstream_headers_names` to be present.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Semantic Plugins**: Fixed an issue by using a separate column to store the namespace instead of including it in the table name to avoid truncation. This change invalidates previous caches created by AI Semantic Cache, AI Semantic Prompt Guard, and AI Proxy Advanced. If a user is using a very long cache TTL, cache warmup is required after this change.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where incorrect an delimiter in cluster events caused cache key problems, preventing Dev Portal from updating the page cache properly in hybrid deployment mode.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**prometheus**: Fixed an issue where Prometheus metrics would show empty consumer identifiers when consumers didn't have a username. The plugin now falls back to using the consumer's `custom_id` when the username is not available, ensuring consumer identification in metrics.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where results were lost when querying LMDB page by page.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**request-callout**: Fixed regression where the upstream request body would not be forwarded if `upstream.body.custom` was empty.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-callout**: `request.by_lua` code will now run before a request is made or a cached callout is fetched. Previously, it did not run before an attempt to fetch from cache, which did not allow for cache key customization.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-callout**: The plugin now uses additional components to generate the cache key: request consumer, consumer groups, plugin ID, route ID; callout request method, URL, query params, headers, and body.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-callout**: Fixed an issue where expressions could not read headers, query, and URI captures via shortcuts of the form `$(headers.some_header)`.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**response-transformer-advanced**: Fixed a failure that occurred when Nginx gzip was enabled for an upstream.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fix an issue where the CLI command and the kong process could throw warning messages about the user directive not being used when running as a non-root user.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where PDK returned non-empty header when requests were not proxied to upstream.",
-        "type": "bugfix",
-        "scope": "PDK"
-      },
-      {
-        "message": "**solace-upstream**: Fixed an issue where `forward_body` dropped request bodies larger than Nginx’s\ndefault buffer size (16 KB). It now reads up to 1 MB and returns an error if the body can't be fully read.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-semantic-cache**: Fixed an issue where the SSE terminator could have incorrect ending characters.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the incremental sync did not work properly for the stream subsystem.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Fixed an issue where adding consumers to consumer groups could crash the data plane during incremental sync.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Fixed an issue where some schema endpoints in the Admin API didn't include the `ttl` field in GET responses. This includes:\n - `keyauth_enc_credentials`\n - `ratelimiting_metrics`\n - `keyauth_credentials`\n - `oauth2_tokens`\n - `oauth2_authorization_codes`\n - `clustering_data_planes`\n - `acme_storage`\n - `sessions`\n - `audit_requests`\n - `audit_objects`\n",
-        "type": "bugfix",
-        "scope": "Admin API"
-      },
-      {
-        "message": "Fixed an issue where setting credential TTL to null caused an unexpected error.\n",
-        "type": "bugfix",
-        "scope": "Admin API"
-      },
-      {
-        "message": "Fixed an issue where control planes could consume unnecessary memory when only incremental data planes were connected.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**vault**: Fixed an issue where vault config `base64_decode` caused DP to fail to start.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**xml-threat-protection**: Fixed an issue where requests without a body were blocked.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Azure Content Safety**: Fixed the plugin to work with multi-modal content.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI AWS GuardRails**: Fixed the plugin to work with multi-modal content.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Prompt Compressor**: Fixed the plugin when no model parameter is specified.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Fixed an issue where the Dimensionality was not sent for Gemini embeddings calls.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Proxy Advanced**: Fixed an issue where the Gemini provider didn't support Model Garden.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Proxy Advanced**: Fixed an issue where managed identity could be cached incorrectly.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-semantic-prompt-guard**: Fixed the deletion of guard instances and improved error handling.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-semantic-response-guard**: Fixed the deletion of guard instances and improved error handling.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where enabling `openid-connect` authentication in Kong Manager would fail due to `authenticated_groups` being a string.\n",
-        "type": "bugfix",
-        "scope": "Admin API"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where the resource was not being passed correctly when using Azure as the provider.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**confluent**: Fixed an issue where the plugin did not use `conf.cluster_name`.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**embeddings**: Fixed an issue where the `text-embedding-ada-002` model would return a 400 error when the `dimensions` parameter was set.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**mtls-auth**: Fixed an issue where a certificate with an empty DN led to a runtime exception.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka**: Fixed an issue where the Kafka or Confluent Consume plugins couldn't consume the correct message when the consuming offset of the topic was not 0.\n**kafka**: Fixed an issue with parsing `ListOffset` Response version 0.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the request count was not being updated based on the `license_creation_date` of the license.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**AI Proxy Advanced**: Fixed an issue where Mistral models would return `Unsupported field: seed` when using some inference libraries.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**mocking**: Fixed an issue where empty arrays defined in the mocking plugin schema were incorrectly returned as object types instead of array types in response bodies.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oauth2-introspection**: Fixed an issue where authentication failures did not log messages in the error logs.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Proxy Advanced**: Fixed an issue where array input wasn't being properly validated for certain providers. Note that Bedrock, Gemini Public, and Mistral providers don't support array input, as before.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Proxy Advanced**: Fixed an issue where some Titan embeddings models reported malformed requests.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-sanitizer**: Fixed an issue where responses could not be redacted correctly when there were multiple redact texts of different lengths sharing the same prefix.\n",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**tls-metadata-headers**: Fixed an issue where a certificate with an empty DN led to a runtime exception.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Proxy Advanced**: Added support for Gemini Rerank in native format.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**PDK Request ID**: Added support for retrieving the request ID via the `kong.request.get_id()` function in the PDK.\n",
-        "type": "feature",
-        "scope": "PDK"
-      },
-      {
-        "message": "**PDK**: Added support for calling the `kong.response.get_raw_body()` and `kong.response.set_raw_body()` PDK functions from plugin `:response()` handlers.\n",
-        "type": "feature",
-        "scope": "PDK"
-      },
-      {
-        "message": "**prometheus**: Optimized fetching of the `kong_db_entities_total` metric by using internal counters instead of the `select count(*)` query through the database. If this metric is found to be of sync with the real row counts, use the command `kong migrations reinitialize-workspace-entity-counters` to re-sync the counts.",
-        "type": "performance",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**jwe-decrypt**: Fixed an issue where the `key_sets` cache could not be invalidated correctly.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Proxy Advanced**: Exposed `input_tokens_details.cached_tokens_details.image_tokens_count` in observability metrics.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**perf**: Improved the efficiency of entity field access on hot path.\n",
-        "type": "performance",
-        "scope": "Performance"
-      },
-      {
-        "message": "**perf**: improve efficiency of entity field access on hot-path.\n",
-        "type": "performance",
-        "scope": "Performance"
-      },
-      {
-        "message": "**Kong Manager**: In the Confluent Consume, Kafka Consume, Kafka Upstream, Kafka Log, and Confluent plugins, \nsetting `schema_registry.confluent.authentication.mode` or `topics.schema_registry.confluent.authentication.mode` to `none` may not be saved after submission.\n",
-        "type": "known-issues",
-        "scope": "Kong Manager"
-      },
-      {
-        "message": "**ai-gcp-model-armor**: Added a new `GCP Model Armor` plugin that can protect requests and responses to/from AI LLM.\n",
-        "scope": "Plugin",
-        "type": "feature"
-      }
-    ],
-    "kong-manager-ee": [
-      {
-        "message": "Added support for failover targets in upstreams.",
-        "type": "feature",
-        "githubs": [
-          4005
-        ],
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the vault picker was missing in the Request Callout plugin.",
-        "type": "bugfix",
-        "githubs": [
-          3967
-        ],
-        "scope": "Core"
-      },
-      {
-        "message": "**jwt-signer**: Added support for new parameters in the JWT Signer plugin.",
-        "type": "feature",
-        "githubs": [
-          4016
-        ],
-        "scope": "Core"
-      },
-      {
-        "message": "**service-protection**: Revamped the UI of the Service Protection plugin.",
-        "type": "feature",
-        "githubs": [
-          3987
-        ],
-        "scope": "Core"
-      },
-      {
-        "message": "**key-auth, key-auth-enc**: You can now configure the TTL parameter for the Key Authentication and Key Authentication Encrypted plugins.",
-        "type": "feature",
-        "githubs": [
-          3996
-        ],
-        "scope": "Core"
-      },
-      {
-        "message": "Updated documentation links in the Kong Manager Enterprise Edition to point to the latest resources.",
-        "type": "feature",
-        "githubs": [
-          3962
-        ],
-        "scope": "Core"
-      }
-    ]
-  },
   "3.10.0.6": {
     "kong": [
       {
@@ -18258,1340 +15559,6 @@
     ],
     "kong-manager-ee": []
   },
-  "3.13.0.0": {
-    "kong": [
-      {
-        "message": "Bumped lua-resty-healthcheck to version 3.1.1 to remove incorrect deprecation notice on active healthchecks headers.\n",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "**active-tracing**: Added exponential backoff retry support for the websocket connections of debug sessions.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**AI Plugins**: Added xAI provider support to the LLM plugin, enabling integration with xAI's Grok chat and image generation models.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Adds support for AWS Bedrock Bearer Token authentication in Kong AI plugins, allowing secure access to Bedrock models using temporary or long-lived tokens.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Added support for the Gemini Files operations, through the `llm_format: gemini` native-SDK option.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Added AI Lakera Guard plugin, to integrate with the safety API provided by https://www.lakera.ai/lakera-guard.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Added support for `stream_options` to request server response usage statistics when using SSE streaming response mode.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Clustering**: Add a mechanism to suppress connection retry logs within 100 seconds from last error.\n",
-        "type": "feature",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**Datadog**: Added a configuration option to tag the metrics with the Kong route name, or the route ID if the name is empty.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Added dimension configuration support for Amazon Titan Embed v2 models.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**sandbox**: Improved protection for whitelisted modules.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**AI Plugins**: Fixed an issue where Bedrock 'Nova' models would not correctly run tool calls when combined with thinking text.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Fixed an issue where the Gemini provider would not correctly return Model Armor 'Floor' blocking responses to the caller.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Fixed an issue where Gemini (Vertex) models didn't return JSON formatted responses when instructed.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Fixed an issue where Gemini with native format was not correctly reporting total tokens.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Fixed an issue where it was not possible to use \"Search Tools\" and \"extra_body\" when calling Gemini models in OpenAI format.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Fixed an issue where OpenAI, OpenAI-compatible, and HuggingFace models may have a 0 `completion_tokens` count with SSE streaming responses.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Fixed an issue where Bedrock requests with missing model names in the request path would not be properly validated. Now returns a clear error when model name is required in the path but not provided.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the restart command read configuration multiple times and failed to stop nginx.\n",
-        "type": "bugfix",
-        "scope": "Configuration"
-      },
-      {
-        "message": "**ai-gcp-model-armor**: Fixed an issue where SDP (Sensitive Data Protection) filter violations were not detected. The plugin now correctly handles both RAI-style results (matchState + confidenceLevel) and SDP-style results (matchState + findings array with infoType and likelihood).\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ip-restriction**: Fixed an issue where blocking an IP over TCP would log error: \"function cannot be called in preread phase\" (#14749)\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ldap-auth**: Fixed an issue where a failed ssl handshake with the ldap server would return 401 instead of 500.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      }
-    ],
-    "kong-ee": [
-      {
-        "message": "Added a new PDK method - kong.service.request.set_authentication_headers()",
-        "type": "feature",
-        "scope": "PDK"
-      },
-      {
-        "message": "**aws-lambda**: added a verbose error level logging for better debugging of AWS Lambda invocation issues.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Bumped ca-certificates (debug tool) from 2025-07-15 to 2025-11-04.",
-        "type": "dependency",
-        "scope": "CLI Command"
-      },
-      {
-        "message": "Bumped curl (debug tool) from 8.15.0 to 8.17.0.",
-        "type": "dependency",
-        "scope": "CLI Command"
-      },
-      {
-        "message": "Bumped jq from 1.7.1 to 1.8.1.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped kong-redis-cluster from 1.5.6 to 1.5.7.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped libexpat from 2.7.1 to 2.7.3.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped libxml2 from 2.12.10 to 2.15.0.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Switched lua-resty-ljsonschema dependency to Kong's maintained fork lua-resty-ljsonschema. Bumped version to kong-lua-resty-ljsonschema 1.3.1.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-resty-acme from 0.15.0 to 0.16.0.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-resty-aws from 1.6.0 to 1.7.1.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-resty-gcp from 0.0.14 to 0.0.16.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-resty-openssl from 1.5.1 to 1.7.0.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-resty-session from 4.1.4 to 4.1.5. Added cloud Redis authentication support.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped nghttp2 (debug tool) from 1.66.0 to 1.68.0.",
-        "type": "dependency",
-        "scope": "CLI Command"
-      },
-      {
-        "message": "Bumped OpenSSL to 3.4.3 in Core dependencies.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped PCRE2 from 10.46 to 10.47.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "**ace**: Enabled at-rest keyring encryption for sensitive fields in ACE plugin.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**acme**: Enabled at-rest keyring encryption for sensitive fields in ACME plugin.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-aws-guardrails**: Enabled at-rest keyring encryption for sensitive fields in AI AWS Guardrails plugin.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-azure-content-safety**: Enabled at-rest keyring encryption for sensitive fields in AI Azure Content Safety plugin.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Enabled at-rest keyring encryption for sensitive fields in Event Hooks.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**hmac-auth**: Enabled at-rest keyring encryption for sensitive fields in HMAC Auth plugin.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Enabled at-rest keyring encryption for sensitive fields in HashiCorp Vault integration.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**acme**: added support for the `tls_certificate_verify` global option. When this option is enabled, the plugin's `storage_config.vault.tls_verify` setting cannot be disabled.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**active-tracing**: Added instrumentation for log phase operations and created a new trace for the log phase spans.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**ACE**: Added `operation_id` in analytics and set it to the header `X-ACE-Operation-ID`.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Added support for Cerebras - a new AI Provider.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI**: Added instrumentation for GenAI spans.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added `ai_mcp_reqs` to reporting metrics to count AI MCP request usage.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**opentelemetry**: Added support for exporting OpenTelemetry metrics via OTLP/HTTP protocol to an observability backend (e.g. OpenTelemetry Collector). Please enable this feature by configuring the `metrics.endpoint` parameter in the OpenTelemetry plugin.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ais**: Add new partials(vectordb, embeddings and model) in ai plugins configs\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**core**: Added directive 'proxy_protocol_passthrough' to allow gateway keep the proxy_protocol header unmodified.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "Starting from this version, Kong Gateway Enterprise supports using common Cloud Authentication methods to connect to Cloud Redis instances. This includes supporting for the following products:\n- AWS ElastiCache for Redis with AWS IAM Authentication\n- Azure Cache for Redis with Azure Microsoft Entra Authentication\n- Google Cloud Memorystore for Redis with GCP IAM Authentication\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-proxy**: Added support for HuggingFace's new serverless API in the AI Proxy plugin, enabling seamless integration and improved compatibility.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-aws-guardrails**: Added block reason info metrics to AWS Guardrails plugin analytics.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-aws-guardrails**: added the flag `ssl_verify` to control\ncertificate verification when connecting to the bedrock service.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-azure-content-safety**: Added support for the global `tls_certificate_verify` option.\nWhen enabled globally via `kong.conf`, the plugin's `ssl_verify` config field cannot be set to `false`.\nThis ensures SSL/TLS certificate verification cannot be disabled when global security policy requires it.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-gcp-model-armor**: Added block reason and processing latency metrics to GCP Model Armor plugin analytics.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**llm**: Added a shared filter to mark requests using AI EE plugins for license enforcement. let ai request not \"double-dipping\" the API Requests by counting twice.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Added support for MCP ACL control.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Added support for cookie in OpenAPI spec when doing MCP conversion.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Added support for structured output from MCP conversion.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Supported health checks and circuit breaker for the load balancer. Added two new fields `max_fails` and `fail_timeout`.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Added missing `least-connections` load balancing algorithm to the AI Proxy Advanced plugin which was missed in the previous release.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed balancer retry failures caused by expired DNS entries by preloading DNS for targets.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Added support for Gemini live websocket in the ai-proxy-advanced plugin.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Added support for native format video generation in Bedrock and Gemini LLM drivers, allowing direct passthrough of provider-specific video generation requests without format conversion.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-rate-limiting-advanced**: added support to count cost for routes with dynamic AI models.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-request-transformer**: added support for the `tls_certificate_verify` global option. When this option is enabled, the plugin's `https_verify` setting cannot be disabled.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-response-transformer**: added support for the `tls_certificate_verify` global option. When this option is enabled, the plugin's `https_verify` setting cannot be disabled.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-sanitizer**: Added a `skip_logging_sanitized_items` option to control whether to log the sanitized items, which may contain sensitive data.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI AWS Guardrails Plugin**: Introduced a new mask mode feature in the AWS Guardrails plugin that allows sensitive data to be masked instead of blocked for requests, responses or both.",
-        "scope": "Plugin",
-        "type": "feature"
-      },
-      {
-        "message": "**azure-functions**: added support for the `tls_certificate_verify` global option.\nWhen this option is enabled, the plugin's `https_verify` flag cannot be disabled.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**basic-auth**: Added brute force protection with exponential backoff for failed login attempts.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Added support for batch API of bedrock.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**confluent-consume**: added new config option `tls_certificate_verify` to support verifying server certificates.\nAdded support for the `tls_certificate_verify` global option. When this option is enabled, the plugin's `tls_certificate_verify` setting cannot be disabled.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**confluent**: added new config option `ssl_verify` to support verifying server certificates.\nAdded support for the `tls_certificate_verify` global option. When this option is enabled, the plugin's `ssl_verify` setting cannot be disabled.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Introduced Alibaba Dashscope as new provider.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**datakit**: Added json_to_xml node to support converting JSON or lua table to XML data.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**datakit**: Added xml_to_json node to support converting XML data to lua table and JSON format.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**datakit**: Added support for dynamic url in `call` node.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**datakit**: Added support for using the `call` node in the post-proxy phase.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "*datakit*: the `call` node now supports performing requests via a proxy server.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**datakit**: Add support for using `application/x-www-form-urlencoded` as the body encoding.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**datakit**: added the `ssl_verify` flag to the call node. This flag allows\nusers to control certificate verification when making HTTPS requests to the\nconfigured `url` endpoint. It cannot be disabled when the\n`tls_certificate_verify` global option is enabled.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**datakit**: Added support for clearing headers from the service_request and response nodes\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**DP Resilience**: added support for \"gs://\" schema in config sync backup strategy.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**forward-proxy**: added support for the `tls_certificate_verify` global option. When this option is enabled, the plugin's `https_verify` setting cannot be disabled.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added OAuth2 authentication to the Hashicorp Vault backend.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**header-cert-auth**: added support for the `tls_certificate_verify` global option.\nWhen this option is enabled, the plugin's `ssl_verify` flag\ncannot be disabled.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**header-cert-auth**: added the flag `ssl_verify` to control certificate\nverification when connecting to the server of the OCSP responder's URL and to\nthe server of the CRL Distribution Point.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**http-log**: added support for the `tls_certificate_verify` global option.\nWhen this option is enabled, the plugin's `ssl_verify` flag\ncannot be disabled.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**http-log**: added the flag `ssl_verify` to control certificate\nverification when pushing logs to the configured `http_endpoint`.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**jwt-signer**: added support to the `tls_certificate_verify` global option.\nWhen this option is enabled the plugin's flags related to certificate\nverification cannot be disabled.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**jwt-signer**: added the flags `access_token_endpoints_ssl_verify`\nand `channel_token_endpoints_ssl_verify` to switch certificate verification\non the related fields.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-consume**: added new config option `ssl_verify` to support verifying server certificates.\nAdded support for the `tls_certificate_verify` global option. When this option is enabled, the\nplugin's `ssl_verify` setting cannot be disabled.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-log**: added new config option `ssl_verify` to support verifying server certificates.\nAdded support for the `tls_certificate_verify` global option. When this option is enabled, the\nplugin's `ssl_verify` setting cannot be disabled.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka**: Added support for `tls_verify` in the Kafka library.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**kafka-upstream**: added new config option `ssl_verify` to support verifying server certificates.\nAdded support for the `tls_certificate_verify` global option. When this option is enabled, the\nplugin's `ssl_verify` setting cannot be disabled.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ldap-auth-advanced**: added support for the `tls_certificate_verify` global option. When this option is enabled and LDAPS is used, the plugin's `verify_ldap_host` setting cannot be disabled.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ldap-auth**: added support for the `tls_certificate_verify` global option. When this option is enabled and LDAPS is used, the plugin's `verify_ldap_host` or `start_tls` setting cannot be disabled.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**mtls-auth**: added support for the `tls_certificate_verify` global option.\nWhen this option is enabled, the plugin's `ssl_verify` flag\ncannot be disabled.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**mtls-auth**: added the flag `ssl_verify` to control certificate\nverification when connecting to the server of the OCSP responder's URL and to\nthe server of the CRL Distribution Point.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Added support for collecting all validation errors when `collect_all_errors` is set to `true` in the plugin configuration. Note: Enabling this option with OpenAPI 3.0 will affect performance.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Support readOnly and writeOnly keywords for OpenAPI 3.1.x.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**opa**: added support for the `tls_certificate_verify` global option. When this option is enabled, the plugin's `ssl_verify` setting cannot be disabled.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: added support to the `tls_certificate_verify`\nglobal option. When this option is enabled the plugin's flags\n`ssl_verify`, `tls_client_auth_ssl_verify`, and `session_memcached_ssl_verify`\ncannot be disabled.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: added the flags `session_memcached_ssl` and\n`session_memcached_ssl_verify` to switch certificate verification when\nconnecting to Memcached server.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**opentelemetry**: Added support for exporting access logs via OTLP/HTTP protocol to an observability backend (e.g. OpenTelemetry Collector). Please enable this feature by configuring the `access_logs_endpoint` parameter in the OpenTelemetry plugin.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added support for GCP authentication methods to connect to GCP CloudSQL Postgres databases.  Configurations include `pg_gcp_auth` and `pg_gcp_service_account_key`.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**rate-limiting-advanced**: Added `route` support to fields `identifier` and `compound_identifier`.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added support for the `tls_certificate_verify` global option in\n`kong.tools.redis` and `kong.enterprise_edition.tools.redis.v2` modules.\nWhen this option is enabled and Redis is configured to connect to a secure\nendpoint, the module's `ssl_verify` flag cannot be disabled.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**Redis Configuration**: Added vault reference support for Redis `host`, `port`, and `server_name` fields in plugins using Redis configuration (such as `rate-limiting-advanced`).\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "Added `ai_model_usage:{\"provider/model\": num}` to the anonymous report to count AI usage per model.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**prometheus**: Added a new label `type` for `http_requests_total` and `stream_sessions_total` metrics providing more specific information.\n",
-        "scope": "Plugin",
-        "type": "feature"
-      },
-      {
-        "message": "**request-callout**: added support for the `tls_certificate_verify` global option. When this option is enabled, the plugin's `ssl_verify` setting for HTTPS callouts cannot be disabled.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-validator**: Provided detailed error messages for `oneOf` / `anyOf` subschemas.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Proxy Advanced**: Added load balance, failover and circuit breaker feature for semantic routing.",
-        "scope": "Plugin",
-        "type": "feature"
-      },
-      {
-        "message": "When global `tls_certificate_verify` is enabled, service entities cannot\ndisable certificate verification using the `tls_verify` option anymore.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**solace-consume**: allowed basic auth credentials to be passed from downstream clients.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**solace-log**: allowed basic auth credentials to be passed from downstream clients.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**solace-upstream**: allowed basic auth credentials to be passed from downstream clients.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Core**: Added SSL verification monitoring when global `tls_certificate_verify` is enabled. You will see a warning if plugins try to disable SSL verification. This will be an error in Kong 3.14.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-proxy**: Added support for batch mode of anthropic.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Added support for inline batch mode of gemini\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**tcp-log**: added new config option `ssl_verify` to support verifying server certificates.\nAdded support for the `tls_certificate_verify` global option. When this option is enabled, the\nplugin's `ssl_verify` setting cannot be disabled.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added TLS certificate verification enforcement. When\ntls_certificate_verify option is \"on\", certificate verification can't\nbe disabled by Service or Plugin entities.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**upstream-oauth**: added support for the `tls_certificate_verify` global option. When this option is enabled, the plugin's `client.ssl_verify` setting cannot be disabled.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Added support for video generation with `video/v1/videos/generations` route type for multiple LLM providers.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ace**: ace_credentials can now be linked to Consumers or Consumer Groups",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added a configuration option `authenticated_groups_delimiter` (available values: `,`, `;`, `|`) to `admin_gui_auth_conf` for OIDC. This option specifies the delimiter used to split group values retrieved from JWT claims. \nWhen multiple group values are concatenated in a single claim using a specific delimiter, this configuration allows multiple groups to be extracted from that single claim value",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where `500` response status can occasionally occur during reconfiguration.",
-        "scope": "Core",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ace**: Fixed an issue where the anonymous consumer was not being set properly when authentication failed.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ace**: Fixed an issue where users could set the `anonymous` field in the OpenID Connect configuration of ACE auth strategies, which is not supported and could lead to unexpected authentication behavior.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**acme**: Fixed an issue where the plugin would not properly handle cases when a referenced key_set does not exist, now returns a clear error message instead of causing unexpected behavior.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**active-tracing**: Fixed parent span for body filter plugin spans",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where **active-tracing** debug sessions are not reporting headers and payloads when proxy is used to connect to the telemetry endpoint.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**active-tracing**: Fixed an issue where WebSocket connections to the control plane are not correctly closed in debug sessions.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**GCP Model Armor**: Fixed an issue where PARTIAL invocationResult was not handled.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**GCP Model Armor**: Fixed an issue where short-lived credentials were not being refreshed properly.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**llm**: Fixed an issue where Gemini embeddings driver did not use correct url.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where the token count for Gemini Vertex embeddings API in native format was incorrect.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where the token count for Gemini Vertex embeddings API in OpenAI format was incorrect.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**llm**: Fixed an issue where HuggingFace embeddings driver did not handle response correctly.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-oauth2**: Fixed an issue where MCP-like request was not authenticated.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-oauth2**: Fixed an issue where the oidc schema was polluted during merging.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-oauth2**: Fixed an issue where resource without path was not correctly handled.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-oauth2**: Fixed an issue where there was an unexpected `required: false` in the plugin schema.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where path traversal can be done with path parameter.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where MCP server could not call upstream when proxy protocol is used.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where failing to fetch tools cache was not handled properly.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where forwarding client headers to upstream could not be disabled.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where trusted ip relative headers were forwarded upstream.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where `tools/call` could accept malformed requests and generate wrong responses.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-oauth2**: Fixed an issue where x-forwarded-* headers were not respected.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where path invalid error was not handled properly.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where we could not override the upstream's scheme when converting MCP tool to RESTful API.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where MCP server could not call upstream when self-signed certificate is used in Kong.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-prompt-template**: Fixed an issue where non-OpenAI requests were not being processed correctly.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed intermittent 500 responses from the AI Proxy Advanced plugin when using Azure OpenAI\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where the native format option did not work correctly for non-openai formats.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where the semantic load balancing with pgvector namespace was not functioning correctly.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where cohere embedding model on Bedrock returned a bad request error\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where `tls_certificate_verify` configuration was not respected in JSON-RPC and AWS STS calls.\n",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-rate-limiting-advanced**: Fixed an issue where the plugin decreased requests by whole numbers when using Redis. This is an opt-in fix and can be enabled by setting `decrease_by_fractions_in_redis` to true in the plugin configuration.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Request Transformer**: Fixed an issue where ai-request-transformer plugin does not accept capture groups for deployment field\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where `ai_reqs` and `ai_model_usage` were increased even for non-ai requests.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**AI Sanitize**: Fixed an issue where ai-sanitize plugin does not accept non-OpenAI format.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-semantic-cache**: Fixed an issue where cost savings attributes `ai_proxy_cache_cost_savings` were not properly calculated when cache hits.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-semantic-cache**: Fixed an issue where Cohere and Huggingface models did not work with the semantic cache because of the polluted request format.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-semantic-cache**: Fixed an issue where the plugin did not report time to first token (TTFT) metrics when hit.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-semantic-response-guard**: Fixed an issue where a stacktrace error occurred during initialization and teardown.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue when using responses API and background mode.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-semantic-cache**: Fixed an issue where the plugin did not allow /responses api to be used with Azure.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where Kong Manager failed to generate a cookie when OIDC was enabled due to a missing `password` grant type in `auth_methods`.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**AI Proxy Advanced**: Fixed an issue where Files content analytics extraction is not handled properly for Azure.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Proxy Advanced**: Fixed an issue where requests to Anthropic Claude models via Azure Foundry were not being processed correctly.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**balancer**: Fixed an issue where the dns query not stopped when related upstream deleted.\n",
-        "type": "bugfix",
-        "scope": "Configuration"
-      },
-      {
-        "message": "**balancer**: Fixed an issue where the unsupported field `sticky_sessions_cookie_path` was blocking configuration syncing on data planes older than version 3.11.\n",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where AWS Bedrock invoke command is not properly proxied.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**OpenID-Connect**: Fixed an issue where for incremental sync, consumer related caches may not be properly invalidated, causing stale data to be served.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the CLI command `kong runner` crashes when clustering cert and key are provided as content from environment variables.\n",
-        "type": "bugfix",
-        "scope": "CLI Command"
-      },
-      {
-        "message": "**confluent**: Fixed an issue where `forward_body` dropped request bodies larger than Nginx's\ndefault buffer size (16 KB). It now reads up to 1 MB and returns an error if the body can't be fully read.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Clustering** Fixed an issue where consumer groups may cause incremental sync to fail at the first sync of a DP.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Fixed an issue where consumer group renaming may not be properly populated, causing stale cache to be served.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**datakit**: Fixed implicit request node headers field to be correct type.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Fixed an issue where the partial entities cannot be deleted when cascading delete a workspace.**",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where certain record/map fields with an empty-object default value\nwere incorrectly JSON-encoded as arrays.\n",
-        "type": "Breaking Change",
-        "scope": "Admin API"
-      },
-      {
-        "message": "**template**: Fixed an issue where duplicated \"proxy_protocol on\" directive in nginx-kong-stream.conf when KONG_NGINX_SPROXY_PROXY_PROTOCOL was set for ssl stream.\n",
-        "type": "bugfix",
-        "scope": "Configuration"
-      },
-      {
-        "message": "**event-hooks**: Fixed an issue where the event_hook crud events cannot be handled in traditional cluster mode.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**AI Proxy Advanced**: Fixed an issue where the Gemini image generation model responses were not being processed correctly.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**AI AWS Guardrails**: Fixed an issue where the error does not reflect the root cause when the `guardrails_version` did not match the expected pattern.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-azure-content-safety, ai-aws-guardrail**: Fixed an issue where the plugins failed to decompress gzip-encoded responses, leading to errors in response handling.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where upstreams were unhealthy when `healthchecks.threshold` is set to 100.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where Kong incorrectly logged upstream status codes as 000 (or empty) when HTTP/2 clients disconnected during response processing. This occurred when response buffering was enabled. Kong now correctly records the actual upstream status code even when the HTTP/2 client disconnects before receiving the complete response.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-proxy**: Added tool_calls passthrough and preserved finish_reason in Huggingface driver responses.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where HuggingFace embedding driver were incorrectly parsed responses from embedding API\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Proxy Advanced**: Fixed missing `id` and `created` fields in certain drivers.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "Fixed an issue where the prometheus metric `kong_control_plane_connected` was missing when the Data Plane side enabled incremental sync.\n",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**kafka-consume, confluent-consume**: Added `enforce_latest_offset_reset` flag to fix incorrect `latest` offset behavior. When `false` (default), maintains backwards compatibility where `latest` acts like `earliest`. When `true`, `latest` correctly starts from end of topic. Also fixed offset commit bug when no records are consumed, preventing feedback loop with true latest behavior.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-upstream**: Fixed issue where Kafka producer cached TLS certificates, causing failures when certificates were updated. Now, the plugin properly reloads updated certificates.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-consume**: Fixed an issue where the SSE connection was not terminated when there was an error in Schema Registry.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Key-Auth-Enc**: Fixed an issue where for incremental sync, caches may not be properly invalidated, causing stale data to be served.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**response**: Fixed an issue where the `kong.response.exit() didn't interrupt the execution flow of plugins in header_filter phase`.\nAlso added a new configuration `pdk_response_exit_header_filter_early_exit` to control this behavior to avoid silent breaking changes.\nThe current default value is 'off', and output a warning log when `kong.response.exit()` is called in header_filter phase.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Plugins**: Fixed an issue where `log_payloads` configuration would not work when `log_statistics` was disabled in the logging configuration.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy, ai-proxy-advanced**: Fix SSE response parsing when the response is gzip-encoded, last chunk was not processed.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**llm**: Fixed an issue where the subrequest implemented in LLM drivers did not handle error properly.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the `kong.log.serialize()` function incorrectly ommitted the `consumer_id` in the `authenticated_entity` log field.",
-        "type": "bugfix",
-        "scope": "PDK"
-      },
-      {
-        "message": "**log-pdk**: Fixed an issue in log-pdk where log serialization could cause a panic due to incorrect type handling in `set_serialize_value`. Strengthened validation to prevent this.\n",
-        "type": "bugfix",
-        "scope": "PDK"
-      },
-      {
-        "message": "**AI Plugins**: Fixed an issue where max_request_body_size can't be 0 and set default to 1048576 (1M).",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**AI MCP Proxy**: Fixed an issue where mcp proxy is not parsing default values properly.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "Fixed an issue where migrations could fail due to missing database relations by repositioning basic-auth and key-auth plugin scripts for correct execution order.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**mocking**: Fixed an issue where path match pattern failed when `()[]` were in the path pattern.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Proxy Advanced**: Fixed an issue where the `max_completion_tokens` parameter was not being set correctly for O1 series models (e.g., `o1`, `o3`, `o4`, `gpt-5`).",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where parameter data extraction failed when `$` appears in the path pattern.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where nested references in oneOf / anyOf when they are used with a discriminator are not unfolded.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**OpenID-Connect**: Fixed an issue where the issuer mismatch error message for the token's `iss` claim did not reflect the correct token type and expected issuers.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**OpenID-Connect**: Fixed an issue where the `client_credentials`/`authorization_code` auth would not auto-recover if IdP was not accessible during Kong startup.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**OpenID Connect**: Improved claim validation logic to correctly handle timestamp claims (exp, nbf, iat) even when provided as non-numeric types.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**OpenID-Connect**: Fixed an issue where TLS client certificate loading failed in non-default workspaces. The certificate lookup now explicitly specifies the plugin's workspace when querying the database during configuration initialization.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**OpenTelemetry**: Fixed an issue where the instrumentation started unexpectedly on control planes of hybird mode.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**opentelemetry**: Fixed an issue where the reference removing did not match the correct property in otel logs.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where `otlp.prepare_logs` did not reset the `spans` field, causing unsupported data exported to OTel backends.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**ACL**: Fixed an issue where the cache was not being invalidated for incremental sync in certain scenarios, leading to stale data being served.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Prometheus**: Fixed an issue where the Prometheus plugin would not return DB connections to the connection pool, potentially leading to exhaustion of available connections under high load.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-callout**: Fix duplicated content-type headers in the callout request when body.custom is enabled and content-type header is also set in headers.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka**: Fixed an issue where consumed messages were not validated against their JSON schema.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka**: Fixed an issue where Schema Registry didn't properly validate JSON schemas.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Semantic Prompt Guard**: deprecate config.rules.max_request_body_size with config.max_request_body_size.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "Fixed an issue where plugin preparation incorrectly retained userdata values; they are now set to `nil` during preparation.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**SAML**: Fixed an issue that caused a crash when the NameID Format was set to `Unspecified`.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**solace-log**: Fixed end-to-end tracing context propagation.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**solace-upstream**: Fixed end-to-end tracing context propagation.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the data plane did not stop the health checker before cleaning up old configurations, which could lead to resource leaks.\n",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where YAML 1.1 `null` values were parsed incorrectly.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-llm-as-judge**: Added validation to prevent disabling `https_verify` when the global `tls_certificate_verify` configuration option is enabled.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kong.tools.jose**: Allow arbitrary size RSA keys.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**Fixed a typo in certificate phase name in kong.tools.yield module.**",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where unnecessary table allocations were occurring when encoding traces and logs.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where `Via` header includes dashes `-` in it (like `1.1 kong/3.13.0.0-enterprise-edition`), which is not allowed by RFC 9001 and may cause issues with some .NET HTTP servers.\nA new `kong.conf` configuration option `via_header_comply_rfc` was added, when enabled, the `Via` header will not include Kong version and dashes (like `1.1 kong`).\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**ace**: Fixed an issue where multiple key-auth strategies could not use the same apikey.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ace**: Fixed an issue where observability headers could not be set correctly in some unhappy paths.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Proxy**: Fixed an issue where extra inputs were not permitted for huggingface inference provider\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**AI Proxy**: Fixed an issue where using ai-proxy-advanced in conjunction with a logging plugin (such as file-log) resulting in missing information on the last entry of the balancer \"tries\" section.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue when using passthrough-mode, tools without tool ACL do not apply default ACL.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-aws-guardrails**: Fixed an issue where the ai-aws-guardrails metrics could not be recorded.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**confluent-consume**: Fixed an issue where the plugin would fail to connect using mTLS.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**file-log**: Fixed an issue where the configuration with leading or trailing spaces in the `path` field could cause upgrade failures.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-consume**: Fixed an issue where the plugin would fail to connect using mTLS.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-upstream**: Fixed an issue where the kafka-upstream plugin fails to connect certain Kafka clusters using SCRAM-SHA-256 or SCRAM-SHA-512\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**key-auth**: Fixed an issue where the consumer authentication cache was not isolated by realm.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**core**: Improved performance of deleting expired rows for Postgres versions below 12.",
-        "type": "performance",
-        "scope": "Core"
-      },
-      {
-        "message": "**core**: Improved performance of Kong core.",
-        "type": "performance",
-        "scope": "Core"
-      },
-      {
-        "message": "Improved the performance of Konnect Analytics on the Data Plane side.\n",
-        "type": "performance",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**request-transformer**: improved performance of the request-transformer plugin.\n",
-        "type": "performance",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Removed analytics metrics related to rate limiting and threats on the data plane side.\n",
-        "type": "feature",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Replaced resty-cli with rusty-cli",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "*request-callout*: Ensure that upstream headers are cleared after custom expressions are executed.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-rag-injector**: Added metadata filtering and ACL (Access Control List) capabilities to the RAG plugin. This feature enables fine-grained control over document retrieval based on metadata attributes and user permissions, supporting both pgvector and Redis vector database backends.\n",
-        "scope": "Plugin",
-        "type": "feature"
-      }
-    ],
-    "kong-manager-ee": [
-      {
-        "message": "Added support for AWS, Azure, GCP authentication providers in Redis config.",
-        "type": "feature",
-        "githubs": [
-          4121
-        ],
-        "scope": "Core"
-      },
-      {
-        "message": "Added support for using OAuth2 with HashiCorp Vault.",
-        "type": "feature",
-        "githubs": [
-          4122
-        ],
-        "scope": "Core"
-      }
-    ]
-  },
   "3.4.3.23": {
     "kong": [
       {
@@ -20216,2523 +16183,6 @@
     ],
     "kong-manager-ee": []
   },
-  "3.14.0.0": {
-    "kong": [
-      {
-        "message": "**ai-a2a-proxy**: Added Prometheus and OpenTelemetry observability with A2A-specific\nmetrics and tracing spans.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**opentelemetry**: Fixed an issue where invalid `x-b3-flags` header values caused 500 responses.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where DP's proxy listener could not be verified because of it was disabled in CP.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**ldap-auth**: Fixed a security issue.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where a SQL injection vulnerability existed in the clustering RPC procedure, ensuring safer SQL operations.\n",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Fixed an issue where disabling `tls_certificate_verify` via `kong reload` did not take effect because the derived `proxy_ssl_verify` directive persisted in `.kong_env` from a previous reload.",
-        "type": "bugfix",
-        "scope": "Configuration"
-      },
-      {
-        "message": "**key-auth, key-auth-enc, basic-auth, hmac-auth, ldap-auth, oauth2, oauth2-introspection, vault-auth, ldap-auth-advanced**: Changed the default value of `hide_credentials` from `false` to `true` to enhance security. Users should verify their configurations if relying on the previous default.\n",
-        "type": "Breaking Change",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added a new configuration option `schema_alias_conflict_mode` that controls the behavior when a deprecated alias field and its canonical replacement field are both present with mismatched values. The default value `error` preserves the existing strict validation behavior. Setting it to `warn` accepts the configuration with a warning log and always uses the canonical field value, allowing upgrades to proceed without requiring all legacy plugin configurations to be corrected first.",
-        "type": "feature",
-        "scope": "Configuration"
-      },
-      {
-        "message": "Optimized `GET /kong` endpoint to use `SELECT DISTINCT` for populating `enabled_in_cluster` instead of iterating all plugin rows.",
-        "type": "performance",
-        "scope": "Admin API"
-      }
-    ],
-    "kong-ee": [
-      {
-        "message": "**ai-proxy-advanced**: Added native passthrough support for Vertex AI multimodal embeddings. Introduced new `llm/v1/multimodal-embeddings` route type.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Bumped lua-resty-gcp from 0.0.17 to 0.0.19 to address GCP access token handling improvements.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-resty-gcp from 0.0.16 to 0.0.17.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped OpenSSL from 3.4.3 to 3.5.5 to address the issue: CVE-2025-15467.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-a2a-proxy**: Added A2A analytics support for Konnect, enabling visibility into A2A protocol operations including method calls, latencies, and task states.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-a2a-proxy**: Added new plugin for Google A2A (Agent-to-Agent) protocol support,\nenabled AI agent interoperability with JSON-RPC and REST bindings, built-in observability.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ACL**: Added WebSocket protocol support (`ws`/`wss`). The plugin now enforces allow/deny group rules during the WebSocket handshake phase.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**acme**: Added support for the `tls_certificate_verify` global option. When this option is enabled, the plugin's `storage_config.redis.tls_verify` setting cannot be disabled.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**active-tracing**: Added auto-decompression for gzipped bodies when capturing payload\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**openid-connect**: Added `consumer_claims` to support mapping consumers from multiple claim paths, while retaining and supporting the existing `consumer_claim` as a shorthand configuration.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-oauth2**: Added Token Exchange support to swap JWT tokens before accessing MCP Server.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-aws-guardrails**: the `ssl_verify` option to validate TLS certificate\nwhen connecting to the bedrock service is now enabled by default.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-azure-content-safety**: the `ssl_verify` option to verify the certificate\npresented by the Azure Content Safety service when using HTTPS is now enabled\nby default.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Added support for databricks provider.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Added support for DeepSeek provider.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-oauth2**: Added support for mapping claim to authenticated credential.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-oauth2**: Made the client_id field not required when client_auth is set\n  to something other than client_secret_basic or client_secret_post\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-oauth2**: Added `upstream_headers` field for mapping token claims to upstream headers using path-based access. Mutually exclusive with `claim_to_header`.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-oauth2**: Added support for passing tokens upstream.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-oauth2**: Added support for multiple token validation methods.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Added support for ACL with OAuth claim.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Added support for session sharing and active notice when doing MCP conversion.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed structured output and tool calls for Ollama (also Llama2 and Mistral) providers.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Updated mappings for Ollama (also Llama2 and Mistral) providers.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Added the Ollama provider, for native support for all Ollama-hosted models.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Added ACL support that blocks requests matching deny rules, requires allow rules to pass when present, and resolves consumer/model values once per request.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Updated to use /v2/chat when proxying text generation request to cohere provider.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Added the ability to select target models by request models in same AI Proxy Advanced plugin.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Added support for proxying cohere embeddings models on bedrock.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-rate-limiting-advanced**: Added a policy-based rate limiting mode with\nmulti-dimensional match conditions and request counting strategy.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-rate-limiting-advanced**: Added prompt token estimation for `prompt_tokens`, `total_tokens`, and `cost` strategies in policies mode, enabling early request rejection before the upstream responds.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**llm**: Added bytes-based tokenizer.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Added support for vLLM provider.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Added native Anthropic streaming mode support, enabling direct passthrough of Anthropic SSE events with proper message reordering for tool calls.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added request and response content evolution support to the debugger session. This allows the debugger to capture and compare request and response contents across different phases of the request lifecycle, providing insights into how the contents change as they flow through Kong Gateway.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "Kong will validate the database connection configuration at startup and will not start if errors are detected.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**AWS-Lambda**: Added `ssl_verify` config field to control SSL certificate verification when connecting to AWS APIs.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**azure-functions**: the `https_verify` option to validate the Azure Functions\nserver certificate is now enabled by default.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**basic-auth**: Uses SHA256 by default even in non-FIPS mode instead of SHA1.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Added support for batch API in openai-compatible mode when providers are anthropic, bedrock, gemini and gemini vertex.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**core**: Added support for decoding JSON null values in objects as Lua `nil` via `cjson.decode_null_object_value_as_nil` (and exposed as `kong.tools.cjson.decode_null_object_value_as_nil`).",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**Conditional Plugin Execution**: Added support for conditional plugin execution through a new `condition` field in the plugin configuration. Plugins can now be conditionally skipped at runtime based on request attributes such as HTTP method, path, headers, query parameters, consumer, route, service, and network information. The condition expression uses the ATC expression language and is evaluated once during the collecting phase; skipped plugins are excluded from all downstream phases automatically.\n",
-        "scope": "Core",
-        "type": "feature"
-      },
-      {
-        "message": "**DP Resilience**: Added support for Azure Blob Storage in config sync backup strategy.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "Added `lru_cache_size` to allow configuration of in-memory LRU cache size.",
-        "type": "feature",
-        "scope": "Configuration"
-      },
-      {
-        "message": "**confluent-consume**: the `ssl_verify` option to validate the server\ncertificate is now enabled by default.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**confluent**: the `security.ssl_verify` option is now enabled by default.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-custom-guardrail**: Added a new custom guardrail plugin which enables integration with 3rd party guardrail service.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**datakit**: Added more implicit node outputs:\n    * `request.path`\n    * `request.raw_path`\n    * `request.port`\n    * `request.method`\n    * `request.scheme`\n    * `request.version`\n    * `service_response.status`\n    * service_response.raw_body\n    * call.raw_body\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**datakit**: Added JWT nodes: `jwt_decode` for decoding tokens without verification, `jwt_verify` for signature verification and claim validation using JWKS, and `jwt_sign` for creating and signing JWTs.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**datakit**: Consumer can now be set via property node.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**datakit**: the call node's `ssl_verify` option to verify the TLS certificate\nwhen making HTTPS requests is now enabled by default.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**debuggability**: Add CPU profiling support for debuggability to Kong.\n",
-        "scope": "Core",
-        "type": "feature"
-      },
-      {
-        "message": "**debugger**: Added sanitization support for payload using configurable redaction rules.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**debugger**: Added status code and status message to plugin span attributes when using kong.response to exit.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**Configuration**: The `tls_certificate_verify` option is now enabled by\ndefault, preventing Kong from bypassing certificate verification on any\nsecure connection.\n",
-        "type": "Breaking Change",
-        "scope": "Core"
-      },
-      {
-        "message": "**event hooks**: Sign event hook calls with HMAC-SHA256 instead of HMAC-SHA1.\n",
-        "type": "Breaking Change",
-        "scope": "Core"
-      },
-      {
-        "message": "**event-hooks**: The options `ssl_verify` for the webhook type handler are now enabled by default.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**forward-proxy**: the `https_verify` option to validate the `https_proxy_host`\nserver certificate is now enabled by default.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added AWS auth method authentication to the HashiCorp Vault backend.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "Added Azure authentication to the HashiCorp Vault backend.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "Added GCP auth method authentication to the HashiCorp Vault backend.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**header-cert-auth**: the `ssl_verify` option to switch verification of the\ncertificate presented by the server of the OCSP responder's URL and by the\nserver of the CRL Distribution Point is now enabled by default.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**hmac-auth**: Add support for HMAC-SHA224, and removes HMAC-SHA1 from the default set of algorithms\n               (still supports HMAC-SHA1 when configured).\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**http-log**: the `ssl_verify` option to validate the `http_endpoint` server\ncertificate is now enabled by default.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**metrics**: Added metrics to show the time consumption excluding upstream, third-party I/O, and client in the HTTP context for Prometheus, Analytics, and logs.\n",
-        "type": "feature",
-        "scope": "Performance"
-      },
-      {
-        "message": "**json-threat-protection**: Added support for `allow_non_json_requests` configuration to allow non-JSON requests to bypass all checks.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**jwt-signer**: calls to the `/rotate` endpoint now enable certificate\nverification by default when connecting to the configured endpoint to rotate\nthe keys.\n",
-        "type": "Breaking Change",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**jwt-signer**: The options `access_token_endpoints_ssl_verify` and\n`channel_token_endpoints_ssl_verify`, which control SSL certificate\nverification for signature verification and introspection endpoints, are now\nenabled by default.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-consume**: Added support for posting commit offsets.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-upstream**: The option `security.ssl_verify`, which controls the verification\nof the certificate presented by the server, is now enabled by default.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-log**: The options `security.ssl_verify` which control SSL certificate\nverification for Kafka endpoints, are now enabled by default.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-upstream**: The option `ssl_verify`, which controls the verification\nof the certificate presented by the server, is now enabled by default.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ldap-auth-advanced**: the `verify_ldap_host` option to validate the LDAP\nserver certificate is now enabled by default.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ldap-auth**: the `verify_ldap_host` option to validate the LDAP server\ncertificate is now enabled by default.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**llm**: Added `conf.model.metadata` configuration to specify model options separately from the main configuration. Metadata options are merged into the model options during request normalization\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**metering-and-billing**: Added a new plugin for metering and billing.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**mtls-auth**: the `ssl_verify` option to validate verification of the\ncertificate presented by the server of the OCSP responder's URL and by the\nserver of the CRL Distribution Point is now enabled by default.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**mtls-auth**: Added WebSocket protocol support. This authentication plugin can now protect WebSocket connections (`ws` and `wss` protocols) in addition to HTTP/HTTPS. In hybrid mode, using `ws`/`wss` with this plugin requires data planes running DP >= 3.14, or explicit removal of `ws`/`wss` protocols from configurations targeting older data planes.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oauth2-introspection**: The authenticated token is now stored in the request context via `kong.client.set_token`.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oauth2**: The authenticated token is now stored in the request context via `kong.client.set_token`.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oauth2**: Uses SHA256 for access token cache key instead of SHA1.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oauth2**: the option `ssl_verify`, to verify the certificate presented by\nthe IdP when using HTTPS, is now on by default.\n",
-        "type": "Breaking Change",
-        "scope": "Core"
-      },
-      {
-        "message": "**openid-connect**: Marked `issuers_allowed` as a referenceable field.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Added `jwks_endpoint` configuration to override the discovered `jwks_uri` when a custom JWKS endpoint is required.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Marked fields `issuer`, `extra_jwks_uris`, and `introspection_endpoint` are now supported as vault references.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: The authenticated token is now stored in the request context via `kong.client.set_token`.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Added `upstream_headers` and `downstream_headers` schema fields that support nested claims.\n\nThe previous `upstream_headers_claims`, `upstream_headers_names`, `downstream_headers_claims`,\nand `downstream_headers_names` schema fields are now deprecated.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: the `ssl_verify`(for verifying identity provider server certificate) and the `session_memcached_ssl_verify`(for verifying session storing memcached server certificate) option\nare now enabled by default as well.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Added support for token exchange from multiple IdPs based on RFC8693.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Added WebSocket protocol support. This authentication plugin can now protect WebSocket connections (`ws` and `wss` protocols) in addition to HTTP/HTTPS. In hybrid mode, WebSocket protocol support for this plugin requires data planes running Kong Gateway 3.14 or later; for older data planes, ensure routes do not use `ws`/`wss` protocols, as their propagation will be blocked.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**opentelemetry**: Added support for AI/MCP access log",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**opentelemetry**: Added the Konnect Cluster ID and the optional Cluster Member ID to access logs.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**opentelemetry**: Added support for customizing access logs via Lua code snippets. The previous `access_logs_endpoint` schema field has been deprecated in favor of a new `access_logs.endpoint` field, which can be used alongside the `access_logs.custom_attributes_by_lua` field to specify Lua code snippets for custom attributes.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**opentelemetry**: Added support for AI/MCP metrics",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**opentelemetry**: Add Konnect Cluster ID and the optional Cluster Member ID attributes to OpenTelemetry metrics in Konnect mode.\n",
-        "scope": "Plugin",
-        "type": "feature"
-      },
-      {
-        "message": "**opentelemetry**: Added support for official MCP metrics",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**opentelemetry**: Support WebSocket related metrics to OpenTelemetry plugin for enhanced observability.\n",
-        "scope": "Plugin",
-        "type": "feature"
-      },
-      {
-        "message": "Added `kong.client.get_jwt_token_header()` to retrieve a decoded JWT token header.\n",
-        "type": "feature",
-        "scope": "PDK"
-      },
-      {
-        "message": "Added `kong.client.get_jwt_token_payload()` to retrieve a decoded JWT token payload.\n",
-        "type": "feature",
-        "scope": "PDK"
-      },
-      {
-        "message": "Added `kong.client.get_token()` function to retrieve a shared authenticated token.\n",
-        "type": "feature",
-        "scope": "PDK"
-      },
-      {
-        "message": "Added `kong.client.set_token()` function to share authenticated token with other plugins.\n",
-        "type": "feature",
-        "scope": "PDK"
-      },
-      {
-        "message": "Added support for PostgreSQL OAuth/OAUTHBEARER SASL authentication.\nKong can now authenticate with PostgreSQL using OAuth 2.0 bearer tokens\nobtained via client credentials grant from an identity provider.\nThis requires PostgreSQL 18+ with OAUTHBEARER support and the updated\npgmoon library with OAUTHBEARER SASL implementation.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**Redis Partials**: changed the default value for the `ssl_verify` from `off`\nto `on`.",
-        "type": "Breaking Change",
-        "scope": "Core"
-      },
-      {
-        "message": "**request-callout**: The option `callouts.http_opts.ssl_verify`, which controls the verification\nof the certificate presented by the server, is now enabled by default.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Routes**: Change default protocols from `http, https` to `https` for routes entities.\n",
-        "type": "Breaking Change",
-        "scope": "Core"
-      },
-      {
-        "message": "**sandbox**: Added `strict` and `lax` modes for `untrusted_lua`. The default mode changed from `sandbox` to `strict`.\n",
-        "type": "Breaking Change",
-        "scope": "Core"
-      },
-      {
-        "message": "**solace-upstream, solace-log, solace-consume**: Added support for the global `tls_certificate_verify` option. When enabled, plugins using secure protocols (tcps://, wss://, https://) must have `ssl_validate_certificate` set to `true`.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**solace-upstream**: Added `content_type` / `content_encoding` (with request-header fallback) and `forward_body_raw_only` for raw payload passthrough; headers can be forwarded into Solace user properties.\n",
-        "scope": "Plugin",
-        "type": "feature"
-      },
-      {
-        "message": "**ai-mcp-oauth2**: Added support mapping claims in token to `consumer` and `consumer_groups`.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Added support for sampling rate in sessions of active tracing",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**tcp-log**: the `ssl_verify` option is now enabled by default.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Upgraded lua-resty-aws library to the 1.7.2 version.",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**Hashicorp Vault**: Added `ssl_verify` config field to control SSL certificate verification when connecting to Hashicorp Vault servers.\n",
-        "type": "feature",
-        "scope": "Core"
-      },
-      {
-        "message": "**vectordb**: Added Valkey support for vector database operations, providing an alternative to Redis Stack for vector search capabilities.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**vectordb**: The option `ssl_verify`, which control SSL certificate\nverification for the pgvector database, is now enabled by default.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**core**: Add `lua_gc_tuning` option to control garbage collection parameters on Control Plane.\n",
-        "type": "feature",
-        "scope": "Configuration"
-      },
-      {
-        "message": "**acl**: Fixed an issue where the ACL plugin did not check consumer groups from all sources, causing it to incorrectly deny access when consumer groups were set by other plugins like ACE in `ngx.ctx.authenticated_consumer_groups`.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-aws-guardrails**: Allowed streaming of responses when `guarding_mode` was set to `INPUT` with `allow_masking` enabled.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-gcp-model-armor**: By default now blocks unrecognized/new filters added to GCP Model Armor.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**llm**: Fixed an issue where we could not specify the correct dimensions for Gemini embeddings model provider.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where attributes for GenAI spans were incorrect according to https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where the latest 2025-11-25 spec defines the Authorization error codes which are different from ours.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-mcp-oauth2**: Fixed an issue where we didn't clear header for absent claim.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where ACL denial caused parsing body failure.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where the ACL metric label value was incorrect.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where `tools/list` could expose tools to consumers denied by tool ACL in listener mode.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where we didn't keep the port after MCP conversion.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where we have not reported metrics to konnect since 3.13.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where PATCHing the tool caused an error.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed excessive DNS warning logs for template variable endpoints like `$(headers.x_gcp_endpoint)`. These warnings appeared on every configuration change because template variables cannot be resolved until request time.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed `usage.cost` for OpenAI `llm/v1/files/{file_id}/content` batch output analytics.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where metrics were missing and v2 API was unavailable in Cohere native format.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where id/created fields were missing in multiple drivers.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where gzip streaming response in OpenAI format was broken.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-proxy**: Fixed a crash in the observability module when upstream returned `choices: null` (JSON null). The `header_filter` phase would crash with \"attempt to get length of field 'choices' (a userdata value)\" because `ngx.null` is truthy in Lua.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where content-type header, from non-200 response of streaming request, was overridden.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-proxy**: Fixed an issue where format-compatible streaming routes did not collect metrics and logging.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-rate-limiting-advanced**: Fixed an issue where the plugin did not validate whether the configured `dictionary_name` exists before use, which could lead to runtime errors.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-sanitizer**: fixed an issue where the sanitizer plugin always sanitize the entire request body, which was fixed with latest message only.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-semantic-prompt-guard**: Fixed an issue where a vectorDB error occurred during initialization or config reload.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**aws-lambda**: Fixed an issue where Lambda responses with empty or null body caused 500 errors when `is_proxy_integration` is enabled.\n",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**aws-lambda**: Fixed an issue where headers from Lambda proxy responses were not merged correctly, causing case-insensitive header deduplication to fail. User-supplied headers now properly overwrite existing headers regardless of casing.\n",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "Fixed an issue where the balancer's health checker is not properly clean up when config changed in CP/DP mode.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**basic-auth**: Brute Force Protection: when using redis strategy and the connection fails,\nthe plugin will now fall back to using the memory strategy.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kong.service.request.clear_query_arg**: Fixed an issue where an extra `=` was appended to empty query arguments.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where using Google Cloud Storage cannot use the Application Default Credentials method order when the environment variable GCP_AUTH_METHOD_ORDER is set to \"adc\".",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**core**: Resolved an issue where HTTPS was incorrectly detected if multiple `X-Forwarded-Proto` values were provided.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Apply Nginx patch for a man-in-the-middle upstream response injection (CVE-2026-1642)",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**datakit**: Fixed type system bug to allow defining maps with string values for vault node.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**datakit**: Fixed an issue where datakit cache node instantiate proxy-cache-advanced redis module at config time causing dependency issue on Koko.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**datakit**: Fixed xml_to_json node to recognize `text/xml` content-type in addition to `application/xml` for XML request body processing, ensuring RFC 7303 compliance.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the Active Tracing would report incorrect `latencies.client` values due to not capturing the access end time properly. This fix ensures that the access end timestamp is always recorded regardless of Active Tracing being active or not.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the request and response contents (headers and body) of external HTTP or Redis calls were not being recorded in the Content Evolution Capture.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where GCP tokens would not be proactively refreshed before expiration.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy**: Fixed streaming token count metrics for third-party models hosted on Vertex AI (claude-*, mistral-*, jamba-*) that reported inflated totals because incremental counts were treated as cumulative.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**graphql-rate-limiting-advanced**: Fixed an issue where the plugin could fail\nto connect to the upstream server to introspect the upstream schema.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**degraphql**: Fixed an issue where the plugin failed to parse GraphQL variables with nested array types like `[String]!`. The error `attempt to index field 'name' (a nil value)` occurred because the type parser did not correctly handle deeply nested type structures such as `nonNullType(listType(namedType))`.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Injection Protection**: Fixed an issue where the plugin was too sensitive to certain injection patterns.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-consume, confluent-consume**: Increased the minimum API version of FetchRequest from 0 to 4 for Kafka 3.x. For Kafka 4.0 it is already using version 4.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka**: Fixed issue where Kafka message key deserialization failed silently, returning raw string data instead of deserialized objects. \n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**confluent, confluent-consume**: Fix issue where Kafka plugin failed to encode and validate message keys when using Confluent Schema Registry.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka**: Fix issue where Kafka plugin produced records with incorrect `offsetDelta` in the record package.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where `kong health` command would fail to run when kong configuration contains vault references.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**ldap-auth-advanced**: Fixed a security issue.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**mtls-auth**: Fixed an issue where client certificates with Subject Alternative Name (SAN) DirectoryName extensions caused authentication errors. Added a new `san_dirname_matcher` configuration option to specify which Distinguished Name attributes from the SAN DirectoryName extension should be used for consumer lookup.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where response body buffering was not properly disabled when `validate_response_body` was set to `false`.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where parameter validation errors caused a runtime crash when `collect_all_errors` was enabled.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where swagger `formData` parameters were not properly handled.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where `minLength` and `maxLength` constraints defined in a Swagger 2.0 parameter schema were not enforced.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where the validator cache did not account for the `collect_all_errors` setting.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**opa**: Fixed json body processing to recognize `application/json` content-type with charset, ensuring proper handling of JSON request bodies.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed zero usage statistics for OpenAI `llm/v1/responses` in streaming mode.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Fixed an issue where client-provided headers could be forwarded to upstream services when the corresponding JWT claim was missing from the token. The plugin now clears client headers before processing `upstream_headers_names`, ensuring that only verified JWT claim values are sent to upstream or downstream.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Fixed an issue where the `username` and `password` were used for Redis Sentinel and no authentication supported for Redis, causing `NOAUTH Authentication Required` errors.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**opentelemetry**: Fixed an issue where valid response codes from vendor endpoints were incorrectly rejected when exporting `traces`, `logs` or `metrics`.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**opentelemetry**: Fixed an issue where the `http.response.status_code` attribute of the `http.server.request.count` metric was incorrectly set to `kong.response.status_code`. Now, the attribute name follows the OTel specification.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**opentelemetry**: Fixed an issue where the `kong.upstream.status_code` field of access logs was incorrectly populated with string value instead of integer value when there was one or more retries to the upstream.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the postinstall script changed the ownership of `/etc/kong/kong.logrotate` to `kong:kong`, causing permission issues when executed by the root user. Ownership now resets to `root:root` after postinstall.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where PDK logs were not captured by observability when your gateway log level was higher than the log entry level.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the postinstall script changed kong.logrotate permissions; it now resets to 644.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed external plugin server to properly return 500 error responses when RPC calls fail, instead of silently ignoring the failures.",
-        "scope": "Core",
-        "type": "bugfix"
-      },
-      {
-        "message": "Fixed an issue where the Redis cloud authentication feature cannot fetch a correct credential for connecting to Azure Redis, especially when using Azure Workload Identity.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed AWS STS throttling during Redis IAM authentication via token caching.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**request-callout**: Fixed keepalive support in callout HTTP requests to improve connection reuse and performance.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-transformer**: Fixed an issue where the `add.headers` operation lowercased the header name, causing the configured letter case to be lost when adding new headers to the request.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-rate-limiting-advanced**: Extended deferred rate limiting callback to support model-partitioned policies and cost strategy.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the tracing PDK was missing in the Sandbox environment.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where functions in required sandbox modules could not be called in sandboxed Lua code due to the `__call` metamethod not being properly handled.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where, when the global tls_certificate_verify option is enabled,\nservice entities with an unset tls_verify field would fail validation. The\ntls_verify field now defaults to the proxy_ssl_verify nginx setting when not\nexplicitly set.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where GCP Vault authentication method order could not be set by the `GCP_AUTH_METHOD_ORDER` environment variable.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**solace-upstream, solace-log, solace-consume**: Fixed an issue where enabling `ssl_validate_certificate` would fail because `SESSION_SSL_TRUST_STORE_DIR` was not set.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**vault**: Fixed an issue where `kong.vault.update()` changed the secret to an empty string temporarily after changed vault config.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**websocket**: Fixed an issue where proxied WebSocket services did not fall back to Nginx’s `proxy_ssl_verify` when `tls_verify` was left unset.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the `network.peer.name` attribute in OpenTelemetry traces showed\nthe same hostname for all retry attempts instead of capturing the specific hostname\nfor each attempt.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where context sensitive plugins would not execute when dynamic ordering is enabled in the plugins iterator.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**AI Plugins**: Added support for custom GCP OAuth token and metadata endpoints via `gcp_oauth_token_url` and `gcp_metadata_url` configuration options in the `auth` section. This enables GCP authentication in restricted network environments or with custom GCP endpoints.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**core**: Reduced transient table churn and associated GC pressure by introducing preallocated table pools for hot-path table allocations.",
-        "type": "performance",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-proxy-advanced**: decoded OpenAI response only when necessary.\n",
-        "type": "performance",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: reduced tool cache build time and avoided long blocking.\n",
-        "type": "performance",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-rate-limiting-advanced**: Removed the `parse-request` shared filter and deprecated the `llm_format` configuration field.\n",
-        "type": "deprecation",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**llm**: Removed ineffective `ssl_cafile` parameter from HTTP requests. This parameter is not supported by lua-resty-http and was silently ignored. TLS verification relies on the global `lua_ssl_trusted_certificate` nginx directive.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      }
-    ],
-    "kong-manager-ee": []
-  },
-  "3.13.0.3": {
-    "kong": [
-      {
-        "message": "**opentelemetry**: Fixed an issue where invalid `x-b3-flags` header values caused 500 responses.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Optimized `GET /kong` endpoint to use `SELECT DISTINCT` for populating `enabled_in_cluster` instead of iterating all plugin rows.",
-        "type": "performance",
-        "scope": "Admin API"
-      }
-    ],
-    "kong-ee": [
-      {
-        "message": "**acl**: Fixed an issue where anonymous consumers with valid legacy ACL group credentials were rejected with 403 when `include_consumer_groups` was enabled and no enterprise consumer groups were assigned.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-aws-guardrails**: Allowed streaming of responses when `guarding_mode` was set to `INPUT` with `allow_masking` enabled.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-gcp-model-armor**: By default now blocks unrecognized/new filters added to GCP Model Armor.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where attributes for GenAI spans were incorrect according to https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where the latest 2025-11-25 spec defines the Authorization error codes which are different from ours.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where the ACL metric label value was incorrect.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where we have not reported metrics to konnect since 3.13.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where Azure OpenAI authentication failed during load balancer failover due to token refresh attempts in `balancer_by_lua`. Tokens are now pre-fetched in the `access` phase.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed `usage.cost` for OpenAI `llm/v1/files/{file_id}/content` batch output analytics.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where metrics were missing and v2 API was unavailable in Cohere native format.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where id/created fields were missing in multiple drivers.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where gzip streaming response in OpenAI format was broken.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where content-type header, from non-200 response of streaming request, was overridden.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-semantic-prompt-guard**: Fixed an issue where a vectorDB error occurred during initialization or config reload.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where DP may spawn multiple sync timers when downgrading sync protocol to v1, which may cause excessive load on CP and lead to performance degradation.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Added `lru_cache_size` to allow configuration of in-memory LRU cache size.",
-        "type": "bugfix",
-        "scope": "Configuration"
-      },
-      {
-        "message": "Fixed an issue where the Active Tracing would report incorrect `latencies.client` values due to not capturing the access end time properly. This fix ensures that the access end timestamp is always recorded regardless of Active Tracing being active or not.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped kong-gql from 0.2.3 to 0.2.4 to fix the null value issue in the GraphQL query syntax that causes a parsed AST error in degraphql plugin.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "**graphql-rate-limiting-advanced**: Fixed an issue where the graphql-rate-limiting-advanced plugin's API throws 500 when handling HTTP PUT request.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-consume, confluent-consume**: Increased the minimum API version of FetchRequest from 0 to 4 for Kafka 3.x. For Kafka 4.0 it is already using version 4.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-log**: Fixed an issue where cached producers could cause memory leaks.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where parameter validation errors caused a runtime crash when `collect_all_errors` was enabled.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where swagger `formData` parameters were not properly handled.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where `minLength` and `maxLength` constraints defined in a Swagger 2.0 parameter schema were not enforced.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where the validator cache did not account for the `collect_all_errors` setting.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Fixed DPoP verification for opaque tokens (RFC 9449 Section 6.2) where Kong failed to correctly parse nested `cnf.jkt` claims from introspection responses.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Fixed an issue where client-provided headers could be forwarded to upstream services when the corresponding JWT claim was missing from the token. The plugin now clears client headers before processing `upstream_headers_names`, ensuring that only verified JWT claim values are sent to upstream or downstream.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Fixed an issue where the `username` and `password` were used for Redis Sentinel and no authentication supported for Redis, causing `NOAUTH Authentication Required` errors.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the postinstall script changed the ownership of `/etc/kong/kong.logrotate` to `kong:kong`, causing permission issues when executed by the root user. Ownership now resets to `root:root` after postinstall.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the postinstall script changed kong.logrotate permissions; it now resets to 644.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where `$remote_addr` was not replaced with the proxy protocol source address for early nginx error responses (501, 505) when `proxy_protocol` is enabled on the proxy listener. Also added proper error body messages for 501 and 505 status codes.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed AWS STS throttling during Redis IAM authentication via token caching.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**service-protection**: Fixed an issue where the Service Protection plugin could count requests already rejected by Rate Limiting Advanced. Service Protection now executes after Rate Limiting Advanced and only evaluates requests that pass rate limiting, by updating its priority from 915 to 901.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**vault**: Fixed an issue where `kong.vault.update()` changed the secret to an empty string temporarily after changed vault config.",
-        "type": "bugfix",
-        "scope": "Core"
-      }
-    ],
-    "kong-manager-ee": [
-      {
-        "message": "Fixed workspace navigation for workspace names containing non-ASCII characters.",
-        "type": "bugfix",
-        "githubs": [
-          4243
-        ],
-        "scope": "Core"
-      }
-    ]
-  },
-  "3.10.0.10": {
-    "kong": [
-      {
-        "message": "Optimized `GET /kong` endpoint to use `SELECT DISTINCT` for populating `enabled_in_cluster` instead of iterating all plugin rows.",
-        "type": "performance",
-        "scope": "Admin API"
-      }
-    ],
-    "kong-ee": [
-      {
-        "message": "**kafka-log, kafka-upstream**: Added support for Kafka 4.0 to fix the Confluent deprecation.\n",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where DP may spawn multiple sync timers when downgrading sync protocol to v1, which may cause excessive load on CP and lead to performance degradation.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**core**: Resolved an issue where HTTPS was incorrectly detected if multiple `X-Forwarded-Proto` values were provided.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the Active Tracing would report incorrect `latencies.client` values due to not capturing the access end time properly. This fix ensures that the access end timestamp is always recorded regardless of Active Tracing being active or not.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped kong-gql from 0.2.3 to 0.2.4 to fix the null value issue in the GraphQL query syntax that causes a parsed AST error in degraphql plugin.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "**graphql-rate-limiting-advanced**: Fixed an issue where the graphql-rate-limiting-advanced plugin's API throws 500 when handling HTTP PUT request.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-consume, confluent-consume**: Increased the minimum API version of FetchRequest from 0 to 4 for Kafka 3.x. For Kafka 4.0 it is already using version 4.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-log**: Fixed an issue where certificates could not be loaded from non-default workspaces.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka**: Fix issue where Kafka plugin produced records with incorrect `offsetDelta` in the record package.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where `minLength` and `maxLength` constraints defined in a Swagger 2.0 parameter schema were not enforced.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Fixed DPoP verification for opaque tokens (RFC 9449 Section 6.2) where Kong failed to correctly parse nested `cnf.jkt` claims from introspection responses.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Fixed an issue where client-provided headers could be forwarded to upstream services when the corresponding JWT claim was missing from the token. The plugin now clears client headers before processing `upstream_headers_names`, ensuring that only verified JWT claim values are sent to upstream or downstream.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the postinstall script changed the ownership of `/etc/kong/kong.logrotate` to `kong:kong`, causing permission issues when executed by the root user. Ownership now resets to `root:root` after postinstall.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the postinstall script changed kong.logrotate permissions; it now resets to 644.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where `$remote_addr` was not replaced with the proxy protocol source address for early nginx error responses (501, 505) when `proxy_protocol` is enabled on the proxy listener. Also added proper error body messages for 501 and 505 status codes.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**service-protection**: Fixed an issue where the Service Protection plugin could count requests already rejected by Rate Limiting Advanced. Service Protection now executes after Rate Limiting Advanced and only evaluates requests that pass rate limiting, by updating its priority from 915 to 901.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**vault**: Fixed an issue where `kong.vault.update()` changed the secret to an empty string temporarily after changed vault config.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**kafka**: Fixed an issue where the kafka/confluent consume plugin cannot consume the correct message when the consuming offset of the topic was not 0.\n**kafka**: Fixed an issue of parsing ListOffset Response version 0.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**core**: Improved performance of Kong core by using ngx.var.http_* instead of kong.tools.http.get_header.",
-        "type": "performance",
-        "scope": "Core"
-      }
-    ],
-    "kong-manager-ee": [
-      {
-        "message": "Fixed workspace navigation for workspace names containing non-ASCII characters.",
-        "type": "bugfix",
-        "githubs": [
-          4242
-        ],
-        "scope": "Core"
-      }
-    ]
-  },
-  "3.4.3.25": {
-    "kong": [],
-    "kong-ee": [
-      {
-        "message": "**graphql-rate-limiting-advanced**: Fixed an issue where the graphql-rate-limiting-advanced plugin's API throws 500 when handling HTTP PUT request.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Fixed an issue where client-provided headers could be forwarded to upstream services when the corresponding JWT claim was missing from the token. The plugin now clears client headers before processing `upstream_headers_names`, ensuring that only verified JWT claim values are sent to upstream or downstream.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where `$remote_addr` was not replaced with the proxy protocol source address for early nginx error responses (501, 505) when `proxy_protocol` is enabled on the proxy listener. Also added proper error body messages for 501 and 505 status codes.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**vault**: Fixed an issue where `kong.vault.update()` changed the secret to an empty string temporarily after changed vault config.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**OpenID-Connect**: Removed issuer discovery from schema to improve performance upon plugin initialization or updating. The issuer discovery will only be triggerd by client requests.",
-        "type": "performance",
-        "scope": "Plugin"
-      }
-    ],
-    "kong-manager-ee": [
-      {
-        "message": "Fixed workspace navigation for workspace names containing non-ASCII characters.",
-        "type": "bugfix",
-        "githubs": [
-          4241
-        ],
-        "scope": "Core"
-      }
-    ]
-  },
-  "3.14.0.1": {
-    "kong": [],
-    "kong-ee": [
-      {
-        "message": "**openid-connect**: Fixed an issue where nested claim paths were not resolved correctly.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      }
-    ],
-    "kong-manager-ee": []
-  },
-  "3.12.0.5": {
-    "kong": [
-      {
-        "message": "Optimized `GET /kong` endpoint to use `SELECT DISTINCT` for populating `enabled_in_cluster` instead of iterating all plugin rows.",
-        "type": "performance",
-        "scope": "Admin API"
-      }
-    ],
-    "kong-ee": [
-      {
-        "message": "Added `lru_cache_size` to allow configuration of in-memory LRU cache size.",
-        "type": "feature",
-        "scope": "Configuration"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where we didn't keep the port after MCP conversion.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where id/created fields were missing in multiple drivers.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where DP may spawn multiple sync timers when downgrading sync protocol to v1, which may cause excessive load on CP and lead to performance degradation.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**core**: Resolved an issue where HTTPS was incorrectly detected if multiple `X-Forwarded-Proto` values were provided.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the Active Tracing would report incorrect `latencies.client` values due to not capturing the access end time properly. This fix ensures that the access end timestamp is always recorded regardless of Active Tracing being active or not.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped kong-gql from 0.2.3 to 0.2.4 to fix the null value issue in the GraphQL query syntax that causes a parsed AST error in degraphql plugin.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "**graphql-rate-limiting-advanced**: Fixed an issue where the graphql-rate-limiting-advanced plugin's API throws 500 when handling HTTP PUT request.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**JWT**: Fixed an issue where malformed JWT tokens (e.g. tokens without dots) caused a 500 Internal Server Error instead of returning 401 Unauthorized.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-log**: Fixed an issue where cached producers could cause memory leaks.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where nested references in oneOf / anyOf when they are used with a discriminator are not unfolded.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where swagger `formData` parameters were not properly handled.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where `minLength` and `maxLength` constraints defined in a Swagger 2.0 parameter schema were not enforced.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Fixed DPoP verification for opaque tokens (RFC 9449 Section 6.2) where Kong failed to correctly parse nested `cnf.jkt` claims from introspection responses.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Fixed an issue where client-provided headers could be forwarded to upstream services when the corresponding JWT claim was missing from the token. The plugin now clears client headers before processing `upstream_headers_names`, ensuring that only verified JWT claim values are sent to upstream or downstream.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the postinstall script changed the ownership of `/etc/kong/kong.logrotate` to `kong:kong`, causing permission issues when executed by the root user. Ownership now resets to `root:root` after postinstall.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where `$remote_addr` was not replaced with the proxy protocol source address for early nginx error responses (501, 505) when `proxy_protocol` is enabled on the proxy listener. Also added proper error body messages for 501 and 505 status codes.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**vault**: Fixed an issue where `kong.vault.update()` changed the secret to an empty string temporarily after changed vault config.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**AI Proxy**: Fixed an issue where using ai-proxy-advanced in conjunction with a logging plugin (such as file-log) resulting in missing information on the last entry of the balancer \"tries\" section.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where Incremental Sync (ICS) would crash and stops further sync attempts.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**core**: Improved performance of Kong core by using ngx.var.http_* instead of kong.tools.http.get_header.",
-        "type": "performance",
-        "scope": "Core"
-      }
-    ],
-    "kong-manager-ee": [
-      {
-        "message": "Fixed an issue where workspace navigation failed for workspace names containing non-ASCII characters.",
-        "type": "bugfix",
-        "githubs": [
-          4244
-        ],
-        "scope": "Core"
-      }
-    ]
-  },
-  "3.11.0.9": {
-    "kong": [
-      {
-        "message": "Optimized `GET /kong` endpoint to use `SELECT DISTINCT` for populating `enabled_in_cluster` instead of iterating all plugin rows.",
-        "type": "performance",
-        "scope": "Admin API"
-      }
-    ],
-    "kong-ee": [
-      {
-        "message": "Added `lru_cache_size` to allow configuration of in-memory LRU cache size.",
-        "type": "feature",
-        "scope": "Configuration"
-      },
-      {
-        "message": "Fixed an issue where DP may spawn multiple sync timers when downgrading sync protocol to v1, which may cause excessive load on CP and lead to performance degradation.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**core**: Resolved an issue where HTTPS was incorrectly detected if multiple `X-Forwarded-Proto` values were provided.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the Active Tracing would report incorrect `latencies.client` values due to not capturing the access end time properly. This fix ensures that the access end timestamp is always recorded regardless of Active Tracing being active or not.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped kong-gql from 0.2.3 to 0.2.4 to fix the null value issue in the GraphQL query syntax that causes a parsed AST error in degraphql plugin.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "**graphql-rate-limiting-advanced**: Fixed an issue where the graphql-rate-limiting-advanced plugin's API throws 500 when handling HTTP PUT request.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**JWT**: Fixed an issue where malformed JWT tokens (e.g. tokens without dots) caused a 500 Internal Server Error instead of returning 401 Unauthorized.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where swagger `formData` parameters were not properly handled.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where `minLength` and `maxLength` constraints defined in a Swagger 2.0 parameter schema were not enforced.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Fixed DPoP verification for opaque tokens (RFC 9449 Section 6.2) where Kong failed to correctly parse nested `cnf.jkt` claims from introspection responses.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Fixed an issue where client-provided headers could be forwarded to upstream services when the corresponding JWT claim was missing from the token. The plugin now clears client headers before processing `upstream_headers_names`, ensuring that only verified JWT claim values are sent to upstream or downstream.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the postinstall script changed the ownership of `/etc/kong/kong.logrotate` to `kong:kong`, causing permission issues when executed by the root user. Ownership now resets to `root:root` after postinstall.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where `$remote_addr` was not replaced with the proxy protocol source address for early nginx error responses (501, 505) when `proxy_protocol` is enabled on the proxy listener. Also added proper error body messages for 501 and 505 status codes.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**vault**: Fixed an issue where `kong.vault.update()` changed the secret to an empty string temporarily after changed vault config.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where Incremental Sync (ICS) would crash and stops further sync attempts.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**core**: Improved performance of Kong core by using ngx.var.http_* instead of kong.tools.http.get_header.",
-        "type": "performance",
-        "scope": "Core"
-      }
-    ],
-    "kong-manager-ee": [
-      {
-        "message": "Fixed an issue where workspace navigation failed for workspace names containing non-ASCII characters.",
-        "type": "bugfix",
-        "githubs": [
-          4245
-        ],
-        "scope": "Core"
-      }
-    ]
-  },
-  "3.11.0.10": {
-    "kong": [],
-    "kong-ee": [
-      {
-        "message": "Bumped lua-resty-healthcheck from 3.1.1 to 3.1.2",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed clustering sync reliability issues by immediately failing pending sync v2 RPC callbacks on disconnect with a `connection closed` error.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**Debugger**: Fixed an issue where Redis command arguments were incorrectly included in Redis spans.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**Debugger**: Fixed an issue where the Konnect Debugger concatenated `nil` and errored when accessing Kong Gateway via a Unix socket (e.g. `unix:/<prefix>/sockets/am:tls`).",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**Debugger**: Fixed an issue where the time spent during the TLS handshake was incorrectly added to Kong internal latency. This fix moved it to the client side latency.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the real client IP from Proxy Protocol was not correctly reflected in access logs and logging plugins when nginx rejected requests early (497 plain HTTP to HTTPS port) or when the client disconnected prematurely during header parsing. Added an nginx patch to resolve $remote_addr from $proxy_protocol_addr on early request termination, and added error_page 497 routing through kong_error_handler.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**service-protection**: Fixed an issue where the Service Protection plugin could count requests already rejected by Rate Limiting Advanced. Service Protection now executes after Rate Limiting Advanced and only evaluates requests that pass rate limiting, by updating its priority from 915 to 901.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**forward-proxy**: Added `ca_certificates` option for per-plugin TLS verification.\nIt allows certificate chain and hostname checks against specified CAs instead of\nglobal settings, ensuring explicit trust.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      }
-    ],
-    "kong-manager-ee": []
-  },
-  "3.14.0.2": {
-    "kong": [
-      {
-        "message": "**ai-mcp-oauth2**: Fixed an issue where `token_exchange.cache.enabled = false` was ignored and exchanged tokens were still cached because the cache toggle incorrectly read `token_exchange.cache.ttl` instead of `token_exchange.cache.enabled`.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      }
-    ],
-    "kong-ee": [
-      {
-        "message": "Bumped kong-pgmoon from 2.3.3.0 to 2.3.4.0, which adds SHA-384 support\nfor SCRAM channel binding during PostgreSQL SSL authentication.\n",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-resty-healthcheck from 3.1.1 to 3.1.2.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where Claude Code (or CLI) statistics were missing when using an Anthropic model via the Bedrock provider.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**acl**: Fixed an issue where anonymous consumers with valid legacy ACL group credentials were rejected with 403 when `include_consumer_groups` was enabled and no enterprise consumer groups were assigned.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-oauth2**: Fixed an issue where token exchange actor tokens were not sourced correctly from `token_exchange.request`, ensuring correct forwarding of actor tokens configured in headers or plugin config.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where WWW-Authenticate: Bearer error=\"insufficient_scope\" header was not emitted.\n",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where observability errors occurred when `gpt-image-1.5` returned image token usage details.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where Azure OpenAI authentication failed during load balancer failover due to token refresh attempts in `balancer_by_lua`. Tokens are now pre-fetched in the `access` phase.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where we treated plaintext Anthropic response as gzipped.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where we didn't correctly ungzip streaming response.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-transformers**: Fixed an issue where `ai-request-transformer` and `ai-response-tranformer`\nplugins did not work properly with the `ollama` provider.\n",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "Fixed clustering sync reliability issues by immediately failing pending sync v2 RPC callbacks on disconnect with a `connection closed` error.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Fixed an issue where DP may spawn multiple sync timers when downgrading sync protocol to v1, which may cause excessive load on CP and lead to performance degradation.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**Debugger**: Fixed an issue where Redis command arguments were incorrectly included in Redis spans.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**Debugger**: Fixed an issue where the Konnect Debugger concatenated `nil` and errored when accessing Kong Gateway via a Unix socket (e.g. `unix:/<prefix>/sockets/am:tls`).",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped kong-gql from 0.2.3 to 0.2.4 to fix the null value issue in the GraphQL query syntax that causes a parsed AST error in degraphql plugin.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "**graphql-rate-limiting-advanced**: Fixed an issue where the graphql-rate-limiting-advanced plugin's API throws 500 when handling HTTP PUT request.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**JWT**: Fixed an issue where malformed JWT tokens (e.g. tokens without dots) caused a 500 Internal Server Error instead of returning 401 Unauthorized.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**kafka-log**: Fixed an issue where cached producers could cause memory leaks.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Debugger**: Fixed an issue where the time spent during the TLS handshake was incorrectly added to Kong internal latency. This fix moved it to the client side latency.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**opa**: Fixed json body processing to recognize `application/json` content-type with charset, ensuring proper handling of JSON request bodies.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Fixed DPoP verification for opaque tokens (RFC 9449 Section 6.2) where Kong failed to correctly parse nested `cnf.jkt` claims from introspection responses.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the real client IP from Proxy Protocol was not correctly reflected in access logs and logging plugins when nginx rejected requests early (497 plain HTTP to HTTPS port) or when the client disconnected prematurely during header parsing. Added an nginx patch to resolve $remote_addr from $proxy_protocol_addr on early request termination, and added error_page 497 routing through kong_error_handler.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where `$remote_addr` was not replaced with the proxy protocol source address for early nginx error responses (501, 505) when `proxy_protocol` is enabled on the proxy listener. Also added proper error body messages for 501 and 505 status codes.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed a bug where tables in `strict` and `lax` `untrusted_lua` modes were not properly protected against modification.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**service-protection**: Fixed an issue where the Service Protection plugin could count requests already rejected by Rate Limiting Advanced. Service Protection now executes after Rate Limiting Advanced and only evaluates requests that pass rate limiting, by updating its priority from 915 to 901.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where Incremental Sync (ICS) would crash and stops further sync attempts.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      }
-    ],
-    "kong-manager-ee": [
-      {
-        "message": "Fixed an issue where the `tls_sans` field was missing in the service entity form.",
-        "type": "bugfix",
-        "githubs": [
-          4332
-        ],
-        "scope": "Core"
-      }
-    ]
-  },
-  "3.11.0.11": {
-    "kong": [
-      {
-        "message": "**aws-lambda**: Fixed an issue where a 500 error occurred when `is_proxy_integration` was enabled and the Lambda function returned `null` values in `headers` or `multiValueHeaders`. Null values are now converted to empty strings.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      }
-    ],
-    "kong-ee": [
-      {
-        "message": "**aws-lambda**: Fixed an issue where empty JSON array bodies (`[]`) were incorrectly converted to objects (`{}`) when using `is_proxy_integration=true` and `empty_arrays_mode=correct` alongside the exit-transformer plugin.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      }
-    ],
-    "kong-manager-ee": []
-  },
-  "3.12.0.6": {
-    "kong": [],
-    "kong-ee": [
-      {
-        "message": "Bumped lua-resty-healthcheck from 3.1.1 to 3.1.2.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed clustering sync reliability issues by immediately failing pending sync v2 RPC callbacks on disconnect with a `connection closed` error.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**Debugger**: Fixed an issue where Redis command arguments were incorrectly included in Redis spans.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**Debugger**: Fixed an issue where the Konnect Debugger concatenated `nil` and errored when accessing Kong Gateway via a Unix socket (e.g. `unix:/<prefix>/sockets/am:tls`).",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**Debugger**: Fixed an issue where the time spent during the TLS handshake was incorrectly added to Kong internal latency. This fix moved it to the client side latency.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the real client IP from Proxy Protocol was not correctly reflected in access logs and logging plugins when nginx rejected requests early (497 plain HTTP to HTTPS port) or when the client disconnected prematurely during header parsing. Added an nginx patch to resolve $remote_addr from $proxy_protocol_addr on early request termination, and added error_page 497 routing through kong_error_handler.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**service-protection**: Fixed an issue where the Service Protection plugin could count requests already rejected by Rate Limiting Advanced. Service Protection now executes after Rate Limiting Advanced and only evaluates requests that pass rate limiting, by updating its priority from 915 to 901.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      }
-    ],
-    "kong-manager-ee": []
-  },
-  "3.13.0.4": {
-    "kong": [],
-    "kong-ee": [
-      {
-        "message": "Bumped lua-resty-healthcheck from 3.1.1 to 3.1.2.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where ACL denial caused parsing body failure.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where we didn't keep the port after MCP conversion.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed excessive DNS warning logs for template variable endpoints like `$(headers.x_gcp_endpoint)`. These warnings appeared on every configuration change because template variables cannot be resolved until request time.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed clustering sync reliability issues by immediately failing pending sync v2 RPC callbacks on disconnect with a `connection closed` error.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**Debugger**: Fixed an issue where Redis command arguments were incorrectly included in Redis spans.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**Debugger**: Fixed an issue where the Konnect Debugger concatenated `nil` and errored when accessing Kong Gateway via a Unix socket (e.g. `unix:/<prefix>/sockets/am:tls`).",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**JWT**: Fixed an issue where malformed JWT tokens (e.g. tokens without dots) caused a 500 Internal Server Error instead of returning 401 Unauthorized.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**Debugger**: Fixed an issue where the time spent during the TLS handshake was incorrectly added to Kong internal latency. This fix moved it to the client side latency.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the real client IP from Proxy Protocol was not correctly reflected in access logs and logging plugins when nginx rejected requests early (497 plain HTTP to HTTPS port) or when the client disconnected prematurely during header parsing. Added an nginx patch to resolve $remote_addr from $proxy_protocol_addr on early request termination, and added error_page 497 routing through kong_error_handler.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**request-transformer**: Fixed an issue where the `add.headers` operation lowercased the header name, causing the configured letter case to be lost when adding new headers to the request.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where Incremental Sync (ICS) would crash and stops further sync attempts.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**ai-prompt-decorator**: Fixed an issue where the plugin corrupted native-format\nrequests (gemini, anthropic, bedrock, cohere, huggingface) by forwarding an\nOpenAI-shaped body upstream instead of the original native body shape.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      }
-    ],
-    "kong-manager-ee": []
-  },
-  "3.4.3.26": {
-    "kong": [],
-    "kong-ee": [
-      {
-        "message": "Bumped kong-lua-resty-ljsonschema from 1.2.0 to 1.3.3.\n",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-resty-healthcheck from 3.1.1 to 3.1.2.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed an issue where the real client IP from Proxy Protocol was not correctly reflected in access logs and logging plugins when nginx rejected requests early (497 plain HTTP to HTTPS port) or when the client disconnected prematurely during header parsing. Added an nginx patch to resolve $remote_addr from $proxy_protocol_addr on early request termination, and added error_page 497 routing through kong_error_handler.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**request-validator**: Added `array_length_compat` config option to allow legacy Draft 4 schemas to use `minLength`/`maxLength` keywords for array length validation.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      }
-    ],
-    "kong-manager-ee": [
-      {
-        "message": "Fixed workspace list and routing not working correctly when workspace count exceeds 1000.",
-        "type": "bugfix",
-        "githubs": [
-          4299
-        ],
-        "scope": "Core"
-      }
-    ]
-  },
-  "3.10.0.11": {
-    "kong": [],
-    "kong-ee": [
-      {
-        "message": "Bumped kong-lua-resty-ljsonschema from 1.2.0 to 1.3.3.\n",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped lua-resty-healthcheck from 3.1.1 to 3.1.2.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Added a safeguard to prevent the CP or DP from sending payloads larger than the configured `cluster_max_payload` size to each other, which could avoid the frequent disconnections and reconnection attempts and improve performance. Emitted a log entry telling the config payload size and the configured `cluster_max_payload` size when this happens.",
-        "type": "feature",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Fixed an issue where Kong Manager users authenticated through IDPs such as OIDC or LDAP could retain stale RBAC groups or IDP-sourced roles after claim changes, or end up with inconsistent mappings during concurrent authentication requests.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Fixed clustering sync reliability issues by immediately failing pending sync v2 RPC callbacks on disconnect with a `connection closed` error.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**Debugger**: Fixed an issue where Redis command arguments were incorrectly included in Redis spans.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**Debugger**: Fixed an issue where the Konnect Debugger concatenated `nil` and errored when accessing Kong Gateway via a Unix socket (e.g. `unix:/<prefix>/sockets/am:tls`).",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**Debugger**: Fixed an issue where the time spent during the TLS handshake was incorrectly added to Kong internal latency. This fix moved it to the client side latency.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**opa**: Fixed json body processing to recognize `application/json` content-type with charset, ensuring proper handling of JSON request bodies.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Fixed an issue where Redis-backed session storage could fail when Redis connections were routed through a proxy.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the real client IP from Proxy Protocol was not correctly reflected in access logs and logging plugins when nginx rejected requests early (497 plain HTTP to HTTPS port) or when the client disconnected prematurely during header parsing. Added an nginx patch to resolve $remote_addr from $proxy_protocol_addr on early request termination, and added error_page 497 routing through kong_error_handler.\n",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**key-auth**: Fixed an issue where region was not permitted to be null for remote identity realms.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-validator**: Added `array_length_compat` config option to allow legacy Draft 4 schemas to use `minLength`/`maxLength` keywords for array length validation.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where Incremental Sync (ICS) would crash and stops further sync attempts.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Added a `--lts_314_compatibility` option to the `check` command to perform configuration compatibility checks for upgrading to version 3.14.x.x.",
-        "type": "feature",
-        "scope": "CLI Command"
-      }
-    ],
-    "kong-manager-ee": []
-  },
-  "3.14.0.3": {
-    "kong": [
-      {
-        "message": "**ai-prompt-decorator**: Fixed an issue where the plugin corrupted native-format\nrequests (gemini, anthropic, bedrock, cohere, huggingface) by forwarding an\nOpenAI-shaped body upstream instead of the original native body shape.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      }
-    ],
-    "kong-ee": [
-      {
-        "message": "**ai-azure-content-safety**: Fixed a crash (HTTP 500) when `azure_use_managed_identity` is enabled.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where dashscope replied 500 to inference request.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where GenAI spans were not finished sometimes.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-oauth2**: Fixed an issue where downstream scope-based ACL evaluation used claims from the inbound token instead of the exchanged token when token exchange was enabled.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where raw non-200 upstream responses triggered misleading MCP body parse warnings.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where, since 3.14, call tools converted from API could fail when Kong used a self-signed certificate.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where tool id might be repeated.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where we didn't support Azure GA version of Realtime API.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where OpenAI-format chat reasoning requests were not mapped consistently across Anthropic, Gemini, Bedrock and more providers.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where system prompt of Claude Code was truncated when doing non-passthrough proxy.",
-        "scope": "Plugin",
-        "type": "bugfix"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where we didn't use the huggingface's token usage if available.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-advanced-proxy**: Fixed an issue where we never stored response model in streaming path. It always fallback to the request model",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where anonymous reports omitted model usage when one provider used multiple models.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-sanitizer**: Fixed an issue where the AI sanitizer plugin could not parse the request body correctly.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where the request context could inherit metatables from previous TLS connections, leading to cross-request context leakage and increased memory usage.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-guardrail**: Fixed an issue where latency metrics were missing in the Prometheus output.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      }
-    ],
-    "kong-manager-ee": []
-  },
-  "3.4.3.27": {
-    "kong": [],
-    "kong-ee": [
-      {
-        "message": "Bumped libexpat from 2.7.3 to 2.8.1 to address the issues: CVE-2026-25210, CVE-2026-24515, CVE-2026-32778, CVE-2026-32777, CVE-2026-32776, CVE-2026-41080, and CVE-2026-45186.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped OpenSSL from 3.5.5 to 3.5.6 to address the issues: CVE-2026-31790, CVE-2026-2673, CVE-2026-28387, CVE-2026-28388, CVE-2026-28389, CVE-2026-28390, and CVE-2026-31789.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Security: Fixed CVE-2026-6338 in core proxy request header handling by preserving inbound `Content-Length` headers during hop-by-hop Connection header cleanup, preventing CL.0 request smuggling with crafted `Connection: Content-Length` headers on requests with a body.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Applied upstream nginx security patches for CVE-2026-40701, CVE-2026-40460, CVE-2026-42934, CVE-2026-42946, CVE-2026-42945, and CVE-2026-9256.",
-        "type": "bugfix",
-        "scope": "Core"
-      }
-    ],
-    "kong-manager-ee": []
-  },
-  "3.10.0.12": {
-    "kong": [],
-    "kong-ee": [
-      {
-        "message": "Bumped libexpat from 2.7.3 to 2.8.1 to address the issues: CVE-2026-25210, CVE-2026-24515, CVE-2026-32778, CVE-2026-32777, CVE-2026-32776, CVE-2026-41080, and CVE-2026-45186.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped OpenSSL from 3.5.5 to 3.5.6 to address the issues: CVE-2026-31790, CVE-2026-2673, CVE-2026-28387, CVE-2026-28388, CVE-2026-28389, CVE-2026-28390, and CVE-2026-31789.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Security: Fixed CVE-2026-6338 in core proxy request header handling by preserving inbound `Content-Length` headers during hop-by-hop Connection header cleanup, preventing CL.0 request smuggling with crafted `Connection: Content-Length` headers on requests with a body.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Applied upstream nginx security patches for CVE-2026-40701, CVE-2026-40460, CVE-2026-42934, CVE-2026-42946, CVE-2026-42945, and CVE-2026-9256.",
-        "type": "bugfix",
-        "scope": "Core"
-      }
-    ],
-    "kong-manager-ee": []
-  },
-  "3.11.0.12": {
-    "kong": [],
-    "kong-ee": [
-      {
-        "message": "Bumped libexpat from 2.7.3 to 2.8.1 to address the issues: CVE-2026-25210, CVE-2026-24515, CVE-2026-32778, CVE-2026-32777, CVE-2026-32776, CVE-2026-41080, and CVE-2026-45186.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped OpenSSL from 3.5.5 to 3.5.6 to address the issues: CVE-2026-31790, CVE-2026-2673, CVE-2026-28387, CVE-2026-28388, CVE-2026-28389, CVE-2026-28390, and CVE-2026-31789.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Security: Fixed CVE-2026-6338 in core proxy request header handling by preserving inbound `Content-Length` headers during hop-by-hop Connection header cleanup, preventing CL.0 request smuggling with crafted `Connection: Content-Length` headers on requests with a body.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Applied upstream nginx security patches for CVE-2026-40701, CVE-2026-40460, CVE-2026-42934, CVE-2026-42946, CVE-2026-42945, and CVE-2026-9256.",
-        "type": "bugfix",
-        "scope": "Core"
-      }
-    ],
-    "kong-manager-ee": []
-  },
-  "3.12.0.7": {
-    "kong": [],
-    "kong-ee": [
-      {
-        "message": "Bumped libexpat from 2.7.3 to 2.8.1 to address the issues: CVE-2026-25210, CVE-2026-24515, CVE-2026-32778, CVE-2026-32777, CVE-2026-32776, CVE-2026-41080, and CVE-2026-45186.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped OpenSSL from 3.5.5 to 3.5.6 to address the issues: CVE-2026-31790, CVE-2026-2673, CVE-2026-28387, CVE-2026-28388, CVE-2026-28389, CVE-2026-28390, and CVE-2026-31789.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Security: Fixed CVE-2026-6338 in core proxy request header handling by preserving inbound `Content-Length` headers during hop-by-hop Connection header cleanup, preventing CL.0 request smuggling with crafted `Connection: Content-Length` headers on requests with a body.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Applied upstream nginx security patches for CVE-2026-40701, CVE-2026-40460, CVE-2026-42934, CVE-2026-42946, CVE-2026-42945, and CVE-2026-9256.",
-        "type": "bugfix",
-        "scope": "Core"
-      }
-    ],
-    "kong-manager-ee": []
-  },
-  "3.13.0.5": {
-    "kong": [],
-    "kong-ee": [
-      {
-        "message": "Bumped libexpat from 2.7.3 to 2.8.1 to address the issues: CVE-2026-25210, CVE-2026-24515, CVE-2026-32778, CVE-2026-32777, CVE-2026-32776, CVE-2026-41080, and CVE-2026-45186.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped OpenSSL from 3.5.5 to 3.5.6 to address the issues: CVE-2026-31790, CVE-2026-2673, CVE-2026-28387, CVE-2026-28388, CVE-2026-28389, CVE-2026-28390, and CVE-2026-31789.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Security: Fixed CVE-2026-6338 in core proxy request header handling by preserving inbound `Content-Length` headers during hop-by-hop Connection header cleanup, preventing CL.0 request smuggling with crafted `Connection: Content-Length` headers on requests with a body.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Applied upstream nginx security patches for CVE-2026-40701, CVE-2026-40460, CVE-2026-42934, CVE-2026-42946, CVE-2026-42945, and CVE-2026-9256.",
-        "type": "bugfix",
-        "scope": "Core"
-      }
-    ],
-    "kong-manager-ee": []
-  },
-  "3.14.0.4": {
-    "kong": [],
-    "kong-ee": [
-      {
-        "message": "Bumped libexpat from 2.7.3 to 2.8.1 to address the issues: CVE-2026-25210, CVE-2026-24515, CVE-2026-32778, CVE-2026-32777, CVE-2026-32776, CVE-2026-41080, and CVE-2026-45186.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Bumped OpenSSL from 3.5.5 to 3.5.6 to address the issues: CVE-2026-31790, CVE-2026-2673, CVE-2026-28387, CVE-2026-28388, CVE-2026-28389, CVE-2026-28390, and CVE-2026-31789.",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Security: Fixed CVE-2026-6338 in core proxy request header handling by preserving inbound `Content-Length` headers during hop-by-hop Connection header cleanup, preventing CL.0 request smuggling with crafted `Connection: Content-Length` headers on requests with a body.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "Applied upstream nginx security patches for CVE-2026-40701, CVE-2026-40460, CVE-2026-42934, CVE-2026-42946, CVE-2026-42945, and CVE-2026-9256.",
-        "type": "bugfix",
-        "scope": "Core"
-      }
-    ],
-    "kong-manager-ee": []
-  },
-  "3.14.0.5": {
-    "kong": [
-      {
-        "message": "**aws-lambda**: Fixed an issue where a 500 error occurred when `is_proxy_integration` was enabled and the Lambda function returned `null` values in `headers` or `multiValueHeaders`. Null values are now converted to empty strings.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      }
-    ],
-    "kong-ee": [
-      {
-        "message": "Bumped kong-lua-resty-ljsonschema from 1.3.1 to 1.3.3.\n",
-        "type": "dependency",
-        "scope": "Core"
-      },
-      {
-        "message": "Added a safeguard to prevent the CP or DP from sending payloads larger than the configured `cluster_max_payload` size to each other, which could avoid the frequent disconnections and reconnection attempts and improve performance. Emitted a log entry telling the config payload size and the configured `cluster_max_payload` size when this happens.",
-        "type": "feature",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Fixed an issue where Kong Manager users authenticated through IDPs such as OIDC or LDAP could retain stale RBAC groups or IDP-sourced roles after claim changes, or end up with inconsistent mappings during concurrent authentication requests.",
-        "type": "bugfix",
-        "scope": "Core"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where `stream_options` was forwarded to Databricks upstreams, causing a 400 error since Databricks does not support this field.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai**: Fixed an issue where non-200 responses from Bedrock embeddings API were not properly handled, leading to incorrect feedback to the client.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed stale tools cache after full-sync reconfigure (e.g. `deck sync`), causing `tools/list` to return empty results.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-mcp-proxy**: Fixed an issue where converted HTTPS MCP tool calls lost the original forwarded port on the internal TLS Unix socket.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where full-sync reconfigure reset balancer state even when plugin configs were unchanged.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where driver transformers returned errors or stream metadata in the wrong return position.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where OpenAI-compatible Anthropic chat requests only preserved the last system message.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where configured model name may never be used for Azure provider.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-proxy-advanced**: Fixed an issue where we didn't collect the model name in OpenAI streaming response from Azure.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-request-transformer**: Fixed an issue where runtime template placeholders (e.g. `$(uri_captures.*)`) in `config.llm.model.*` fields were not interpolated.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-response-transformer**: Fixed an issue where runtime template placeholders (e.g. `$(uri_captures.*)`) in `config.llm.model.*` fields were not interpolated.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**ai-semantic-prompt-guard**, **ai-semantic-response-guard**: Fixed an issue where full-sync reconfigure rebuilt semantic vectorDB indexes even when the plugin configuration was unchanged.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**aws-lambda**: Fixed an issue where empty JSON array bodies (`[]`) were incorrectly converted to objects (`{}`) when using `is_proxy_integration=true` and `empty_arrays_mode=correct` alongside the exit-transformer plugin.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where a config backup exported by a data plane could not be re-imported if it contained non-workspaceable entities such as `ca_certificates` or `oic_issuers`. The export incorrectly included a `ws_id` field for those entities, which the declarative config schema rejects as an unknown field.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**ai-guardrails**: Fixed an issue where multiple guardrail plugins can not function together.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where incremental DP (sync v2) would not export config to fallback storage when the control plane uses periodic polling instead of notify_new_version.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "**jwt-signer**: Fixed an issue where the plugin failed to load configuration and errored when `null` or `nil` values were passed to `access_token_keyset` or `channel_token_keyset`.",
-        "type": "bugfix",
-        "Scope": "Plugin",
-        "scope": "Core"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where path parameters were extracted from the wrong URI segment when `custom_base_path` was used with bare `/{param}` paths.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**oas-validation**: Fixed an issue where the OAS specification cache failed to distinguish between different values of `api_spec_encoded` for the same specification content.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**openid-connect**: Fixed an issue where Redis-backed session storage could fail when Redis connections were routed through a proxy.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**opentelemetry**: Fixed an issue where template 'resource_attributes' in configuration of the plugin could not work as expected for metrics.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**request-validator**: Added `array_length_compat` config option to allow legacy Draft 4 schemas to use `minLength`/`maxLength` keywords for array length validation.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "**forward-proxy**: Added `ca_certificates` option for per-plugin TLS verification.\nIt allows certificate chain and hostname checks against specified CAs instead of\nglobal settings, ensuring explicit trust.\n",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Improved performance of analytics data collection by introducing a shared payload pool and reducing the default local buffer size.\n",
-        "type": "performance",
-        "scope": "Core"
-      }
-    ],
-    "kong-manager-ee": []
-  },
-  "3.10.0.13": {
-    "kong": [
-      {
-        "message": "Fixed an issue where DP syncing failed with large configs. Added yielding to prevent CPU stall, and set Konnect mode RPC timeout to 30 seconds for successful full-sync.\n",
-        "type": "bugfix",
-        "scope": "Clustering"
-      }
-    ],
-    "kong-ee": [
-      {
-        "message": "Fixed an issue where incremental DP (sync v2) would not export config to fallback storage when the control plane uses periodic polling instead of notify_new_version.",
-        "type": "bugfix",
-        "scope": "Clustering"
-      },
-      {
-        "message": "Fixed Kafka broker returning failed connections to the keepalive pool, added SSL handshake retry, and improved error propagation.",
-        "type": "bugfix",
-        "scope": "Plugin"
-      },
-      {
-        "message": "Fixed an issue where `kong.service.set_tls_cert_key` did not update the upstream keepalive pool name. Now includes a cert fingerprint for proper connection isolation.",
-        "type": "bugfix",
-        "scope": "Core"
-      }
-    ],
-    "kong-manager-ee": []
-  },
   "3.14.0.6": {
     "kong-ee": [
       {
@@ -22784,6 +16234,6309 @@
         "message": "Applied upstream nginx security patches for limiting the maximum number of headers (CVE-2026-49975).",
         "type": "bugfix",
         "scope": "Core"
+      }
+    ]
+  },
+  "3.14.0.5": {
+    "kong-ee": [
+      {
+        "message": "Bumped kong-lua-resty-ljsonschema from 1.3.1 to 1.3.3.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Added a safeguard to prevent the CP or DP from sending payloads larger than the configured `cluster_max_payload` size to each other, which could avoid the frequent disconnections and reconnection attempts and improve performance. Emitted a log entry telling the config payload size and the configured `cluster_max_payload` size when this happens.",
+        "type": "feature",
+        "scope": "Clustering"
+      },
+      {
+        "message": "**ai**: Fixed an issue where non-200 responses from Bedrock embeddings API were not properly handled, leading to incorrect feedback to the client.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-guardrails**: Fixed an issue where multiple guardrail plugins couldn't function together.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where converted HTTPS MCP tool calls lost the original forwarded port on the internal TLS Unix socket.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed stale tools cache after full-sync reconfiguration (e.g. after a `deck sync`), causing `tools/list` to return empty results.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where full-sync reconfiguration would reset the balancer state even when plugin configs were unchanged.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where driver transformers returned errors or stream metadata in the wrong return position.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where OpenAI-compatible Anthropic chat requests only preserved the last system message.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where the configured model name wasn't used for the Azure provider.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where we didn't collect the model name in OpenAI streaming responses from Azure.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where the `stream_options` field was forwarded to Databricks upstreams, causing a 400 error since Databricks does not support this field.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-request-transformer**: Fixed an issue where runtime template placeholders (e.g. `$(uri_captures.*)`) in `config.llm.model.*` fields were not interpolated.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-response-transformer**: Fixed an issue where runtime template placeholders (e.g. `$(uri_captures.*)`) in `config.llm.model.*` fields were not interpolated.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-semantic-prompt-guard**, **ai-semantic-response-guard**: Fixed an issue where full-sync reconfiguration rebuilt semantic vectorDB indices even when the plugin configuration was unchanged.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**aws-lambda**: Fixed an issue where empty JSON array bodies (`[]`) were incorrectly converted to objects (`{}`) when using `is_proxy_integration=true` and `empty_arrays_mode=correct` alongside the exit-transformer plugin.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**aws-lambda**: Fixed an issue where a 500 error occurred when `is_proxy_integration` was enabled and the Lambda function returned `null` values in `headers` or `multiValueHeaders`. Null values are now converted to empty strings.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Fixed an issue where a config backup exported by a data plane could not be re-imported if it contained non-workspaceable entities such as `ca_certificates` or `oic_issuers`. The export incorrectly included a `ws_id` field for those entities, which the declarative config schema rejects as an unknown field.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where incremental DP (sync v2) would not export config to fallback storage when the control plane used periodic polling instead of `notify_new_version`.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where Kong Manager users authenticated through IDPs such as OIDC or LDAP could retain stale RBAC groups or IDP-sourced roles after claim changes, or end up with inconsistent mappings during concurrent authentication requests.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**forward-proxy**: Added the `ca_certificates` parameter for per-plugin TLS verification.\nThis setting allows certificate chain and hostname checks against specified CAs instead of\nglobal settings, ensuring explicit trust.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**jwt-signer**: Fixed an issue where the plugin failed to load configuration and errored when `null` or `nil` values were passed to `access_token_keyset` or `channel_token_keyset`.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where the OAS specification cache failed to distinguish between different values of `api_spec_encoded` for the same specification content.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where path parameters were extracted from the wrong URI segment when `custom_base_path` was used with bare `/{param}` paths.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Fixed an issue where Redis-backed session storage could fail when Redis connections were routed through a proxy.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opentelemetry**: Fixed an issue where the template `resource_attributes` in the plugin configuration didn't work as expected for metrics.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-validator**: Added `array_length_compat` config option to allow legacy Draft 4 schemas to use `minLength`/`maxLength` keywords for array length validation.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Improved performance of analytics data collection by introducing a shared payload pool and reducing the default local buffer size.",
+        "type": "performance",
+        "scope": "Core"
+      }
+    ]
+  },
+  "3.14.0.4": {
+    "kong-ee": [
+      {
+        "message": "Bumped libexpat from 2.7.3 to 2.8.1 to address the issues: CVE-2026-25210, CVE-2026-24515, CVE-2026-32778, CVE-2026-32777, CVE-2026-32776, CVE-2026-41080, and CVE-2026-45186.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped OpenSSL from 3.5.5 to 3.5.6 to address the issues: CVE-2026-31790, CVE-2026-2673, CVE-2026-28387, CVE-2026-28388, CVE-2026-28389, CVE-2026-28390, and CVE-2026-31789.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Applied upstream nginx security patches for CVE-2026-40701, CVE-2026-40460, CVE-2026-42934, CVE-2026-42946, CVE-2026-42945, and CVE-2026-9256.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Security: Fixed CVE-2026-6338 in core proxy request header handling by preserving inbound `Content-Length` headers during hop-by-hop Connection header cleanup, preventing CL.0 request smuggling with crafted `Connection: Content-Length` headers on requests with a body.",
+        "type": "bugfix",
+        "scope": "Core"
+      }
+    ]
+  },
+  "3.14.0.3": {
+    "kong-ee": [
+      {
+        "message": "**ai-azure-content-safety**: Fixed a crash (HTTP 500) that occurred when `azure_use_managed_identity` was enabled.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-guardrail**: Fixed an issue where latency metrics were missing in the Prometheus output.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-oauth2**: Fixed an issue where downstream scope-based ACL evaluation used claims from the inbound token instead of the exchanged token when token exchange was enabled.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where, since 3.14, call tools converted from API could fail when Kong used a self-signed certificate.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where the tool ID might be repeated.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where raw non-200 upstream responses triggered misleading MCP body parse warnings.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-prompt-decorator**: Fixed an issue where the plugin corrupted native-format\nrequests (Gemini, Anthropic, Bedrock, Cohere, Hugging Face) by forwarding an\nOpenAI-shaped body upstream instead of the original native body shape.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where GenAI spans were not finished sometimes.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where we didn't support Azure GA version of Realtime API.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where OpenAI-format chat reasoning requests were not mapped consistently across Anthropic, Gemini, Bedrock and more providers.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where system prompt of Claude Code was truncated when doing non-passthrough proxy.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where we didn't use Hugging Face's token usage when it was available.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where we never stored the response model in the streaming path, causing it to always fall back to the request model.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where DashScope replied to inference requests with a 500.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-sanitizer**: Fixed an issue where the AI sanitizer plugin could not parse the request body correctly.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Fixed an issue where anonymous reports omitted model usage when one provider used multiple models.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the request context could inherit metatables from previous TLS connections, leading to cross-request context leakage and increased memory usage.",
+        "type": "bugfix",
+        "scope": "Core"
+      }
+    ]
+  },
+  "3.14.0.2": {
+    "kong-ee": [
+      {
+        "message": "Bumped kong-gql from 0.2.3 to 0.2.4 to fix the null value issue in the GraphQL query syntax that caused a parsed AST error in DeGraphQL plugin.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped kong-pgmoon from 2.3.3.0 to 2.3.4.0, which adds SHA-384 support\nfor SCRAM channel binding during PostgreSQL SSL authentication.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-resty-healthcheck from 3.1.1 to 3.1.2.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "**acl**: Fixed an issue where anonymous consumers with valid legacy ACL group credentials were rejected with 403 when `include_consumer_groups` was enabled and no enterprise consumer groups were assigned.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-oauth2**: Fixed an issue where token exchange actor tokens were not sourced correctly from `token_exchange.request`, ensuring correct forwarding of actor tokens configured in headers or plugin config.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-oauth2**: Fixed an issue where `token_exchange.cache.enabled = false` was ignored and exchanged tokens were still cached because the cache toggle incorrectly read `token_exchange.cache.ttl` instead of `token_exchange.cache.enabled`.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where the `WWW-Authenticate: Bearer error=\"insufficient_scope\"` header was not emitted.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where observability errors occurred when `gpt-image-1.5` returned image token usage details.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where Azure OpenAI authentication failed during load balancer failover due to token refresh attempts in `balancer_by_lua`. Tokens are now pre-fetched in the `access` phase.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where we treated plaintext Anthropic response as gzipped.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where we didn't correctly ungzip the streaming response.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where Claude Code (or CLI) statistics were missing when using an Anthropic model via the Bedrock provider.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-transformers**: Fixed an issue where AI Request Transformer and AI Response Transformer\nplugins did not work properly with the Ollama provider.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Debugger**: Fixed an issue where Redis command arguments were incorrectly included in Redis spans.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**Debugger**: Fixed an issue where the time spent during the TLS handshake was incorrectly added to Kong internal latency. This fix moved it to the client side latency.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**Debugger**: Fixed an issue where the Konnect Debugger concatenated `nil` and errored when accessing Kong Gateway via a Unix socket (e.g. `unix:/<prefix>/sockets/am:tls`).",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed a bug where tables in `strict` and `lax` `untrusted_lua` modes were not properly protected against modification.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where Incremental Sync (ICS) would crash and stop further sync attempts.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where `$remote_addr` was not replaced with the proxy protocol source address for early nginx error responses (501, 505) when `proxy_protocol` is enabled on the proxy listener. Also added proper error body messages for 501 and 505 status codes.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the DP could spawn multiple sync timers when downgrading sync protocol to v1, which could cause excessive load on the CP and lead to performance degradation.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where the real client IP from Proxy Protocol was not correctly reflected in access logs and logging plugins when nginx rejected requests early (497 plain HTTP to HTTPS port) or when the client disconnected prematurely during header parsing. Added an nginx patch to resolve `$remote_addr` from `$proxy_protocol_addr` on early request termination, and added `error_page` 497 routing through `kong_error_handler`.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed clustering sync reliability issues by immediately failing pending sync v2 RPC callbacks on disconnect with a `connection closed` error.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "**graphql-rate-limiting-advanced**: Fixed an issue where the GraphQL Rate Limiting Advanced plugin's API threw 500 errors when handling HTTP PUT requests.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**JWT**: Fixed an issue where malformed JWT tokens (e.g. tokens without dots) caused a 500 Internal Server Error instead of returning 401 Unauthorized.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-log**: Fixed an issue where cached producers could cause memory leaks.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opa**: Fixed json body processing to recognize `application/json` content-type with charset, ensuring proper handling of JSON request bodies.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Fixed DPoP verification for opaque tokens (RFC 9449 Section 6.2) where Kong failed to correctly parse nested `cnf.jkt` claims from introspection responses.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Service Protection**: Fixed an issue where the Service Protection plugin could count requests already rejected by Rate Limiting Advanced. Service Protection now executes after Rate Limiting Advanced and only evaluates requests that pass rate limiting, by updating its priority from 915 to 901.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      }
+    ],
+    "kong-manager-ee": [
+      {
+        "message": "Fixed an issue where the `tls_sans` field was missing in the service entity form.",
+        "type": "bugfix",
+        "scope": "Default"
+      }
+    ]
+  },
+  "3.14.0.1": {
+    "kong-ee": [
+      {
+        "message": "**openid-connect**: Fixed an issue where nested claim paths were not resolved correctly.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      }
+    ]
+  },
+  "3.14.0.0": {
+    "kong-ee": [
+      {
+        "message": "**Configuration**: The `tls_certificate_verify` option is now enabled by\ndefault, preventing Kong from bypassing certificate verification on any\nsecure connection.",
+        "type": "Breaking Change",
+        "scope": "Core"
+      },
+      {
+        "message": "**event hooks**: Sign event hook calls with HMAC-SHA256 instead of HMAC-SHA1.",
+        "type": "Breaking Change",
+        "scope": "Core"
+      },
+      {
+        "message": "**jwt-signer**: calls to the `/rotate` endpoint now enable certificate\nverification by default when connecting to the configured endpoint to rotate\nthe keys.",
+        "type": "Breaking Change",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**key-auth, key-auth-enc, basic-auth, hmac-auth, ldap-auth, oauth2, oauth2-introspection, vault-auth, ldap-auth-advanced**: Changed the default value of `hide_credentials` from `false` to `true` to enhance security. Users should verify their configurations if relying on the previous default.",
+        "type": "Breaking Change",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oauth2**: the option `ssl_verify`, to verify the certificate presented by\nthe IdP when using HTTPS, is now on by default.",
+        "type": "Breaking Change",
+        "scope": "Core"
+      },
+      {
+        "message": "**Redis Partials**: changed the default value for the `ssl_verify` from `off`\nto `on`.",
+        "type": "Breaking Change",
+        "scope": "Core"
+      },
+      {
+        "message": "**Routes**: Change default protocols from `http, https` to `https` for routes entities.",
+        "type": "Breaking Change",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-resty-gcp from 0.0.16 to 0.0.19 to address GCP access token handling improvements.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped OpenSSL from 3.4.3 to 3.5.5 to address the issue: CVE-2025-15467.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "**ai-rate-limiting-advanced**: Removed the `parse-request` shared filter and deprecated the `llm_format` configuration field.",
+        "type": "deprecation",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ACL**: Added WebSocket protocol support (`ws`/`wss`). The plugin now enforces allow/deny group rules during the WebSocket handshake phase.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**acme**: Added support for the `tls_certificate_verify` global option. When this option is enabled, the plugin's `storage_config.redis.tls_verify` setting cannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**active-tracing**: Added auto-decompression for gzipped bodies when capturing payload",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added a new configuration option `schema_alias_conflict_mode` that controls the behavior when a deprecated alias field and its canonical replacement field are both present with mismatched values. The default value `error` preserves the existing strict validation behavior. Setting it to `warn` accepts the configuration with a warning log and always uses the canonical field value, allowing upgrades to proceed without requiring all legacy plugin configurations to be corrected first.",
+        "type": "feature",
+        "scope": "Configuration"
+      },
+      {
+        "message": "Added `kong.client.get_jwt_token_payload()` to retrieve a decoded JWT token payload.",
+        "type": "feature",
+        "scope": "PDK"
+      },
+      {
+        "message": "Added `kong.client.get_jwt_token_header()` to retrieve a decoded JWT token header.",
+        "type": "feature",
+        "scope": "PDK"
+      },
+      {
+        "message": "Added `kong.client.get_token()` function to retrieve a shared authenticated token.",
+        "type": "feature",
+        "scope": "PDK"
+      },
+      {
+        "message": "Added `kong.client.set_token()` function to share authenticated token with other plugins.",
+        "type": "feature",
+        "scope": "PDK"
+      },
+      {
+        "message": "Added `lru_cache_size` to allow configuration of in-memory LRU cache size.",
+        "type": "feature",
+        "scope": "Configuration"
+      },
+      {
+        "message": "Added request and response content evolution support to the debugger session. This allows the debugger to capture and compare request and response contents across different phases of the request lifecycle, providing insights into how the contents change as they flow through Kong Gateway.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added support for PostgreSQL OAuth/OAUTHBEARER SASL authentication.\nKong can now authenticate with PostgreSQL using OAuth 2.0 bearer tokens\nobtained via client credentials grant from an identity provider.\nThis requires PostgreSQL 18+ with OAUTHBEARER support and the updated\npgmoon library with OAUTHBEARER SASL implementation.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added support for sampling rate in sessions of active tracing",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**ai-a2a-proxy**: Added A2A analytics support for Konnect, enabling visibility into A2A protocol operations including method calls, latencies, and task states.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-a2a-proxy**: Added new plugin for Google A2A (Agent-to-Agent) protocol support,\nenabled AI agent interoperability with JSON-RPC and REST bindings, built-in observability.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-a2a-proxy**: Added Prometheus and OpenTelemetry observability with A2A-specific\nmetrics and tracing spans.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-aws-guardrails**: the `ssl_verify` option to validate TLS certificate\nwhen connecting to the bedrock service is now enabled by default.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-azure-content-safety**: the `ssl_verify` option to verify the certificate\npresented by the Azure Content Safety service when using HTTPS is now enabled\nby default.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-custom-guardrail**: Added a new custom guardrail plugin which enables integration with 3rd party guardrail service.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-oauth2**: Added support for passing tokens upstream.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-oauth2**: Added support for multiple token validation methods.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-oauth2**: Added support for mapping claim to authenticated credential.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-oauth2**: Added Token Exchange support to swap JWT tokens before accessing MCP Server.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-oauth2**: Added `upstream_headers` field for mapping token claims to upstream headers using path-based access. Mutually exclusive with `claim_to_header`.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-oauth2**: Made the client_id field not required when client_auth is set\n  to something other than client_secret_basic or client_secret_post",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-oauth2**: Added support mapping claims in token to `consumer` and `consumer_groups`.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Added support for session sharing and active notice when doing MCP conversion.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Added support for ACL with OAuth claim.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Added support for custom GCP OAuth token and metadata endpoints via `gcp_oauth_token_url` and `gcp_metadata_url` configuration options in the `auth` section. This enables GCP authentication in restricted network environments or with custom GCP endpoints.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Added native Anthropic streaming mode support, enabling direct passthrough of Anthropic SSE events with proper message reordering for tool calls.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Added ACL support that blocks requests matching deny rules, requires allow rules to pass when present, and resolves consumer/model values once per request.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Added native passthrough support for Vertex AI multimodal embeddings. Introduced new `llm/v1/multimodal-embeddings` route type.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Added support for DeepSeek provider.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Added support for proxying cohere embeddings models on bedrock.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Added support for vLLM provider.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Added support for databricks provider.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Added the ability to select target models by request models in same AI Proxy Advanced plugin.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Added the Ollama provider, for native support for all Ollama-hosted models.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Updated to use /v2/chat when proxying text generation request to cohere provider.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Added support for batch API in openai-compatible mode when providers are anthropic, bedrock, gemini and gemini vertex.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-rate-limiting-advanced**: Added a policy-based rate limiting mode with\nmulti-dimensional match conditions and request counting strategy.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-rate-limiting-advanced**: Added prompt token estimation for `prompt_tokens`, `total_tokens`, and `cost` strategies in policies mode, enabling early request rejection before the upstream responds.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AWS-Lambda**: Added `ssl_verify` config field to control SSL certificate verification when connecting to AWS APIs.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**azure-functions**: the `https_verify` option to validate the Azure Functions\nserver certificate is now enabled by default.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**basic-auth**: Uses SHA256 by default even in non-FIPS mode instead of SHA1.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Conditional Plugin Execution**: Added support for conditional plugin execution through a new `condition` field in the plugin configuration. Plugins can now be conditionally skipped at runtime based on request attributes such as HTTP method, path, headers, query parameters, consumer, route, service, and network information. The condition expression uses the ATC expression language and is evaluated once during the collecting phase; skipped plugins are excluded from all downstream phases automatically.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**confluent-consume**: the `security.ssl_verify` option to validate the server\ncertificate is now enabled by default.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**confluent**: the `security.ssl_verify` option is now enabled by default.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**core**: Add `lua_gc_tuning` option to control garbage collection parameters on Control Plane.",
+        "type": "feature",
+        "scope": "Configuration"
+      },
+      {
+        "message": "**core**: Added support for decoding JSON null values in objects as Lua `nil` via `cjson.decode_null_object_value_as_nil` (and exposed as `kong.tools.cjson.decode_null_object_value_as_nil`).",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**datakit**: Added JWT nodes: `jwt_decode` for decoding tokens without verification, `jwt_verify` for signature verification and claim validation using JWKS, and `jwt_sign` for creating and signing JWTs.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**datakit**: Added more implicit node outputs:\n    * `request.path`\n    * `request.raw_path`\n    * `request.port`\n    * `request.method`\n    * `request.scheme`\n    * `request.version`\n    * `service_response.status`\n    * service_response.raw_body\n    * call.raw_body",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**datakit**: Consumer can now be set via property node.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**datakit**: the call node's `ssl_verify` option to verify the TLS certificate\nwhen making HTTPS requests is now enabled by default.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**debugger**: Add CPU profiling support for debugger to Kong.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**debugger**: Added sanitization support for payload using configurable redaction rules.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**debugger**: Added status code and status message to plugin span attributes when using kong.response to exit.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**DP Resilience**: Added support for Azure Blob Storage in config sync backup strategy.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**event-hooks**: The options `ssl_verify` for the webhook type handler are now enabled by default.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**forward-proxy**: the `https_verify` option to validate the `https_proxy_host`\nserver certificate is now enabled by default.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Hashicorp Vault**: Added AWS auth method authentication to the HashiCorp Vault backend.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**Hashicorp Vault**: Added Azure authentication to the HashiCorp Vault backend.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**Hashicorp Vault**: Added GCP auth method authentication to the HashiCorp Vault backend.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**Hashicorp Vault**: Added `ssl_verify` config field to control SSL certificate verification when connecting to Hashicorp Vault servers.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**header-cert-auth**: the `ssl_verify` option to switch verification of the\ncertificate presented by the server of the OCSP responder's URL and by the\nserver of the CRL Distribution Point is now enabled by default.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**hmac-auth**: Add support for HMAC-SHA224, and removes HMAC-SHA1 from the default set of algorithms\n               (still supports HMAC-SHA1 when configured).",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**http-log**: the `ssl_verify` option to validate the `http_endpoint` server\ncertificate is now enabled by default.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**json-threat-protection**: Added support for `allow_non_json_requests` configuration to allow non-JSON requests to bypass all checks.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**jwt-signer**: The options `access_token_endpoints_ssl_verify` and\n`channel_token_endpoints_ssl_verify`, which control SSL certificate\nverification for signature verification and introspection endpoints, are now\nenabled by default.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-consume**: Added support for posting commit offsets.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-log**: The options `security.ssl_verify` which control SSL certificate\nverification for Kafka endpoints, are now enabled by default.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-upstream**: The option `security.ssl_verify`, which controls the verification\nof the certificate presented by the server, is now enabled by default.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Kong will validate the database connection configuration at startup and will not start if errors are detected.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**ldap-auth-advanced**: the `verify_ldap_host` option to validate the LDAP\nserver certificate is now enabled by default.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ldap-auth**: the `verify_ldap_host` option to validate the LDAP server\ncertificate is now enabled by default.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**llm**: Added bytes-based tokenizer.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**llm**: Added `conf.model.metadata` configuration to specify model options separately from the main configuration. Metadata options are merged into the model options during request normalization",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**metering-and-billing**: Added a new plugin for metering and billing.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**metrics**: Added metrics to show the time consumption excluding upstream, third-party I/O, and client in the HTTP context for Prometheus, Analytics, and logs.",
+        "type": "feature",
+        "scope": "Performance"
+      },
+      {
+        "message": "**mtls-auth**: Added WebSocket protocol support. This authentication plugin can now protect WebSocket connections (`ws` and `wss` protocols) in addition to HTTP/HTTPS. In hybrid mode, using `ws`/`wss` with this plugin requires data planes running DP >= 3.14, or explicit removal of `ws`/`wss` protocols from configurations targeting older data planes.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**mtls-auth**: the `ssl_verify` option to validate verification of the\ncertificate presented by the server of the OCSP responder's URL and by the\nserver of the CRL Distribution Point is now enabled by default.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oauth2-introspection**: The authenticated token is now stored in the request context via `kong.client.set_token`.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oauth2**: The authenticated token is now stored in the request context via `kong.client.set_token`.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oauth2**: Uses SHA256 for access token cache key instead of SHA1.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Added `consumer_claims` to support mapping consumers from multiple claim paths, while retaining and supporting the existing `consumer_claim` as a shorthand configuration.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Added `jwks_endpoint` configuration to override the discovered `jwks_uri` when a custom JWKS endpoint is required.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Added support for token exchange from multiple IdPs based on RFC8693.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Added `upstream_headers` and `downstream_headers` schema fields that support nested claims.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Added WebSocket protocol support. This authentication plugin can now protect WebSocket connections (`ws` and `wss` protocols) in addition to HTTP/HTTPS. In hybrid mode, WebSocket protocol support for this plugin requires data planes running Kong Gateway 3.14 or later; for older data planes, ensure routes do not use `ws`/`wss` protocols, as their propagation will be blocked.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Marked fields `issuer`, `extra_jwks_uris`, and `introspection_endpoint` are now supported as vault references.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Marked `issuers_allowed` as a referenceable field.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: The authenticated token is now stored in the request context via `kong.client.set_token`.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: the `ssl_verify`(for verifying identity provider server certificate) and the `session_memcached_ssl_verify`(for verifying session storing memcached server certificate) option\nare now enabled by default as well.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opentelemetry**: Add Konnect Cluster ID and the optional Cluster Member ID attributes to OpenTelemetry metrics in Konnect mode.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opentelemetry**: Added support for AI/MCP metrics",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opentelemetry**: Added support for AI/MCP access log",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opentelemetry**: Added support for customizing access logs via Lua code snippets. The previous `access_logs_endpoint` schema field has been deprecated in favor of a new `access_logs.endpoint` field, which can be used alongside the `access_logs.custom_attributes_by_lua` field to specify Lua code snippets for custom attributes.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opentelemetry**: Added support for official MCP metrics",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opentelemetry**: Added the Konnect Cluster ID and the optional Cluster Member ID to access logs.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opentelemetry**: Support WebSocket related metrics to OpenTelemetry plugin for enhanced observability.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: The option `callouts.http_opts.ssl_verify`, which controls the verification\nof the certificate presented by the server, is now enabled by default.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**sandbox**: Added `strict` and `lax` modes for `untrusted_lua`. The default mode changed from `sandbox` to `strict`.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**solace-upstream**: Added `content_type` / `content_encoding` (with request-header fallback) and `forward_body_raw_only` for raw payload passthrough; headers can be forwarded into Solace user properties.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**solace-upstream, solace-log, solace-consume**: Added support for the global `tls_certificate_verify` option. When enabled, plugins using secure protocols (tcps://, wss://, https://) must have `ssl_validate_certificate` set to `true`.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**tcp-log**: the `ssl_verify` option is now enabled by default.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Upgraded lua-resty-aws library to the 1.7.2 version.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**vectordb**: Added Valkey support for vector database operations, providing an alternative to Redis Stack for vector search capabilities.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**vectordb**: The option `ssl_verify`, which control SSL certificate\nverification for the pgvector database, is now enabled by default.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**acl**: Fixed an issue where the ACL plugin did not check consumer groups from all sources, causing it to incorrectly deny access when consumer groups were set by other plugins like ACE in `ngx.ctx.authenticated_consumer_groups`.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-aws-guardrails**: Allowed streaming of responses when `guarding_mode` was set to `INPUT` with `allow_masking` enabled.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-gcp-model-armor**: By default now blocks unrecognized/new filters added to GCP Model Armor.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-oauth2**: Fixed an issue where we didn't clear header for absent claim.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where ACL denial caused parsing body failure.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where the ACL metric label value was incorrect.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where `tools/list` could expose tools to consumers denied by tool ACL in listener mode.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where we didn't keep the port after MCP conversion.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where we have not reported metrics to konnect since 3.13.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where PATCHing the tool caused an error.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where the latest 2025-11-25 spec defines the Authorization error codes which are different from ours.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where metrics were missing and v2 API was unavailable in Cohere native format.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where id/created fields were missing in multiple drivers.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where gzip streaming response in OpenAI format was broken.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where content-type header, from non-200 response of streaming request, was overridden.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where GCP tokens would not be proactively refreshed before expiration.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where attributes for GenAI spans were incorrect according to https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed excessive DNS warning logs for template variable endpoints like `$(headers.x_gcp_endpoint)`. These warnings appeared on every configuration change because template variables cannot be resolved until request time.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed structured output and tool calls for Ollama (also Llama2 and Mistral) providers.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed `usage.cost` for OpenAI `llm/v1/files/{file_id}/content` batch output analytics.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed zero usage statistics for OpenAI `llm/v1/responses` in streaming mode.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Updated mappings for Ollama (also Llama2 and Mistral) providers.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed a crash in the observability module when upstream returned `choices: null` (JSON null). The `header_filter` phase would crash with \"attempt to get length of field 'choices' (a userdata value)\" because `ngx.null` is truthy in Lua.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where format-compatible streaming routes did not collect metrics and logging.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed streaming token count metrics for third-party models hosted on Vertex AI (claude-*, mistral-*, jamba-*) that reported inflated totals because incremental counts were treated as cumulative.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-rate-limiting-advanced**: Extended deferred rate limiting callback to support model-partitioned policies and cost strategy.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-rate-limiting-advanced**: Fixed an issue where the plugin did not validate whether the configured `dictionary_name` exists before use, which could lead to runtime errors.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-sanitizer**: fixed an issue where the sanitizer plugin always sanitize the entire request body, which was fixed with latest message only.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-semantic-prompt-guard**: Fixed an issue where a vectorDB error occurred during initialization or config reload.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Apply Nginx patch for a man-in-the-middle upstream response injection (CVE-2026-1642)",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**aws-lambda**: Fixed an issue where headers from Lambda proxy responses were not merged correctly, causing case-insensitive header deduplication to fail. User-supplied headers now properly overwrite existing headers regardless of casing.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**aws-lambda**: Fixed an issue where Lambda responses with empty or null body caused 500 errors when `is_proxy_integration` is enabled.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**basic-auth**: Brute Force Protection: when using redis strategy and the connection fails,\nthe plugin will now fall back to using the memory strategy.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**confluent, confluent-consume**: Fix issue where Kafka plugin failed to encode and validate message keys when using Confluent Schema Registry.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**core**: Resolved an issue where HTTPS was incorrectly detected if multiple `X-Forwarded-Proto` values were provided.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**datakit**: Fixed an issue where datakit cache node instantiate proxy-cache-advanced redis module at config time causing dependency issue on Koko.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**datakit**: Fixed type system bug to allow defining maps with string values for vault node.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**datakit**: Fixed xml_to_json node to recognize `text/xml` content-type in addition to `application/xml` for XML request body processing, ensuring RFC 7303 compliance.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**degraphql**: Fixed an issue where the plugin failed to parse GraphQL variables with nested array types like `[String]!`. The error `attempt to index field 'name' (a nil value)` occurred because the type parser did not correctly handle deeply nested type structures such as `nonNullType(listType(namedType))`.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Fixed an issue where a SQL injection vulnerability existed in the clustering RPC procedure, ensuring safer SQL operations.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where context sensitive plugins would not execute when dynamic ordering is enabled in the plugins iterator.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where disabling `tls_certificate_verify` via `kong reload` did not take effect because the derived `proxy_ssl_verify` directive persisted in `.kong_env` from a previous reload.",
+        "type": "bugfix",
+        "scope": "Configuration"
+      },
+      {
+        "message": "Fixed an issue where DP's proxy listener could not be verified because of it was disabled in CP.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where functions in required sandbox modules could not be called in sandboxed Lua code due to the `__call` metamethod not being properly handled.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where GCP Vault authentication method order could not be set by the `GCP_AUTH_METHOD_ORDER` environment variable.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where in the postinstall script that changed /etc/kong/kong.logrotate's ownership and permissions; the script now restores ownership to root:root and sets permissions to 0644.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where `kong health` command would fail to run when kong configuration contains vault references.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where PDK logs were not captured by observability when your gateway log level was higher than the log entry level.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the Active Tracing would report incorrect `latencies.client` values due to not capturing the access end time properly. This fix ensures that the access end timestamp is always recorded regardless of Active Tracing being active or not.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the balancer's health checker is not properly clean up when config changed in CP/DP mode.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where the `network.peer.name` attribute in OpenTelemetry traces showed\nthe same hostname for all retry attempts instead of capturing the specific hostname\nfor each attempt.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the Redis cloud authentication feature cannot fetch a correct credential for connecting to Azure Redis, especially when using Azure Workload Identity.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the request and response contents (headers and body) of external HTTP or Redis calls were not being recorded in the Content Evolution Capture.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the tracing PDK was missing in the Sandbox environment.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where using Google Cloud Storage cannot use the Application Default Credentials method order when the environment variable GCP_AUTH_METHOD_ORDER is set to \"adc\".",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where, when the global tls_certificate_verify option is enabled,\nservice entities with an unset tls_verify field would fail validation. The\ntls_verify field now defaults to the proxy_ssl_verify nginx setting when not\nexplicitly set.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed AWS STS throttling during Redis IAM authentication via token caching.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed external plugin server to properly return 500 error responses when RPC calls fail, instead of silently ignoring the failures.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**graphql-rate-limiting-advanced**: Fixed an issue where the plugin could fail\nto connect to the upstream server to introspect the upstream schema.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Injection Protection**: Fixed an issue where the plugin was too sensitive to certain injection patterns.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-consume, confluent-consume**: Increased the minimum API version of FetchRequest from 0 to 4 for Kafka 3.x. For Kafka 4.0 it is already using version 4.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka**: Fix issue where Kafka plugin produced records with incorrect `offsetDelta` in the record package.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka**: Fixed issue where Kafka message key deserialization failed silently, returning raw string data instead of deserialized objects.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kong.service.request.clear_query_arg**: Fixed an issue where an extra `=` was appended to empty query arguments.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ldap-auth-advanced**: Fixed a security issue.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ldap-auth**: Fixed a security issue.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**llm**: Fixed an issue where we could not specify the correct dimensions for Gemini embeddings model provider.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**llm**: Removed ineffective `ssl_cafile` parameter from HTTP requests. This parameter is not supported by lua-resty-http and was silently ignored. TLS verification relies on the global `lua_ssl_trusted_certificate` nginx directive.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**mtls-auth**: Fixed an issue where client certificates with Subject Alternative Name (SAN) DirectoryName extensions caused authentication errors. Added a new `san_dirname_matcher` configuration option to specify which Distinguished Name attributes from the SAN DirectoryName extension should be used for consumer lookup.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where parameter validation errors caused a runtime crash when `collect_all_errors` was enabled.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where swagger `formData` parameters were not properly handled.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where `minLength` and `maxLength` constraints defined in a Swagger 2.0 parameter schema were not enforced.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where the validator cache did not account for the `collect_all_errors` setting.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where response body buffering was not properly disabled when `validate_response_body` was set to `false`.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opa**: Fixed json body processing to recognize `application/json` content-type with charset, ensuring proper handling of JSON request bodies.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Fixed an issue where the `username` and `password` were used for Redis Sentinel and no authentication supported for Redis, causing `NOAUTH Authentication Required` errors.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Fixed an issue where client-provided headers could be forwarded to upstream services when the corresponding JWT claim was missing from the token. The plugin now clears client headers before processing `upstream_headers_names`, ensuring that only verified JWT claim values are sent to upstream or downstream.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opentelemetry**: Fixed an issue where invalid `x-b3-flags` header values caused 500 responses.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opentelemetry**: Fixed an issue where the `kong.upstream.status_code` field of access logs was incorrectly populated with string value instead of integer value when there was one or more retries to the upstream.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opentelemetry**: Fixed an issue where the `http.response.status_code` attribute of the `http.server.request.count` metric was incorrectly set to `kong.response.status_code`. Now, the attribute name follows the OTel specification.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opentelemetry**: Fixed an issue where valid response codes from vendor endpoints were incorrectly rejected when exporting `traces`, `logs` or `metrics`.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: Fixed keepalive support in callout HTTP requests to improve connection reuse and performance.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-transformer**: Fixed an issue where the `add.headers` operation lowercased the header name, causing the configured letter case to be lost when adding new headers to the request.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**solace-upstream, solace-log, solace-consume**: Fixed an issue where enabling `ssl_validate_certificate` would fail because `SESSION_SSL_TRUST_STORE_DIR` was not set.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**vault**: Fixed an issue where `kong.vault.update()` changed the secret to an empty string temporarily after changed vault config.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**websocket**: Fixed an issue where proxied WebSocket services did not fall back to Nginx’s `proxy_ssl_verify` when `tls_verify` was left unset.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**ai-mcp-proxy**: reduced tool cache build time and avoided long blocking.",
+        "type": "performance",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: decoded OpenAI response only when necessary.",
+        "type": "performance",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**core**: Reduced transient table churn and associated GC pressure by introducing preallocated table pools for hot-path table allocations.",
+        "type": "performance",
+        "scope": "Core"
+      },
+      {
+        "message": "Optimized `GET /kong` endpoint to use `SELECT DISTINCT` for populating `enabled_in_cluster` instead of iterating all plugin rows.",
+        "type": "performance",
+        "scope": "Admin API"
+      }
+    ]
+  },
+  "3.13.0.5": {
+    "kong-ee": [
+      {
+        "message": "Bumped libexpat from 2.7.3 to 2.8.1 to address the issues: CVE-2026-25210, CVE-2026-24515, CVE-2026-32778, CVE-2026-32777, CVE-2026-32776, CVE-2026-41080, and CVE-2026-45186.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped OpenSSL from 3.5.5 to 3.5.6 to address the issues: CVE-2026-31790, CVE-2026-2673, CVE-2026-28387, CVE-2026-28388, CVE-2026-28389, CVE-2026-28390, and CVE-2026-31789.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Applied upstream nginx security patches for CVE-2026-40701, CVE-2026-40460, CVE-2026-42934, CVE-2026-42946, CVE-2026-42945, and CVE-2026-9256.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Security: Fixed CVE-2026-6338 in core proxy request header handling by preserving inbound `Content-Length` headers during hop-by-hop Connection header cleanup, preventing CL.0 request smuggling with crafted `Connection: Content-Length` headers on requests with a body.",
+        "type": "bugfix",
+        "scope": "Core"
+      }
+    ]
+  },
+  "3.13.0.4": {
+    "kong-ee": [
+      {
+        "message": "Bumped lua-resty-healthcheck from 3.1.1 to 3.1.2.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where we didn't keep the port after MCP conversion.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where ACL denial caused a body parsing failure.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-prompt-decorator**: Fixed an issue where the plugin corrupted native-format requests (gemini, anthropic, bedrock, cohere, huggingface) by forwarding an OpenAI-shaped body upstream instead of the original native body shape.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed excessive DNS warning logs for template variable endpoints like `$(headers.x_gcp_endpoint)`. These warnings appeared on every configuration change because template variables cannot be resolved until request time.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Debugger**: Fixed an issue where Redis command arguments were incorrectly included in Redis spans.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**Debugger**: Fixed an issue where the time spent during the TLS handshake was incorrectly added to Kong internal latency. This fix moved it to the client side latency.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**Debugger**: Fixed an issue where the Konnect Debugger concatenated `nil` and errored when accessing Kong Gateway via a Unix socket (e.g. `unix:/<prefix>/sockets/am:tls`).",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where Incremental Sync (ICS) would crash and stop further sync attempts.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where the real client IP from Proxy Protocol was not correctly reflected in access logs and logging plugins when nginx rejected requests early (497 plain HTTP to HTTPS port) or when the client disconnected prematurely during header parsing. Added an nginx patch to resolve `$remote_addr` from `$proxy_protocol_addr` on early request termination, and added `error_page` 497 routing through `kong_error_handler`.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed clustering sync reliability issues by immediately failing pending sync v2 RPC callbacks on disconnect with a `connection closed` error.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "**JWT**: Fixed an issue where malformed JWT tokens (e.g. tokens without dots) caused a 500 Internal Server Error instead of returning 401 Unauthorized.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-transformer**: Fixed an issue where the `add.headers` operation lowercased the header name, causing the configured letter case to be lost when adding new headers to the request.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      }
+    ]
+  },
+  "3.13.0.3": {
+    "kong-ee": [
+      {
+        "message": "Bumped kong-gql from 0.2.3 to 0.2.4 to fix the null value issue in the GraphQL query syntax that caused a parsed AST error in the degraphql plugin.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "**acl**: Fixed an issue where anonymous consumers with valid legacy ACL group credentials were rejected with 403 when `include_consumer_groups` was enabled and no enterprise consumer groups were assigned.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Added `lru_cache_size` to allow configuration of in-memory LRU cache size.",
+        "type": "bugfix",
+        "scope": "Configuration"
+      },
+      {
+        "message": "**ai-aws-guardrails**: This plugin now allows streaming of responses when `guarding_mode` is set to `INPUT` with `allow_masking` enabled.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-gcp-model-armor**: By default, this plugin now blocks unrecognized/new filters added to GCP Model Armor.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where the ACL metric label value was incorrect.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where metrics were not reported to Konnect since 3.13.0.0.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where the latest 2025-11-25 spec defined the Authorization error codes, which are different from the error codes that Kong uses.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where Azure OpenAI authentication failed during load balancer failover due to token refresh attempts in `balancer_by_lua`. Tokens are now pre-fetched in the `access` phase.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where metrics were missing and v2 API was unavailable in Cohere native format.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where id/created fields were missing in multiple drivers.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where gzip streaming response in OpenAI format was broken.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where the content-type header from non-200 responses to streaming requests was overridden.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where attributes for GenAI spans were incorrect according to https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-spans.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed `usage.cost` for OpenAI `llm/v1/files/{file_id}/content` batch output analytics.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-semantic-prompt-guard**: Fixed an issue where a vectorDB error occurred during initialization or config reload.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Fixed an issue where in the postinstall script that changed /etc/kong/kong.logrotate's ownership and permissions; the script now restores ownership to root:root and sets permissions to 0644.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where `$remote_addr` was not replaced with the proxy protocol source address for early nginx error responses (501, 505) when `proxy_protocol` was enabled on the proxy listener. Also added proper error body messages for 501 and 505 status codes.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the Active Tracing would report incorrect `latencies.client` values due to not capturing the access end time properly. This fix ensures that the access end timestamp is always recorded regardless of Active Tracing being active or not.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the DP could spawn multiple sync timers when downgrading sync protocol to v1, which could cause excessive load on the CP and lead to performance degradation.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed AWS STS throttling during Redis IAM authentication via token caching.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**graphql-rate-limiting-advanced**: Fixed an issue where the graphql-rate-limiting-advanced plugin's API threw 500 errors when handling HTTP PUT requests.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-consume, confluent-consume**: Increased the minimum API version of FetchRequest from 0 to 4 for Kafka 3.x. No changes made for Kafka 4.0, as it is already using version 4.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-log**: Fixed an issue where cached producers could cause memory leaks.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where swagger `formData` parameters were not properly handled.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where `minLength` and `maxLength` constraints defined in a Swagger 2.0 parameter schema were not enforced.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where the validator cache did not account for the `collect_all_errors` setting.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where parameter validation errors caused a runtime crash when `collect_all_errors` was enabled.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Fixed an issue where the `username` and `password` were used for Redis Sentinel and no authentication was supported for Redis, causing `NOAUTH Authentication Required` errors.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Fixed an issue where client-provided headers could be forwarded to upstream services when the corresponding JWT claim was missing from the token. The plugin now clears client headers before processing `upstream_headers_names`, ensuring that only verified JWT claim values are sent to upstream or downstream.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Fixed DPoP verification for opaque tokens (RFC 9449 Section 6.2) where Kong failed to correctly parse nested `cnf.jkt` claims from introspection responses.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opentelemetry**: Fixed an issue where invalid `x-b3-flags` header values caused 500 responses.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**service-protection**: Fixed an issue where the Service Protection plugin could count requests already rejected by Rate Limiting Advanced. Service Protection now executes after Rate Limiting Advanced and only evaluates requests that pass rate limiting, by updating its priority from 915 to 901.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**vault**: Fixed an issue where `kong.vault.update()` changed the secret to an empty string temporarily after changing a vault config.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Optimized `GET /kong` endpoint to use `SELECT DISTINCT` for populating `enabled_in_cluster` instead of iterating all plugin rows.",
+        "type": "performance",
+        "scope": "Admin API"
+      }
+    ],
+    "kong-manager-ee": [
+      {
+        "message": "Fixed workspace navigation for workspace names containing non-ASCII characters.",
+        "type": "bugfix",
+        "scope": "Default"
+      }
+    ]
+  },
+  "3.13.0.0": {
+    "kong": [
+      {
+        "message": "Bumped lua-resty-healthcheck to version 3.1.1 to remove incorrect deprecation notice on active healthchecks headers.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "**active-tracing**: Added exponential backoff retry support for the websocket connections of debug sessions.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**AI Plugins**: Added AI Lakera Guard plugin, to integrate with the safety API provided by https://www.lakera.ai/lakera-guard.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Added support for `stream_options` to request server response usage statistics when using SSE streaming response mode.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Added support for the Gemini Files operations, through the `llm_format: gemini` native-SDK option.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Added xAI provider support to the LLM plugin, enabling integration with xAI's Grok chat and image generation models.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Adds support for AWS Bedrock Bearer Token authentication in Kong AI plugins, allowing secure access to Bedrock models using temporary or long-lived tokens.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Clustering**: Add a mechanism to suppress connection retry logs within 100 seconds from last error.",
+        "type": "feature",
+        "scope": "Clustering"
+      },
+      {
+        "message": "**Datadog**: Added a configuration option to tag the metrics with the Kong route name, or the route ID if the name is empty.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**sandbox**: Improved protection for whitelisted modules.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**ai-gcp-model-armor**: Fixed an issue where SDP (Sensitive Data Protection) filter violations were not detected. The plugin now correctly handles both RAI-style results (matchState + confidenceLevel) and SDP-style results (matchState + findings array with infoType and likelihood).",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Fixed an issue where the Gemini provider would not correctly return Model Armor 'Floor' blocking responses to the caller.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Fixed an issue where Gemini (Vertex) models didn't return JSON formatted responses when instructed.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Fixed an issue where Gemini with native format was not correctly reporting total tokens.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Fixed an issue where it was not possible to use \"Search Tools\" and \"extra_body\" when calling Gemini models in OpenAI format.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Fixed an issue where OpenAI, OpenAI-compatible, and HuggingFace models may have a 0 `completion_tokens` count with SSE streaming responses.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Fixed an issue where Bedrock requests with missing model names in the request path would not be properly validated. Now returns a clear error when model name is required in the path but not provided.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Fixed an issue where Bedrock 'Nova' models would not correctly run tool calls when combined with thinking text.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Added dimension configuration support for Amazon Titan Embed v2 models.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Fixed an issue where the restart command read configuration multiple times and failed to stop nginx.",
+        "type": "bugfix",
+        "scope": "Configuration"
+      },
+      {
+        "message": "**ip-restriction**: Fixed an issue where blocking an IP over TCP would log error: \"function cannot be called in preread phase\" (#14749)",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ldap-auth**: Fixed an issue where a failed ssl handshake with the ldap server would return 401 instead of 500.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      }
+    ],
+    "kong-ee": [
+      {
+        "message": "Fixed an issue where certain record/map fields with an empty-object default value\nwere incorrectly JSON-encoded as arrays.",
+        "type": "Breaking Change",
+        "scope": "Admin API"
+      },
+      {
+        "message": "Bumped ca-certificates (debug tool) from 2025-07-15 to 2025-11-04.",
+        "type": "dependency",
+        "scope": "CLI Command"
+      },
+      {
+        "message": "Bumped curl (debug tool) from 8.15.0 to 8.17.0.",
+        "type": "dependency",
+        "scope": "CLI Command"
+      },
+      {
+        "message": "Bumped jq from 1.7.1 to 1.8.1.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped kong-redis-cluster from 1.5.6 to 1.5.7.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped libexpat from 2.7.1 to 2.7.3.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped libxml2 from 2.12.10 to 2.15.0.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-resty-acme from 0.15.0 to 0.16.0.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-resty-aws from 1.6.0 to 1.7.1.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-resty-gcp from 0.0.14 to 0.0.16.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-resty-openssl from 1.5.1 to 1.7.0.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-resty-session from 4.1.4 to 4.1.5. Added cloud Redis authentication support.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped nghttp2 (debug tool) from 1.66.0 to 1.68.0.",
+        "type": "dependency",
+        "scope": "CLI Command"
+      },
+      {
+        "message": "Bumped OpenSSL to 3.4.3 in Core dependencies.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped PCRE2 from 10.46 to 10.47.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Replaced resty-cli with rusty-cli",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Switched lua-resty-ljsonschema dependency to Kong's maintained fork lua-resty-ljsonschema. Bumped version to kong-lua-resty-ljsonschema 1.3.1.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "**ace**: ace_credentials can now be linked to Consumers or Consumer Groups",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ACE**: Added `operation_id` in analytics and set it to the header `X-ACE-Operation-ID`.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ace**: Enabled at-rest keyring encryption for sensitive fields in ACE plugin.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**acme**: added support for the `tls_certificate_verify` global option. When this option is enabled, the plugin's `storage_config.vault.tls_verify` setting cannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**acme**: Enabled at-rest keyring encryption for sensitive fields in ACME plugin.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**active-tracing**: Added instrumentation for log phase operations and created a new trace for the log phase spans.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added a configuration option `authenticated_groups_delimiter` (available values: `,`, `;`, `|`) to `admin_gui_auth_conf` for OIDC. This option specifies the delimiter used to split group values retrieved from JWT claims.\nWhen multiple group values are concatenated in a single claim using a specific delimiter, this configuration allows multiple groups to be extracted from that single claim value",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added a new PDK method - kong.service.request.set_authentication_headers()",
+        "type": "feature",
+        "scope": "PDK"
+      },
+      {
+        "message": "Added `ai_mcp_reqs` to reporting metrics to count AI MCP request usage.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added `ai_model_usage:{\"provider/model\": num}` to the anonymous report to count AI usage per model.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added OAuth2 authentication to the Hashicorp Vault backend.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added support for GCP authentication methods to connect to GCP CloudSQL Postgres databases.  Configurations include `pg_gcp_auth` and `pg_gcp_service_account_key`.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added support for the `tls_certificate_verify` global option in\n`kong.tools.redis` and `kong.enterprise_edition.tools.redis.v2` modules.\nWhen this option is enabled and Redis is configured to connect to a secure\nendpoint, the module's `ssl_verify` flag cannot be disabled.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added TLS certificate verification enforcement. When\ntls_certificate_verify option is \"on\", certificate verification can't\nbe disabled by Service or Plugin entities.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**AI**: Added instrumentation for GenAI spans.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-aws-guardrails**: Added block reason info metrics to AWS Guardrails plugin analytics.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-aws-guardrails**: added the flag `ssl_verify` to control\ncertificate verification when connecting to the bedrock service.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-aws-guardrails**: Enabled at-rest keyring encryption for sensitive fields in AI AWS Guardrails plugin.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI AWS Guardrails Plugin**: Introduced a new mask mode feature in the AWS Guardrails plugin that allows sensitive data to be masked instead of blocked for requests, responses or both.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-azure-content-safety**: Added support for the global `tls_certificate_verify` option.\nWhen enabled globally via `kong.conf`, the plugin's `ssl_verify` config field cannot be set to `false`.\nThis ensures SSL/TLS certificate verification cannot be disabled when global security policy requires it.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-azure-content-safety**: Enabled at-rest keyring encryption for sensitive fields in AI Azure Content Safety plugin.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-gcp-model-armor**: Added block reason and processing latency metrics to GCP Model Armor plugin analytics.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Added support for cookie in OpenAPI spec when doing MCP conversion.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Added support for structured output from MCP conversion.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Added support for MCP ACL control.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ais**: Add new partials(vectordb, embeddings and model) in ai plugins configs",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Added support for video generation with `video/v1/videos/generations` route type for multiple LLM providers.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Added support for Cerebras - a new AI Provider.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Added support for HuggingFace's new serverless API in the AI Proxy plugin, enabling seamless integration and improved compatibility.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Added support for native format video generation in Bedrock and Gemini LLM drivers, allowing direct passthrough of provider-specific video generation requests without format conversion.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy Advanced**: Added load balance, failover and circuit breaker feature for semantic routing.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Added missing `least-connections` load balancing algorithm to the AI Proxy Advanced plugin which was missed in the previous release.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Added support for Gemini live websocket in the ai-proxy-advanced plugin.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Supported health checks and circuit breaker for the load balancer. Added two new fields `max_fails` and `fail_timeout`.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Added support for batch mode of anthropic.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Added support for inline batch mode of gemini",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Added support for batch API of bedrock.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Introduced Alibaba Dashscope as new provider.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-rag-injector**: Added metadata filtering and ACL (Access Control List) capabilities to the RAG plugin. This feature enables fine-grained control over document retrieval based on metadata attributes and user permissions, supporting both pgvector and Redis vector database backends.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-rate-limiting-advanced**: added support to count cost for routes with dynamic AI models.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-request-transformer**: added support for the `tls_certificate_verify` global option. When this option is enabled, the plugin's `https_verify` setting cannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-response-transformer**: added support for the `tls_certificate_verify` global option. When this option is enabled, the plugin's `https_verify` setting cannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-sanitizer**: Added a `skip_logging_sanitized_items` option to control whether to log the sanitized items, which may contain sensitive data.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "AWS ElastiCache for Redis with AWS IAM Authentication",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**aws-lambda**: added a verbose error level logging for better debugging of AWS Lambda invocation issues.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Azure Cache for Redis with Azure Microsoft Entra Authentication",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**azure-functions**: added support for the `tls_certificate_verify` global option.\nWhen this option is enabled, the plugin's `https_verify` flag cannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**basic-auth**: Added brute force protection with exponential backoff for failed login attempts.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**confluent**: added new config option `ssl_verify` to support verifying server certificates.\nAdded support for the `tls_certificate_verify` global option. When this option is enabled, the plugin's `ssl_verify` setting cannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**confluent-consume**: added new config option `tls_certificate_verify` to support verifying server certificates.\nAdded support for the `tls_certificate_verify` global option. When this option is enabled, the plugin's `tls_certificate_verify` setting cannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**core**: Added directive 'proxy_protocol_passthrough' to allow gateway keep the proxy_protocol header unmodified.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**Core**: Added SSL verification monitoring when global `tls_certificate_verify` is enabled. You will see a warning if plugins try to disable SSL verification. This will be an error in Kong 3.14.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**datakit**: Add support for using `application/x-www-form-urlencoded` as the body encoding.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**datakit**: Added json_to_xml node to support converting JSON or lua table to XML data.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**datakit**: Added support for clearing headers from the service_request and response nodes",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**datakit**: Added support for dynamic url in `call` node.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**datakit**: Added support for using the `call` node in the post-proxy phase.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**datakit**: added the `ssl_verify` flag to the call node. This flag allows\nusers to control certificate verification when making HTTPS requests to the\nconfigured `url` endpoint. It cannot be disabled when the\n`tls_certificate_verify` global option is enabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**datakit**: Added xml_to_json node to support converting XML data to lua table and JSON format.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "*datakit*: the `call` node now supports performing requests via a proxy server.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**DP Resilience**: added support for \"gs://\" schema in config sync backup strategy.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Enabled at-rest keyring encryption for sensitive fields in HashiCorp Vault integration.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Enabled at-rest keyring encryption for sensitive fields in Event Hooks.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**forward-proxy**: added support for the `tls_certificate_verify` global option. When this option is enabled, the plugin's `https_verify` setting cannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Google Cloud Memorystore for Redis with GCP IAM Authentication",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**header-cert-auth**: added support for the `tls_certificate_verify` global option.\nWhen this option is enabled, the plugin's `ssl_verify` flag\ncannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**header-cert-auth**: added the flag `ssl_verify` to control certificate\nverification when connecting to the server of the OCSP responder's URL and to\nthe server of the CRL Distribution Point.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**hmac-auth**: Enabled at-rest keyring encryption for sensitive fields in HMAC Auth plugin.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**http-log**: added support for the `tls_certificate_verify` global option.\nWhen this option is enabled, the plugin's `ssl_verify` flag\ncannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**http-log**: added the flag `ssl_verify` to control certificate\nverification when pushing logs to the configured `http_endpoint`.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**jwt-signer**: added support to the `tls_certificate_verify` global option.\nWhen this option is enabled the plugin's flags related to certificate\nverification cannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**jwt-signer**: added the flags `access_token_endpoints_ssl_verify`\nand `channel_token_endpoints_ssl_verify` to switch certificate verification\non the related fields.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka**: Added support for `tls_verify` in the Kafka library.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**kafka-consume**: added new config option `ssl_verify` to support verifying server certificates.\nAdded support for the `tls_certificate_verify` global option. When this option is enabled, the\nplugin's `ssl_verify` setting cannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-log**: added new config option `ssl_verify` to support verifying server certificates.\nAdded support for the `tls_certificate_verify` global option. When this option is enabled, the\nplugin's `ssl_verify` setting cannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-upstream**: added new config option `ssl_verify` to support verifying server certificates.\nAdded support for the `tls_certificate_verify` global option. When this option is enabled, the\nplugin's `ssl_verify` setting cannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ldap-auth**: added support for the `tls_certificate_verify` global option. When this option is enabled and LDAPS is used, the plugin's `verify_ldap_host` or `start_tls` setting cannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ldap-auth-advanced**: added support for the `tls_certificate_verify` global option. When this option is enabled and LDAPS is used, the plugin's `verify_ldap_host` setting cannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**llm**: Added a shared filter to mark requests using AI EE plugins for license enforcement. let ai request not \"double-dipping\" the API Requests by counting twice.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**mtls-auth**: added support for the `tls_certificate_verify` global option.\nWhen this option is enabled, the plugin's `ssl_verify` flag\ncannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**mtls-auth**: added the flag `ssl_verify` to control certificate\nverification when connecting to the server of the OCSP responder's URL and to\nthe server of the CRL Distribution Point.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Added support for collecting all validation errors when `collect_all_errors` is set to `true` in the plugin configuration. Note: Enabling this option with OpenAPI 3.0 will affect performance.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Support readOnly and writeOnly keywords for OpenAPI 3.1.x.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opa**: added support for the `tls_certificate_verify` global option. When this option is enabled, the plugin's `ssl_verify` setting cannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: added support to the `tls_certificate_verify`\nglobal option. When this option is enabled the plugin's flags\n`ssl_verify`, `tls_client_auth_ssl_verify`, and `session_memcached_ssl_verify`\ncannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: added the flags `session_memcached_ssl` and\n`session_memcached_ssl_verify` to switch certificate verification when\nconnecting to Memcached server.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opentelemetry**: Added support for exporting access logs via OTLP/HTTP protocol to an observability backend (e.g. OpenTelemetry Collector). Please enable this feature by configuring the `access_logs_endpoint` parameter in the OpenTelemetry plugin.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opentelemetry**: Added support for exporting OpenTelemetry metrics via OTLP/HTTP protocol to an observability backend (e.g. OpenTelemetry Collector). Please enable this feature by configuring the `metrics.endpoint` parameter in the OpenTelemetry plugin.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**prometheus**: Added a new label `type` for `http_requests_total` and `stream_sessions_total` metrics providing more specific information.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**rate-limiting-advanced**: Added `route` support to fields `identifier` and `compound_identifier`.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Redis Configuration**: Added vault reference support for Redis `host`, `port`, and `server_name` fields in plugins using Redis configuration (such as `rate-limiting-advanced`).",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Removed analytics metrics related to rate limiting and threats on the data plane side.",
+        "type": "feature",
+        "scope": "Clustering"
+      },
+      {
+        "message": "**request-callout**: added support for the `tls_certificate_verify` global option. When this option is enabled, the plugin's `ssl_verify` setting for HTTPS callouts cannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-validator**: Provided detailed error messages for `oneOf` / `anyOf` subschemas.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**solace-consume**: allowed basic auth credentials to be passed from downstream clients.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**solace-log**: allowed basic auth credentials to be passed from downstream clients.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**solace-upstream**: allowed basic auth credentials to be passed from downstream clients.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Starting from this version, Kong Gateway Enterprise supports using common Cloud Authentication methods to connect to Cloud Redis instances. This includes supporting for the following products:",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**tcp-log**: added new config option `ssl_verify` to support verifying server certificates.\nAdded support for the `tls_certificate_verify` global option. When this option is enabled, the\nplugin's `ssl_verify` setting cannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**upstream-oauth**: added support for the `tls_certificate_verify` global option. When this option is enabled, the plugin's `client.ssl_verify` setting cannot be disabled.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "When global `tls_certificate_verify` is enabled, service entities cannot\ndisable certificate verification using the `tls_verify` option anymore.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**ace**: Fixed an issue where multiple key-auth strategies could not use the same apikey.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ace**: Fixed an issue where observability headers could not be set correctly in some unhappy paths.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ace**: Fixed an issue where the anonymous consumer was not being set properly when authentication failed.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ace**: Fixed an issue where users could set the `anonymous` field in the OpenID Connect configuration of ACE auth strategies, which is not supported and could lead to unexpected authentication behavior.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ACL**: Fixed an issue where the cache was not being invalidated for incremental sync in certain scenarios, leading to stale data being served.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**acme**: Fixed an issue where the plugin would not properly handle cases when a referenced key_set does not exist, now returns a clear error message instead of causing unexpected behavior.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**active-tracing**: Fixed an issue where WebSocket connections to the control plane are not correctly closed in debug sessions.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**active-tracing**: Fixed parent span for body filter plugin spans",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**ai-aws-guardrails**: Fixed an issue where the ai-aws-guardrails metrics could not be recorded.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI AWS Guardrails**: Fixed an issue where the error does not reflect the root cause when the `guardrails_version` did not match the expected pattern.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-azure-content-safety, ai-aws-guardrail**: Fixed an issue where the plugins failed to decompress gzip-encoded responses, leading to errors in response handling.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-llm-as-judge**: Added validation to prevent disabling `https_verify` when the global `tls_certificate_verify` configuration option is enabled.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-oauth2**: Fixed an issue where the oidc schema was polluted during merging.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-oauth2**: Fixed an issue where resource without path was not correctly handled.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-oauth2**: Fixed an issue where there was an unexpected `required: false` in the plugin schema.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-oauth2**: Fixed an issue where x-forwarded-* headers were not respected.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-oauth2**: Fixed an issue where MCP-like request was not authenticated.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI MCP Proxy**: Fixed an issue where mcp proxy is not parsing default values properly.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue when using passthrough-mode, tools without tool ACL do not apply default ACL.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where MCP server could not call upstream when proxy protocol is used.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where failing to fetch tools cache was not handled properly.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where forwarding client headers to upstream could not be disabled.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where trusted ip relative headers were forwarded upstream.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where `tools/call` could accept malformed requests and generate wrong responses.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where path invalid error was not handled properly.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where we could not override the upstream's scheme when converting MCP tool to RESTful API.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where MCP server could not call upstream when self-signed certificate is used in Kong.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where path traversal can be done with path parameter.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Fixed an issue where max_request_body_size can't be 0 and set default to 1048576 (1M).",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Fixed an issue where `log_payloads` configuration would not work when `log_statistics` was disabled in the logging configuration.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-prompt-template**: Fixed an issue where non-OpenAI requests were not being processed correctly.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Added tool_calls passthrough and preserved finish_reason in Huggingface driver responses.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy Advanced**: Fixed an issue where the `max_completion_tokens` parameter was not being set correctly for O1 series models (e.g., `o1`, `o3`, `o4`, `gpt-5`).",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where the token count for Gemini Vertex embeddings API in OpenAI format was incorrect.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where the native format option did not work correctly for non-openai formats.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where the semantic load balancing with pgvector namespace was not functioning correctly.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue when using responses API and background mode.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy Advanced**: Fixed an issue where Files content analytics extraction is not handled properly for Azure.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy Advanced**: Fixed an issue where requests to Anthropic Claude models via Azure Foundry were not being processed correctly.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where AWS Bedrock invoke command is not properly proxied.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy Advanced**: Fixed an issue where the Gemini image generation model responses were not being processed correctly.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where the token count for Gemini Vertex embeddings API in native format was incorrect.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed balancer retry failures caused by expired DNS entries by preloading DNS for targets.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed intermittent 500 responses from the AI Proxy Advanced plugin when using Azure OpenAI",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy Advanced**: Fixed missing `id` and `created` fields in certain drivers.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy, ai-proxy-advanced**: Fix SSE response parsing when the response is gzip-encoded, last chunk was not processed.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where `tls_certificate_verify` configuration was not respected in JSON-RPC and AWS STS calls.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where HuggingFace embedding driver were incorrectly parsed responses from embedding API",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy**: Fixed an issue where extra inputs were not permitted for huggingface inference provider",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy**: Fixed an issue where using ai-proxy-advanced in conjunction with a logging plugin (such as file-log) resulting in missing information on the last entry of the balancer \"tries\" section.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where cohere embedding model on Bedrock returned a bad request error",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-rate-limiting-advanced**: Fixed an issue where the plugin decreased requests by whole numbers when using Redis. This is an opt-in fix and can be enabled by setting `decrease_by_fractions_in_redis` to true in the plugin configuration.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Request Transformer**: Fixed an issue where ai-request-transformer plugin does not accept capture groups for deployment field",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Sanitize**: Fixed an issue where ai-sanitize plugin does not accept non-OpenAI format.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-semantic-cache**: Fixed an issue where Cohere and Huggingface models did not work with the semantic cache because of the polluted request format.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-semantic-cache**: Fixed an issue where the plugin did not report time to first token (TTFT) metrics when hit.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-semantic-cache**: Fixed an issue where the plugin did not allow /responses api to be used with Azure.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-semantic-cache**: Fixed an issue where cost savings attributes `ai_proxy_cache_cost_savings` were not properly calculated when cache hits.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Semantic Prompt Guard**: deprecate config.rules.max_request_body_size with config.max_request_body_size.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-semantic-response-guard**: Fixed an issue where a stacktrace error occurred during initialization and teardown.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**balancer**: Fixed an issue where the unsupported field `sticky_sessions_cookie_path` was blocking configuration syncing on data planes older than version 3.11.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "**balancer**: Fixed an issue where the dns query not stopped when related upstream deleted.",
+        "type": "bugfix",
+        "scope": "Configuration"
+      },
+      {
+        "message": "**Clustering** Fixed an issue where consumer groups may cause incremental sync to fail at the first sync of a DP.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "**confluent-consume**: Fixed an issue where the plugin would fail to connect using mTLS.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**confluent**: Fixed an issue where `forward_body` dropped request bodies larger than Nginx's\ndefault buffer size (16 KB). It now reads up to 1 MB and returns an error if the body can't be fully read.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**datakit**: Fixed implicit request node headers field to be correct type.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**event-hooks**: Fixed an issue where the event_hook crud events cannot be handled in traditional cluster mode.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**file-log**: Fixed an issue where the configuration with leading or trailing spaces in the `path` field could cause upgrade failures.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Fixed a typo in certificate phase name in kong.tools.yield module.**",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where `500` response status can occasionally occur during reconfiguration.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where **active-tracing** debug sessions are not reporting headers and payloads when proxy is used to connect to the telemetry endpoint.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where `ai_reqs` and `ai_model_usage` were increased even for non-ai requests.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where consumer group renaming may not be properly populated, causing stale cache to be served.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where Kong incorrectly logged upstream status codes as 000 (or empty) when HTTP/2 clients disconnected during response processing. This occurred when response buffering was enabled. Kong now correctly records the actual upstream status code even when the HTTP/2 client disconnects before receiving the complete response.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where Kong Manager failed to generate a cookie when OIDC was enabled due to a missing `password` grant type in `auth_methods`.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where migrations could fail due to missing database relations by repositioning basic-auth and key-auth plugin scripts for correct execution order.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where `otlp.prepare_logs` did not reset the `spans` field, causing unsupported data exported to OTel backends.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where plugin preparation incorrectly retained userdata values; they are now set to `nil` during preparation.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the CLI command `kong runner` crashes when clustering cert and key are provided as content from environment variables.",
+        "type": "bugfix",
+        "scope": "CLI Command"
+      },
+      {
+        "message": "Fixed an issue where the data plane did not stop the health checker before cleaning up old configurations, which could lead to resource leaks.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where the `kong.log.serialize()` function incorrectly ommitted the `consumer_id` in the `authenticated_entity` log field.",
+        "type": "bugfix",
+        "scope": "PDK"
+      },
+      {
+        "message": "**Fixed an issue where the partial entities cannot be deleted when cascading delete a workspace.**",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the prometheus metric `kong_control_plane_connected` was missing when the Data Plane side enabled incremental sync.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where unnecessary table allocations were occurring when encoding traces and logs.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where upstreams were unhealthy when `healthchecks.threshold` is set to 100.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where `Via` header includes dashes `-` in it (like `1.1 kong/3.13.0.0-enterprise-edition`), which is not allowed by RFC 9001 and may cause issues with some .NET HTTP servers.\nA new `kong.conf` configuration option `via_header_comply_rfc` was added, when enabled, the `Via` header will not include Kong version and dashes (like `1.1 kong`).",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**GCP Model Armor**: Fixed an issue where short-lived credentials were not being refreshed properly.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**GCP Model Armor**: Fixed an issue where PARTIAL invocationResult was not handled.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-consume, confluent-consume**: Added `enforce_latest_offset_reset` flag to fix incorrect `latest` offset behavior. When `false` (default), maintains backwards compatibility where `latest` acts like `earliest`. When `true`, `latest` correctly starts from end of topic. Also fixed offset commit bug when no records are consumed, preventing feedback loop with true latest behavior.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-consume**: Fixed an issue where the plugin would fail to connect using mTLS.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-consume**: Fixed an issue where the SSE connection was not terminated when there was an error in Schema Registry.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka**: Fixed an issue where consumed messages were not validated against their JSON schema.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka**: Fixed an issue where Schema Registry didn't properly validate JSON schemas.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-upstream**: Fixed an issue where the kafka-upstream plugin fails to connect certain Kafka clusters using SCRAM-SHA-256 or SCRAM-SHA-512",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-upstream**: Fixed issue where Kafka producer cached TLS certificates, causing failures when certificates were updated. Now, the plugin properly reloads updated certificates.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Key-Auth-Enc**: Fixed an issue where for incremental sync, caches may not be properly invalidated, causing stale data to be served.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**key-auth**: Fixed an issue where the consumer authentication cache was not isolated by realm.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kong.tools.jose**: Allow arbitrary size RSA keys.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**llm**: Fixed an issue where Gemini embeddings driver did not use correct url.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**llm**: Fixed an issue where HuggingFace embeddings driver did not handle response correctly.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**llm**: Fixed an issue where the subrequest implemented in LLM drivers did not handle error properly.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**log-pdk**: Fixed an issue in log-pdk where log serialization could cause a panic due to incorrect type handling in `set_serialize_value`. Strengthened validation to prevent this.",
+        "type": "bugfix",
+        "scope": "PDK"
+      },
+      {
+        "message": "**mocking**: Fixed an issue where path match pattern failed when `()[]` were in the path pattern.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where nested references in oneOf / anyOf when they are used with a discriminator are not unfolded.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where YAML 1.1 `null` values were parsed incorrectly.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where parameter data extraction failed when `$` appears in the path pattern.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**OpenID-Connect**: Fixed an issue where the issuer mismatch error message for the token's `iss` claim did not reflect the correct token type and expected issuers.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**OpenID-Connect**: Fixed an issue where the `client_credentials`/`authorization_code` auth would not auto-recover if IdP was not accessible during Kong startup.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**OpenID-Connect**: Fixed an issue where TLS client certificate loading failed in non-default workspaces. The certificate lookup now explicitly specifies the plugin's workspace when querying the database during configuration initialization.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**OpenID-Connect**: Fixed an issue where for incremental sync, consumer related caches may not be properly invalidated, causing stale data to be served.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**OpenID Connect**: Improved claim validation logic to correctly handle timestamp claims (exp, nbf, iat) even when provided as non-numeric types.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opentelemetry**: Fixed an issue where the reference removing did not match the correct property in otel logs.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**OpenTelemetry**: Fixed an issue where the instrumentation started unexpectedly on control planes of hybird mode.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Prometheus**: Fixed an issue where the Prometheus plugin would not return DB connections to the connection pool, potentially leading to exhaustion of available connections under high load.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "*request-callout*: Ensure that upstream headers are cleared after custom expressions are executed.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: Fix duplicated content-type headers in the callout request when body.custom is enabled and content-type header is also set in headers.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**response**: Fixed an issue where the `kong.response.exit() didn't interrupt the execution flow of plugins in header_filter phase`.\nAlso added a new configuration `pdk_response_exit_header_filter_early_exit` to control this behavior to avoid silent breaking changes.\nThe current default value is 'off', and output a warning log when `kong.response.exit()` is called in header_filter phase.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**SAML**: Fixed an issue that caused a crash when the NameID Format was set to `Unspecified`.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**solace-log**: Fixed end-to-end tracing context propagation.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**solace-upstream**: Fixed end-to-end tracing context propagation.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**template**: Fixed an issue where duplicated \"proxy_protocol on\" directive in nginx-kong-stream.conf when KONG_NGINX_SPROXY_PROXY_PROTOCOL was set for ssl stream.",
+        "type": "bugfix",
+        "scope": "Configuration"
+      },
+      {
+        "message": "**core**: Improved performance of deleting expired rows for Postgres versions below 12.",
+        "type": "performance",
+        "scope": "Core"
+      },
+      {
+        "message": "**core**: Improved performance of Kong core.",
+        "type": "performance",
+        "scope": "Core"
+      },
+      {
+        "message": "Improved the performance of Konnect Analytics on the Data Plane side.",
+        "type": "performance",
+        "scope": "Clustering"
+      },
+      {
+        "message": "**request-transformer**: improved performance of the request-transformer plugin.",
+        "type": "performance",
+        "scope": "Plugin"
+      }
+    ],
+    "kong-manager-ee": [
+      {
+        "message": "Added support for AWS, Azure, GCP authentication providers in Redis config.",
+        "type": "feature",
+        "scope": "Default"
+      },
+      {
+        "message": "Added support for using OAuth2 with HashiCorp Vault.",
+        "type": "feature",
+        "scope": "Default"
+      }
+    ]
+  },
+  "3.12.0.7": {
+    "kong-ee": [
+      {
+        "message": "Bumped libexpat from 2.7.3 to 2.8.1 to address the issues: CVE-2026-25210, CVE-2026-24515, CVE-2026-32778, CVE-2026-32777, CVE-2026-32776, CVE-2026-41080, and CVE-2026-45186.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped OpenSSL from 3.5.5 to 3.5.6 to address the issues: CVE-2026-31790, CVE-2026-2673, CVE-2026-28387, CVE-2026-28388, CVE-2026-28389, CVE-2026-28390, and CVE-2026-31789.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Applied upstream nginx security patches for CVE-2026-40701, CVE-2026-40460, CVE-2026-42934, CVE-2026-42946, CVE-2026-42945, and CVE-2026-9256.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Security: Fixed CVE-2026-6338 in core proxy request header handling by preserving inbound `Content-Length` headers during hop-by-hop Connection header cleanup, preventing CL.0 request smuggling with crafted `Connection: Content-Length` headers on requests with a body.",
+        "type": "bugfix",
+        "scope": "Core"
+      }
+    ]
+  },
+  "3.12.0.6": {
+    "kong-ee": [
+      {
+        "message": "Bumped lua-resty-healthcheck from 3.1.1 to 3.1.2.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "**Debugger**: Fixed an issue where Redis command arguments were incorrectly included in Redis spans.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**Debugger**: Fixed an issue where the time spent during the TLS handshake was incorrectly added to Kong internal latency. This fix moved it to the client side latency.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**Debugger**: Fixed an issue where the Konnect Debugger concatenated `nil` and errored when accessing Kong Gateway via a Unix socket (e.g. `unix:/<prefix>/sockets/am:tls`).",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the real client IP from Proxy Protocol was not correctly reflected in access logs and logging plugins when nginx rejected requests early (497 plain HTTP to HTTPS port) or when the client disconnected prematurely during header parsing. Added an nginx patch to resolve `$remote_addr` from `$proxy_protocol_addr` on early request termination, and added `error_page` 497 routing through `kong_error_handler`.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed clustering sync reliability issues by immediately failing pending sync v2 RPC callbacks on disconnect with a `connection closed` error.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "**service-protection**: Fixed an issue where the Service Protection plugin could count requests already rejected by Rate Limiting Advanced. Service Protection now executes after Rate Limiting Advanced and only evaluates requests that pass rate limiting, by updating its priority from 915 to 901.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      }
+    ]
+  },
+  "3.12.0.5": {
+    "kong-ee": [
+      {
+        "message": "Bumped kong-gql from 0.2.3 to 0.2.4 to fix the null value issue in the GraphQL query syntax that caused a parsed AST error in the DeGraphQL plugin.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Added `lru_cache_size` to allow configuration of in-memory LRU cache size.",
+        "type": "bugfix",
+        "scope": "Configuration"
+      },
+      {
+        "message": "**ai-mcp-proxy**: Fixed an issue where we didn't keep the port after MCP conversion.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where `id`/`created` fields were missing in multiple drivers.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy**: Fixed an issue where using ai-proxy-advanced in conjunction with a logging plugin (such as file-log) resulting in missing information on the last entry of the balancer \"tries\" section.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**core**: Resolved an issue where HTTPS was incorrectly detected if multiple `X-Forwarded-Proto` values were provided.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where DP may spawn multiple sync timers when downgrading sync protocol to v1, which may cause excessive load on CP and lead to performance degradation.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where Incremental Sync (ICS) would crash and stop further sync attempts.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where `$remote_addr` was not replaced with the proxy protocol source address for early nginx error responses (501, 505) when `proxy_protocol` was enabled on the proxy listener. Also added proper error body messages for 501 and 505 status codes.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the Active Tracing would report incorrect `latencies.client` values due to not capturing the access end time properly. This fix ensures that the access end timestamp is always recorded regardless of Active Tracing being active or not.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the postinstall script changed the ownership of `/etc/kong/kong.logrotate` to `kong:kong`, causing permission issues when executed by the root user. Ownership now resets to `root:root` after postinstall.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**graphql-rate-limiting-advanced**: Fixed an issue where the graphql-rate-limiting-advanced plugin's API threw 500 errors when handling HTTP PUT requests.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**JWT**: Fixed an issue where malformed JWT tokens (e.g. tokens without dots) caused a 500 Internal Server Error instead of returning 401 Unauthorized.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-log**: Fixed an issue where cached producers could cause memory leaks.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where swagger `formData` parameters were not properly handled.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where `minLength` and `maxLength` constraints defined in a Swagger 2.0 parameter schema were not enforced.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where nested references in `oneOf`/`anyOf` were not unfolded when used with a discriminator.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Fixed an issue where client-provided headers could be forwarded to upstream services when the corresponding JWT claim was missing from the token. The plugin now clears client headers before processing `upstream_headers_names`, ensuring that only verified JWT claim values are sent to upstream or downstream.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Fixed DPoP verification for opaque tokens (RFC 9449 Section 6.2) where Kong failed to correctly parse nested `cnf.jkt` claims from introspection responses.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**vault**: Fixed an issue where `kong.vault.update()` changed the secret to an empty string temporarily after changing vault config.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**core**: Improved performance of Kong core by using `ngx.var.http_*` instead of `kong.tools.http.get_header`.",
+        "type": "performance",
+        "scope": "Core"
+      },
+      {
+        "message": "Optimized `GET /kong` endpoint to use `SELECT DISTINCT` for populating `enabled_in_cluster` instead of iterating all plugin rows.",
+        "type": "performance",
+        "scope": "Admin API"
+      }
+    ],
+    "kong-manager-ee": [
+      {
+        "message": "Fixed workspace navigation for workspace names containing non-ASCII characters.",
+        "type": "bugfix",
+        "scope": "Default"
+      }
+    ]
+  },
+  "3.12.0.0": {
+    "kong": [
+      {
+        "message": "**AI Plugins**: Support relative path for tool paths in MCP plugins.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Added `time_to_first_token` and `request_mode` for observability.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Fixed an issue where Structured Output did not work correctly with Anthropic Claude models.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Fixed an issue where structured output did not work for the Bedrock provider when SSE streaming responses.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Fixed an issue where Structured Output did not work correctly with Bedrock (Converse API) models.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Fixed an issue where `id`, `created`, and/or `finish_reason` fields were missing from or incorrect in Gemini responses.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Fixed an issue where Structured-Output requests were ignored.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Fixed an issue where Bedrock (Converse API) didn't properly parse multiple `toolUse` tool calls in one turn, on some models.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where JSON array data wasn't correctly parsed.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where the Anthropic provider failed to stream function call responses.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where the Anthropic provider could truncate tokens in streaming responses.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where OpenAI chat completion's `tool_choice` was not converted to Anthropic's.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where the `model` field was incorrect in Gemini responses when a variable was used as the model name.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where the `model` field was missing in OpenAI-format Gemini responses in some situations.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where the Gemini provider did not properly handle multiple tool calls across different turns.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where an empty array was encoded as an empty object in structured output.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where AWS stream parser didn't parse correctly when the frame was incomplete.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where the Anthropic provider mapped the wrong `stop_reason` to Chat and Completions responses.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**exit-transformer**: Fixed an issue where exit-transformer affected the Status API.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Fixed an issue where stream/proxy listeners could unexpectedly access the router from the control plane. Stream/proxy listeners are now disabled for the control plane.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**prometheus**: Fixed an issue where WebSocket wasn't recorded in the Prometheus metrics.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      }
+    ],
+    "kong-ee": [
+      {
+        "message": "**kafka-consume**: Added `typedefs.no_service` to the `kafka-consume` plugin to prevent binding to a service, as it does not proxy to one. Note that this is a breaking change. If you previously attached a kafka-consume plugin to a service, it will no longer take effect. In such cases, requests will instead be proxied to the upstream configured in the service.",
+        "type": "Breaking Change",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**konnect-application-auth - Konnect user only**: Changed the priority of konnect application auth plugin from 950 to 960. This change is to make sure the execution sequences of the konnect-application-auth plugin and the ACL plugin are as expected. If you're using the konnect-application-auth plugin and other custom plugins that have a dependency with the konnect-application-auth plugin and have a priority between 950 and 960, you may need to adjust the priorities of these custom plugins accordingly or use dynamic plugin ordering.",
+        "type": "Breaking Change",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Bumped ca-certificates (debug tool) from 2025-02-25 to 2025-07-15.",
+        "type": "dependency",
+        "scope": "CLI Command"
+      },
+      {
+        "message": "Bumped curl (debug tool) from 8.12.1 to 8.15.0.",
+        "type": "dependency",
+        "scope": "CLI Command"
+      },
+      {
+        "message": "Bumped kong-redis-cluster from 1.5.5 to 1.5.6. This fixes an issue where Redis connections were not reused properly.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped libexpat from 2.6.4 to 2.7.1.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped libxslt from 1.1.42 to 1.1.43.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-muiltipart from 0.5.9 to 0.5.11",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-protobuf from 0.5.2 to 0.5.3.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-resty-aws from 1.5.4 to 1.6.0.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-resty-azure from 1.7.0 to 1.10.0.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-resty-cookie from 0.3.0 to 0.4.1.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-resty-gcp from 0.0.13 to 0.0.14.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-resty-jq from 0.1.0 to 0.2.0.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-resty-lmdb to version 1.6.1.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-resty-session from 4.0.5 to 4.1.4.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-resty-websocket to version 0.4.0.2 to solve an issue with connecting to an HTTP/1.0 proxy, and to add an enhancement for status code return.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped LuaRocks from 3.11.1 to 3.12.2.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped multipart from 0.5.9 to 0.5.10.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped nghttp2 (debug tool) from 1.65.0 to 1.66.0.",
+        "type": "dependency",
+        "scope": "CLI Command"
+      },
+      {
+        "message": "Bumped PCRE2 from 10.45 to 10.46.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped snappy from 1.2.1 to 1.2.2.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped xmlua from 1.2.1 to 1.2.2.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "The lua-resty-kafka module `resty.kafka` inside the Kong Gateway package is now deprecated. Developers can still use it, but it will no longer receive any updates.",
+        "type": "deprecation",
+        "scope": "Core"
+      },
+      {
+        "message": "**ace**: Add the `ace` plugin.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Added a feature to show the basic incremental sync information\non the Data Plane side.",
+        "type": "feature",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Added a new `kong.client.get_aws_vpce_id()` function for returning the VPC ID of the endpoint in the PROXY protocol v2 header PP2_SUBTYPE_AWS_VPCE_ID.",
+        "type": "feature",
+        "scope": "PDK"
+      },
+      {
+        "message": "Added failover support for upstream targets, allowing load balancing to backup\ntargets when primary targets are offline.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added `$kong_upstream_*` Nginx variables to correctly log upstream information in `log_format`.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added the new metric `target_id` (Target entity ID) to the Konnect Analytics to improve the observability.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added the `/status/timers` endpoint to the Status API for data planes, mirroring the Admin API `/timers` endpoint.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added vault support to the Datakit plugin. This unblocks common use cases such as storing secrets in Vault and retrieving them as tokens in Datakit.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-aws-guardrails**: Add support for AWS IAM role to the ai-aws-guardrails plugin.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-azure-content-safety**: Added response guard to filter AI responses for safety and compliance.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-llm-as-judge**: Introduced the AI LLM as Judge plugin, enabling you to evaluate an LLM and use the score as a balancer.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp**: Added observability support for AI MCP traffic.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp**: Introduced the AI MCP plugin, enabling you to export any API to AI applications via MCP.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "AI MCP metrics are now reported to Konnect Analytics.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**ai-mcp-oauth2**: Dropped the `enabled` field, as we already have one in plugin table.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-oauth2**: Introduced the AI MCP OAuth2 plugin, which protects the MCP traffic with OAuth2.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp-proxy**: The plugin now forwards client headers when calling the tool.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp**: The plugin now supports using multiple tools in the same plugin instance.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-mcp**: The plugin now supports path parameters.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Added a new `endpoint_id` field for GCP Gemini options to support Model Garden.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ais**: Added the MemoryDB vector database strategy to LLM plugins.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: GCP authentication order can now be configured using the `GCP_AUTH_METHOD_ORDER` environment variable.\nSetting it to `adc` allows the plugin to select Application Default Credentials (ADC) in precedence over Service Account.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Added latency and cost observability to realtime API.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy Advanced**: Added support for Gemini Rerank in native format.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy Advanced**: Exposed `input_tokens_details.cached_tokens_details.image_tokens_count` in observability metrics.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-sanitizer**: Added a `block_if_detected` option to reject requests containing PII data instead of sanitizing them. When `block_if_detected` is enabled, requests with detected PII will be blocked with a 400 response containing details about the identified PII types and count.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-sanitizer**: Added support for sanitizing LLM responses.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-semantic-response-guard**: Introduced the AI Semantic Response Guard plugin, enabling you to guard LLM responses against semantic content.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Analytics**: Added the `cache.status` field to collect the cache status of proxy-cache plugin.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**AWS-Lambda**: Added support for AWS API Gateway payload v2. A new configuration field `awsgateway_compatible_payload_version` has been added to control the version of the payload.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**confluent-consume**: Added `websocket` mode to the `confluent-consume` plugin.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**datakit**: Added caching support via a new `cache` node type.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**datakit**: Added support for conditional execution via the `branch` node.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**injection-protection**: Added the ability to allow users to check a request path or query.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**jwt-signer**: Added new options `access_token_signing` and `channel_token_signing` to quickly turn on and off token signing or re-signing.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**jwt-signer**: Added new options to support optional claim verification: `access_channel_token_(introspection_)optional_claims.` The specified claims are verified only if they are present.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**jwt-signer**: Added new options to support claim existence verification: `access_channel_token_(introspection_)required_claims.` The specified claims must be present in the token payload.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**jwt-signer**: Added support for additional claim validations, including `notbefore`, `issuer`, `subject`, and `audience`.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka**: Added support for OAuth 2.0 authorization for Confluent Schema Registry.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-consume, confluent-consume**: The plugin now supports modifying the returned content as needed.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Kafka**: Supported sending failed messages to dead letter queue topics.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Kong now supports Azure authentication methods for connecting to Azure PostgreSQL databases. A new configuration option `pg_azure_auth` as well as corresponding configuration fields `pg_azure_client_id`, `pg_azure_client_secret`, and `pg_azure_tenant_id` have been added to the Kong configuration file. When `pg_azure_auth` is set to `on`, Kong will use Azure authentication methods to connect to Azure PostgreSQL databases.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**openid-connect**: Added support for claim to consumer groups mapping.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Added support for session binding (IP, scheme, and/or User-Agent header).",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opentelemetry**: Added the `peer.service` attribute to the balancer span to link multiple services together. This allows for better tracing of requests that span multiple services.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**PDK**: Added support for calling the `kong.response.get_raw_body()` and `kong.response.set_raw_body()` PDK functions from plugin `:response()` handlers.",
+        "type": "feature",
+        "scope": "PDK"
+      },
+      {
+        "message": "**PDK Request ID**: Added support for retrieving the request ID via the `kong.request.get_id()` function in the PDK.",
+        "type": "feature",
+        "scope": "PDK"
+      },
+      {
+        "message": "**Rate-Limiting-Advanced**: Added request throttling feature.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: The plugin now supports dynamic request URLs in the form of Lua expressions `$(some_lua_expression)`.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**session**: Added support for session binding (IP, scheme, and/or User-Agent header).",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**solace**: Added WebSocket transport support for `PERSISTENT` delivery mode.",
+        "type": "feature",
+        "scope": "Default"
+      },
+      {
+        "message": "**Solace Consume** Added the `solace-consume` plugin, which adds Solace consumption capabilities to Kong.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**solace-log**: Added the `solace-log` plugin to support logging to Solace PubSub+ event broker.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI AWS GuardRails**: Fixed the plugin to work with multi-modal content.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Azure Content Safety**: Fixed the plugin to work with multi-modal content.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-driver**: Fixed an issue where AI Proxy and AI Proxy Advanced generated incorrect default ports for upstream schemes, leading to 400 errors.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-llm-as-judge**: Fix an issue where the ai-llm-as-judge plugin didn't work with non-OpenAI provider configuration.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Fixed an issue where the Dimensionality was not sent for Gemini embeddings calls.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ais**: Fixed an issue where the LLM license migration could fail if the license counter contained more than one week of data.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Prompt Compressor**: Fixed the plugin when no model parameter is specified.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where the ai-retry phase was not correctly setting the namespace in the `kong.plugin.ctx`, causing the ai-proxy-advanced balancer to retry the first target more than once.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy Advanced**: Fixed an issue where the Gemini provider didn't support Model Garden.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy Advanced**: Fixed an issue where managed identity could be cached incorrectly.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy Advanced**: Fixed an issue where Mistral models would return `Unsupported field: seed` when using some inference libraries.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy Advanced**: Fixed an issue where array input wasn't being properly validated for certain providers. Note that Bedrock, Gemini Public, and Mistral providers don't support array input, as before.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy Advanced**: Fixed an issue where some Titan embeddings models reported malformed requests.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where the AI Proxy Advanced plugin's lowest latency load balancer could fail to select a target when only one target was available, leading to 500 errors.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy, ai-proxy-advanced**: Fix panic in LLM observability when populating token usage for AI Proxy token usage details.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy, ai-proxy-advanced**: Fixed an issue where AI Proxy and AI Proxy Advanced could produce duplicate content in the response when the SSE event was truncated.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy, ai-proxy-advanced**: Fixed an issue where AI Proxy and AI Proxy Advanced could drop content in the response when the SSE event was truncated.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy, ai-proxy-advanced**: Fixed an issue where AI Proxy and AI Proxy Advanced couldn't properly failover to a Bedrock target.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where AWS Bedrock streaming requests would panic when the ai-semantic-cache plugin was enabled.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where the resource was not being passed correctly when using Azure as the provider.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where AWS Bedrock did not properly handle image editing requests through the `image/v1/images/edits` route.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue with Azure Managed Identity credentials causing improper request balancing.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-sanitizer**: Fixed an issue where responses could not be redacted correctly when there were multiple redact texts of different lengths sharing the same prefix.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-semantic-cache**: Fixed an issue where the DELETE `/ai-semantic-cache` endpoint returned an incorrect 204 status for non-existent keys.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-semantic-cache**: Fixed an issue where AI inference requests to non-OpenAI providers in the stream mode were not supported.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-semantic-cache**: Fixed an issue where the SSE terminator could have incorrect ending characters.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-semantic-cache**: Fixed an issue where the DELETE `/ai-semantic-cache` endpoint returned 500 errors for successful deletions when using pgvector as the vector database.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Semantic Plugins**: Fixed an issue by using a separate column to store the namespace instead of including it in the table name to avoid truncation. This change invalidates previous caches created by AI Semantic Cache, AI Semantic Prompt Guard, and AI Proxy Advanced. If a user is using a very long cache TTL, cache warmup is required after this change.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-semantic-prompt-guard**: Fixed the deletion of guard instances and improved error handling.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-semantic-response-guard**: Fixed the deletion of guard instances and improved error handling.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**analytics**: Fixed an issue where multi-model tokens usage metrics were not reported to Konnect.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**app-dynamics**: Fixed an issue where response time measurements to backend services were inaccurate. The plugin now captures the full request duration, including upstream.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**aws-lambda**: Fixed an issue where the AWS Gateway compatible payload generated by the plugin did not include the `resource` field in some cases.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**confluent**: Fixed an issue where the plugin did not use `conf.cluster_name`.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**datakit**: Fixed an issue where an invalid plugin instance could affect other plugins.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**datakit**: Fixed plugin config validation to catch more invalid usage of the `property` node.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**embeddings**: Fixed an issue where the `text-embedding-ada-002` model would return a 400 error when the `dimensions` parameter was set.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Fix an issue where the CLI command and the kong process could throw warning messages about the user directive not being used when running as a non-root user.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where adding consumers to consumer groups could crash the data plane during incremental sync.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where control planes could consume unnecessary memory when only incremental data planes were connected.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where enabling `openid-connect` authentication in Kong Manager would fail due to `authenticated_groups` being a string.",
+        "type": "bugfix",
+        "scope": "Admin API"
+      },
+      {
+        "message": "Fixed an issue where incorrect an delimiter in cluster events caused cache key problems, preventing Dev Portal from updating the page cache properly in hybrid deployment mode.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where PDK returned non-empty header when requests were not proxied to upstream.",
+        "type": "bugfix",
+        "scope": "PDK"
+      },
+      {
+        "message": "Fixed an issue where results were lost when querying LMDB page by page.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where setting credential TTL to null caused an unexpected error.",
+        "type": "bugfix",
+        "scope": "Admin API"
+      },
+      {
+        "message": "Fixed an issue where some schema endpoints in the Admin API didn't include the `ttl` field in GET responses. This includes:\n - `keyauth_enc_credentials`\n - `ratelimiting_metrics`\n - `keyauth_credentials`\n - `oauth2_tokens`\n - `oauth2_authorization_codes`\n - `clustering_data_planes`\n - `acme_storage`\n - `sessions`\n - `audit_requests`\n - `audit_objects`",
+        "type": "bugfix",
+        "scope": "Admin API"
+      },
+      {
+        "message": "Fixed an issue where the `/clustering/data-planes` endpoint returned an incorrect DP hostname when incremental sync was enabled.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where the incremental sync did not work properly for the stream subsystem.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where the request count was not being updated based on the `license_creation_date` of the license.",
+        "type": "bugfix",
+        "scope": "Default"
+      },
+      {
+        "message": "Fixed redundant configuration exports when multiple data planes were connected concurrently by coalescing triggers and delegating export/broadcast operations to the background push loop.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "**jwe-decrypt**: Fixed an issue where the `key_sets` cache could not be invalidated correctly.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka**: Fixed an issue where the Kafka or Confluent Consume plugins couldn't consume the correct message when the consuming offset of the topic was not 0.\n**kafka**: Fixed an issue with parsing `ListOffset` Response version 0.",
+        "type": "bugfix",
+        "scope": "Default"
+      },
+      {
+        "message": "**kafka-log, kafka-upstream, kafka-consume**: Added warnings when the strategy is SASL without a mechanism, or the mechanism is set without a SASL strategy.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-upstream**: Fixed an issue where `forward_body` dropped request bodies larger than Nginx's\ndefault buffer size (16 KB). It now reads up to 1 MB and returns an error if the body can't be fully read.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**keyring**: Fixed an issue where 'key not found' was incorrectly reported as a warning continuously.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**ldap-auth-advanced**: Fixed a group validation issue where LDAP group names containing asterisk (`*`) characters were incorrectly marked as invalid during Kong Manager RBAC authentication. Group names with asterisk characters (such as `*Dev - EXAMPLE - TOP`) now properly validate and allow role mapping.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**mocking**: Fixed an issue where empty arrays defined in the mocking plugin schema were incorrectly returned as object types instead of array types in response bodies.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**mtls-auth**: Fixed an issue where a certificate with an empty DN led to a runtime exception.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where certain query strings in URLs that did not conform to the configured OpenAPI specification could cause the plugin to throw an unexpected runtime error and respond with an HTTP 500 error.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oauth2-introspection**: Fixed a high memory usage issue caused by caching negative introspection responses.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oauth2-introspection**: Fixed an issue where authentication failures did not log messages in the error logs.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Fixed an issue where `upstream_session_id_header` and `downstream_session_id_header` mistakenly required the `downstream_headers_claims` and `downstream_headers_names` to be present.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**postgres**: Improved error logging for PostgreSQL connection failures.\n**vault**: Log more details when vault callback execution fails.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**prometheus**: Fixed an issue where Prometheus metrics would show empty consumer identifiers when consumers didn't have a username. The plugin now falls back to using the consumer's `custom_id` when the username is not available, ensuring consumer identification in metrics.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: Fixed an issue where expressions could not read headers, query, and URI captures via shortcuts of the form `$(headers.some_header)`.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: Fixed an issue where `untrusted_lua_sandbox_requires` option was not respected.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: Fixed regression where the upstream request body would not be forwarded if `upstream.body.custom` was empty.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: `request.by_lua` code will now run before a request is made or a cached callout is fetched. Previously, it did not run before an attempt to fetch from cache, which did not allow for cache key customization.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: The plugin now uses additional components to generate the cache key: request consumer, consumer groups, plugin ID, route ID; callout request method, URL, query params, headers, and body.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**response-transformer-advanced**: Fixed a failure that occurred when Nginx gzip was enabled for an upstream.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Semantic Plugins**: Fixed an issue where Gemini Vertex AI embeddings failed due to incorrect URL construction and response parsing.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**solace-upstream**: Fixed an issue where `forward_body` dropped request bodies larger than Nginx’s\ndefault buffer size (16 KB). It now reads up to 1 MB and returns an error if the body can't be fully read.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**tls-metadata-headers**: Fixed an issue where a certificate with an empty DN led to a runtime exception.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**vault**: Fixed an issue where vault config `base64_decode` caused DP to fail to start.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**xml-threat-protection**: Fixed an issue where requests without a body were blocked.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**perf**: Improved the efficiency of entity field access on hot path.",
+        "type": "performance",
+        "scope": "Performance"
+      },
+      {
+        "message": "**prometheus**: Optimized fetching of the `kong_db_entities_total` metric by using internal counters instead of the `select count(*)` query through the database. If this metric is found to be of sync with the real row counts, use the command `kong migrations reinitialize-workspace-entity-counters` to re-sync the counts.",
+        "type": "performance",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Kong Manager**: In the Confluent Consume, Kafka Consume, Kafka Upstream, Kafka Log, and Confluent plugins, \nsetting `schema_registry.confluent.authentication.mode` or `topics.schema_registry.confluent.authentication.mode` to `none` may not be saved after submission.\n",
+        "type": "known-issues",
+        "scope": "Kong Manager"
+      }
+    ],
+    "kong-manager-ee": [
+      {
+        "message": "Added support for failover targets in upstreams.",
+        "type": "feature",
+        "scope": "Default"
+      },
+      {
+        "message": "**jwt-signer**: Added support for new parameters in the JWT Signer plugin.",
+        "type": "feature",
+        "scope": "Default"
+      },
+      {
+        "message": "**key-auth, key-auth-enc**: You can now configure the TTL parameter for the Key Authentication and Key Authentication Encrypted plugins.",
+        "type": "feature",
+        "scope": "Default"
+      },
+      {
+        "message": "**service-protection**: Revamped the UI of the Service Protection plugin.",
+        "type": "feature",
+        "scope": "Default"
+      },
+      {
+        "message": "Updated documentation links in the Kong Manager Enterprise Edition to point to the latest resources.",
+        "type": "feature",
+        "scope": "Default"
+      },
+      {
+        "message": "Fixed an issue where the vault picker was missing in the Request Callout plugin.",
+        "type": "bugfix",
+        "scope": "Default"
+      }
+    ]
+  },
+  "3.11.0.12": {
+    "kong-ee": [
+      {
+        "message": "Bumped libexpat from 2.7.3 to 2.8.1 to address the issues: CVE-2026-25210, CVE-2026-24515, CVE-2026-32778, CVE-2026-32777, CVE-2026-32776, CVE-2026-41080, and CVE-2026-45186.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped OpenSSL from 3.5.5 to 3.5.6 to address the issues: CVE-2026-31790, CVE-2026-2673, CVE-2026-28387, CVE-2026-28388, CVE-2026-28389, CVE-2026-28390, and CVE-2026-31789.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Applied upstream nginx security patches for CVE-2026-40701, CVE-2026-40460, CVE-2026-42934, CVE-2026-42946, CVE-2026-42945, and CVE-2026-9256.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Security: Fixed CVE-2026-6338 in core proxy request header handling by preserving inbound `Content-Length` headers during hop-by-hop Connection header cleanup, preventing CL.0 request smuggling with crafted `Connection: Content-Length` headers on requests with a body.",
+        "type": "bugfix",
+        "scope": "Core"
+      }
+    ]
+  },
+  "3.11.0.11": {
+    "kong-ee": [
+      {
+        "message": "**aws-lambda**: Fixed an issue where empty JSON array bodies (`[]`) were incorrectly converted to objects (`{}`) when using `is_proxy_integration=true` and `empty_arrays_mode=correct` alongside the exit-transformer plugin.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**aws-lambda**: Fixed an issue where a 500 error occurred when `is_proxy_integration` was enabled and the Lambda function returned `null` values in `headers` or `multiValueHeaders`. Null values are now converted to empty strings.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      }
+    ]
+  },
+  "3.11.0.10": {
+    "kong-ee": [
+      {
+        "message": "Bumped lua-resty-healthcheck from 3.1.1 to 3.1.2",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "**Debugger**: Fixed an issue where Redis command arguments were incorrectly included in Redis spans.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**Debugger**: Fixed an issue where the time spent during the TLS handshake was incorrectly added to Kong internal latency. This fix moved it to the client side latency.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**Debugger**: Fixed an issue where the Konnect Debugger concatenated `nil` and errored when accessing Kong Gateway via a Unix socket (e.g. `unix:/<prefix>/sockets/am:tls`).",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the real client IP from Proxy Protocol was not correctly reflected in access logs and logging plugins when nginx rejected requests early (497 plain HTTP to HTTPS port) or when the client disconnected prematurely during header parsing. Added an nginx patch to resolve `$remote_addr` from `$proxy_protocol_addr` on early request termination, and added `error_page` 497 routing through `kong_error_handler`.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed clustering sync reliability issues by immediately failing pending sync v2 RPC callbacks on disconnect with a `connection closed` error.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "**Forward Proxy Advanced**: Added `ca_certificates` option for per-plugin TLS verification.\nIt allows certificate chain and hostname checks against specified CAs instead of\nglobal settings, ensuring explicit trust.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Service Protection**: Fixed an issue where the Service Protection plugin could count requests already rejected by Rate Limiting Advanced. Service Protection now executes after Rate Limiting Advanced and only evaluates requests that pass rate limiting, by updating its priority from 915 to 901.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      }
+    ]
+  },
+  "3.11.0.9": {
+    "kong-ee": [
+      {
+        "message": "Bumped kong-gql from 0.2.3 to 0.2.4 to fix the null value issue in the GraphQL query syntax that caused a parsed AST error in the DeGraphQL plugin.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Added `lru_cache_size` to allow configuration of in-memory LRU cache size.",
+        "type": "bugfix",
+        "scope": "Configuration"
+      },
+      {
+        "message": "**core**: Resolved an issue where HTTPS was incorrectly detected if multiple `X-Forwarded-Proto` values were provided.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where DP may spawn multiple sync timers when downgrading sync protocol to v1, which may cause excessive load on CP and lead to performance degradation.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where Incremental Sync (ICS) would crash and stop further sync attempts.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where `$remote_addr` was not replaced with the proxy protocol source address for early nginx error responses (501, 505) when `proxy_protocol` was enabled on the proxy listener. Also added proper error body messages for 501 and 505 status codes.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the Active Tracing would report incorrect `latencies.client` values due to not capturing the access end time properly. This fix ensures that the access end timestamp is always recorded regardless of Active Tracing being active or not.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the postinstall script changed the ownership of `/etc/kong/kong.logrotate` to `kong:kong`, causing permission issues when executed by the root user. Ownership now resets to `root:root` after postinstall.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**graphql-rate-limiting-advanced**: Fixed an issue where the graphql-rate-limiting-advanced plugin's API threw 500 errors when handling HTTP PUT requests.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**JWT**: Fixed an issue where malformed JWT tokens (e.g. tokens without dots) caused a 500 Internal Server Error instead of returning 401 Unauthorized.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where `minLength` and `maxLength` constraints defined in a Swagger 2.0 parameter schema were not enforced.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where swagger `formData` parameters were not properly handled.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Fixed an issue where client-provided headers could be forwarded to upstream services when the corresponding JWT claim was missing from the token. The plugin now clears client headers before processing `upstream_headers_names`, ensuring that only verified JWT claim values are sent to upstream or downstream.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Fixed DPoP verification for opaque tokens (RFC 9449 Section 6.2) where Kong failed to correctly parse nested `cnf.jkt` claims from introspection responses.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**vault**: Fixed an issue where `kong.vault.update()` changed the secret to an empty string temporarily after changing vault config.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**core**: Improved performance of Kong core by using `ngx.var.http_*` instead of `kong.tools.http.get_header`.",
+        "type": "performance",
+        "scope": "Core"
+      },
+      {
+        "message": "Optimized `GET /kong` endpoint to use `SELECT DISTINCT` for populating `enabled_in_cluster` instead of iterating all plugin rows.",
+        "type": "performance",
+        "scope": "Admin API"
+      }
+    ],
+    "kong-manager-ee": [
+      {
+        "message": "Fixed workspace navigation for workspace names containing non-ASCII characters.",
+        "type": "bugfix",
+        "scope": "Default"
+      }
+    ]
+  },
+  "3.11.0.0": {
+    "kong": [
+      {
+        "message": "Bumped lua-kong-nginx-module from 0.15.1 to 0.15.2.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped OpenResty from 1.27.1.1 to 1.27.1.2.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "**Wasm**: removed ngx_wasm_module from default builds.",
+        "type": "dependency",
+        "scope": "Default"
+      },
+      {
+        "message": "**ai**: Added support for transforming, introspecting, and collecting metrics for image and audio generation requests, Responses API, and Realtime API. Added support for proxying Files, Batches, and Assistants API.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Added new config field genai_category 'text/embeddings' and new route_type 'llm/v1/embeddings'",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Fixed an issue where the Gemini provider could not use Anthropic 'rawPredict' endpoint models hosted in Vertex.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where latency metric was not implemented for streaming responses.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where SSE terminator may not have correct ending characters.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where the response body for observability may be larger than the real one because of the stale data.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where large request payload was not logged.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AWS-Lambda**: A warning message was added during schema validation on those plugins that contain a function name that does not comply with AWS Lambda's FunctionName pattern.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**cors**: Fixed an issue where requests with empty `origin` headers would cause empty reply from server.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Fixed an issue where `ca_certificate` cache was not invalidated when incremental sync was enabled.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where upstream connection pooling failed when pool names exceeded 32 characters  by applying a patch from upstream OpenResty.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed several issues that `kong start` and `kong stop` command throw error when the configuration contains vault reference and a prefix directory exists.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**jwt**: Fixed an issue where the WWW-Authenticate header used an incorrect delimiter, now using a comma as specified by RFC 7235.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Reverted removal of `translate_backwards` from plugins' metaschema in order to maintain backward compatibility.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Improved the performance of string splitting functions in Kong's core.",
+        "type": "performance",
+        "scope": "Core"
+      }
+    ],
+    "kong-ee": [
+      {
+        "message": "Bumped lua-kong-nginx-module from 0.15.2 to 0.15.3.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-resty-azure from 1.6.1 to 1.7.0.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped luarocks from 3.11.1 to 3.12.1. This fixes the error `main function has more than 65536 constants`, which was preventing rocks from being published or installed.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "ai-proxy, ai-proxy-advanced: Deprecated the `preserve` route_type. You are encouraged to use new route_types added in version 3.11.x.x and onwards.",
+        "type": "deprecation",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Added a configuration option `vault_secrets_lazy_load` to control how vault\nsecrets are loaded. When enabled, plugin options stored as vault secrets are\nloaded only when needed. This can save memory and reduce startup time but may\nincrease latency the first time a secret is accessed or after it expires. The\ndefault value is `off`, preserving the behavior of previous releases.",
+        "type": "feature",
+        "scope": "Configuration"
+      },
+      {
+        "message": "Added a new `kong.request.get_raw_forwarded_path()` function for returning non-normalized `forwarded_path`.",
+        "type": "feature",
+        "scope": "PDK"
+      },
+      {
+        "message": "Added an optional configuration parameter `admin_gui_hide_konnect_cta` that controls the visibility of the Konnect call-to-action in the Admin GUI.",
+        "type": "feature",
+        "scope": "Configuration"
+      },
+      {
+        "message": "Added an optional configuration parameter `service.tls_sans`. This allows to specify additional entries (either DNS names or URIs) for Subject Alternative Names validation of a TLS-based upstream.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added certificate-based authentication to the Hashicorp vault backend.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added support for OpenTelemetry formatted logs to the (tech preview) Active\nTracing feature",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added support for reporting whether `new_dns_client` and `incremental_sync` were enabled in anonymous reports.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added the sticky-sessions load-balancer algorithm.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**ai**: add support for the `huggingface` LLM Native format in the ai related plugins.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai**: added `model.options.bedrock.performance_config_latency` config parameter, to allow administrators to enforce performanceConfig 'latency' for all AWS Bedrock requests.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai**: Added support for the `cohere` LLM format in the ai related plugins. This allows users can directly use the `cohere` rerank API.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-aws-guardrails**: Added a new AI plugin that can protect requests and responses to/from AI LLM.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai**: Change sales counter sync per hour instead of per week.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**ai**: changed a description for the max_request_body_size schema field to clarify relation to the request body size limit.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai**: maps performanceConfig 'latency' field from client requests, for AWS Bedrock requests.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-prompt-compressor**: Added a new plugin that compresses prompt information in requests before they are proxied by the AI Proxy or AI Proxy Advanced plugin.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-rate-limiting-advanced**: Added support for the `namespace` field in the AI Rate Limiting Advanced plugin. This allows users to specify a ratelimiting namespace for the plugin, Similar to the existing `namespace` field in the `rate-limiting-advanced` plugin.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**confluent**: Added support for sending messages with dynamic keys to determine partitions.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Conjur Vault**: Added support for CyberArk Conjur Vault.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**Core**: Provided more granular and valuable latency metrics in Kong Gateway, aligning with our Active Tracing measurements.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Created internal JSON Object Signing and Encryption (JOSE) library to improve performance, features and security of several plugins.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**datakit**: Added new datakit plugin",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Fixed an issue where the `ai-prompt-decorator` plugin prompt field was too short.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**graphql-rate-limiting-advanced**: Added support for passing all downstream headers to GraphQL upstream servers in introspection requests.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**jwe**: Supported more encryption algorithms for jwe, including A128KW, A192KW, A256KW, ECDH-ES+A128KW, ECDH-ES+A192KW, ECDH-ES+A256KW, A128GCMKW, A192GCMKW, A256GCMKW.",
+        "type": "feature",
+        "scope": "PDK"
+      },
+      {
+        "message": "**kafka-consume**: Added WebSocket support to the kafka-consume plugin for consuming Kafka messages.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-log**: Added support for Kafka 4.0.\n**kafka-upstream**: Added support for Kafka 4.0.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-log**: Added support for Schema Registry integration with Confluent Schema Registry for AVRO and JSON schemas.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-log**: Added support for sending messages with dynamic keys to determine partitions.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-upstream**: Added support for sending messages with dynamic keys to determine partitions.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**llm**: Added support for Bedrock agent SDK, including rerand, converse, converse-stream, retrieveAndGenerate, and retrieveAndGenerate-stream.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Logged license model_hours exceeded warning when LLM model usage exceeded the limit.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**oas-validation**: Added support for validating `multipart/form-data` requests.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opentelemetry**: Added a new configuration field `sampling_strategy` to the plugin. The field allowed you to specify the sampling strategies for OTLP `traces`.\nSet `parent_drop_probability_fallback` if you want parent-based sampling when the parent span contains a `false` sampled flag, and fallback to probability-based sampling otherwise.\nSet `parent_probability_fallback` if you want parent-based sampling when the parent span contains a valid sampled flag (`true` or `false`), and fallback to probability-based sampling otherwise.\nThe default value is `parent_drop_probability_fallback` and keeps the instrumentation, sampling and exporting behaviour as before.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**prometheus**: added `consumer` label for ai metrics and added metrics for ai-rag-injector plugin.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: Marked the `auth_password` as an `encrypted` field.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: The plugin now logs the request URL, response code, and request latency (in milliseconds).",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: The plugin now sends a custom User-Agent header if one isn't provided. The default value is `kong/<kong_version>/request-callout`.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-validator**: Added support for specifying JSON schema draft versions.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Schema map values can now assume null values.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**Solace Upstream (beta)**: Added a new plugin which allows to transform requests into Solace messages in a Solace queue or topic.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**vault**: Added support to decode base64 secrets before using them.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added a new configuration, `route_match_calculation`, which included bug fixes for the `traditional_compatible` and the `expressions` router flavors.\nThe default value `original` retained the current `3.x` router matching behavior without changes. The value `strict` enforced the router matching behavior with corrected calculation as follows:\n1. The weight (priority point) of a route was incorrectly\n   downgraded.\n2. A route of HTTPS-only protocol with SNIs incorrectly captured\n   requests over HTTP routes.\n3. A route of TLS-only protocol with SNIs incorrectly captured\n   requests over TCP or UDP routes.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**ai-aws-guardrails**: Fixed an issue where the plugin did not support inspecting responses in non-stream mode.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "AI Azure Content Safety: Fixed an issue where Blocklist breaches are not correctly parsed.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI**: Fixed an issue where the password for the pgvector strategy was not being set correctly in the database.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**AI Plugins**: Fixed unable to use Titan Text Embeddings models.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-prompt-decorator**: Fixed an issue where the plugin would miss the model, temperature, and other user-defined fields.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Add `tried_targets` field in serialized analytics logs for record of all tried ai targets.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fix consistent-hashing algorithm not using correct value to hash.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy Advanced**: Fixed an issue where the stale semantic key vector may not be refreshed after the plugin config is updated.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy Advanced**: Fixed an issue where AI Proxy Advanced can't failover from other provider to Bedrock.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where model name did not escape when using AWS Bedrock inference profile.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where AI Proxy returns 403 using gemini provider.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where patterns using multiple capture groups (e.g., `$(group1)/$(group2)`) failed to extract expected matches.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-rate-limiting-advanced**: Fixed an issue where AI rate limiting advanced plugin might panic when use redis strategy and sync_rate is set to 0.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-semantic-cache**: Fixed an issue where SSE terminator may not have correct ending characters.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Blocked plugins to execute retry logic. Also improve testing funtions",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**degraphql**: Fixed an issue where the degraphql handle type Boolean was not being assigned correctly in the degraphql router.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Fix issue where schema library would fail with a nil reference if configurations are set via both deprecated and new names with diverging values",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where a change to a Partial in a custom workspace caused a communication issue between CP and DP on Incremental Config Sync mode.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where adding the `hash_subject` and `store_metadata` fields to the `portal_session_conf` in the Dev Portal was not working as expected.",
+        "type": "bugfix",
+        "scope": "Default"
+      },
+      {
+        "message": "Fixed an issue where AI Proxy and AI Proxy Advanced would use corrupted plugin config.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Fixed an issue where an external Python plugin cannot receive the updated value for its referenceable configuration fields.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Fixed an issue where CP may send sync notifications too frequently when incremental sync is enabled.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where crud event was triggered multiple times by event_hooks.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where data plane (DP) might receive incorrect data if the control plane's (CP) configuration version was older than the DP's version.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where dataplane nodes sometimes did not recover from sync failures, leading to recursive retries and failures.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where debug level logs for incremental sync were insufficient, making debugging more difficult.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where deleting an RBAC user would also delete a non-default role with the same name.",
+        "type": "bugfix",
+        "scope": "Admin API"
+      },
+      {
+        "message": "Fixed an issue where error logs were excessive when changing routes.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where events mechanism of clustering might be initialized repeatedly.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where full configuration sync caused data plane to stop proxying when incremental config sync is enabled.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where LMDB operation failures during incremental sync were not reported.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where modifying x-forwarded-for header before access phase may not take effect",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where new custom plugin creation during a full sync with incremental enabled would cause inconsistency. It now fails and reinitiating the sync in such case.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "-> Fixed an issue where newly spawned workers used outdated router data because the `init` phase was skipped.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where Pgvector index failed when using special characters in the name.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where Plugins were not exported correctly when using Partials in a custom workspace in Hybrid Mode.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where rate-limiting library could cause deadlock with Postgres.",
+        "type": "bugfix",
+        "scope": "Performance"
+      },
+      {
+        "message": "Fixed an issue where RPC calls miss the retry mechanism in the clustering system for resilience against transient network issues.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where some logs are missing when incremental sync is enabled on the Data Plane side.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where some of ai metrics was missed in analytics",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "-> Fixed an issue where sometimes the paginated sync incorrectly reports \"history lost\" and fails.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where the Active Tracing total time was not including connection and handshake times.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the Admin API returned a 500 error instead of a 401 error when an empty string was provided for the `Kong-Admin-Token` header.",
+        "type": "bugfix",
+        "scope": "Admin API"
+      },
+      {
+        "message": "Fixed an issue where the admin API might not fetch the workspace correctly during batch updates.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the CLI command `kong runner` crashes if using off strategy.",
+        "type": "bugfix",
+        "scope": "CLI Command"
+      },
+      {
+        "message": "Fixed an issue where the Control Plane (CP) would send duplicate sync notifications when configuration changes occurred.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where the control plane might not send RPC calls to the data plane correctly in some corner cases.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where the data plane (DP) may report healthy before it is actually ready to accept traffic.",
+        "type": "bugfix",
+        "scope": "Admin API"
+      },
+      {
+        "message": "Fixed an issue where the delta coalescing logic on the CP side might work inefficiently.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where the delta type was not being validated during incremental sync.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the error logs generated during router rebuilding might be excessively noisy.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the field `user_token_ident` was not being disallowed for update in the Admin API.",
+        "type": "bugfix",
+        "scope": "Admin API"
+      },
+      {
+        "message": "Fixed an issue where the IAM Authentication for RDS failed due to token not being refreshed under certain conditions.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the LMDB database file was created with incorrect permission when running kong cli command with root privileges.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the log lines might be incorrectly logged.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the Lua VM memory size returned by status API is not accurate on the control plane.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the rate limiting plugins can't handle decimal numbers when using Redis strategy.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Fixed an issue where the RPC framework might handle connections incorrectly on the data plane.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where the /schemas/plugins/validate endpoint returned a validation error\nwhen a plugin was linked to a partial containing a vault key.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the send request time was incorrectly calculated, now it should be more accurate.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where updating an entity in a non-default workspace during incremental sync\nmay not have been applied correctly.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where users encountered duplicate key violation errors on `rbac_role_entities_pkey` while using the `deck sync` command.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where validation incorrectly passed for mis-matched deprecated and new fields if the new field value\nwas false.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where validation might not report error message correctly when incremental sync was enabled.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where validation required all of `timeout` fields (`connect_timeout`, `read_timeout`, `send_timeout`)\nto have the same value. In reality only `connect_timeout` has to have the same value since that is the value used for\ngenerating the `timeout` field in the response if it is missing in the request.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where with small chance DP might repeatedly full sync when incremental sync is enabled.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "**forward-proxy**: Marked the `auth_password` in the `forward_proxy` plugin as an `encrypted` field.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**header-cert-auth**: Fixed an issue where Header Cert Authentication plugin failed to validate revocation using OCSP when the downstream connection wasn't an SSL connection.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**jwt-signer**: Fixed an issue where data planes didn't use the keys passed from the control plane to sign/re-sign.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka**: Fixed an issue where the Kafka SCRAM authentication did not send the server nonce.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**key-auth**: Fixed an issue where region was not permitted to be null for remote identity realms.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**key-auth**: Fixed an issue where external consumers could not be used with traditional Kong deployments, such as with KIC.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ldap-auth-advanced**: Fixed an issue that caused browsers to automatically pop up dialog boxes when authentication failed while `ldap-auth-advanced` was enabled in the Kong Manager.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**mocking**: Fixed an issue where an empty array set in the mocking plugin returned an object type instead of an array type in the response body.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**mtls-auth**: Fixed an issue where uselss interface is called when doing the OCSP client cert verification.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where the plugin throws an error for responses without a Content-Type header.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where query parameters with explode=false couldn't be validated.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where the plugin raises \"path not found error\" when include_base_path is set to true and the server url is \"/\".",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ollama**: Fixed an issue where 'tools' and 'RAG' decoration did not work for Ollama (llama2) provider.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Fixed an issue where the OIDC plugin caused the third-party IDP to throw an error during logout attempts if the session had already been invalidated.\nAdded the `client_id` to the logout URL to ensure the logout request is sent to the correct client, preventing such errors.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**OpenID-Connect**: Fixed an issue where caused IdP to report invalid redirect_uri errors when `config.redirect_uri` was not configured and the uri path contained spaces.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**prometheus**: Fixed an issue where AI latency histogram might miss some calculation.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**prometheus**: Fixed an issue where the metric `data_plane_config_hash` might not work correctly for incremental sync.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Prometheus**: Fixed an issue where the control plane failed to expose the `db_entities_total` metric.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: Fix issue where a callout response would not be available to response `by_lua` code",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: Fixed an issue where callouts with the same name would be accepted.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: Fixed an issue where values in `custom` would not accept explicit null values for removal of fields",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: Fixed an issue where callout and upstream request body customizations were not performed when an empty request body was provided; now, an empty JSON body is used and content-type JSON is added to the request.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: Fixed an issue where callout plugin failed with timeout when `callouts.request.body.custom` is null and `callouts.request.headers.forward` is true.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: Fixed an issue where the client request body is forwarded to upstream when `upstream.body.forward` is false.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: Fixed an issue where caching options modified via `by_lua` would apply to all subsequent callouts.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: Query parameters specified via `callout.request.query` will now correctly replace those in the callout URL.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-validator**: Fixed an issue where multipart/form-data content type was rejected.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**upstream-timeout**: Fixed an issue where `read_timeout`, `write_timeout`, and `connect_timeout` were set to 0, causing a runtime error.  After this release, any existing upstream-timeout plugin with these fields set to 0 will automatically update them to the default value of 60000.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Visiting kconfig.js from the Kong Manager UI no longer triggers warnings for vitals and portal deprecation.",
+        "type": "bugfix",
+        "scope": "Admin API"
+      },
+      {
+        "message": "**ai-proxy**: Implemented a faster SSE parser.",
+        "type": "performance",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Bumped page size for cluster sync to improve performance of full syncs.",
+        "type": "performance",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Improved performance by removing the n+1 query problem for plugins.\nPlugins are now fetched in bulk with plugins_partials and partials.",
+        "type": "performance",
+        "scope": "Core"
+      },
+      {
+        "message": "Improved RPC message queue responsiveness.",
+        "type": "performance",
+        "scope": "Clustering"
+      },
+      {
+        "message": "**JWT**: refactored plugin code to be more performant (measured to be at least three times faster).",
+        "type": "performance",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Improved performance for OpenAPI 3.1.",
+        "type": "performance",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: improved the performance of signature verification.",
+        "type": "performance",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Optimized query of the default workspace by directly accessing LMDB, improving performance.",
+        "type": "performance",
+        "scope": "Core"
+      },
+      {
+        "message": "**Rate-Limiting-Advanced**: Limited the length of the bucket identifier to prevent using strings longer than 256 characters for cache indexing, which could lead to high memory consumption in high-traffic scenarios.",
+        "type": "performance",
+        "scope": "Plugin"
+      },
+      {
+        "message": "If any [AI Gateway plugin](/plugins/?category=ai) has been enabled in a self-managed Kong Gateway deployment for more than a week, upgrades from 3.10 versions to 3.11.0.0 will fail due to a license migration issue.\nThis does not affect Konnect deployments. A fix will be provided in 3.11.0.1.\n\nSee [breaking changes in 3.11](/gateway/breaking-changes/#known-issues-in-3-11-0-0) for a temporary workaround.\n",
+        "type": "known-issues",
+        "scope": "Plugin",
+        "plugins": [
+          "ai-proxy",
+          "ai-proxy-advanced",
+          "ai-azure-content-safety",
+          "ai-prompt-decorator",
+          "ai-prompt-guard",
+          "ai-prompt-template",
+          "ai-rag-injector",
+          "ai-rate-limiting-advanced",
+          "ai-request-transformer",
+          "ai-response-transformer",
+          "ai-sanitizer",
+          "ai-semantic-cache",
+          "ai-semantic-prompt-guard"
+        ]
+      },
+      {
+        "message": "The Brotli module is missing from all of the following ARM64 Kong Gateway Docker images:\n* RHEL 9\n* Debian 12\n* Amazon Linux 2\n* Amazon Linux 2023\n",
+        "type": "known-issues",
+        "scope": "Core"
+      }
+    ],
+    "kong-manager-ee": [
+      {
+        "message": "Added a feature to persist the configuration format preference.",
+        "type": "feature",
+        "scope": "Default"
+      },
+      {
+        "message": "Added a new UI for the Request Callout plugin.",
+        "type": "feature",
+        "scope": "Default"
+      },
+      {
+        "message": "Improved the Route configuration form for a better user experience.",
+        "type": "feature",
+        "scope": "Default"
+      },
+      {
+        "message": "Improved the user experience in Kong Manager by fixing various UI-related issues.",
+        "type": "bugfix",
+        "scope": "Default"
+      }
+    ]
+  },
+  "3.10.0.13": {
+    "kong-ee": [
+      {
+        "message": "Fixed an issue where DP syncing failed with large configs. Added yielding to prevent CPU stall, and set Konnect mode RPC timeout to 30 seconds for successful full-sync.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where incremental DP (sync v2) would not export config to fallback storage when the control plane used periodic polling instead of `notify_new_version`.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where `kong.service.set_tls_cert_key` did not update the upstream keepalive pool name. It now includes a cert fingerprint for proper connection isolation.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue with the Kafka broker returning failed connections to the keepalive pool, added SSL handshake retry, and improved error propagation.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      }
+    ]
+  },
+  "3.10.0.12": {
+    "kong-ee": [
+      {
+        "message": "Bumped libexpat from 2.7.3 to 2.8.1 to address the issues: CVE-2026-25210, CVE-2026-24515, CVE-2026-32778, CVE-2026-32777, CVE-2026-32776, CVE-2026-41080, and CVE-2026-45186.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped OpenSSL from 3.5.5 to 3.5.6 to address the issues: CVE-2026-31790, CVE-2026-2673, CVE-2026-28387, CVE-2026-28388, CVE-2026-28389, CVE-2026-28390, and CVE-2026-31789.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Applied upstream nginx security patches for CVE-2026-40701, CVE-2026-40460, CVE-2026-42934, CVE-2026-42946, CVE-2026-42945, and CVE-2026-9256.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Security: Fixed CVE-2026-6338 in core proxy request header handling by preserving inbound `Content-Length` headers during hop-by-hop Connection header cleanup, preventing CL.0 request smuggling with crafted `Connection: Content-Length` headers on requests with a body.",
+        "type": "bugfix",
+        "scope": "Core"
+      }
+    ]
+  },
+  "3.10.0.11": {
+    "kong-ee": [
+      {
+        "message": "Bumped kong-lua-resty-ljsonschema from 1.2.0 to 1.3.3.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-resty-healthcheck from 3.1.1 to 3.1.2.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Added a `--lts_314_compatibility` option to the `check` command to perform configuration compatibility checks for upgrading to version 3.14.x.x.",
+        "type": "feature",
+        "scope": "CLI Command"
+      },
+      {
+        "message": "Added a safeguard to prevent the CP or DP from sending payloads larger than the configured `cluster_max_payload` size to each other, which could avoid the frequent disconnections and reconnection attempts and improve performance. Emitted a log entry telling the config payload size and the configured `cluster_max_payload` size when this happens.",
+        "type": "feature",
+        "scope": "Clustering"
+      },
+      {
+        "message": "**Debugger**: Fixed an issue where Redis command arguments were incorrectly included in Redis spans.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**Debugger**: Fixed an issue where the time spent during the TLS handshake was incorrectly added to Kong internal latency. This fix moved it to the client side latency.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**Debugger**: Fixed an issue where the Konnect Debugger concatenated `nil` and errored when accessing Kong Gateway via a Unix socket (e.g. `unix:/<prefix>/sockets/am:tls`).",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where Incremental Sync (ICS) would crash and stop further sync attempts.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Fixed an issue where Kong Manager users authenticated through IDPs such as OIDC or LDAP could retain stale RBAC groups or IDP-sourced roles after claim changes, or end up with inconsistent mappings during concurrent authentication requests.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the real client IP from Proxy Protocol was not correctly reflected in access logs and logging plugins when nginx rejected requests early (497 plain HTTP to HTTPS port) or when the client disconnected prematurely during header parsing. Added an nginx patch to resolve `$remote_addr` from `$proxy_protocol_addr` on early request termination, and added `error_page` 497 routing through `kong_error_handler`.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed clustering sync reliability issues by immediately failing pending sync v2 RPC callbacks on disconnect with a `connection closed` error.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "**key-auth**: Fixed an issue that prevented `region` from being set to `null` for remote identity realms.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**opa**: Fixed json body processing to recognize the `application/json` content-type with charset, ensuring proper handling of JSON request bodies.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Fixed an issue where Redis-backed session storage could fail when Redis connections were routed through a proxy.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-validator**: Added the `array_length_compat` config option to allow legacy Draft 4 schemas to use `minLength`/`maxLength` keywords for array length validation.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      }
+    ]
+  },
+  "3.10.0.10": {
+    "kong-ee": [
+      {
+        "message": "Bumped kong-gql from 0.2.3 to 0.2.4 to fix the null value issue in the GraphQL query syntax that causes a parsed AST error in the degraphql plugin.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "**kafka-log** and **kafka-upstream**: Added support for Kafka 4.0 to fix the Confluent deprecation.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**core**: Resolved an issue where HTTPS was incorrectly detected if multiple `X-Forwarded-Proto` values were provided.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where in the postinstall script that changed `/etc/kong/kong.logrotate`'s ownership and permissions. The script now restores ownership to `root:root` and sets permissions to 0644.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where `$remote_addr` was not replaced with the proxy protocol source address for early nginx error responses (501, 505) when `proxy_protocol` was enabled on the proxy listener. Also added proper error body messages for 501 and 505 status codes.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the Active Tracing would report incorrect `latencies.client` values due to not capturing the access end time properly. This fix ensures that the access end timestamp is always recorded regardless of Active Tracing being active or not.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the DP could spawn multiple sync timers when downgrading sync protocol to v1, which could cause excessive load on the CP and lead to performance degradation.",
+        "type": "bugfix",
+        "scope": "Clustering"
+      },
+      {
+        "message": "**graphql-rate-limiting-advanced**: Fixed an issue where the graphql-rate-limiting-advanced plugin's API threw 500 errors when handling HTTP PUT request.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-consume** and **confluent-consume**: Fixed an issue where the Kafka Consume and Confluent Consume plugins couldn't consume the correct message when the consuming offset of the topic was not 0.\n**kafka**: Fixed an issue of parsing ListOffset Response version 0.",
+        "type": "bugfix",
+        "scope": "Default"
+      },
+      {
+        "message": "**kafka-consume, confluent-consume**: Increased the minimum API version of FetchRequest from 0 to 4 for Kafka 3.x. No changes made for Kafka 4.0, as it is already using version 4.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka**: Fix issue where Kafka plugins produced records with incorrect `offsetDelta` in the record package.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-log**: Fixed an issue where certificates could not be loaded from non-default workspaces.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where `minLength` and `maxLength` constraints defined in a Swagger 2.0 parameter schema were not enforced.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Fixed an issue where client-provided headers could be forwarded to upstream services when the corresponding JWT claim was missing from the token. The plugin now clears client headers before processing `upstream_headers_names`, ensuring that only verified JWT claim values are sent to upstream or downstream.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Fixed DPoP verification for opaque tokens (RFC 9449 Section 6.2) where Kong failed to correctly parse nested `cnf.jkt` claims from introspection responses.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**service-protection**: Fixed an issue where the Service Protection plugin could count requests already rejected by Rate Limiting Advanced. Service Protection now executes after Rate Limiting Advanced and only evaluates requests that pass rate limiting, by updating its priority from 915 to 901.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**vault**: Fixed an issue where `kong.vault.update()` changed the secret to an empty string temporarily after changing vault config.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**core**: Improved performance of Kong core by using ngx.var.http_* instead of kong.tools.http.get_header.",
+        "type": "performance",
+        "scope": "Core"
+      },
+      {
+        "message": "Optimized `GET /kong` endpoint to use `SELECT DISTINCT` for populating `enabled_in_cluster` instead of iterating all plugin rows.",
+        "type": "performance",
+        "scope": "Admin API"
+      }
+    ],
+    "kong-manager-ee": [
+      {
+        "message": "Fixed workspace navigation for workspace names containing non-ASCII characters.",
+        "type": "bugfix",
+        "scope": "Default"
+      }
+    ]
+  },
+  "3.10.0.0": {
+    "kong": [
+      {
+        "message": "**AI Plugins**: Changed the serialized log key of AI metrics from `ai.ai-proxy` to `ai.proxy` to avoid conflicts with metrics generated from plugins other than AI Proxy and AI Proxy Advanced. If you are using logging plugins (for example, File Log, HTTP Log, etc.), you will have to update metrics pipeline configurations to reflect this change.",
+        "type": "Breaking Change",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kong.service.request.clear_query_arg**: Changed the encoding of spaces in query arguments from `+`\nto `%20` as a short-term solution to an issue that some users are reporting. While the `+` character is the correct\nencoding of space in querystrings, Kong uses `%20` in many other APIs (inherited from Nginx / OpenResty).",
+        "type": "Breaking Change",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Bumped atc-router from v1.6.2 to v1.7.1. This release contains upgraded dependencies and a new interface for validating expressions.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped Kong Nginx Module from 0.15.0 to 0.15.1.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped libexpat from 2.6.2 to 2.6.4 to fix a crash in the XML_ResumeParser function caused by XML_StopParser stopping an uninitialized parser.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-kong-nginx-module from 0.13.0 to 0.14.0.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-resty-simdjson from 1.1.0 to 1.2.0.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped `ngx_wasm_module` to `a376e67ce02c916304cc9b9ef25a540865ee6740`",
+        "type": "dependency",
+        "scope": "Default"
+      },
+      {
+        "message": "Bumped OpenResty from 1.25.3.2 to 1.27.1.1.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped OpenSSL to 3.4.1 in Core dependencies.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped PCRE2 from 10.44 to 10.45 (https://github.com/PCRE2Project/pcre2/blob/pcre2-10.45/NEWS).",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped Snappy Library from 1.2.0 to 1.2.1.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "**AI Plugins**: Deprecated `preserve` mode in `config.route_type`. Use `config.llm_format` instead. The `preserve` mode setting will be removed in a future release.",
+        "type": "deprecation",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Added a new configuration parameter `admin_gui_csp_header` to Gateway, which controls the Content-Security-Policy (CSP) header served with Admin GUI (Kong Manager). This defaults to `\"off\"`, and you can opt-in by setting it to `\"on\"`.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added a new field `x5t` to the entity `keys`, letting you use a X.509 Certificate Thumbprint to identify the key.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Backported the `balancer.set_upstream_tls` feature from the OpenResty upstream [openresty/lua-resty-core#460](https://github.com/openresty/lua-resty-core/pull/460).",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**CORS**: Added an option to skip returning the Access-Control-Allow-Origin response header when requests don't have the Origin header.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "dynamic control upstream tls when kong.service.request.set_scheme was called",
+        "type": "feature",
+        "scope": "PDK"
+      },
+      {
+        "message": "**OpenTelemetry**: This plugin now supports instana headers in propagation.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Opentelemetry**: This plugin now supports variable resource attributes.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Prometheus**: Added gauge to expose connectivity state to the control plane.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Prometheus**: Added the capability to enable or disable exporting of Proxy-Wasm metrics.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**session**: Added two boolean configuration fields `hash_subject` (default `false`) and `store_metadata` (default `false`) to store the session's metadata in the database.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "The upstream URI variable is now refreshed when the proxy pass balancer is recreated.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added a patch for `kong.resty.set_next_upstream()` to control the next upstream retry logic on the Lua side.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**AI Plugins**: Fixed an issue where AI upstream URL trailing would be empty.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed a bug in the Azure provider where `model.options.upstream_path` overrides would always return a 404 response.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed a bug where response streaming in Gemini and Bedrock providers was returning whole chat responses in one chunk.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed a bug where Azure streaming responses would be missing individual tokens.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed a bug with the Gemini provider, where multimodal requests (in OpenAI format) would not transform properly.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**authentications**: Improved the error message which occurred when an anonymous consumer was configured but did not exist.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AWS-Lambda**: Fixed an issue that occurred when `is_proxy_integration` was enabled, where Kong's response could behave incorrectly when the response was changed after the execution of the AWS Lambda plugin. The Content-Length header in the lambda function response is now ignored by the AWS Lambda plugin.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**file-log**: Fixed an issue where an error would occur when there were spaces at the beginning or end of a path.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Fixed an issue where a GET request to the Admin API root `/` path would return a 500 server error.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where a valid declarative config with certificate or SNI entities couldn't be loaded in DB-less mode.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where consistent hashing did not correctly handle hyphenated-Pascal-case headers, leading to uneven distribution of requests across upstream targets.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where `POST /config?flatten_errors=1` could return a JSON object instead of an empty array.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where `POST /config?flatten_errors=1` could not return a proper response if the input contained duplicate consumer credentials.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where `socket_path` permissions were not correctly set to `755` when the umask setting did not give enough permissions.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where targets couldn't be removed from the DNS query if they were deleted or updated via the Admin API.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the `db_resurrect_ttl` configuration didn't take effect.",
+        "type": "bugfix",
+        "scope": "Configuration"
+      },
+      {
+        "message": "Fixed an issue where the error reason wasn't thrown when parsing the certificate from vault.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the new DNS client did not correctly handle the timeout option in resolv.conf.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the schema library would error with a nil reference if an entity checker referred to a nonexistent field.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the `tls_verify`, `tls_verify_depth`, and `ca_certificates` properties of a service were not included in the upstream keepalive pool name.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed error caused by duplicate `Content-Type`.",
+        "type": "bugfix",
+        "scope": "Admin API"
+      },
+      {
+        "message": "Fixed potential connection leaks when the data plane failed to connect to the control plane.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**grpc-web** and **grpc-gateway**: Fixed a bug where the `TE` (transfer-encoding) header would not be sent to the upstream gRPC servers when `grpc-web` or `grpc-gateweay` are in use.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**response-ratelimiting**: Fixed an issue where usage headers that were supposed to be sent to the upstream were lost instead.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Users can now use a backslash to escape dots in logging plugins' `custom_fields_by_lua`  key strings, preventing dots from creating nested tables.",
+        "type": "bugfix",
+        "scope": "PDK"
+      },
+      {
+        "message": "Improved performance of trace ID size lookup.",
+        "type": "performance",
+        "scope": "Core"
+      },
+      {
+        "message": "Reduced the LMDB storage space by optimizing the key format.",
+        "type": "performance",
+        "scope": "Core"
+      },
+      {
+        "message": "Refined PDK usage for better performance.",
+        "type": "performance",
+        "scope": "PDK"
+      }
+    ],
+    "kong-ee": [
+      {
+        "message": "**ai-rate-limiting-advanced**: `window_size` and `limit` now require an array of numbers instead of a single number.\nIf you configured the plugin before 3.10 and use `kong migrations` to upgrade to 3.10, it will be automatically migrated to use the array.",
+        "type": "Breaking Change",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Free mode is no longer available. Starting Kong without a license will now function the same as Kong with an expired license.",
+        "type": "Breaking Change",
+        "scope": "Core"
+      },
+      {
+        "message": "**openid-connect**: Fixed an issue where forbidden requests were redirected to `unauthorized_redirect_uri` if configured. After the fix, forbidden requests will be redirected to `forbidden_redirect_uri` if configured.",
+        "type": "Breaking Change",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Bumped libxml2 from 2.12.9 to 2.12.10.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Updated included debug tools: `curl` to 8.12.1, the Mozilla CA Certificate Store to 2025-02-25, and `nghttp2` to 1.65.0.",
+        "type": "dependency",
+        "scope": "CLI Command"
+      },
+      {
+        "message": "Added a feature to store the last sync time on the Data Plane side.",
+        "type": "feature",
+        "scope": "Clustering"
+      },
+      {
+        "message": "Added a new core entity to Kong Gateway: partials. Partials enable users to define shared configuration for Redis.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added a new feature to invalidate the admin's or the developer's related session while changing the password.",
+        "type": "feature",
+        "scope": "Default"
+      },
+      {
+        "message": "Added external consumer support for Konnect.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "Added support for incremental config sync for hybrid mode deployments. Instead of sending the entire entity config to data planes on each config update, incremental config sync lets you send only the changed configuration to data planes.",
+        "type": "feature",
+        "scope": "Clustering"
+      },
+      {
+        "message": "**ai**: Added an AI Gateway sales counter for license reporting.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**ai**: Added support for boto3 SDKs for Bedrock provider, and for Google GenAI SDKs for Gemini provider.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai**: Added support for `pgvector` database in the `ai` related plugins.",
+        "type": "feature",
+        "scope": "Core"
+      },
+      {
+        "message": "**AI Plugins**: Added the `huggingface`, `azure`, `vertex`, and `bedrock` providers to embeddings. They can be used by the ai-proxy-advanced, ai-semantic-cache, ai-semantic-prompt-guard, and ai-rag-injector plugins.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Plugins**: Allow authentication to Bedrock services with assume roles in AWS.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy Advanced**: Added cost to `tokens_count_strategy` when using the lowest-usage load balancing strategy.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Added new `priority` balancer algorithm, which allows setting apriority group for each upstream model.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy Advanced**: Added the ability to set a catch-all target in semantic routing.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Added the `failover_criteria` configuration option, which allows retrying requests to the next upstream server in case of failure.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI-RAG-Injector**: Added a new plugin which allows automatically injecting documents to simplify building RAG pipelines.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-rate-limiting-advanced**: Added support for allowing multiple rate limits for the same providers.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-sanitizer**: Added a new plugin that can sanitize the PII information in requests before the requests are proxied by the AI Proxy or AI Proxy Advanced plugin.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Confluent**: Added support for message manipulation with the new configuration field `message_by_lua_functions`.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Confluent**: Added support for sending messages to multiple topics with `topics_query_arg`, and enabled topic allowlisting with `allowed_topics`.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**json-threat-protection**: Added the schema field `allow_duplicate_object_entry_name` to allow or disallow duplicate object keys in JSON payloads. When set to `false`, the plugin will reject JSON payloads with duplicate object keys. The default value is `true`, which is same as the previous behavior.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**jwe**: JWE now supports the following encryption algorithms: A128GCM, A192GCM, A128CBC-HS256, A192CBC-HS384, A256CBC-HS512.",
+        "type": "feature",
+        "scope": "PDK"
+      },
+      {
+        "message": "**kafka-consume** Added the `kafka-consume` plugin, which adds Kafka consumption capabilities to Kong.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-upstream**: Added support for message manipulation with the new configuration field `message_by_lua_functions`.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**kafka-upstream**: Added support for sending messages to multiple topics with `topics_query_arg`, and enabled topic allowlisting with `allowed_topics`.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Added support for `oneOf`, `anyOf`, `allOf`, and `not` keywords.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Added support for the `discriminator` keyword in OpenAPI specs.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**request-callout**: Added the `request-callout` plugin, which provides complex request augmentation and internal authentication.",
+        "type": "feature",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Updated `/license/report` endpoint to include counts for Kafka consumption, Confluent Kafka consumption, and Confluent production.",
+        "type": "feature",
+        "scope": "Admin API"
+      },
+      {
+        "message": "Added an optional configuration parameter `admin_gui_csp_header_value` to Gateway, which controls the value of the Content-Security-Policy (CSP) header served with Admin GUI (Kong Manager).",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Added support for the new Ollama streaming content type in the AI driver.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**AI Plugins**:",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where the ai-proxy-advanced plugin identity running failed in retry scenarios.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy-advanced**: Fixed an issue where the ai-proxy-advanced plugin failed to failover between providers of different formats.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an incorrect error thrown when trying to log streaming responses.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed an issue where Gemini streaming responses were getting truncated and/or missing tokens.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed preserve mode.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-proxy**: Fixed tool calls not working in streaming mode for Bedrock and Gemini providers.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-semantic-cache**: Fixed an issue where the Refresh header wasn't properly sent to the client.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-semantic-cache**: Fixed issue where the SSE body may have extra trailing.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ai-semantic-prompt-guard**: Fixed an issue where Kong Gateway was not able to reconfigure the plugin when using DB-less mode.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Analytics**: Fixed an issue where `trace_id` did not honor the value extracted during tracing headers propagation.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**app-dynamics**: Fixed a segmentation fault caused by a missing destructor call on process exit.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Created connection pools for each `host`, `port`, `username`, `ssl` combination to fix the following issues:",
+        "type": "bugfix",
+        "scope": "Default"
+      },
+      {
+        "message": "Fixed an issue where a certificate entity configured with a vault reference occasionally didn't get refreshed on time when initialized with an invalid string.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where a false error log was generated when a DELETE request with `Content-Type: application/json` and no body was made.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where a mismatch between If-Match in requests and ETag in responses would result in a bad case in the response phase.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where a newly spawned worker couldn't use RDS IAM authentication when an old worker was decommissioned.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where Admin API Enterprise-only entities were not writable when a license expired but was still in the grace period.",
+        "type": "bugfix",
+        "scope": "Admin API"
+      },
+      {
+        "message": "Fixed an issue where DNS answers with TTL=0 were incorrectly cached indefinitely in the new DNS client.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where event hooks sometimes ignored events, caused by the normalized table not including values of type number or boolean.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where Kong could have connection leaks when failing to connect to an upstream by websocket.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where Konnect analytics were missing for Kong AI Gateway.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where modifying x-forwarded header before access phase may not take effect",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where templates weren't being resolved correctly.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "Fixed an issue where the \"meta\" field was not validated when creating or updating a portal developer.",
+        "type": "bugfix",
+        "scope": "Admin API"
+      },
+      {
+        "message": "Fixed an issue where the PEM-formatted private keys in the keys entity were not encrypted when keyring was enabled.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**forward-proxy**: Fixed an issue where the `upstream_status` field was empty in logs when using the `forward-proxy` plugin.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**jq**: Fixed an issue where jq did not work properly with proxy-cache-advanced.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**json-threat-protection**: This plugin now accurately supports proxying for non-`POST/PUT/PATCH` requests.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**jwt-signer**: Fixed an issue where the jwt-signer plugin failed to upsert jwks if the jwks contains extra custom fields.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**ldap-auth-advanced**: Fixed an issue where binary string was truncated at the first null character.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**mocking**: Fixed an issue where random delays were out of range.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**oas-validation**: Fixed an issue where query params without values caused an assertion failure.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**pre-function**: Fixed an issue where a duplicate `protocols` field was accidentally added to the `pre-function` schema.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**rate-limiting-advanced**: Fixed an issue where the runtime failed due to `sync_rate` not being set if the `strategy` was `local`.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**service-protection**: Enhanced robustness for user misconfigurations. The following use cases are now handled:\n  - RLA and service-protection are configured on the same service.\n  - There is no service but the service-protection plugin is enabled with global scope.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**service-protection**: Fixed an issue where the runtime failed due to `sync_rate` not being set if the `strategy` was `local`.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "The plugins now support nested fields.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Vault**: Updated the AWS Vault supported regions list to the latest.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**oas-validation**: Improved performance on OpenAPI 3.0.",
+        "type": "performance",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**OpenID-Connect**: Removed issuer discovery from schema to improve performance upon plugin initialization or updating. The issuer discovery will only be triggerd by client requests.",
+        "type": "performance",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**AI Proxy**: Some active tracing latency values are incorrectly reported as having zero length when using the AI Proxy plugin.\n",
+        "type": "known-issues",
+        "scope": "Plugin"
+      },
+      {
+        "message": "The Brotli module is missing from all of the following ARM64 Kong Gateway Docker images:\n* RHEL 9\n* Debian 12\n* Amazon Linux 2\n* Amazon Linux 2023\n",
+        "type": "known-issues",
+        "scope": "Core"
+      },
+      {
+        "message": "When running in incremental sync mode ([`incremental_sync=on`](/gateway/configuration/#incremental-sync)), Kong Gateway can't apply configuration deltas to the stream subsystem. \nThis issue affects versions 3.10.0.0 and above, where incremental sync is enabled alongside stream proxying ([`stream_listen`](/gateway/configuration/#stream-listen)).\nAs a workaround for this issue, set `incremental_sync=off` when using stream proxying.\n",
+        "type": "known-issues",
+        "scope": "Core"
+      },
+      {
+        "message": "**Kafka Consume**: Kong Gateway allows you to configure the Kafka Consume plugin without authentication settings, but authentication must be configured for the plugin to work.\n\nIf authentication is not configured, or if the authentication strategy is missing, the plugin will fail with a generic authentication error.\n",
+        "type": "known-issues",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**Confluent Consume and Kafka Consume plugins**: An error message appears in the logs about a missing cluster name, even when the name is specified.\n",
+        "type": "known-issues",
+        "scope": "Plugin"
+      },
+      {
+        "message": "A bug originating from the underlying OpenResty platform affects connection pooling in certain circumstances. \nThis issue impacts transaction handling and negatively impacts performance, resulting in reduced request rates and increased latencies. \nVersions 3.10.0.0 and 3.10.0.1 are both affected. To resolve this regression, please upgrade to Kong Gateway 3.10.0.2 or later.\n",
+        "type": "known-issues",
+        "scope": "Core"
+      },
+      {
+        "message": "**Vault Auth**: The Vault Auth plugin doesn't clear its cache when incremental sync is turned on. This means that deleted secrets will remain in the cache, and can still be accessed by the plugin.\n",
+        "type": "known-issues",
+        "scope": "Plugin"
+      }
+    ],
+    "kong-manager-ee": [
+      {
+        "message": "Add Redis shared configuration support in Plugins.",
+        "type": "feature",
+        "scope": "Default"
+      },
+      {
+        "message": "Kong Manager now returns to the previous page upon canceling plugin editing.",
+        "type": "feature",
+        "scope": "Default"
+      },
+      {
+        "message": "Kong Manager now shows the scope option in gray when it can't be changed.",
+        "type": "feature",
+        "scope": "Default"
+      },
+      {
+        "message": "Fixed an issue where creating `jwt-credential` with special algorithms (`PS256`, `PS384`, `PS512`, and `EdDSA`) couldn't populate `rsa_public_key` in the Kong Manager.",
+        "type": "bugfix",
+        "scope": "Default"
+      },
+      {
+        "message": "Fixed an issue where editing an upstream would not remove the values of some fields (`client certificate`, `tags`, `timeouts`, and `host_header`, etc) in the Kong Manager.",
+        "type": "bugfix",
+        "scope": "Default"
+      },
+      {
+        "message": "Fixed an issue where the license expiration date was calculated incorrectly.",
+        "type": "bugfix",
+        "scope": "Default"
+      },
+      {
+        "message": "Fixed an issue where the lists in the UI would flicker under some circumstances.",
+        "type": "bugfix",
+        "scope": "Default"
+      }
+    ]
+  },
+  "3.4.3.27": {
+    "kong-ee": [
+      {
+        "message": "Bumped libexpat from 2.7.3 to 2.8.1 to address the issues: CVE-2026-25210, CVE-2026-24515, CVE-2026-32778, CVE-2026-32777, CVE-2026-32776, CVE-2026-41080, and CVE-2026-45186.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped OpenSSL from 3.5.5 to 3.5.6 to address the issues: CVE-2026-31790, CVE-2026-2673, CVE-2026-28387, CVE-2026-28388, CVE-2026-28389, CVE-2026-28390, and CVE-2026-31789.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Applied upstream nginx security patches for CVE-2026-40701, CVE-2026-42934, CVE-2026-42946, CVE-2026-42945, and CVE-2026-9256.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "Security: Fixed CVE-2026-6338 in core proxy request header handling by preserving inbound `Content-Length` headers during hop-by-hop Connection header cleanup, preventing CL.0 request smuggling with crafted `Connection: Content-Length` headers on requests with a body.",
+        "type": "bugfix",
+        "scope": "Core"
+      }
+    ]
+  },
+  "3.4.3.26": {
+    "kong-ee": [
+      {
+        "message": "Bumped kong-lua-resty-ljsonschema from 1.2.0 to 1.3.3.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Bumped lua-resty-healthcheck from 3.1.1 to 3.1.2.",
+        "type": "dependency",
+        "scope": "Core"
+      },
+      {
+        "message": "Fixed an issue where the real client IP from Proxy Protocol was not correctly reflected in access logs and logging plugins when nginx rejected requests early (497 plain HTTP to HTTPS port) or when the client disconnected prematurely during header parsing. Added an nginx patch to resolve `$remote_addr` from `$proxy_protocol_addr` on early request termination, and added `error_page` 497 routing through `kong_error_handler`.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**request-validator**: Added `array_length_compat` config option to allow legacy Draft 4 schemas to use `minLength`/`maxLength` keywords for array length validation.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      }
+    ],
+    "kong-manager-ee": [
+      {
+        "message": "Fixed workspace list and routing not working correctly when workspace count exceeds 1000.",
+        "type": "bugfix",
+        "scope": "Default"
+      }
+    ]
+  },
+  "3.4.3.25": {
+    "kong-ee": [
+      {
+        "message": "Fixed an issue where `$remote_addr` was not replaced with the proxy protocol source address for early nginx error responses (501, 505) when `proxy_protocol` is enabled on the proxy listener. Also added proper error body messages for 501 and 505 status codes.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**graphql-rate-limiting-advanced**: Fixed an issue where the graphql-rate-limiting-advanced plugin's API threw 500 errors when handling HTTP PUT requests.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**openid-connect**: Fixed an issue where client-provided headers could be forwarded to upstream services when the corresponding JWT claim was missing from the token. The plugin now clears client headers before processing `upstream_headers_names`, ensuring that only verified JWT claim values are sent to upstream or downstream.",
+        "type": "bugfix",
+        "scope": "Plugin"
+      },
+      {
+        "message": "**vault**: Fixed an issue where `kong.vault.update()` changed the secret to an empty string temporarily after changing a vault config.",
+        "type": "bugfix",
+        "scope": "Core"
+      },
+      {
+        "message": "**OpenID-Connect**: Removed issuer discovery from schema to improve performance upon plugin initialization or updating. The issuer discovery will only be triggerd by client requests.",
+        "type": "performance",
+        "scope": "Plugin"
+      }
+    ],
+    "kong-manager-ee": [
+      {
+        "message": "Fixed workspace navigation for workspace names containing non-ASCII characters.",
+        "type": "bugfix",
+        "scope": "Default"
       }
     ]
   }


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

We are now generating changelogs from the reviewed final version of the eng file, and reverse-engineering them to build the changelogs on the docs site. Regenerating these changelogs to pick up any edits that were made to those files.

Regenerated the latest supported minor versions (3.10.0.0, 3.11.0.0, 3.12.0.0, 3.13.0.0, 3.14.0.0) and all patch versions that have happened since the 3.14.0.0 release.

Please merge this before merging any other changelog PRs.

## Preview

https://deploy-preview-5595--kongdeveloper.netlify.app/gateway/changelog