### PR TITLE
fix(ai-gateway): Align providers docs with 0.0.47 API schema

### DIFF
--- a/app/_ai_gateway_entities/ai-agent.md
+++ b/app/_ai_gateway_entities/ai-agent.md
@@ -61,12 +61,12 @@ faqs:
 
   - q: How do I limit which AI Consumers can reach an AI Agent?
     a: |
-      Set the [`acls`](#schema-aigateway-agent-acls) field on the AI Agent with allow or deny lists. Each entry is a string that
+      Set the [`access.acls`](#schema-aigateway-agent-access) field on the AI Agent with an allow list or a deny list. Each entry is a string that
       references an AI Consumer, AI Consumer Group, or Authenticated Group by name.
 
-  - q: Can the same plugin run on an AI Agent that I'd attach to a route or service?
+  - q: How do I attach AI Policies to an AI Agent?
     a: |
-      Plugin configuration that applies to the AI Agent goes through the [AI Policy entity](/ai-gateway/entities/ai-policy/).
+      Configuration that applies to the AI Agent goes through the [AI Policy entity](/ai-gateway/entities/ai-policy/).
       Attach AI Policies to the AI Agent through its [`policies`](#schema-aigateway-agent-policies) field.
 ---
 
@@ -282,7 +282,7 @@ When an upstream agent returns an agent card, the runtime rewrites the [`url`](#
 
 To track agent performance, debug issues, and monitor A2A traffic patterns, enable statistics logging. {{site.ai_gateway}} emits structured A2A telemetry that flows to {{site.konnect_short_name}} analytics, logging plugins, and OpenTelemetry for full visibility into agent operations.
 
-The telemetry data is emitted into the `ai.a2a` namespace (consumed by {{site.konnect_short_name}} analytics and logging plugins) and creates a `kong.a2a` child span when you've configured [{{site.base_gateway}} tracing](/gateway/tracing/). For the canonical metric and attribute list, see [A2A metrics](/ai-gateway/ai-otel-metrics/#a2a-metrics).
+The telemetry data is emitted into the `ai.a2a` namespace (consumed by {{site.konnect_short_name}} analytics and logging AI Policies) and creates a `kong.a2a` child span when you've configured [{{site.base_gateway}} tracing](/gateway/tracing/). For the canonical metric and attribute list, see [A2A metrics](/ai-gateway/ai-otel-metrics/#a2a-metrics).
 
 {:.info}
 > When statistics logging is enabled, the runtime removes the `Accept-Encoding` request header
@@ -299,17 +299,17 @@ You can view A2A analytics in {{site.konnect_short_name}} Explorer and Dashboard
 
 ### Log output fields
 
-{% include /plugins/ai-a2a-proxy/log-output-fields.md %}
+{% include md/ai-gateway/v2/log-output-fields.md %}
 
 ### OpenTelemetry span attributes
 
 When statistics logging is enabled and {{site.base_gateway}} tracing is configured, the runtime creates a `kong.a2a` child span with the following attributes:
 
-{% include /plugins/ai-a2a-proxy/otel-span-attributes.md %}
+{% include md/ai-gateway/v2/otel-span-attributes.md %}
 
 ## Access control
 
-To restrict which consumers or teams can reach a specific agent, use ACLs. The [`acls`](#schema-aigateway-agent-acls) field defines `allow` and `deny` lists of identities that can access the agent. Each entry references an [AI Consumer](/ai-gateway/entities/ai-consumer/), [AI Consumer Group](/ai-gateway/entities/ai-consumer-group/), or Authenticated Group by name. An **Authenticated Group** is a dynamic group representing all consumers authenticated via a specific OAuth2 scope or claim. Access is enforced before traffic reaches the upstream agent.
+To restrict which AI Consumers or teams can reach a specific agent, use ACLs. The [`access.acls`](#schema-aigateway-agent-access) field defines either an `allow` or a `deny` list of identities that can access the agent. Each entry references an [AI Consumer](/ai-gateway/entities/ai-consumer/), [AI Consumer Group](/ai-gateway/entities/ai-consumer-group/), or Authenticated Group by name. An Authenticated Group is a dynamic group representing all consumers authenticated via a specific OAuth2 scope or claim. Access is enforced before traffic reaches the upstream agent.
 
 For per-request authentication and identity validation, attach an authentication AI Policy to the AI Agent.
 
@@ -329,9 +329,10 @@ data:
   display_name: KongAir Flight Booking Agent
   name: kongair-flight-booking-agent
   type: a2a
-  acls:
-    allow:
-      - internal-teams
+  access:
+    acls:
+      allow:
+        - internal-teams
   policies: []
   config:
     url: https://booking-agent.internal.kongair.com
@@ -344,6 +345,30 @@ data:
       max_payload_size: 1048576
 {% endentity_example %}
 
+
+<!-- Uncomment before GA (kongctl AI Gateway declarative support not yet documented in app/kongctl/supported-resources.md):
+```yaml
+agents:
+  - name: kongair-flight-booking-agent
+    ref: kongair-flight-booking-agent
+    display_name: "KongAir Flight Booking Agent"
+    type: a2a
+    access:
+      acls:
+        allow:
+          - internal-teams
+    policies: []
+    config:
+      url: https://booking-agent.internal.kongair.com
+      route:
+        paths:
+          - /kongair-flight-booking
+      logging:
+        statistics: true
+        payloads: false
+        max_payload_size: 1048576
+```
+-->
 ## Schema
 
 {% entity_schema %}

--- a/app/_ai_gateway_entities/ai-agent.md
+++ b/app/_ai_gateway_entities/ai-agent.md
@@ -48,8 +48,8 @@ faqs:
   - q: Why is the agent-card URL rewritten?
     a: |
       A2A clients use agent-card responses (at `/.well-known/agent-card.json`) to discover where to
-      send subsequent requests. Rewriting the [`url`](#schema-aigateway-agent-config-url) field, and any [`additionalInterfaces[].url`](#schema-aigateway-agent-config-additional-interfaces-url)
-      fields, to the {{site.ai_gateway}} address means clients route follow-up traffic through the
+      send subsequent requests. Rewriting the [`url`](#schema-aigateway-agent-config-url) field, and any `additionalInterfaces[].url`
+      fields on the agent card response, to the {{site.ai_gateway}} address means clients route follow-up traffic through the
       gateway instead of bypassing it. The rewrite honors `X-Forwarded-*` headers when the gateway
       sits behind a load balancer.
 
@@ -87,6 +87,7 @@ AI Agents can be created and managed through:
 
 * {{site.konnect_short_name}} UI
 * {{site.ai_gateway}} API: `/v1/ai-gateways/{aiGatewayId}/agents`
+* [kongctl](/kongctl/)
 
 For configuration examples and step-by-step setup instructions, see the following [Set up an AI Agent](#set-up-an-ai-agent) section.
 

--- a/app/_ai_gateway_entities/ai-consumer-group.md
+++ b/app/_ai_gateway_entities/ai-consumer-group.md
@@ -104,6 +104,7 @@ AI Consumer Groups can be created and managed through:
 
 * {{site.konnect_short_name}} UI
 * {{site.ai_gateway}} API: `/v1/ai-gateways/{aiGatewayId}/consumer-groups`
+* [kongctl](/kongctl/)
 
 For configuration examples and step-by-step setup instructions, see [Set up an AI Consumer Group](#set-up-an-ai-consumer-group) below.
 

--- a/app/_ai_gateway_entities/ai-consumer-group.md
+++ b/app/_ai_gateway_entities/ai-consumer-group.md
@@ -59,7 +59,8 @@ faqs:
 
   - q: How do I gate access to an AI Model, AI Agent, or AI MCP Server with an AI Consumer Group?
     a: |
-      Add the AI Consumer Group's name to the parent entity's `acls.allow` or `acls.deny` list.
+      Add the AI Consumer Group's name to the parent entity's `access.acls.allow` or `access.acls.deny` list.
+      For AI Models and AI Agents, configure exactly one of `allow` or `deny`. For AI MCP Servers, both can be set simultaneously.
       ACLs accept AI Consumer, AI Consumer Group, and Authenticated Group names.
       See the [AI Model entity](/ai-gateway/entities/ai-model/) reference.
 ---
@@ -143,7 +144,7 @@ You can attach multiple AI Policies to a single AI Consumer Group with different
 
 ## Use in parent entity ACLs
 
-To restrict access to specific [AI Models](/ai-gateway/entities/ai-model/), [AI Agents](/ai-gateway/entities/ai-agent/), or [AI MCP Servers](/ai-gateway/entities/ai-mcp-server/) by AI Consumer Group (for example, allowing only Gold tier AI Consumers to access premium models), use ACLs. The `acls` field on these entities accepts AI Consumer Group names alongside AI Consumer and Authenticated Group names. Add an AI Consumer Group to a parent entity's `acls.allow` list to permit its members access, or to `acls.deny` to block them.
+To restrict access to specific [AI Models](/ai-gateway/entities/ai-model/), [AI Agents](/ai-gateway/entities/ai-agent/), or [AI MCP Servers](/ai-gateway/entities/ai-mcp-server/) by AI Consumer Group (for example, allowing only Gold tier AI Consumers to access premium models), use ACLs. The `access.acls` field on these entities accepts AI Consumer Group names alongside AI Consumer and Authenticated Group names. For AI Models and AI Agents, configure exactly one of `access.acls.allow` to permit access or `access.acls.deny` to block it. You can't set both at the same time. For AI MCP Servers, `access.acls` supports setting `allow`, `deny`, or both.
 
 AI Consumer Group membership is resolved after the request is authenticated and the AI Consumer is identified.
 
@@ -158,6 +159,16 @@ data:
   name: internal-teams
   policies: []
 {% endentity_example %}
+
+<!-- Uncomment before GA (kongctl AI Gateway declarative support not yet documented in app/kongctl/supported-resources.md):
+```yaml
+consumer_groups:
+  - name: internal-teams
+    ref: internal-teams
+    display_name: "Internal Teams"
+    policies: []
+```
+-->
 
 ## Schema
 

--- a/app/_ai_gateway_entities/ai-consumer.md
+++ b/app/_ai_gateway_entities/ai-consumer.md
@@ -40,15 +40,17 @@ faqs:
 
   - q: How do I add credentials to an AI Consumer?
     a: |
-      Credentials are managed through a separate credentials endpoint, not as a field on the Consumer.
-      Create them via POST to `/consumers/{id}/credentials` with the credential type and details.
+      For `type: api-key` AI Consumers, credentials are managed through a separate credentials
+      endpoint, not as a field on the Consumer. Create them via POST to `/consumers/{id}/credentials`.
+      `type: oauth` AI Consumers don't use this endpoint — see the next question.
 
   - q: "What's the difference between `type: api-key` and `type: oauth`?"
     a: |
-      The `type` declares which credential family the AI Consumer authenticates with. An `api-key`
-      AI Consumer holds one or more `api-key` Credentials. An `oauth` AI Consumer holds one or more
-      `oauth` Credentials whose `custom_id` maps to the OAuth provider's identifier. The
-      Credential's `type` must match the Consumer's `type`.
+      The `type` declares how the AI Consumer authenticates. An `api-key` AI Consumer holds one or
+      more `api-key` Credentials created through the credentials endpoint. An `oauth` AI Consumer
+      has no Credentials — instead, its own `custom_id` field is set (at creation or update time) to
+      the identifier your OIDC provider issues (for example, a `sub` claim), and an authentication
+      policy maps the incoming token to that AI Consumer.
 
   - q: Can an AI Consumer belong to multiple AI Consumer Groups?
     a: |
@@ -98,6 +100,7 @@ AI Consumers can be created and managed through:
 
 * {{site.konnect_short_name}} UI
 * {{site.ai_gateway}} API: `/v1/ai-gateways/{aiGatewayId}/consumers`
+* [kongctl](/kongctl/)
 
 For configuration examples and step-by-step setup instructions, see [Set up an AI Consumer](#set-up-an-ai-consumer) below.
 
@@ -116,11 +119,11 @@ rows:
   - type: "`api-key`"
     use_case: Simple, stateless authentication for internal services or mobile apps using a shared secret.
   - type: "`oauth`"
-    use_case: Federated identity with an external OIDC provider. {{site.ai_gateway}} accepts any standards-compliant OAuth 2.0 / OpenID Connect provider configured through the [OpenID Connect Policy](/ai-gateway/policies/openid-connect/), or for MCP traffic through the [AI MCP OAuth2 Policy](/ai-gateway/policies/ai-mcp-oauth2/). The credential's `custom_id` field maps to the OAuth provider's user identifier (for example, an OIDC Client ID or `sub` claim).
+    use_case: Federated identity with an external OIDC provider. {{site.ai_gateway}} accepts any standards-compliant OAuth 2.0 / OpenID Connect provider configured through the [OpenID Connect Policy](/ai-gateway/policies/openid-connect/), or for MCP traffic through the [AI MCP OAuth2 Policy](/ai-gateway/policies/ai-mcp-oauth2/). The AI Consumer's own `custom_id` field maps to the OAuth provider's user identifier (for example, an OIDC Client ID or `sub` claim).
 {% endtable %}
 <!-- vale on -->
 
-The `type` of every Credential configured on the AI Consumer must match the AI Consumer's `type`.
+`api-key` AI Consumers authenticate through one or more `api-key` Credentials created via the credentials endpoint. `oauth` AI Consumers don't have Credentials — set `custom_id` directly on the AI Consumer instead.
 
 ## AI Consumer Group membership
 
@@ -138,7 +141,10 @@ For supported policy types and how AI Policies attach to other entities, see the
 
 ## Set up an AI Consumer
 
-The following example creates an AI Consumer assigned to a single AI Consumer Group.
+{% navtabs "consumer_type" %}
+{% navtab "api-key" %}
+
+The following example creates an `api-key` AI Consumer assigned to a single AI Consumer Group. After creating it, add one or more API key Credentials (see [Create Consumer Credentials](#create-consumer-credentials) below).
 
 {% entity_example %}
 type: consumer
@@ -149,14 +155,27 @@ data:
   policies: []
 {% endentity_example %}
 
+{% endnavtab %}
+{% navtab "oauth" %}
+
+The following example creates an `oauth` AI Consumer. Set `custom_id` to the identifier your OIDC provider issues (for example, a `sub` claim) — this is how {{site.ai_gateway}} maps an incoming token to this AI Consumer. `oauth` AI Consumers don't have Credentials.
+
+{% entity_example %}
+type: consumer
+data:
+  display_name: OAuth User 1
+  name: oauth-user-1
+  type: oauth
+  custom_id: user-id-from-oidc-provider
+  policies: []
+{% endentity_example %}
+
+{% endnavtab %}
+{% endnavtabs %}
+
 ## Create Consumer Credentials
 
-After creating an AI Consumer, create credentials for authentication. Credentials are managed through a separate endpoint.
-
-{% navtabs "credential_type" %}
-{% navtab "api-key" %}
-
-Create an API key credential for an AI Consumer with `type: api-key`:
+After creating an `api-key` AI Consumer, create one or more Credentials for authentication. Credentials are managed through a separate endpoint and only support `type: api-key` — `oauth` AI Consumers authenticate through their `custom_id` field instead (see [Set up an AI Consumer](#set-up-an-ai-consumer) above).
 
 <!-- vale off -->
 {% konnect_api_request %}
@@ -174,32 +193,6 @@ body:
 <!-- vale on -->
 
 The response includes the generated `api_key` value. Store this securely — it cannot be retrieved later.
-
-{% endnavtab %}
-{% navtab "oauth" %}
-
-Create an OAuth credential for an AI Consumer with `type: oauth`:
-
-<!-- vale off -->
-{% konnect_api_request %}
-url: /v1/ai-gateways/$AI_GATEWAY_ID/consumers/$CONSUMER_ID/credentials
-status_code: 201
-method: POST
-headers:
-  - 'Content-Type: application/json'
-  - 'Accept: application/json, application/problem+json'
-body:
-  display_name: OAuth User 1
-  name: oauth-user-1
-  type: oauth
-  custom_id: user-id-from-oidc-provider
-{% endkonnect_api_request %}
-<!-- vale on -->
-
-The `custom_id` must match the user identifier from your OAuth provider (for example, the `sub` claim from an OIDC token).
-
-{% endnavtab %}
-{% endnavtabs %}
 
 ## Schema
 

--- a/app/_ai_gateway_entities/ai-identity-provider.md
+++ b/app/_ai_gateway_entities/ai-identity-provider.md
@@ -71,7 +71,7 @@ faqs:
 Your [AI Models](/ai-gateway/entities/ai-model/) often need access control: some teams should reach certain AI Models and others should not, and you need a way to verify who is calling before a request consumes tokens or touches sensitive data. An AI Identity Provider lets you declare an inbound authentication mechanism at the gateway level and attach it to specific AI Models.
 
 Use AI Identity Providers to:
-* Authenticate API keys and map them to AI Consumers
+* Authenticate API keys and map them to [AI Consumers](/ai-gateway/entities/ai-consumer/)
 * Authenticate enterprise users through an existing identity provider (Okta, Azure AD, Google, or any OIDC-compliant IdP) without managing keys manually
 * Apply different authentication to different models. For example, API keys for internal automation and OIDC bearer tokens for user-facing applications.
 

--- a/app/_ai_gateway_entities/ai-identity-provider.md
+++ b/app/_ai_gateway_entities/ai-identity-provider.md
@@ -71,8 +71,7 @@ faqs:
 Your AI Models often need access control: some teams should reach certain AI Models and others should not, and you need a way to verify who is calling before a request consumes tokens or touches sensitive data. An AI Identity Provider lets you declare an inbound authentication mechanism at the gateway level and attach it to specific AI Models.
 
 Use AI Identity Providers to:
-
-* Issue API keys to AI Consumers and restrict which models they can access
+* Authenticate API keys and map them to AI Consumers
 * Authenticate enterprise users through an existing identity provider (Okta, Azure AD, Google, or any OIDC-compliant IdP) without managing keys manually
 * Apply different authentication to different models. For example, API keys for internal automation and OIDC bearer tokens for user-facing applications.
 
@@ -86,8 +85,8 @@ flowchart LR
     KeyAuth["Key Auth"]
     OIDC["OpenID Connect"]
     Decision{Auth?}
-    AnonErr["Anonymous AI Consumer<br/>Request Terminating w/ 401"]
-    ModelSel["ai-model-selector"]
+    AnonErr["Request Terminating w/ 401"]
+    ModelSel["Model selection"]
     ACLs["ACLs"]
     Model1["AI Model A"]
     Model2["AI Model B"]
@@ -98,11 +97,11 @@ flowchart LR
     Decision-->|no auth|AnonErr
     Decision-->|auth|ModelSel
     ModelSel-->|selects model|ACLs
-    ACLs-->Model1
-    ACLs-->Model2
+    ACLs-->|allowed|Model1
+    ACLs-->|denied|Model2
 {% endmermaid %}
 
-Authentication runs before `ai-model-selector` so that unauthenticated requests never reach model routing or policy evaluation.
+Authentication runs before model selection so that unauthenticated requests never reach model routing or policy evaluation.
 
 ## Manage AI Identity Providers
 
@@ -110,12 +109,13 @@ AI Identity Providers can be created and managed through:
 
 * {{site.konnect_short_name}} UI
 * {{site.ai_gateway}} API: `/v1/ai-gateways/{aiGatewayId}/identity`
+* [kongctl](/kongctl/)
 
 For configuration examples and step-by-step setup instructions, see [Set up an AI Identity Provider](#set-up-an-ai-identity-provider) below.
 
 ## Authentication types
 
-{{site.ai_gateway}} supports two identity provider types. Pick based on how your AI Consumers authenticate:
+{{site.ai_gateway}} supports two identity provider types. Choose based on how your AI Consumers authenticate:
 
 {% table %}
 columns:
@@ -219,6 +219,23 @@ data:
     key_in_query: false
     hide_credentials: true
 {% endentity_example %}
+
+<!-- TODO: Uncomment before GA — kongctl declarative support for identity_providers is not yet released.
+```yaml
+ai_gateways:
+  - ref: <your-ai-gateway-ref>
+    identity_providers:
+      - ref: api-key-auth
+        name: api-key-auth
+        display_name: API Key Auth
+        type: key-auth
+        config:
+          key_names:
+            - X-API-Key
+          key_in_header: true
+          key_in_query: false
+          hide_credentials: true
+``` -->
 
 ### OIDC bearer token authentication
 

--- a/app/_ai_gateway_entities/ai-identity-provider.md
+++ b/app/_ai_gateway_entities/ai-identity-provider.md
@@ -68,7 +68,7 @@ faqs:
 
 ## What is an AI Identity Provider?
 
-Your AI Models often need access control: some teams should reach certain models and others should not, and you need a way to verify who is calling before a request consumes tokens or touches sensitive data. An AI Identity Provider lets you declare an inbound authentication mechanism at the gateway level and attach it to specific models.
+Your AI Models often need access control: some teams should reach certain AI Models and others should not, and you need a way to verify who is calling before a request consumes tokens or touches sensitive data. An AI Identity Provider lets you declare an inbound authentication mechanism at the gateway level and attach it to specific AI Models.
 
 Use AI Identity Providers to:
 

--- a/app/_ai_gateway_entities/ai-identity-provider.md
+++ b/app/_ai_gateway_entities/ai-identity-provider.md
@@ -175,7 +175,7 @@ Set `config.issuer` to the IdP's discovery URL (for example, `https://dev-123456
 
 The default `config.auth_methods` are `bearer` and `client_credentials`. If your AI Consumers use a different grant flow, add it to the list. For a full list of supported values, see the [OpenID Connect Policy reference](/ai-gateway/policies/openid-connect/).
 
-To map the token to an existing AI Consumer, set `config.consumer_claim` to the JSON path of the claim in the token that carries the AI Consumer identifier. If no mapping is needed, set `config.consumer_optional: true` to allow unauthenticated token holders through ACL checks.
+To map the token to an existing AI Consumer, set `config.consumer_claims` to an array of path segments locating the claim in the token that carries the AI Consumer identifier (for example, `[["user", "info", "id"]]` to map to a nested `user.info.id` claim). If no mapping is needed, set `config.consumer_optional: true` to allow unauthenticated token holders through ACL checks.
 
 {:.warning}
 > All AI Models in the same {{site.ai_gateway}} that use OIDC authentication must reference the same `openid-connect` AI Identity Provider. Using different OIDC providers across models in the same {{site.ai_gateway}} is not supported.

--- a/app/_ai_gateway_entities/ai-identity-provider.md
+++ b/app/_ai_gateway_entities/ai-identity-provider.md
@@ -189,7 +189,8 @@ access:
   identity_providers:
     - my-key-auth-provider
   acls:
-    - allowed-ai-consumer-group
+    allow:
+      - allowed-ai-consumer-group
 ```
 
 {:.info}

--- a/app/_ai_gateway_entities/ai-identity-provider.md
+++ b/app/_ai_gateway_entities/ai-identity-provider.md
@@ -1,0 +1,246 @@
+---
+title: AI Identity Providers
+content_type: reference
+entities:
+  - ai-identity-provider
+products:
+  - ai-gateway
+min_version:
+  ai-gateway: '2.0'
+permalink: /ai-gateway/entities/ai-identity-provider/
+breadcrumbs:
+  - /ai-gateway/
+  - /ai-gateway/entities/
+description: Configure inbound AI Consumer authentication for AI Models in {{site.ai_gateway}}.
+schema:
+  api: konnect/ai-gateway
+  path: /schemas/AIGatewayIdentityProvider
+works_on:
+  - konnect
+tools:
+  - konnect-api
+related_resources:
+  - text: "About {{site.ai_gateway}}"
+    url: /ai-gateway/
+  - text: AI Model entity
+    url: /ai-gateway/entities/ai-model/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
+  - text: AI Consumer entity
+    url: /ai-gateway/entities/ai-consumer/
+  - text: AI Consumer Group entity
+    url: /ai-gateway/entities/ai-consumer-group/
+  - text: Key Auth policy reference
+    url: /ai-gateway/policies/key-auth/
+  - text: OpenID Connect policy reference
+    url: /ai-gateway/policies/openid-connect/
+faqs:
+  - q: What is the difference between an AI Identity Provider and an AI Model Provider?
+    a: |
+      An AI Identity Provider manages inbound authentication: it validates credentials that AI Consumers
+      present when calling an AI Model. An AI Model Provider manages outbound credentials: the secrets
+      {{site.ai_gateway}} uses to authenticate to an upstream LLM service on behalf of the AI Consumer.
+
+  - q: Can an AI Model use both key-auth and OIDC authentication at the same time?
+    a: |
+      Yes. An AI Model supports one `key-auth` AI Identity Provider and one `openid-connect`
+      AI Identity Provider simultaneously. An AI Consumer's request is authenticated
+      if it satisfies either provider.
+
+  - q: What happens when a request carries no valid credentials?
+    a: |
+      {{site.ai_gateway}} treats the request as an anonymous AI Consumer. A request-termination
+      policy on that anonymous AI Consumer returns `401 Unauthorized` before the request reaches
+      the AI Model.
+
+  - q: Can I reuse the same AI Identity Provider across multiple AI Models?
+    a: |
+      Yes. Create an AI Identity Provider once and reference it by `name` or `id` in the
+      `access.identity_providers` array of any AI Model in the same gateway.
+
+  - q: Which OIDC flows does the openid-connect type support?
+    a: |
+      By default, bearer token and client credentials flows are enabled. The full set includes
+      `authorization_code`, `bearer`, `client_credentials`, `introspection`, `kong_oauth2`,
+      `password`, `refresh_token`, `session`, and `userinfo`. Configure which flows are active
+      with `config.auth_methods`.
+---
+
+## What is an AI Identity Provider?
+
+Your AI Models often need access control: some teams should reach certain models and others should not, and you need a way to verify who is calling before a request consumes tokens or touches sensitive data. An AI Identity Provider lets you declare an inbound authentication mechanism at the gateway level and attach it to specific models.
+
+Use AI Identity Providers to:
+
+* Issue API keys to AI Consumers and restrict which models they can access
+* Authenticate enterprise users through an existing identity provider (Okta, Azure AD, Google, or any OIDC-compliant IdP) without managing keys manually
+* Apply different authentication to different models. For example, API keys for internal automation and OIDC bearer tokens for user-facing applications.
+
+An AI Identity Provider manages inbound authentication, which is distinct from the outbound credentials managed by an [AI Model Provider](/ai-gateway/entities/ai-model-provider/). When an AI Consumer calls an AI Model, the AI Identity Provider checks who they are. The AI Model then uses the AI Model Provider's credentials to forward the request upstream.
+
+The following diagram shows where authentication fits in the request pipeline:
+
+{% mermaid %}
+flowchart LR
+    Client["AI Consumer"]
+    KeyAuth["Key Auth"]
+    OIDC["OpenID Connect"]
+    Decision{Auth?}
+    AnonErr["Anonymous AI Consumer<br/>Request Terminating w/ 401"]
+    ModelSel["ai-model-selector"]
+    ACLs["ACLs"]
+    Model1["AI Model A"]
+    Model2["AI Model B"]
+
+    Client-->KeyAuth
+    KeyAuth-->OIDC
+    OIDC-->Decision
+    Decision-->|no auth|AnonErr
+    Decision-->|auth|ModelSel
+    ModelSel-->|selects model|ACLs
+    ACLs-->Model1
+    ACLs-->Model2
+{% endmermaid %}
+
+Authentication runs before `ai-model-selector` so that unauthenticated requests never reach model routing or policy evaluation.
+
+## Manage AI Identity Providers
+
+AI Identity Providers can be created and managed through:
+
+* {{site.konnect_short_name}} UI
+* {{site.ai_gateway}} API: `/v1/ai-gateways/{aiGatewayId}/identity`
+
+For configuration examples and step-by-step setup instructions, see [Set up an AI Identity Provider](#set-up-an-ai-identity-provider) below.
+
+## Authentication types
+
+{{site.ai_gateway}} supports two identity provider types. Pick based on how your AI Consumers authenticate:
+
+{% table %}
+columns:
+  - title: Type
+    key: type
+  - title: When to use
+    key: when
+  - title: AI Consumer credential
+    key: credential
+  - title: Policy
+    key: policy
+rows:
+  - type: "`key-auth`"
+    when: "Your AI Consumers are internal tools, scripts, or teams that you control. You want to issue and rotate static API keys without involving an external identity provider."
+    credential: "API key in a request header, query parameter, or request body"
+    policy: "[Key Auth](/ai-gateway/policies/key-auth/)"
+  - type: "`openid-connect`"
+    when: "Your AI Consumers already authenticate through an enterprise IdP (Okta, Azure AD, Google, or similar). You want to accept the tokens they already have rather than issuing separate keys."
+    credential: "JWT bearer token or OAuth 2.0 grant from an external IdP"
+    policy: "[OpenID Connect](/ai-gateway/policies/openid-connect/)"
+{% endtable %}
+
+### API key authentication
+
+The `key-auth` type uses the [Key Auth policy](/ai-gateway/policies/key-auth/) to validate an API key that the AI Consumer passes on every request. The gateway looks for the key in a configurable header or query parameter, checks it against the AI Consumer's registered key, and either authenticates the request or routes it to the anonymous AI Consumer (which terminates with `401`).
+
+By default, {{site.ai_gateway}} accepts the key in an `apikey` header or `apikey` query parameter. Override the key name with `config.key_names`. For example, set `config.key_names: ["X-API-Key"]` to enforce a standard header name across your APIs.
+
+{% table %}
+columns:
+  - title: Option
+    key: option
+  - title: Default
+    key: default
+  - title: Description
+    key: description
+rows:
+  - option: "`key_in_header`"
+    default: "`true`"
+    description: "Accept the key in a request header."
+  - option: "`key_in_query`"
+    default: "`true`"
+    description: "Accept the key as a query parameter."
+  - option: "`key_in_body`"
+    default: "`false`"
+    description: "Accept the key in the request body. Supports `application/json`, `application/x-www-form-urlencoded`, and `multipart/form-data`."
+  - option: "`hide_credentials`"
+    default: "`true`"
+    description: "Strip the key from the request before forwarding upstream."
+{% endtable %}
+
+### OIDC token authentication
+
+The `openid-connect` type uses the [OpenID Connect policy](/ai-gateway/policies/openid-connect/) to validate a JWT or OAuth 2.0 token that the AI Consumer obtains from an external IdP. The gateway verifies the token against the IdP's published keys, maps the token to an AI Consumer, and either authenticates the request or routes it to the anonymous AI Consumer (which terminates with `401`).
+
+Set `config.issuer` to the IdP's discovery URL (for example, `https://dev-123456.okta.com`). {{site.ai_gateway}} uses the OIDC discovery endpoint to fetch signing keys automatically.
+
+The default `config.auth_methods` are `bearer` and `client_credentials`. If your AI Consumers use a different grant flow, add it to the list. For a full list of supported values, see the [OpenID Connect policy reference](/ai-gateway/policies/openid-connect/).
+
+To map the token to an existing AI Consumer, set `config.consumer_claim` to the JSON path of the claim in the token that carries the AI Consumer identifier. If no mapping is needed, set `config.consumer_optional: true` to allow unauthenticated token holders through ACL checks.
+
+{:.warning}
+> All AI Models in the same {{site.ai_gateway}} that use OIDC authentication must reference the same `openid-connect` AI Identity Provider. Using different OIDC providers across models in the same {{site.ai_gateway}} is not supported.
+
+## Assigning an AI Identity Provider to an AI Model
+
+An AI Identity Provider takes effect only when assigned to an [AI Model](/ai-gateway/entities/ai-model/). Reference the provider by `name` or `id` in the `access.identity_providers` array on the AI Model:
+
+```yaml
+access:
+  identity_providers:
+    - my-key-auth-provider
+  acls:
+    - allowed-ai-consumer-group
+```
+
+{:.info}
+> **Assignment rules**
+> * Each AI Model supports one `key-auth` identity provider and one `openid-connect` identity provider.
+> * You can assign both types to the same AI Model. A request is authenticated if it satisfies either provider.
+
+If you plan to rename the AI Identity Provider later, reference it by `id` rather than name. The ID is stable across renames.
+
+## Set up an AI Identity Provider
+
+### API key authentication
+
+The following example creates a `key-auth` AI Identity Provider that accepts AI Consumer API keys in the `X-API-Key` header:
+
+{% entity_example %}
+type: identity-provider
+data:
+  display_name: API Key Auth
+  name: api-key-auth
+  type: key-auth
+  config:
+    key_names:
+      - X-API-Key
+    key_in_header: true
+    key_in_query: false
+    hide_credentials: true
+{% endentity_example %}
+
+### OIDC bearer token authentication
+
+The following example creates an `openid-connect` AI Identity Provider that accepts bearer tokens issued by Okta:
+
+{% entity_example %}
+type: identity-provider
+data:
+  display_name: Okta AI SE
+  name: okta-ai-se
+  type: openid-connect
+  config:
+    issuer: https://dev-123456.okta.com
+    client_id:
+      - my-client-id
+    client_secret:
+      - my-client-secret
+    auth_methods:
+      - bearer
+    scopes:
+      - openid
+{% endentity_example %}
+
+## Schema
+
+{% entity_schema %}

--- a/app/_ai_gateway_entities/ai-identity-provider.md
+++ b/app/_ai_gateway_entities/ai-identity-provider.md
@@ -68,7 +68,7 @@ faqs:
 
 ## What is an AI Identity Provider?
 
-Your AI Models often need access control: some teams should reach certain AI Models and others should not, and you need a way to verify who is calling before a request consumes tokens or touches sensitive data. An AI Identity Provider lets you declare an inbound authentication mechanism at the gateway level and attach it to specific AI Models.
+Your [AI Models](/ai-gateway/entities/ai-model/) often need access control: some teams should reach certain AI Models and others should not, and you need a way to verify who is calling before a request consumes tokens or touches sensitive data. An AI Identity Provider lets you declare an inbound authentication mechanism at the gateway level and attach it to specific AI Models.
 
 Use AI Identity Providers to:
 * Authenticate API keys and map them to AI Consumers

--- a/app/_ai_gateway_entities/ai-identity-provider.md
+++ b/app/_ai_gateway_entities/ai-identity-provider.md
@@ -169,7 +169,7 @@ rows:
 
 ### OIDC token authentication
 
-The `openid-connect` type uses the [OpenID Connect policy](/ai-gateway/policies/openid-connect/) to validate a JWT or OAuth 2.0 token that the AI Consumer obtains from an external IdP. The gateway verifies the token against the IdP's published keys, maps the token to an AI Consumer, and either authenticates the request or routes it to the anonymous AI Consumer (which terminates with `401`).
+The `openid-connect` type uses the [OpenID Connect Policy](/ai-gateway/policies/openid-connect/) to validate a JWT or OAuth 2.0 token that the AI Consumer obtains from an external IdP. The gateway verifies the token against the IdP's published keys, maps the token to an AI Consumer, and either authenticates the request or routes it to the anonymous AI Consumer (which terminates with `401`).
 
 Set `config.issuer` to the IdP's discovery URL (for example, `https://dev-123456.okta.com`). {{site.ai_gateway}} uses the OIDC discovery endpoint to fetch signing keys automatically.
 

--- a/app/_ai_gateway_entities/ai-identity-provider.md
+++ b/app/_ai_gateway_entities/ai-identity-provider.md
@@ -173,7 +173,7 @@ The `openid-connect` type uses the [OpenID Connect Policy](/ai-gateway/policies/
 
 Set `config.issuer` to the IdP's discovery URL (for example, `https://dev-123456.okta.com`). {{site.ai_gateway}} uses the OIDC discovery endpoint to fetch signing keys automatically.
 
-The default `config.auth_methods` are `bearer` and `client_credentials`. If your AI Consumers use a different grant flow, add it to the list. For a full list of supported values, see the [OpenID Connect policy reference](/ai-gateway/policies/openid-connect/).
+The default `config.auth_methods` are `bearer` and `client_credentials`. If your AI Consumers use a different grant flow, add it to the list. For a full list of supported values, see the [OpenID Connect Policy reference](/ai-gateway/policies/openid-connect/).
 
 To map the token to an existing AI Consumer, set `config.consumer_claim` to the JSON path of the claim in the token that carries the AI Consumer identifier. If no mapping is needed, set `config.consumer_optional: true` to allow unauthenticated token holders through ACL checks.
 

--- a/app/_ai_gateway_entities/ai-identity-provider.md
+++ b/app/_ai_gateway_entities/ai-identity-provider.md
@@ -140,7 +140,7 @@ rows:
 
 ### API key authentication
 
-The `key-auth` type uses the [Key Auth policy](/ai-gateway/policies/key-auth/) to validate an API key that the AI Consumer passes on every request. The gateway looks for the key in a configurable header or query parameter, checks it against the AI Consumer's registered key, and either authenticates the request or routes it to the anonymous AI Consumer (which terminates with `401`).
+The `key-auth` type uses the [Key Auth Policy](/ai-gateway/policies/key-auth/) to validate an API key that the AI Consumer passes on every request. The gateway looks for the key in a configurable header or query parameter, checks it against the AI Consumer's registered key, and either authenticates the request or routes it to the anonymous AI Consumer (which terminates with `401`).
 
 By default, {{site.ai_gateway}} accepts the key in an `apikey` header or `apikey` query parameter. Override the key name with `config.key_names`. For example, set `config.key_names: ["X-API-Key"]` to enforce a standard header name across your APIs.
 

--- a/app/_ai_gateway_entities/ai-identity-provider.md
+++ b/app/_ai_gateway_entities/ai-identity-provider.md
@@ -37,7 +37,7 @@ related_resources:
 faqs:
   - q: What is the difference between an AI Identity Provider and an AI Model Provider?
     a: |
-      An AI Identity Provider manages inbound authentication: it validates credentials that AI Consumers
+      An AI Identity Provider manages inbound authentication: it validates the credentials that AI Consumers
       present when calling an AI Model. An AI Model Provider manages outbound credentials: the secrets
       {{site.ai_gateway}} uses to authenticate to an upstream LLM service on behalf of the AI Consumer.
 

--- a/app/_ai_gateway_entities/ai-mcp-server.md
+++ b/app/_ai_gateway_entities/ai-mcp-server.md
@@ -48,13 +48,13 @@ faqs:
 
   - q: Can the same AI Consumer's identity gate access to specific tools?
     a: |
-      Yes. Set [`default_tool_acls`](#schema-aigateway-mcpserver-default-tool-acls) on the AI MCP Server with `allow` and `deny` lists, and override per
-      tool through [`tools[].acls`](#schema-aigateway-mcpserver-tools-acls). A per-tool ACL replaces the default for that tool, it doesn't
+      Yes. Set [`access.default_tool_acls`](#schema-aigateway-mcpserver-access-default-tool-acls) on the AI MCP Server with `allow` and `deny` lists, and override per
+      tool through [`tools[].access.acls`](#schema-aigateway-mcpserver-tools-access). A per-tool ACL replaces the default for that tool, it doesn't
       merge.
 
   - q: How do OAuth-based ACLs differ from AI Consumer-based ACLs?
     a: |
-      Set [`acl_attribute_type`](#schema-aigateway-mcpserver-acl-attribute-type) to `oauth_access_token` and provide [`access_token_claim_field`](#schema-aigateway-mcpserver-access-token-claim-field) (a jq
+      Set [`access.acl_attribute_type`](#schema-aigateway-mcpserver-access-acl-attribute-type) to `oauth_access_token` and provide [`access.access_token_claim_field`](#schema-aigateway-mcpserver-access-access-token-claim-field) (a jq
       filter, for example `.user.email`). ACLs then evaluate against the claim value extracted from
       the OAuth access token instead of the resolved AI Consumer identity. The OAuth flow is supplied
       by the [AI MCP OAuth2 Policy](/ai-gateway/policies/ai-mcp-oauth2/).
@@ -312,7 +312,7 @@ For richer mapping, supply [`request_body`](#schema-aigateway-mcpserver-tools-re
 
 Tools can also carry MCP-spec [`annotations`](#schema-aigateway-mcpserver-tools-annotations) that hint at tool behavior to clients (for example, whether a tool is read-only, idempotent, or destructive). Annotations don't change runtime behavior; they help clients decide whether to surface a tool, confirm before invocation, or treat it as safe to retry.
 
-[Per-tool ACLs](#schema-aigateway-mcpserver-tools-acls) override the MCP Server's [default tool ACLs](#schema-aigateway-mcpserver-default-tool-acls). For more information, see [ACL tool control](#acl-tool-control).
+[Per-tool ACLs](#schema-aigateway-mcpserver-tools-access) override the MCP Server's [default tool ACLs](#schema-aigateway-mcpserver-access-default-tool-acls). For more information, see [ACL tool control](#acl-tool-control).
 
 ## Sessions
 
@@ -339,23 +339,30 @@ This way, AI Consumers only interact with tools appropriate to their role, while
 {:.info}
 > **ACL in `listener` mode**
 >
-> Listener mode does not support direct ACL configuration. Instead, it inherits ACL rules from tagged `conversion-listener` or `conversion-only` AI MCP Servers.
+> `listener` mode supports direct ACL configuration on the MCP Server itself.
 >
 > To use ACLs with `listener` mode:
-> 1. Configure `conversion-listener` or `conversion-only` AI MCP Servers with ACL rules and tags.
-> 1. Configure `listener` mode to aggregate tools by matching tags.
-> 1. Set [`include_consumer_groups`](#schema-aigateway-mcpserver-include-consumer-groups): true on the listener. Without this setting, the listener cannot pass AI Consumer Group membership to the aggregated tools, and ACL rules will not evaluate correctly.
+> 1. Configure authentication on the listener route so requests resolve to an authenticated AI Consumer.
+> 1. Set ACL fields directly on the listener: [`access.acl_attribute_type`](#schema-aigateway-mcpserver-access-acl-attribute-type), [`access.access_token_claim_field`](#schema-aigateway-mcpserver-access-access-token-claim-field) (when using `oauth_access_token`), [`access.acls`](#schema-aigateway-mcpserver-access-acls) for server-level fallback rules, [`access.default_tool_acls`](#schema-aigateway-mcpserver-access-default-tool-acls) for the default tool ACL, and per-tool [`tools[].access.acls`](#schema-aigateway-mcpserver-tools-access) for tool-specific overrides.
+> 1. Configure [AI Consumers](/ai-gateway/entities/ai-consumer/) and [AI Consumer Groups](/ai-gateway/entities/ai-consumer-group/) to match the `allow` and `deny` entries.
+>
+> ACL behavior:
+>
+> - `access.default_tool_acls` applies to all tools by default.
+> - If `access.default_tool_acls` isn't set, the listener falls back to the top-level `access.acls`.
+> - A tool's own `acls` fully overrides the default ACL for that tool.
+> - [`config.server.tag`](#schema-aigateway-mcpserver-config-server-tag) is used for tool filtering and aggregation, not for inheriting ACLs from other AI MCP Servers.
 
 ### Attribute types
 
-For modes that support ACL configuration (`conversion-listener`, `conversion-only`, `upstream-server`), two attribute types determine what the AI MCP Server evaluates ACL rules against:
+For modes that support ACL configuration (`conversion-listener`, `conversion-only`, `upstream-server`, `listener`), two attribute types determine what the AI MCP Server evaluates ACL rules against:
 
 1. **`consumer`** (default). Evaluates against the resolved AI Consumer identity.
-1. **`oauth_access_token`**. Evaluates against a claim extracted from the OAuth access token. Set [`access_token_claim_field`](#schema-aigateway-mcpserver-access-token-claim-field) to a jq filter (for example, `.user.email` for a nested claim). The OAuth flow itself is supplied by the [AI MCP OAuth2 Policy](/ai-gateway/policies/ai-mcp-oauth2/).
+1. **`oauth_access_token`**. Evaluates against a claim extracted from the OAuth access token. Set [`access.access_token_claim_field`](#schema-aigateway-mcpserver-access-access-token-claim-field) to a jq filter (for example, `.user.email` for a nested claim). The OAuth flow itself is supplied by the [AI MCP OAuth2 Policy](/ai-gateway/policies/ai-mcp-oauth2/).
 
 ### Using AI Consumers and Groups in ACLs
 
-When `acl_attribute_type` is `consumer`, you can gate access by individual [AI Consumers](/ai-gateway/entities/ai-consumer/) (using username, UUID, or custom ID) or by [AI Consumer Group](/ai-gateway/entities/ai-consumer-group/) membership. This flexibility lets you define rules at the right level: deny a specific user, allow a tier-based group, or mix both in the same ACL. The runtime checks the authenticated AI Consumer's identity and group memberships against your `allow` and `deny` lists.
+When `access.acl_attribute_type` is `consumer`, you can gate access by individual [AI Consumers](/ai-gateway/entities/ai-consumer/) (using username, UUID, or custom ID) or by [AI Consumer Group](/ai-gateway/entities/ai-consumer-group/) membership. This flexibility lets you define rules at the right level: deny a specific user, allow a tier-based group, or mix both in the same ACL. The runtime checks the authenticated AI Consumer's identity and group memberships against your `allow` and `deny` lists.
 
 ### How default and per-tool ACLs work
 
@@ -369,20 +376,20 @@ columns:
   - title: Description
     key: description
 rows:
-  - field: "`default_tool_acls`"
+  - field: "`access.default_tool_acls`"
     description: |
       Baseline rules that apply to all tools unless overridden.
-  - field: "`tools[].acls`"
+  - field: "`tools[].access.acls`"
     description: |
-      When configured, these rules replace the default ACL for that specific tool. The per-tool ACL doesn't inherit or merge with `default_tool_acls`. It is an all-or-nothing override.
+      When configured, these rules replace the default ACL for that specific tool. The per-tool ACL doesn't inherit or merge with `access.default_tool_acls`. It is an all-or-nothing override.
 {% endtable %}
 <!-- vale on -->
 
 {:.info}
-> If a tool defines its own ACL, the runtime ignores `default_tool_acls` for that tool:
+> If a tool defines its own ACL, the runtime ignores `access.default_tool_acls` for that tool:
 >
 > - Tools with no ACL configuration inherit the default rules (both `allow` and `deny` lists).
-> - Tools with an ACL must explicitly list all allowed subjects (even if they were already in `default_tool_acls`).
+> - Tools with an ACL must explicitly list all allowed subjects (even if they were already in `access.default_tool_acls`).
 
 ### ACL evaluation logic
 
@@ -549,13 +556,14 @@ data:
   type: conversion-listener
   enabled: true
   policies: []
-  acl_attribute_type: consumer
-  acls:
-    allow:
-      - __never_match__
-  default_tool_acls:
-    deny:
-      - __never_match__
+  access:
+    acl_attribute_type: consumer
+    acls:
+      allow:
+        - __never_match__
+    default_tool_acls:
+      deny:
+        - __never_match__
   config:
     url: https://api.weatherapi.com/v1/current.json
     route:
@@ -582,6 +590,51 @@ data:
             type: string
           description: Location query. Accepts US Zipcode, UK Postcode, Canada postal code, IP address, latitude/longitude, or city name.
 {% endentity_example %}
+
+<!-- Uncomment before GA (kongctl AI Gateway declarative support not yet documented in app/kongctl/supported-resources.md):
+```yaml
+mcp_servers:
+  - name: weather-mcp
+    ref: weather-mcp
+    display_name: "Weather API"
+    type: conversion-listener
+    enabled: true
+    policies: []
+    access:
+      acl_attribute_type: consumer
+      acls:
+        allow:
+          - __never_match__
+      default_tool_acls:
+        deny:
+          - __never_match__
+    config:
+      url: https://api.weatherapi.com/v1/current.json
+      route:
+        paths:
+          - /weather
+      logging:
+        payloads: false
+        statistics: true
+      server:
+        timeout: 60000
+    tools:
+      - name: get-current-weather
+        description: Get current weather for a location
+        method: GET
+        path: /weather
+        query:
+          key:
+            - $WEATHERAPI_API_KEY
+        parameters:
+          - name: q
+            in: query
+            required: true
+            schema:
+              type: string
+            description: Location query. Accepts US Zipcode, UK Postcode, Canada postal code, IP address, latitude/longitude, or city name.
+```
+-->
 
 ## Schema
 

--- a/app/_ai_gateway_entities/ai-mcp-server.md
+++ b/app/_ai_gateway_entities/ai-mcp-server.md
@@ -87,6 +87,7 @@ AI MCP Servers can be created and managed through the:
 
 * {{site.konnect_short_name}} UI
 * {{site.ai_gateway}} API: `/v1/ai-gateways/{aiGatewayId}/mcp-servers`
+* [kongctl](/kongctl/)
 
 For configuration examples and step-by-step setup instructions, see [Set up an AI MCP Server](#set-up-an-ai-mcp-server).
 

--- a/app/_ai_gateway_entities/ai-model.md
+++ b/app/_ai_gateway_entities/ai-model.md
@@ -26,8 +26,10 @@ related_resources:
     url: /ai-gateway/ai-providers/
   - text: Load balancing
     url: /ai-gateway/load-balancing/
-  - text: AI Provider entity
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
+  - text: AI Identity Provider entity
+    url: /ai-gateway/entities/ai-identity-provider/
   - text: AI Policy entity
     url: /ai-gateway/entities/ai-policy/
   - text: "{{site.ai_gateway}} entities"
@@ -55,13 +57,13 @@ faqs:
 
   - q: How do I limit which AI Consumers can reach an AI Model?
     a: |
-      Set the [`acls`](#schema-aigateway-model-acls) field on the AI Model with allow or deny lists.
+      Set the [`access.acls`](#schema-aigateway-model-access) field on the AI Model with an allow list or a deny list.
       Each entry is a string that references an AI Consumer, AI Consumer Group, or Authenticated Group by name.
 
-  - q: Does the AI Model entity store AI Provider credentials?
+  - q: Does the AI Model entity store AI Model Provider credentials?
     a: |
-      No. AI Provider credentials live on the [AI Provider entity](/ai-gateway/entities/ai-provider/) and are materialized into the underlying primitives at AI Model creation time.
-      Updating an AI Provider propagates the credential change to all AI Models that reference it.
+      No. AI Model Provider credentials live on the [AI Model Provider entity](/ai-gateway/entities/ai-model-provider/) and are materialized into the underlying primitives at AI Model creation time.
+      Updating an AI Model Provider propagates the credential change to all AI Models that reference it.
 
   - q: Can a client override the model name from the request body?
     a: |
@@ -90,7 +92,7 @@ The AI Model entity lets you expose LLM endpoints through {{site.ai_gateway}} fo
 * [Add observability](#logging-and-observability) to model traffic
 * [Attach policies](#attach-ai-policies) for security and transformation
 
-An AI Model declares which capabilities it exposes (like `chat` or `embeddings`), which upstream AI Provider models it routes to, and how requests are distributed and logged. {{site.ai_gateway}} handles the routing and translation, so clients interact with a single unified endpoint.
+An AI Model declares which capabilities it exposes (like `chat` or `embeddings`), which upstream LLM models it routes to via [AI Model Providers](/ai-gateway/entities/ai-model-provider/), and how requests are distributed and logged. Consumer authentication is configured through [AI Identity Providers](/ai-gateway/entities/ai-identity-provider/) on the model. {{site.ai_gateway}} handles routing and translation, so clients interact with a single unified endpoint.
 
 ## Manage AI Models
 
@@ -106,8 +108,8 @@ For configuration examples and step-by-step setup instructions, see [Set up an A
 At request time, the AI Model mediates traffic between clients and upstream AI Provider APIs:
 
 1. Translates between the request and response format chosen for the AI Model and the upstream AI Provider's native format.
-1. Resolves upstream connection coordinates (protocol, host, port, path, HTTP method) from the selected target and its [AI Provider](/ai-gateway/entities/ai-provider/), unless the target is a self-hosted model.
-1. Authenticates to the upstream AI Provider using credentials stored on the AI Provider entity.
+1. Resolves upstream connection coordinates (protocol, host, port, path, HTTP method) from the selected target and its [AI Model Provider](/ai-gateway/entities/ai-model-provider/), unless the target is a self-hosted model.
+1. Authenticates to the upstream LLM service using credentials stored on the [AI Model Provider](/ai-gateway/entities/ai-model-provider/) entity.
 1. Decorates the upstream request with per-target configuration (such as temperature or token-limit overrides) declared on [`targets[].config`](#schema-aigateway-model-targets).
 1. Records usage statistics (tokens, cost, latency) for attached log AI Policies, and optionally the full request and response when payload logging is enabled.
 1. Fulfills requests to self-hosted models using the supported native format transformations.
@@ -116,9 +118,9 @@ A single AI Model can expose multiple upstream AI Providers behind a consistent 
 
 ## Model lifecycle
 
-When you create or update an AI Model, {{site.ai_gateway}} provisions the necessary runtime resources and applies the configuration atomically. Credentials are sourced from the AI Provider entity that the AI Model's [`targets`](#schema-aigateway-model-targets) reference at model creation time. If you update the AI Provider's credentials later, those changes automatically propagate to all AI Models that use it.
+When you create or update an AI Model, {{site.ai_gateway}} provisions the necessary runtime resources and applies the configuration atomically. Credentials are sourced from the [AI Model Provider](/ai-gateway/entities/ai-model-provider/) entity that the AI Model's [`targets`](#schema-aigateway-model-targets) reference at model creation time. If you update the AI Model Provider's credentials later, those changes automatically propagate to all AI Models that use it.
 
-An AI Model is a managed entity—{{site.ai_gateway}} owns its runtime configuration. Direct modifications through other APIs are not supported. To change an AI Model's configuration, update the AI Model entity directly.
+An AI Model is a managed entity. {{site.ai_gateway}} owns its runtime configuration. Direct modifications through other APIs are not supported. To change an AI Model's configuration, update the AI Model entity directly.
 
 ## Capabilities
 
@@ -127,7 +129,7 @@ When you expose an AI Model, you choose which AI capabilities it provides throug
 * **`model` type**: for synchronous request/response workloads. Available capabilities: `generate`, `agentic`, `embeddings`, `audio/speech`, `audio/transcription`, `audio/translation`, `image`, `video`, `realtime`, `rerank`.
 * **`api` type**: for asynchronous batch processing. Available capabilities: `batches`, `files`.
 
-Not every AI Provider supports every capability. The set of capabilities you can declare on an AI Model depends on what the AI Provider in [`targets`](#schema-aigateway-model-targets) exposes. See [{{site.ai_gateway}} providers](/ai-gateway/ai-providers/) for per-provider details.
+Not every LLM service supports every capability. The set of capabilities you can declare on an AI Model depends on what the AI Model Provider in [`targets`](#schema-aigateway-model-targets) exposes. See [{{site.ai_gateway}} providers](/ai-gateway/ai-providers/) for per-provider details.
 
 <!-- vale off -->
 {% table %}
@@ -223,7 +225,7 @@ When a native format is set, only the corresponding provider is supported with i
 
 An AI Model is a virtual model: it exposes one Route ([`config.route`](#schema-aigateway-model-config-route)) and one set of capabilities, and routes requests to one or more concrete upstream models declared in its [`targets`](#schema-aigateway-model-targets) array. Each entry represents a single upstream model instance with one URL.
 
-For each target, you provide the upstream model name (for example, `gpt-4o`) and reference the AI Provider to use by its `name`. Each target can also override settings such as [`temperature`](#schema-aigateway-target-config-temperature), [`max_tokens`](#schema-aigateway-target-config-max-tokens), [`input_cost`](#schema-aigateway-target-config-input-cost), and [`output_cost`](#schema-aigateway-target-config-output-cost).
+For each target, you provide the upstream model name (for example, `gpt-4o`) and reference the AI Model Provider to use by its `name`. Each target can also override settings such as [`temperature`](#schema-aigateway-target-config-temperature), [`max_tokens`](#schema-aigateway-target-config-max-tokens), [`input_cost`](#schema-aigateway-target-config-input-cost), and [`output_cost`](#schema-aigateway-target-config-output-cost).
 
 There's no separate target entity or endpoint. Targets are managed only as nested data inside an AI Model, through the same AI Model API surface used to create, update, and delete the parent. Adding, removing, or modifying a target is an update to the AI Model itself.
 
@@ -301,7 +303,7 @@ For deeper background on vector storage and similarity matching, see [Embedding-
 
 Configure an embedding model to enable semantic routing. This lets {{site.ai_gateway}} route requests based on meaning and content similarity rather than just cost or latency. For example, route domain-specific queries to specialized providers or keep similar requests on the same provider for consistency.
 
-Set [`config.balancer.embeddings`](#schema-aigateway-model-config-balancer-embeddings) to reference an AI Provider and embedding model name. Supported provider types: `azure`, `bedrock`, `gemini`, `huggingface`. The embedding model also powers the `semantic` load balancing algorithm.
+Set [`config.balancer.embeddings`](#schema-aigateway-model-config-balancer-embeddings) to reference an AI Model Provider and embedding model name. Supported provider types: `azure`, `bedrock`, `gemini`, `huggingface`. The embedding model also powers the `semantic` load balancing algorithm.
 
 ## Templating
 
@@ -323,7 +325,9 @@ When an alias is set, clients can send that alias in the request `model` field i
 
 ## Access control
 
-When you need to limit which teams or applications can call an AI Model—for example, restricting an expensive model to your internal team or blocking access to sensitive models—use the [`acls`](#schema-aigateway-model-acls) field to set either an allow list or a deny list. Reference [AI Consumers](/ai-gateway/entities/ai-consumer/) (individual applications), [AI Consumer Groups](/ai-gateway/entities/ai-consumer-group/) (teams), or Authenticated Groups (all consumers authenticated via a specific OAuth2 scope or claim) by name. To control *how* consumers authenticate (API keys, OAuth2, etc.) rather than *who* can access, attach an authentication AI Policy to the model.
+To limit which teams or applications can call an AI Model, use the [`access.acls`](#schema-aigateway-model-access) field to set an allow list or a deny list. Reference [AI Consumers](/ai-gateway/entities/ai-consumer/) (individual applications), [AI Consumer Groups](/ai-gateway/entities/ai-consumer-group/) (teams), or Authenticated Groups (all consumers authenticated via a specific OAuth2 scope or claim) by name.
+
+To control how consumers authenticate before their access is evaluated, configure the [`access.identity_providers`](#schema-aigateway-model-access-identity-providers) array with one or more [AI Identity Provider](/ai-gateway/entities/ai-identity-provider/) references. Each AI Model supports one `key-auth` identity provider and one `openid-connect` identity provider simultaneously.
 
 ## Attach AI Policies
 
@@ -333,7 +337,7 @@ Reference AI Policies through the [`policies`](#schema-aigateway-model-policies)
 
 ### AI Policy execution order
 
-AI Policies attach to AI Models and execute in a defined order based on policy type. Authentication policies run early to verify access. Other policies run after routing is resolved. If execution order matters for your use case, refer to the [{{site.baze_gateway}} priority documentation](/gateway/entities/plugin/#plugin-priority).
+AI Policies attach to AI Models and execute in a defined order based on policy type. Authentication policies run early to verify access. Other policies run after routing is resolved. If execution order matters for your use case, refer to the [plugin priority documentation](/gateway/entities/plugin/#plugin-priority).
 
 ## Upstream proxy configuration
 
@@ -369,10 +373,10 @@ data:
     - generate
   formats:
     - type: openai
-  acls:
-    allow:
-      - internal-teams
-    deny: []
+  access:
+    acls:
+      allow:
+        - internal-teams
   policies: []
   targets:
     - name: gpt-4o
@@ -396,6 +400,46 @@ data:
     balancer:
       algorithm: round-robin
 {% endentity_example %}
+
+<!-- Uncomment before GA (kongctl AI Gateway declarative support not yet documented in app/kongctl/supported-resources.md):
+```yaml
+models:
+  - name: gpt-4o-production
+    ref: gpt-4o-production
+    display_name: "GPT-4o Production"
+    type: model
+    capabilities:
+      - generate
+    formats:
+      - type: openai
+    access:
+      acls:
+        allow:
+          - internal-teams
+    policies: []
+    targets:
+      - name: gpt-4o
+        provider: my-openai-account
+        weight: 100
+        config:
+          type: openai
+          temperature: 0.7
+          max_tokens: 4096
+          input_cost: 0.0000025
+          output_cost: 0.000010
+    config:
+      route:
+        paths:
+          - /ai
+      logging:
+        statistics: true
+        payloads: false
+      model:
+        name_header: true
+      balancer:
+        algorithm: round-robin
+```
+-->
 
 ## Schema
 

--- a/app/_ai_gateway_entities/ai-model.md
+++ b/app/_ai_gateway_entities/ai-model.md
@@ -100,6 +100,7 @@ AI Models can be created and managed through:
 
 * {{site.konnect_short_name}} UI
 * {{site.ai_gateway}} API: `/v1/ai-gateways/{aiGatewayId}/models`
+* [kongctl](/kongctl/)
 
 For configuration examples and step-by-step setup instructions, see [Set up an AI Model](#set-up-an-ai-model) below.
 
@@ -303,13 +304,13 @@ For deeper background on vector storage and similarity matching, see [Embedding-
 
 Configure an embedding model to enable semantic routing. This lets {{site.ai_gateway}} route requests based on meaning and content similarity rather than just cost or latency. For example, route domain-specific queries to specialized providers or keep similar requests on the same provider for consistency.
 
-Set [`config.balancer.embeddings`](#schema-aigateway-model-config-balancer-embeddings) to reference an AI Model Provider and embedding model name. Supported provider types: `azure`, `bedrock`, `gemini`, `huggingface`. The embedding model also powers the `semantic` load balancing algorithm.
+Set [`config.balancer.embeddings`](#schema-aigateway-model-config-balancer-embeddings) to reference an AI Model Provider and embedding model name. Supported provider types: `azure`, `bedrock`, `databricks`, `gemini`, `huggingface`, `vercel`, `vertex`. The embedding model also powers the `semantic` load balancing algorithm.
 
 ## Templating
 
 The AI Model resolves runtime values from request data using placeholder substitution. This lets you select the target model dynamically per request, route to per-deployment Azure endpoints, or fan out to multiple providers from a single AI Model.
 
-Substitution applies to the [`name`](#schema-aigateway-model-target-models-name) of each target model and to any per-target [`config`](#schema-aigateway-model-target-models-config) option. Three placeholders are available:
+Substitution applies to the [`name`](#schema-aigateway-model-targets-name) of each target model and to any per-target [`config`](#schema-aigateway-model-targets-config) option. Three placeholders are available:
 
 * `$(headers.header_name)`: the value of a request header.
 * `$(uri_captures.path_parameter_name)`: the value of a captured URI path parameter.
@@ -349,7 +350,7 @@ Use the [`config.proxy`](#schema-aigateway-model-config-proxy) object to specify
 
 Enable [`statistics`](#schema-aigateway-model-config-logging-statistics) logging to track token consumption, request latency, and per-provider costs. This data flows into {{site.konnect_short_name}} analytics and any attached logging AI Policies, letting you monitor API spend, identify slow providers, and audit which AI Models drive the most usage.
 
-Optionally enable [`payloads`](#schema-aigateway-model-config-logging-payloads) to capture full request and response bodies (truncated at [`max_payload_size`](#schema-aigateway-model-config-logging-max-payload_size) bytes, default 1 MB). This is useful for debugging model responses, auditing sensitive operations, or replaying requests.
+Optionally enable [`payloads`](#schema-aigateway-model-config-logging-payloads) to capture full request and response bodies. This is useful for debugging model responses, auditing sensitive operations, or replaying requests.
 
 {:.warning}
 > Payload logging may expose sensitive data in your logging destination. Only enable it when your logging pipeline is prepared to handle request and response bodies, and verify that logging destinations comply with your data residency and privacy policies.
@@ -361,44 +362,33 @@ For response streaming behavior, see [Streaming](/ai-gateway/streaming/).
 The following example creates an OpenAI Model that exposes the `generate` capability, routed through a single OpenAI Provider, with token usage logging enabled.
 
 {:.info}
-> This AI Model proxies client requests to `/ai/chat/completions`. The base path `/ai` comes from [`config.route.paths`](#schema-aigateway-model-config-route-paths), and `/chat/completions` is appended by the `generate` capability automatically.
+> This AI Model proxies client requests to `/v1/chat/completions`. The base path `/v1` comes from [`config.route.paths`](#schema-aigateway-model-config-route-paths), and `/chat/completions` is appended by the `generate` capability automatically.
 
 {% entity_example %}
 type: model
 data:
-  display_name: GPT-4o Production
-  name: gpt-4o-production
+  display_name: my-gpt-4o
+  name: my-gpt-4o
   type: model
   capabilities:
     - generate
   formats:
     - type: openai
-  access:
-    acls:
-      allow:
-        - internal-teams
   policies: []
   targets:
     - name: gpt-4o
-      provider: my-openai-account
-      weight: 100
+      provider: generic-openai
       config:
         type: openai
-        temperature: 0.7
-        max_tokens: 4096
-        input_cost: 0.0000025
-        output_cost: 0.000010
   config:
     route:
       paths:
-        - /ai
+        - /v1
     logging:
       statistics: true
       payloads: false
     model:
-      name_header: true
-    balancer:
-      algorithm: round-robin
+      alias: my-gpt-4o
 {% endentity_example %}
 
 <!-- Uncomment before GA (kongctl AI Gateway declarative support not yet documented in app/kongctl/supported-resources.md):

--- a/app/_ai_gateway_entities/ai-policy.md
+++ b/app/_ai_gateway_entities/ai-policy.md
@@ -75,6 +75,7 @@ AI Policies are managed through:
 
 * {{site.konnect_short_name}} UI
 * {{site.ai_gateway}} API: `/v1/ai-gateways/{aiGatewayId}/policies`
+* [kongctl](/kongctl/)
 
 For configuration examples and step-by-step setup instructions, see [Set up a global AI Policy](#set-up-a-global-ai-policy) below.
 

--- a/app/_ai_gateway_entities/ai-provider.md
+++ b/app/_ai_gateway_entities/ai-provider.md
@@ -143,7 +143,7 @@ You can't attach [AI Policies](/ai-gateway/entities/ai-policy/) directly to an A
 
 To apply an AI Policy across requests using a particular AI Model Provider, you can:
 1. Set the policy to `global: true` to apply it to all resources in the gateway.
-1. Attach the same policy to each AI Model that references the AI Model Provider
+1. Attach the same policy to each AI Model that references the AI Model Provider.
 1. Create an AI Consumer Group with the policy and control access to AI Models via ACLs
 
 ## Set up an AI Model Provider

--- a/app/_ai_gateway_entities/ai-provider.md
+++ b/app/_ai_gateway_entities/ai-provider.md
@@ -144,7 +144,7 @@ You can't attach [AI Policies](/ai-gateway/entities/ai-policy/) directly to an A
 To apply an AI Policy across requests using a particular AI Model Provider, you can:
 1. Set the policy to `global: true` to apply it to all resources in the gateway.
 1. Attach the same policy to each AI Model that references the AI Model Provider.
-1. Create an AI Consumer Group with the policy and control access to AI Models via ACLs
+1. Create an AI Consumer Group with the policy and control access to AI Models via ACLs.
 
 ## Set up an AI Model Provider
 

--- a/app/_ai_gateway_entities/ai-provider.md
+++ b/app/_ai_gateway_entities/ai-provider.md
@@ -66,9 +66,9 @@ AI Model Providers and AI Models have a many-to-many relationship: one AI Model 
 
 When configuring an [AI Model](/ai-gateway/entities/ai-model/), you reference an AI Model Provider by setting the `provider` field in each item of the [`targets`](/ai-gateway/entities/ai-model/#schema-aigateway-model-targets) array. You can reference by [`name`](#schema-aigateway-model-provider-name) or `id`. Use `id` if you plan to rename the AI Model Provider later.
 
-## Supported AI Providers
+## Supported upstream LLM providers
 
-{{site.ai_gateway}} supports the following upstream AI providers. The AI Model Provider's [`type`](#schema-aigateway-model-provider-type) field selects one of these targets. The following AI provider-specific pages document supported capabilities, configuration requirements, and limitations.
+{{site.ai_gateway}} supports the following upstream LLM providers. The AI Model Provider's [`type`](#schema-aigateway-model-provider-type) field selects one of these targets. The following provider-specific pages document supported capabilities, configuration requirements, and limitations.
 
 {% html_tag type="div" css_classes="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3" %}
 {% icon_card icon="openai.svg" title="OpenAI" cta_url="/ai-gateway/ai-providers/openai/" %}

--- a/app/_ai_gateway_entities/ai-provider.md
+++ b/app/_ai_gateway_entities/ai-provider.md
@@ -49,7 +49,7 @@ The AI Model Provider entity lets you securely store and manage credentials for 
 * Centrally manage and rotate credentials across multiple AI Models
 * Enforce consistent authentication across your deployments
 
-{{site.ai_gateway}} has two distinct provider entity types. An AI Model Provider holds outbound credentials: the secrets {{site.ai_gateway}} uses to authenticate to an upstream LLM service on your behalf. An [AI Identity Provider](/ai-gateway/entities/ai-identity-provider/) configures inbound authentication: the mechanism that validates AI Consumer identity before a request reaches an AI Model. When an AI Consumer calls an AI Model, the AI Identity Provider checks who they are; the AI Model then uses the AI Model Provider's credentials to forward the request upstream.
+An AI Model Provider manages outbound credentials, which is distinct from the inbound authentication managed by an [AI Identity Provider](/ai-gateway/entities/ai-identity-provider/). When an AI Consumer calls an AI Model, the AI Identity Provider checks who they are. The AI Model then uses the AI Model Provider's credentials to forward the request upstream.
 
 Each AI Model Provider has a [`type`](#schema-aigateway-model-provider-type) that selects the upstream LLM service and configures provider-specific options. See the [schema](#schema) below for supported types, and the per-provider pages under [{{site.ai_gateway}} providers](/ai-gateway/ai-providers/) for provider-specific configuration and limitations.
 
@@ -163,6 +163,23 @@ data:
         - name: Authorization
           value: Bearer <your-openai-key>
 {% endentity_example %}
+
+<!-- TODO: Uncomment before GA — kongctl declarative support for model_providers is not yet released.
+```yaml
+ai_gateways:
+  - ref: <your-ai-gateway-ref>
+    model_providers:
+      - ref: my-openai-account
+        name: my-openai-account
+        display_name: OpenAI Production
+        type: openai
+        config:
+          auth:
+            type: basic
+            header_name: Authorization
+            header_value: Bearer <your-openai-key>
+```
+-->
 
 ## Schema
 

--- a/app/_ai_gateway_entities/ai-provider.md
+++ b/app/_ai_gateway_entities/ai-provider.md
@@ -59,6 +59,7 @@ AI Model Providers can be created and managed through:
 
 * {{site.konnect_short_name}} UI
 * {{site.ai_gateway}} API: `/v1/ai-gateways/{aiGatewayId}/model-providers`
+* [kongctl](/kongctl/)
 
 For configuration examples and step-by-step setup instructions, see [Set up an AI Model Provider](#set-up-an-ai-model-provider) below.
 

--- a/app/_ai_gateway_entities/ai-provider.md
+++ b/app/_ai_gateway_entities/ai-provider.md
@@ -1,20 +1,20 @@
 ---
-title: AI Providers
+title: AI Model Providers
 content_type: reference
 entities:
-  - ai-provider
+  - ai-model-provider
 products:
   - ai-gateway
 min_version:
   ai-gateway: '2.0'
-permalink: /ai-gateway/entities/ai-provider/
+permalink: /ai-gateway/entities/ai-model-provider/
 breadcrumbs:
   - /ai-gateway/
   - /ai-gateway/entities/
-description: AI Provider credentials and configuration used by {{site.ai_gateway}}.
+description: AI Model Provider credentials and configuration used by {{site.ai_gateway}}.
 schema:
   api: konnect/ai-gateway
-  path: /schemas/AIGatewayProvider
+  path: /schemas/AIGatewayModelProvider
 works_on:
   - konnect
 tools:
@@ -29,44 +29,46 @@ related_resources:
   - text: AI Policy entity
     url: /ai-gateway/entities/ai-policy/
 faqs:
-  - q: What happens when I update an AI Provider's credentials?
+  - q: What happens when I update an AI Model Provider's credentials?
     a: |
       {{site.ai_gateway}} propagates the credential change to every AI Model that references the
-      AI Provider (by `name` or `id`). The next request through any of those AI Models uses the updated
+      AI Model Provider (by `name` or `id`). The next request through any of those AI Models uses the updated
       credentials.
 
-  - q: How does an AI Model reference an AI Provider?
+  - q: How does an AI Model reference an AI Model Provider?
     a: |
-      Set the `provider` field in each item of the [`targets`](/ai-gateway/entities/ai-model/#schema-aigateway-model-targets) array on the AI Model to the AI Provider's `name` or `id`.
+      Set the `provider` field in each item of the [`targets`](/ai-gateway/entities/ai-model/#schema-aigateway-model-targets) array on the AI Model to the AI Model Provider's `name` or `id`.
 ---
 
-## What is an AI Provider?
+## What is an AI Model Provider?
 
-The AI Provider entity lets you securely store and manage credentials for connecting to upstream LLM services. Use AI Providers to:
+The AI Model Provider entity lets you securely store and manage credentials for connecting to upstream LLM services. Use AI Model Providers to:
 * Store API keys for OpenAI, Azure, Bedrock, or any other LLM provider
 * Centrally manage and rotate credentials across multiple AI Models
 * Enforce consistent authentication across your deployments
 
-Each AI Provider has a [`type`](#schema-aigateway-provider-type) that selects the upstream LLM service and configures provider-specific options. See the [schema](#schema) below for supported types, and the per-provider pages under [{{site.ai_gateway}} providers](/ai-gateway/ai-providers/) for provider-specific configuration and limitations.
+{{site.ai_gateway}} has two distinct provider entity types. An AI Model Provider holds outbound credentials: the secrets {{site.ai_gateway}} uses to authenticate to an upstream LLM service on your behalf. An [AI Identity Provider](/ai-gateway/entities/ai-identity-provider/) configures inbound authentication: the mechanism that validates consumer identity before a request reaches a model. When a consumer calls an AI Model, the AI Identity Provider checks who they are; the AI Model then uses the AI Model Provider's credentials to forward the request upstream.
 
-## Manage AI Providers
+Each AI Model Provider has a [`type`](#schema-aigateway-model-provider-type) that selects the upstream LLM service and configures provider-specific options. See the [schema](#schema) below for supported types, and the per-provider pages under [{{site.ai_gateway}} providers](/ai-gateway/ai-providers/) for provider-specific configuration and limitations.
 
-AI Providers can be created and managed through:
+## Manage AI Model Providers
+
+AI Model Providers can be created and managed through:
 
 * {{site.konnect_short_name}} UI
-* {{site.ai_gateway}} API: `/v1/ai-gateways/{aiGatewayId}/providers`
+* {{site.ai_gateway}} API: `/v1/ai-gateways/{aiGatewayId}/model-providers`
 
-For configuration examples and step-by-step setup instructions, see [Set up an AI Provider](#set-up-an-ai-provider) below.
+For configuration examples and step-by-step setup instructions, see [Set up an AI Model Provider](#set-up-an-ai-model-provider) below.
 
 ### Relationship to AI Models
 
-AI Providers and AI Models have a many-to-many relationship: one AI Provider can back many AI Models, and one AI Model can route to multiple AI Providers. For example, a single `openai` AI Provider might be used by both a chat AI Model and an embeddings AI Model, while a single AI Model might route to OpenAI and Anthropic targets for failover.
+AI Model Providers and AI Models have a many-to-many relationship: one AI Model Provider can back many AI Models, and one AI Model can route to multiple AI Model Providers. For example, a single `openai` AI Model Provider might be used by both a chat AI Model and an embeddings AI Model, while a single AI Model might route to OpenAI and Anthropic targets for failover.
 
-When configuring an [AI Model](/ai-gateway/entities/ai-model/), you reference an AI Provider by setting the `provider` field in each item of the [`targets`](/ai-gateway/entities/ai-model/#schema-aigateway-model-targets) array. You can reference by [`name`](#schema-aigateway-provider-name) or `id`. Use `id` if you plan to rename the AI Provider later.
+When configuring an [AI Model](/ai-gateway/entities/ai-model/), you reference an AI Model Provider by setting the `provider` field in each item of the [`targets`](/ai-gateway/entities/ai-model/#schema-aigateway-model-targets) array. You can reference by [`name`](#schema-aigateway-model-provider-name) or `id`. Use `id` if you plan to rename the AI Model Provider later.
 
 ## Supported AI Providers
 
-{{site.ai_gateway}} supports the following upstream AI providers. The AI Provider's [`type`](#schema-aigateway-provider-type) field selects one of these targets. The following AI Provider-specific pages document supported capabilities, configuration requirements, and limitations.
+{{site.ai_gateway}} supports the following upstream AI providers. The AI Model Provider's [`type`](#schema-aigateway-model-provider-type) field selects one of these targets. The following AI provider-specific pages document supported capabilities, configuration requirements, and limitations.
 
 {% html_tag type="div" css_classes="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3" %}
 {% icon_card icon="openai.svg" title="OpenAI" cta_url="/ai-gateway/ai-providers/openai/" %}
@@ -92,15 +94,15 @@ When configuring an [AI Model](/ai-gateway/entities/ai-model/), you reference an
 
 ## Authentication
 
-The [`config.auth`](#schema-aigateway-provider-config-auth) object declares how {{site.ai_gateway}} authenticates to the upstream AI Provider. The shape of `auth` depends on the AI Provider's [`type`](#schema-aigateway-provider-type):
+The [`config.auth`](#schema-aigateway-model-provider-config-auth) object declares how {{site.ai_gateway}} authenticates to the upstream AI provider. The shape of `auth` depends on the AI Model Provider's [`type`](#schema-aigateway-model-provider-type):
 
-* **`basic`**: header- or query-parameter-based auth. Used by most AI Provider types.
+* **`basic`**: Header- or parameter-based auth. Supports up to one auth header (`config.auth.headers`) and one auth parameter (`config.auth.params`). Parameters can be sent as a query string or in the request body (`config.auth.params[].location`). Used by most AI Model Provider types.
 * **`aws`**: IAM access-key and assume-role auth. Used by [Bedrock](/ai-gateway/ai-providers/bedrock/).
 * **`azure`**: Microsoft Entra ID or managed-identity auth. Used by [Azure OpenAI](/ai-gateway/ai-providers/azure/).
 * **`gcp`**: Google service-account auth. Used by [Gemini](/ai-gateway/ai-providers/gemini/) and [Vertex AI](/ai-gateway/ai-providers/vertex/).
 
 {:.info}
-> Bedrock, Azure OpenAI, and Gemini can also fall back to `basic` auth.
+> Bedrock, Azure OpenAI, Gemini, and Vertex AI can also fall back to `basic` auth.
 
 {% table %}
 columns:
@@ -115,39 +117,39 @@ columns:
 rows:
   - type: "`aws`"
     providers: "[Bedrock](/ai-gateway/ai-providers/bedrock/)"
-    approach: "IAM via static credentials, assume role, or environment auto-detection (EC2 instance profiles, environment variables, local AWS config). Role assumption recommended for production. Cross-account access supported."
+    approach: "IAM via static credentials, assume role, or environment auto-detection (EC2 instance profiles, environment variables, local AWS config). Role assumption recommended for production. Cross-account access supported. Use `config.auth.batch_role_arn` to specify a separate IAM role for Bedrock batch API calls."
     fallback: "`basic`"
   - type: "`azure`"
     providers: "[Azure OpenAI](/ai-gateway/ai-providers/azure/)"
-    approach: "Microsoft Entra ID via Managed Identity (recommended when running in Azure). For explicit credentials, provide client ID, secret, and tenant ID."
+    approach: "Microsoft Entra ID via Managed Identity (recommended when running in Azure). For explicit credentials, provide client ID, secret, and tenant ID. Requires `config.instance` (your Azure instance name, for example `kong-az-east`)."
     fallback: "`basic`"
   - type: "`gcp`"
     providers: "[Gemini](/ai-gateway/ai-providers/gemini/), [Vertex AI](/ai-gateway/ai-providers/vertex/)"
-    approach: "Google service accounts via environment auto-detection (service account JSON or Compute Engine metadata server). Custom metadata or OAuth token endpoints for restricted networks."
+    approach: "Google service accounts via environment auto-detection (service account JSON or Compute Engine metadata server). For restricted networks, set `config.auth.metadata_url` or `config.auth.oauth_token_url` to custom endpoints."
     fallback: "`basic`"
 {% endtable %}
 
 ## Lifecycle
 
-Creating an AI Provider stores the entity but doesn't generate any runtime primitives. AI Provider credentials enter the runtime only when an AI Model references the AI Provider. At that point, the credentials are materialized into the underlying primitives of the AI Model.
+Creating an AI Model Provider stores the entity but doesn't generate any runtime primitives. AI Model Provider credentials enter the runtime only when an AI Model references the AI Model Provider. At that point, the credentials are materialized into the underlying primitives of the AI Model.
 
-Updating an AI Provider re-materializes credentials into every AI Model that references it. The change takes effect on the next request through any referencing AI Model.
+Updating an AI Model Provider re-materializes credentials into every AI Model that references it. The change takes effect on the next request through any referencing AI Model.
 
-## AI Policies and AI Providers
+## AI Policies and AI Model Providers
 
-You can't attach [AI Policies](/ai-gateway/entities/ai-policy/) directly to an AI Provider entity instance. AI Policies attach to [AI Models](/ai-gateway/entities/ai-model/), [AI Agents](/ai-gateway/entities/ai-agent/), [AI Consumers](/ai-gateway/entities/ai-consumer/), or [AI Consumer Groups](/ai-gateway/entities/ai-consumer-group/) to control security, rate limiting, guardrails, and observability.
+You can't attach [AI Policies](/ai-gateway/entities/ai-policy/) directly to an AI Model Provider entity instance. AI Policies attach to [AI Models](/ai-gateway/entities/ai-model/), [AI Agents](/ai-gateway/entities/ai-agent/), [AI Consumers](/ai-gateway/entities/ai-consumer/), or [AI Consumer Groups](/ai-gateway/entities/ai-consumer-group/) to control security, rate limiting, guardrails, and observability.
 
-To apply an AI Policy across requests using a particular AI Provider, you can:
+To apply an AI Policy across requests using a particular AI Model Provider, you can:
 1. Set the policy to `global: true` to apply it to all resources in the gateway
-2. Attach the same policy to each AI Model that references the AI Provider
-3. Create an AI Consumer Group with the policy and control access to AI Models via ACLs
+1. Attach the same policy to each AI Model that references the AI Model Provider
+1. Create an AI Consumer Group with the policy and control access to AI Models via ACLs
 
-## Set up an AI Provider
+## Set up an AI Model Provider
 
-The following example creates an OpenAI Provider that authenticates with a single bearer-token header. An AI Model can then route to this AI Provider by setting the `provider` field in a `targets` array item to `my-openai-account` (or the AI Provider `id`).
+The following example creates an OpenAI AI Model Provider that authenticates with a single bearer-token header. An AI Model can then route to this AI Model Provider by setting the `provider` field in a `targets` array item to `my-openai-account` (or the AI Model Provider `id`).
 
 {% entity_example %}
-type: provider
+type: model-provider
 data:
   display_name: OpenAI Production
   name: my-openai-account

--- a/app/_ai_gateway_entities/ai-provider.md
+++ b/app/_ai_gateway_entities/ai-provider.md
@@ -142,7 +142,7 @@ Updating an AI Model Provider re-materializes credentials into every AI Model th
 You can't attach [AI Policies](/ai-gateway/entities/ai-policy/) directly to an AI Model Provider entity instance. AI Policies attach to [AI Models](/ai-gateway/entities/ai-model/), [AI Agents](/ai-gateway/entities/ai-agent/), [AI Consumers](/ai-gateway/entities/ai-consumer/), or [AI Consumer Groups](/ai-gateway/entities/ai-consumer-group/) to control security, rate limiting, guardrails, and observability.
 
 To apply an AI Policy across requests using a particular AI Model Provider, you can:
-1. Set the policy to `global: true` to apply it to all resources in the gateway
+1. Set the policy to `global: true` to apply it to all resources in the gateway.
 1. Attach the same policy to each AI Model that references the AI Model Provider
 1. Create an AI Consumer Group with the policy and control access to AI Models via ACLs
 

--- a/app/_ai_gateway_entities/ai-provider.md
+++ b/app/_ai_gateway_entities/ai-provider.md
@@ -28,6 +28,8 @@ related_resources:
     url: /ai-gateway/entities/ai-model/
   - text: AI Policy entity
     url: /ai-gateway/entities/ai-policy/
+  - text: AI Identity Provider entity
+    url: /ai-gateway/entities/ai-identity-provider/
 faqs:
   - q: What happens when I update an AI Model Provider's credentials?
     a: |

--- a/app/_ai_gateway_entities/ai-provider.md
+++ b/app/_ai_gateway_entities/ai-provider.md
@@ -46,7 +46,7 @@ faqs:
 
 The AI Model Provider entity lets you securely store and manage credentials for connecting to upstream LLM services. Use AI Model Providers to:
 * Store API keys for OpenAI, Azure, Bedrock, or any other LLM provider
-* Centrally manage and rotate credentials across multiple AI Models
+* Centrally manage and rotate credentials across multiple [AI Models](/ai-gateway/entities/ai-model/)
 * Enforce consistent authentication across your deployments
 
 An AI Model Provider manages outbound credentials, which is distinct from the inbound authentication managed by an [AI Identity Provider](/ai-gateway/entities/ai-identity-provider/). When an AI Consumer calls an AI Model, the AI Identity Provider checks who they are. The AI Model then uses the AI Model Provider's credentials to forward the request upstream.

--- a/app/_ai_gateway_entities/ai-provider.md
+++ b/app/_ai_gateway_entities/ai-provider.md
@@ -133,9 +133,11 @@ rows:
 
 ## Lifecycle
 
-Creating an AI Model Provider stores the entity but doesn't generate any runtime primitives. AI Model Provider credentials enter the runtime only when an AI Model references the AI Model Provider. At that point, the credentials are materialized into the underlying primitives of the AI Model.
+An AI Model Provider stores the credentials, but doesn't generate any runtime primitives.
 
-Updating an AI Model Provider re-materializes credentials into every AI Model that references it. The change takes effect on the next request through any referencing AI Model.
+AI Model Provider credentials are passed to the runtime only when an AI Model references the AI Model Provider. At that point, the credentials are then passed to the AI Model.
+
+When you update a the credentials of an AI Model Provider, the new credentials are passed to every AI Model that references it the next time a request is made through the AI Model.
 
 ## AI Policies and AI Model Providers
 

--- a/app/_ai_gateway_entities/ai-provider.md
+++ b/app/_ai_gateway_entities/ai-provider.md
@@ -94,7 +94,7 @@ When configuring an [AI Model](/ai-gateway/entities/ai-model/), you reference an
 {% icon_card icon="vllm.svg" title="vLLM" cta_url="/ai-gateway/ai-providers/vllm/" %}
 {% endhtml_tag %}
 
-## Authentication
+## Outbound authentication
 
 The [`config.auth`](#schema-aigateway-model-provider-config-auth) object declares how {{site.ai_gateway}} authenticates to the upstream AI provider. The shape of `auth` depends on the AI Model Provider's [`type`](#schema-aigateway-model-provider-type):
 

--- a/app/_ai_gateway_entities/ai-provider.md
+++ b/app/_ai_gateway_entities/ai-provider.md
@@ -47,7 +47,7 @@ The AI Model Provider entity lets you securely store and manage credentials for 
 * Centrally manage and rotate credentials across multiple AI Models
 * Enforce consistent authentication across your deployments
 
-{{site.ai_gateway}} has two distinct provider entity types. An AI Model Provider holds outbound credentials: the secrets {{site.ai_gateway}} uses to authenticate to an upstream LLM service on your behalf. An [AI Identity Provider](/ai-gateway/entities/ai-identity-provider/) configures inbound authentication: the mechanism that validates consumer identity before a request reaches a model. When a consumer calls an AI Model, the AI Identity Provider checks who they are; the AI Model then uses the AI Model Provider's credentials to forward the request upstream.
+{{site.ai_gateway}} has two distinct provider entity types. An AI Model Provider holds outbound credentials: the secrets {{site.ai_gateway}} uses to authenticate to an upstream LLM service on your behalf. An [AI Identity Provider](/ai-gateway/entities/ai-identity-provider/) configures inbound authentication: the mechanism that validates AI Consumer identity before a request reaches an AI Model. When an AI Consumer calls an AI Model, the AI Identity Provider checks who they are; the AI Model then uses the AI Model Provider's credentials to forward the request upstream.
 
 Each AI Model Provider has a [`type`](#schema-aigateway-model-provider-type) that selects the upstream LLM service and configures provider-specific options. See the [schema](#schema) below for supported types, and the per-provider pages under [{{site.ai_gateway}} providers](/ai-gateway/ai-providers/) for provider-specific configuration and limitations.
 

--- a/app/_ai_gateway_entities/ai-vault.md
+++ b/app/_ai_gateway_entities/ai-vault.md
@@ -22,8 +22,10 @@ tools:
 related_resources:
   - text: "About {{site.ai_gateway}}"
     url: /ai-gateway/
-  - text: AI Provider
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider
+    url: /ai-gateway/entities/ai-model-provider/
+  - text: AI Identity Provider
+    url: /ai-gateway/entities/ai-identity-provider/
   - text: AI Model
     url: /ai-gateway/entities/ai-model/
   - text: AI MCP Server
@@ -46,7 +48,7 @@ faqs:
 
   - q: How are AI Vault secrets referenced from other {{site.ai_gateway}} entities?
     a: |
-      Sensitive fields on AI Provider, AI Model, AI MCP Server, and other entities are annotated as
+      Sensitive fields on AI Model Provider, AI Identity Provider, AI Model, AI MCP Server, and other entities are annotated as
       referenceable. Set those fields to a vault reference string (for example, a `{vault://...}`
       placeholder) instead of a literal value. The AI Vault `name` is the lookup key.
 
@@ -59,7 +61,7 @@ faqs:
 
 ## What is an AI Vault?
 
-You need to store secrets like API keys and authentication tokens somewhere secure instead of embedding them directly in your configurations. An AI Vault entity lets you register an external secret backend (AWS Secrets Manager, HashiCorp Vault, environment variables, or others) so that [AI Providers](/ai-gateway/entities/ai-provider/), [AI Models](/ai-gateway/entities/ai-model/), and [AI MCP Servers](/ai-gateway/entities/ai-mcp-server/) can reference secrets instead of storing them as literal values.
+You must store secrets like API keys and authentication tokens somewhere secure instead of embedding them directly in your configurations. An AI Vault entity lets you register an external secret backend (AWS Secrets Manager, HashiCorp Vault, environment variables, or others) so that [AI Model Providers](/ai-gateway/entities/ai-model-provider/), [AI Identity Providers](/ai-gateway/entities/ai-identity-provider/), [AI Models](/ai-gateway/entities/ai-model/), and [AI MCP Servers](/ai-gateway/entities/ai-mcp-server/) can reference secrets instead of storing them as literal values.
 
 An AI Vault entity stores the connection configuration and credentials needed to reach your secret backend. When other entities reference a secret, {{site.ai_gateway}}:
 1. Looks up the vault at request time
@@ -100,8 +102,10 @@ columns:
   - title: Sensitive fields
     key: fields
 rows:
-  - entity: AI Provider
+  - entity: AI Model Provider
     fields: Authentication credentials (API keys, bearer tokens) in auth headers for upstream LLM providers
+  - entity: AI Identity Provider
+    fields: OIDC client secret for openid-connect type providers
   - entity: AI Model
     fields: Backend-specific authentication required by target model configurations
   - entity: AI MCP Server
@@ -131,10 +135,10 @@ For example, if you created a vault named `prod-aws-vault` and stored an OpenAI 
 {vault://prod-aws-vault/openai-api-key}
 ```
 
-Here's how you'd use that reference in an AI Provider entity:
+Here's how you'd use that reference in an AI Model Provider entity:
 
 {% entity_example %}
-type: provider
+type: model-provider
 data:
   display_name: OpenAI Production
   name: openai-prod
@@ -203,6 +207,19 @@ data:
   config:
     prefix: KONG_
 {% endentity_example %}
+
+<!-- Uncomment before GA (kongctl AI Gateway declarative support not yet documented in app/kongctl/supported-resources.md):
+```yaml
+vaults:
+  - name: prod-env-vault
+    ref: prod-env-vault
+    display_name: "Production Env Vault"
+    description: "Vault for production secrets sourced from environment variables."
+    type: env
+    config:
+      prefix: KONG_
+```
+-->
 
 ## Schema
 

--- a/app/_ai_gateway_entities/ai-vault.md
+++ b/app/_ai_gateway_entities/ai-vault.md
@@ -74,6 +74,7 @@ AI Vaults can be created and managed through:
 
 * {{site.konnect_short_name}} UI
 * {{site.ai_gateway}} API: `/v1/ai-gateways/{aiGatewayId}/vaults`
+* [kongctl](/kongctl/)
 
 For configuration examples and step-by-step setup instructions, see [Set up an AI Vault](#set-up-an-ai-vault).
 

--- a/app/_data/entity_examples/config.yml
+++ b/app/_data/entity_examples/config.yml
@@ -208,7 +208,7 @@ formats:
   ui:
     label: 'UI'
     entities:
-      - ai-provider
+      - ai-model-provider
       - ai-identity-provider
       - ai-model
       - ai-agent

--- a/app/_data/entity_examples/config.yml
+++ b/app/_data/entity_examples/config.yml
@@ -140,6 +140,7 @@ formats:
       agent:           '/agents'
       mcp_server:      '/mcp-servers'
       provider:        '/providers'
+      model-provider:  '/model-providers'
       consumer:       '/consumers'
       consumer_group: '/consumer-groups'
       vault:          '/vaults'

--- a/app/_data/entity_examples/config.yml
+++ b/app/_data/entity_examples/config.yml
@@ -141,6 +141,7 @@ formats:
       mcp_server:      '/mcp-servers'
       provider:        '/providers'
       model-provider:  '/model-providers'
+      identity-provider: '/identity'
       consumer:       '/consumers'
       consumer_group: '/consumer-groups'
       vault:          '/vaults'
@@ -208,6 +209,7 @@ formats:
     label: 'UI'
     entities:
       - ai-provider
+      - ai-identity-provider
       - ai-model
       - ai-agent
       - ai-mcp-server

--- a/app/_includes/md/ai-gateway/v2/faqs/azure-identity.md
+++ b/app/_includes/md/ai-gateway/v2/faqs/azure-identity.md
@@ -1,7 +1,7 @@
-Yes, if {{site.ai_gateway}} is running on Azure, you can configure an [AI Provider](/ai-gateway/entities/ai-provider/) to detect the designated Managed Identity or User-Assigned Identity of that Azure Compute resource and use it for authentication.
+Yes, if {{site.ai_gateway}} is running on Azure, you can configure an [AI Model Provider](/ai-gateway/entities/ai-model-provider/) to detect the designated Managed Identity or User-Assigned Identity of that Azure Compute resource and use it for authentication.
 
-In your [AI Provider](/ai-gateway/entities/ai-provider/) configuration:
+In your [AI Model Provider](/ai-gateway/entities/ai-model-provider/) configuration:
 * Set `auth.azure_use_managed_identity` to `true` to use an Azure-Assigned Managed Identity.
 * Set `auth.azure_use_managed_identity` to `true` and `auth.azure_client_id` to the client ID to use a User-Assigned Identity.
 
-Then reference this [AI Provider](/ai-gateway/entities/ai-provider/) in your [AI Model](/ai-gateway/entities/ai-model/) to proxy requests with the appropriate Azure credentials.
+Then reference this [AI Model Provider](/ai-gateway/entities/ai-model-provider/) in your [AI Model](/ai-gateway/entities/ai-model/) to proxy requests with the appropriate Azure credentials.

--- a/app/_includes/md/ai-gateway/v2/faqs/bedrock-rerank.md
+++ b/app/_includes/md/ai-gateway/v2/faqs/bedrock-rerank.md
@@ -1,1 +1,1 @@
-Configure an [AI Model](/ai-gateway/entities/ai-model/) with a Bedrock [AI Provider](/ai-gateway/entities/ai-provider/) and set up AWS authentication using IAM credentials or assumed roles.
+Configure an [AI Model](/ai-gateway/entities/ai-model/) with a Bedrock [AI Model Provider](/ai-gateway/entities/ai-model-provider/) and set up AWS authentication using IAM credentials or assumed roles.

--- a/app/_includes/md/ai-gateway/v2/faqs/cohere-rerank.md
+++ b/app/_includes/md/ai-gateway/v2/faqs/cohere-rerank.md
@@ -1,1 +1,1 @@
-Configure an [AI Model](/ai-gateway/entities/ai-model/) with a Cohere [AI Provider](/ai-gateway/entities/ai-provider/) and send queries with candidate documents. The model filters for relevance and returns answers with citations.
+Configure an [AI Model](/ai-gateway/entities/ai-model/) with a Cohere [AI Model Provider](/ai-gateway/entities/ai-model-provider/) and send queries with candidate documents. The model filters for relevance and returns answers with citations.

--- a/app/_includes/md/ai-gateway/v2/faqs/gemini-model-params.md
+++ b/app/_includes/md/ai-gateway/v2/faqs/gemini-model-params.md
@@ -2,7 +2,7 @@ You can configure model generation parameters when calling Gemini through {{site
 
 - **Using the {{ site.gemini }} SDK**:
 
-    1. Create an [AI Provider](/ai-gateway/entities/ai-provider/) for Gemini and an [AI Model](/ai-gateway/entities/ai-model/) that references it.
+    1. Create an [AI Model Provider](/ai-gateway/entities/ai-model-provider/) for Gemini and an [AI Model](/ai-gateway/entities/ai-model/) that references it.
     1. Configure parameters like `temperature`, `top_p`, and `top_k` on the client side:
         ```python
         model = genai.GenerativeModel(
@@ -17,7 +17,7 @@ You can configure model generation parameters when calling Gemini through {{site
         ```
 
 - **Using the OpenAI SDK** with {{site.ai_gateway}}:
-    1. Create an [AI Provider](/ai-gateway/entities/ai-provider/) for Gemini with `llm_format` set to `openai`.
+    1. Create an [AI Model Provider](/ai-gateway/entities/ai-model-provider/) for Gemini with `llm_format` set to `openai`.
     1. You can configure parameters in one of three ways:
         - Configure them in the [AI Model](/ai-gateway/entities/ai-model/) only.
         - Configure them in the client only.

--- a/app/_includes/md/ai-gateway/v2/faqs/gemini-search.md
+++ b/app/_includes/md/ai-gateway/v2/faqs/gemini-search.md
@@ -1,1 +1,1 @@
-Configure an [AI Model](/ai-gateway/entities/ai-model/) that uses a Gemini [AI Provider](/ai-gateway/entities/ai-provider/), then declare the `googleSearch` tool in your requests.
+Configure an [AI Model](/ai-gateway/entities/ai-model/) that uses a Gemini [AI Model Provider](/ai-gateway/entities/ai-model-provider/), then declare the `googleSearch` tool in your requests.

--- a/app/_includes/md/ai-gateway/v2/otel-span-attributes.md
+++ b/app/_includes/md/ai-gateway/v2/otel-span-attributes.md
@@ -1,0 +1,45 @@
+<!-- vale off -->
+{% table %}
+columns:
+  - title: Attribute
+    key: key
+  - title: Value Type
+    key: type
+  - title: Description
+    key: desc
+rows:
+  - key: "`kong.a2a.operation`"
+    type: string
+    desc: A2A operation name
+  - key: "`kong.a2a.protocol.version`"
+    type: string
+    desc: "Value of the `A2A-Version` request header, or `unknown`"
+  - key: "`kong.a2a.task.id`"
+    type: string
+    desc: Task ID from the response
+  - key: "`kong.a2a.task.state`"
+    type: string
+    desc: Normalized task state
+  - key: "`kong.a2a.context.id`"
+    type: string
+    desc: A2A context ID
+  - key: "`kong.a2a.error`"
+    type: string
+    desc: Error type string when present
+  - key: "`kong.a2a.streaming`"
+    type: boolean
+    desc: "`true` for SSE streaming responses"
+  - key: "`kong.a2a.ttfb_latency`"
+    type: int
+    desc: Time to first byte in milliseconds (streaming only)
+  - key: "`kong.a2a.sse_events_count`"
+    type: int
+    desc: Count of SSE events (streaming only)
+  - key: "`rpc.system`"
+    type: string
+    desc: "`jsonrpc` (JSON-RPC binding only)"
+  - key: "`rpc.method`"
+    type: string
+    desc: A2A operation name (JSON-RPC binding only)
+{% endtable %}
+<!-- vale on -->

--- a/app/_includes/md/ai-gateway/v2/providers.md
+++ b/app/_includes/md/ai-gateway/v2/providers.md
@@ -1,7 +1,7 @@
 <!--vale off-->
 {%- assign provider = include.providers.providers | where: "name", include.provider_name | first -%}
 {% if provider %}
-You can proxy requests to {{ provider.name }} AI models through {{site.ai_gateway}} by creating [AI Providers](/ai-gateway/entities/ai-provider/) and [AI Models](/ai-gateway/entities/ai-model/). This reference documents all supported AI capabilities, configuration requirements, and provider-specific details needed for proper integration.
+You can proxy requests to {{ provider.name }} AI models through {{site.ai_gateway}} by creating [AI Model Provider](/ai-gateway/entities/ai-model-provider/) and [AI Model](/ai-gateway/entities/ai-model/) entities. This reference documents all supported AI capabilities, configuration requirements, and provider-specific details needed for proper integration.
 
 ## Upstream paths
 

--- a/app/_landing_pages/ai-gateway.yaml
+++ b/app/_landing_pages/ai-gateway.yaml
@@ -80,8 +80,8 @@ rows:
       type: h2
       text: "{{site.ai_gateway}} providers"
       description: |
-        {{site.ai_gateway}} routes AI requests through provider-agnostic APIs by combining AI Providers and AI Models.
-        AI Providers store upstream connectivity and credentials, while AI Models reference Providers to expose stable client-facing endpoints and routing behavior.
+        {{site.ai_gateway}} routes AI requests through provider-agnostic APIs by combining AI Model Providers and AI Models.
+        AI Model Providers store upstream connectivity and credentials, while AI Models reference AI Model Providers to expose stable client-facing endpoints and routing behavior.
     column_count: 4
     columns:
       - blocks:
@@ -195,7 +195,7 @@ rows:
                 text: |
                   Define a single endpoint for any traffic type: LLM, MCP, or A2A. Configure [AI Models](/ai-gateway/entities/ai-model/), [AI MCP Servers](/ai-gateway/entities/ai-mcp-server/), and [AI Agents](/ai-gateway/entities/ai-agent/) once, then govern them from a [unified control plane](https://cloud.konghq.com/ai-manager) with built-in auth, policy enforcement, and observability:
 
-                    * [Routing and load balancing](/ai-gateway/load-balancing/) across AI Providers
+                    * [Routing and load balancing](/ai-gateway/load-balancing/) across AI Model Providers
                     * [Streaming and authentication](/ai-gateway/streaming/) with [AI Policies](/ai-gateway/entities/ai-policy/)
                     * Access control with [AI Consumers](/ai-gateway/entities/ai-consumer/) and ACLs
                     * [Usage analytics](/ai-gateway/monitor-ai-llm-metrics/) for requests, tokens, errors, and latency
@@ -226,11 +226,11 @@ rows:
   #     - blocks:
   #       - type: card
   #         config:
-  #           title: AI Provider reference
-  #           description: Use an AI Provider to configure upstream LLM connectivity and authentication, then reuse it across AI Models.
+  #           title: AI Model Provider reference
+  #           description: Use an AI Model Provider to configure upstream LLM connectivity and authentication, then reuse it across AI Models.
   #           icon: /assets/icons/provider.svg
   #           cta:
-  #             url: /ai-gateway/entities/ai-provider/
+  #             url: /ai-gateway/entities/ai-model-provider/
   #             align: end
 
   - header:
@@ -469,7 +469,7 @@ rows:
         - type: card
           config:
             title: AI Entities
-            description: Entities are the building blocks that make up the {{site.ai_gateway}} ecosystem. This includes AI Models, AI Providers, AI Agents, AI MCP Servers, and AI Consumers.
+            description: Entities are the building blocks that make up the {{site.ai_gateway}} ecosystem. This includes AI Models, AI Model Providers, AI Identity Providers, AI Agents, AI MCP Servers, and AI Consumers.
             cta:
               url: /ai-gateway/entities/
               align: end

--- a/app/_landing_pages/ai-gateway/ai-providers.yaml
+++ b/app/_landing_pages/ai-gateway/ai-providers.yaml
@@ -22,7 +22,7 @@ rows:
               blocks:
                 - type: text
                   text: |
-                    The core of [{{site.ai_gateway}}](/ai-gateway/) is the ability to serve [AI Models](/ai-gateway/entities/ai-model/) from various [AI Providers](/ai-gateway/entities/ai-provider/) via a provider-agnostic API. This normalized API layer affords developers and organizations multiple benefits:
+                    The core of [{{site.ai_gateway}}](/ai-gateway/) is the ability to serve [AI Models](/ai-gateway/entities/ai-model/) from various [AI Model Providers](/ai-gateway/entities/ai-model-provider/) via a provider-agnostic API. This normalized API layer affords developers and organizations multiple benefits:
 
                 - type: unordered_list
                   items:

--- a/app/_landing_pages/ai-gateway/entities.yaml
+++ b/app/_landing_pages/ai-gateway/entities.yaml
@@ -23,18 +23,18 @@ rows:
       - blocks:
           - type: card
             config:
-              title: "AI Provider"
-              description: Register upstream LLM providers with authentication and configuration. Reusable across models.
+              title: "AI Model Provider"
+              description: Register upstream LLM providers with authentication and configuration. Reusable across AI Models.
               cta:
-                text: AI Provider entity
-                url: /ai-gateway/entities/ai-provider/
+                text: AI Model Provider entity
+                url: /ai-gateway/entities/ai-model-provider/
       - blocks:
           - type: card
             config:
               title: AI Model
               description: Define how to reach and interact with a specific LLM, including routing, load balancing, LLM capabilities, and AI Policies.
               cta:
-                text: Model entity
+                text: AI Model entity
                 url: /ai-gateway/entities/ai-model/
       - blocks:
           - type: card
@@ -90,6 +90,14 @@ rows:
               cta:
                 text: AI Vault entity
                 url: /ai-gateway/entities/ai-vault/
+      - blocks:
+          - type: card
+            config:
+              title: AI Identity Provider
+              description: Configure inbound authentication for AI Consumers calling AI Models. Supports API key and OIDC token authentication.
+              cta:
+                text: AI Identity Provider entity
+                url: /ai-gateway/entities/ai-identity-provider/
       - blocks:
           - type: card
             config:

--- a/app/ai-gateway/ai-otel-metrics.md
+++ b/app/ai-gateway/ai-otel-metrics.md
@@ -46,7 +46,7 @@ works_on:
 You can use these metrics to:
 
 * Track LLM request latency and upstream provider processing time
-* Monitor token consumption across AI Providers, AI Models, and AI Consumers
+* Monitor token consumption across AI Model Providers, AI Models, and AI Consumers
 * Measure time-to-first-token (TTFT) and inter-token latency (TPOT) for streaming responses
 * Calculate AI request costs
 * Observe MCP tool-call latency, error rates, and ACL decisions

--- a/app/ai-gateway/ai-providers/anthropic.md
+++ b/app/ai-gateway/ai-providers/anthropic.md
@@ -31,8 +31,8 @@ related_resources:
     url: /ai-gateway/policies/
   - text: AI Providers
     url: /ai-gateway/ai-providers/
-  - text: AI Provider entity
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
   - text: AI Model entity
     url: /ai-gateway/entities/ai-model/
 
@@ -45,7 +45,7 @@ related_resources:
 
 ## Configure {{ provider.name }}
 
-To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Provider](/ai-gateway/entities/ai-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from {{ provider.name }}.
+To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model Provider](/ai-gateway/entities/ai-model-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from {{ provider.name }}.
 
 Here's a minimal configuration for chat completions:
 

--- a/app/ai-gateway/ai-providers/azure.md
+++ b/app/ai-gateway/ai-providers/azure.md
@@ -31,8 +31,8 @@ related_resources:
     url: /ai-gateway/policies/
   - text: AI Providers
     url: /ai-gateway/ai-providers/
-  - text: AI Provider entity
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
   - text: AI Model entity
     url: /ai-gateway/entities/ai-model/
 
@@ -47,7 +47,7 @@ faqs:
 
 ## Configure {{ provider.name }}
 
-To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Provider](/ai-gateway/entities/ai-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
+To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model Provider](/ai-gateway/entities/ai-model-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
 
 Here's a minimal configuration for chat completions:
 

--- a/app/ai-gateway/ai-providers/bedrock.md
+++ b/app/ai-gateway/ai-providers/bedrock.md
@@ -31,8 +31,8 @@ related_resources:
     url: /ai-gateway/policies/
   - text: AI Providers
     url: /ai-gateway/ai-providers/
-  - text: AI Provider entity
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
   - text: AI Model entity
     url: /ai-gateway/entities/ai-model/
 
@@ -60,7 +60,7 @@ faqs:
 
 ## Configure {{ provider.name }}
 
-To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Provider](/ai-gateway/entities/ai-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
+To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model Provider](/ai-gateway/entities/ai-model-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
 
 Here's a minimal configuration for chat completions:
 

--- a/app/ai-gateway/ai-providers/cerebras.md
+++ b/app/ai-gateway/ai-providers/cerebras.md
@@ -31,8 +31,8 @@ related_resources:
     url: /ai-gateway/policies/
   - text: AI Providers
     url: /ai-gateway/ai-providers/
-  - text: AI Provider entity
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
   - text: AI Model entity
     url: /ai-gateway/entities/ai-model/
 
@@ -42,7 +42,7 @@ related_resources:
 
 ## Configure {{ provider.name }}
 
-To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Provider](/ai-gateway/entities/ai-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from {{ provider.name }}.
+To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model Provider](/ai-gateway/entities/ai-model-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from {{ provider.name }}.
 
 Here's a minimal configuration for chat completions:
 

--- a/app/ai-gateway/ai-providers/cohere.md
+++ b/app/ai-gateway/ai-providers/cohere.md
@@ -31,8 +31,8 @@ related_resources:
     url: /ai-gateway/policies/
   - text: AI Providers
     url: /ai-gateway/ai-providers/
-  - text: AI Provider entity
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
   - text: AI Model entity
     url: /ai-gateway/entities/ai-model/
 
@@ -50,7 +50,7 @@ faqs:
 
 ## Configure {{ provider.name }}
 
-To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Provider](/ai-gateway/entities/ai-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
+To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model Provider](/ai-gateway/entities/ai-model-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
 
 Here's a minimal configuration for chat completions:
 

--- a/app/ai-gateway/ai-providers/dashscope.md
+++ b/app/ai-gateway/ai-providers/dashscope.md
@@ -31,8 +31,8 @@ related_resources:
     url: /ai-gateway/policies/
   - text: AI Providers
     url: /ai-gateway/ai-providers/
-  - text: AI Provider entity
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
   - text: AI Model entity
     url: /ai-gateway/entities/ai-model/
 
@@ -43,7 +43,7 @@ related_resources:
 
 ## Configure {{ provider.name }}
 
-To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Provider](/ai-gateway/entities/ai-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
+To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model Provider](/ai-gateway/entities/ai-model-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
 
 Here's a minimal configuration for chat completions:
 

--- a/app/ai-gateway/ai-providers/databricks.md
+++ b/app/ai-gateway/ai-providers/databricks.md
@@ -31,8 +31,8 @@ related_resources:
     url: /ai-gateway/policies/
   - text: AI Providers
     url: /ai-gateway/ai-providers/
-  - text: AI Provider entity
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
   - text: AI Model entity
     url: /ai-gateway/entities/ai-model/
 
@@ -43,7 +43,7 @@ related_resources:
 
 ## Configure {{ provider.name }}
 
-To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Provider](/ai-gateway/entities/ai-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
+To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model Provider](/ai-gateway/entities/ai-model-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
 
 Here's a minimal configuration for chat completions:
 

--- a/app/ai-gateway/ai-providers/deepseek.md
+++ b/app/ai-gateway/ai-providers/deepseek.md
@@ -31,8 +31,8 @@ related_resources:
     url: /ai-gateway/policies/
   - text: AI Providers
     url: /ai-gateway/ai-providers/
-  - text: AI Provider entity
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
   - text: AI Model entity
     url: /ai-gateway/entities/ai-model/
 
@@ -43,7 +43,7 @@ related_resources:
 
 ## Configure {{ provider.name }}
 
-To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Provider](/ai-gateway/entities/ai-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from {{ provider.name }}.
+To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model Provider](/ai-gateway/entities/ai-model-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from {{ provider.name }}.
 
 Here's a minimal configuration for chat completions:
 

--- a/app/ai-gateway/ai-providers/gemini.md
+++ b/app/ai-gateway/ai-providers/gemini.md
@@ -31,8 +31,8 @@ related_resources:
     url: /ai-gateway/policies/
   - text: AI Providers
     url: /ai-gateway/ai-providers/
-  - text: AI Provider entity
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
   - text: AI Model entity
     url: /ai-gateway/entities/ai-model/
 
@@ -58,7 +58,7 @@ faqs:
 
 ## Configure {{ provider.name }}
 
-To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Provider](/ai-gateway/entities/ai-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
+To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model Provider](/ai-gateway/entities/ai-model-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
 
 Here's a minimal configuration for chat completions:
 

--- a/app/ai-gateway/ai-providers/huggingface.md
+++ b/app/ai-gateway/ai-providers/huggingface.md
@@ -31,8 +31,8 @@ related_resources:
     url: /ai-gateway/policies/
   - text: AI Providers
     url: /ai-gateway/ai-providers/
-  - text: AI Provider entity
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
   - text: AI Model entity
     url: /ai-gateway/entities/ai-model/
 
@@ -45,7 +45,7 @@ related_resources:
 
 ## Configure {{ provider.name }}
 
-To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Provider](/ai-gateway/entities/ai-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
+To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model Provider](/ai-gateway/entities/ai-model-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
 
 Here's a minimal configuration for chat completions:
 

--- a/app/ai-gateway/ai-providers/kimi.md
+++ b/app/ai-gateway/ai-providers/kimi.md
@@ -36,8 +36,8 @@ related_resources:
     url: /ai-gateway/policies/
   - text: AI Providers
     url: /ai-gateway/ai-providers/
-  - text: AI Provider entity
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
   - text: AI Model entity
     url: /ai-gateway/entities/ai-model/
 
@@ -48,7 +48,7 @@ related_resources:
 
 ## Configure {{ provider.name }}
 
-To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Provider](/ai-gateway/entities/ai-provider/) as follows:
+To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model Provider](/ai-gateway/entities/ai-model-provider/) as follows:
 
 <!--vale off-->
 {% konnect_api_request %}

--- a/app/ai-gateway/ai-providers/llama.md
+++ b/app/ai-gateway/ai-providers/llama.md
@@ -31,8 +31,8 @@ related_resources:
     url: /ai-gateway/policies/
   - text: AI Providers
     url: /ai-gateway/ai-providers/
-  - text: AI Provider entity
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
   - text: AI Model entity
     url: /ai-gateway/entities/ai-model/
 
@@ -43,7 +43,7 @@ related_resources:
 
 ## Configure {{ provider.name }}
 
-To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Provider](/ai-gateway/entities/ai-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
+To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model Provider](/ai-gateway/entities/ai-model-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
 
 Here's a minimal configuration for chat completions:
 

--- a/app/ai-gateway/ai-providers/mistral.md
+++ b/app/ai-gateway/ai-providers/mistral.md
@@ -31,8 +31,8 @@ related_resources:
     url: /ai-gateway/policies/
   - text: AI Providers
     url: /ai-gateway/ai-providers/
-  - text: AI Provider entity
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
   - text: AI Model entity
     url: /ai-gateway/entities/ai-model/
 
@@ -43,7 +43,7 @@ related_resources:
 
 ## Configure {{ provider.name }}
 
-To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Provider](/ai-gateway/entities/ai-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
+To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model Provider](/ai-gateway/entities/ai-model-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
 
 Here's a minimal configuration for chat completions:
 

--- a/app/ai-gateway/ai-providers/ollama.md
+++ b/app/ai-gateway/ai-providers/ollama.md
@@ -31,8 +31,8 @@ related_resources:
     url: /ai-gateway/policies/
   - text: AI Providers
     url: /ai-gateway/ai-providers/
-  - text: AI Provider entity
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
   - text: AI Model entity
     url: /ai-gateway/entities/ai-model/
 
@@ -43,7 +43,7 @@ related_resources:
 
 ## Configure {{ provider.name }}
 
-To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Provider](/ai-gateway/entities/ai-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from {{ provider.name }}.
+To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model Provider](/ai-gateway/entities/ai-model-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from {{ provider.name }}.
 
 Here's a minimal configuration for chat completions:
 

--- a/app/ai-gateway/ai-providers/openai.md
+++ b/app/ai-gateway/ai-providers/openai.md
@@ -31,8 +31,8 @@ related_resources:
     url: /ai-gateway/policies/
   - text: AI Providers
     url: /ai-gateway/ai-providers/
-  - text: AI Provider entity
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
   - text: AI Model entity
     url: /ai-gateway/entities/ai-model/
 
@@ -43,7 +43,7 @@ related_resources:
 
 ## Configure {{ provider.name }}
 
-To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Provider](/ai-gateway/entities/ai-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
+To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model Provider](/ai-gateway/entities/ai-model-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
 
 Here's a minimal configuration for chat completions:
 

--- a/app/ai-gateway/ai-providers/vercel.md
+++ b/app/ai-gateway/ai-providers/vercel.md
@@ -31,8 +31,8 @@ related_resources:
     url: /ai-gateway/policies/
   - text: AI Providers
     url: /ai-gateway/ai-providers/
-  - text: AI Provider entity
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
   - text: AI Model entity
     url: /ai-gateway/entities/ai-model/
 ---
@@ -42,7 +42,7 @@ related_resources:
 
 ## Configure a {{ provider.name }} provider
 
-To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Provider](/ai-gateway/entities/ai-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
+To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model Provider](/ai-gateway/entities/ai-model-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
 
 Note that, {{ site.vercel }} hosts [models](https://vercel.com/ai-gateway/models) from other providers so in this example we use `openai/gpt-5.5`.
 

--- a/app/ai-gateway/ai-providers/vertex.md
+++ b/app/ai-gateway/ai-providers/vertex.md
@@ -31,8 +31,8 @@ related_resources:
     url: /ai-gateway/policies/
   - text: AI Providers
     url: /ai-gateway/ai-providers/
-  - text: AI Provider entity
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
   - text: AI Model entity
     url: /ai-gateway/entities/ai-model/
 
@@ -44,7 +44,7 @@ related_resources:
 
 ## Configure {{ provider.name }}
 
-To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Provider](/ai-gateway/entities/ai-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
+To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model Provider](/ai-gateway/entities/ai-model-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
 
 Here's a minimal configuration for chat completions:
 

--- a/app/ai-gateway/ai-providers/vllm.md
+++ b/app/ai-gateway/ai-providers/vllm.md
@@ -33,8 +33,8 @@ related_resources:
     url: /ai-gateway/policies/
   - text: AI Providers
     url: /ai-gateway/ai-providers/
-  - text: AI Provider entity
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
   - text: AI Model entity
     url: /ai-gateway/entities/ai-model/
 
@@ -44,7 +44,7 @@ related_resources:
 
 ## Configure {{ provider.name }}
 
-To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Provider](/ai-gateway/entities/ai-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from {{ provider.name }}.
+To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model Provider](/ai-gateway/entities/ai-model-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from {{ provider.name }}.
 
 Here's a minimal configuration for chat completions:
 

--- a/app/ai-gateway/ai-providers/xai.md
+++ b/app/ai-gateway/ai-providers/xai.md
@@ -31,8 +31,8 @@ related_resources:
     url: /ai-gateway/policies/
   - text: AI Providers
     url: /ai-gateway/ai-providers/
-  - text: AI Provider entity
-    url: /ai-gateway/entities/ai-provider/
+  - text: AI Model Provider entity
+    url: /ai-gateway/entities/ai-model-provider/
   - text: AI Model entity
     url: /ai-gateway/entities/ai-model/
 
@@ -45,7 +45,7 @@ related_resources:
 
 ## Configure {{ provider.name }}
 
-To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Provider](/ai-gateway/entities/ai-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
+To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model Provider](/ai-gateway/entities/ai-model-provider/). You can then access supported [AI Models](/ai-gateway/entities/ai-model/) from  {{ provider.name }}.
 
 Here's a minimal configuration for chat completions:
 

--- a/app/ai-gateway/llm-open-telemetry.md
+++ b/app/ai-gateway/llm-open-telemetry.md
@@ -45,7 +45,7 @@ You can also capture [A2A agent traffic](#a2a-span-attributes) by enabling stati
 
 You can export these attributes via a supported backend to:
 
-* Inspect which AI Model or AI Provider handled a request
+* Inspect which AI Model or AI Model Provider handled a request
 * Track conversation/session identifiers across requests
 * Analyze prompt structure (system vs. user vs. tool messages)
 * Evaluate model parameters (such as temperature, top-k)

--- a/app/ai-gateway/load-balancing.md
+++ b/app/ai-gateway/load-balancing.md
@@ -135,10 +135,10 @@ flowchart LR
     subgraph AIGateway
         LBLB[/Load Balancer/]
     end
-    LBLB -->|Request| AIProvider1(AI Provider 1)
+    LBLB -->|Request| AIProvider1(AI Model Provider 1)
     AIProvider1 --> Decision1{Is Success?}
     Decision1 -->|Yes| Client
-    Decision1 -->|No| AIProvider2(AI Provider 2)
+    Decision1 -->|No| AIProvider2(AI Model Provider 2)
     subgraph Retry
         AIProvider2 --> Decision2{Is Success?}
     end

--- a/app/ai-gateway/monitor-ai-llm-metrics.md
+++ b/app/ai-gateway/monitor-ai-llm-metrics.md
@@ -30,7 +30,7 @@ works_on:
   - konnect
 ---
 
-{{site.ai_gateway}} calls LLM-based services according to the settings of your [Providers](/ai-gateway/entities/ai-provider/) and [Models](/ai-gateway/entities/ai-model/). You can use the built in logging and a [Prometheus](/ai-gateway/policies/prometheus/) Policy to aggregate the LLM provider responses to count the number of tokens sent through {{site.ai_gateway}}. If you have defined input and output costs in the models, you can also calculate aggregate costs. You can also track whether the requests have been cached by {{site.ai_gateway}}, saving the cost of contacting the LLM providers, which improves performance.
+{{site.ai_gateway}} calls LLM-based services according to the settings of your [AI Model Providers](/ai-gateway/entities/ai-model-provider/) and [Models](/ai-gateway/entities/ai-model/). You can use the built in logging and a [Prometheus](/ai-gateway/policies/prometheus/) Policy to aggregate the LLM provider responses to count the number of tokens sent through {{site.ai_gateway}}. If you have defined input and output costs in the models, you can also calculate aggregate costs. You can also track whether the requests have been cached by {{site.ai_gateway}}, saving the cost of contacting the LLM providers, which improves performance.
 
 In addition to LLM usage, {{site.ai_gateway}} can also log MCP server traffic. [MCP logging](/ai-gateway/entities/ai-mcp-server/#logging-and-audits) provides visibility into latency, response sizes, and error rates when AI Policies invoke external MCP tools and servers.
 

--- a/app/ai-gateway/streaming.md
+++ b/app/ai-gateway/streaming.md
@@ -22,7 +22,7 @@ description: This guide walks you through setting up AI Models with streaming.
 
 ## What is request streaming?
 
-In an LLM (Large Language Model) inference request, {{site.ai_gateway}} uses the upstream AI Provider's REST API to generate the next chat message from the caller.
+In an LLM (Large Language Model) inference request, {{site.ai_gateway}} uses the upstream AI Model Provider's REST API to generate the next chat message from the caller.
 
 Normally, this request is processed and completely buffered by the LLM before being sent back to {{site.ai_gateway}} and then to the caller in a single large JSON block. This process can be time-consuming, depending on the [`max_tokens`](/ai-gateway/entities/ai-model/#targets), other request parameters, and the complexity of the request sent to the LLM model. Request streaming in {{site.ai_gateway}} uses the [AI Model entity](/ai-gateway/entities/ai-model/). 
 
@@ -171,7 +171,7 @@ for chunk in stream:
 ```
 
 {:.info}
-> This feature works with any AI Provider and AI Model when [`formats`](/ai-gateway/entities/ai-model/#request-and-response-formats) is set to `openai` mode.
+> This feature works with any AI Model Provider and AI Model when [`formats`](/ai-gateway/entities/ai-model/#request-and-response-formats) is set to `openai` mode.
 >
 > See the [OpenAI API Documentation](https://platform.openai.com/docs/api-reference/chat/create#chat_create-stream_options) for more information on stream options.
 


### PR DESCRIPTION
## Description

This PR updates AI Provider entity docs, and aligns them with the [latest API schema](https://platformapi.konghq.tech/apis/konnect-ai-gateway-dev-0-0-47/versions/963f0891-dd54-4287-9cd9-152e0e12a70e/). Recap of changes:

AI Model Provider
- Renamed the old entity from AI Provider to AI Model Provider
- Added paragraph distinguishing outbound credentials (AI Model Provider authenticates to the upstream LLM) from inbound authentication (AI Identity Provider validates the AI Consumer calling the model)
- Added AI Identity Provider to `related_resources`

**AI Identity Provider (new file)**
- Created aew entity reference page covering `key-auth` and `openid-connect` provider types
- Documented per-model assignment via `access.identity_providers`, one provider per type per model maximum
- Covered anonymous consumer fallback behavior (unauthenticated requests terminate with `401`)
- Added a note that all models in the same gateway sharing OIDC auth must reference the same `openid-connect` identity provider
- `client_secret` on the OIDC type is referenceable from an AI Vault
- Fixed `access.acls` code example to use correct `allow`/`deny` object shape per v0.0.47 spec

Context [here](https://kongstrong.slack.com/archives/C08GKTWJHDX/p1783093109048949)

Note:
This affects all other AI Gateway 2.0 documentation, I will be opening up PRs against this branch with various updates.

## Preview Links

https://deploy-preview-5875--kongdeveloper.netlify.app/ai-gateway/entities/ai-model-provider
https://deploy-preview-5875--kongdeveloper.netlify.app/ai-gateway/entities/ai-identity-provider

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
