### PR TITLE
fix(aigw): set content_type: plugin to aigw policies.

### DIFF
--- a/app/_ai_gateway_policies/ai-aws-guardrails/index.md
+++ b/app/_ai_gateway_policies/ai-aws-guardrails/index.md
@@ -5,7 +5,7 @@ works_on:
   - konnect
 products:
   - ai-gateway
-content_type: policy
+content_type: plugin
 ---
 
 

--- a/app/_ai_gateway_policies/ai-gcp-model-armor/index.md
+++ b/app/_ai_gateway_policies/ai-gcp-model-armor/index.md
@@ -5,7 +5,7 @@ works_on:
   - konnect
 products:
   - ai-gateway
-content_type: policy
+content_type: plugin
 
 faqs:
   - q: What do I do if I see the error `Blocked by Model Armor Floor Setting`?

--- a/app/_ai_gateway_policies/ai-lakera-guard/index.md
+++ b/app/_ai_gateway_policies/ai-lakera-guard/index.md
@@ -5,7 +5,7 @@ works_on:
   - konnect
 products:
   - ai-gateway
-content_type: policy
+content_type: plugin
 ---
 
 The AI Lakera Guard Policy evaluates requests and responses that pass through {{site.ai_gateway}} to Large Language Models (LLMs). It uses the [Lakera Guard SaaS service](https://www.lakera.ai/) to detect safety policy violations and block unsafe content before it reaches upstream LLMs or returns to clients. The AI Lakera Guard Policy supports multiple inspection modes and guards both inbound prompts and outbound model outputs.

--- a/app/_ai_gateway_policies/ai-llm-as-judge/index.md
+++ b/app/_ai_gateway_policies/ai-llm-as-judge/index.md
@@ -5,7 +5,7 @@ works_on:
   - konnect
 products:
   - ai-gateway
-content_type: policy
+content_type: plugin
 ---
 
 The AI LLM as Judge Policy enables automated evaluation of prompt-response pairs using a dedicated LLM. The Policy assigns a numerical score to LLM responses from 1 to 100, where:

--- a/app/_ai_gateway_policies/ai-mcp-oauth2/index.md
+++ b/app/_ai_gateway_policies/ai-mcp-oauth2/index.md
@@ -5,7 +5,7 @@ works_on:
   - konnect
 products:
   - ai-gateway
-content_type: policy
+content_type: plugin
 tech_preview: true
 related_resources:
   - text: OAuth 2.0 specification for MCP

--- a/app/_ai_gateway_policies/ai-prompt-compressor/index.md
+++ b/app/_ai_gateway_policies/ai-prompt-compressor/index.md
@@ -5,7 +5,7 @@ works_on:
   - konnect
 products:
   - ai-gateway
-content_type: policy
+content_type: plugin
 ---
 
 The AI Prompt Compressor Policy compresses retrieved chunks before sending them to a Large Language Model (LLM), reducing text length while preserving meaning. It uses the [LLMLingua 2 library](https://github.com/microsoft/LLMLingua) for fast, high-quality compression. The AI Prompt Compressor Policy supports:

--- a/app/_ai_gateway_policies/ai-prompt-decorator/index.md
+++ b/app/_ai_gateway_policies/ai-prompt-decorator/index.md
@@ -5,7 +5,7 @@ works_on:
   - konnect
 products:
   - ai-gateway
-content_type: policy
+content_type: plugin
 ---
 
 The AI Prompt Decorator Policy adds an array of `llm/v1/chat` messages to either the start or end of an LLM consumer's chat history.

--- a/app/_ai_gateway_policies/ai-prompt-guard/index.md
+++ b/app/_ai_gateway_policies/ai-prompt-guard/index.md
@@ -5,7 +5,7 @@ works_on:
   - konnect
 products:
   - ai-gateway
-content_type: policy
+content_type: plugin
 related_resources:
   - text: AI Semantic Prompt Guard Policy
     url: /ai-gateway/policies/ai-semantic-prompt-guard/

--- a/app/_ai_gateway_policies/ai-prompt-template/index.md
+++ b/app/_ai_gateway_policies/ai-prompt-template/index.md
@@ -5,7 +5,7 @@ works_on:
   - konnect
 products:
   - ai-gateway
-content_type: policy
+content_type: plugin
 ---
 
 The AI Prompt Template Policy lets you provide tuned AI prompts to users.

--- a/app/_ai_gateway_policies/ai-request-transformer/index.md
+++ b/app/_ai_gateway_policies/ai-request-transformer/index.md
@@ -5,7 +5,7 @@ works_on:
   - konnect
 products:
   - ai-gateway
-content_type: policy
+content_type: plugin
 ---
 
 The AI Request Transformer Policy uses a configured LLM service to transform a client request body before proxying the request upstream.

--- a/app/_ai_gateway_policies/ai-response-transformer/index.md
+++ b/app/_ai_gateway_policies/ai-response-transformer/index.md
@@ -5,7 +5,7 @@ works_on:
   - konnect
 products:
   - ai-gateway
-content_type: policy
+content_type: plugin
 related_resources:
   - text: AI Request Transformer Policy
     url: /ai-gateway/policies/ai-request-transformer/

--- a/app/_ai_gateway_policies/ai-sanitizer/index.md
+++ b/app/_ai_gateway_policies/ai-sanitizer/index.md
@@ -5,7 +5,7 @@ works_on:
   - konnect
 products:
   - ai-gateway
-content_type: policy
+content_type: plugin
 ---
 
 The AI PII Sanitizer Policy for {{site.ai_gateway}} helps protect sensitive information in client request bodies before they reach upstream AI providers or tools.

--- a/app/_ai_gateway_policies/ai-semantic-cache/index.md
+++ b/app/_ai_gateway_policies/ai-semantic-cache/index.md
@@ -5,7 +5,7 @@ works_on:
   - konnect
 products:
   - ai-gateway
-content_type: policy
+content_type: plugin
 related_resources:
   - text: Embedding-based similarity matching in Kong AI gateway plugins
     url: /ai-gateway/semantic-similarity/

--- a/app/_ai_gateway_policies/ai-semantic-prompt-guard/index.md
+++ b/app/_ai_gateway_policies/ai-semantic-prompt-guard/index.md
@@ -5,7 +5,7 @@ works_on:
   - konnect
 products:
   - ai-gateway
-content_type: policy
+content_type: plugin
 related_resources:
   - text: Get started with {{site.ai_gateway}}
     url: /ai-gateway/get-started/


### PR DESCRIPTION
Fixes an issue where the `edit this page` wasn't being rendered.

All our plugins and policies have content_type: plugin, only specific pages have `content_type: policy` which is used for pages that we dont want people to edit.


## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
