### PR TITLE
feat(gateway): Oauth2 token support in event plugins

### DIFF
--- a/app/_includes/plugins/confluent/auth.md
+++ b/app/_includes/plugins/confluent/auth.md
@@ -1,4 +1,4 @@
-The plugin supports the following authentication options for Confluent Cloud connections:
+The {{include.name}} plugin supports the following authentication options for Confluent Cloud connections:
 {% table %}
 columns:
   - title: "Auth method"

--- a/app/_includes/plugins/confluent/auth.md
+++ b/app/_includes/plugins/confluent/auth.md
@@ -1,0 +1,21 @@
+The plugin supports the following authentication options for Confluent Cloud connections:
+{% table %}
+columns:
+  - title: "Auth method"
+    key: method
+  - title: Description
+    key: description
+  - title: Example
+    key: example
+rows:
+  - method: "API key (`cluster_api_key` / `cluster_api_secret`)"
+    description: "Authenticates using a Confluent Cloud API key and secret via SASL/PLAIN."
+    example: "--"
+  - method: |
+      SASL/OAUTHBEARER (`oauthbearer`) {% new_in 3.15 %}
+    description: |
+      Authenticates using short-lived OAuth 2.0 access tokens fetched automatically by {{site.base_gateway}}.
+      <br><br>
+      {{site.base_gateway}} uses the `client_credentials` grant to retrieve tokens from the configured `oauthbearer.token_endpoint_url`, caches them until expiry, and presents them in the SASL/OAUTHBEARER handshake. When `oauthbearer` is set, it takes precedence over `cluster_api_key`/`cluster_api_secret`.
+    example: "[SASL/OAUTHBEARER authentication](./examples/oauthbearer/)"
+{% endtable %}

