### PR TITLE
feat(aigw): add placeholder banner to plugins that have `ai_gateway_url`

### DIFF
--- a/app/_includes/plugins/banners.md
+++ b/app/_includes/plugins/banners.md
@@ -1,7 +1,7 @@
 {% if page.overview? -%}
 {%- if page.ai_gateway_url %}
 {:.warning.-my-4}
-> **AI Gateway 2.0:** Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat [here]({{page.ai_gateway_url}}).
+> You're viewing the AI Gateway 1.0 version of this plugin. Looking for the AI Gateway 2.0 policy? [Go to the AI Gateway 2.0 version]({{page.ai_gateway_url}}).
 {% endif %}{%- if page.premium_partner and page.third_party %}
 
 {:.decorative.w-full.-my-4}

--- a/app/_includes/plugins/banners.md
+++ b/app/_includes/plugins/banners.md
@@ -1,7 +1,7 @@
 {% if page.overview? -%}
 {%- if page.ai_gateway_url %}
 {:.warning.-my-4}
-> You're viewing the{{site.ai_gateway}} 1.0 version of this plugin. Looking for the {{site.ai_gateway}} 2.0 policy? [Go to the {{site.ai_gateway}} 2.0 version]({{page.ai_gateway_url}}).
+> Looking for {{site.ai_gateway}} 2.0? [See the policy for the current version]({{page.ai_gateway_url}}).
 {% endif %}{%- if page.premium_partner and page.third_party %}
 
 {:.decorative.w-full.-my-4}

--- a/app/_includes/plugins/banners.md
+++ b/app/_includes/plugins/banners.md
@@ -1,7 +1,7 @@
 {% if page.overview? -%}
 {%- if page.ai_gateway_url %}
 {:.warning.-my-4}
-> You're viewing the AI Gateway 1.0 version of this plugin. Looking for the AI Gateway 2.0 policy? [Go to the AI Gateway 2.0 version]({{page.ai_gateway_url}}).
+> You're viewing the{{site.ai_gateway}} 1.0 version of this plugin. Looking for the {{site.ai_gateway}} 2.0 policy? [Go to the {{site.ai_gateway}} 2.0 version]({{page.ai_gateway_url}}).
 {% endif %}{%- if page.premium_partner and page.third_party %}
 
 {:.decorative.w-full.-my-4}

--- a/app/_includes/plugins/banners.md
+++ b/app/_includes/plugins/banners.md
@@ -1,5 +1,8 @@
 {% if page.overview? -%}
-{%- if page.premium_partner and page.third_party %}
+{%- if page.ai_gateway_url %}
+{:.warning.-my-4}
+> **AI Gateway 2.0:** Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat [here]({{page.ai_gateway_url}}).
+{% endif %}{%- if page.premium_partner and page.third_party %}
 
 {:.decorative.w-full.-my-4}
 > **Premium Partner:** This plugin is developed, tested, and maintained by [{{site.data.plugin_publishers[page.publisher].name}}]({{page.support_url}}).

--- a/app/_kong_plugins/ai-proxy/index.md
+++ b/app/_kong_plugins/ai-proxy/index.md
@@ -19,6 +19,8 @@ works_on:
 min_version:
     gateway: '3.6'
 
+ai_gateway_url: "/ai-gateway/entities/ai-policy/"
+
 topologies:
   on_prem:
     - hybrid


### PR DESCRIPTION
## Description

Render a banner on plugins that have `ai_gateway_url` set. Text is a placeholder for now.

## Preview Links
http://deploy-preview-5793--kongdeveloper.netlify.app/ai-gateway/plugins/ai-proxy
https://deploy-preview-5793--kongdeveloper.netlify.app/plugins/ai-proxy/
## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
