### PR TITLE
fix(aigw): Quickstart positioning

### DIFF
--- a/app/_landing_pages/ai-gateway.yaml
+++ b/app/_landing_pages/ai-gateway.yaml
@@ -25,45 +25,43 @@ rows:
               blocks:
                 - type: text
                   text: |
-                    As AI systems grow from basic LLM calls to complex architectures with agents and tool servers, infrastructure must keep pace with challenges around authentication, governance, and observability. {{site.ai_gateway}} provides a unified control plane that secures and governs all AI traffic through first-class AI Entities and AI Policies.
+                    As AI systems grow from basic LLM calls to complex architectures with agents and tool servers, infrastructure must keep pace with challenges around authentication, governance, and observability. 
+                    {{site.ai_gateway}} provides a unified control plane that secures and governs all AI traffic through first-class AI Entities and AI Policies.
           - type: text
             config: |
               [Sign up for {{site.konnect_short_name}}](https://konghq.com/products/kong-konnect/register?utm_medium=referral&utm_source=docs&utm_content=ai-gateway) to configure {{site.ai_gateway}} using {{site.konnect_short_name}}.
-          - type: tabs
-            tab_group: run-ai-gateway
-            config:
-              - title: Quickstart
-                content: |
-                  You can use the [quickstart script](https://get.konghq.com/ai) to get a demo instance of {{site.ai_gateway}} running almost instantly.
-
-                  This command requires a [Konnect Access Token](https://cloud.konghq.com/global/account/tokens).
-
-                  ```sh
-                  curl -Ls https://get.konghq.com/ai | bash -s -- -k $KONNECT_TOKEN
-                  ```
-
-                  The script creates an {{site.ai_gateway}} control plane in {{site.konnect_short_name}} and deploys a local data plane using Docker.
-
-                  All licensing is handled automatically by {{site.konnect_short_name}}.
-              - title: Konnect UI
-                content: |
-                  To set up {{site.ai_gateway}} using the {{site.konnect_short_name}} UI, use the following steps:
-                  1. Sign in to your Konnect account at [cloud.konghq.com](https://cloud.konghq.com/), then navigate to **{{site.ai_gateway}}** and click **New {{site.ai_gateway}}**.
-                  1. Enter a **Display name** and, optionally, a **Gateway description**, then click **Next**.
-                  1. Choose your environment:
-                   * In **Where do you want to run your {{site.ai_gateway}}?**: Select **Self-managed**.
-                   * In **How do you want to run your gateway?**: Select **Docker** or Linux.
-                  1. Under **General information**, enter a **Display name** and, optionally, a **Gateway description**, then click **Create**.
-                  1. On the gateway **Overview** page, click **Deploy a data plane node**.
-                  1. Under **Select a version and platform**, choose your **Gateway version** and deployment platform (for example, **Mac (Docker)**), then click **Generate certificate and script**.
-                  1. Copy the generated Docker command and run it on your data plane host.
-                  1. Once the control plane recognizes the connected data plane, return to the main **{{site.ai_gateway}}** overview page to confirm the node is listed.
 
       - blocks:
           - type: image
             config:
               url: /assets/images/gateway/ai-gateway-overview.svg
               alt_text: Overview of AI gateway
+
+  - header:
+      type: h2
+      text: "Install {{ site.ai_gateway }}"
+    columns:
+      - blocks:
+        - type: tabs
+          tab_group: run-ai-gateway
+          config:
+            - title: Quickstart
+              content: |
+                You can use the [quickstart script](https://get.konghq.com/ai) to get a demo instance of {{site.ai_gateway}} running almost instantly.
+
+                This command requires a [Konnect Access Token](https://cloud.konghq.com/global/account/tokens).
+
+                ```sh
+                curl -Ls https://get.konghq.com/ai | bash -s -- -k $KONNECT_TOKEN
+                ```
+
+                The script creates an {{site.ai_gateway}} control plane in {{site.konnect_short_name}} and deploys a local data plane using Docker.
+
+                All licensing is handled automatically by {{site.konnect_short_name}}.
+            - title: Konnect UI
+              content: |
+                To set up {{site.ai_gateway}} using the {{site.konnect_short_name}} UI, sign in to your Konnect account at [cloud.konghq.com](https://cloud.konghq.com/), 
+                then navigate to **{{site.ai_gateway}}** and click **New {{site.ai_gateway}}**.
 
   - header:
       type: h2

--- a/app/_landing_pages/sitemap.yaml
+++ b/app/_landing_pages/sitemap.yaml
@@ -123,7 +123,8 @@ rows:
               blocks:
               - type: unordered_list
                 items:
-                  - "[Gateway changelog](/gateway/changelog/)"
+                  - "[API Gateway changelog](/gateway/changelog/)"
+                  - "[{{site.ai_gateway}} changelog](/ai-gateway/changelog/)"
                   - "[{{site.event_gateway_short}} changelog](/event-gateway/changelog/)"
                   - "[Mesh changelog](/mesh/changelog/)"
                   - "[{{site.konnect_short_name}} changelog (all {{site.konnect_short_name}} apps and platform changes)](https://releases.konghq.com/en)"


### PR DESCRIPTION
Move AIGW landing page quickstart section + add missing changelog URL.

Removes the detailed UI instructions; we can't really keep up with the UI in the docs here, and the UI should speak for itself. The instructions now just tell them how to start the process and the UI will take over from there.