### PR TITLE
Feat/aigw policy api pages

### DIFF
--- a/api-specs/ai-gateway/policies/ai-prompt-compressor/openapi.yaml
+++ b/api-specs/ai-gateway/policies/ai-prompt-compressor/openapi.yaml
@@ -1,0 +1,142 @@
+openapi: 3.1.1
+
+info:
+  title: AI Compress Server API
+  description: >
+    This spec describes the APIs that can work with AI Prompt Compressor plugin to compress the prompt in the request body.
+  version: 1.0.0
+
+paths:
+  /llm/v1/compressPrompt:
+    post:
+      summary: Compress the prompt in the request body
+      description: Returns the compressed prompt and compression results.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [text, model_name, compress_type, compress_ranges]
+              properties:
+                text:
+                  type: [array, string]
+                  items:
+                    type: object
+                    required: ["msg_id", "text"]
+                    properties:
+                      msg_id:
+                        type: integer
+                      text:
+                        type: string
+                compress_type:
+                  type: string
+                  enum:
+                    - "rate"
+                    - "target_token"
+                compress_ranges:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      min_tokens:
+                        type: integer
+                      max_tokens:
+                        type: integer
+                      value:
+                        type: number
+                model_name:
+                  type: string
+                advanced_logging:
+                  type: boolean
+                  default: false
+
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  text:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        compress_prompt:
+                          type: string
+                        compressor_results:
+                          type: object
+                          properties:
+                            msg_id:
+                              type: integer
+                            original_token_count:
+                              type: integer
+                            compress_token_count:
+                              type: integer
+                            save_token_count:
+                              type: integer
+                            compress_value:
+                              type: number
+                            compress_type:
+                              type: string
+                              enum:
+                                - "rate"
+                                - "target_token"
+                            compressor_model:
+                              type: string
+                            original_text:
+                              type: string
+                            compress_text:
+                              type: string
+                            information:
+                              type: string
+                        msg_id:
+                          type: integer
+
+
+                  duration:
+                    type: number
+        '400':
+          description: when error happens
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: object
+                    properties:
+                      message:
+                        type: string
+
+  /status:
+    get:
+      summary: Health check
+      description: Returns the health status of the service.
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: "ok"
+                  model_name:
+                    type: string
+                    enum:
+                      - "microsoft/llmlingua-2-xlm-roberta-large-meetingbank"
+                      - "microsoft/llmlingua-2-bert-base-multilingual-cased-meetingbank"
+                  device_map:
+                    type: string
+                    enum:
+                      - "cuda"
+                      - "cpu"
+                      - "mps"
+                      - "balanced"
+                      - "balanced_low_0"
+                      - "auto"

--- a/api-specs/ai-gateway/policies/ai-sanitizer/openapi.yaml
+++ b/api-specs/ai-gateway/policies/ai-sanitizer/openapi.yaml
@@ -1,0 +1,118 @@
+openapi: 3.1.1
+
+info:
+  title: PII Server API
+  description: >
+    This spec describes the APIs that are exposed by AI PII service that can work with AI Sanitizer Plugin to sanitize PII entities in the requests.
+  version: 1.0.0
+
+paths:
+  /llm/v1/sanitize:
+    post:
+      summary: sanitize the PII entities in the request body
+      description: Returns the sanitized results.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: ['text', 'anonymize', 'options']
+              properties:
+                text:
+                  type: string
+                anonymize:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/PIIEntity'
+                options:
+                  type: object
+                  properties:
+                    redact_type:
+                      type: string
+                      enum: ['synthetic', 'placeholder']
+                custom_patterns:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      name:
+                        type: string
+                      regex:
+                        type: string
+                      score:
+                        type: number
+
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  text:
+                    type: string
+                  identified_pii:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PIIEntity'
+                  anonymized_pii:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/PIIEntity'
+                  detected_languages:
+                    type: array
+                    items:
+                      type: string
+                  duration:
+                    type: number
+        '400':
+          description: when error happens
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+
+  /llm/v1/status:
+    get:
+      summary: Health check
+      description: Returns the health status of the service.
+      responses:
+        '200':
+          description: Service is healthy
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+
+
+components:
+  schemas:
+    PIIEntity:
+      enum:
+        - general
+        - phone
+        - creditcard
+        - crypto
+        - date
+        - ip
+        - nrp
+        - ssn
+        - url
+        - medical
+        - driverlicense
+        - passport
+        - bank
+        - nationalid
+        - custom
+        - credentials
+        - all
+        - all_and_credentials

