### PR TITLE
docs(ai-gateway): add "Set up AI Proxy with Eden AI" how-to

### DIFF
--- a/app/_data/schemas/frontmatter/tags.json
+++ b/app/_data/schemas/frontmatter/tags.json
@@ -78,6 +78,7 @@
     "dynamic-client-registration",
     "dynatrace",
     "ecs",
+    "edenai",
     "encryption",
     "environments",
     "errors",

--- a/app/_how-tos/ai-gateway/set-up-ai-proxy-with-edenai.md
+++ b/app/_how-tos/ai-gateway/set-up-ai-proxy-with-edenai.md
@@ -1,0 +1,106 @@
+---
+title: Set up AI Proxy with {{ site.edenai }} in {{site.base_gateway}}
+permalink: /how-to/set-up-ai-proxy-with-edenai/
+content_type: how_to
+related_resources:
+  - text: "{{site.ai_gateway}}"
+    url: /ai-gateway/
+  - text: AI Proxy
+    url: /plugins/ai-proxy/
+
+description: Configure the AI Proxy plugin to create a chat route using Eden AI.
+
+products:
+  - gateway
+  - ai-gateway
+
+works_on:
+  - on-prem
+  - konnect
+
+min_version:
+  gateway: '3.6'
+
+plugins:
+  - ai-proxy
+
+entities:
+  - service
+  - route
+  - plugin
+
+tags:
+  - ai
+  - openai
+  - edenai
+
+tldr:
+  q: How do I use the AI Proxy plugin with Eden AI?
+  a: Create a Gateway Service and a Route, then enable the AI Proxy plugin and configure it with the OpenAI provider, an Eden AI model, your Eden AI API key, and Eden AI's upstream URL.
+
+tools:
+  - deck
+
+prereqs:
+  inline:
+    - title: Eden AI
+      content: |
+        This tutorial requires an [Eden AI](https://www.edenai.co/) API key.
+
+        1. [Create an Eden AI account](https://app.edenai.run/user/register).
+        1. Open **Settings** and copy your API key.
+        1. Create a decK variable with the API key:
+
+           ```sh
+           export DECK_EDENAI_API_KEY='YOUR EDEN AI API KEY'
+           ```
+  entities:
+    services:
+      - example-service
+    routes:
+      - example-route
+
+cleanup:
+  inline:
+    - title: Clean up Konnect environment
+      include_content: cleanup/platform/konnect
+      icon_url: /assets/icons/gateway.svg
+    - title: Destroy the {{site.base_gateway}} container
+      include_content: cleanup/products/gateway
+      icon_url: /assets/icons/gateway.svg
+---
+
+## Configure the plugin
+
+[Eden AI](https://www.edenai.co/) exposes an OpenAI-compatible API, so you can reach it with the `openai` provider by pointing `upstream_url` at Eden AI's endpoint. Eden AI is EU-based and GDPR-compliant, and a single key gives you access to models from many providers (OpenAI, Anthropic, Mistral, Google, and more) with provider fallback.
+
+The model name is Eden AI's own `provider/model` identifier. In this example, we'll use the `openai/gpt-4o-mini` model:
+
+{% entity_examples %}
+entities:
+  plugins:
+    - name: ai-proxy
+      config:
+        route_type: llm/v1/chat
+        auth:
+          header_name: Authorization
+          header_value: Bearer ${api_key}
+        model:
+          provider: openai
+          name: openai/gpt-4o-mini
+          options:
+            upstream_url: https://api.edenai.run/v3/chat/completions
+            max_tokens: 512
+            temperature: 1.0
+variables:
+  api_key:
+    value: $EDENAI_API_KEY
+    description: The API key to use to connect to Eden AI.
+{% endentity_examples %}
+
+{:.info}
+> For strict EU data residency, point `upstream_url` at Eden AI's EU endpoint (`https://api.eu.edenai.run/v3/chat/completions`) and use an EU-hosted model, for example `amazon/mistral.mistral-large-2402-v1:0`. The EU endpoint only serves EU-region models, so US-only models such as `openai/gpt-4o-mini` aren't available there.
+
+## Validate
+
+{% include how-tos/steps/ai-proxy-validate.md %}

--- a/jekyll.yml
+++ b/jekyll.yml
@@ -157,6 +157,7 @@ grok: Grok
 cerebras: Cerebras
 ollama: Ollama
 deepseek: DeepSeek
+edenai: Eden AI
 # Product names
 google_cloud: Google Cloud
 google_analytics: Google Analytics


### PR DESCRIPTION
## Summary

Adds a **Set up AI Proxy with Eden AI** how-to under `app/_how-tos/ai-gateway/`, plus the `site.edenai` vendor name.

[Eden AI](https://www.edenai.co/) exposes an OpenAI-compatible API, so it works with the AI Proxy `openai` provider by pointing `upstream_url` at Eden AI's endpoint — the same "dummy OpenAI-compatible provider" pattern already documented for **DeepSeek**. The guide mirrors that existing page.

## What's in the guide

- `provider: openai`, `name: openai/gpt-4o-mini`, `options.upstream_url: https://api.edenai.run/v3/chat/completions`
- `Authorization: Bearer ${api_key}` where `api_key` is a decK variable sourced from `$EDENAI_API_KEY` (key is never in the config)
- an EU-data-residency note for the `https://api.eu.edenai.run/v3` endpoint

## Why it's useful

Eden AI is an EU-based, GDPR-compliant gateway that fronts models from many providers (OpenAI, Anthropic, Mistral, Google, ...) behind a single key with provider fallback — a convenient data-sovereign upstream for AI Proxy users, and a documented answer to the recurring "how do I use an OpenAI-compatible provider" question.

## Verification

- The upstream contract the guide configures — `POST https://api.edenai.run/v3/chat/completions` with `model: openai/gpt-4o-mini` and Bearer auth — was run live and returned a valid chat completion (`200`).
- The EU-endpoint note was verified separately: `https://api.eu.edenai.run/v3/chat/completions` returns `200` with an EU-hosted model (e.g. `amazon/mistral.mistral-large-2402-v1:0`), and correctly rejects US-only models like `openai/gpt-4o-mini` — the note reflects that.
- The guide structure mirrors the merged `set-up-ai-proxy-with-deepseek` page. I wasn't able to run `make vale` / a local Jekyll build in my environment (missing toolchain), so a style-lint/preview pass on CI would be appreciated.
