### PR TITLE
chore(aigw): Update missing redirects for plugins 

### DIFF
--- a/app/_kong_plugins/ai-a2a-proxy/index.md
+++ b/app/_kong_plugins/ai-a2a-proxy/index.md
@@ -27,6 +27,8 @@ topologies:
 min_version:
   gateway: '3.14'
 
+ai_gateway_url: "/ai-gateway/a2a/"
+
 categories:
   - ai
   - analytics-monitoring

--- a/app/_kong_plugins/ai-mcp-proxy/index.md
+++ b/app/_kong_plugins/ai-mcp-proxy/index.md
@@ -19,6 +19,8 @@ works_on:
 min_version:
     gateway: '3.12'
 
+ai_gateway_url: "/ai-gateway/entities/ai-mcp-server/"
+
 topologies:
   on_prem:
     - hybrid

--- a/app/_kong_plugins/ai-proxy-advanced/index.md
+++ b/app/_kong_plugins/ai-proxy-advanced/index.md
@@ -20,6 +20,8 @@ works_on:
 min_version:
     gateway: '3.8'
 
+ai_gateway_url: "/ai-gateway/entities/ai-model/"
+
 topologies:
   on_prem:
     - hybrid

--- a/app/_kong_plugins/ai-proxy/index.md
+++ b/app/_kong_plugins/ai-proxy/index.md
@@ -19,7 +19,7 @@ works_on:
 min_version:
     gateway: '3.6'
 
-ai_gateway_url: "/ai-gateway/entities/ai-policy/"
+ai_gateway_url: "/ai-gateway/entities/ai-model/"
 
 topologies:
   on_prem:


### PR DESCRIPTION
Checked all the AI plugins and updated their banner links to point to the correct 2.0 doc.

To check, go to the plugins and click their banner link:
https://deploy-preview-5933--kongdeveloper.netlify.app/plugins/ai-a2a-proxy/
https://deploy-preview-5933--kongdeveloper.netlify.app/plugins/ai-proxy/
https://deploy-preview-5933--kongdeveloper.netlify.app/plugins/ai-proxy-advanced/
https://deploy-preview-5933--kongdeveloper.netlify.app/plugins/ai-mcp-proxy/