--- a/app/_includes/layouts/policies/nav_header.html
+++ b/app/_includes/layouts/policies/nav_header.html
@@ -5,6 +5,9 @@
             {% if page.has_overview? %}<a class="tab-button__horizontal{% if page.overview? %} tab-button__horizontal--active{% endif %}" href="{{page.overview_url}}">Overview</a>{% endif %}
             {% if page.get_started_url %}<a class="tab-button__horizontal{% if page.example? %} tab-button__horizontal--active{% endif %}" href="{{page.get_started_url}}">Examples</a>{% endif %}
             <a class="tab-button__horizontal{% if page.reference? %} tab-button__horizontal--active{% endif %}" href="{{page.reference_url}}">Configuration reference</a>
+            {% if page.api_spec_exists? %}
+              <a class="tab-button__horizontal{% if page.api_reference? %} tab-button__horizontal--active{% endif %}" href="{{page.api_reference_url}}">API reference</a>
+            {% endif %}
         </div>
         </div>
     </div>

--- a/app/_layouts/policies/api_reference.html
+++ b/app/_layouts/policies/api_reference.html
@@ -1,0 +1,13 @@
+---
+layout: policies/without_aside
+plugin_api_spec: true
+---
+
+<div class="flex flex-col">
+
+  <div id="plugin-api-spec"></div>
+
+  <script>
+    window.apiSpec = {{ page.api_spec | jsonify }}
+  </script>
+</div>

--- a/app/_plugins/generators/ai_gateway_policy/generator.rb
+++ b/app/_plugins/generators/ai_gateway_policy/generator.rb
@@ -26,8 +26,19 @@ module Jekyll
         generate_overview_page(policy) unless policy.overview_content.empty?
 
         reference = generate_reference_page(policy)
+        generate_api_reference_page(policy)
 
         site.data[key][policy.slug] ||= reference
+      end
+
+      def generate_api_reference_page(policy)
+        return unless policy.api_spec_exists?
+
+        api_reference = api_reference_page_class
+                        .new(policy:, file: policy.api_spec_file_path)
+                        .to_jekyll_page
+
+        site.pages << api_reference
       end
     end
   end

--- a/app/_plugins/generators/ai_gateway_policy/pages/api_reference.rb
+++ b/app/_plugins/generators/ai_gateway_policy/pages/api_reference.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'yaml'
+require_relative './base'
+
+module Jekyll
+  module AIGatewayPolicyPages
+    module Pages
+      class ApiReference < Base # rubocop:disable Style/Documentation
+        def self.url(policy)
+          if policy.unreleased?
+            "#{base_url}#{policy.slug}/api/#{policy.min_release}/"
+          else
+            "#{base_url}#{policy.slug}/api/"
+          end
+        end
+
+        def content
+          ''
+        end
+
+        def markdown_content
+          @markdown_content ||= File.read('app/_includes/plugins/api_reference.md')
+        end
+
+        def data
+          super.merge('api_reference?' => true, 'toc' => false, 'api_spec' => api_spec)
+        end
+
+        def layout
+          'policies/api_reference'
+        end
+
+        private
+
+        def api_spec
+          @api_spec ||= YAML.load(File.read(file))
+        end
+      end
+    end
+  end
+end

--- a/app/_plugins/generators/ai_gateway_policy/pages/base.rb
+++ b/app/_plugins/generators/ai_gateway_policy/pages/base.rb
@@ -23,12 +23,24 @@ module Jekyll
               'has_overview?' => !@policy.overview_content.empty?,
               'title' => "#{@policy.metadata['title']} Policy"
             )
+            .merge(api_reference_data)
         end
 
         def icon
           return unless @policy.icon
 
           "/assets/icons/plugins/#{@policy.icon}"
