### PR TITLE
fix(docs-improvements): Text colour for versions in light mode

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -308,7 +308,7 @@ edit_and_issue_links: false
 
         <div class="flex flex-col border-t border-primary">
             <a href="https://releases.konghq.com/en" class="flex items-center gap-6 py-4 border-b border-primary hover:bg-hover-component/100 hover:px-4 hover:-mx-4 transition-all no-icon hover:no-underline group">
-                <span class="text-lg text-brand w-20 shrink-0 text-right">&#8734;</span>
+                <span class="text-lg text-links w-20 shrink-0 text-right">&#8734;</span>
                 <span class="text-sm text-primary flex-1">{{ site.konnect_product_name }}</span>
                 <span class="text-terciary group-hover:text-brand transition-colors">&rarr;</span>
             </a>
@@ -319,7 +319,7 @@ edit_and_issue_links: false
             {%- assign latest = product_data.releases | where: "latest", true | first -%}
             {%- assign _ver = latest["ee-version"] | default: latest.version | default: latest.release -%}
             <a href="{{ item.changelog_url }}" class="flex items-center gap-6 py-4 border-b border-primary hover:bg-hover-component/100 hover:px-4 hover:-mx-4 transition-all no-icon hover:no-underline group">
-                <span class="font-mono text-sm text-brand w-20 shrink-0 text-right">v{{ _ver }}</span>
+                <span class="font-mono text-sm text-links w-20 shrink-0 text-right">v{{ _ver }}</span>
                 <span class="text-sm text-primary flex-1">{{ product_data.name }}</span>
                 <span class="text-terciary group-hover:text-brand transition-colors">&rarr;</span>
             </a>


### PR DESCRIPTION
Fixes the text color in light mode:

<img width="365" height="577" alt="Screenshot 2026-07-10 at 1 13 54 PM" src="https://github.com/user-attachments/assets/ce123586-a2a1-4c5e-a45e-9996e440cad1" />
