### PR TITLE
fix(konnect): Cleanup Mesh Manager/Gateway Manager naming

### DIFF
--- a/.github/styles/base/Kongterms.yml
+++ b/.github/styles/base/Kongterms.yml
@@ -20,3 +20,5 @@ swap:
   ServiceHub: Service Hub
   Runtime Manager: API Gateway
   dbless: DB-less
+  Gateway Manager: API Gateway
+  Mesh Manager: Service Mesh

--- a/app/_how-tos/dev-portal/package-apis-with-dev-portal.md
+++ b/app/_how-tos/dev-portal/package-apis-with-dev-portal.md
@@ -290,7 +290,8 @@ Operations from your API's OpenAPI spec should overlap with Routes to ensure req
 
 ## Assign operations to API packages
 
-Now, you can create an API package by picking operations from your API. Operations are automatically mapped to Routes using your API's OpenAPI spec. The Gateway configuration isn't directly modified – any unmatched operations will be highlighted to indicate that a user needs Gateway Manager permissions to perform an action.
+Now, you can create an API package by picking operations from your API. Operations are automatically mapped to Routes using your API's OpenAPI spec. 
+The Gateway configuration isn't directly modified, so any unmatched operations will be highlighted to indicate that a user needs API Gateway permissions to perform an action.
 
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
 1. Click the **API packages** tab.

--- a/app/_includes/plugins/crowdstrike-aidr/install.md
+++ b/app/_includes/plugins/crowdstrike-aidr/install.md
@@ -68,7 +68,7 @@ In {{site.konnect_short_name}} hybrid mode, upload the plugin schema to the cont
      --data "{\"lua_schema\": $(jq -Rs . kong/plugins/{{include.plugin_slug}}/schema.lua)}"
    ```
 
-   Your control plane ID is visible in the {{site.konnect_short_name}} API Gateway URL, or on the control plane's overview page.
+Your control plane ID is visible in the URL when viewing the control plane in {{site.konnect_short_name}}, or on the control plane's overview page.
 
 1. Build the custom {{site.base_gateway}} image using the Dockerfile in the repository:
 

--- a/app/_includes/plugins/crowdstrike-aidr/install.md
+++ b/app/_includes/plugins/crowdstrike-aidr/install.md
@@ -68,7 +68,7 @@ In {{site.konnect_short_name}} hybrid mode, upload the plugin schema to the cont
      --data "{\"lua_schema\": $(jq -Rs . kong/plugins/{{include.plugin_slug}}/schema.lua)}"
    ```
 
-   Your control plane ID is visible in the {{site.konnect_short_name}} Gateway Manager URL, or on the control plane's overview page.
+   Your control plane ID is visible in the {{site.konnect_short_name}} API Gateway URL, or on the control plane's overview page.
 
 1. Build the custom {{site.base_gateway}} image using the Dockerfile in the repository:
 

--- a/app/_landing_pages/catalog.yaml
+++ b/app/_landing_pages/catalog.yaml
@@ -25,7 +25,7 @@ rows:
                 - type: text
                   text: |
                     {{site.konnect_catalog}} provides a centralized catalog of all services and APIs running in your organization. 
-                    By integrating with internal applications, like Gateway Manager and Mesh Manager, and external tools, like GitHub and PagerDuty, 
+                    By integrating with internal applications, like API Gateway and Service Mesh, and external tools, like GitHub and PagerDuty, 
                     it offers a 360-degree overview of your services, including:
                 - type: unordered_list
                   items:

--- a/app/catalog/api-packaging.md
+++ b/app/catalog/api-packaging.md
@@ -109,7 +109,7 @@ Packaging APIs involves the following steps:
 1. Create an API and attach an OpenAPI spec. Operations from your API's OpenAPI spec should overlap with Routes to ensure requests will be routed to the correct Service. Gateway routing configuration isn't directly modified by adding operations.
 1. Link a control plane to allow developer consumption. 
 1. Apply the Access Control Enforcement (ACE) plugin globally.
-1. Create an API package by adding operations and package rate limits. Operations are automatically mapped to Routes using your API's OpenAPI spec or you can create them manually. The Gateway configuration isn't directly modified, so any unmatched operations will be highlighted to indicate that a user needs API Gateway permissions needs to perform an action.
+1. Create an API package by adding operations and package rate limits. Operations are automatically mapped to Routes using your API's OpenAPI spec or you can create them manually. The Gateway configuration isn't directly modified, so any unmatched operations will be highlighted to indicate that a user needs API Gateway permissions to perform an action.
 
 ### ACE plugin
 