+        end
+
+        private
+
+        def api_reference_data
+          return {} unless @policy.api_spec_exists?
+
+          {
+            'api_spec_exists?' => true,
+            'api_reference_url' => ApiReference.url(@policy)
+          }
         end
       end
     end

--- a/app/_plugins/generators/ai_gateway_policy/policy.rb
+++ b/app/_plugins/generators/ai_gateway_policy/policy.rb
@@ -17,6 +17,14 @@ module Jekyll
         @examples ||= []
       end
 
+      def api_spec_exists?
+        File.exist?(api_spec_file_path)
+      end
+
+      def api_spec_file_path
+        @api_spec_file_path ||= File.join('api-specs', 'ai-gateway', 'policies', slug, 'openapi.yaml')
+      end
+
       def metadata
         @metadata ||= api_plugin
                       .data['plugin']

--- a/app/_plugins/generators/policies/generator.rb
+++ b/app/_plugins/generators/policies/generator.rb
@@ -34,7 +34,10 @@ module Jekyll
 
         generate_reference_page(policy)
         generate_example_pages(policy)
+        generate_api_reference_page(policy)
       end
+
+      def generate_api_reference_page(_policy); end
 
       def generate_overview_page(policy)
         overview = overview_page_class

--- a/app/_plugins/generators/policies/generator_base.rb
+++ b/app/_plugins/generators/policies/generator_base.rb
@@ -19,6 +19,10 @@ module Jekyll
         "#{namespace}::Pages::Example".constantize
       end
 
+      def api_reference_page_class
+        "#{namespace}::Pages::ApiReference".constantize
+      end
+
       def namespace
         self.class.name.deconstantize
       end

--- a/spec/app/_plugins/generators/ai_gateway_policy/pages/api_reference_spec.rb
+++ b/spec/app/_plugins/generators/ai_gateway_policy/pages/api_reference_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require_relative '../../../../../spec_helper'
+
+RSpec.describe Jekyll::AIGatewayPolicyPages::Pages::ApiReference do
+  let(:policy) do
+    instance_double(
+      Jekyll::AIGatewayPolicyPages::Policy,
+      slug: 'my-policy',
+      metadata: { 'title' => 'My Policy', 'scopes' => [] },
+      overview_page_class: Jekyll::AIGatewayPolicyPages::Pages::Overview,
+      reference_page_class: Jekyll::AIGatewayPolicyPages::Pages::Reference,
+      examples: [],
+      latest_release_in_range: '1.0',
+      publish?: true,
+      schema: { 'properties' => { 'config' => {} } },
+      icon: nil,
+      unreleased?: false,
+      min_release: nil,
+      overview_content: '',
+      api_spec_exists?: true
+    )
+  end
+
+  let(:spec_file) { 'api-specs/ai-gateway/policies/my-policy/openapi.yaml' }
+  let(:page) { described_class.new(policy:, file: spec_file) }
+
+  describe '.url' do
+    context 'when the policy is released' do
+      it { expect(described_class.url(policy)).to eq('/ai-gateway/policies/my-policy/api/') }
+    end
+
+    context 'when the policy is unreleased' do
+      before do
+        allow(policy).to receive(:unreleased?).and_return(true)
+        allow(policy).to receive(:min_release).and_return('2.0')
+      end
+
+      it { expect(described_class.url(policy)).to eq('/ai-gateway/policies/my-policy/api/2.0/') }
+    end
+  end
+
+  describe '#layout' do
+    it { expect(page.layout).to eq('policies/api_reference') }
+  end
+
+  describe '#content' do
+    it { expect(page.content).to eq('') }
+  end
+
+  describe '#markdown_content' do
+    it 'reads the shared plugin api_reference include' do
+      expect(page.markdown_content).to eq(File.read('app/_includes/plugins/api_reference.md'))
+    end
+  end
+
+  describe '#data' do
+    let(:raw_spec) { { 'openapi' => '3.0.0', 'info' => { 'title' => 'My Policy API' } } }
+
+    before do
+      allow(File).to receive(:read).and_call_original
+      allow(File).to receive(:read).with(spec_file).and_return(raw_spec.to_yaml)
+    end
+
+    subject(:data) { page.data }
+
+    it { expect(data['api_reference?']).to be(true) }
+    it { expect(data['toc']).to be(false) }
+    it { expect(data['api_spec']).to eq(raw_spec) }
+    it { expect(data['layout']).to eq('policies/api_reference') }
+    it { expect(data['api_spec_exists?']).to be(true) }
+    it { expect(data['api_reference_url']).to eq('/ai-gateway/policies/my-policy/api/') }
+  end
+end

