### PR TITLE
Feat/policy overview pages

### DIFF
--- a/app/_ai_gateway_policies/ai-aws-guardrails/index.md
+++ b/app/_ai_gateway_policies/ai-aws-guardrails/index.md
@@ -7,3 +7,6 @@ products:
   - ai-gateway
 content_type: plugin
 ---
+
+
+Dummy content

--- a/app/_ai_gateway_policies/ai-aws-guardrails/index.md
+++ b/app/_ai_gateway_policies/ai-aws-guardrails/index.md
@@ -5,8 +5,8 @@ works_on:
   - konnect
 products:
   - ai-gateway
-content_type: plugin
+content_type: policy
 ---
 
 
-Dummy content
+The AI AWS Guardrails Policy enforces introspection on both inbound requests and outbound responses handled by the AI Proxy plugin. It integrates with the AWS Bedrock Guardrails service to apply compliance and safety policies at the gateway level. This ensures all data exchanged between clients and upstream LLMs adheres to the configured security standards.

--- a/app/_plugins/generators/ai_gateway_policy/generator.rb
+++ b/app/_plugins/generators/ai_gateway_policy/generator.rb
@@ -23,9 +23,11 @@ module Jekyll
 
       # TODO: for now, until we have overviews and examples
       def generate_pages(policy)
+        generate_overview_page(policy) unless policy.overview_content.empty?
+
         reference = generate_reference_page(policy)
 
-        site.data[key][policy.slug] = reference
+        site.data[key][policy.slug] ||= reference
       end
     end
   end

--- a/app/_plugins/generators/ai_gateway_policy/pages/base.rb
+++ b/app/_plugins/generators/ai_gateway_policy/pages/base.rb
@@ -20,7 +20,7 @@ module Jekyll
           super
             .merge(
               'schema' => @policy.schema,
-              'has_overview?' => !!@policy.overview_content.empty?,
+              'has_overview?' => !@policy.overview_content.empty?,
               'title' => "#{@policy.metadata['title']} Policy"
             )
         end

--- a/app/_plugins/generators/ai_gateway_policy/pages/base.rb
+++ b/app/_plugins/generators/ai_gateway_policy/pages/base.rb
@@ -20,7 +20,7 @@ module Jekyll
           super
             .merge(
               'schema' => @policy.schema,
-              'has_overview?' => false,
+              'has_overview?' => !!@policy.overview_content.empty?,
               'title' => "#{@policy.metadata['title']} Policy"
             )
         end

--- a/app/_plugins/generators/ai_gateway_policy/policy.rb
+++ b/app/_plugins/generators/ai_gateway_policy/policy.rb
@@ -25,6 +25,10 @@ module Jekyll
                       .merge(super)
       end
 
+      def overview_content
+        @overview_content ||= Jekyll::Utils::MarkdownParser.new(index_file).content.strip
+      end
+
       private
 
       def api_plugin

--- a/app/_plugins/generators/policies/base.rb
+++ b/app/_plugins/generators/policies/base.rb
@@ -21,9 +21,7 @@ module Jekyll
       end
 
       def metadata
-        @metadata ||= Jekyll::Utils::MarkdownParser.new(
-          File.read(File.join(@folder, 'index.md'))
-        ).frontmatter
+        @metadata ||= Jekyll::Utils::MarkdownParser.new(index_file).frontmatter
       end
 
       def example_files
@@ -69,6 +67,12 @@ module Jekyll
 
       def max_version
         @max_version ||= metadata.fetch('max_version', {})
+      end
+
+      private
+
+      def index_file
+        @index_file ||= File.read(File.join(@folder, 'index.md'))
       end
     end
   end

--- a/spec/app/_plugins/generators/ai_gateway_policy/pages/overview_spec.rb
+++ b/spec/app/_plugins/generators/ai_gateway_policy/pages/overview_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Jekyll::AIGatewayPolicyPages::Pages::Overview do
       schema: { 'properties' => { 'config' => {} } },
       icon: nil,
       unreleased?: false,
-      min_release: nil
+      min_release: nil,
+      overview_content: 'Some content'
     )
   end
 
@@ -58,9 +59,18 @@ RSpec.describe Jekyll::AIGatewayPolicyPages::Pages::Overview do
 
     it { expect(data['title']).to eq('KONG Policy') }
     it { expect(data['overview?']).to be(true) }
