### PR TITLE
feat(aigw): add banner to changelog

### DIFF
--- a/app/_assets/javascripts/apps/components/SearchModalResultItem.vue
+++ b/app/_assets/javascripts/apps/components/SearchModalResultItem.vue
@@ -59,7 +59,7 @@ export default {
         return this.item.title;
       }
       if (this.item.content_type === 'plugin') {
-        if (this.item.products && (this.item.products.includes('mesh') || this.item.products.includes('event-gateway') || this.item.products.includes('ai-gateway'))) {
+        if (this.item.products && (this.item.products.includes('mesh') || this.item.products.includes('event-gateway') || this.item.products === 'ai-gateway')) {
           return `${this.item.hierarchy.lvl1} Policy`;
         } else {
           return `${this.item.hierarchy.lvl1} Plugin`;
@@ -79,7 +79,7 @@ export default {
         .map(([key, value]) => value);
 
       if (this.item.content_type === 'plugin') {
-        if (this.item.products && (this.item.products.includes('mesh') || this.item.products.includes('event-gateway') || this.item.products.includes('ai-gateway'))) {
+        if (this.item.products && (this.item.products.includes('mesh') || this.item.products.includes('event-gateway') || this.item.products === 'ai-gateway')) {
           levels.unshift('Policies')
         } else {
           levels.unshift('Plugins')

--- a/app/ai-gateway/changelog.md
+++ b/app/ai-gateway/changelog.md
@@ -21,6 +21,6 @@ search_aliases:
 Changelog for supported {{site.ai_gateway_name}} versions.
 
 {:.warning}
-> This is the changelog for the on-prem {{site.ai_gateway_name}} runtime. policies are the control-plane concept. in the runtime they’re implemented as plugins, which is the terminology you’ll see in the runtime changelog.
+> This is the changelog for the on-prem {{site.ai_gateway_name}} runtime. policies are a control plane concept. In the runtime they’re implemented as plugins, which is the terminology you’ll see in this changelog.
 
 {% gateway_changelog %}

--- a/app/ai-gateway/changelog.md
+++ b/app/ai-gateway/changelog.md
@@ -20,4 +20,7 @@ search_aliases:
 
 Changelog for supported {{site.ai_gateway_name}} versions.
 
+{:.warning}
+> This is the changelog for the on-prem {{site.ai_gateway_name}} runtime. policies are the control-plane concept. in the runtime they’re implemented as plugins, which is the terminology you’ll see in the runtime changelog.
+
 {% gateway_changelog %}


### PR DESCRIPTION
## Description

Add banner to aigw changelog, it also includes a fix for the search results that prevents plugins from being presented as policies. Policies will show up once we re-index algolia

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
