### PR TITLE
chore(aigw): AIGW 2.0 homepage updates

### DIFF
--- a/app/_data/homepage.yml
+++ b/app/_data/homepage.yml
@@ -52,19 +52,34 @@ agents_section:
       cta_url: /skills/
       cta_text: "Browse all skills"
       icon: /assets/icons/brain.svg
-    - id: cookbooks
-      title: "AI Cookbooks"
+    - id: aigw
+      title: "AI Gateway 2.0"
+      badge: "New"
+      snippet_label: "QUICKSTART"
+      snippet_lines:
+        - "curl -Ls https://get.konghq.com/ai | bash -s -- -k $KONNECT_TOKEN"
+      description: "Connectivity and governance layer for modern AI-native applications."
       ctas:
-        - text: "Model-based routing"
-          url: /cookbooks/model-based-routing/
-        - text: "Claude Code SSO"
-          url: /cookbooks/claude-code-sso/
-        - text: "LLM cost optimization"
-          url: /cookbooks/llm-cost-optimization/
-        - text: "View all cookbooks"
-          url: /cookbooks/
-      description: "End-to-end recipes for agents on top of Kong AI Gateway."
-      icon: /assets/icons/book.svg
+        - text: "Other ways to get started"
+          url: /ai-gateway/#guided-quickstarts
+        - text: "View all AI Gateway 2.0 docs"
+          url: /ai-gateway/
+      icon: /assets/icons/ai.svg
+
+##### Taking out cookbooks until they're updated for AIGW 2.0; when they're ready, remove AIGW section above and uncomment this one.
+    # - id: aigw
+    #   title: "AI Cookbooks"
+    #   ctas:
+    #     - text: "Model-based routing"
+    #       url: /cookbooks/model-based-routing/
+    #     - text: "Claude Code SSO"
+    #       url: /cookbooks/claude-code-sso/
+    #     - text: "LLM cost optimization"
+    #       url: /cookbooks/llm-cost-optimization/
+    #     - text: "View all cookbooks"
+    #       url: /cookbooks/
+    #   description: "End-to-end recipes for agents on top of Kong AI Gateway."
+    #   icon: /assets/icons/book.svg
 
 products_section:
   categories:
@@ -151,8 +166,11 @@ products_section:
             - text: All documentation
               url: /index/gateway/
         - title: AI Gateway
+          product: ai-gateway
+          changelog_url: /ai-gateway/changelog/
+          whats_new: true
           icon: /assets/icons/ai.svg
-          description: "Connectivity and governance layer for modern AI-native applications built on top of Kong Gateway."
+          description: "Connectivity and governance layer for modern AI-native applications."
           links:
             - text: Overview
               url: /ai-gateway/
@@ -257,7 +275,7 @@ products_section:
 
 specs_section:
   featured_api_slugs:
-    - "konnect/control-planes"
+    - "konnect/ai-gateway"
     - "konnect/control-planes-config"
     - "konnect/event-gateway"
     - "konnect/portal-management"

--- a/app/_landing_pages/changelogs.yaml
+++ b/app/_landing_pages/changelogs.yaml
@@ -18,17 +18,25 @@ rows:
           - type: card
             config:
               title: "{{site.konnect_product_name}}"
-              description: "Release notes for all Konnect apps and platform changes."
+              description: "Release notes for all {{site.konnect_short_name}} apps and platform changes."
               cta:
-                text: "Konnect changelog"
+                text: "{{site.konnect_short_name}} changelog"
                 url: https://releases.konghq.com/en
+      - blocks:
+          - type: card
+            config:
+              title: "{{site.ai_gateway_name}}"
+              description: "Release notes for {{site.ai_gateway}}, starting with version 2.0."
+              cta:
+                text: "{{site.ai_gateway}} changelog"
+                url: /ai-gateway/changelog/
       - blocks:
           - type: card
             config:
               title: "{{site.base_gateway}}"
               description: "Release notes for {{site.base_gateway}}, including new features, bug fixes, and breaking changes."
               cta:
