### PR TITLE
feat(codeblocks): wrap codeblocks if they have the `wrap` present

### DIFF
--- a/app/_assets/stylesheets/index.css
+++ b/app/_assets/stylesheets/index.css
@@ -822,12 +822,8 @@
   }
 
   .custom-code-block.wrap {
-    [data-code-snippet] {
-      @apply overflow-visible;
-    }
-
     pre {
-      @apply whitespace-pre-wrap overflow-visible;
+      @apply whitespace-pre-wrap overflow-auto;
     }
   }
 

--- a/app/_assets/stylesheets/index.css
+++ b/app/_assets/stylesheets/index.css
@@ -821,6 +821,16 @@
     }
   }
 
+  .custom-code-block.wrap {
+    [data-code-snippet] {
+      @apply overflow-visible;
+    }
+
+    pre {
+      @apply whitespace-pre-wrap overflow-visible;
+    }
+  }
+
   clipboard-copy {
     @apply p-1 rounded border border-transparent hover:border-primary text-secondary hover:text-primary transition-colors;
 

--- a/app/_support/code-10-error-invalid-unique-name.md
+++ b/app/_support/code-10-error-invalid-unique-name.md
@@ -30,6 +30,7 @@ This returns the following error:
 ```json
 {"code":10,"name":"invalid unique name","message":"must not be one of: workspaces, consumers, certificates, services, routes, snis, upstreams, targets, consumer_groups, plugins, tags, ca_certificates, clustering_data_planes, parameters, vaults, key_sets, keys, filter_chains, files, legacy_files, workspace_entity_counters, consumer_reset_secrets, credentials, audit_requests, audit_objects, rbac_users, rbac_roles, rbac_user_roles, rbac_role_entities, rbac_role_endpoints, admins, developers, document_objects, applications, application_instances, groups, group_rbac_roles, login_attempts, keyring_meta, keyring_keys, event_hooks, licenses, consumer_group_plugins, consumer_group_consumers, rbac_user_groups"}
 ```
+{:.no-copy-code.wrap}
 
 ## Cause
 

--- a/app/_support/configuration-does-not-fit-in-lmdb-database-error.md
+++ b/app/_support/configuration-does-not-fit-in-lmdb-database-error.md
@@ -25,7 +25,7 @@ The following LMDB error is returned when pushing configuration to data planes:
 ```
 time="2023-01-31T11:12:33Z" level=error msg="could not update kong admin" error="posting new config to /config: HTTP status 413 (message: \"Configuration does not fit in LMDB database, consider raising the \\\"lmdb_map_size\\\" config for Kong\")" subsystem=dataplane-synchronizer
 ```
-{:.no-copy-code}
+{:.no-copy-code.wrap}
 
 
 ## Solution

--- a/app/_support/configuration-does-not-fit-in-lmdb-database-error.md
+++ b/app/_support/configuration-does-not-fit-in-lmdb-database-error.md
@@ -14,7 +14,7 @@ tldr:
     planes. Increase the size by raising `lmdb_map_size` (for example, `KONG_LMDB_MAP_SIZE=256m`,
     or `lmdb_map_size: "256m"` on Kubernetes, along with a larger `prefixDir` `sizeLimit`).
 related_resources:
-  - text: "`lmdb_map_size`"
+  - text: "lmdb_map_size"
     url: /gateway/configuration/#lmdb-map-size
 ---
 

--- a/app/_support/error-nginx-kong-lua-9-expected-near-customformat-when-using-a-custom-log-format.md
+++ b/app/_support/error-nginx-kong-lua-9-expected-near-customformat-when-using-a-custom-log-format.md
@@ -36,6 +36,7 @@ stack traceback:
         [C]: in function 'xpcall'
         init_worker_by_lua:53: in function <init_worker_by_lua:51>
 ```
+{:.no-copy-code.wrap}
 
 Where `customformat` is the name you've given to the `log_format`.
 

--- a/app/_support/error-require-resty-http-not-allowed-within-sandbox.md
+++ b/app/_support/error-require-resty-http-not-allowed-within-sandbox.md
@@ -13,9 +13,9 @@ tldr:
     The plugin runs in a sandbox that blocks `require` of certain modules.
     Add the module to `untrusted_lua_sandbox_requires` (preferred), or set `untrusted_lua` to `on` to disable the sandbox entirely (use with caution).
 related_resources:
-  - text: "`untrusted_lua_sandbox_requires`"
+  - text: "untrusted_lua_sandbox_requires"
     url: /gateway/configuration/#untrusted-lua-sandbox-requires
-  - text: "`untrusted_lua`"
+  - text: "untrusted_lua"
     url: /gateway/configuration/#untrusted-lua
 ---
 

--- a/app/_support/error-this-instance-contains-workspaced-entities-that-need-a-custom-migration-in-helm-upgrade.md
+++ b/app/_support/error-this-instance-contains-workspaced-entities-that-need-a-custom-migration-in-helm-upgrade.md
@@ -28,7 +28,7 @@ please use the provided helpers to migrate them:
 kong migrations upgrade-workspace-table vaults_beta
 Error: nginx not running in prefix: /tmp/tmp.okiPjN Run with --v (verbose) or --vv (debug) for more details
 ```
-{:.no-copy-code}
+{:.no-copy-code.wrap}
 
 ## Solution
 

--- a/app/_support/how-to-get-the-exit-transformer-to-return-a-null-in-the-response-body.md
+++ b/app/_support/how-to-get-the-exit-transformer-to-return-a-null-in-the-response-body.md
@@ -10,7 +10,7 @@ works_on:
 related_resources:
   - text: Exit Transformer plugin
     url: /plugins/exit-transformer/
-  - text: "`untrusted_lua`"
+  - text: "untrusted_lua"
     url: /gateway/configuration/#untrusted-lua
 tldr:
   q: How do I configure the Exit Transformer plugin to return a field with a null value in the response body?

--- a/app/_support/how-to-use-topologyspreadconstraints-to-distribute-pods-evenly.md
+++ b/app/_support/how-to-use-topologyspreadconstraints-to-distribute-pods-evenly.md
@@ -45,6 +45,7 @@ k8s-master-node   Ready    control-plane   116d   v1.24.3   kubernetes.io/hostna
 k8s-worker-1      Ready    <none>          116d   v1.24.3   kubernetes.io/hostname=k8s-worker-1,zone=1
 k8s-worker-2      Ready    <none>          116d   v1.24.3   kubernetes.io/hostname=k8s-worker-2,zone=2
 ```
+{:.no-copy-code.wrap}
 
 The key parameters are:
 
@@ -76,6 +77,7 @@ Each pod is scheduled on a separate node:
 kong-enterprise-kong-785c5d5db8-bqqfx  | k8s-master-node |
 kong-enterprise-kong-785c5d5db8-pn9z5  | k8s-worker-1    |
 ```
+{:.no-copy-code.wrap}
 
 ### Example 2: 3 pods across 3 nodes
 
@@ -87,6 +89,7 @@ kong-enterprise-kong-785c5d5db8-bqqfx | k8s-master-node |
 kong-enterprise-kong-785c5d5db8-pn9z5 | k8s-worker-1    |
 kong-enterprise-kong-785c5d5db8-8gq6s | k8s-worker-2    |
 ```
+{:.no-copy-code.wrap}
 
 ### Example 3: 3 pods across 2 nodes using a zone label
 
@@ -108,5 +111,6 @@ kong-enterprise-kong-579f9678bd-mm5mj  | k8s-worker-2    |
 kong-enterprise-kong-579f9678bd-p788t  | k8s-worker-1    |
 kong-enterprise-kong-579f9678bd-whqrg  | k8s-worker-2    |
 ```
+{:.no-copy-code.wrap}
 
 This is a fairly simple load balancing scenario, but `topologySpreadConstraints` offers greater flexibility than affinity rules.

--- a/app/_support/how-to-view-the-contents-of-shared-dictionaries.md
+++ b/app/_support/how-to-view-the-contents-of-shared-dictionaries.md
@@ -72,4 +72,4 @@ The result in the Kong log:
 2023/02/06 07:44:30 [error] 2207#0: *990 [kong] [string "kong.log.err("PRE FUNCTION EXECUTED")..."]:8 [pre-function] jLcEZU3Fr004xsxam1jELW07UfLf8D7p|1675669470|1|172.18.0.1|sync, client: 172.18.0.1, server: kong, request: "GET /bin HTTP/1.1", host: "localhost:8000"
 2023/02/06 07:44:30 [error] 2207#0: *990 [kong] [string "kong.log.err("PRE FUNCTION EXECUTED")..."]:11 [pre-function] PRE FUNCTION ENDED, client: 172.18.0.1, server: kong, request: "GET /bin HTTP/1.1", host: "localhost:8000"
 ```
-{:.no-copy-code}
+{:.no-copy-code.wrap}

--- a/app/_support/kong-gateway-error-connecting-kong-to-postgresql-failed-to-retrieve-postgresql-server-version-num-fatal-no-pg-hba-conf-entry-ssl-off.md
+++ b/app/_support/kong-gateway-error-connecting-kong-to-postgresql-failed-to-retrieve-postgresql-server-version-num-fatal-no-pg-hba-conf-entry-ssl-off.md
@@ -13,9 +13,9 @@ tldr:
     {{site.base_gateway}} is connecting without SSL, but the PostgreSQL server requires it.
     Set `pg_ssl` to `on` (and `pg_ssl_version` if needed) to connect with SSL.
 related_resources:
-  - text: "`pg_ssl_version`"
+  - text: "pg_ssl_version"
     url: /gateway/configuration/#pg-ssl-version
-  - text: "`pg_ssl`"
+  - text: "pg_ssl"
     url: /gateway/configuration/#pg-ssl
 ---
 
@@ -26,14 +26,14 @@ You see this error when trying to connect {{site.base_gateway}} to your PostgreS
 ```text
 Error: [PostgreSQL error] failed to retrieve PostgreSQL server_version_num: FATAL: no pg_hba.conf entry for host "<IP/Hostname>", user "<user>", database "kong", SSL off
 ```
-{:.no-copy-code}
+{:.no-copy-code.wrap}
 
 Another variation of the error looks like this:
 
 ```text
 Error: [PostgreSQL error] failed to retrieve PostgreSQL server_version_num: FATAL: no pg_hba.conf entry for host "<IP/Hostname>", user "<user>", database "kong", no encryption"
 ```
-{:.no-copy-code}
+{:.no-copy-code.wrap}
 
 ## Cause
 

--- a/app/_support/pg_max_concurrent_queries-per-worker-process.md
+++ b/app/_support/pg_max_concurrent_queries-per-worker-process.md
@@ -10,9 +10,9 @@ works_on:
   - konnect
 
 related_resources:
-  - text: "`pg_max_concurrent_queries`"
+  - text: "pg_max_concurrent_queries"
     url: /gateway/configuration/#pg-max-concurrent-queries
-  - text: "`nginx_worker_processes`"
+  - text: "nginx_worker_processes"
     url: /gateway/configuration/#nginx-worker-processes
 
 tldr:

--- a/app/_support/when-trying-to-log-into-kong-manager-getting-error-config-secret-length-must-be-at-least-1.md
+++ b/app/_support/when-trying-to-log-into-kong-manager-getting-error-config-secret-length-must-be-at-least-1.md
@@ -21,7 +21,7 @@ When trying to log into Kong Manager, you receive the following error:
 ```
 [error] 2142#0: *3867 [lua] kong.lua:429: fn(): kong[auth][postgres] schema violation (config.client_secret: {"length must be at least 1"}), client: 123.123.123.1, server: kong_admin, request: "GET /auth?Kong-Admin-User=sample@email.com HTTP/1.1", host:"localhost:8001", referrer: "http://localhost:8002/"
 ```
-{:.no-copy-code}
+{:.no-copy-code.wrap}
 
 ## Cause
 

--- a/app/_support/why-does-the-output-of-the-file-log-plugin-get-mixed-with-kong-log-entries.md
+++ b/app/_support/why-does-the-output-of-the-file-log-plugin-get-mixed-with-kong-log-entries.md
@@ -13,9 +13,9 @@ tldr:
     Logs interleave because the Linux kernel can't guarantee atomicity for `write()` calls larger than the `PIPE_BUF` limit (4096 bytes), and this limit can't be changed.
     Use `custom_fields_by_lua` to remove unneeded fields from the File Log output and keep entries under the limit.
 related_resources:
-  - text: file-log
+  - text: File Log plugin
     url: /plugins/file-log/
-  - text: "`custom_fields_by_lua`"
+  - text: "custom_fields_by_lua"
     url: /plugins/file-log/#custom-fields-by-lua
   - text: Kong charts values.yaml
     url: https://github.com/Kong/charts/blob/kong-2.47.0/charts/kong/values.yaml#L101-L108

--- a/app/_support/why-does-the-output-of-the-file-log-plugin-get-mixed-with-kong-log-entries.md
+++ b/app/_support/why-does-the-output-of-the-file-log-plugin-get-mixed-with-kong-log-entries.md
@@ -1,7 +1,7 @@
 ---
 title: File Log plugin output mixed with {{site.base_gateway}} log entries
 content_type: support
-description: "When the File Lof plugin writes to /dev/stdout in a containerized environment, log entries can interleave because the Linux kernel can't guarantee atomicity for writes larger than the PIPE_BUF limit (4096 bytes)."
+description: "When the File Log plugin writes to /dev/stdout in a containerized environment, log entries can interleave because the Linux kernel can't guarantee atomicity for writes larger than the PIPE_BUF limit (4096 bytes)."
 products:
   - gateway
 works_on:


### PR DESCRIPTION
## Description

Wrap codeblocks instead of adding the scrollbar if they have the `wrap` class.

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