--- a/app/_includes/plugins/kafka/auth.md
+++ b/app/_includes/plugins/kafka/auth.md
@@ -1,4 +1,4 @@
-The plugin supports the following SASL authentication mechanisms for broker connections via [`authentication.mechanism`](./reference/#schema--config-authentication-mechanism):
+The {{include.name}} plugin supports the following SASL authentication mechanisms for broker connections via [`authentication.mechanism`](./reference/#schema--config-authentication-mechanism):
 {% table %}
 columns:
   - title: "Mechanism"

--- a/app/_includes/plugins/kafka/auth.md
+++ b/app/_includes/plugins/kafka/auth.md
@@ -1,0 +1,41 @@
+The plugin supports the following SASL authentication mechanisms for broker connections via [`authentication.mechanism`](./reference/#schema--config-authentication-mechanism):
+{% table %}
+columns:
+  - title: "Mechanism"
+    key: mechanism
+  - title: Description
+    key: description
+  - title: Example
+    key: example
+rows:
+  - mechanism: "`PLAIN`"
+    description: |
+      Authenticates using a username and password.
+      <br><br>
+      Set `authentication.strategy` to `sasl` and provide `authentication.user` and `authentication.password`.
+    example: |
+      {% if include.slug == "kafka-consume" %}--{% else %}[Plain authentication](./examples/plain-auth/){% endif %}
+  - mechanism: "`SCRAM-SHA-256`"
+    description: |
+      Authenticates using a username and password with SCRAM-SHA-256 hashing.
+      <br><br>
+      Set `authentication.strategy` to `sasl` and provide `authentication.user` and `authentication.password`.
+    example: |
+      {% if include.slug == "kafka-consume" %}--{% else %}[SCRAM-SHA-256 authentication](./examples/scram-sha-256/){% endif %}
+  - mechanism: "`SCRAM-SHA-512`"
+    description: |
+      Authenticates using a username and password with SCRAM-SHA-512 hashing.
+      <br><br>
+      Set `authentication.strategy` to `sasl` and provide `authentication.user` and `authentication.password`.
+    example: |
+      {% if include.slug == "kafka-consume" %}--{% else %}[SCRAM-SHA-512 authentication](./examples/scram-sha-512/){% endif %}
+  - mechanism: |
+      `OAUTHBEARER` {% new_in 3.15 %}
+    description: |
+      Authenticates using short-lived OAuth 2.0 access tokens fetched automatically by {{site.base_gateway}}.
+      <br><br>
+      {{site.base_gateway}} uses the `client_credentials` grant to retrieve tokens from the configured `authentication.oauthbearer.token_endpoint_url`, caches them until expiry, and presents them in the SASL/OAUTHBEARER handshake.
+      <br><br>
+      Requires the `authentication.oauthbearer` block.
+    example: "[SASL/OAUTHBEARER authentication](./examples/oauthbearer/)"
+{% endtable %}

--- a/app/_includes/plugins/solace/auth.md
+++ b/app/_includes/plugins/solace/auth.md
@@ -1,0 +1,37 @@
+The plugin supports the following authentication schemes for Solace broker connections through [`session.authentication.scheme`](./reference/#schema--config-session-authentication-scheme):
+{% table %}
+columns:
+  - title: "Scheme"
+    key: scheme
+  - title: Description
+    key: description
+  - title: Example
+    key: example
+rows:
+  - scheme: "`NONE`"
+    description: "No authentication."
+    example: "--"
+  - scheme: "`BASIC`"
+    description: |
+      Authenticates using a username and password.
+      <br><br>
+      Provide `session.authentication.username` and `session.authentication.password`, or supply credentials via `session.authentication.basic_auth_header`.
+    example: |
+      {% if include.slug == "solace-upstream" %}[Send message to Solace queues with persistent delivery](./examples/configure-solace/){% elsif include.slug == "solace-log" %}[Enable Solace Logging](./examples/enable-solace-log/){% else %}--{% endif %}
+  - scheme: "`OAUTH2`"
+    description: |
+      Authenticates using a static OAuth 2.0 access token.
+      <br><br>
+      Provide `session.authentication.access_token` directly, or supply it via `session.authentication.access_token_header`.
+      The token must be rotated manually when it expires.
+    example: "--"
+  - scheme: |
+      `CLIENT_CREDENTIALS` {% new_in 3.15 %}
+    description: |
+      Authenticates using short-lived OAuth 2.0 access tokens fetched and renewed automatically by {{site.base_gateway}}.
+      <br><br>
+      {{site.base_gateway}} uses the `client_credentials` grant to retrieve tokens from `session.authentication.client_credentials.token_endpoint`, caches them until expiry, and retries with a fresh token if Solace returns an unauthenticated response.
+      <br><br>
+      Requires the `session.authentication.client_credentials` block.
+    example: "[OAuth 2.0 client credentials authentication](./examples/oauth-client-credentials/)"
+{% endtable %}

--- a/app/_includes/plugins/solace/auth.md
+++ b/app/_includes/plugins/solace/auth.md
@@ -1,4 +1,4 @@
-The plugin supports the following authentication schemes for Solace broker connections through [`session.authentication.scheme`](./reference/#schema--config-session-authentication-scheme):
+The {{include.name}} plugin supports the following authentication schemes for Solace broker connections through [`session.authentication.scheme`](./reference/#schema--config-session-authentication-scheme):
 {% table %}
 columns:
   - title: "Scheme"

--- a/app/_kong_plugins/confluent-consume/examples/oauthbearer.yaml
+++ b/app/_kong_plugins/confluent-consume/examples/oauthbearer.yaml
@@ -1,0 +1,49 @@
+description: 'Authenticate to Confluent Cloud using SASL/OAUTHBEARER. {{site.base_gateway}} fetches and renews OAuth 2.0 access tokens automatically using the client credentials grant.'
+
+title: 'SASL/OAUTHBEARER authentication'
+
+weight: 900
+
+min_version:
+  gateway: '3.15'
+
+requirements:
+  - "[Create a Kafka cluster in Confluent Cloud](https://docs.confluent.io/cloud/current/get-started/index.html#step-1-create-a-ak-cluster-in-ccloud)"
+  - "[Create a Kafka topic in the cluster](https://docs.confluent.io/cloud/current/get-started/index.html#step-2-create-a-ak-topic)"
+  - "An OAuth 2.0 identity provider that supports the client credentials grant"
+
+variables:
+  host:
+    description: 'The bootstrap server host.'
+    value: $BOOTSTRAP_SERVER_HOST
+  topic:
+    description: 'The name of the Kafka topic to consume from.'
+    value: $KAFKA_TOPIC
+  token_endpoint_url:
+    description: 'The URL of the OAuth 2.0 token endpoint.'
+    value: $TOKEN_ENDPOINT_URL
+  client_id:
+    description: 'The OAuth 2.0 client ID.'
+    value: $CLIENT_ID
+  client_secret:
+    description: 'The OAuth 2.0 client secret.'
+    value: $CLIENT_SECRET
+
+config:
+  bootstrap_servers:
+  - host: ${host}
+    port: 9092
+  topics:
+  - name: ${topic}
+  mode: http-get
+  oauthbearer:
+    token_endpoint_url: ${token_endpoint_url}
+    client_id: ${client_id}
+    client_secret: ${client_secret}
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform

--- a/app/_kong_plugins/confluent-consume/index.md
+++ b/app/_kong_plugins/confluent-consume/index.md
@@ -64,7 +64,7 @@ Kong also provides a [plugin for publishing messages to Confluent Cloud](/plugin
 
 ## Authentication
 
-{% include_cached /plugins/confluent/auth.md slug=page.slug %}
+{% include_cached /plugins/confluent/auth.md slug=page.slug name=page.name %}
 
 ## Implementation details
 

--- a/app/_kong_plugins/confluent-consume/index.md
+++ b/app/_kong_plugins/confluent-consume/index.md
@@ -62,6 +62,10 @@ For more information, see the [Confluent Cloud documentation](https://docs.confl
 
 Kong also provides a [plugin for publishing messages to Confluent Cloud](/plugins/confluent/).
 
+## Authentication
+
+{% include_cached /plugins/confluent/auth.md slug=page.slug %}
+
 ## Implementation details
 
 The plugin supports the following modes of operation:

--- a/app/_kong_plugins/confluent/examples/oauthbearer.yaml
+++ b/app/_kong_plugins/confluent/examples/oauthbearer.yaml
@@ -1,0 +1,47 @@
+description: 'Authenticate to Confluent Cloud using SASL/OAUTHBEARER. {{site.base_gateway}} fetches and renews OAuth 2.0 access tokens automatically using the client credentials grant.'
+
+title: 'SASL/OAUTHBEARER authentication'
+
+weight: 900
+
+min_version:
+  gateway: '3.15'
+
+requirements:
+  - "[Create a Kafka cluster in Confluent Cloud](https://docs.confluent.io/cloud/current/get-started/index.html#step-1-create-a-ak-cluster-in-ccloud)"
+  - "[Create a Kafka topic in the cluster](https://docs.confluent.io/cloud/current/get-started/index.html#step-2-create-a-ak-topic)"
+  - "An OAuth 2.0 identity provider that supports the client credentials grant"
+
+variables:
+  host:
+    description: 'The bootstrap server host.'
+    value: $BOOTSTRAP_SERVER_HOST
+  topic:
+    description: 'The name of the Kafka topic.'
+    value: $KAFKA_TOPIC
+  token_endpoint_url:
+    description: 'The URL of the OAuth 2.0 token endpoint.'
+    value: $TOKEN_ENDPOINT_URL
+  client_id:
+    description: 'The OAuth 2.0 client ID.'
+    value: $CLIENT_ID
+  client_secret:
+    description: 'The OAuth 2.0 client secret.'
+    value: $CLIENT_SECRET
+
+config:
+  bootstrap_servers:
+  - host: ${host}
+    port: 9092
+  topic: ${topic}
+  oauthbearer:
+    token_endpoint_url: ${token_endpoint_url}
+    client_id: ${client_id}
+    client_secret: ${client_secret}
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform

--- a/app/_kong_plugins/confluent/index.md
+++ b/app/_kong_plugins/confluent/index.md
@@ -64,6 +64,10 @@ With Kafka at its core, [Confluent](https://confluent.io) offers complete, fully
 > * The message format is not customizable.
 > * {{site.base_gateway}} supports Kafka 4.0 starting from version 3.10.
 
+## Authentication
+
+{% include_cached /plugins/confluent/auth.md slug=page.slug %}
+
 ## Schema registry support {% new_in 3.11 %}
 
 {% include_cached /plugins/confluent-kafka-consume/schema-registry.md name=page.name slug=page.slug workflow='producer' %}

--- a/app/_kong_plugins/confluent/index.md
+++ b/app/_kong_plugins/confluent/index.md
@@ -66,7 +66,7 @@ With Kafka at its core, [Confluent](https://confluent.io) offers complete, fully
 
 ## Authentication
 
-{% include_cached /plugins/confluent/auth.md slug=page.slug %}
+{% include_cached /plugins/confluent/auth.md slug=page.slug name=page.name %}
 
 ## Schema registry support {% new_in 3.11 %}
 

--- a/app/_kong_plugins/kafka-consume/examples/oauthbearer.yaml
+++ b/app/_kong_plugins/kafka-consume/examples/oauthbearer.yaml
@@ -1,0 +1,52 @@
+description: 'Authenticate to a Kafka broker using SASL/OAUTHBEARER. {{site.base_gateway}} fetches and renews OAuth 2.0 access tokens automatically using the client credentials grant.'
+
+title: 'SASL/OAUTHBEARER authentication'
+
+weight: 900
+
+min_version:
+  gateway: '3.15'
+
+requirements:
+  - "You have a [Kafka cluster](https://kafka.apache.org/documentation/#quickstart)"
+  - "You have a [Kafka topic](https://kafka.apache.org/documentation/#quickstart_createtopic) in the cluster"
+  - "An OAuth 2.0 identity provider that supports the client credentials grant"
+
+variables:
+  host:
+    description: 'The bootstrap server host.'
+    value: $BOOTSTRAP_SERVER_HOST
+  topic:
+    description: 'The name of the Kafka topic to consume from.'
+    value: $KAFKA_TOPIC
+  token_endpoint_url:
+    description: 'The URL of the OAuth 2.0 token endpoint.'
+    value: $TOKEN_ENDPOINT_URL
+  client_id:
+    description: 'The OAuth 2.0 client ID.'
+    value: $CLIENT_ID
+  client_secret:
+    description: 'The OAuth 2.0 client secret.'
+    value: $CLIENT_SECRET
+
+config:
+  bootstrap_servers:
+  - host: ${host}
+    port: 9092
+  topics:
+  - name: ${topic}
+  mode: http-get
+  authentication:
+    strategy: sasl
+    mechanism: OAUTHBEARER
+    oauthbearer:
+      token_endpoint_url: ${token_endpoint_url}
+      client_id: ${client_id}
+      client_secret: ${client_secret}
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform

--- a/app/_kong_plugins/kafka-consume/index.md
+++ b/app/_kong_plugins/kafka-consume/index.md
@@ -105,3 +105,7 @@ In traditional mode, {{site.base_gateway}} will log an error-level message at st
 In DB-less mode, if the declarative configuration file contains a `kafka-consume` plugin scoped to a Service, {{site.base_gateway}} will fail to start. In this case, you must update the declarative configuration before restarting {{site.base_gateway}}.
 
 In hybrid mode, if a `kafka-consume` plugin scoped to a Service exists in PostgreSQL, upgrading and restarting the control plane will succeed. However, before updating the data plane, you must update the plugin configuration. Otherwise, once the data plane is upgraded and restarted, it will fail to sync the configuration due to validation errors.
+
+## Authentication
+
+{% include_cached /plugins/kafka/auth.md slug=page.slug %}

--- a/app/_kong_plugins/kafka-consume/index.md
+++ b/app/_kong_plugins/kafka-consume/index.md
@@ -102,9 +102,14 @@ If you try to scope this plugin to a Service on a fresh {{site.base_gateway}} in
 
 In traditional mode, {{site.base_gateway}} will log an error-level message at startup if a `kafka-consume` plugin scoped to a Service is detected. The plugin configuration must be updated after startup. Until the configuration is updated, requests to the previous plugin URL will continue to be forwarded to the upstream Service, and responses will be returned to the downstream client as before.
 
-In DB-less mode, if the declarative configuration file contains a `kafka-consume` plugin scoped to a Service, {{site.base_gateway}} will fail to start. In this case, you must update the declarative configuration before restarting {{site.base_gateway}}.
+In DB-less mode, if the declarative configuration file contains a `kafka-consume` plugin scoped to a Service, {{site.base_gateway}} will fail to start. In this case, proceed as follows:
 
-In hybrid mode, if a `kafka-consume` plugin scoped to a Service exists in PostgreSQL, upgrading and restarting the control plane will succeed. However, before updating the data plane, you must update the plugin configuration. Otherwise, once the data plane is upgraded and restarted, it will fail to sync the configuration due to validation errors.
+1. Update the declarative configuration 1. Restart {{site.base_gateway}}.
+
+In hybrid mode, if a `kafka-consume` plugin scoped to a Service exists in PostgreSQL, upgrading and restarting the control plane will succeed. Then, to avoid validation errors on sync, follow these steps:
+
+1. Update the plugin configuration.
+1. Update and restart the data plane.
 
 ## Authentication
 

--- a/app/_kong_plugins/kafka-consume/index.md
+++ b/app/_kong_plugins/kafka-consume/index.md
@@ -108,4 +108,4 @@ In hybrid mode, if a `kafka-consume` plugin scoped to a Service exists in Postgr
 
 ## Authentication
 
-{% include_cached /plugins/kafka/auth.md slug=page.slug %}
+{% include_cached /plugins/kafka/auth.md slug=page.slug name=page.name %}

--- a/app/_kong_plugins/kafka-log/examples/oauthbearer.yaml
+++ b/app/_kong_plugins/kafka-log/examples/oauthbearer.yaml
@@ -1,0 +1,44 @@
+description: 'Authenticate to a Kafka broker using SASL/OAUTHBEARER. {{site.base_gateway}} fetches and renews OAuth 2.0 access tokens automatically using the client credentials grant.'
+
+title: 'SASL/OAUTHBEARER authentication'
+
+weight: 900
+
+min_version:
+  gateway: '3.15'
+
+requirements:
+  - "[Kafka installed](https://kafka.apache.org/quickstart#quickstart_download) and running"
+  - "[Create a Kafka topic](https://kafka.apache.org/quickstart#quickstart_createtopic)"
+  - "An OAuth 2.0 identity provider that supports the client credentials grant"
+
+variables:
+  topic:
+    description: 'The name of your Kafka topic.'
+    value: $KAFKA_TOPIC
+  token_endpoint_url:
+    description: 'The URL of the OAuth 2.0 token endpoint.'
+    value: $TOKEN_ENDPOINT_URL
+  client_id:
+    description: 'The OAuth 2.0 client ID.'
+    value: $CLIENT_ID
+  client_secret:
+    description: 'The OAuth 2.0 client secret.'
+    value: $CLIENT_SECRET
+
+config:
+  topic: ${topic}
+  authentication:
+    strategy: sasl
+    mechanism: OAUTHBEARER
+    oauthbearer:
+      token_endpoint_url: ${token_endpoint_url}
+      client_id: ${client_id}
+      client_secret: ${client_secret}
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform

--- a/app/_kong_plugins/kafka-log/index.md
+++ b/app/_kong_plugins/kafka-log/index.md
@@ -85,4 +85,4 @@ slug=page.slug %}
 
 ## Authentication
 
-{% include_cached /plugins/kafka/auth.md slug=page.slug %}
+{% include_cached /plugins/kafka/auth.md slug=page.slug name=page.name %}

--- a/app/_kong_plugins/kafka-log/index.md
+++ b/app/_kong_plugins/kafka-log/index.md
@@ -82,3 +82,7 @@ slug=page.slug %}
 ## Schema registry support {% new_in 3.11 %}
 
 {% include_cached /plugins/confluent-kafka-consume/schema-registry.md name=page.name slug=page.slug workflow='producer' %}
+
+## Authentication
+
+{% include_cached /plugins/kafka/auth.md slug=page.slug %}

--- a/app/_kong_plugins/kafka-upstream/examples/oauthbearer.yaml
+++ b/app/_kong_plugins/kafka-upstream/examples/oauthbearer.yaml
@@ -1,0 +1,44 @@
+description: 'Authenticate to a Kafka broker using SASL/OAUTHBEARER. {{site.base_gateway}} fetches and renews OAuth 2.0 access tokens automatically using the client credentials grant.'
+
+title: 'SASL/OAUTHBEARER authentication'
+
+weight: 900
+
+min_version:
+  gateway: '3.15'
+
+requirements:
+  - "[Kafka installed](https://kafka.apache.org/quickstart#quickstart_download) and running"
+  - "[Create a Kafka topic](https://kafka.apache.org/quickstart#quickstart_createtopic)"
+  - "An OAuth 2.0 identity provider that supports the client credentials grant"
+
+variables:
+  topic:
+    description: 'The name of your Kafka topic.'
+    value: $KAFKA_TOPIC
+  token_endpoint_url:
+    description: 'The URL of the OAuth 2.0 token endpoint.'
+    value: $TOKEN_ENDPOINT_URL
+  client_id:
+    description: 'The OAuth 2.0 client ID.'
+    value: $CLIENT_ID
+  client_secret:
+    description: 'The OAuth 2.0 client secret.'
+    value: $CLIENT_SECRET
+
+config:
+  topic: ${topic}
+  authentication:
+    strategy: sasl
+    mechanism: OAUTHBEARER
+    oauthbearer:
+      token_endpoint_url: ${token_endpoint_url}
+      client_id: ${client_id}
+      client_secret: ${client_secret}
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform

--- a/app/_kong_plugins/kafka-upstream/index.md
+++ b/app/_kong_plugins/kafka-upstream/index.md
@@ -75,4 +75,4 @@ Known limitations:
 
 ## Authentication
 
-{% include_cached /plugins/kafka/auth.md slug=page.slug %}
+{% include_cached /plugins/kafka/auth.md slug=page.slug name=page.name %}

--- a/app/_kong_plugins/kafka-upstream/index.md
+++ b/app/_kong_plugins/kafka-upstream/index.md
@@ -72,3 +72,7 @@ Known limitations:
 
 1. Message compression is not supported.
 1. In {{site.base_gateway}} 3.9 or earlier, the message format is not customizable.
+
+## Authentication
+
+{% include_cached /plugins/kafka/auth.md slug=page.slug %}

--- a/app/_kong_plugins/solace-consume/examples/oauth-client-credentials.yaml
+++ b/app/_kong_plugins/solace-consume/examples/oauth-client-credentials.yaml
@@ -1,0 +1,53 @@
+description: 'Authenticate to a Solace broker using OAuth 2.0 client credentials. {{site.base_gateway}} fetches and renews access tokens automatically.'
+
+title: 'OAuth 2.0 client credentials authentication'
+
+weight: 900
+
+min_version:
+  gateway: '3.15'
+
+requirements:
+  - "[Solace installed](https://docs.solace.com/API/API-Developer-Guide/Installation.htm) and running"
+  - "An OAuth 2.0 identity provider that supports the client credentials grant"
+  - "The Solace broker configured to accept OAuth 2.0 tokens"
+
+variables:
+  host:
+    description: 'The [IPv4 or IPv6 address or hostname](https://docs.solace.com/API-Developer-Online-Ref-Documentation/c/index.html#host-entry) of the Solace broker. Use a TLS listener, for example `tcps://127.0.0.1:55443`.'
+    value: SOLACE_HOST
+  queue:
+    description: 'The name of the Solace queue to consume from.'
+    value: SOLACE_QUEUE
+  token_endpoint:
+    description: 'The URL of the OAuth 2.0 token endpoint.'
+    value: $TOKEN_ENDPOINT_URL
+  client_id:
+    description: 'The OAuth 2.0 client ID.'
+    value: $CLIENT_ID
+  client_secret:
+    description: 'The OAuth 2.0 client secret.'
+    value: $CLIENT_SECRET
+
+config:
+  session:
+    host: ${host}
+    vpn_name: default
+    ssl_validate_certificate: true
+    authentication:
+      scheme: CLIENT_CREDENTIALS
+      client_credentials:
+        token_endpoint: ${token_endpoint}
+        client_id: ${client_id}
+        client_secret: ${client_secret}
+        eagerly_expire: 5
+  flow:
+    binds:
+      - name: ${queue}
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform

--- a/app/_kong_plugins/solace-consume/index.md
+++ b/app/_kong_plugins/solace-consume/index.md
@@ -133,6 +133,9 @@ rows:
     desc: "Enable SSL validation."
   - example: "[URI capture](./examples/uri-capture/)"
     desc: "Capture the URI of the request and use it as the message destination name."
+  - example: |
+      [OAuth 2.0 client credentials](./examples/oauth-client-credentials/) {% new_in 3.15 %}
+    desc: "Authenticate to a Solace broker using the `CLIENT_CREDENTIALS` scheme, with Kong fetching and renewing OAuth 2.0 tokens automatically."
 {% endtable %}
 
 ## Implementation details
@@ -150,3 +153,7 @@ The plugin supports the following modes of operation:
 ### Message delivery guarantees
 
 {% include /plugins/confluent-kafka-consume/message-delivery.md %}
+
+## Authentication
+
+{% include_cached /plugins/solace/auth.md slug=page.slug %}

--- a/app/_kong_plugins/solace-consume/index.md
+++ b/app/_kong_plugins/solace-consume/index.md
@@ -156,4 +156,4 @@ The plugin supports the following modes of operation:
 
 ## Authentication
 
-{% include_cached /plugins/solace/auth.md slug=page.slug %}
+{% include_cached /plugins/solace/auth.md slug=page.slug name=page.name %}

--- a/app/_kong_plugins/solace-log/examples/oauth-client-credentials.yaml
+++ b/app/_kong_plugins/solace-log/examples/oauth-client-credentials.yaml
@@ -1,0 +1,55 @@
+description: 'Authenticate to a Solace broker using OAuth 2.0 client credentials. {{site.base_gateway}} fetches and renews access tokens automatically.'
+
+title: 'OAuth 2.0 client credentials authentication'
+
+weight: 900
+
+min_version:
+  gateway: '3.15'
+
+requirements:
+  - "[Solace installed](https://docs.solace.com/API/API-Developer-Guide/Installation.htm) and running"
+  - "An OAuth 2.0 identity provider that supports the client credentials grant"
+  - "The Solace broker configured to accept OAuth 2.0 tokens"
+
+variables:
+  host:
+    description: 'The [IPv4 or IPv6 address or hostname](https://docs.solace.com/API-Developer-Online-Ref-Documentation/c/index.html#host-entry) of the Solace broker. Use a TLS listener, for example `tcps://127.0.0.1:55443`.'
+    value: SOLACE_HOST
+  destination:
+    description: 'The name of the Solace queue or topic to publish logs to.'
+    value: SOLACE_DESTINATION
+  token_endpoint:
+    description: 'The URL of the OAuth 2.0 token endpoint.'
+    value: $TOKEN_ENDPOINT_URL
+  client_id:
+    description: 'The OAuth 2.0 client ID.'
+    value: $CLIENT_ID
+  client_secret:
+    description: 'The OAuth 2.0 client secret.'
+    value: $CLIENT_SECRET
+
+config:
+  session:
+    host: ${host}
+    vpn_name: default
+    ssl_validate_certificate: true
+    authentication:
+      scheme: CLIENT_CREDENTIALS
+      client_credentials:
+        token_endpoint: ${token_endpoint}
+        client_id: ${client_id}
+        client_secret: ${client_secret}
+        eagerly_expire: 5
+  message:
+    destinations:
+      - name: ${destination}
+        type: QUEUE
+    delivery_mode: PERSISTENT
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform

--- a/app/_kong_plugins/solace-log/index.md
+++ b/app/_kong_plugins/solace-log/index.md
@@ -87,4 +87,4 @@ slug=page.slug %}
 
 ## Authentication
 
-{% include_cached /plugins/solace/auth.md slug=page.slug %}
+{% include_cached /plugins/solace/auth.md slug=page.slug name=page.name %}

--- a/app/_kong_plugins/solace-log/index.md
+++ b/app/_kong_plugins/solace-log/index.md
@@ -78,9 +78,13 @@ If the [custom Lua code](#custom-fields-by-lua) associated with the log fields f
 
 ## Custom fields by Lua
 
-{% include /plugins/logging/log-custom-fields-by-lua.md 
-custom_fields_by_lua='config.message.custom_fields_by_lua' 
-custom_fields_by_lua_slug='config-message-custom-fields-by-lua' 
-custom_fields_by_lua_name='custom_fields_by_lua' 
-name=page.name 
+{% include /plugins/logging/log-custom-fields-by-lua.md
+custom_fields_by_lua='config.message.custom_fields_by_lua'
+custom_fields_by_lua_slug='config-message-custom-fields-by-lua'
+custom_fields_by_lua_name='custom_fields_by_lua'
+name=page.name
 slug=page.slug %}
+
+## Authentication
+
+{% include_cached /plugins/solace/auth.md slug=page.slug %}

--- a/app/_kong_plugins/solace-upstream/examples/configure-solace.yaml
+++ b/app/_kong_plugins/solace-upstream/examples/configure-solace.yaml
@@ -16,19 +16,19 @@ weight: 900
 variables:
   host:
     description: 'The [IPv4 or IPv6 address or hostname](https://docs.solace.com/API-Developer-Online-Ref-Documentation/c/index.html#host-entry) of the Solace broker to connect to. For example, `tcp://127.0.0.1:55555`.'
-    value: SOLACE_HOST
+    value: $SOLACE_HOST
   username:
     description: 'The username used with `BASIC` authentication scheme when connecting to an event broker.'
-    value: SOLACE_USERNAME
+    value: $SOLACE_USERNAME
   password:
     description: 'The password used with `BASIC` authentication scheme when connecting to an event broker.'
-    value: SOLACE_PASSWORD
+    value: $SOLACE_PASSWORD
   queue1:
     description: 'The name of the first destination queue.'
-    value: QUEUE_NAME
+    value: $QUEUE_NAME
   queue2:
     description: 'The name of the second destination queue.'
-    value: ANOTHER_QUEUE_NAME
+    value: $ANOTHER_QUEUE_NAME
 
 config:
   session:

--- a/app/_kong_plugins/solace-upstream/examples/oauth-client-credentials.yaml
+++ b/app/_kong_plugins/solace-upstream/examples/oauth-client-credentials.yaml
@@ -1,0 +1,55 @@
+description: 'Authenticate to a Solace broker using OAuth 2.0 client credentials. {{site.base_gateway}} fetches and renews access tokens automatically.'
+
+title: 'OAuth 2.0 client credentials authentication'
+
+weight: 900
+
+min_version:
+  gateway: '3.15'
+
+requirements:
+  - "[Solace installed](https://docs.solace.com/API/API-Developer-Guide/Installation.htm) and running"
+  - "An OAuth 2.0 identity provider that supports the client credentials grant"
+  - "The Solace broker configured to accept OAuth 2.0 tokens"
+
+variables:
+  host:
+    description: 'The [IPv4 or IPv6 address or hostname](https://docs.solace.com/API-Developer-Online-Ref-Documentation/c/index.html#host-entry) of the Solace broker. Use a TLS listener, for example `tcps://127.0.0.1:55443`.'
+    value: SOLACE_HOST
+  topic:
+    description: 'The name of the Solace topic to publish to.'
+    value: SOLACE_TOPIC
+  token_endpoint:
+    description: 'The URL of the OAuth 2.0 token endpoint.'
+    value: $TOKEN_ENDPOINT_URL
+  client_id:
+    description: 'The OAuth 2.0 client ID.'
+    value: $CLIENT_ID
+  client_secret:
+    description: 'The OAuth 2.0 client secret.'
+    value: $CLIENT_SECRET
+
+config:
+  session:
+    host: ${host}
+    vpn_name: default
+    ssl_validate_certificate: true
+    authentication:
+      scheme: CLIENT_CREDENTIALS
+      client_credentials:
+        token_endpoint: ${token_endpoint}
+        client_id: ${client_id}
+        client_secret: ${client_secret}
+        eagerly_expire: 5
+  message:
+    destinations:
+      - name: ${topic}
+        type: TOPIC
+    delivery_mode: DIRECT
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform

--- a/app/_kong_plugins/solace-upstream/index.md
+++ b/app/_kong_plugins/solace-upstream/index.md
@@ -64,5 +64,5 @@ When encoding request bodies, several things happen:
 
 ## Authentication
 
-{% include_cached /plugins/solace/auth.md slug=page.slug %}
+{% include_cached /plugins/solace/auth.md slug=page.slug name=page.name %}
 

--- a/app/_kong_plugins/solace-upstream/index.md
+++ b/app/_kong_plugins/solace-upstream/index.md
@@ -62,3 +62,7 @@ When encoding request bodies, several things happen:
   then the body will be base64-encoded to ensure that the message can be sent as JSON. In such a case,
   the message has an extra attribute called `body_base64` set to `true`.
 
+## Authentication
+
+{% include_cached /plugins/solace/auth.md slug=page.slug %}
+


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Adds auth tables and examples.
No how-to guide at the moment; might add one in the future for one of the plugins (a separate one for each would be overkill).

Fixes #5404 
Fixes #5405 

## Preview Links

See all event plugins: https://deploy-preview-5608--kongdeveloper.netlify.app/plugins/?terms=event
