### PR TITLE
fix(gateway): clarify DB-less license priority

### DIFF
--- a/app/_gateway_entities/license.md
+++ b/app/_gateway_entities/license.md
@@ -43,7 +43,7 @@ A License entity allows you configure a License in your self-managed {{site.base
 
 You receive a license file when you sign up for a {{site.ee_product_name}} subscription. If you purchased a subscription but haven’t received a license file, contact your sales representative.
 
-{{site.base_gateway}} checks for a license in the following order:
+In hybrid and traditional modes, {{site.base_gateway}} checks for a license in the following order and loads the license at startup:
 
 1. The contents of the environmental variable `KONG_LICENSE_DATA`.
 2. The default location `/etc/kong/license.json`.
@@ -51,6 +51,8 @@ You receive a license file when you sign up for a {{site.ee_product_name}} subsc
 4. A License directly deployed with the [`/licenses` Admin API endpoint](/api/gateway/admin-ee/#/operations/create-licenses).
 
 Each node independently checks for the license file when the {{site.base_gateway}} process starts. Network connectivity isn't required for license validation.
+
+In DB-less deployments (for example, when applying declarative configuration via `POST /config`), a license in the declarative configuration overrides `KONG_LICENSE_DATA`, because the environment variable is only read at startup. When a [`KongLicense` resource](/kubernetes-ingress-controller/license/) exists, {{ site.kic_product_name }} sends it in the configuration payload and it takes precedence.
 
 ## Deployment methods
 
@@ -255,4 +257,3 @@ rows:
       The data in the `license_expiration_date` field is incorrectly formatted. Try re-downloading and installing your license file from Kong. If you still receive this error after reinstallation, [contact Kong support](https://support.konghq.com).
 {% endtable %}
 <!--vale on-->
-

--- a/app/kubernetes-ingress-controller/license.md
+++ b/app/kubernetes-ingress-controller/license.md
@@ -77,6 +77,9 @@ There is no need to restart your Pods when updating a license.
 
 An alternative option is to use a static license Secret that will be used to populate {{ site.base_gateway }}'s `KONG_LICENSE_DATA` environment variable. This option allows you to store the license in Kubernetes secrets, but requires a Pod restart when the value of the secret changes.
 
+{:.info}
+> If a `KongLicense` resource also exists, it takes precedence over the static `KONG_LICENSE_DATA` license, because {{ site.kic_product_name }} sends it in the `POST /config` configuration payload. Deleting the `KongLicense` resource doesn't roll back to the environment variable—the gateway keeps the last pushed license until the Pod restarts.
+
 1. Create a file named `license.json` containing your {{site.base_gateway}} license and store it in a Kubernetes secret:
 
    ```bash


### PR DESCRIPTION


<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

In DB-less/declarative mode, a license pushed via POST /config overrides KONG_LICENSE_DATA at runtime. Documented on the Gateway and KIC license pages.

Fixes [FTI-7253](https://konghq.atlassian.net/browse/FTI-7253)

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).


[FTI-7253]: https://konghq.atlassian.net/browse/FTI-7253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