### PR TITLE
feat(gateway): Kafka upstream detailed errors

### DIFF
--- a/app/_kong_plugins/kafka-upstream/index.md
+++ b/app/_kong_plugins/kafka-upstream/index.md
@@ -66,6 +66,21 @@ When encoding request bodies, several things happen:
 
 {% include_cached /plugins/confluent-kafka-consume/schema-registry.md name=page.name slug=page.slug workflow='producer' %}
 
+## Debugging {% new_in 3.15 %}
+
+By default, produce failures return a generic error to the HTTP client and log the real cause in the {{site.base_gateway}} logs:
+
+```json
+{"message": "Bad Gateway", "error": "could not send message to topic"}
+```
+
+To include the detailed Kafka client error in the response instead, set [`config.error_handling.return_error_message`](/plugins/kafka-upstream/reference/#schema--config-error-handling-return-error-message) to `true` (`false` by default).
+This lets you see the exact broker rejection (for example, `TopicAuthorizationFailed`) without checking the {{site.base_gateway}} logs.
+
+{:.warning}
+> **Warning**: Do not enable this in production.
+> The detailed error may expose internal details like topic names and ACL denials.
+
 ## Known issues and limitations
 
 Known limitations:

--- a/app/_kong_plugins/kafka-upstream/index.md
+++ b/app/_kong_plugins/kafka-upstream/index.md
@@ -68,7 +68,7 @@ When encoding request bodies, several things happen:
 
 ## Debugging {% new_in 3.15 %}
 
-By default, produce failures return a generic error to the HTTP client and log the real cause in the {{site.base_gateway}} logs:
+By default, when producing a message fails, the plugin returns a generic error to the HTTP client and logs the real cause in the {{site.base_gateway}} logs:
 
 ```json
 {"message": "Bad Gateway", "error": "could not send message to topic"}


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Adds a debugging section for the kafka upstream plugin with the new error handling setting. No plugin example since it's a one-param change, but it felt like having info about debugging the plugin might be useful (even if it's just one setting).

Based on https://github.com/Kong/kong-technical-enablement/tree/main/api-gateway/3.15/surface-kafka-upstream-errors

## Preview Links
