### PR TITLE
feat(gateway): Gateway docker hub & cloudsmith links

### DIFF
--- a/app/_data/support/packages.yml
+++ b/app/_data/support/packages.yml
@@ -7,9 +7,11 @@ amazonlinux1:
 amazonlinux2:
   os: Amazon Linux
   version: 2
+  docker_tag: amazonlinux-2
 amazonlinux2023:
   os: Amazon Linux
   version: 2023
+  docker_tag: amazonlinux-2023
 centos7:
   os: CentOS
   version: 7
@@ -32,16 +34,19 @@ debian11:
   os: Debian
   version: 11
   codename: bullseye
+  docker_tag: debian
 debian12:
   os: Debian
   version: 12
   codename: bookworm
+  docker_tag: debian
 debian-stable:
   os: Debian
   version: stable
 distroless:
   os: Distroless
   version: N/A
+  docker_tag: distroless
 rhel7:
   os: RHEL
   version: 7.x
@@ -50,10 +55,12 @@ rhel8:
   os: RHEL
   version: 8.x
   codename: 8
+  docker_tag: rhel
 rhel9:
   os: RHEL
   version: 9.x
   codename: 9
+  docker_tag: rhel
 ubuntu1604:
   os: Ubuntu
   version: 16.04
@@ -68,7 +75,9 @@ ubuntu2204:
   os: Ubuntu
   version: 22.04
   codename: jammy
+  docker_tag: ubuntu
 ubuntu2404:
   os: Ubuntu
   version: 24.04
   codename: noble
+  docker_tag: ubuntu

--- a/app/_includes/support/gateway.html
+++ b/app/_includes/support/gateway.html
@@ -17,15 +17,20 @@ rows:
 {%- assign distro = d | first | last -%}
 {%- assign package = site.data.support.packages[key] -%}
 {%- assign distro_eol = distro.eol | default: include.release.eol -%}
-{%- if distro.package %}
-  - target: "{{ package.os }} {{ package.version }} (package)"
+{%- if distro.package -%}
+{%- assign cloudsmith_version = include.release.release | remove: "." %}
+  - target: "[{{ package.os }} {{ package.version }} (package)](https://cloudsmith.io/~kong/repos/gateway-{{ cloudsmith_version }}/packages/)"
     arm: "{% if distro.package_support.arm %}Yes{% else %}No{% endif %}"
     fips: "{% if distro.package_support.fips %}Yes{% else %}No{% endif %}"
     graviton: "{% if distro.package_support.graviton %}Yes{% else %}No{% endif %}"
     eol: "{{ distro_eol }}"
 {%- endif -%}
-{%- if distro.docker %}
+{%- if distro.docker -%}
+{%- if package.docker_tag %}
+  - target: "[{{ package.os }} {{ package.version }} (docker)](https://hub.docker.com/r/kong/kong-gateway/tags?name={{ include.release.release }}-{{ package.docker_tag }})"
+{%- else %}
   - target: "{{ package.os }} {{ package.version }} (docker)"
+{%- endif %}
     arm: "{% if distro.docker_support.arm %}Yes{% else %}No{% endif %}"
     fips: "{% if distro.docker_support.fips %}Yes{% else %}No{% endif %}"
     graviton: "{% if distro.docker_support.graviton %}Yes{% else %}No{% endif %}"
@@ -58,13 +63,19 @@ rows:
                 <td class="capitalize px-0">
                     <div class="flex flex-col items-center divide-y divide-primary/5 *:py-4 first:*:pt-0 last:*:pb-0">
                         {% if distro.package %}
+                        {% assign cloudsmith_version = include.release.release | remove: "." %}
                         <div class="flex w-full items-center justify-center">
-                            <span class='badge'>package</span>
+                            <a href="https://cloudsmith.io/~kong/repos/gateway-{{ cloudsmith_version }}/packages/" class="badge" target="_blank" rel="noopener">package</a>
                         </div>
                         {% endif %}
                         {% if distro.docker %}
                         <div class="flex w-full items-center justify-center">
-                            <span class='badge'>docker</span>
+                            {% if package.docker_tag %}
+                            {% assign docker_url = "https://hub.docker.com/r/kong/kong-gateway/tags?name=" | append: include.release.release | append: "-" | append: package.docker_tag %}
+                            <a href="{{ docker_url }}" class="badge" target="_blank" rel="noopener">docker</a>
+                            {% else %}
+                            <span class="badge">docker</span>
+                            {% endif %}
                         </div>
                         {% endif %}
                     </div>

--- a/app/_includes/support/gateway.html
+++ b/app/_includes/support/gateway.html
@@ -65,14 +65,14 @@ rows:
                         {% if distro.package %}
                         {% assign cloudsmith_version = include.release.release | remove: "." %}
                         <div class="flex w-full items-center justify-center">
-                            <a href="https://cloudsmith.io/~kong/repos/gateway-{{ cloudsmith_version }}/packages/" class="badge" target="_blank" rel="noopener">package</a>
+                            <a href="https://cloudsmith.io/~kong/repos/gateway-{{ cloudsmith_version }}/packages/" class="badge" target="_blank" rel="noopener noreferrer">package</a>
                         </div>
                         {% endif %}
                         {% if distro.docker %}
                         <div class="flex w-full items-center justify-center">
                             {% if package.docker_tag %}
                             {% assign docker_url = "https://hub.docker.com/r/kong/kong-gateway/tags?name=" | append: include.release.release | append: "-" | append: package.docker_tag %}
-                            <a href="{{ docker_url }}" class="badge" target="_blank" rel="noopener">docker</a>
+                            <a href="{{ docker_url }}" class="badge" target="_blank" rel="noopener noreferrer">docker</a>
                             {% else %}
                             <span class="badge">docker</span>
                             {% endif %}


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Adds links to download locations for gateway packages and images. We've had users comment in the past that they always think the badges in the table are clickable, and expected them to do something, so this addresses that issue.

I chose to link only to the top-level cloudsmith version page instead of specific distros, since they're all available in multiple architectures. I couldn't find a cleaner way to specify them without also hiding that (+ FIPS).

To do: double-check all the links.


(I thought we had a ticket for this, but now I can't find it.)

## Preview Links

https://deploy-preview-5910--kongdeveloper.netlify.app/gateway/version-support-policy/#supported-versions
