### PR TITLE
feat(gateway): Kafka record headers reference + examples

### DIFF
--- a/app/_includes/plugins/confluent-kafka-consume/record-headers.md
+++ b/app/_includes/plugins/confluent-kafka-consume/record-headers.md
@@ -1,0 +1,28 @@
+The {{include.name}} plugin can forward HTTP request headers as [Kafka record headers](https://kafka.apache.org/documentation/#recordheader), which are per-record key/value metadata that lives alongside the message key and value.
+This lets consumers read routing, tracing, or tenancy context without parsing the message payload.
+
+Configure the [`config.headers`](./reference/#schema--config-headers) block to control which headers are forwarded:
+
+{% table %}
+columns:
+  - title: Mode
+    key: mode
+  - title: Description
+    key: description
+  - title: Example
+    key: example
+rows:
+  - mode: "Allowlist ([`forward_all_by_default: false`](./reference/#schema--config-headers-forward-all-by-default))"
+    description: "Only forward headers listed in [`include_headers`](./reference/#schema--config-headers-include-headers)."
+    example: "[Forward HTTP headers as Kafka record headers (allowlist mode)](./examples/record-headers-allowlist/)"
+  - mode: "Blocklist ([`forward_all_by_default: true`](./reference/#schema--config-headers-forward-all-by-default))"
+    description: "Forward all headers except those listed in [`exclude_headers`](./reference/#schema--config-headers-exclude-headers)."
+    example: "[Forward HTTP headers as Kafka record headers (blocklist mode)](./examples/record-headers-blocklist/)"
+{% endtable %}
+
+Use [`config.headers.name_mappings`](./reference/#schema--config-headers-name-mappings) to rename an HTTP header to a different Kafka record header key.
+
+Use [`config.headers.repeated_headers_behavior`](./reference/#schema--config-headers-repeated-headers-behavior) to control how duplicate HTTP headers are handled: `retain_duplicates` (default) creates a separate record header per value, `take_first` uses only the first value, and `concatenate_by_comma` joins all values with a comma.
+
+{:.info}
+> **Note**: The [`config.forward_headers`](./reference/#schema--config-forward-headers) setting embeds request headers inside the message body. `config.headers` is a separate configuration block that sets native Kafka record headers on the produced record.

--- a/app/_kong_plugins/confluent/examples/record-headers-allowlist.yaml
+++ b/app/_kong_plugins/confluent/examples/record-headers-allowlist.yaml
@@ -1,4 +1,4 @@
-description: 'Forward HTTP request headers as Kafka record headers.'
+description: 'Forward selected HTTP request headers as Kafka record headers.'
 extended_description: |
   Use `config.headers` to copy HTTP request headers onto the produced Kafka record as native record headers.
   This makes routing, tracing, and tenancy context available to consumers without parsing the message payload.
@@ -14,16 +14,25 @@ min_version:
   gateway: '3.15'
 
 requirements:
- - "[Kafka installed](https://kafka.apache.org/quickstart#quickstart_download) and running"
- - "[Create a Kafka topic](https://kafka.apache.org/quickstart#quickstart_createtopic)"
+- "[Create a Kafka cluster in Confluent Cloud](https://docs.confluent.io/cloud/current/get-started/index.html#step-1-create-a-ak-cluster-in-ccloud)"
+- "[Create a Kafka topic in the cluster](https://docs.confluent.io/cloud/current/get-started/index.html#step-2-create-a-ak-topic)"
+- "Create an API key and secret in the cluster"
 
 variables:
   topic:
     description: The name of your Kafka topic.
     value: $KAFKA_TOPIC
+  cluster_api_key:
+    value: $CONFLUENT_CLUSTER_API_KEY
+    description: Your Confluent cluster API key.
+  cluster_api_secret:
+    value: $CONFLUENT_CLUSTER_API_SECRET
+    description: Your Confluent cluster API secret.
 
 config:
   topic: ${topic}
+  cluster_api_key: ${cluster_api_key}
+  cluster_api_secret: ${cluster_api_secret}
   headers:
     forward_http_headers_as_record_headers: true
     forward_all_by_default: false

--- a/app/_kong_plugins/confluent/examples/record-headers-blocklist.yaml
+++ b/app/_kong_plugins/confluent/examples/record-headers-blocklist.yaml
@@ -12,16 +12,25 @@ min_version:
   gateway: '3.15'
 
 requirements:
- - "[Kafka installed](https://kafka.apache.org/quickstart#quickstart_download) and running"
- - "[Create a Kafka topic](https://kafka.apache.org/quickstart#quickstart_createtopic)"
+- "[Create a Kafka cluster in Confluent Cloud](https://docs.confluent.io/cloud/current/get-started/index.html#step-1-create-a-ak-cluster-in-ccloud)"
+- "[Create a Kafka topic in the cluster](https://docs.confluent.io/cloud/current/get-started/index.html#step-2-create-a-ak-topic)"
+- "Create an API key and secret in the cluster"
 
 variables:
   topic:
     description: The name of your Kafka topic.
     value: $KAFKA_TOPIC
+  cluster_api_key:
+    value: $CONFLUENT_CLUSTER_API_KEY
+    description: Your Confluent cluster API key.
+  cluster_api_secret:
+    value: $CONFLUENT_CLUSTER_API_SECRET
+    description: Your Confluent cluster API secret.
 
 config:
   topic: ${topic}
+  cluster_api_key: ${cluster_api_key}
+  cluster_api_secret: ${cluster_api_secret}
   headers:
     forward_http_headers_as_record_headers: true
     forward_all_by_default: true

--- a/app/_kong_plugins/confluent/index.md
+++ b/app/_kong_plugins/confluent/index.md
@@ -67,3 +67,34 @@ With Kafka at its core, [Confluent](https://confluent.io) offers complete, fully
 ## Schema registry support {% new_in 3.11 %}
 
 {% include_cached /plugins/confluent-kafka-consume/schema-registry.md name=page.name slug=page.slug workflow='producer' %}
+
+## Kafka record headers {% new_in 3.15 %}
+
+The Confluent plugin can forward HTTP request headers as [Kafka record headers](https://kafka.apache.org/documentation/#recordheader), which are per-record key/value metadata that lives alongside the message key and value.
+This lets consumers read routing, tracing, or tenancy context without parsing the message payload.
+
+Configure the [`config.headers`](/plugins/confluent/reference/#schema--config-headers) block to control which headers are forwarded:
+
+{% table %}
+columns:
+  - title: Mode
+    key: mode
+  - title: Description
+    key: description
+  - title: Example
+    key: example
+rows:
+  - mode: "Allowlist ([`forward_all_by_default: false`](/plugins/confluent/reference/#schema--config-headers-forward-all-by-default))"
+    description: "Only forward headers listed in [`include_headers`](/plugins/confluent/reference/#schema--config-headers-include-headers)."
+    example: "[Forward HTTP headers as Kafka record headers (allowlist mode)](/plugins/confluent/examples/record-headers-allowlist/)"
+  - mode: "Blocklist ([`forward_all_by_default: true`](/plugins/confluent/reference/#schema--config-headers-forward-all-by-default))"
+    description: "Forward all headers except those listed in [`exclude_headers`](/plugins/confluent/reference/#schema--config-headers-exclude-headers)."
+    example: "[Forward HTTP headers as Kafka record headers (blocklist mode)](/plugins/confluent/examples/record-headers-blocklist/)"
+{% endtable %}
+
+Use [`config.headers.name_mappings`](/plugins/confluent/reference/#schema--config-headers-name-mappings) to rename an HTTP header to a different Kafka record header key.
+
+Use [`config.headers.repeated_headers_behavior`](/plugins/confluent/reference/#schema--config-headers-repeated-headers-behavior) to control how duplicate HTTP headers are handled: `retain_duplicates` (default) creates a separate record header per value, `take_first` uses only the first value, and `concatenate_by_comma` joins all values with a comma.
+
+{:.info}
+> **Note**: The [`config.forward_headers`](/plugins/confluent/reference/#schema--config-forward-headers) setting embeds request headers inside the message body. `config.headers` is a separate configuration block that sets native Kafka record headers on the produced record.

--- a/app/_kong_plugins/confluent/index.md
+++ b/app/_kong_plugins/confluent/index.md
@@ -70,31 +70,4 @@ With Kafka at its core, [Confluent](https://confluent.io) offers complete, fully
 
 ## Kafka record headers {% new_in 3.15 %}
 
-The Confluent plugin can forward HTTP request headers as [Kafka record headers](https://kafka.apache.org/documentation/#recordheader), which are per-record key/value metadata that lives alongside the message key and value.
-This lets consumers read routing, tracing, or tenancy context without parsing the message payload.
-
-Configure the [`config.headers`](/plugins/confluent/reference/#schema--config-headers) block to control which headers are forwarded:
-
-{% table %}
-columns:
-  - title: Mode
-    key: mode
-  - title: Description
-    key: description
-  - title: Example
-    key: example
-rows:
-  - mode: "Allowlist ([`forward_all_by_default: false`](/plugins/confluent/reference/#schema--config-headers-forward-all-by-default))"
-    description: "Only forward headers listed in [`include_headers`](/plugins/confluent/reference/#schema--config-headers-include-headers)."
-    example: "[Forward HTTP headers as Kafka record headers (allowlist mode)](/plugins/confluent/examples/record-headers-allowlist/)"
-  - mode: "Blocklist ([`forward_all_by_default: true`](/plugins/confluent/reference/#schema--config-headers-forward-all-by-default))"
-    description: "Forward all headers except those listed in [`exclude_headers`](/plugins/confluent/reference/#schema--config-headers-exclude-headers)."
-    example: "[Forward HTTP headers as Kafka record headers (blocklist mode)](/plugins/confluent/examples/record-headers-blocklist/)"
-{% endtable %}
-
-Use [`config.headers.name_mappings`](/plugins/confluent/reference/#schema--config-headers-name-mappings) to rename an HTTP header to a different Kafka record header key.
-
-Use [`config.headers.repeated_headers_behavior`](/plugins/confluent/reference/#schema--config-headers-repeated-headers-behavior) to control how duplicate HTTP headers are handled: `retain_duplicates` (default) creates a separate record header per value, `take_first` uses only the first value, and `concatenate_by_comma` joins all values with a comma.
-
-{:.info}
-> **Note**: The [`config.forward_headers`](/plugins/confluent/reference/#schema--config-forward-headers) setting embeds request headers inside the message body. `config.headers` is a separate configuration block that sets native Kafka record headers on the produced record.
+{% include_cached /plugins/confluent-kafka-consume/record-headers.md name=page.name %}

--- a/app/_kong_plugins/kafka-upstream/examples/record-headers-allowlist.yaml
+++ b/app/_kong_plugins/kafka-upstream/examples/record-headers-allowlist.yaml
@@ -1,0 +1,44 @@
+description: 'Forward HTTP request headers as Kafka record headers.'
+extended_description: |
+  Use `config.headers` to copy HTTP request headers onto the produced Kafka record as native record headers.
+  This makes routing, tracing, and tenancy context available to Consumers without parsing the message payload.
+
+  In allowlist mode (`forward_all_by_default: false`), only headers listed in `include_headers` are forwarded.
+  Use `name_mappings` to rename an HTTP header to a different record header key, for example renaming `x-request-id` to `trace-id`.
+
+title: 'Forward HTTP headers as Kafka record headers (allowlist mode)'
+
+weight: 890
+
+min_version:
+  gateway: '3.15'
+
+requirements:
+ - "[Kafka installed](https://kafka.apache.org/quickstart#quickstart_download) and running"
+ - "[Create a Kafka topic](https://kafka.apache.org/quickstart#quickstart_createtopic)"
+
+variables:
+  topic:
+    description: 'The name of your Kafka topic.'
+    value: $KAFKA_TOPIC
+
+config:
+  topic: ${topic}
+  headers:
+    forward_http_headers_as_record_headers: true
+    forward_all_by_default: false
+    include_headers:
+      - x-request-id
+      - x-tenant-id
+      - x-correlation-id
+    name_mappings:
+      x-request-id: trace-id
+      x-tenant-id: tenant
+    repeated_headers_behavior: concatenate_by_comma
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform

--- a/app/_kong_plugins/kafka-upstream/examples/record-headers-blocklist.yaml
+++ b/app/_kong_plugins/kafka-upstream/examples/record-headers-blocklist.yaml
@@ -1,0 +1,38 @@
+description: 'Forward all HTTP request headers as Kafka record headers, except those on an exclusion list.'
+extended_description: |
+  Use blocklist mode (`forward_all_by_default: true`) to forward every incoming HTTP header as a Kafka record header,
+  except for headers listed in `exclude_headers`.
+  This is useful for stripping sensitive headers like `authorization` or `cookie` while preserving all others.
+
+title: 'Forward HTTP headers as Kafka record headers (blocklist mode)'
+
+weight: 889
+
+min_version:
+  gateway: '3.15'
+
+requirements:
+ - "[Kafka installed](https://kafka.apache.org/quickstart#quickstart_download) and running"
+ - "[Create a Kafka topic](https://kafka.apache.org/quickstart#quickstart_createtopic)"
+
+variables:
+  topic:
+    description: 'The name of your Kafka topic.'
+    value: $KAFKA_TOPIC
+
+config:
+  topic: ${topic}
+  headers:
+    forward_http_headers_as_record_headers: true
+    forward_all_by_default: true
+    exclude_headers:
+      - authorization
+      - cookie
+    repeated_headers_behavior: retain_duplicates
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform

--- a/app/_kong_plugins/kafka-upstream/index.md
+++ b/app/_kong_plugins/kafka-upstream/index.md
@@ -66,6 +66,38 @@ When encoding request bodies, several things happen:
 
 {% include_cached /plugins/confluent-kafka-consume/schema-registry.md name=page.name slug=page.slug workflow='producer' %}
 
+## Kafka record headers {% new_in 3.15 %}
+
+The Kafka Upstream plugin can forward HTTP request headers as [Kafka record headers](https://kafka.apache.org/documentation/#recordheader), which are per-record key/value metadata that lives alongside the message key and value.
+This lets consumers read routing, tracing, or tenancy context without parsing the message payload.
+
+Configure the [`config.headers`](/plugins/kafka-upstream/reference/#schema--config-headers) block to control forwarding headers:
+
+{% table %}
+columns:
+  - title: Mode
+    key: mode
+  - title: Description
+    key: description
+  - title: Example
+    key: example
+rows:
+  - mode: "Allowlist ([`forward_all_by_default: false`](/plugins/kafka-upstream/reference/#schema--config-headers-forward-all-by-default))"
+    description: "Only forward headers listed in [`include_headers`](/plugins/kafka-upstream/reference/#schema--config-headers-include-headers)."
+    example: "[Forward HTTP headers as Kafka record headers (allowlist mode)](/plugins/kafka-upstream/examples/record-headers-allowlist/)"
+  - mode: "Blocklist ([`forward_all_by_default: true`](/plugins/kafka-upstream/reference/#schema--config-headers-forward-all-by-default))"
+    description: "Forward all headers except those listed in [`exclude_headers`](/plugins/kafka-upstream/reference/#schema--config-headers-exclude-headers)."
+    example: "[Forward HTTP headers as Kafka record headers (blocklist mode)](/plugins/kafka-upstream/examples/record-headers-blocklist/)"
+{% endtable %}
+
+Use [`config.headers.name_mappings`](/plugins/kafka-upstream/reference/#schema--config-headers-name-mappings) to rename an HTTP header to a different Kafka record header key.
+
+Use [`config.headers.repeated_headers_behavior`](/plugins/kafka-upstream/reference/#schema--config-headers-repeated-headers-behavior) to control how duplicate HTTP headers are handled: `retain_duplicates` (default) creates a separate record header per value, `take_first` uses only the first value, and `concatenate_by_comma` joins all values with a comma.
+
+{:.info}
+> **Note**: The [`config.forward_headers`](/plugins/kafka-upstream/reference/#schema--config-forward-headers) setting embeds request headers inside the message body. `config.headers` is a separate configuration block that sets native Kafka record headers on the produced record.
+
+
 ## Known issues and limitations
 
 Known limitations:

--- a/app/_kong_plugins/kafka-upstream/index.md
+++ b/app/_kong_plugins/kafka-upstream/index.md
@@ -68,34 +68,7 @@ When encoding request bodies, several things happen:
 
 ## Kafka record headers {% new_in 3.15 %}
 
-The Kafka Upstream plugin can forward HTTP request headers as [Kafka record headers](https://kafka.apache.org/documentation/#recordheader), which are per-record key/value metadata that lives alongside the message key and value.
-This lets consumers read routing, tracing, or tenancy context without parsing the message payload.
-
-Configure the [`config.headers`](/plugins/kafka-upstream/reference/#schema--config-headers) block to control forwarding headers:
-
-{% table %}
-columns:
-  - title: Mode
-    key: mode
-  - title: Description
-    key: description
-  - title: Example
-    key: example
-rows:
-  - mode: "Allowlist ([`forward_all_by_default: false`](/plugins/kafka-upstream/reference/#schema--config-headers-forward-all-by-default))"
-    description: "Only forward headers listed in [`include_headers`](/plugins/kafka-upstream/reference/#schema--config-headers-include-headers)."
-    example: "[Forward HTTP headers as Kafka record headers (allowlist mode)](/plugins/kafka-upstream/examples/record-headers-allowlist/)"
-  - mode: "Blocklist ([`forward_all_by_default: true`](/plugins/kafka-upstream/reference/#schema--config-headers-forward-all-by-default))"
-    description: "Forward all headers except those listed in [`exclude_headers`](/plugins/kafka-upstream/reference/#schema--config-headers-exclude-headers)."
-    example: "[Forward HTTP headers as Kafka record headers (blocklist mode)](/plugins/kafka-upstream/examples/record-headers-blocklist/)"
-{% endtable %}
-
-Use [`config.headers.name_mappings`](/plugins/kafka-upstream/reference/#schema--config-headers-name-mappings) to rename an HTTP header to a different Kafka record header key.
-
-Use [`config.headers.repeated_headers_behavior`](/plugins/kafka-upstream/reference/#schema--config-headers-repeated-headers-behavior) to control how duplicate HTTP headers are handled: `retain_duplicates` (default) creates a separate record header per value, `take_first` uses only the first value, and `concatenate_by_comma` joins all values with a comma.
-
-{:.info}
-> **Note**: The [`config.forward_headers`](/plugins/kafka-upstream/reference/#schema--config-forward-headers) setting embeds request headers inside the message body. `config.headers` is a separate configuration block that sets native Kafka record headers on the produced record.
+{% include_cached /plugins/confluent-kafka-consume/record-headers.md name=page.name %}
 
 
 ## Known issues and limitations


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Adds a reference blurb and examples for forwarding kafka record headers to the Kafka Upstream and Confluent plugins.

Fixes #5437 

## Preview Links

https://deploy-preview-5622--kongdeveloper.netlify.app/plugins/kafka-upstream/#kafka-record-headers
https://deploy-preview-5622--kongdeveloper.netlify.app/plugins/confluent/#kafka-record-headers