### PR TITLE
fix(plugin-examples): remove tags if they are not set from plugin

### DIFF
--- a/app/_plugins/drops/plugin_config_example.rb
+++ b/app/_plugins/drops/plugin_config_example.rb
@@ -24,12 +24,7 @@ module Jekyll
           EntityExampleBlock::Plugin.new(
             example: {
               'type' => 'plugin',
-              'data' => {
-                'name' => plugin_slug,
-                target => nil,
-                'config' => config,
-                'tags' => tags
-              },
+              'data' => build_data(target),
               'formats' => formats,
               'variables' => example.fetch('variables', {})
             },
@@ -56,6 +51,14 @@ module Jekyll
                  else
                    "/plugins/#{@plugin.slug}/examples/#{slug}/"
                  end
+      end
+
+      private
+
+      def build_data(target)
+        data = { 'name' => plugin_slug, target => nil, 'config' => config }
+        data['tags'] = tags unless tags.empty?
+        data
       end
     end
   end


### PR DESCRIPTION
## Description

As reported in [slack](https://kongstrong.slack.com/archives/CDSTDSG9J/p1781875708488829)

The terraform manifest contains tags = [] even though it is optional. The APIs for plugins omit the key when tags are not defined, leading to configuration drift when terraform plan is run.

Removing tags from the config if they aren't present.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