-                text: "Gateway changelog"
+                text: "{{site.base_gateway}} changelog"
                 url: /gateway/changelog/
       - blocks:
           - type: card
@@ -36,7 +44,7 @@ rows:
               title: "{{site.event_gateway}}"
               description: "Release notes for {{site.event_gateway}}, the Kafka proxy for controlled, secure client access."
               cta:
-                text: "Event Gateway changelog"
+                text: "{{site.event_gateway_short}} changelog"
                 url: /event-gateway/changelog/
       - blocks:
           - type: card
@@ -52,7 +60,7 @@ rows:
               title: "{{site.kic_product_name}}"
               description: "Release notes for {{site.kic_product_name}}, which configures {{site.base_gateway}} using Kubernetes CRDs."
               cta:
-                text: "KIC changelog"
+                text: "{{site.kic_product_name_short}} changelog"
                 url: https://github.com/Kong/kubernetes-ingress-controller/blob/main/CHANGELOG.md
       - blocks:
           - type: card
@@ -60,7 +68,7 @@ rows:
               title: "{{site.operator_product_name}}"
               description: "Release notes for {{site.operator_product_name}}, for deploying and managing Kong on Kubernetes."
               cta:
-                text: "Operator changelog"
+                text: "{{site.operator_product_name_short}} changelog"
                 url: /operator/changelog/
 
   - header:

--- a/app/_landing_pages/sitemap.yaml
+++ b/app/_landing_pages/sitemap.yaml
@@ -75,6 +75,11 @@ rows:
           - type: structured_text
             config:
               blocks:
+                - type: text
+                  text: "**Plugins**"
+          - type: structured_text
+            config:
+              blocks:
               - type: unordered_list
                 items:
                   - "[Gateway plugin hub](/plugins/)"
@@ -83,11 +88,22 @@ rows:
           - type: structured_text
             config:
               blocks:
+                - type: text
+                  text: "**Policies**"
+          - type: structured_text
+            config:
+              blocks:
               - type: unordered_list
                 items:
+                  - "[{{site.ai_gateway}} policy hub](/ai-gateway/policies/)"
                   - "[Mesh policy hub](/mesh/policies/)"
                   - "[{{site.event_gateway_short}} policy hub](/event-gateway/policies/)"
       - blocks:
+          - type: structured_text
+            config:
+              blocks:
+                - type: text
+                  text: "**Other**"
           - type: structured_text
             config:
               blocks:

--- a/app/index.html
+++ b/app/index.html
@@ -132,7 +132,7 @@ edit_and_issue_links: false
                     {% include_svg fcard.icon class="card__icon" aria-label=fcard.title %}
                     <span class="font-semibold text-sm flex-1 ml-2">{{ fcard.title }}</span>
                     {%- if fcard.badge -%}
-                    <span class="text-xs font-semibold bg-brand/20 text-brand px-1.5 py-0.5 rounded shrink-0">{{ fcard.badge }}</span>
+                    <span class="text-xs font-semibold bg-brand/20 text-button dark:text-brand px-1.5 py-0.5 rounded shrink-0">{{ fcard.badge }}</span>
                     {%- endif -%}
                     {%- if fcard.snippet_label -%}
                     <div class="relative flex items-center gap-1 shrink-0">

--- a/app/index.html
+++ b/app/index.html
@@ -131,6 +131,9 @@ edit_and_issue_links: false
                 <div class="flex items-center justify-between gap-2 px-5 py-4 border-b border-primary">
                     {% include_svg fcard.icon class="card__icon" aria-label=fcard.title %}
                     <span class="font-semibold text-sm flex-1 ml-2">{{ fcard.title }}</span>
+                    {%- if fcard.badge -%}
+                    <span class="text-xs font-semibold bg-brand/20 text-brand px-1.5 py-0.5 rounded shrink-0">{{ fcard.badge }}</span>
+                    {%- endif -%}
                     {%- if fcard.snippet_label -%}
                     <div class="relative flex items-center gap-1 shrink-0">
                         <div class="absolute right-8 flex text-xs text-button bg-brand p-1 rounded invisible opacity-0">Copied!</div>
