### PR TITLE
docs(expressions): rename starts_with/ends_with to startsWith/endsWith

### DIFF
--- a/app/_includes/gateway/expressions/migrate.md
+++ b/app/_includes/gateway/expressions/migrate.md
@@ -5,8 +5,8 @@ In {{site.base_gateway}} 3.14, the feature was in beta and used ATC (Abstract Tr
 Any conditional expression that worked in 3.14 will need to be rewritten for 3.15.
 The main syntax changes are:
 
-* Prefix matching: `^=` → `starts_with()`. For example, `http.path ^= "/api"` becomes `http.path.starts_with("/api")`.
-* Suffix matching: `=^` → `ends_with()`. For example, `http.path =^ ".json"` becomes `http.path.ends_with(".json")`.
+* Prefix matching: `^=` → `startsWith()`. For example, `http.path ^= "/api"` becomes `http.path.startsWith("/api")`.
+* Suffix matching: `=^` → `endsWith()`. For example, `http.path =^ ".json"` becomes `http.path.endsWith(".json")`.
 * Regex matching: `~` → `matches()`. For example, `http.path ~ r#"^/api/v[0-9]+"#` becomes `http.path.matches("^/api/v[0-9]+")`.
 * The `http.path.segments.<index>` fields are replaced by `http.path_segments` (a list).
 * Header and query fields now return `null` when absent (instead of an empty string), so null checks may be needed.

--- a/app/gateway/plugins/expressions.md
+++ b/app/gateway/plugins/expressions.md
@@ -223,7 +223,7 @@ rows:
     type: "`string`"
     description: "The normalized request path, without query parameters."
     example: |
-      `http.path.starts_with("/api/v2")`
+      `http.path.startsWith("/api/v2")`
   - field: "`http.path_segments`"
     type: "`list<string>`"
     description: |
@@ -500,9 +500,9 @@ rows:
     description: "Tests whether a value is a member of a list."
   - type: "`contains()`"
     description: "Returns `true` if the string contains the given substring."
-  - type: "`starts_with()`"
+  - type: "`startsWith()`"
     description: "Returns `true` if the string starts with the given prefix."
-  - type: "`ends_with()`"
+  - type: "`endsWith()`"
     description: "Returns `true` if the string ends with the given suffix."
   - type: "`matches()`"
     description: |


### PR DESCRIPTION
Renames the expression plugin matcher functions in the docs from snake_case to camelCase:

- `starts_with()` → `startsWith()`
- `ends_with()` → `endsWith()`

Affected files:
- `app/gateway/plugins/expressions.md`
- `app/_includes/gateway/expressions/migrate.md`


We should keep our function name in plugin/expresssions with original [CEL spec](https://github.com/cel-expr/cel-spec/blob/master/doc/langdef.md), and it also aligns with [KEG expression](https://developer.konghq.com/event-gateway/expressions/).

background: https://kongstrong.slack.com/archives/C0A1JBUT7A9/p1782182809676519