### PR TITLE
feat(m&b): Tax codes

### DIFF
--- a/app/_how-tos/metering-and-billing/configure-metering-and-billing-tax-codes.md
+++ b/app/_how-tos/metering-and-billing/configure-metering-and-billing-tax-codes.md
@@ -24,7 +24,6 @@ prereqs:
     - title: "{{site.konnect_product_name}}"
       include_content: prereqs/products/konnect-account-only
       icon_url: /assets/icons/gateway.svg
-  inline:
     - title: "{{site.konnect_short_name}} roles"
       content: |
         You need the [{{site.metering_and_billing}} Admin role](/konnect-platform/teams-and-roles/#metering-billing) in {{site.konnect_short_name}} to configure {{site.metering_and_billing}}.

--- a/app/_how-tos/metering-and-billing/configure-metering-and-billing-tax-codes.md
+++ b/app/_how-tos/metering-and-billing/configure-metering-and-billing-tax-codes.md
@@ -19,6 +19,11 @@ tags:
 
 prereqs:
   skip_product: true
+  show_works_on: false
+  inline:
+    - title: "{{site.konnect_product_name}}"
+      include_content: prereqs/products/konnect-account-only
+      icon_url: /assets/icons/gateway.svg
   inline:
     - title: "{{site.konnect_short_name}} roles"
       content: |
@@ -85,10 +90,10 @@ If none of the system-managed codes match your product category, you can create 
 1. Click the **Tax Codes** tab.
 1. Click **Create tax code**.
 1. Enter a name, key, and optional description.
-1. Add one or more app mappings.
+1. (Optional) Add one or more app mappings.
    For Stripe, the value must follow the `txcd_XXXXXXXX` format.
    You can browse available values in the [Stripe Tax Code reference](https://docs.stripe.com/tax/tax-codes).
-1. Optionally, set the code as the **Invoicing Default** or **Credit Grant Default**.
+1. (Optional) Set the code as the **Invoicing Default** or **Credit Grant Default**.
 1. Click **Save**.
 
 {:.info}
@@ -105,11 +110,11 @@ You can apply a tax code at two levels within your product catalog.
 This sets the tax code for a specific product or fee, overriding the organization default.
 
 1. In the {{site.konnect_short_name}} sidebar, click **Metering & Billing** > **Product Catalog**.
-1. Click **Plans** or **Add-ons** and select a plan or add-on.
+1. Click the **Plans** or **Add-ons** tab and select a plan or add-on.
 1. Open or create a rate card.
 1. In the **Pricing Model** configuration, expand **Advanced Settings**.
-1. Select the **Tax Behavior**.
-1. Set the **Tax Code** to your custom code.
+1. In the **Tax Behavior** dropdown, select the behavior you want to apply.
+1. In the **Tax Code** dropdown, select your custom code.
 1. Save the rate card.
 
 ### Apply a tax code on a subscription rate card
@@ -122,8 +127,8 @@ This overrides the tax code for a specific customer's subscription, without chan
 1. Click **Manage** and expand **Advanced Settings**.
 1. Enable **Advanced Customization**.
 1. Click **Next**.
-1. Open or create a rate card.
+1. Edit or create a rate card.
 1. In the **Pricing Model** configuration, expand **Advanced Settings**.
-1. Select the **Tax Behavior**.
-1. Set the **Tax Code** to your custom code.
+1. In the **Tax Behavior** dropdown, select the behavior you want to apply.
+1. In the **Tax Code** dropdown, select your custom code.
 1. Save the rate card.

--- a/app/_how-tos/metering-and-billing/configure-metering-and-billing-tax-codes.md
+++ b/app/_how-tos/metering-and-billing/configure-metering-and-billing-tax-codes.md
@@ -1,0 +1,129 @@
+---
+title: Create and apply {{site.metering_and_billing}} tax codes
+permalink: /how-to/configure-metering-and-billing-tax-codes/
+description: Learn how to review system-managed tax codes, create custom tax codes, and apply them at the organization and rate-card level in {{site.konnect_short_name}} {{site.metering_and_billing}}.
+content_type: how_to
+
+breadcrumbs:
+  - /metering-and-billing/
+
+products:
+    - metering-and-billing
+
+works_on:
+    - konnect
+
+tags:
+    - metering
+    - billing
+
+prereqs:
+  skip_product: true
+  inline:
+    - title: "{{site.konnect_short_name}} roles"
+      content: |
+        You need the [{{site.metering_and_billing}} Admin role](/konnect-platform/teams-and-roles/#metering-billing) in {{site.konnect_short_name}} to configure {{site.metering_and_billing}}.
+      icon_url: /assets/icons/kogo-white.svg
+
+cleanup:
+  inline:
+    - title: Clean up Konnect environment
+      include_content: cleanup/platform/konnect
+      icon_url: /assets/icons/gateway.svg
+
+tldr:
+  q: How do I configure tax codes in {{site.konnect_short_name}} {{site.metering_and_billing}}?
+  a: |
+    {{site.metering_and_billing}} pre-provisions the most commonly used Stripe tax codes and sets two organization defaults (invoicing and credit grant) when your organization is created.
+    Review those defaults, create custom tax codes if needed, and apply them at the organization level or on individual rate cards.
+
+related_resources:
+  - text: Tax codes reference
+    url: /metering-and-billing/tax-codes/
+  - text: Billing and invoicing
+    url: /metering-and-billing/billing-invoicing/
+  - text: Product Catalog reference
+    url: /metering-and-billing/product-catalog/
+
+faqs:
+  - q: Why can't I edit or delete a tax code?
+    a: |
+      Edit and delete actions are only available for user-managed codes.
+      System-managed codes are read-only and can't be modified.
+
+automated_tests: false
+---
+
+Tax codes classify goods and services so that your payment provider can calculate tax correctly on invoices.
+{{site.metering_and_billing}} pre-provisions the most commonly used Stripe tax codes for every organization and sets two defaults at org creation time.
+
+In this guide, you'll:
+
+* Review your system-managed defaults
+* Create a custom tax code
+* Apply a tax code at the organization or rate-card level
+
+For background on how tax codes work and how the fallback chain is evaluated, see [Tax codes](/metering-and-billing/tax-codes/).
+
+## Review default organization tax codes
+
+When your organization is created, {{site.metering_and_billing}} sets up two defaults: one for invoicing and one for credit grants.
+Review these before creating custom codes, as the pre-provisioned codes may already cover your needs.
+
+1. In the {{site.konnect_short_name}} sidebar, click **Metering & Billing** > **Settings**.
+1. Click the **Tax Codes** tab.
+1. Review the list of system-managed and user-created tax codes and the current defaults.
+1. To change which code is the default, click the action menu on any row and select **Set as Invoicing Default** or **Set as Credit Grant Default**.
+
+If the system-managed codes cover your needs, you can skip the next step and go directly to [Apply a tax code to a rate card](#apply-a-tax-code-to-a-rate-card).
+
+## Create a tax code
+
+If none of the system-managed codes match your product category, you can create a custom tax code:
+
+1. In the {{site.konnect_short_name}} sidebar, click **Metering & Billing** > **Settings**.
+1. Click the **Tax Codes** tab.
+1. Click **Create tax code**.
+1. Enter a name, key, and optional description.
+1. Add one or more app mappings.
+   For Stripe, the value must follow the `txcd_XXXXXXXX` format.
+   You can browse available values in the [Stripe Tax Code reference](https://docs.stripe.com/tax/tax-codes).
+1. Optionally, set the code as the **Invoicing Default** or **Credit Grant Default**.
+1. Click **Save**.
+
+{:.info}
+> **Note:** Only one tax code can be set as the default per category at a time.
+> You can't delete a default tax code.
+> To delete it, first set a different code as the default, then delete the original.
+
+## Apply a tax code to a rate card
+
+You can apply a tax code at two levels within your product catalog.
+
+### Apply a tax code on a plan or add-on rate card
+
+This sets the tax code for a specific product or fee, overriding the organization default.
+
+1. In the {{site.konnect_short_name}} sidebar, click **Metering & Billing** > **Product Catalog**.
+1. Click **Plans** or **Add-ons** and select a plan or add-on.
+1. Open or create a rate card.
+1. In the **Pricing Model** configuration, expand **Advanced Settings**.
+1. Select the **Tax Behavior**.
+1. Set the **Tax Code** to your custom code.
+1. Save the rate card.
+
+### Apply a tax code on a subscription rate card
+
+This overrides the tax code for a specific customer's subscription, without changing the underlying plan.
+
+1. In the {{site.konnect_short_name}} sidebar, click **Metering & Billing** > **Billing**.
+1. Click a customer.
+1. Click the **Subscription** tab.
+1. Click **Manage** and expand **Advanced Settings**.
+1. Enable **Advanced Customization**.
+1. Click **Next**.
+1. Open or create a rate card.
+1. In the **Pricing Model** configuration, expand **Advanced Settings**.
+1. Select the **Tax Behavior**.
+1. Set the **Tax Code** to your custom code.
+1. Save the rate card.

--- a/app/_includes/konnect/metering-and-billing/tax.md
+++ b/app/_includes/konnect/metering-and-billing/tax.md
@@ -4,7 +4,7 @@
 
 * Inclusive: The listed price already includes tax. A 10% inclusive tax on a $500 item still results in a $500 invoice.
 * Exclusive: Tax is added on top of the listed price. A 10% exclusive tax on a $500 item raises the invoice total to $550.
-* Tax codes: Apply a tax code to a feature. Some payment providers, like Stripe, apply their own default [tax code](https://docs.stripe.com/tax/tax-codes). In those cases, you can leave {{site.metering_and_billing}}'s tax settings blank.
+* [Tax codes](/metering-and-billing/tax-codes/): Apply a tax code to a feature.
 
 You can enable tax collection from a [Rate Card](/metering-and-billing/product-catalog/) or the [billing profile settings](https://cloud.konghq.com/metering-billing/billing-profiles).
 

--- a/app/_indices/metering-and-billing.yaml
+++ b/app/_indices/metering-and-billing.yaml
@@ -69,18 +69,18 @@ sections:
       - title: Invoicing
         description: Learn how to set up invoicing in {{site.konnect_short_name}} {{site.metering_and_billing}}.
         url: /metering-and-billing/billing-invoicing/#invoicing
+      - title: Tax calculations
+        description: Manage tax codes and configure tax behavior for invoices.
+        url: /metering-and-billing/billing-invoicing/#tax-calculations
+      - path: /metering-and-billing/tax-codes/
       - path: /metering-and-billing/stripe-integration/
-  - title: How tos 
+  - title: How-tos
     items:
       - title: Get started with generic metering
         description: Meter any billable usage, like compute, storage, or application layer. Learn how to ingest usage events.
         url: /how-to/get-started-with-metering-and-billing-generic-meters/
-      - title: API gateway metering
-        description: Real-time usage metering for {{site.base_gateway}} API requests. Monetize API traffic with flexible pricing models.
-        url: /metering-and-billing/get-started/
-      - title: LLM token metering
-        description: Learn how to meter and bill AI Gateway LLM tokens.
-        url: /how-to/meter-llm-traffic/
-      - title: Meter and bill active users
-        url: /how-to/meter-and-bill-active-users/
+      - path: /metering-and-billing/get-started/
+      - path: /how-to/meter-llm-traffic/
+      - path: /how-to/meter-and-bill-active-users/
+      - path: /how-to/configure-metering-and-billing-tax-codes/
       - path: /how-to/get-started-with-prepaid-credits/

--- a/app/_landing_pages/metering-and-billing.yaml
+++ b/app/_landing_pages/metering-and-billing.yaml
@@ -244,6 +244,16 @@ rows:
               cta:
                 text: Learn more
                 url: /metering-and-billing/credits/
+      - blocks:
+          - type: card
+            config:
+              title: Tax calculations
+              description: |
+                Manage tax codes and configure tax behavior for invoices.
+              icon: /assets/icons/money.svg
+              cta:
+                text: Learn more
+                url: /metering-and-billing/billing-invoicing/#tax-calculations
 
   - header:
       type: h2

--- a/app/metering-and-billing/credits/grants.md
+++ b/app/metering-and-billing/credits/grants.md
@@ -140,4 +140,4 @@ Purchase terms describe how the credits are funded.
 They define the purchase currency and the per-unit cost used to calculate the purchase amount.
 
 Tax configuration is relevant for revenue recognition on usage charges that consume credits.
-Set tax configuration on all usage charges that need to be classified correctly for revenue recognition.
+Set [tax configuration](/metering-and-billing/tax-codes/) on all usage charges that need to be classified correctly for revenue recognition.

--- a/app/metering-and-billing/overview.md
+++ b/app/metering-and-billing/overview.md
@@ -95,7 +95,7 @@ rows:
     support: "{{site.metering_and_billing}}"
   - capability: "[**Invoice generation** (billing periods, lines)](/metering-and-billing/billing-invoicing/#invoicing)"
     support: "{{site.metering_and_billing}}"
-  - capability: "**Sales tax calculations** (based on geo and tax code)"
+  - capability: "**Sales tax calculations** (based on geo and [tax code](/metering-and-billing/tax-codes/))"
     support: |
       Third-party integrations:
       * [Stripe Tax](/metering-and-billing/stripe-integration/#optional-automatic-tax-calculation)

--- a/app/metering-and-billing/pricing-models.md
+++ b/app/metering-and-billing/pricing-models.md
@@ -67,7 +67,7 @@ rows:
 
       See [Tax calculations](/metering-and-billing/product-catalog/#tax-calculations) for details.
   - parameter: Stripe Tax Code
-    description: Select a [Stripe product tax code](https://docs.stripe.com/tax/tax-codes).
+    description: Select a [tax code](/metering-and-billing/tax-codes/). For Stripe, see the [Stripe Tax Code reference](https://docs.stripe.com/tax/tax-codes) for available values.
 {% endtable %}
 
 ## Usage based
@@ -112,7 +112,7 @@ rows:
 
       See [Tax calculations](/metering-and-billing/product-catalog/#tax-calculations) for details.
   - parameter: Stripe Tax Code
-    description: Select a [Stripe product tax code](https://docs.stripe.com/tax/tax-codes).
+    description: Select a [tax code](/metering-and-billing/tax-codes/). For Stripe, see the [Stripe Tax Code reference](https://docs.stripe.com/tax/tax-codes) for available values.
 {% endtable %}
 
 ## Tiered
@@ -198,7 +198,7 @@ rows:
 
       See [Tax calculations](/metering-and-billing/product-catalog/#tax-calculations) for details.
   - parameter: Stripe Tax Code
-    description: Select a [Stripe product tax code](https://docs.stripe.com/tax/tax-codes).
+    description: Select a [tax code](/metering-and-billing/tax-codes/). For Stripe, see the [Stripe Tax Code reference](https://docs.stripe.com/tax/tax-codes) for available values.
 {% endtable %}
 
 ### Volume pricing
@@ -275,7 +275,7 @@ rows:
 
       See [Tax calculations](/metering-and-billing/product-catalog/#tax-calculations) for details.
   - parameter: Stripe Tax Code
-    description: Select a [Stripe product tax code](https://docs.stripe.com/tax/tax-codes).
+    description: Select a [tax code](/metering-and-billing/tax-codes/). For Stripe, see the [Stripe Tax Code reference](https://docs.stripe.com/tax/tax-codes) for available values.
 {% endtable %}
 
 ### Flat prices in tiers
@@ -449,7 +449,7 @@ rows:
 
       See [Tax calculations](/metering-and-billing/product-catalog/#tax-calculations) for details.
   - parameter: Stripe Tax Code
-    description: Select a [Stripe product tax code](https://docs.stripe.com/tax/tax-codes).
+    description: Select a [tax code](/metering-and-billing/tax-codes/). For Stripe, see the [Stripe Tax Code reference](https://docs.stripe.com/tax/tax-codes) for available values.
 {% endtable %}
 
 ## Dynamic
@@ -500,7 +500,7 @@ rows:
 
       See [Tax calculations](/metering-and-billing/product-catalog/#tax-calculations) for details.
   - parameter: Stripe Tax Code
-    description: Select a [Stripe product tax code](https://docs.stripe.com/tax/tax-codes).
+    description: Select a [tax code](/metering-and-billing/tax-codes/). For Stripe, see the [Stripe Tax Code reference](https://docs.stripe.com/tax/tax-codes) for available values.
 {% endtable %}
 
 ### Tracking cost with meters

--- a/app/metering-and-billing/stripe-integration.md
+++ b/app/metering-and-billing/stripe-integration.md
@@ -102,7 +102,7 @@ Stripe calculates tax based on:
 * Product tax code (global default or per [rate card](/metering-and-billing/product-catalog/#rate-cards))
 
   {:.info}
-  > **Defining tax codes:** To define tax codes for rate cards, you can set default tax codes in the [billing settings in {{site.konnect_short_name}}](https://cloud.konghq.com/us/metering-billing/billing-profiles). You can also specify tax codes per rate card by editing the product catalog when creating a plan.
+  > **Defining tax codes:** To define tax codes for rate cards, you can set default tax codes in [{{site.metering_and_billing}} tax code settings](/metering-and-billing/tax-codes/). You can also specify tax codes per rate card by editing the product catalog when creating a plan.
 
 To enable automatic tax calculation in Stripe, make sure you:
 

--- a/app/metering-and-billing/tax-codes.md
+++ b/app/metering-and-billing/tax-codes.md
@@ -1,0 +1,104 @@
+---
+title: "Tax codes"
+content_type: reference
+description: "Learn how tax codes work in {{site.konnect_short_name}} {{site.metering_and_billing}}, including tax behavior, organization defaults, and the fallback chain."
+layout: reference
+products:
+  - metering-and-billing
+tools:
+  - konnect-api
+works_on:
+  - konnect
+breadcrumbs:
+  - /metering-and-billing/
+related_resources:
+  - text: "Billing and invoicing"
+    url: /metering-and-billing/billing-invoicing/
+  - text: "Configure tax codes"
+    url: /how-to/configure-metering-and-billing-tax-codes/
+  - text: "Stripe Tax Code reference"
+    url: https://docs.stripe.com/tax/tax-codes
+---
+
+Tax codes classify goods and services for tax purposes.
+{{site.konnect_short_name}} {{site.metering_and_billing}} uses them to pass structured tax information to payment providers so that tax is calculated correctly on invoices.
+
+## What is a tax code?
+
+A tax code is a named, reusable object in your organization that maps a product category to provider-specific identifiers.
+Each tax code has:
+
+* A human-readable key and name (for example, key: `saas-software`, name: `SaaS Software`).
+* An optional description.
+* One or more app mappings, which are the provider-specific code strings for each connected payment app.
+
+For Stripe, app mapping values follow Stripe's tax code format: `txcd_XXXXXXXX` (for example, `txcd_10000000`).
+You can browse available codes in the [Stripe Tax Code reference](https://docs.stripe.com/tax/tax-codes).
+
+{:.info}
+> **Note:** {{site.metering_and_billing}} pre-provisions the most commonly used Stripe tax codes for every organization.
+> These system-managed codes are read-only and can't be edited or deleted.
+> You can set a system-managed code as the organization default.
+
+## Tax behavior
+
+Every taxable object carries a tax behavior that controls how the listed price is interpreted:
+
+<!--vale off-->
+{% table %}
+columns:
+  - title: Value
+    key: value
+  - title: Meaning
+    key: meaning
+rows:
+  - value: "`exclusive`"
+    meaning: Tax is added on top of the stated price.
+  - value: "`inclusive`"
+    meaning: Tax is included in the stated price.
+  - value: "`empty`"
+    meaning: Falls back to the provider's default behavior.
+{% endtable %}
+<!--vale on-->
+
+## Default organization tax codes
+
+Defaul organization tax codes act as a safety net, guaranteeing that every taxable item has a tax code even when there's no specific setting configured.
+Tax code defaults are defined once per organization and apply across all billing profiles, customers, plans, and invoices.
+
+{{site.metering_and_billing}} sets two defaults when your organization is created:
+
+<!--vale off-->
+{% table %}
+columns:
+  - title: Default
+    key: default
+  - title: Applies to
+    key: applies_to
+  - title: Used when
+    key: used_when
+  - title: Name
+    key: name
+  - title: Value
+    key: value
+rows:
+  - default: Invoicing default
+    applies_to: Flat-fee charges and usage-based charges
+    used_when: The charge has no tax code from any more specific layer.
+    name: Provider default
+    value: No app mappings. Falls back to the provider's default behavior.
+  - default: Credit grant default
+    applies_to: Credit purchase charges (credit grants)
+    used_when: The credit purchase has no explicit tax code.
+    name: Nontaxable
+    value: "Stripe: `txcd_00000000`"
+{% endtable %}
+<!--vale on-->
+
+## Fallback chain
+
+{{site.metering_and_billing}} uses a fallback chain when determining which tax code to apply, in the following order of priority:
+
+1. **Rate card tax code**: Set on the rate card or add-on.
+1. **Organization default**: The invoicing or credit grant default for the org.
+1. **Provider default**: Used when the tax code has no app mappings.

--- a/app/metering-and-billing/tax-codes.md
+++ b/app/metering-and-billing/tax-codes.md
@@ -32,7 +32,7 @@ Each tax code has:
 * An optional description.
 * One or more app mappings, which are the provider-specific code strings for each connected payment app.
 
-For Stripe, app mapping values follow Stripe's tax code format: `txcd_XXXXXXXX` (for example, `txcd_10000000`).
+If you've [integrated Stripe](/metering-and-billing/stripe-integration/) with {{site.metering_and_billing}}, app mapping values follow Stripe's tax code format: `txcd_XXXXXXXX` (for example, `txcd_10000000`).
 You can browse available codes in the [Stripe Tax Code reference](https://docs.stripe.com/tax/tax-codes).
 
 {:.info}
@@ -84,7 +84,7 @@ columns:
 rows:
   - default: Invoicing default
     applies_to: Flat-fee charges and usage-based charges
-    used_when: The charge has no tax code from any more specific layer.
+    used_when: The charge doesn't have a tax code from a more specific layer.
     name: Provider default
     value: No app mappings. Falls back to the provider's default behavior.
   - default: Credit grant default
@@ -95,9 +95,14 @@ rows:
 {% endtable %}
 <!--vale on-->
 
+To view your default and user-created tax codes, navigate to **Metering & Billing** > **Settings** and click the **Tax Codes** tab.
+
+To apply tax codes other than the default, navigate to the rate card on any plan, add-on, or customer subscription, and expand the advanced settings for the pricing model. 
+For a complete tutorial, see [Create and apply {{site.metering_and_billing}} tax codes](/how-to/configure-metering-and-billing-tax-codes/).
+
 ## Fallback chain
 
-{{site.metering_and_billing}} uses a fallback chain when determining which tax code to apply, in the following order of priority:
+{{site.metering_and_billing}} uses a fallback chain to determine which tax code to apply, in the following order of priority:
 
 1. **Rate card tax code**: Set on the rate card or add-on.
 1. **Organization default**: The invoicing or credit grant default for the org.

--- a/app/metering-and-billing/tax-codes.md
+++ b/app/metering-and-billing/tax-codes.md
@@ -28,7 +28,7 @@ Tax codes classify goods and services for tax purposes.
 A tax code is a named, reusable object in your organization that maps a product category to provider-specific identifiers.
 Each tax code has:
 
-* A human-readable key and name (for example, key: `saas-software`, name: `SaaS Software`).
+* A human-readable key and name (for example, key: `saas_software`, name: `SaaS Software`).
 * An optional description.
 * One or more app mappings, which are the provider-specific code strings for each connected payment app.
 

--- a/app/metering-and-billing/tax-codes.md
+++ b/app/metering-and-billing/tax-codes.md
@@ -63,7 +63,7 @@ rows:
 
 ## Default organization tax codes
 
-Defaul organization tax codes act as a safety net, guaranteeing that every taxable item has a tax code even when there's no specific setting configured.
+Default organization tax codes act as a safety net, guaranteeing that every taxable item has a tax code even when there's no specific setting configured.
 Tax code defaults are defined once per organization and apply across all billing profiles, customers, plans, and invoices.
 
 {{site.metering_and_billing}} sets two defaults when your organization is created:


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

No feature ticket, this is already live. Doc update was requested by team on Slack.

You can test this in the docs org on .com.

The how-to is a bit unorthodox - it feels like half-reference, half how-to. How do we feel about this approach?

## Preview Links

[M&B landing page tile](https://deploy-preview-5752--kongdeveloper.netlify.app/metering-and-billing/#billing)
[Tax codes reference](https://deploy-preview-5752--kongdeveloper.netlify.app/metering-and-billing/tax-codes/)
[Tax codes guide](https://deploy-preview-5752--kongdeveloper.netlify.app/how-to/configure-metering-and-billing-tax-codes/)
[Index](https://deploy-preview-5752--kongdeveloper.netlify.app/index/metering-and-billing/#billing)

