### PR TITLE
docs(operator): add KO 2.2.x Gateway API compatibility (v1.5.1)

### DIFF
--- a/app/_how-tos/operator/operator-dataplane-cert-manager.md
+++ b/app/_how-tos/operator/operator-dataplane-cert-manager.md
@@ -97,8 +97,7 @@ spec:
 Create the following resources:
 
 * A `GatewayConfiguration` and a `GatewayClass` to configure your gateway with the latest {{site.base_gateway}} version and {{site.operator_product_name}} as the controller.
-* A `Gateway` with the `cert-manager.io/issuer: "selfsigned-issuer"` annotation and the `tls.certificateRefs` pointing to the name of the Secret to provision.
-* A `Certificate` that references the cert-manager issuer and the provisioned Secret.
+* A `Gateway` with the `cert-manager.io/issuer: "selfsigned-issuer"` annotation, the `tls.certificateRefs` pointing to the name of the Secret to provision and `cert-manager.io/secret-template` to label the generated TLS Secret with konghq.com/secret=true.
 
 ```sh
 echo '
@@ -135,6 +134,7 @@ metadata:
   namespace: kong
   annotations:
     cert-manager.io/issuer: "selfsigned-issuer"
+    cert-manager.io/secret-template: "{\"labels\":{\"konghq.com/secret\":\"true\"}}"
 spec:
   gatewayClassName: kong-cert-manager
   listeners:
@@ -148,22 +148,6 @@ spec:
           - group: ""
             kind: Secret
             name: example-tls-secret
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: example-tls-certificate
-  namespace: kong
-spec:
-  secretName: example-tls-secret
-  issuerRef:
-    name: selfsigned-issuer
-    kind: Issuer
-  dnsNames:
-    - example.localdomain.dev
-  secretTemplate:
-    labels:
-      konghq.com/secret: "true"' | kubectl apply -f -
 ```
 
 ## Create an echo Service

--- a/app/_how-tos/operator/operator-dataplane-cert-manager.md
+++ b/app/_how-tos/operator/operator-dataplane-cert-manager.md
@@ -44,6 +44,12 @@ When you annotate a `Gateway` resource with a cert-manager issuer, cert-manager 
    helm repo update
    ```
 
+1. Install the Kubernetes Gateway API CRDs. cert-manager checks for these CRDs at startup when Gateway API support is enabled, so they must exist before you install cert-manager:
+
+   ```sh
+   kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v{{ site.gwapi_version }}/standard-install.yaml --server-side
+   ```
+
 1. Install [cert-manager](https://cert-manager.io/) on your cluster with Gateway API support enabled:
 
    ```sh
@@ -80,6 +86,50 @@ When you annotate a `Gateway` resource with a cert-manager issuer, cert-manager 
    indent: 3
    {% endkonnect %}
 