@@ -150,14 +153,14 @@ edit_and_issue_links: false
                 <div class="bg-code-block border-b border-primary">
                     {%- if fcard.snippet_label -%}
                     <div class="flex items-center gap-2 px-5 py-2 border-b border-primary">
-                        {% include_svg '/assets/icons/third-party/claude.svg' class="w-4 h-4 shrink-0" aria-hidden="true" %}
+                        {%- if fcard.snippet_label_link -%}{% include_svg '/assets/icons/third-party/claude.svg' class="w-4 h-4 shrink-0" aria-hidden="true" %}{%- endif -%}
                         <span class="text-xs font-mono font-bold text-primary dark:text-brand uppercase tracking-widest">{{ fcard.snippet_label }}</span>
                         {%- if fcard.snippet_label_link -%}
                         <a href="{{ fcard.snippet_label_link.url }}" class="text-xs italic text-terciary ml-auto no-icon hover:text-secondary">{{ fcard.snippet_label_link.text }}</a>
                         {%- endif -%}
                     </div>
                     {%- endif -%}
-                    <pre class="bg-transparent m-0 px-5 py-3 border-0 rounded-none"><code id="{{ fcard_id }}" class="bg-transparent border-0 p-0 text-xs">{% for line in fcard.snippet_lines %}<span class="text-secondary">{{ line }}</span>
+                    <pre class="bg-transparent m-0 px-5 py-3 border-0 rounded-none whitespace-pre-wrap break-words"><code id="{{ fcard_id }}" class="bg-transparent border-0 p-0 text-xs">{% for line in fcard.snippet_lines %}<span class="text-secondary">{{ line }}</span>
 {% endfor %}</code></pre>
                 </div>
                 {%- endif -%}

--- a/app/index.md.html
+++ b/app/index.md.html
@@ -19,14 +19,13 @@ llm: false
 
 ### Agent tools
 
-{%- assign mcp = site.data.homepage.agents_section.featured_cards | where: "id", "mcp" | first %}
-- **{{ mcp.title }}** (endpoint: `{{ mcp.endpoint }}`) - {{ mcp.description }} [Explore]({{ mcp.cta_url }})
-{%- assign skills = site.data.homepage.agents_section.featured_cards | where: "id", "skills" | first %}
-- **{{ skills.title }}** (install: `{{ skills.snippet_lines | join: " && " }}`) - {{ skills.description }} [Explore]({{ skills.cta_url }})
-{%- assign cookbooks = site.data.homepage.agents_section.featured_cards | where: "id", "cookbooks" | first %}
-- **{{ cookbooks.title }}** {{ cookbooks.description }}
-{% for cta in cookbooks.ctas %}
-   - [{{ cta.text }}]({{ cta.url }})
+{%- for fcard in site.data.homepage.agents_section.featured_cards %}
+- **{{ fcard.title }}**{% if fcard.endpoint %} (endpoint: `{{ fcard.endpoint }}`){% elsif fcard.snippet_lines %} (install: `{{ fcard.snippet_lines | join: " && " }}`){% endif %}: {{ fcard.description }}
+{%- if fcard.ctas %}{%- for cta in fcard.ctas %}
+  - [{{ cta.text }}]({{ cta.url }})
+{%- endfor %}{%- elsif fcard.cta_url %}
+  - [{{ fcard.cta_text }}]({{ fcard.cta_url }})
+{%- endif %}
 {%- endfor %}
 
 ## Platform


### PR DESCRIPTION


## Description

* Replaces AI Cookbooks with AI Gateway 2.0 quickstart tile
* Adds AIGW to changelogs and API specs
* Fixes the llm version of the page

New tile on the right:

<img width="1313" height="549" alt="Screenshot 2026-07-13 at 11 12 33 AM" src="https://github.com/user-attachments/assets/d54c8e6a-f18d-43c7-bf9d-3c2bea309efd" />

## Preview

https://deploy-preview-5926--kongdeveloper.netlify.app/
https://deploy-preview-5926--kongdeveloper.netlify.app/changelogs
https://deploy-preview-5926--kongdeveloper.netlify.app/sitemap
