### PR TITLE
fix(ai-gateway): v2.0 AI and MCP landing page edits

### DIFF
--- a/app/_landing_pages/ai-gateway.yaml
+++ b/app/_landing_pages/ai-gateway.yaml
@@ -33,17 +33,12 @@ rows:
               blocks:
                 - type: text
                   text: |
-                    [Sign up for {{site.konnect_short_name}}](https://konghq.com/products/kong-konnect/register?utm_medium=referral&utm_source=docs&utm_content=ai-gateway) to get started with {{site.ai_gateway}}.
-
-                    Or, launch a local demo instance of {{site.ai_gateway}} with a single command:
+                    [Sign up for {{site.konnect_short_name}}](https://konghq.com/products/kong-konnect/register?utm_medium=referral&utm_source=docs&utm_content=ai-gateway) to get started with {{site.ai_gateway}} or launch a local demo instance of {{site.ai_gateway}} with a single command:
                     ```sh
                     curl -Ls https://get.konghq.com/ai | bash
                     ```
 
-                    Or, choose your starting point using one of our quickstart guides:
-                    - Proxy an LLM
-                    - Expose tools via MCP
-                    - Route agents through {{site.ai_gateway}}
+                    Or, proxy your first model through {{site.ai_gateway}} with the [LLM quickstart guide](/ai-gateway/get-started/).
 
       - blocks:
           - type: image
@@ -51,41 +46,11 @@ rows:
               url: /assets/images/gateway/ai-gateway-overview.svg
               alt_text: Overview of AI gateway
 
-
-  - columns:
-      - blocks:
-        - type: card
-          config:
-            title: LLM quickstart
-            description: Proxy your first model through {{site.ai_gateway}} with a guided setup.
-            icon: /assets/icons/llm-quickstart.svg
-            cta:
-              url: /ai-gateway/get-started/
-              align: end
-      - blocks:
-        - type: card
-          config:
-            title: MCP quickstart
-            description: Expose and observe your first tool server over Model Context Protocol.
-            icon: /assets/icons/mcp-quickstart.svg
-            cta:
-              url: /ai-gateway/mcp/
-              align: end
-      - blocks:
-        - type: card
-          config:
-            title: A2A quickstart
-            description: Route and secure agent-to-agent traffic with protocol-aware observability.
-            icon: /assets/icons/a2a-quickstart.svg
-            cta:
-              url: /ai-gateway/a2a/
-              align: end
-
   - header:
       type: h2
       text: "{{site.ai_gateway}} providers"
       description: |
-        {{site.ai_gateway}} routes AI requests through [provider-agnostic APIs](./#universal-api) by combining AI Providers and AI Models.
+        {{site.ai_gateway}} routes AI requests through provider-agnostic APIs by combining AI Providers and AI Models.
         AI Providers store upstream connectivity and credentials, while AI Models reference Providers to expose stable client-facing endpoints and routing behavior.
     column_count: 4
     columns:
@@ -155,38 +120,6 @@ rows:
 
   - header:
       type: h2
-      text: "Deploy {{site.ai_gateway}}"
-    columns:
-      - header:
-          type: h3
-          text: "Tools to manage {{site.ai_gateway}}"
-        blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: unordered_list
-                  items:
-                    - "[{{site.konnect_product_name}} {{site.ai_gateway}} editor](https://cloud.konghq.com/ai-gateway): GUI for managing all your {{site.ai_gateway}} resources in one place."
-                    # - "[decK](/deck/): Manage {{site.ai_gateway}} and {{site.base_gateway}} configuration through declarative state files."
-                    - "[Control Plane Config API](/api/konnect/control-planes-config/): Manage {{site.ai_gateway}} resources within {{site.konnect_short_name}} Control Planes via an API."
-                    - "[kongctl](/kongctl/): Use Kong's swiss-army knife command line tool for managing and interacting with {{site.ai_gateway}} resources and configurations within {{site.konnect_short_name}}."
-      - header:
-          type: h3
-          text: Deployment checklist
-        blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: unordered_list
-                  items:
-                    - "[{{site.ai_gateway}} resource sizing guidelines](/ai-gateway/resource-sizing-guidelines-ai/): Review recommended resource allocation guidelines for {{site.ai_gateway}}."
-
-  - header:
-      type: h2
-      text: "Overview of {{site.ai_gateway}}"
-
-  - header:
-      type: h2
       text: Three traffic types, unified control
     columns:
       - blocks:
@@ -195,84 +128,22 @@ rows:
             blocks:
               - type: text
                 text: |
-                  Define a single endpoint for any traffic type: LLM, MCP, or A2A. Use unified entity resources by configuring [AI Models](/ai-gateway/entities/ai-model/), [AI MCP Servers](/ai-gateway/entities/ai-mcp-server/), and [AI Agents](/ai-gateway/entities/ai-agent/) once, then reuse across consumers and policies.
+                  Define a single endpoint for any traffic type: LLM, MCP, or A2A. Use unified entity resources by configuring [AI Models](/ai-gateway/entities/ai-model/), [AI MCP Servers](/ai-gateway/entities/ai-mcp-server/), and [AI Agents](/ai-gateway/entities/ai-agent/) once, then reuse across AI Consumers and AI Policies.
+                  Each entity includes built-in authentication, policy enforcement, and observability.
 
-                  Govern, secure, and observe all AI traffic through dedicated AI Gateway entities. Each includes built-in authentication, policy enforcement, and observability.
+                  {{site.konnect_short_name}} provides a [unified control plane](https://cloud.konghq.com/ai-manager) to create, manage, and monitor LLMs
+                  using the {{site.konnect_short_name}} platform.
 
-                  - [**Easy to manage**](/ai-gateway/entities/ai-model/): Define your endpoint once and expose a stable interface to clients.
-
-                  - [**Load balancing**](/ai-gateway/load-balancing/): Distribute requests across target services for performance and cost efficiency.
-
-                  - [**Retry and fallback**](/ai-gateway/load-balancing/#retry-and-fallback): Route based on performance, cost, or availability.
-
-                  - [**Policy integration**](/ai-gateway/entities/ai-policy/): Attach [AI Policies](/ai-gateway/entities/ai-policy/) for authentication, guardrails, transformations, and governance.
-      - blocks:
+                    Key features include:
+                    * [Routing and load balancing](/ai-gateway/load-balancing/): Configure AI Models and `target_models` routing across [AI Providers](/ai-gateway/entities/ai-provider/).
+                    * [Streaming and authentication](/ai-gateway/streaming/): Enable streaming responses on AI Models, AI Agents, and AI MCP Servers; enforce auth through [AI Policies](/ai-gateway/entities/ai-policy/).
+                    * Access control: Use [AI Consumers](/ai-gateway/entities/ai-consumer/) and [AI Consumer Groups](/ai-gateway/entities/ai-consumer-group/), plus ACL fields on AI Models, AI Agents, and AI MCP Servers.
+                    * [Usage analytics](/ai-gateway/monitor-ai-llm-metrics/): Monitor request and token volumes, track error rates, and measure average latency with historical comparisons.
+      - blocks: 
         - type: image
           config:
             url: /assets/images/gateway/universal-api.svg
             alt_text: Overview of AI gateway
-
-  - column_count: 3
-    columns:
-      - blocks:
-        - type: card
-          config:
-            title: LLM traffic
-            description: Route LLM requests through a provider-agnostic Universal API. Load-balance across providers, transform requests and responses, enforce policies, and collect usage analytics.
-            icon: /assets/icons/plugins/universal-api.svg
-            cta:
-              url: /ai-gateway/entities/ai-model/
-              align: end
-      - blocks:
-        - type: card
-          config:
-            title: MCP traffic
-            description: Expose and govern tool traffic over Model Context Protocol. Control which agents access which tools, enforce rate limits, authenticate callers, and observe all tool invocations.
-            icon: /assets/icons/mcp.svg
-            cta:
-              url: /ai-gateway/mcp/
-              align: end
-      - blocks:
-        - type: card
-          config:
-            title: A2A traffic
-            description: Route Agent-to-Agent traffic with protocol-aware security and observability. Rewrite agent cards, extract task state, stream events, and emit structured telemetry.
-            icon: /assets/icons/plugins/ai-a2a-proxy.png
-            cta:
-              url: /ai-gateway/a2a/
-              align: end
-
-  - header:
-      type: h2
-      text: "Govern {{site.ai_gateway}} with entities and policies"
-      description: |
-        Enforce authentication, rate limiting, guardrails, transformations, and governance by attaching AI Policies to your AI entities. Create AI Models, AI Providers, AI Agents, and AI MCP Servers to manage your AI traffic.
-    column_count: 3
-    columns:
-      - blocks:
-        - type: card
-          config:
-            title: AI Policies
-            description: Attach governance behavior for authentication, guardrails, transformations, and more.
-            cta:
-              url: /ai-gateway/entities/ai-policy/
-              align: end
-      - blocks:
-        - type: card
-          config:
-            title: AI Entities
-            description: Learn about AI Models, AI Providers, AI Agents, AI MCP Servers, and AI Consumers.
-            cta:
-              url: /ai-gateway/entities/
-              align: end
-      - blocks:
-        - type: card
-          config:
-            title: Learn more
-            description: Explore all AI Gateway capabilities and detailed entity documentation.
-            cta:
-              url: /ai-gateway/
-              align: end
 
   # - columns:
   #     - blocks:
@@ -294,41 +165,46 @@ rows:
   #             url: /ai-gateway/entities/ai-provider/
   #             align: end
 
-  - columns:
-      - blocks:
+  - header:
+      type: h2
+      text: "Deploy {{site.ai_gateway}}"
+    columns:
+      - header:
+          type: h3
+          text: "Tools to manage {{site.ai_gateway}}"
+        blocks:
           - type: structured_text
             config:
-              header:
-                text: "{{site.ai_gateway}} in {{site.konnect_short_name}}"
               blocks:
-                - type: text
-                  text: |
-                    {{site.konnect_short_name}} provides a [unified control plane](https://cloud.konghq.com/ai-manager) to create, manage, and monitor LLMs
-                    using the {{site.konnect_short_name}} platform.
-
-                    Key features include:
-                    * [Routing and load balancing](/ai-gateway/load-balancing/): Configure [AI Models](/ai-gateway/entities/ai-model/) and `target_models` routing across [AI Providers](/ai-gateway/entities/ai-provider/).
-                    * [Streaming and authentication](/ai-gateway/entities/ai-model/): Enable streaming responses on [AI Models](/ai-gateway/entities/ai-model/), [AI Agents](/ai-gateway/entities/ai-agent/), and [AI MCP Servers](/ai-gateway/entities/ai-mcp-server/); enforce auth through [AI Policies](/ai-gateway/entities/ai-policy/).
-                    * [Access control](/ai-gateway/entities/ai-consumer/): Use [AI Consumers](/ai-gateway/entities/ai-consumer/) and [AI Consumer Groups](/ai-gateway/entities/ai-consumer-group/), plus ACL fields on [AI Models](/ai-gateway/entities/ai-model/), [AI Agents](/ai-gateway/entities/ai-agent/), and [AI MCP Servers](/ai-gateway/entities/ai-mcp-server/).
-                    * [Usage analytics](/observability/explorer/): Monitor request and token volumes, track error rates, and measure average latency with historical comparisons.
-                    * [Visual traffic maps](/observability/explorer/): Explore interactive maps that show how requests flow between clients, entities, and upstreams in real time.
-
-      - blocks:
-          - type: image
+                - type: unordered_list
+                  items:
+                    - "[{{site.konnect_product_name}} {{site.ai_gateway}} editor](https://cloud.konghq.com/ai-manager): GUI for managing all your {{site.ai_gateway}} resources in one place."
+                    # - "[decK](/deck/): Manage {{site.ai_gateway}} and {{site.base_gateway}} configuration through declarative state files."
+                    - "[Control Plane Config API](/api/konnect/control-planes-config/): Manage {{site.ai_gateway}} resources within {{site.konnect_short_name}} Control Planes via an API."
+                    - "[kongctl](/kongctl/): Use Kong's swiss-army knife command line tool for managing and interacting with {{site.ai_gateway}} resources and configurations within {{site.konnect_short_name}}."
+      - header:
+          type: h3
+          text: Deployment checklist
+        blocks:
+          - type: structured_text
             config:
-              url: /assets/images/konnect/ai-manager.png
-              alt_text: "{{site.ai_gateway}} Dashboard in Konnect"
-
+              blocks:
+                - type: unordered_list
+                  items:
+                    - "[{{site.ai_gateway}} resource sizing guidelines](/ai-gateway/resource-sizing-guidelines-ai/): Review recommended resource allocation guidelines for {{site.ai_gateway}}."
+  
   - header:
       type: h2
       text: "Governance"
       description: |
-        {{site.ai_gateway}} provides policy-managed governance capabilities attached to [AI Models](/ai-gateway/entities/ai-model/), [AI Agents](/ai-gateway/entities/ai-agent/), [AI MCP Servers](/ai-gateway/entities/ai-mcp-server/), [AI Consumers](/ai-gateway/entities/ai-consumer/), and [AI Consumer Groups](/ai-gateway/entities/ai-consumer-group/). Control how sensitive data flows to AI providers, enforce content safety, transform prompts, and manage how requests are processed.
+        {{site.ai_gateway}} provides policy-managed governance capabilities attached to AI Models, AI Agents, AI MCP Servers, AI Consumers, and AI Consumer Groups. 
+        Control how sensitive data flows to AI providers, enforce content safety, transform prompts, and manage how requests are processed.
   - header:
       type: h3
       text: "Data governance"
       description: |
-        {{site.ai_gateway}} enforces governance on outgoing AI prompts through allow/deny lists, blocking unauthorized requests with 4xx responses. It also provides built-in PII sanitization, automatically detecting and redacting sensitive data across 20 categories and 9 languages. Running privately and self-hosted for full control and compliance, {{site.ai_gateway}} ensures consistent protection without burdening developers, which helps simplify AI adoption at scale.
+        {{site.ai_gateway}} enforces governance on outgoing AI prompts through allow/deny lists, blocking unauthorized requests with 4xx responses. It also provides built-in PII sanitization, automatically detecting and redacting sensitive data across 20 categories and 9 languages. 
+        You can run {{site.ai_gateway}} privately and self-hosted for full control and compliance, ensuring consistent protection without burdening developers to simplify AI adoption at scale.
 
         For more information, see the full list of [Data Governance](/ai-gateway/ai-data-gov/) capabilities.
     columns:
@@ -351,7 +227,7 @@ rows:
       description: |
         AI systems are built around prompts, and manipulating those prompts is important for successful adoption of the technologies.
         Prompt engineering is the methodology of manipulating the linguistic inputs that guide the AI system.
-        {{site.ai_gateway}} supports policy-managed prompt capabilities that allow you to set defaults and manipulate prompts as they pass through [AI Model](/ai-gateway/entities/ai-model/) or [AI Agent](/ai-gateway/entities/ai-agent/) traffic.
+        {{site.ai_gateway}} supports policy-managed prompt capabilities that allow you to set defaults and manipulate prompts as they pass through AI Model or AI Agent traffic.
     columns:
       - blocks:
         - type: aigw_policy
@@ -366,7 +242,7 @@ rows:
       type: h3
       text: "Guardrails and content safety"
       description: |
-        As a platform owner, you may need to moderate all user request content against reputable services to comply with specific sensitive categories when proxying Large Language Model (LLM) traffic.
+        Platform owners may need to moderate all user request content against reputable services to comply with specific sensitive categories when proxying Large Language Model (LLM) traffic.
         {{site.ai_gateway}} provides built-in capabilities to handle content moderation and ensure content safety, that help you enforce compliance and protect your users across AI-powered applications.
     column_count: 3
     columns:
@@ -506,8 +382,8 @@ rows:
       description: |
         {{site.ai_gateway}} provides multiple approaches to monitor LLM traffic and operations.
         Track token usage, latency, and costs through audit logs and metrics exporters.
-        Instrument request flows with OpenTelemetry to trace [AI Model](/ai-gateway/entities/ai-model/), [AI MCP Server](/ai-gateway/entities/ai-mcp-server/), and [AI Agent](/ai-gateway/entities/ai-agent/) traffic across your infrastructure.
-        Use {{site.konnect_short_name}} Advanced Analytics for pre-built dashboards, or integrate with your existing observability stack.
+        Instrument request flows with OpenTelemetry to trace AI Model, AI MCP Server, and AI Agent traffic across your infrastructure.
+        Use {{site.konnect_short_name}} {{site.observability}} for pre-built dashboards, or integrate with your existing observability stack.
     column_count: 3
     columns:
       - blocks:
@@ -557,6 +433,28 @@ rows:
               align: end
 
   - header:
+      type: h2
+      text: "Core concepts in {{site.ai_gateway}}"
+    column_count: 3
+    columns:
+      - blocks:
+        - type: card
+          config:
+            title: AI Policies
+            description: Attach governance behavior for authentication, guardrails, transformations, and more.
+            cta:
+              url: /ai-gateway/entities/ai-policy/
+              align: end
+      - blocks:
+        - type: card
+          config:
+            title: AI Entities
+            description: Entities are the building blocks that make up the {{site.ai_gateway}} ecosystem. This includes AI Models, AI Providers, AI Agents, AI MCP Servers, and AI Consumers.
+            cta:
+              url: /ai-gateway/entities/
+              align: end
+
+  - header:
       text: "Frequently Asked Questions"
       type: h2
     columns:
@@ -565,7 +463,7 @@ rows:
           config:
             - q: How do I deploy {{site.ai_gateway}}?
               a: |
-                {{site.ai_gateway}} is managed through {{site.konnect_short_name}}. Data plane nodes run in your environment (self-hosted, cloud, or Kubernetes) and connect to {{site.konnect_short_name}} for configuration and observability.
+                {{site.ai_gateway}} is managed through {{site.konnect_short_name}}. Data plane nodes run in your environment (self-hosted, [cloud](/dedicated-cloud-gateways/), or Kubernetes) and connect to {{site.konnect_short_name}} for configuration and observability.
 
             - q: Why should I use {{site.ai_gateway}} instead of adding the LLM's API behind {{site.base_gateway}}?
               a: |

--- a/app/_landing_pages/ai-gateway.yaml
+++ b/app/_landing_pages/ai-gateway.yaml
@@ -38,14 +38,44 @@ rows:
                     curl -Ls https://get.konghq.com/ai | bash
                     ```
 
-                    Or, proxy your first model through {{site.ai_gateway}} with the [LLM quickstart guide](/ai-gateway/get-started/).
-
       - blocks:
           - type: image
             config:
               url: /assets/images/gateway/ai-gateway-overview.svg
               alt_text: Overview of AI gateway
 
+  - header: 
+      type: h2
+      text: "Quick starts" 
+
+    columns:
+      - blocks:
+        - type: card
+          config:
+            title: LLM quickstart
+            description: Proxy your first model through {{site.ai_gateway}} with a guided setup.
+            icon: /assets/icons/llm-quickstart.svg
+            cta:
+              url: /ai-gateway/get-started/
+              align: end
+      - blocks:
+        - type: card
+          config:
+            title: MCP quickstart
+            description: Expose and observe your first tool server over Model Context Protocol.
+            icon: /assets/icons/mcp-quickstart.svg
+            cta:
+              url: /ai-gateway/mcp/
+              align: end
+      - blocks:
+        - type: card
+          config:
+            title: A2A quickstart
+            description: Route and secure agent-to-agent traffic with protocol-aware observability.
+            icon: /assets/icons/a2a-quickstart.svg
+            cta:
+              url: /ai-gateway/a2a/
+              align: end
   - header:
       type: h2
       text: "{{site.ai_gateway}} providers"
@@ -85,6 +115,42 @@ rows:
 
   - header:
       type: h2
+      text: Proxy AI CLI tools
+      description: |
+        {{site.ai_gateway}} can proxy requests from AI command-line tools to LLM providers. This gives you centralized control over AI traffic, including authentication, governance, and observability.
+    column_count: 4
+    columns:
+      - blocks:
+        - type: icon_card
+          config:
+            title: Claude Code
+            icon: /assets/icons/anthropic.svg
+            cta:
+              url: /ai-gateway/ai-clis/#claude-code
+      - blocks:
+        - type: icon_card
+          config:
+            title: Codex CLI
+            icon: /assets/icons/openai.svg
+            cta:
+              url: /ai-gateway/ai-clis/#codex-cli
+      - blocks:
+        - type: icon_card
+          config:
+            title: Gemini CLI
+            icon: /assets/icons/gemini.svg
+            cta:
+              url: /ai-gateway/ai-clis/#gemini-cli
+      - blocks:
+        - type: icon_card
+          config:
+            title: More...
+            icon: /assets/icons/dots.svg
+            cta:
+              url: /ai-gateway/ai-clis/
+
+  - header:
+      type: h2
       text: Implement common scenarios
       description: |
         Explore end-to-end recipes for building real-world AI scenarios with {{site.ai_gateway}}, or check our [AI Cookbooks](/cookbooks/) to discover more.
@@ -117,7 +183,6 @@ rows:
             cta:
               url: /cookbooks/secure-external-mcp-gateway/
               align: end
-
   - header:
       type: h2
       text: Three traffic types, unified control
@@ -128,18 +193,21 @@ rows:
             blocks:
               - type: text
                 text: |
-                  Define a single endpoint for any traffic type: LLM, MCP, or A2A. Use unified entity resources by configuring [AI Models](/ai-gateway/entities/ai-model/), [AI MCP Servers](/ai-gateway/entities/ai-mcp-server/), and [AI Agents](/ai-gateway/entities/ai-agent/) once, then reuse across AI Consumers and AI Policies.
-                  Each entity includes built-in authentication, policy enforcement, and observability.
+                  Define a single endpoint for any traffic type: LLM, MCP, or A2A. Configure [AI Models](/ai-gateway/entities/ai-model/), [AI MCP Servers](/ai-gateway/entities/ai-mcp-server/), and [AI Agents](/ai-gateway/entities/ai-agent/) once, then govern them from a [unified control plane](https://cloud.konghq.com/ai-manager) with built-in auth, policy enforcement, and observability:
 
-                  {{site.konnect_short_name}} provides a [unified control plane](https://cloud.konghq.com/ai-manager) to create, manage, and monitor LLMs
-                  using the {{site.konnect_short_name}} platform.
-
-                    Key features include:
-                    * [Routing and load balancing](/ai-gateway/load-balancing/): Configure AI Models and `target_models` routing across [AI Providers](/ai-gateway/entities/ai-provider/).
-                    * [Streaming and authentication](/ai-gateway/streaming/): Enable streaming responses on AI Models, AI Agents, and AI MCP Servers; enforce auth through [AI Policies](/ai-gateway/entities/ai-policy/).
-                    * Access control: Use [AI Consumers](/ai-gateway/entities/ai-consumer/) and [AI Consumer Groups](/ai-gateway/entities/ai-consumer-group/), plus ACL fields on AI Models, AI Agents, and AI MCP Servers.
-                    * [Usage analytics](/ai-gateway/monitor-ai-llm-metrics/): Monitor request and token volumes, track error rates, and measure average latency with historical comparisons.
-      - blocks: 
+                    * [Routing and load balancing](/ai-gateway/load-balancing/) across AI Providers
+                    * [Streaming and authentication](/ai-gateway/streaming/) with [AI Policies](/ai-gateway/entities/ai-policy/)
+                    * Access control with [AI Consumers](/ai-gateway/entities/ai-consumer/) and ACLs
+                    * [Usage analytics](/ai-gateway/monitor-ai-llm-metrics/) for requests, tokens, errors, and latency
+              - type: text
+                text: |
+                  Manage these resources through multiple interfaces:
+              - type: unordered_list
+                items:
+                  - "[{{site.ai_gateway}} manager](https://cloud.konghq.com/ai-manager): manage all your {{site.ai_gateway}} resources from {{site.konnect_short_name}}."
+                  - "[Control Plane Config API](/api/konnect/control-planes-config/): manage resources within {{site.konnect_short_name}} Control Planes via the API."
+                  - "[kongctl](/kongctl/): manage resources and configuration from the command line."
+      - blocks:
         - type: image
           config:
             url: /assets/images/gateway/universal-api.svg
@@ -167,46 +235,14 @@ rows:
 
   - header:
       type: h2
-      text: "Deploy {{site.ai_gateway}}"
-    columns:
-      - header:
-          type: h3
-          text: "Tools to manage {{site.ai_gateway}}"
-        blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: unordered_list
-                  items:
-                    - "[{{site.konnect_product_name}} {{site.ai_gateway}} editor](https://cloud.konghq.com/ai-manager): GUI for managing all your {{site.ai_gateway}} resources in one place."
-                    # - "[decK](/deck/): Manage {{site.ai_gateway}} and {{site.base_gateway}} configuration through declarative state files."
-                    - "[Control Plane Config API](/api/konnect/control-planes-config/): Manage {{site.ai_gateway}} resources within {{site.konnect_short_name}} Control Planes via an API."
-                    - "[kongctl](/kongctl/): Use Kong's swiss-army knife command line tool for managing and interacting with {{site.ai_gateway}} resources and configurations within {{site.konnect_short_name}}."
-      - header:
-          type: h3
-          text: Deployment checklist
-        blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: unordered_list
-                  items:
-                    - "[{{site.ai_gateway}} resource sizing guidelines](/ai-gateway/resource-sizing-guidelines-ai/): Review recommended resource allocation guidelines for {{site.ai_gateway}}."
-  
-  - header:
-      type: h2
       text: "Governance"
       description: |
-        {{site.ai_gateway}} provides policy-managed governance capabilities attached to AI Models, AI Agents, AI MCP Servers, AI Consumers, and AI Consumer Groups. 
-        Control how sensitive data flows to AI providers, enforce content safety, transform prompts, and manage how requests are processed.
+        Attach policies to AI Models, AI Agents, AI MCP Servers, and AI Consumers to control how data flows to providers, enforce content safety, and transform prompts.
   - header:
       type: h3
       text: "Data governance"
       description: |
-        {{site.ai_gateway}} enforces governance on outgoing AI prompts through allow/deny lists, blocking unauthorized requests with 4xx responses. It also provides built-in PII sanitization, automatically detecting and redacting sensitive data across 20 categories and 9 languages. 
-        You can run {{site.ai_gateway}} privately and self-hosted for full control and compliance, ensuring consistent protection without burdening developers to simplify AI adoption at scale.
-
-        For more information, see the full list of [Data Governance](/ai-gateway/ai-data-gov/) capabilities.
+        Enforce allow/deny lists and built-in PII sanitization across 20 categories and 9 languages, with the option to run self-hosted for full compliance. See all [Data Governance](/ai-gateway/ai-data-gov/) capabilities.
     columns:
       - blocks:
         - type: aigw_policy
@@ -225,9 +261,7 @@ rows:
       type: h3
       text: "Prompt engineering"
       description: |
-        AI systems are built around prompts, and manipulating those prompts is important for successful adoption of the technologies.
-        Prompt engineering is the methodology of manipulating the linguistic inputs that guide the AI system.
-        {{site.ai_gateway}} supports policy-managed prompt capabilities that allow you to set defaults and manipulate prompts as they pass through AI Model or AI Agent traffic.
+        Set defaults and manipulate prompts as they pass through AI Model or AI Agent traffic.
     columns:
       - blocks:
         - type: aigw_policy
@@ -242,8 +276,7 @@ rows:
       type: h3
       text: "Guardrails and content safety"
       description: |
-        Platform owners may need to moderate all user request content against reputable services to comply with specific sensitive categories when proxying Large Language Model (LLM) traffic.
-        {{site.ai_gateway}} provides built-in capabilities to handle content moderation and ensure content safety, that help you enforce compliance and protect your users across AI-powered applications.
+        Moderate request content against trusted services to enforce compliance and protect users across AI-powered applications.
     column_count: 3
     columns:
       - blocks:
@@ -281,9 +314,7 @@ rows:
       type: h3
       text: "Request transformations"
       description: |
-        {{site.ai_gateway}} allows you to use AI technology to augment other API traffic.
-        One example is routing API responses through an AI language translation prompt before returning it to the client.
-        {{site.ai_gateway}} provides two policies that can be used in conjunction with other upstream API services to weave AI capabilities into API request processing.
+        Use AI to augment other API traffic, such as routing responses through a translation prompt before returning them to the client.
     columns:
       - blocks:
         - type: aigw_policy
@@ -324,10 +355,7 @@ rows:
       type: h2
       text: "Load balancing"
       description: |
-        {{site.ai_gateway}}'s load balancer routes requests across AI models to optimize for speed, cost, and reliability.
-        It supports algorithms like consistent hashing, lowest-latency, usage-based, round-robin, and semantic matching, with built-in retries and fallback for resilience.
-
-        The balancer dynamically selects models based on real-time performance and prompt relevance, and works across mixed environments including OpenAI, Mistral, and Llama models.
+        Route requests across AI models to optimize for speed, cost, and reliability, with algorithms like lowest-latency, usage-based, and semantic matching plus built-in retries and fallback.
     columns:
       - blocks:
         - type: card
@@ -380,10 +408,7 @@ rows:
       type: h2
       text: "Observability and metrics"
       description: |
-        {{site.ai_gateway}} provides multiple approaches to monitor LLM traffic and operations.
-        Track token usage, latency, and costs through audit logs and metrics exporters.
-        Instrument request flows with OpenTelemetry to trace AI Model, AI MCP Server, and AI Agent traffic across your infrastructure.
-        Use {{site.konnect_short_name}} {{site.observability}} for pre-built dashboards, or integrate with your existing observability stack.
+        Track token usage, latency, and costs through audit logs, metrics exporters, and OpenTelemetry, or use {{site.konnect_short_name}} {{site.observability}} for pre-built dashboards.
     column_count: 3
     columns:
       - blocks:

--- a/app/_landing_pages/ai-gateway/mcp.yaml
+++ b/app/_landing_pages/ai-gateway/mcp.yaml
@@ -43,35 +43,21 @@ rows:
             config:
               header:
                 type: h2
-                text: "Generate MCP servers from API specs"
+                text: "Generate, secure, and govern MCP servers"
               blocks:
                 - type: text
                   text: |
-                    {{site.ai_gateway}} {% new_in 2.0 %} manages MCP traffic through the entity model. Create an [AI MCP Server](/ai-gateway/entities/ai-mcp-server/) to expose MCP tools and services, then attach [AI Policies](/ai-gateway/entities/ai-policy/) for authentication, access control, and observability.
-          - type: card
-            config:
-              icon: /assets/icons/linked-services.svg
-              title: AI MCP Server entity
-              description: Generate an AI MCP Server from an API spec to expose tools and services over MCP in {{site.ai_gateway}}.
-              cta:
-                text: AI MCP Server reference
-                url: "/ai-gateway/entities/ai-mcp-server/"
-      - blocks:
-          - type: structured_text
-            config:
-              header:
-                type: h2
-                text: "Secure and govern MCP servers"
-              blocks:
-                - type: text
-                  text: |
-                    Attach [AI Policies](/ai-gateway/entities/ai-policy/) to your [AI MCP Server](/ai-gateway/entities/ai-mcp-server/) entities to apply security, governance, and observability controls across your MCP infrastructure.
+                    {{site.ai_gateway}} {% new_in 2.0 %} manages MCP traffic through the entity model. 
+                    Generate an AI MCP Server from an API spec to expose MCP tools and services, then attach AI Policies for authentication, access control, and observability.
+
+                    Attach AI Policies to your AI MCP Server entities to apply security, governance, and observability controls across your MCP infrastructure.
 
                     Use AI Policies to:
                     - Secure access with the MCP OAuth2 AI Policy or other authentication methods
                     - Monitor MCP traffic using AI metrics and AI audit logs
                     - Enforce access controls for MCP tool usage
                     - Govern usage with rate limiting and traffic control
+      - blocks:
           - type: card
             config:
               icon: /assets/icons/lock.svg
@@ -83,7 +69,7 @@ rows:
                 - text: Rate Limiting
                   url: "/ai-gateway/policies/rate-limiting/"
                 - text: Observability
-                  url: "/ai-gateway/ai-audit-log-reference/#ai-mcp-logs"
+                  url: "/ai-gateway/monitor-ai-llm-metrics/"
 
   - header:
       type: h2

--- a/app/_landing_pages/ai-gateway/mcp.yaml
+++ b/app/_landing_pages/ai-gateway/mcp.yaml
@@ -47,7 +47,7 @@ rows:
               blocks:
                 - type: text
                   text: |
-                    {{site.ai_gateway}} {% new_in 2.0 %} manages MCP traffic through the entity model. 
+                    {{site.ai_gateway}} {% new_in 2.0 %} manages traffic through the [AI MCP Server](/ai-gateway/entities/ai-mcp-server/) entity.
                     Generate an AI MCP Server from an API spec to expose MCP tools and services, then attach AI Policies for authentication, access control, and observability.
 
                     Attach AI Policies to your AI MCP Server entities to apply security, governance, and observability controls across your MCP infrastructure.
@@ -58,18 +58,18 @@ rows:
                     - Enforce access controls for MCP tool usage
                     - Govern usage with rate limiting and traffic control
       - blocks:
-          - type: card
+          - type: structured_text
             config:
-              icon: /assets/icons/lock.svg
-              title: Security and governance with AI Policies
-              description: Secure MCP servers and govern traffic with AI Policies.
-              ctas:
-                - text: MCP OAuth2 policy
-                  url: "/ai-gateway/policies/ai-mcp-oauth2/"
-                - text: Rate Limiting
-                  url: "/ai-gateway/policies/rate-limiting/"
-                - text: Observability
-                  url: "/ai-gateway/monitor-ai-llm-metrics/"
+              header:
+                type: h3
+                text: "Security and governance with AI Policies"
+              blocks:
+                - type: text
+                  text: |
+                    Secure MCP servers and govern traffic with AI Policies:
+                    - [MCP OAuth2 policy](/ai-gateway/policies/ai-mcp-oauth2/)
+                    - [Rate Limiting](/ai-gateway/policies/rate-limiting/)
+                    - [Observability](/ai-gateway/monitor-ai-llm-metrics/)
 
   - header:
       type: h2


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

I've made the following edits:
- I've attempted to reduce the redundant descriptions on the AI Gateway landing page. Originally, it had several sections that rehashed the features, entities, etc. in similar wording, just different sections.
- I combined the AI Gateway on Konnect and the "Three traffic types, unified control" sections. The "Three traffic types" section links all said they weren't compatible with on-prem, so I thought that both these sections were talking about Konnect-only features.
- Removed the MCP server and Agent tiles from the get started section. These pointed to reference pages and I couldn't find a how to that would match these. I don't think the reference links will help someone who is looking for a quickstart.
- I consolidated the first h2 subheadings in the MCP landing page because they were saying similar things and we didn't have enough content links to have two ctas tiles.

Additionally, I have the following feedback that would require more edits than I can make here:
- Content on the AI Gateway landing page could be further pared down, there's a lot of content there.
- _Reduce the jargon and descriptions of "how the sausage is made"_ on both the AI Gateway and MCP landing pages: 
  - The pages are currently written in a very feature centric way instead of use case centric. For example, we explain that you can create AI Agent, Model, and MCP server entities and apply policies to them. This would be useful information on a reference page, but someone who is new to AI Gateway likely doesn't care that these are entities. Instead, they want to govern an agent or create a MCP server from their spec. The landing pages should talk more about use cases and then link off to related references where we can then reveal that they achieve their use case via an entity and policy.
  - Compared to competitors, what we are offering seems extremely complex and complicated based on how we are presenting it.
- _Landing pages make on-prem feel unsupported:_ All feature pages (load balancing, streaming, llm metrics) say they aren't compatible with on-prem. Every link you click on (other than cookbooks) seems to be Konnect only, which makes it seem like on-prem isn't supported at all. 
- _Lack of quickstarts/how tos:_ I'm concerned that we don't seem to have any v2.0 quickstarts or how tos other than cookbooks. Almost everything links to a reference, which will make it difficult to use AI Gateway 2.0.
- _Policy pages only contain a reference:_ Is this expected that policy pages only contain the autogenerated reference? This seems like a significant downgrade to the plugin experience where we had examples and overview content about how it worked.

## Preview Links
- /ai-gateway/
- /ai-gateway/mcp/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
