### PR TITLE
feat(ai-gateway) migration review skill

### DIFF
--- a/skills/ai-gateway-migration-review/SKILL.md
+++ b/skills/ai-gateway-migration-review/SKILL.md
@@ -143,6 +143,24 @@ Not all v1 how-to guides have been migrated to v2. The only migrated v2 how-to i
 
 Any link in a v2 file that points to a how-to guide URL not directly in `app/_how-tos/ai-gateway/` should be flagged. Links to v1 how-tos (containing `/v1/`) should either be removed or flagged.
 
+### v1 release tracking (`app/_config/releases/ai-gateway/v1.yml`)
+
+This file tracks every v1 page and whether a v2 equivalent has been written. Each entry looks like:
+
+```yaml
+app/_how-tos/ai-gateway/v1/some-guide.md:
+  status: pending       # still needs a v2 equivalent
+  canonical_url:        # should point to the v2 page once written
+```
+
+When a new v2 page is created, the corresponding v1 entry in this file must be updated:
+- Remove `status: pending`
+- Set `canonical_url` to the new v2 page's permalink
+
+When reviewing a newly created v2 file, check whether its v1 counterpart exists in `v1.yml` and still has `status: pending`. If so, flag it: the reviewer should remove `status: pending` and set `canonical_url` to the new page's permalink.
+
+When reviewing all files, read `app/_config/releases/ai-gateway/v1.yml` and report all entries that still have `status: pending` — these are v1 pages that have not yet been migrated.
+
 ---
 
 ## Reporting format
@@ -163,6 +181,9 @@ When producing a **report**, structure it like this for each file reviewed:
 
 **Unmigrated how-to links:**
 - <link> — not yet migrated, remove or update
+
+**v1 release tracking (`v1.yml`):**
+- <v1 file path> — still has `status: pending`, set `canonical_url` to <v2 permalink>
 
 **On-prem references:**
 - Line N: <quote> — flag for removal

