### PR TITLE
Fix streaming plugin specs

### DIFF
--- a/app/_how-tos/gateway/stream-custom-plugins.md
+++ b/app/_how-tos/gateway/stream-custom-plugins.md
@@ -24,9 +24,11 @@ prereqs:
       include_content: prereqs/custom-plugin-permissions
       icon_url: /assets/icons/kogo-white.svg
   gateway:
-    - name: "KONG_CUSTOM_PLUGIN_STREAMING_ENABLED=on"
+    - name: "KONG_CUSTOM_PLUGIN_STREAMING_ENABLED"
+      value: "on"
   konnect:
-    - name: "KONG_CUSTOM_PLUGIN_STREAMING_ENABLED=on"
+    - name: "KONG_CUSTOM_PLUGIN_STREAMING_ENABLED"
+      value: "on"
   entities:
     services:
         - example-service

--- a/app/_how-tos/gateway/stream-custom-plugins.md
+++ b/app/_how-tos/gateway/stream-custom-plugins.md
@@ -119,6 +119,7 @@ custom_plugins:
       return WordReplacerHandler
 EOF
 ```
+{:data-test-step='block'}
 
 Where:
 * `custom_plugins.name`: A unique name for the plugin.
@@ -157,6 +158,7 @@ custom_plugins:
       return ReflectorHandler
 EOF
 ```
+{:data-test-step='block'}
 
 ## Configure the plugins
 

--- a/app/_includes/prereqs/products/gateway.md
+++ b/app/_includes/prereqs/products/gateway.md
@@ -60,7 +60,7 @@ to get an instance of {{site.base_gateway}} running almost instantly.
    {% if page.output_format == 'markdown' %}
    {{vanilla_snippet | liquify | indent: 3}}
    {% else %}
-   <div data-test-setup='{ "gateway": "{{page.min_version.gateway}}" }' markdown="1">
+   <div data-test-setup='{ "gateway": "{{page.min_version.gateway}}"{% for variable in include.env_variables %}{% if variable.value %}, "{{variable.name}}": "{{variable.value}}"{% else %}{% assign parts = variable.name | split: "=" %}, "{{parts[0]}}": "{{parts[1]}}"{% endif %}{% endfor %} }' markdown="1">
 {{vanilla_snippet | indent: 3}}
    </div>
 

--- a/app/_plugins/drops/entity_examples.rb
+++ b/app/_plugins/drops/entity_examples.rb
@@ -15,7 +15,7 @@ module Jekyll
 
       def data
         @data ||= EntityExample::Utils::VariableReplacer::DeckData.run(
-          data: Jekyll::Utils::HashToYAML.new(entities).convert,
+          data: requote_conditions(Jekyll::Utils::HashToYAML.new(entities).convert),
           variables: variables
         )
       end
@@ -30,6 +30,16 @@ module Jekyll
 
       def variables
         @variables ||= @config.fetch('variables', {})
+      end
+
+      private
+
+      def requote_conditions(yaml)
+        yaml.gsub(/^(\s+condition:\s+)'((?:[^']|'')*)'/) do
+          prefix = $1
+          inner = $2.gsub("''", "'").gsub('\\', '\\\\').gsub('"', '\\"')
+          "#{prefix}\"#{inner}\""
+        end
       end
     end
   end

--- a/tools/automated-tests/config/runtimes.yaml
+++ b/tools/automated-tests/config/runtimes.yaml
@@ -47,6 +47,9 @@ on-prem:
       commands:
         - curl -Ls https://get.konghq.com/quickstart | bash -s -- -r "" -i $KONG_IMAGE_NAME -t $KONG_IMAGE_TAG -e KONG_LICENSE_DATA
 
+      env_variables:
+        command: curl -Ls https://get.konghq.com/quickstart | bash -s -- -r "" -i $KONG_IMAGE_NAME -t $KONG_IMAGE_TAG -e KONG_LICENSE_DATA
+
       rbac:
         commands:
           - |

--- a/tools/automated-tests/instructions/runner.js
+++ b/tools/automated-tests/instructions/runner.js
@@ -39,6 +39,13 @@ function compareVersions(v1, v2) {
   return 0; // Versions are equal
 }
 
+function appendEnvFlags(command, env_variables) {
+  const flags = Object.entries(env_variables)
+    .map(([key, value]) => (value ? `-e ${key}=${value}` : `-e ${key}`))
+    .join(" ");
+  return `${command} ${flags}`;
+}
+
 async function runConfig(config, container) {
   try {
     if (config.commands) {
@@ -145,7 +152,7 @@ async function runSteps(steps, runtimeConfig, container) {
 
 export async function runInstructions(instructions, runtimeConfig, container) {
   let result = { name: instructions.name };
-  const { rbac, wasm } = await getSetupConfig(instructions.setup);
+  const { rbac, wasm, env_variables } = await getSetupConfig(instructions.setup);
   try {
     const check = await checkSetup(
       instructions.setup,
@@ -157,6 +164,16 @@ export async function runInstructions(instructions, runtimeConfig, container) {
       result["status"] = "skipped";
       result["assertions"] = [];
       return result;
+    }
+
+    if (
+      Object.keys(env_variables).length > 0 &&
+      runtimeConfig.setup?.env_variables?.command
+    ) {
+      await executeCommand(
+        container,
+        appendEnvFlags(runtimeConfig.setup.env_variables.command, env_variables)
+      );
     }
 
     if (rbac && runtimeConfig.setup?.rbac?.commands) {

--- a/tools/automated-tests/instructions/setup.js
+++ b/tools/automated-tests/instructions/setup.js
@@ -3,17 +3,23 @@ export async function processSetup(setup) {
   let version;
   let rbac;
   let wasm;
+  let env_variables = {};
   if (typeof setup === "object") {
     // It should be one key/value pair, e.g. { gateway: 'x.y' }
     runtime = Object.keys(setup)[0];
     version = setup[runtime];
     rbac = setup.rbac;
     wasm = setup.wasm;
+
+    const knownKeys = new Set([runtime, "rbac", "wasm"]);
+    env_variables = Object.fromEntries(
+      Object.entries(setup).filter(([key]) => !knownKeys.has(key)),
+    );
   } else {
     // Not an object, for products/platforms that don't have versions.
     runtime = setup;
   }
-  return { runtime, version, rbac, wasm };
+  return { runtime, version, rbac, wasm, env_variables };
 }
 
 export async function getSetupConfig(setup) {


### PR DESCRIPTION
## Description

fix(entity_examples): requote single-quoted condition scalars as double-quoted.
Psych emits single-quoted YAML for condition values starting with `!`
(e.g. `'!http.path.contains("skip")'`), which collides with the outer
`echo '...'` wrapper in the rendered deck command and breaks copy-paste.

fix:  variables passed to gateway's prereq and add support for running
gateway in automated tests with arbitrary variables

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