-    it { expect(data['has_overview?']).to be(false) }
     it { expect(data['overview_url']).to eq('/ai-gateway/policies/my-policy/') }
     it { expect(data['schema']).to eq({ 'properties' => { 'config' => {} } }) }
     it { expect(data['scopes']).to eq(%w[ai-model global]) }
+
+    context 'when the policy has overview content' do
+      it { expect(data['has_overview?']).to be(false) }
+    end
+
+    context 'when the policy has no overview content' do
+      before { allow(policy).to receive(:overview_content).and_return('') }
+
+      it { expect(data['has_overview?']).to be(true) }
+    end
   end
 end

--- a/spec/app/_plugins/generators/ai_gateway_policy/pages/overview_spec.rb
+++ b/spec/app/_plugins/generators/ai_gateway_policy/pages/overview_spec.rb
@@ -64,13 +64,13 @@ RSpec.describe Jekyll::AIGatewayPolicyPages::Pages::Overview do
     it { expect(data['scopes']).to eq(%w[ai-model global]) }
 
     context 'when the policy has overview content' do
-      it { expect(data['has_overview?']).to be(false) }
+      it { expect(data['has_overview?']).to be(true) }
     end
 
     context 'when the policy has no overview content' do
       before { allow(policy).to receive(:overview_content).and_return('') }
 
-      it { expect(data['has_overview?']).to be(true) }
+      it { expect(data['has_overview?']).to be(false) }
     end
   end
 end

--- a/spec/app/_plugins/generators/ai_gateway_policy/pages/reference_spec.rb
+++ b/spec/app/_plugins/generators/ai_gateway_policy/pages/reference_spec.rb
@@ -16,7 +16,8 @@ RSpec.describe Jekyll::AIGatewayPolicyPages::Pages::Reference do
       schema: { 'properties' => { 'config' => {} } },
       icon: nil,
       unreleased?: false,
-      min_release: nil
+      min_release: nil,
+      overview_content: 'Some content'
     )
   end
 
@@ -49,7 +50,6 @@ RSpec.describe Jekyll::AIGatewayPolicyPages::Pages::Reference do
     subject(:data) { page.data }
 
     it { expect(data['title']).to eq('KONG Policy') }
-    it { expect(data['has_overview?']).to be(false) }
     it { expect(data['reference_type']).to eq('base') }
     it { expect(data['content_type']).to eq('reference') }
     it { expect(data['reference?']).to be(true) }
@@ -59,5 +59,15 @@ RSpec.describe Jekyll::AIGatewayPolicyPages::Pages::Reference do
     it { expect(data['overview_url']).to eq('/ai-gateway/policies/my-policy/') }
     it { expect(data).not_to have_key('faqs') }
     it { expect(data['scopes']).to eq(%w[ai-model global]) }
+
+    context 'when the policy has overview content' do
+      it { expect(data['has_overview?']).to be(false) }
+    end
+
+    context 'when the policy has no overview content' do
+      before { allow(policy).to receive(:overview_content).and_return('') }
+
+      it { expect(data['has_overview?']).to be(true) }
+    end
   end
 end

--- a/spec/app/_plugins/generators/ai_gateway_policy/pages/reference_spec.rb
+++ b/spec/app/_plugins/generators/ai_gateway_policy/pages/reference_spec.rb
@@ -61,13 +61,13 @@ RSpec.describe Jekyll::AIGatewayPolicyPages::Pages::Reference do
     it { expect(data['scopes']).to eq(%w[ai-model global]) }
 
     context 'when the policy has overview content' do
-      it { expect(data['has_overview?']).to be(false) }
+      it { expect(data['has_overview?']).to be(true) }
     end
 
     context 'when the policy has no overview content' do
       before { allow(policy).to receive(:overview_content).and_return('') }
 
-      it { expect(data['has_overview?']).to be(true) }
+      it { expect(data['has_overview?']).to be(false) }
     end
   end
 end


### PR DESCRIPTION
## Description

Generate overview pages for aigw policies.
An overview page is generated only if the policy's index file has some content after the metadata.
I've added some dummy content to `app/_ai_gateway_policies/ai-aws-guardrails/index.md` to illustrate how it works

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