--- a/app/catalog/api-packaging.md
+++ b/app/catalog/api-packaging.md
@@ -109,7 +109,7 @@ Packaging APIs involves the following steps:
 1. Create an API and attach an OpenAPI spec. Operations from your API's OpenAPI spec should overlap with Routes to ensure requests will be routed to the correct Service. Gateway routing configuration isn't directly modified by adding operations.
 1. Link a control plane to allow developer consumption. 
 1. Apply the Access Control Enforcement (ACE) plugin globally.
-1. Create an API package by adding operations and package rate limits. Operations are automatically mapped to Routes using your API's OpenAPI spec or you can create them manually. The Gateway configuration isn't directly modified – any unmatched operations will be highlighted to indicate that a user needs Gateway Manager permissions needs to perform an action.
+1. Create an API package by adding operations and package rate limits. Operations are automatically mapped to Routes using your API's OpenAPI spec or you can create them manually. The Gateway configuration isn't directly modified, so any unmatched operations will be highlighted to indicate that a user needs API Gateway permissions needs to perform an action.
 
 ### ACE plugin
 

--- a/app/gateway/data-plane-version-compatibility.md
+++ b/app/gateway/data-plane-version-compatibility.md
@@ -32,7 +32,7 @@ If you experience compatibility errors, [upgrade your data plane nodes](/gateway
 
 ## Compatibility status
 
-{{site.konnect_short_name}} Gateway Manager displays a **Compatibility status** badge for each data plane node. 
+The {{site.konnect_short_name}} API Gateway page displays a **Compatibility status** badge for each data plane node. 
 To see it, go to **API Gateway**, select a control plane, and click the **Data plane nodes** tab. 
 The **Compatibility status** column shows one of the following statuses:
 

--- a/app/konnect-platform/teams-and-roles.md
+++ b/app/konnect-platform/teams-and-roles.md
@@ -519,7 +519,7 @@ rows:
       * Create, read, edit, delete, and list plugins and custom plugins.
       * Create, read, edit, delete, and list Routes.
   - role: "`Event Gateways Creator`"
-    description: "Access to create a new event gateway in Konnect. The creator becomes the owner of the event gateway they create, gaining admin access to the new event gateway. This role does not grant access to existing event gateways, their runtime instances, or their configurations."
+    description: "Access to create a new event gateway in {{site.konnect_short_name}}. The creator becomes the owner of the event gateway they create, gaining admin access to the new event gateway. This role does not grant access to existing event gateways, their runtime instances, or their configurations."
     permissions: |
       * Create and list Event Gateways.
       * When creating an Event Gateway, grants the Event Gateways Admin role on newly created Event Gateways.

--- a/app/konnect-platform/teams-and-roles.md
+++ b/app/konnect-platform/teams-and-roles.md
@@ -519,7 +519,7 @@ rows:
       * Create, read, edit, delete, and list plugins and custom plugins.
       * Create, read, edit, delete, and list Routes.
   - role: "`Event Gateways Creator`"
-    description: "Access to create a new event gateway in Event Gateway Manager. The creator becomes the owner of the event gateway they create, gaining admin access to the new event gateway. This role does not grant access to existing event gateways, their runtime instances, or their configurations."
+    description: "Access to create a new event gateway in Konnect. The creator becomes the owner of the event gateway they create, gaining admin access to the new event gateway. This role does not grant access to existing event gateways, their runtime instances, or their configurations."
     permissions: |
       * Create and list Event Gateways.
       * When creating an Event Gateway, grants the Event Gateways Admin role on newly created Event Gateways.


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Removing straggling mentions of mesh manager and gateway manager. The UI names are API Gateway and Service Mesh.

## Preview Links
Minor edits on various pages:
https://deploy-preview-5908--kongdeveloper.netlify.app/plugins/crowdstrike-aidr-response/#installation-steps
https://deploy-preview-5908--kongdeveloper.netlify.app/how-to/package-apis-with-dev-portal/#assign-operations-to-api-packages
https://deploy-preview-5908--kongdeveloper.netlify.app/catalog/
https://deploy-preview-5908--kongdeveloper.netlify.app/konnect-platform/teams-and-roles/
https://deploy-preview-5908--kongdeveloper.netlify.app/gateway/data-plane-version-compatibility/