+{% konnect %}
+title: Authenticate to Konnect
+step: true
+content: |
+  Create a `KonnectAPIAuthConfiguration` resource so {{ site.operator_product_name }} can authenticate to {{ site.konnect_short_name }}. Export your {{ site.konnect_short_name }} personal access token, then apply the resource:
+
+  ```sh
+  export KONNECT_TOKEN='YOUR KONNECT TOKEN'
+  ```
+
+  ```sh
+  echo '
+  kind: KonnectAPIAuthConfiguration
+  apiVersion: konnect.konghq.com/v1alpha1
+  metadata:
+    name: konnect-api-auth
+    namespace: kong
+  spec:
+    type: token
+    token: "'$KONNECT_TOKEN'"
+    serverURL: us.api.konghq.com
+  ' | kubectl apply -f -
+  ```
+
+  {{ site.konnect_short_name }} provides the Enterprise license automatically once the `Gateway` is linked through this resource. No additional license steps are required.
+{% endkonnect %}
+
+{% on_prem %}
+title: Apply an Enterprise license
+step: true
+content: |
+  {{ site.operator_product_name }} requires an Enterprise license to reconcile Gateway API resources. Apply a `KongLicense`. This assumes that your license is available in `./license.json`:
+
+  ```sh
+  echo "
+  apiVersion: configuration.konghq.com/v1alpha1
+  kind: KongLicense
+  metadata:
+    name: kong-license
+  rawLicenseString: '$(cat ./license.json)'
+  " | kubectl apply -f -
+  ```
+{% endon_prem %}
+
 ## Create a cert-manager issuer
 
 The cert-manager `Issuer` resource represents a certificate authority. For more information, see the [cert-manager documentation](https://cert-manager.io/docs/configuration/).
@@ -105,56 +155,116 @@ Create the following resources:
 * A `GatewayConfiguration` and a `GatewayClass` to configure your gateway with the latest {{site.base_gateway}} version and {{site.operator_product_name}} as the controller.
 * A `Gateway` with the `cert-manager.io/issuer: "selfsigned-issuer"` annotation, the `tls.certificateRefs` pointing to the name of the Secret to provision and `cert-manager.io/secret-template` to label the generated TLS Secret with `konghq.com/secret=true`.
 
-```sh
-echo '
-apiVersion: gateway-operator.konghq.com/v2beta1
-kind: GatewayConfiguration
-metadata:
-  name: kong-gateway-configuration
-  namespace: kong
-spec:
-  dataPlaneOptions:
-    deployment:
-      podTemplateSpec:
-        spec:
-          containers:
-            - image: kong/kong-gateway:{{ site.data.gateway_latest.release }}
-              name: proxy
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: GatewayClass
-metadata:
-  name: kong-cert-manager
-spec:
-  controllerName: konghq.com/gateway-operator
-  parametersRef:
-    group: gateway-operator.konghq.com
-    kind: GatewayConfiguration
+{% on_prem %}
+content: |
+  ```sh
+  echo '
+  apiVersion: gateway-operator.konghq.com/v2beta1
+  kind: GatewayConfiguration
+  metadata:
     name: kong-gateway-configuration
     namespace: kong
----
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: kong-gateway
-  namespace: kong
-  annotations:
-    cert-manager.io/issuer: "selfsigned-issuer"
-    cert-manager.io/secret-template: "{\"labels\":{\"konghq.com/secret\":\"true\"}}"
-spec:
-  gatewayClassName: kong-cert-manager
-  listeners:
-    - name: https
-      port: 443
-      protocol: HTTPS
-      hostname: example.localdomain.dev
-      tls:
-        mode: Terminate
-        certificateRefs:
-          - group: ""
-            kind: Secret
-            name: example-tls-secret' | kubectl apply -f -
-```
+  spec:
+    dataPlaneOptions:
+      deployment:
+        podTemplateSpec:
+          spec:
+            containers:
+              - image: kong/kong-gateway:{{ site.data.gateway_latest.release }}
+                name: proxy
+  ---
+  apiVersion: gateway.networking.k8s.io/v1
+  kind: GatewayClass
+  metadata:
+    name: kong-cert-manager
+  spec:
+    controllerName: konghq.com/gateway-operator
+    parametersRef:
+      group: gateway-operator.konghq.com
+      kind: GatewayConfiguration
+      name: kong-gateway-configuration
+      namespace: kong
+  ---
+  apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: kong-gateway
+    namespace: kong
+    annotations:
+      cert-manager.io/issuer: "selfsigned-issuer"
+      cert-manager.io/secret-template: "{\"labels\":{\"konghq.com/secret\":\"true\"}}"
+  spec:
+    gatewayClassName: kong-cert-manager
+    listeners:
+      - name: https
+        port: 443
+        protocol: HTTPS
+        hostname: example.localdomain.dev
+        tls:
+          mode: Terminate
+          certificateRefs:
+            - group: ""
+              kind: Secret
+              name: example-tls-secret' | kubectl apply -f -
+  ```
+{% endon_prem %}
+
+{% konnect %}
+content: |
+  ```sh
+  echo '
+  apiVersion: gateway-operator.konghq.com/v2beta1
+  kind: GatewayConfiguration
+  metadata:
+    name: kong-gateway-configuration
+    namespace: kong
+  spec:
+    konnect:
+      authRef:
+        name: konnect-api-auth
+    dataPlaneOptions:
+      deployment:
+        podTemplateSpec:
+          spec:
+            containers:
+              - image: kong/kong-gateway:{{ site.data.gateway_latest.release }}
+                name: proxy
+  ---
+  apiVersion: gateway.networking.k8s.io/v1
+  kind: GatewayClass
+  metadata:
+    name: kong-cert-manager
+  spec:
+    controllerName: konghq.com/gateway-operator
+    parametersRef:
+      group: gateway-operator.konghq.com
+      kind: GatewayConfiguration
+      name: kong-gateway-configuration
+      namespace: kong
+  ---
+  apiVersion: gateway.networking.k8s.io/v1
+  kind: Gateway
+  metadata:
+    name: kong-gateway
+    namespace: kong
+    annotations:
+      cert-manager.io/issuer: "selfsigned-issuer"
+      cert-manager.io/secret-template: "{\"labels\":{\"konghq.com/secret\":\"true\"}}"
+  spec:
+    gatewayClassName: kong-cert-manager
+    listeners:
+      - name: https
+        port: 443
+        protocol: HTTPS
+        hostname: example.localdomain.dev
+        tls:
+          mode: Terminate
+          certificateRefs:
+            - group: ""
+              kind: Secret
+              name: example-tls-secret' | kubectl apply -f -
+  ```
+{% endkonnect %}
 
 ## Create an echo Service
 

--- a/app/_how-tos/operator/operator-dataplane-cert-manager.md
+++ b/app/_how-tos/operator/operator-dataplane-cert-manager.md
@@ -40,13 +40,19 @@ When you annotate a `Gateway` resource with a cert-manager issuer, cert-manager 
 
    ```sh
    helm repo add kong https://charts.konghq.com
+   helm repo add jetstack https://charts.jetstack.io
    helm repo update
    ```
 
-1. Install [cert-manager](https://cert-manager.io/) on your cluster:
+1. Install [cert-manager](https://cert-manager.io/) on your cluster with Gateway API support enabled:
 
    ```sh
-   kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.2/cert-manager.yaml
+   helm upgrade --install cert-manager jetstack/cert-manager \
+     --namespace cert-manager \
+     --create-namespace \
+     --set crds.enabled=true \
+     --set config.enableGatewayAPI=true \
+     --wait
    ```
 
 1. Install {{ site.operator_product_name }} using Helm:
@@ -97,7 +103,7 @@ spec:
 Create the following resources:
 
 * A `GatewayConfiguration` and a `GatewayClass` to configure your gateway with the latest {{site.base_gateway}} version and {{site.operator_product_name}} as the controller.
-* A `Gateway` with the `cert-manager.io/issuer: "selfsigned-issuer"` annotation, the `tls.certificateRefs` pointing to the name of the Secret to provision and `cert-manager.io/secret-template` to label the generated TLS Secret with konghq.com/secret=true.
+* A `Gateway` with the `cert-manager.io/issuer: "selfsigned-issuer"` annotation, the `tls.certificateRefs` pointing to the name of the Secret to provision and `cert-manager.io/secret-template` to label the generated TLS Secret with `konghq.com/secret=true`.
 
 ```sh
 echo '
@@ -147,7 +153,7 @@ spec:
         certificateRefs:
           - group: ""
             kind: Secret
-            name: example-tls-secret
+            name: example-tls-secret' | kubectl apply -f -
 ```
 
 ## Create an echo Service
@@ -172,6 +178,7 @@ metadata:
 spec:
   parentRefs:
     - name: kong-gateway
+      namespace: kong
   rules:
     - matches:
         - path:
@@ -188,8 +195,10 @@ spec:
 1.  Check that cert-manager has created the `Certificate` resource and that the `Secret` has been provisioned:
 
     ```bash
+    kubectl wait --for=condition=Ready certificate/example-tls-secret -n kong --timeout=120s
     kubectl get certificate -n kong
-    kubectl get secret example-tls-secret -n kong
+    kubectl get secret example-tls-secret -n kong --show-labels
+    kubectl wait --for=condition=Programmed gateway/kong-gateway -n kong --timeout=300s
     ```
 
 1. Get the Gateway's external IP:

--- a/app/operator/reference/version-compatibility.md
+++ b/app/operator/reference/version-compatibility.md
@@ -81,10 +81,13 @@ versions:
   - "1.2.0"
   - "1.3.0"
   - "1.4.0"
+  - "1.5.0"
+  - "1.5.1"
 compatible_product: "{{site.operator_product_name}}"
 compatible_versions:
   "2.0.x": ["1.0.0", "1.1.0", "1.2.0", "1.3.0"]
   "2.1.x": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0"]
+  "2.2.x": ["1.0.0", "1.1.0", "1.2.0", "1.3.0", "1.4.0", "1.5.0", "1.5.1"]
 {% endversion_compatibility_table %}
 
 [gateway-api]: https://github.com/kubernetes-sigs/gateway-api

--- a/app/operator/reference/version-compatibility.md
+++ b/app/operator/reference/version-compatibility.md
@@ -91,7 +91,7 @@ compatible_versions:
 {% endversion_compatibility_table %}
 
 [gateway-api]: https://github.com/kubernetes-sigs/gateway-api
-[gateway-api-supported-versions]:https://gateway-api.sigs.k8s.io/concepts/versioning/#supported-versions
+[gateway-api-supported-versions]:https://gateway-api.sigs.k8s.io/docs/concepts/versioning/#supported-versions
 
 ### `kubernetes-configuration` CRDs
 


### PR DESCRIPTION
KO 2.2.0 upgraded to Gateway API v1.5.1. Add 2.2.x row and the 1.5.0/1.5.1 version columns to the Gateway API compatibility table.


## Description

Bump the Gateway API versions
Tweak to the cert-manager example to remove the need to create a Certificate resource

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
