### PR TITLE
feat(aigw): Add "Previous versions of this page" sections to the layout

### DIFF
--- a/app/_includes/info_box/sections/previous_versions.html
+++ b/app/_includes/info_box/sections/previous_versions.html
@@ -1,0 +1,18 @@
+<div class="flex flex-col gap-2  w-full">
+  <div class="flex items-center gap-1 text-primary font-medium">
+    <span>Previous Versions of this page</span>
+  </div>
+  <div class="flex gap-3 flex-col">
+    {% assign product = site.data.products[include.product] %}
+    {% for version_map in include.previous_major_urls %}
+      <div class="flex gap-2 items-center">
+        {% include mask_image.html image_url='/assets/icons/service-document.svg' css_classes="w-5 h-5 shrink-0 !bg-icon" %}
+        {% if version_map[1].size > 1 %}
+        <a class="text-terciary" href="/index/{{ include.product }}/{{ version_map[0] }}/">See {{product.name}} {{ version_map[0] }} docs</a>
+        {% else %}
+        <a class="text-terciary" href="{{ version_map[1][0] }}">See {{product.name}} {{ version_map[0] }} version</a>
+        {% endif %}
+      </div>
+    {% endfor %}
+  </div>
+</div>

--- a/app/_layouts/with_aside.html
+++ b/app/_layouts/with_aside.html
@@ -2,6 +2,13 @@
 layout: default
 ---
 
+{% if page.previous_major_urls %}
+{% assign product = page.products[0] %}
+{% contentfor info_box %}
+{% include_cached info_box/sections/previous_versions.html previous_major_urls=page.previous_major_urls  product=product %}
+{% endcontentfor %}
+{% endif %}
+
 <div class="flex gap-16 w-full">
     {% include layouts/main.html class="md:basis-3/4 grow-0 min-w-0" %}
 

--- a/app/_plugins/generators/release_map_loader.rb
+++ b/app/_plugins/generators/release_map_loader.rb
@@ -47,7 +47,8 @@ module Jekyll
       product = product_data(site, major_version)
 
       canonical_page.data['previous_major_urls'] ||= {}
-      canonical_page.data['previous_major_urls'][product.major_version] = page.url
+      canonical_page.data['previous_major_urls'][product.major_version] ||= []
+      canonical_page.data['previous_major_urls'][product.major_version] << page.url
     end
 
     def find_page_by_path!(relative_path, site)

--- a/spec/app/_plugins/generators/release_map_loader_spec.rb
+++ b/spec/app/_plugins/generators/release_map_loader_spec.rb
@@ -48,9 +48,18 @@ RSpec.describe Jekyll::ReleaseMapLoader do
 
   describe '#generate' do
     context 'with a release-map entry pointing at a live current-major page' do
-      let(:pages) { [prev_major_page, current_major_page] }
+      let(:prev_major_page2) do
+        instance_double(Jekyll::Page,
+                        data: { 'major_version' => { 'ai-gateway' => 1 } },
+                        url: '/ai-gateway/v1/valid-page2/',
+                        relative_path: '_how-tos/ai-gateway/v1/valid-page2.md')
+      end
+      let(:pages) { [prev_major_page, prev_major_page2, current_major_page] }
       let(:release_map) do
-        { 'app/_how-tos/ai-gateway/v1/valid-page.md' => { 'canonical_url' => '/ai-gateway/valid-page/' } }
+        {
+          'app/_how-tos/ai-gateway/v1/valid-page.md' => { 'canonical_url' => '/ai-gateway/valid-page/' },
+          'app/_how-tos/ai-gateway/v1/valid-page2.md' => { 'canonical_url' => '/ai-gateway/valid-page/' }
+        }
       end
 
       it 'attaches canonical_url to the page' do
@@ -64,7 +73,7 @@ RSpec.describe Jekyll::ReleaseMapLoader do
         generator.generate(site)
 
         expect(current_major_page.data['previous_major_urls'])
-          .to eq({ 'v1' => '/ai-gateway/v1/valid-page/' })
+          .to eq({ 'v1' => ['/ai-gateway/v1/valid-page/', '/ai-gateway/v1/valid-page2/'] })
       end
     end
 


### PR DESCRIPTION
## Description

Add "Previous versions of this page" sections to the layout based on the older version canonicals

For any page:
- if there's exactly ONE old version page with a canonical pointing to it, we render the link to the previous version
- if there's MORE than one old version pages, we render a link to the old version index page


<img width="422" height="335" alt="Screenshot 2026-06-25 at 11 28 31" src="https://github.com/user-attachments/assets/0aac5a5e-7d86-4800-a59c-115e81697817" />
<img width="417" height="563" alt="Screenshot 2026-06-25 at 11 28 26" src="https://github.com/user-attachments/assets/1cca7df1-a842-44ff-a059-33d3c278a3db" />


no links in landing pages

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