--- a/skills/ai-gateway-migration-review/SKILL.md
+++ b/skills/ai-gateway-migration-review/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: ai-gateway-migration-review
+description: >
+  Reviews AI Gateway documentation files for correctness during the v1 → v2 migration.
+  Use this skill whenever you need to audit or fix AI Gateway docs for migration issues —
+  whether reviewing specific files or all AI Gateway files across how-tos, landing pages,
+  and reference pages. Triggers on requests like "review this ai-gateway file", "check
+  my migration", "audit ai-gateway docs for v2", "find v1 references in ai-gateway pages",
+  "update this file for AI Gateway v2", or any time someone is working on AI Gateway
+  content under app/_how-tos/ai-gateway, app/_landing-pages/ai-gateway, or app/ai-gateway.
+---
+
+# AI Gateway Migration Review Skill
+
+This skill audits and optionally fixes AI Gateway documentation files for the v1 → v2 migration.
+
+## Step 1: Ask the user two questions upfront
+
+Before doing any work, ask (you can ask both in one message):
+
+1. **Scope**: Do they want to review a specific files or directories or all AI Gateway files?
+   - If specific files or directories, ask for the path.
+   - If all files, you'll scan these directories:
+     - `app/_how-tos/ai-gateway/`
+     - `app/_landing_pages/ai-gateway/`
+     - `app/ai-gateway/`
+
+2. **Mode**: Should you make changes directly, or produce a report of issues to fix?
+
+## Step 2: Perform the review
+
+Apply the rules below. For **report mode**, collect all findings and present them as a structured report at the end. For **edit mode**, apply fixes directly and summarize what changed.
+
+---
+
+## Rules for v1 files (under any `v1/` subdirectory)
+
+These files are the legacy v1 content. They need their own internal consistency:
+
+- **Breadcrumbs and links**: Any breadcrumbs or links starting with `/ai-gateway/` must use `/ai-gateway/v1/` (not the bare `/ai-gateway/` path).
+- **Permalinks**: If the file has a `permalink:` frontmatter field, it must contain `/v1/` in the path.
+- **Include and data file references**: References to AI Gateway include files (`{% include_content ... %}`, `{% include ... %}`) and data files must use the `/v1/` variant, e.g. `ai-gateway/v1/some-include` not `ai-gateway/some-include`.
+
+---
+
+## Rules for v2 files (current, non-v1 AI Gateway files)
+
+### Frontmatter requirements
+
+Every v2 AI Gateway page must have this exact frontmatter shape for these fields:
+
+```yaml
+products:
+    - ai-gateway          # Only ai-gateway, no other products
+works_on:
+    - konnect             # Only konnect, no on-prem
+tools:
+    - konnect-api         # Optional field, if it exists, must be only konnect-api
+min_version:
+    ai-gateway: '2.0'
+```
+
+Flag any deviation:
+- `products` containing anything other than `ai-gateway`
+- `works_on` containing `on-prem` or anything other than `konnect`
+- `tools` containing `deck`, `admin-api`, or anything other than `konnect-api`
+- Missing or wrong `min_version` (must be `ai-gateway: '2.0'`)
+
+### Plugin → AI Policy migration
+
+Plugins have been replaced by AI Policies in v2. The four plugins that do **not** exist as policies are exceptions:
+- AI A2A Proxy
+- AI MCP Proxy
+- AI Proxy
+- AI Proxy Advanced
+
+For everything else:
+
+- **Rename in prose**: Replace "X plugin" with "X AI Policy". For example:
+  - "AI Request Transformer plugin" → "AI Request Transformer AI Policy"
+  - "AI Prompt Guard plugin" → "AI Prompt Guard AI Policy"
+
+- **Links to plugins**: Replace `/plugins/` path with `/ai-gateway/policies/`. For example:
+  - `/plugins/ai-prompt-guard/` → `/ai-gateway/policies/ai-prompt-guard/`
+
+- **Exception — flag these**: Any reference to AI A2A Proxy, AI MCP Proxy, AI Proxy, or AI Proxy Advanced as plugins should be flagged for manual review (these don't have policy equivalents).
+
+- **Landing page plugin blocks**: In YAML landing pages (`.yaml` files under `_landing_pages/`), replace `type: plugin` blocks with `type: aigw_policy`. Example:
+  ```yaml
+  # Before (v1)
+  - type: plugin
+    config:
+      slug: ai-prompt-guard
+  
+  # After (v2)
+  - type: aigw_policy
+    config:
+      slug: ai-prompt-guard
+  ```
+
+### Include and data file references
+
+References to AI Gateway include files and data files must use `/v2/`. For example:
+- `ai-gateway/circuit-breaker` → `ai-gateway/v2/circuit-breaker`
+- `_includes/md/ai-gateway/circuit-breaker.md` → `_includes/md/ai-gateway/v2/circuit-breaker.md`
+
+Flag any `{% include /plugins/` tags — v2 AI Gateway pages must not pull in plugin includes. These should be removed or replaced with the appropriate AI Policy equivalent.
+
+### Code block style
+
+Example codeblocks in how-to guides should use `{% konnect_api_request %}` rather than raw curl or deck commands where they're making API calls. Flag any `curl` commands or `deck` commands in example steps that should be `{% konnect_api_request %}` blocks.
+
+### Konnect-only deployments
+
+v2 AI Gateway is Konnect-only. Flag any references to on-premises deployments, self-hosted Kong Gateway, or any instructions that only apply to on-prem.
+
+### Kong Gateway → AI Gateway
+
+References to Kong Gateway or `{{site.base_gateway}}` should be replaced with `{{site.ai_gateway}}`.
+
+### AI Gateway entity names
+
+All AI Gateway entity names (from `app/_ai_gateway_entities/`) must be capitalized and prefixed with "AI". Known entities:
+- AI Agent
+- AI Consumer
+- AI Consumer Credential
+- AI Consumer Group
+- AI Data Plane Certificate
+- AI Data Plane Node
+- AI Gateway
+- AI MCP Server
+- AI Model
+- AI Policy
+- AI Provider
+- AI Vault
+
+Flag any references to these entities without the "AI" prefix (e.g., "model" instead of "AI Model", "provider" instead of "AI Provider", "policy" instead of "AI Policy").
+
+### Links to unmigrated how-to guides
+
+Not all v1 how-to guides have been migrated to v2. The only migrated v2 how-to is currently:
+- `get-started-with-ai-gateway`
+
+Any link in a v2 file that points to a how-to guide URL not directly in `app/_how-tos/ai-gateway/` should be flagged. Links to v1 how-tos (containing `/v1/`) should either be removed or flagged.
+
+---
+
+## Reporting format
+
+When producing a **report**, structure it like this for each file reviewed:
+
+```
+### <filepath>
+
+**Frontmatter issues:**
+- <issue description>
+
+**Plugin → AI Policy issues:**
+- <issue description>
+
+**Include/data file references (including `{% include /plugins/` tags):**
+- <issue description>
+
+**Unmigrated how-to links:**
+- <link> — not yet migrated, remove or update
+
+**On-prem references:**
+- Line N: <quote> — flag for removal
+
+**Entity naming:**
+- <issue description>
+
+**No issues found** (if clean)
+```
+
+For a **single-file edit**, after making changes, produce a brief summary of every change made.
+
+For **all-files edit**, process files one at a time and produce a per-file summary at the end.

--- a/skills/ai-gateway-migration-review/SKILL.md
+++ b/skills/ai-gateway-migration-review/SKILL.md
@@ -76,9 +76,9 @@ Plugins have been replaced by AI Policies in v2. The four plugins that do **not*
 
 For everything else:
 
-- **Rename in prose**: Replace "X plugin" with "X AI Policy". For example:
-  - "AI Request Transformer plugin" → "AI Request Transformer AI Policy"
-  - "AI Prompt Guard plugin" → "AI Prompt Guard AI Policy"
+- **Rename in prose**: Replace "X plugin" with "X Policy". For example:
+  - "AI Request Transformer plugin" → "AI Request Transformer Policy"
+  - "AI Prompt Guard plugin" → "AI Prompt Guard Policy"
 
 - **Links to plugins**: Replace `/plugins/` path with `/ai-gateway/policies/`. For example:
   - `/plugins/ai-prompt-guard/` → `/ai-gateway/policies/ai-prompt-guard/`
@@ -134,7 +134,7 @@ All AI Gateway entity names (from `app/_ai_gateway_entities/`) must be capitaliz
 - AI Provider
 - AI Vault
 
-Flag any references to these entities without the "AI" prefix (e.g., "model" instead of "AI Model", "provider" instead of "AI Provider", "policy" instead of "AI Policy").
+Flag any references to these entities without the "AI" prefix (e.g., "model" instead of "AI Model", "provider" instead of "AI Provider", "policy" instead of "AI Policy"). **Check the entire file including frontmatter** — FAQs, `related_resources` links, and all entity references in link text must use the full "AI" prefix (e.g., `[AI Policy entity]` not `[Policy entity]`).
 
 ### Links to unmigrated how-to guides
 

--- a/skills/ai-gateway-migration-review/SKILL.md
+++ b/skills/ai-gateway-migration-review/SKILL.md
@@ -122,7 +122,7 @@ v2 AI Gateway is Konnect-only. Flag any references to on-premises deployments, s
 
 ### Kong Gateway → AI Gateway
 
-References to Kong Gateway or `{{site.base_gateway}}` should be replaced with `{{site.ai_gateway}}`.
+Most references to Kong Gateway or `{{site.base_gateway}}` should be replaced with `{{site.ai_gateway}}`. However, some are legitimate — when a sentence genuinely compares or contrasts AI Gateway with Kong Gateway (e.g. "When operating {{site.ai_gateway}} alongside {{site.base_gateway}}…"), the `{{site.base_gateway}}` reference may be intentional. Flag these for manual review rather than replacing them automatically.
 
 ### AI Gateway entity names
 
@@ -140,7 +140,15 @@ All AI Gateway entity names (from `app/_ai_gateway_entities/`) must be capitaliz
 - AI Provider
 - AI Vault
 
-Flag any references to these entities without the "AI" prefix (e.g., "model" instead of "AI Model", "provider" instead of "AI Provider", "policy" instead of "AI Policy"). **Check the entire file including frontmatter** — FAQs, `related_resources` links, and all entity references in link text must use the full "AI" prefix (e.g., `[AI Policy entity]` not `[Policy entity]`).
+Flag any references to these entities without the "AI" prefix, in both singular and plural forms. For example:
+- "model" or "models" → "AI Model" / "AI Models"
+- "provider" or "providers" → "AI Provider" / "AI Providers"
+- "policy" or "policies" → "AI Policy" / "AI Policies"
+- "agent" or "agents" → "AI Agent" / "AI Agents"
+- "consumer" or "consumers" → "AI Consumer" / "AI Consumers"
+- "vault" → "AI Vault"
+
+**Check the entire file including frontmatter** — FAQs, `related_resources` links, and all entity references in link text must use the full "AI" prefix (e.g., `[AI Policies](/ai-gateway/entities/ai-policy/)` not `[Policies](/ai-gateway/entities/ai-policy/)`).
 
 ### Links to unmigrated how-to guides
 

--- a/skills/ai-gateway-migration-review/SKILL.md
+++ b/skills/ai-gateway-migration-review/SKILL.md
@@ -104,7 +104,13 @@ References to AI Gateway include files and data files must use `/v2/`. For examp
 - `ai-gateway/circuit-breaker` → `ai-gateway/v2/circuit-breaker`
 - `_includes/md/ai-gateway/circuit-breaker.md` → `_includes/md/ai-gateway/v2/circuit-breaker.md`
 
-Flag any `{% include /plugins/` tags — v2 AI Gateway pages must not pull in plugin includes. These should be removed or replaced with the appropriate AI Policy equivalent.
+Flag any `{% include /plugins/` tags — v2 AI Gateway pages must not pull in plugin includes. These should be removed or replaced with the appropriate AI Policy equivalent. For example:
+
+```
+{% include /plugins/ai-a2a-proxy/log-output-fields.md %}
+```
+
+This should be replaced with a corresponding AI Policy include (e.g. under `_includes/md/ai-gateway/v2/`) or removed if no equivalent exists.
 
 ### Code block style
 
@@ -138,10 +144,9 @@ Flag any references to these entities without the "AI" prefix (e.g., "model" ins
 
 ### Links to unmigrated how-to guides
 
-Not all v1 how-to guides have been migrated to v2. The only migrated v2 how-to is currently:
-- `get-started-with-ai-gateway`
+Not all v1 how-to guides have been migrated to v2. Before checking links, build a list of invalid v1 permalinks by reading every `.md` file under `app/_how-tos/ai-gateway/v1/` and extracting their `permalink:` frontmatter values.
 
-Any link in a v2 file that points to a how-to guide URL not directly in `app/_how-tos/ai-gateway/` should be flagged. Links to v1 how-tos (containing `/v1/`) should either be removed or flagged.
+Then, in the file being reviewed, flag any link whose URL appears in that list. These point to legacy v1 pages and should be removed or updated to point to the v2 equivalent if one exists.
 
 ### v1 release tracking (`app/_config/releases/ai-gateway/v1.yml`)
 


### PR DESCRIPTION
## Description

Here's the report it generated on the AI Gateway landing page:

## Frontmatter issues

- `products` contains `gateway` in addition to `ai-gateway` — remove `gateway`
- `works_on` contains `on-prem` — remove, leave `konnect` only
- `min_version` field is missing — add `min_version: {ai-gateway: '2.0'}`

---

## Plugin → AI Policy issues

16 `type: plugin` blocks must be changed to `type: aigw_policy`:

| Lines | Slug |
|-------|------|
| 338–340 | `ai-prompt-guard` |
| 342–344 | `ai-semantic-prompt-guard` |
| 346–348 | `ai-sanitizer` |
| 359–361 | `ai-prompt-template` |
| 363–365 | `ai-prompt-decorator` |
| 376–378 | `ai-azure-content-safety` |
| 380–382 | `ai-aws-guardrails` |
| 384–386 | `ai-gcp-model-armor` |
| 388–390 | `ai-semantic-prompt-guard` |
| 392–394 | `ai-semantic-response-guard` |
| 396–399 | `ai-lakera-guard` |
| 401–404 | `ai-custom-guardrail` |
| 416–418 | `ai-request-transformer` |
| 420–422 | `ai-response-transformer` |
| 446–448 | `ai-rag-injector` |
| 486–488 | `ai-prompt-compressor` |

Exception plugin references requiring manual review (no policy equivalent):

- Line 413: "These policies can be configured independently of **AI Proxy**." — needs rewording or removal
- Line 483: "you can use **AI Proxy Advanced** to route requests across OpenAI models" — needs rewording or removal

---

## Include/data file references

No `{% include %}` or `{% include /plugins/ %}` tags found. ✅

---

## Unmigrated how-to links

- Line 505: `/how-to/use-semantic-load-balancing` — verify this URL exists and is migrated for v2

---

## On-prem references

- Lines 38–41: "launch a local demo instance of {{site.ai_gateway}} with a single command: `curl -Ls https://get.konghq.com/ai | bash`" — local/self-hosted setup, remove or replace with Konnect onboarding
- Lines 183–184: "Deployment topologies" and "Hosting options" links under "Deployment checklist" reference on-prem concepts; line 183 also contains `{{ site.base_gateway }}` (see Kong Gateway section below)
- Lines 570–572 (FAQ): "available across deployment modes, including … self-hosted traditional, hybrid, and DB-less, and on Kubernetes via the KIC" — explicitly states on-prem availability; update or remove for v2

---

## Kong Gateway → AI Gateway

- Line 170 (commented out): `{{site.base_gateway}}` in a commented deck line — low priority, but worth noting
- Line 183: `{{ site.base_gateway }}` in "Learn about the different ways to deploy `{{ site.base_gateway }}`." — replace with `{{site.ai_gateway}}`
- Line 574: FAQ question "instead of adding the LLM's API behind `{{site.base_gateway}}`?" — replace with `{{site.ai_gateway}}`
- Lines 576–577: Two `{{site.base_gateway}}` references in the FAQ answer — replace both with `{{site.ai_gateway}}`

---

## Entity naming

- Line 251: "Create Models, Providers, Agents, and MCP Servers" — missing "AI" prefix; should be "AI Models, AI Providers, AI Agents, and AI MCP Servers"


## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
