### PR TITLE
docs(dev-portal): note lua_ssl_verify_depth for Auth0 DCR on self-managed data planes

### DIFF
--- a/app/_how-tos/dev-portal/auth0-dcr.md
+++ b/app/_how-tos/dev-portal/auth0-dcr.md
@@ -163,6 +163,11 @@ Now that the application auth strategy is configured, you can apply it to an API
 
 1. Click **Publish API**.
 
+{:.warning}
+> **Certificate verification depth:** {{site.base_gateway}} verifies Auth0's TLS certificate when it connects to the Auth0 issuer to validate tokens. Auth0 certificates issued by Let's Encrypt present a certificate chain with multiple intermediate CAs, which is deeper than the default [`lua_ssl_verify_depth`](/gateway/configuration/#lua-ssl-verify-depth) of `1`. Combined with certificate verification being enabled by default in {{site.base_gateway}} 3.14 and later, this causes the TLS handshake to Auth0 to fail.
+>
+> On self-managed data planes, where you control `kong.conf`, set [`lua_ssl_verify_depth`](/gateway/configuration/#lua-ssl-verify-depth) high enough to cover Auth0's chain. Auth0's chain includes two intermediate CAs, so the value must be at least `2`. Also ensure [`lua_ssl_trusted_certificate`](/gateway/configuration/#lua-ssl-trusted-certificate) includes `system` so the root CA is trusted. After updating `kong.conf`, restart the data plane to apply the changes.
+
 ## Validate
 
 {% include konnect/dcr-validate.md %}


### PR DESCRIPTION
## What this does

Adds a warning to the [Auth0 DCR how-to](https://developer.konghq.com/how-to/auth0-dcr/) explaining a TLS verification failure that self-managed (hybrid) data planes hit when validating tokens against Auth0.

## Why

Auth0 now issues certificates via Let's Encrypt, whose certificate chain has **multiple intermediate CAs**:

```
Depth 0: us.auth0.com                          (leaf)
Depth 1: Let's Encrypt intermediate CA
Depth 2: ISRG intermediate CA
Depth 3: ISRG Root X2                           (trusted root)
```

This is deeper than Kong Gateway's default `lua_ssl_verify_depth` of `1`. Combined with certificate verification being enabled by default in Gateway 3.14+, the TLS handshake to the Auth0 issuer fails when a self-managed data plane connects to validate tokens.

## The fix documented

- Set `lua_ssl_verify_depth` to a value that accommodates the full chain (e.g. `5`, leaving headroom).
- Ensure `lua_ssl_trusted_certificate` includes `system` so the root CA is trusted.
- Note that Konnect-managed data planes aren't affected.

Follows the same house-style `{:.warning}` pattern as the existing Azure SMTP note.

## Notes for reviewer

- I did not run `make vale` locally (toolchain not installed); the prose mirrors an existing note, but please let CI/vale confirm.
- Recommended depth value is `5` for headroom; open to aligning with the `2` used in the Azure SMTP doc if preferred.