--- a/spec/app/_plugins/generators/ai_gateway_policy/pages/base_spec.rb
+++ b/spec/app/_plugins/generators/ai_gateway_policy/pages/base_spec.rb
@@ -6,8 +6,12 @@ RSpec.describe Jekyll::AIGatewayPolicyPages::Pages::Base do
   let(:policy) do
     instance_double(
       Jekyll::AIGatewayPolicyPages::Policy,
+      slug: 'my-policy',
       schema: { 'properties' => { 'config' => {} } },
-      icon: 'my-policy.png'
+      icon: 'my-policy.png',
+      unreleased?: false,
+      min_release: nil,
+      api_spec_exists?: false
     )
   end
 
@@ -30,6 +34,21 @@ RSpec.describe Jekyll::AIGatewayPolicyPages::Pages::Base do
       before { allow(policy).to receive(:icon).and_return(nil) }
 
       it { expect(page.icon).to be_nil }
+    end
+  end
+
+  describe '#api_reference_data (via #data)' do
+    subject(:data) { page.send(:api_reference_data) }
+
+    context 'when the policy has no api spec' do
+      it { expect(data).to eq({}) }
+    end
+
+    context 'when the policy has an api spec' do
+      before { allow(policy).to receive(:api_spec_exists?).and_return(true) }
+
+      it { expect(data['api_spec_exists?']).to be(true) }
+      it { expect(data['api_reference_url']).to eq('/ai-gateway/policies/my-policy/api/') }
     end
   end
 end

--- a/spec/app/_plugins/generators/ai_gateway_policy/pages/overview_spec.rb
+++ b/spec/app/_plugins/generators/ai_gateway_policy/pages/overview_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Jekyll::AIGatewayPolicyPages::Pages::Overview do
       icon: nil,
       unreleased?: false,
       min_release: nil,
-      overview_content: 'Some content'
+      overview_content: 'Some content',
+      api_spec_exists?: false
     )
   end
 

--- a/spec/app/_plugins/generators/ai_gateway_policy/pages/reference_spec.rb
+++ b/spec/app/_plugins/generators/ai_gateway_policy/pages/reference_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Jekyll::AIGatewayPolicyPages::Pages::Reference do
       icon: nil,
       unreleased?: false,
       min_release: nil,
-      overview_content: 'Some content'
+      overview_content: 'Some content',
+      api_spec_exists?: false
     )
   end
 

--- a/spec/app/_plugins/generators/ai_gateway_policy/policy_spec.rb
+++ b/spec/app/_plugins/generators/ai_gateway_policy/policy_spec.rb
@@ -67,6 +67,24 @@ RSpec.describe Jekyll::AIGatewayPolicyPages::Policy do
     it { expect(policy.examples).to eq([]) }
   end
 
+  describe '#api_spec_file_path' do
+    it { expect(policy.api_spec_file_path).to eq("api-specs/ai-gateway/policies/#{slug}/openapi.yaml") }
+  end
+
+  describe '#api_spec_exists?' do
+    context 'when the spec file exists' do
+      before { allow(File).to receive(:exist?).with(policy.api_spec_file_path).and_return(true) }
+
+      it { expect(policy.api_spec_exists?).to be(true) }
+    end
+
+    context 'when the spec file does not exist' do
+      before { allow(File).to receive(:exist?).with(policy.api_spec_file_path).and_return(false) }
+
+      it { expect(policy.api_spec_exists?).to be(false) }
+    end
+  end
+
   describe '#metadata' do
     subject(:metadata) { policy.metadata }
 


### PR DESCRIPTION
## Description

Render api reference pages for aigw policies.
NOTE: the two api specs need to be generated. 

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
