### PR TITLE
chore(event-gateway): add a warning about internal headers

### DIFF
--- a/app/_event_gateway_policies/modify-headers/index.md
+++ b/app/_event_gateway_policies/modify-headers/index.md
@@ -37,6 +37,9 @@ icon: graph.svg
 
 The Modify Headers policy can set or remove headers on requests.
 
+{:.warning}
+> Headers prefixed with `kong/` are reserved for {{site.event_gateway_short}} internal use. The Modify Headers policy doesn't prevent you from reading, writing, or modifying them, but doing so isn't recommended and can interfere with {{site.event_gateway_short}} behavior. For the full list of reserved headers, see the [{{site.event_gateway}} headers reference](/event-gateway/headers/).
+
 ## Use cases
 
 Common use cases for the Modify Headers policy:


### PR DESCRIPTION
Making this clear to avoid people accidently using the product's reserved namespace

EVG-208

## Preview Links


## Checklist 

- [NA] Tested how-to docs. If not, note why here. 
- [NA] All pages contain metadata.
- [NA] Any new docs link to existing docs.
- [NA] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [NA] Every page has a `description` entry in frontmatter.
- [NA] Add new pages to the product documentation index (if applicable).
