### PR TITLE
chore(gateway): Bump CE version to 3.9.3

### DIFF
--- a/app/_data/products/gateway.yml
+++ b/app/_data/products/gateway.yml
@@ -561,7 +561,7 @@ releases:
               - Confluent Cloud
   - release: "3.9"
     ee-version: "3.9.1.2"
-    ce-version: "3.9.2"
+    ce-version: "3.9.3"
     eol: 2025-12-12
     sunset: true
     distributions:

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -215,7 +215,7 @@ mesh:
     - '\[.*\]\(https:\/\/github\.com\/[kK]ong\/kong-mesh.*\)'
 
 # Version vars
-latest_gateway_oss_version: "3.9.2"
+latest_gateway_oss_version: "3.9.3"
 
 # Operator vars
 operator_gatewayconfiguration_api_version: "v2beta1"


### PR DESCRIPTION
Bump to latest available version.

Merge only when release goes out.