### PR TITLE
fix(kongctl): conditionally render the kongctl prereq depending on the

### DIFF
--- a/app/_how-tos/ai-gateway/get-started-with-ai-gateway.md
+++ b/app/_how-tos/ai-gateway/get-started-with-ai-gateway.md
@@ -31,8 +31,6 @@ tools:
 
 prereqs:
   inline:
-    - title: Configure kongctl
-      include_content: md/ai-gateway/v2/prereqs/kongctl
     - title: OpenAI
       include_content: md/ai-gateway/v2/prereqs/openai
       icon_url: /assets/icons/openai.svg

--- a/app/_includes/prereqs/tools/kongctl.md
+++ b/app/_includes/prereqs/tools/kongctl.md
@@ -3,8 +3,27 @@ kongctl
 {% endcapture %}
 
 {% capture details_content %}
+{% assign product=page.products[0] %}
+{% if product == 'ai-gateway' %}
+This tutorial uses [kongctl](/kongctl/) to manage {{site.ai_gateway}} configuration.
+
+1. Install **kongctl** from [developer.konghq.com/kongctl](/kongctl/).
+1. Verify the installation:
+
+   ```sh
+   kongctl version
+   ```
+1. Adopt your {{site.ai_gateway}} into a kongctl namespace so the apply command later in this tutorial can manage it:
+
+    ```sh
+    kongctl adopt ai-gateway "$AI_GATEWAY_ID" \
+        --namespace ai-gateway-get-started \
+        --pat "$KONNECT_TOKEN"
+    ```
+{% else %}
   kongctl is a CLI tool for managing {{site.konnect_short_name}} resources programmatically. To complete this tutorial, 
   install [kongctl](/kongctl/).
+{% endif %}
 {% endcapture %}
 
 {% include how-tos/prereq_cleanup_item.html summary=summary details_content=details_content icon_url='/assets/icons/code.svg' %}


### PR DESCRIPTION
product, aigw needs some extra steps

## Description

Fixes #issue

## Preview Links
/kongctl/get-started/ - should render the original version
/ai-gateway/get-started/


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
