### PR TITLE
docs(gateway): document the plugin_ordering_algorithm option

### DIFF
--- a/.github/styles/base/Dictionary.txt
+++ b/.github/styles/base/Dictionary.txt
@@ -633,6 +633,7 @@ prepends
 prepopulated
 preprocessors
 preread
+priority_preserving
 printf
 prisma
 private_key

--- a/app/_gateway_entities/plugin.md
+++ b/app/_gateway_entities/plugin.md
@@ -160,7 +160,8 @@ You can choose to run a particular plugin `before` or `after` a specified plugin
 
 {:.info}
 > For how the reordering is decided — the principle behind it, how to predict the exact result of an
-> `ordering` configuration, and the difference between the `new` and `legacy` algorithms — see
+> `ordering` configuration, and the difference between the `priority_preserving` and `legacy`
+> algorithms — see
 > [How dynamic plugin ordering works](/gateway/plugins/plugin-ordering/).
 
 The configuration looks like this:
@@ -226,7 +227,7 @@ In some cases, this might be compensated for when you run rate limiting before a
 * **Validation**: Validating dynamic plugin ordering is a non-trivial task and would require insight into the user's business logic. 
 {{site.base_gateway}} tries to catch basic mistakes, but it can't detect all potentially dangerous configurations.
 
-* **Algorithm selection**: The [`plugin_ordering_algorithm`](/gateway/configuration/) parameter selects how plugins are reordered. It defaults to `legacy` (the original behavior); set it to `new` to only move the plugin you configure and keep unconfigured plugins in their priority order. See [How dynamic plugin ordering works](/gateway/plugins/plugin-ordering/).
+* **Algorithm selection**: The [`plugin_ordering_algorithm`](/gateway/configuration/) parameter selects how plugins are reordered. It defaults to `legacy` (the original behavior); set it to `priority_preserving` to only move the plugin you configure — every other plugin's order relative to the other unconfigured plugins stays the same. See [How dynamic plugin ordering works](/gateway/plugins/plugin-ordering/).
 
 {:.info}
 > **Note**: In {{site.base_gateway}} 3.13 and earlier, Consumer and Consumer Group scoping was not compatible with dynamic plugin ordering. If you had [Consumer or Consumer Group-scoped plugins](#scoping-plugins) anywhere in your Workspace or control plane, dynamic plugin ordering would cause those plugins **not to trigger**. This limitation was resolved in {{site.base_gateway}} 3.14.

--- a/app/_gateway_entities/plugin.md
+++ b/app/_gateway_entities/plugin.md
@@ -158,6 +158,11 @@ This determines plugin ordering during the [`access` phase](#plugin-contexts), a
 
 You can choose to run a particular plugin `before` or `after` a specified plugin or list of plugins.
 
+{:.info}
+> For how the reordering is decided — the principle behind it, how to predict the exact result of an
+> `ordering` configuration, and the difference between the `new` and `legacy` algorithms — see
+> [How dynamic plugin ordering works](/gateway/plugins/plugin-ordering/).
+
 The configuration looks like this:
 
 ```yaml
@@ -220,6 +225,8 @@ In some cases, this might be compensated for when you run rate limiting before a
 
 * **Validation**: Validating dynamic plugin ordering is a non-trivial task and would require insight into the user's business logic. 
 {{site.base_gateway}} tries to catch basic mistakes, but it can't detect all potentially dangerous configurations.
+
+* **Algorithm selection**: The [`plugin_ordering_algorithm`](/gateway/reference/configuration/#plugin_ordering_algorithm) parameter selects how plugins are reordered. It defaults to `legacy` (the original behavior); set it to `new` to only move the plugin you configure and keep unconfigured plugins in their priority order. See [How dynamic plugin ordering works](/gateway/plugins/plugin-ordering/).
 
 {:.info}
 > **Note**: In {{site.base_gateway}} 3.13 and earlier, Consumer and Consumer Group scoping was not compatible with dynamic plugin ordering. If you had [Consumer or Consumer Group-scoped plugins](#scoping-plugins) anywhere in your Workspace or control plane, dynamic plugin ordering would cause those plugins **not to trigger**. This limitation was resolved in {{site.base_gateway}} 3.14.

--- a/app/_gateway_entities/plugin.md
+++ b/app/_gateway_entities/plugin.md
@@ -161,8 +161,9 @@ You can choose to run a particular plugin `before` or `after` a specified plugin
 {:.info}
 > For how the reordering is decided — the principle behind it, how to predict the exact result of an
 > `ordering` configuration, and the difference between the `priority_preserving` and `legacy`
-> algorithms — see
-> [How dynamic plugin ordering works](/gateway/plugins/plugin-ordering/).
+> algorithms — see [How priority_preserving dynamic plugin ordering
+> works](/gateway/plugins/plugin-ordering-priority-preserving/) (or [How legacy dynamic plugin
+> ordering works](/gateway/plugins/plugin-ordering-legacy/) for the default algorithm on its own).
 
 The configuration looks like this:
 
@@ -227,7 +228,7 @@ In some cases, this might be compensated for when you run rate limiting before a
 * **Validation**: Validating dynamic plugin ordering is a non-trivial task and would require insight into the user's business logic. 
 {{site.base_gateway}} tries to catch basic mistakes, but it can't detect all potentially dangerous configurations.
 
-* **Algorithm selection**: The [`plugin_ordering_algorithm`](/gateway/configuration/) parameter selects how plugins are reordered. It defaults to `legacy` (the original behavior); set it to `priority_preserving` to only move the plugin you configure — every other plugin's order relative to the other unconfigured plugins stays the same. See [How dynamic plugin ordering works](/gateway/plugins/plugin-ordering/).
+* **Algorithm selection**: The [`plugin_ordering_algorithm`](/gateway/configuration/) parameter selects how plugins are reordered. It defaults to `legacy` (the original behavior; see [How legacy dynamic plugin ordering works](/gateway/plugins/plugin-ordering-legacy/)); set it to `priority_preserving` to only move the plugin you configure — every other plugin's order relative to the other unconfigured plugins stays the same (see [How priority_preserving dynamic plugin ordering works](/gateway/plugins/plugin-ordering-priority-preserving/)).
 
 {:.info}
 > **Note**: In {{site.base_gateway}} 3.13 and earlier, Consumer and Consumer Group scoping was not compatible with dynamic plugin ordering. If you had [Consumer or Consumer Group-scoped plugins](#scoping-plugins) anywhere in your Workspace or control plane, dynamic plugin ordering would cause those plugins **not to trigger**. This limitation was resolved in {{site.base_gateway}} 3.14.

--- a/app/_gateway_entities/plugin.md
+++ b/app/_gateway_entities/plugin.md
@@ -226,7 +226,7 @@ In some cases, this might be compensated for when you run rate limiting before a
 * **Validation**: Validating dynamic plugin ordering is a non-trivial task and would require insight into the user's business logic. 
 {{site.base_gateway}} tries to catch basic mistakes, but it can't detect all potentially dangerous configurations.
 
-* **Algorithm selection**: The [`plugin_ordering_algorithm`](/gateway/reference/configuration/#plugin_ordering_algorithm) parameter selects how plugins are reordered. It defaults to `legacy` (the original behavior); set it to `new` to only move the plugin you configure and keep unconfigured plugins in their priority order. See [How dynamic plugin ordering works](/gateway/plugins/plugin-ordering/).
+* **Algorithm selection**: The [`plugin_ordering_algorithm`](/gateway/configuration/) parameter selects how plugins are reordered. It defaults to `legacy` (the original behavior); set it to `new` to only move the plugin you configure and keep unconfigured plugins in their priority order. See [How dynamic plugin ordering works](/gateway/plugins/plugin-ordering/).
 
 {:.info}
 > **Note**: In {{site.base_gateway}} 3.13 and earlier, Consumer and Consumer Group scoping was not compatible with dynamic plugin ordering. If you had [Consumer or Consumer Group-scoped plugins](#scoping-plugins) anywhere in your Workspace or control plane, dynamic plugin ordering would cause those plugins **not to trigger**. This limitation was resolved in {{site.base_gateway}} 3.14.

--- a/app/_indices/gateway.yaml
+++ b/app/_indices/gateway.yaml
@@ -27,7 +27,8 @@ sections:
       - path: /gateway/entities/route/
       - path: /gateway/entities/consumer/
       - path: /gateway/entities/plugin/
-      - path: /gateway/plugins/plugin-ordering/
+      - path: /gateway/plugins/plugin-ordering-legacy/
+      - path: /gateway/plugins/plugin-ordering-priority-preserving/
       - path: /gateway/entities/upstream/
       - path: /gateway/entities/target/
       - path: /gateway/rate-limiting/

--- a/app/_indices/gateway.yaml
+++ b/app/_indices/gateway.yaml
@@ -27,6 +27,7 @@ sections:
       - path: /gateway/entities/route/
       - path: /gateway/entities/consumer/
       - path: /gateway/entities/plugin/
+      - path: /gateway/plugins/plugin-ordering/
       - path: /gateway/entities/upstream/
       - path: /gateway/entities/target/
       - path: /gateway/rate-limiting/

--- a/app/_redirects
+++ b/app/_redirects
@@ -117,6 +117,7 @@
 /plugins/request-callout/examples/dynamic-url/ /plugins/request-callout/examples/dynamic-url-via-lua-code/
 /gateway/plugin-development/  /custom-plugins/
 /gateway/plugin-development/*  /custom-plugins/
+/gateway/plugins/plugin-ordering/  /gateway/plugins/plugin-ordering-priority-preserving/
 
 # Renames
 /mesh-manager/federate-zone/  /mesh/federate-zone-control-plane-to-konnect/

--- a/app/gateway/plugins/plugin-ordering-legacy.md
+++ b/app/gateway/plugins/plugin-ordering-legacy.md
@@ -1,0 +1,206 @@
+---
+title: How legacy dynamic plugin ordering works
+
+description: A plain-language guide to the `legacy` dynamic plugin ordering algorithm in {{site.base_gateway}} — the principle behind it, worked examples, and its pros, cons, and corner cases.
+content_type: reference
+layout: reference
+
+products:
+  - gateway
+
+works_on:
+  - on-prem
+  - konnect
+
+min_version:
+  gateway: '3.0'
+
+breadcrumbs:
+  - /gateway/
+  - /gateway/entities/
+  - /gateway/entities/plugin/
+
+related_resources:
+  - text: Plugin entity reference
+    url: /gateway/entities/plugin/
+  - text: Plugin priority
+    url: /gateway/entities/plugin/#plugin-priority
+  - text: How priority_preserving dynamic plugin ordering works
+    url: /gateway/plugins/plugin-ordering-priority-preserving/
+---
+
+Every {{site.base_gateway}} plugin has a static [priority](/gateway/entities/plugin/#plugin-priority)
+that decides the order plugins run in. [Dynamic plugin ordering](/gateway/entities/plugin/#dynamic-plugin-ordering)
+lets you override that order for the [`access` phase](/gateway/entities/plugin/#plugin-contexts)
+by giving a plugin an `ordering` rule that runs it `before` or `after` another plugin.
+
+This page covers `legacy`, the algorithm `plugin_ordering_algorithm` selects by default. It
+explains how `legacy` actually decides an order, with worked examples, and its pros, cons, and
+corner cases. For the newer, opt-in algorithm, see [How priority_preserving dynamic plugin
+ordering works](/gateway/plugins/plugin-ordering-priority-preserving/).
+
+{:.warning}
+> Dynamic ordering only affects the **`access` phase**. Every other phase (`header_filter`,
+> `body_filter`, `response`, `log`) always runs in static [plugin priority](/gateway/entities/plugin/#plugin-priority)
+> order, regardless of any `ordering` you set.
+
+## How `legacy` decides the order
+
+`legacy` builds a dependency graph from your `ordering` rules, then visits every plugin exactly
+once, from highest priority to lowest. The first time the walk reaches a plugin, it doesn't place
+that plugin yet. It first visits every plugin the current one depends on — recursively — and
+places each of those first. Only once that recursion finishes does the current plugin get placed.
+
+> **A plugin's entire dependency chain is placed immediately before that plugin is — however far
+> down the priority list that chain reaches.**
+
+`before` and `after` build the *same* dependency edge, regardless of which plugin carries the rule:
+
+* `A before: [B]` records "`B` depends on `A`."
+* `B after: [A]` also records "`B` depends on `A`."
+
+Writing the same relationship either way therefore produces the same graph, and the same output.
+
+A useful analogy: think of each plugin as a person in a line, but nobody can take their seat until
+everyone they're waiting on has already sat down — including people *those* people are waiting on.
+When your turn comes up in priority order, you first go fetch everyone you're waiting on, seat all
+of them, and only then sit down yourself.
+
+## Worked example
+
+Take the customer scenario that motivated this feature:
+
+{% table %}
+columns:
+  - title: Plugin
+    key: plugin
+  - title: Priority
+    key: priority
+  - title: Ordering rule
+    key: ordering
+rows:
+  - plugin: "`pre-function`"
+    priority: 1000000
+    ordering: "`after: [opentelemetry]`"
+  - plugin: "`request-callout`"
+    priority: 812
+    ordering: "*(none)*"
+  - plugin: "`opentelemetry`"
+    priority: 14
+    ordering: "*(none)*"
+{% endtable %}
+
+By static priority alone the order would be `pre-function → request-callout → opentelemetry`. The
+rule "`pre-function` after: `[opentelemetry]`" means `pre-function` depends on `opentelemetry`.
+Here's how `legacy` builds the result:
+
+1. The walk reaches `pre-function` first — it's the highest priority. It depends on
+   `opentelemetry`, so visit that first.
+2. `opentelemetry` depends on nothing. Place it. → placed so far: `opentelemetry`.
+3. Back to `pre-function` — its one dependency is now placed, so place `pre-function` too. →
+   placed so far: `opentelemetry, pre-function`.
+4. The walk continues in priority order and reaches `request-callout`. It depends on nothing, so
+   place it. → placed so far: `opentelemetry, pre-function, request-callout`.
+
+**Result:** `opentelemetry → pre-function → request-callout`.
+
+Notice what happened to `request-callout`: it carries no rule, and no rule names it either — but it
+still moved, from 2nd place to last, purely because `pre-function`'s dependency chain was placed
+ahead of it.
+
+## `before` and `after` are the same rule under `legacy`
+
+Take five plugins in natural priority order — `key-auth (1250)`, `ldap-auth (1200)`,
+`header-cert-auth (1009)`, `response-transformer (800)`, `ai-proxy (770)` — and express one
+relationship two ways:
+
+```
+natural order:                              key-auth, ldap-auth, header-cert-auth, response-transformer, ai-proxy
+
+response-transformer before: [ldap-auth]:   key-auth, response-transformer, ldap-auth, header-cert-auth, ai-proxy
+ldap-auth after: [response-transformer]:    key-auth, response-transformer, ldap-auth, header-cert-auth, ai-proxy
+```
+
+Both forms record the same dependency — "`ldap-auth` depends on `response-transformer`" — so both
+produce the identical result: `response-transformer` rises two slots to the front of the pair, and
+`ldap-auth` and `header-cert-auth` each drop one slot to make room, even though only one
+relationship was ever configured. Under `priority_preserving`, the same two forms move *different*
+plugins and can produce different orders — see [How priority_preserving dynamic plugin ordering
+works](/gateway/plugins/plugin-ordering-priority-preserving/) if you want to compare them
+directly.
+
+## Pros
+
+* **One mental model.** Once you see it as "place what I depend on before I'm placed, recursively,"
+  every result follows from that one rule.
+* **The original, most-tested behavior.** `legacy` is still the default `plugin_ordering_algorithm`,
+  and upgrading {{site.base_gateway}} never changes it on its own.
+* **Agrees with `priority_preserving` when a rule chain has no gaps.** If every link in a chain is
+  configured — nothing left to priority alone — both algorithms give the same answer. Verified
+  example: `header-cert-auth before: [response-transformer]`, `response-transformer before:
+  [ai-proxy]`, and `ai-proxy before: [key-auth]`, with `ldap-auth` configuring nothing:
+
+  ```
+  legacy:              header-cert-auth, response-transformer, ai-proxy, key-auth, ldap-auth
+  priority_preserving: header-cert-auth, response-transformer, ai-proxy, key-auth, ldap-auth
+  ```
+
+  The two algorithms only disagree when a plugin that carries no rule of its own sits *between* a
+  mover and its anchor. A fully linked chain leaves nothing in between to disagree about.
+
+## Cons and corner cases
+
+* **Cascading displacement.** As the worked example above shows, a single rule can move plugins
+  that never appear in any rule — not just the plugin the rule sits on.
+* **`before`/`after` collapse removes a choice.** Because both forms build the same edge, you can't
+  pick which of the two named plugins is the one that moves. `priority_preserving` always moves the
+  plugin carrying the rule; `legacy` moves whichever the dependency direction happens to place.
+* **Cycle errors don't name the cycle.** A contradictory pair of rules (for example
+  `response-transformer before: [ai-proxy]` *and* `ai-proxy before: [response-transformer]`)
+  produces exactly this message, with no path:
+
+  > There is a circular dependency in the graph. It is not possible to derive a topological sort.
+
+  `priority_preserving` reports the same kind of error with the offending plugins named in order,
+  which makes a large configuration easier to fix.
+
+## Plugins that share a priority
+
+A cloned plugin that declares no `priority` override inherits its source plugin's priority, so
+sharing a priority is routine rather than exotic. `key-auth-enc` and `key-auth`, for example, both
+run at priority `1250`.
+
+{{site.base_gateway}} breaks a tie deterministically: by plugin name, descending. It never depends
+on load order or timing. An `ordering` rule between two plugins that share a priority is honored
+exactly like any other rule — for example, `acl` (priority `950`) with `before: [key-auth]` lands
+directly above `key-auth`, and `key-auth-enc` (also `1250`, alphabetically after `key-auth`) is
+unaffected:
+
+```
+natural order:                   key-auth-enc, key-auth, acl
+acl with before: [key-auth]:     key-auth-enc, acl, key-auth
+```
+
+## Scoping and the request path
+
+Dynamic ordering runs per request. A plugin scoped to a specific Route, Service, or Consumer only
+takes part in ordering for requests that match its scope. A scoped plugin that doesn't match the
+current request still counts as a dependency target (so another plugin's `before`/`after` that
+points at it is preserved), but it contributes no rules of its own and does not execute. This is
+why the resulting order can differ from one request path to another.
+
+## Known limitations
+
+If you use dynamic ordering, test your configurations and handle the feature with care:
+
+* **Cascading deletes**: {{site.base_gateway}} does not detect an `ordering` rule that points at a
+  deleted plugin.
+* **Performance**: sorting plugins during a request adds a small amount of latency. Reordering any
+  plugin in a Workspace or control plane affects all plugins in that environment.
+* **Validation**: {{site.base_gateway}} catches basic mistakes (such as circular rules) but cannot
+  validate that an order makes sense for your business logic.
+
+If the corner cases above matter for your setup, `priority_preserving` addresses the first two —
+see [How priority_preserving dynamic plugin ordering
+works](/gateway/plugins/plugin-ordering-priority-preserving/) for what changes and how to enable
+it.

--- a/app/gateway/plugins/plugin-ordering-priority-preserving.md
+++ b/app/gateway/plugins/plugin-ordering-priority-preserving.md
@@ -1,7 +1,7 @@
 ---
-title: How dynamic plugin ordering works
+title: How priority_preserving dynamic plugin ordering works
 
-description: A plain-language guide to dynamic plugin ordering in {{site.base_gateway}} — the principle behind it, how the priority_preserving and legacy algorithms differ, and how to predict the exact execution order your ordering rules produce.
+description: A plain-language guide to the opt-in `priority_preserving` dynamic plugin ordering algorithm in {{site.base_gateway}} — how it decides an order, how it differs from `legacy`, and how to enable it.
 content_type: reference
 layout: reference
 
@@ -25,6 +25,8 @@ related_resources:
     url: /gateway/entities/plugin/
   - text: Plugin priority
     url: /gateway/entities/plugin/#plugin-priority
+  - text: How legacy dynamic plugin ordering works
+    url: /gateway/plugins/plugin-ordering-legacy/
 ---
 
 Every {{site.base_gateway}} plugin has a static [priority](/gateway/entities/plugin/#plugin-priority)
@@ -32,15 +34,19 @@ that decides the order plugins run in. [Dynamic plugin ordering](/gateway/entiti
 lets you override that order for the [`access` phase](/gateway/entities/plugin/#plugin-contexts)
 by giving a plugin an `ordering` rule that runs it `before` or `after` another plugin.
 
-This page explains **how that reordering is decided**, so you can predict the exact result of any
-`ordering` configuration — the part that has historically been hard to reason about.
+This page covers `priority_preserving`, the opt-in alternative selected by the
+`plugin_ordering_algorithm` configuration parameter. It explains how `priority_preserving` decides
+an order — calling out, at every step, which behavior belongs to `priority_preserving` and which
+belongs to `legacy`, the default — so you can predict the exact result of any `ordering`
+configuration and decide whether to switch. For the default algorithm's own mechanics, pros, and
+cons, see [How legacy dynamic plugin ordering works](/gateway/plugins/plugin-ordering-legacy/).
 
 {:.warning}
 > Dynamic ordering only affects the **`access` phase**. Every other phase (`header_filter`,
 > `body_filter`, `response`, `log`) always runs in static [plugin priority](/gateway/entities/plugin/#plugin-priority)
 > order, regardless of any `ordering` you set.
 
-## The one rule that decides everything
+## How `priority_preserving` decides the order
 
 {{site.base_gateway}} builds the access-phase order by repeating a single step until every plugin
 has run:
@@ -50,7 +56,14 @@ has run:
 `before` and `after` only decide *which* plugins are allowed to run yet. Among the plugins that are
 allowed, the higher priority always goes first.
 
-Two consequences fall out of that rule, and they are the whole behavior:
+A useful analogy is boarding a plane: first class boards before economy, but a first-class
+passenger who hasn't reached the gate yet has to wait while a checked-in economy passenger boards.
+Priority decides who goes first; "not ready yet" always wins. (`legacy` doesn't work this way at
+all — it recursively places a plugin's whole dependency chain first, regardless of priority; see
+[How legacy dynamic plugin ordering works](/gateway/plugins/plugin-ordering-legacy/).)
+
+Two consequences fall out of that rule, and under `priority_preserving` they are the whole
+behavior:
 
 * **Only the plugin you name moves.** When you write `before` or `after` on a plugin, that plugin
   (the *mover*) is the one repositioned — next to the plugin it points at (the *anchor*). Think of
@@ -61,7 +74,9 @@ Two consequences fall out of that rule, and they are the whole behavior:
   below, for what that looks like.)
 * **`before` and `after` are not the same statement.** `A before B` moves `A`; `B after A` moves
   `B`. They describe the same relationship but relocate different plugins, so they can produce
-  different orders. Choose the form that names the plugin you actually want to move.
+  different orders. Choose the form that names the plugin you actually want to move. Under
+  `legacy`, both forms build the identical dependency edge and always move the same plugin — see
+  `before` ≠ `after` below for a side-by-side comparison.
 
 ## Predict the order, step by step
 
@@ -89,7 +104,7 @@ rows:
 {% endtable %}
 
 By static priority alone the order would be `pre-function → request-callout → opentelemetry`. You've
-asked for one change: run `pre-function` **after** `opentelemetry`. Here's how {{site.base_gateway}}
+asked for one change: run `pre-function` **after** `opentelemetry`. Here's how `priority_preserving`
 builds the result:
 
 1. **Ready:** `request-callout` (812), `opentelemetry` (14). `pre-function` is *not* ready — it must
@@ -104,37 +119,11 @@ Notice what did **not** happen: `request-callout`, which you never configured, w
 repositioned by any rule — it rose one slot only because `pre-function` dropped past it on the way
 to its anchor. You moved `pre-function`, and only `pre-function` carried an `ordering` rule.
 
-## Plugins that share a priority
-
-A cloned plugin that declares no `priority` override inherits its source plugin's priority, so
-sharing a priority is routine rather than exotic. `key-auth-enc` and `key-auth`, for example, both
-run at priority `1250`.
-
-{{site.base_gateway}} breaks a tie deterministically: by plugin name, descending. It never depends
-on load order or timing, and this holds for both ordering algorithms. An `ordering` rule between
-two plugins that share a priority is honored exactly like any other rule — for example, `acl`
-(priority `950`) with `before: [key-auth]` lands directly above `key-auth`, and `key-auth-enc`
-(also `1250`, alphabetically after `key-auth`) is unaffected either way:
-
-```
-natural order:                   key-auth-enc, key-auth, acl
-acl with before: [key-auth]:     key-auth-enc, acl, key-auth
-```
-
-## `priority_preserving` vs. `legacy` ordering
-
-{{site.base_gateway}} includes two ordering algorithms, selected by the
-[`plugin_ordering_algorithm`](/gateway/configuration/)
-configuration parameter:
-
-* **`priority_preserving`** — the algorithm described above. Only the configured plugin moves;
-  every other plugin's order relative to the other plugins you didn't configure is unchanged;
-  `before` and `after` can differ.
-* **`legacy`** — the original algorithm, kept so upgrades don't change behavior unexpectedly. It
-  treats `before` and `after` as the same relationship, and repositioning one plugin can pull
-  unrelated plugins out of their priority slots.
-
-The scenario above shows the difference plainly:
+**Compare `legacy` on the identical configuration:** it visits `pre-function` first (highest
+priority), recursively places its dependency `opentelemetry` ahead of it, then places
+`pre-function`, and only then reaches `request-callout` — giving `opentelemetry → pre-function →
+request-callout`. Two plugins moved there, `opentelemetry` *and* `request-callout`, even though
+only `pre-function` carried a rule:
 
 {% table %}
 columns:
@@ -153,11 +142,28 @@ rows:
     legacy: "`opentelemetry` jumped to the front and `request-callout` was pushed to the end — **neither was configured**"
 {% endtable %}
 
-Under `legacy`, moving `pre-function` displaced `opentelemetry` and `request-callout` even though
-you never mentioned them. That surprise — an unrelated plugin changing position — is exactly what
-`priority_preserving` removes.
+That surprise — an unrelated plugin changing position — is exactly what `priority_preserving`
+removes: it never repositions a plugin except the one named in a rule, and any plugin a mover
+passes on the way to its anchor only shifts by as much as that one mover's move requires.
 
-### `before` ≠ `after` under `priority_preserving`
+## Plugins that share a priority
+
+A cloned plugin that declares no `priority` override inherits its source plugin's priority, so
+sharing a priority is routine rather than exotic. `key-auth-enc` and `key-auth`, for example, both
+run at priority `1250`.
+
+{{site.base_gateway}} breaks a tie deterministically: by plugin name, descending. It never depends
+on load order or timing, and this holds for both ordering algorithms. An `ordering` rule between
+two plugins that share a priority is honored exactly like any other rule — for example, `acl`
+(priority `950`) with `before: [key-auth]` lands directly above `key-auth`, and `key-auth-enc`
+(also `1250`, alphabetically after `key-auth`) is unaffected either way:
+
+```
+natural order:                   key-auth-enc, key-auth, acl
+acl with before: [key-auth]:     key-auth-enc, acl, key-auth
+```
+
+## `before` ≠ `after` under `priority_preserving`
 
 Take five plugins in natural priority order — `key-auth (1250)`, `ldap-auth (1200)`,
 `header-cert-auth (1009)`, `response-transformer (800)`, `ai-proxy (770)` — and express the same
@@ -189,23 +195,29 @@ one slot. Neither bystander is untouched, but its order relative to `key-auth` a
 the same in both cases. Under `legacy`, `before` and `after` are identical, so **both forms produce
 the same order regardless of which plugin you write the rule on** — `response-transformer` rises
 two slots to the front of the pair, and `ldap-auth` and `header-cert-auth` both drop one slot to
-make room, even though only one relationship was ever configured.
+make room, even though only one relationship was ever configured. (See [How legacy dynamic plugin
+ordering works](/gateway/plugins/plugin-ordering-legacy/) for why: both forms build the identical
+dependency edge under that algorithm.)
 
 ## Why `priority_preserving` is easier to work with
 
 * **Predictable.** Only the plugin you configure moves. You never have to reason about side effects
-  on plugins you didn't touch.
+  on plugins you didn't touch — unlike `legacy`, where a rule can cascade through plugins that
+  configure nothing.
 * **Deterministic.** The same configuration always produces the same order — on every node, every
-  time. Whatever you see in testing is what you get in production.
+  time. Whatever you see in testing is what you get in production. (`legacy` is equally
+  deterministic; the difference is *how far* a single rule can move things, not whether the result
+  is repeatable.)
 * **Expressive.** Because `before` and `after` move different plugins, you can say precisely which
-  plugin should relocate.
+  plugin should relocate — `legacy` always moves the same one regardless of which form you write.
 
 ### What {{site.base_gateway}} guarantees (both algorithms)
 
 * **Your rules are always honored, or the config is rejected.** Every `before`/`after` you set is
   satisfied. If your rules contradict each other (for example `response-transformer before:
   [ai-proxy]` *and* `ai-proxy before: [response-transformer]`), {{site.base_gateway}} reports a
-  **circular dependency** error instead of guessing.
+  **circular dependency** error instead of guessing. `priority_preserving` additionally names the
+  plugins on the cycle; `legacy` reports the same generic message for every cycle.
 * **The result is deterministic.** It never depends on load order or timing.
 
 ### What it does not promise
@@ -252,10 +264,12 @@ resulting order can differ from one request path to another.
      (app/_includes/components/plugin_ordering_simulator.html). A validated standalone
      prototype of this tool exists; the Vue component wiring is a follow-up. -->
 
-## Choosing an algorithm on upgrade
+## Enabling `priority_preserving`
 
-`plugin_ordering_algorithm` defaults to `legacy`, so **upgrading does not change your current
-access-phase order**. When you're ready to adopt the clearer `priority_preserving` behavior:
+`plugin_ordering_algorithm` defaults to `legacy` (see [How legacy dynamic plugin ordering
+works](/gateway/plugins/plugin-ordering-legacy/)), so **upgrading {{site.base_gateway}} does not
+change your current access-phase order**. When you're ready to adopt the clearer
+`priority_preserving` behavior:
 
 1. Set `plugin_ordering_algorithm = priority_preserving` in `kong.conf` (or the
    `KONG_PLUGIN_ORDERING_ALGORITHM` environment variable) on your data planes.

--- a/app/gateway/plugins/plugin-ordering.md
+++ b/app/gateway/plugins/plugin-ordering.md
@@ -1,7 +1,7 @@
 ---
 title: How dynamic plugin ordering works
 
-description: A plain-language guide to dynamic plugin ordering in {{site.base_gateway}} — the principle behind it, how the new and legacy algorithms differ, and how to predict the exact execution order your ordering rules produce.
+description: A plain-language guide to dynamic plugin ordering in {{site.base_gateway}} — the principle behind it, how the priority_preserving and legacy algorithms differ, and how to predict the exact execution order your ordering rules produce.
 content_type: reference
 layout: reference
 
@@ -13,7 +13,7 @@ works_on:
   - konnect
 
 min_version:
-  gateway: '3.15'
+  gateway: '3.16'
 
 breadcrumbs:
   - /gateway/
@@ -50,17 +50,15 @@ has run:
 `before` and `after` only decide *which* plugins are allowed to run yet. Among the plugins that are
 allowed, the higher priority always goes first.
 
-A useful analogy is boarding a plane: first class boards before economy, but a first-class
-passenger who hasn't reached the gate yet has to wait while a checked-in economy passenger boards.
-Priority decides who goes first; "not ready yet" always wins.
-
 Two consequences fall out of that rule, and they are the whole behavior:
 
 * **Only the plugin you name moves.** When you write `before` or `after` on a plugin, that plugin
   (the *mover*) is the one repositioned — next to the plugin it points at (the *anchor*). Think of
   the mover as being given a temporary position right beside its anchor (just above it for
-  `before`, just below it for `after`). Every plugin you did **not** configure keeps its natural
-  priority slot.
+  `before`, just below it for `after`). Every plugin you did **not** configure keeps its order
+  relative to every other plugin you didn't configure — though its absolute position can shift by
+  a slot or two when a mover passes through it on the way to its anchor. (See `before` ≠ `after`,
+  below, for what that looks like.)
 * **`before` and `after` are not the same statement.** `A before B` moves `A`; `B after A` moves
   `B`. They describe the same relationship but relocate different plugins, so they can produce
   different orders. Choose the form that names the plugin you actually want to move.
@@ -102,17 +100,36 @@ builds the result:
 
 **Result:** `request-callout → opentelemetry → pre-function`.
 
-Notice what did **not** happen: `request-callout`, which you never configured, kept its place. You
-moved `pre-function`, and only `pre-function` moved.
+Notice what did **not** happen: `request-callout`, which you never configured, was not itself
+repositioned by any rule — it rose one slot only because `pre-function` dropped past it on the way
+to its anchor. You moved `pre-function`, and only `pre-function` carried an `ordering` rule.
 
-## New vs. legacy ordering
+## Plugins that share a priority
+
+A cloned plugin that declares no `priority` override inherits its source plugin's priority, so
+sharing a priority is routine rather than exotic. `key-auth-enc` and `key-auth`, for example, both
+run at priority `1250`.
+
+{{site.base_gateway}} breaks a tie deterministically: by plugin name, descending. It never depends
+on load order or timing, and this holds for both ordering algorithms. An `ordering` rule between
+two plugins that share a priority is honored exactly like any other rule — for example, `acl`
+(priority `950`) with `before: [key-auth]` lands directly above `key-auth`, and `key-auth-enc`
+(also `1250`, alphabetically after `key-auth`) is unaffected either way:
+
+```
+natural order:                   key-auth-enc, key-auth, acl
+acl with before: [key-auth]:     key-auth-enc, acl, key-auth
+```
+
+## `priority_preserving` vs. `legacy` ordering
 
 {{site.base_gateway}} includes two ordering algorithms, selected by the
 [`plugin_ordering_algorithm`](/gateway/configuration/)
 configuration parameter:
 
-* **`new`** — the algorithm described above. Only the configured plugin moves; unconfigured plugins
-  keep their priority slots; `before` and `after` can differ.
+* **`priority_preserving`** — the algorithm described above. Only the configured plugin moves;
+  every other plugin's order relative to the other plugins you didn't configure is unchanged;
+  `before` and `after` can differ.
 * **`legacy`** — the original algorithm, kept so upgrades don't change behavior unexpectedly. It
   treats `before` and `after` as the same relationship, and repositioning one plugin can pull
   unrelated plugins out of their priority slots.
@@ -123,50 +140,58 @@ The scenario above shows the difference plainly:
 columns:
   - title: ""
     key: item
-  - title: "`new`"
-    key: new
+  - title: "`priority_preserving`"
+    key: priority_preserving
   - title: "`legacy`"
     key: legacy
 rows:
   - item: Result
-    new: "`request-callout, opentelemetry, pre-function`"
+    priority_preserving: "`request-callout, opentelemetry, pre-function`"
     legacy: "`opentelemetry, pre-function, request-callout`"
   - item: What moved
-    new: "only `pre-function` (as configured)"
+    priority_preserving: "only `pre-function` (as configured)"
     legacy: "`opentelemetry` jumped to the front and `request-callout` was pushed to the end — **neither was configured**"
 {% endtable %}
 
 Under `legacy`, moving `pre-function` displaced `opentelemetry` and `request-callout` even though
 you never mentioned them. That surprise — an unrelated plugin changing position — is exactly what
-`new` removes.
+`priority_preserving` removes.
 
-### `before` ≠ `after` under `new`
+### `before` ≠ `after` under `priority_preserving`
 
-Take five plugins in natural priority order `e(500), d(400), c(300), b(200), a(100)` and express
-the same relationship two ways:
+Take five plugins in natural priority order — `key-auth (1250)`, `ldap-auth (1200)`,
+`header-cert-auth (1009)`, `response-transformer (800)`, `ai-proxy (770)` — and express the same
+relationship two ways:
 
 {% table %}
 columns:
   - title: Configuration
     key: config
-  - title: "`new` result"
-    key: new
+  - title: "`priority_preserving` result"
+    key: priority_preserving
   - title: "`legacy` result"
     key: legacy
 rows:
-  - config: "`b` with `before: [d]`"
-    new: "`e, b, d, c, a`"
-    legacy: "`e, b, d, c, a`"
-  - config: "`d` with `after: [b]`"
-    new: "`e, c, b, d, a`"
-    legacy: "`e, b, d, c, a`"
+  - config: "`response-transformer` with `before: [ldap-auth]`"
+    priority_preserving: "`key-auth, response-transformer, ldap-auth, header-cert-auth, ai-proxy`"
+    legacy: "`key-auth, response-transformer, ldap-auth, header-cert-auth, ai-proxy`"
+  - config: "`ldap-auth` with `after: [response-transformer]`"
+    priority_preserving: "`key-auth, header-cert-auth, response-transformer, ldap-auth, ai-proxy`"
+    legacy: "`key-auth, response-transformer, ldap-auth, header-cert-auth, ai-proxy`"
 {% endtable %}
 
-Under `new`, `d after b` moves only `d` (down to just after `b`), so `c` and `e` stay put. Under
-`legacy`, `before` and `after` are identical, so both forms produce the same order — and to get
-there `legacy` lifts `b`, the plugin you only *referenced*.
+Under `priority_preserving`, `response-transformer before: [ldap-auth]` moves only
+`response-transformer` — up past `header-cert-auth` — to land just above `ldap-auth`;
+`header-cert-auth` drops one slot as a side effect. `ldap-auth after: [response-transformer]`
+moves only `ldap-auth` — down past `header-cert-auth` *and* `response-transformer` — to land just
+below `response-transformer`; this time `header-cert-auth` and `response-transformer` each rise
+one slot. Neither bystander is untouched, but its order relative to `key-auth` and `ai-proxy` is
+the same in both cases. Under `legacy`, `before` and `after` are identical, so **both forms produce
+the same order regardless of which plugin you write the rule on** — `response-transformer` rises
+two slots to the front of the pair, and `ldap-auth` and `header-cert-auth` both drop one slot to
+make room, even though only one relationship was ever configured.
 
-## Why `new` is easier to work with
+## Why `priority_preserving` is easier to work with
 
 * **Predictable.** Only the plugin you configure moves. You never have to reason about side effects
   on plugins you didn't touch.
@@ -178,8 +203,9 @@ there `legacy` lifts `b`, the plugin you only *referenced*.
 ### What {{site.base_gateway}} guarantees (both algorithms)
 
 * **Your rules are always honored, or the config is rejected.** Every `before`/`after` you set is
-  satisfied. If your rules contradict each other (for example `A before B` *and* `B before A`),
-  {{site.base_gateway}} reports a **circular dependency** error instead of guessing.
+  satisfied. If your rules contradict each other (for example `response-transformer before:
+  [ai-proxy]` *and* `ai-proxy before: [response-transformer]`), {{site.base_gateway}} reports a
+  **circular dependency** error instead of guessing.
 * **The result is deterministic.** It never depends on load order or timing.
 
 ### What it does not promise
@@ -191,6 +217,28 @@ there `legacy` lifts `b`, the plugin you only *referenced*.
 * **A priority-looking result when you constrain many plugins.** If you order most of your plugins
   explicitly, the output is dictated by those rules and can look nothing like priority order. That's
   expected — you asked for it.
+* **The tightest possible order when rules interact.** `priority_preserving` places each rule next
+  to its anchor rather than searching every valid order for the one with the least overall
+  disruption. In roughly one configuration in twenty that uses `ordering`, this pushes an
+  unconfigured plugin one or two places further than a hand-picked order would need. For example:
+
+  ```
+  natural priority order: key-auth, ldap-auth, response-transformer, ai-proxy
+
+  rules: response-transformer before: [ai-proxy]
+         ai-proxy before: [key-auth]
+
+  result: response-transformer, ai-proxy, key-auth, ldap-auth
+  ```
+
+  `ldap-auth` carries no `ordering` rule of its own, yet it drops from 2nd to last — a valid order
+  exists that satisfies the same two rules without moving `ldap-auth` at all (`ldap-auth,
+  response-transformer, ai-proxy, key-auth`), but `priority_preserving` doesn't search for it.
+
+  **If this matters for your setup, pin the affected plugin with its own rule.** Adding
+  `ldap-auth before: [response-transformer]` here recovers the tighter order — your rules are
+  always honored, so naming the plugin you want protected is the direct fix, rather than reasoning
+  about priority values.
 
 ## Scoping and the request path
 
@@ -207,10 +255,10 @@ resulting order can differ from one request path to another.
 ## Choosing an algorithm on upgrade
 
 `plugin_ordering_algorithm` defaults to `legacy`, so **upgrading does not change your current
-access-phase order**. When you're ready to adopt the clearer `new` behavior:
+access-phase order**. When you're ready to adopt the clearer `priority_preserving` behavior:
 
-1. Set `plugin_ordering_algorithm = new` in `kong.conf` (or the `KONG_PLUGIN_ORDERING_ALGORITHM`
-   environment variable) on your data planes.
+1. Set `plugin_ordering_algorithm = priority_preserving` in `kong.conf` (or the
+   `KONG_PLUGIN_ORDERING_ALGORITHM` environment variable) on your data planes.
 2. Re-test any Workspace that uses `ordering` — the access-phase order of those Workspaces may
    change (that's the fix taking effect). Workspaces with no `ordering` are unaffected either way.
 
@@ -226,3 +274,6 @@ If you use dynamic ordering, test your configurations and handle the feature wit
   plugin in a Workspace or control plane affects all plugins in that environment.
 * **Validation**: {{site.base_gateway}} catches basic mistakes (such as circular rules) but cannot
   validate that an order makes sense for your business logic.
+* **Non-optimal placement**: in an uncommon case, `priority_preserving` can displace an
+  unconfigured plugin more than necessary when multiple `ordering` rules interact. See [What it
+  does not promise](#what-it-does-not-promise) above for a worked example and the fix.

--- a/app/gateway/plugins/plugin-ordering.md
+++ b/app/gateway/plugins/plugin-ordering.md
@@ -66,11 +66,25 @@ Two consequences fall out of that rule, and they are the whole behavior:
 Because the order is built by that one repeated step, you can always work it out by hand. Take the
 customer scenario that motivated this feature:
 
-| Plugin | Priority | Ordering rule |
-|---|---|---|
-| `pre-function` | 1000000 | `after: [opentelemetry]` |
-| `request-callout` | 812 | *(none)* |
-| `opentelemetry` | 14 | *(none)* |
+{% table %}
+columns:
+  - title: Plugin
+    key: plugin
+  - title: Priority
+    key: priority
+  - title: Ordering rule
+    key: ordering
+rows:
+  - plugin: "`pre-function`"
+    priority: 1000000
+    ordering: "`after: [opentelemetry]`"
+  - plugin: "`request-callout`"
+    priority: 812
+    ordering: "*(none)*"
+  - plugin: "`opentelemetry`"
+    priority: 14
+    ordering: "*(none)*"
+{% endtable %}
 
 By static priority alone the order would be `pre-function → request-callout → opentelemetry`. You've
 asked for one change: run `pre-function` **after** `opentelemetry`. Here's how {{site.base_gateway}}

--- a/app/gateway/plugins/plugin-ordering.md
+++ b/app/gateway/plugins/plugin-ordering.md
@@ -8,6 +8,10 @@ layout: reference
 products:
   - gateway
 
+works_on:
+  - on-prem
+  - konnect
+
 min_version:
   gateway: '3.15'
 

--- a/app/gateway/plugins/plugin-ordering.md
+++ b/app/gateway/plugins/plugin-ordering.md
@@ -141,10 +141,22 @@ you never mentioned them. That surprise — an unrelated plugin changing positio
 Take five plugins in natural priority order `e(500), d(400), c(300), b(200), a(100)` and express
 the same relationship two ways:
 
-| Configuration | `new` result | `legacy` result |
-|---|---|---|
-| `b` with `before: [d]` | `e, b, d, c, a` | `e, b, d, c, a` |
-| `d` with `after: [b]` | `e, c, b, d, a` | `e, b, d, c, a` |
+{% table %}
+columns:
+  - title: Configuration
+    key: config
+  - title: "`new` result"
+    key: new
+  - title: "`legacy` result"
+    key: legacy
+rows:
+  - config: "`b` with `before: [d]`"
+    new: "`e, b, d, c, a`"
+    legacy: "`e, b, d, c, a`"
+  - config: "`d` with `after: [b]`"
+    new: "`e, c, b, d, a`"
+    legacy: "`e, b, d, c, a`"
+{% endtable %}
 
 Under `new`, `d after b` moves only `d` (down to just after `b`), so `c` and `e` stay put. Under
 `legacy`, `before` and `after` are identical, so both forms produce the same order — and to get

--- a/app/gateway/plugins/plugin-ordering.md
+++ b/app/gateway/plugins/plugin-ordering.md
@@ -115,10 +115,22 @@ configuration parameter:
 
 The scenario above shows the difference plainly:
 
-| | `new` | `legacy` |
-|---|---|---|
-| Result | `request-callout, opentelemetry, pre-function` | `opentelemetry, pre-function, request-callout` |
-| What moved | only `pre-function` (as configured) | `opentelemetry` jumped to the front and `request-callout` was pushed to the end — **neither was configured** |
+{% table %}
+columns:
+  - title: ""
+    key: item
+  - title: "`new`"
+    key: new
+  - title: "`legacy`"
+    key: legacy
+rows:
+  - item: Result
+    new: "`request-callout, opentelemetry, pre-function`"
+    legacy: "`opentelemetry, pre-function, request-callout`"
+  - item: What moved
+    new: "only `pre-function` (as configured)"
+    legacy: "`opentelemetry` jumped to the front and `request-callout` was pushed to the end — **neither was configured**"
+{% endtable %}
 
 Under `legacy`, moving `pre-function` displaced `opentelemetry` and `request-callout` even though
 you never mentioned them. That surprise — an unrelated plugin changing position — is exactly what

--- a/app/gateway/plugins/plugin-ordering.md
+++ b/app/gateway/plugins/plugin-ordering.md
@@ -90,7 +90,7 @@ moved `pre-function`, and only `pre-function` moved.
 ## New vs. legacy ordering
 
 {{site.base_gateway}} includes two ordering algorithms, selected by the
-[`plugin_ordering_algorithm`](/gateway/reference/configuration/#plugin_ordering_algorithm)
+[`plugin_ordering_algorithm`](/gateway/configuration/)
 configuration parameter:
 
 * **`new`** — the algorithm described above. Only the configured plugin moves; unconfigured plugins

--- a/app/gateway/plugins/plugin-ordering.md
+++ b/app/gateway/plugins/plugin-ordering.md
@@ -1,0 +1,186 @@
+---
+title: How dynamic plugin ordering works
+
+description: A plain-language guide to dynamic plugin ordering in {{site.base_gateway}} — the principle behind it, how the new and legacy algorithms differ, and how to predict the exact execution order your ordering rules produce.
+content_type: reference
+layout: reference
+
+products:
+  - gateway
+
+min_version:
+  gateway: '3.15'
+
+breadcrumbs:
+  - /gateway/
+  - /gateway/entities/
+  - /gateway/entities/plugin/
+
+related_resources:
+  - text: Plugin entity reference
+    url: /gateway/entities/plugin/
+  - text: Plugin priority
+    url: /gateway/entities/plugin/#plugin-priority
+---
+
+Every {{site.base_gateway}} plugin has a static [priority](/gateway/entities/plugin/#plugin-priority)
+that decides the order plugins run in. [Dynamic plugin ordering](/gateway/entities/plugin/#dynamic-plugin-ordering)
+lets you override that order for the [`access` phase](/gateway/entities/plugin/#plugin-contexts)
+by giving a plugin an `ordering` rule that runs it `before` or `after` another plugin.
+
+This page explains **how that reordering is decided**, so you can predict the exact result of any
+`ordering` configuration — the part that has historically been hard to reason about.
+
+{:.warning}
+> Dynamic ordering only affects the **`access` phase**. Every other phase (`header_filter`,
+> `body_filter`, `response`, `log`) always runs in static [plugin priority](/gateway/entities/plugin/#plugin-priority)
+> order, regardless of any `ordering` you set.
+
+## The one rule that decides everything
+
+{{site.base_gateway}} builds the access-phase order by repeating a single step until every plugin
+has run:
+
+> **At each step, run the highest-priority plugin whose `after` requirements are already met.**
+
+`before` and `after` only decide *which* plugins are allowed to run yet. Among the plugins that are
+allowed, the higher priority always goes first.
+
+A useful analogy is boarding a plane: first class boards before economy, but a first-class
+passenger who hasn't reached the gate yet has to wait while a checked-in economy passenger boards.
+Priority decides who goes first; "not ready yet" always wins.
+
+Two consequences fall out of that rule, and they are the whole behavior:
+
+* **Only the plugin you name moves.** When you write `before` or `after` on a plugin, that plugin
+  (the *mover*) is the one repositioned — next to the plugin it points at (the *anchor*). Think of
+  the mover as being given a temporary position right beside its anchor (just above it for
+  `before`, just below it for `after`). Every plugin you did **not** configure keeps its natural
+  priority slot.
+* **`before` and `after` are not the same statement.** `A before B` moves `A`; `B after A` moves
+  `B`. They describe the same relationship but relocate different plugins, so they can produce
+  different orders. Choose the form that names the plugin you actually want to move.
+
+## Predict the order, step by step
+
+Because the order is built by that one repeated step, you can always work it out by hand. Take the
+customer scenario that motivated this feature:
+
+| Plugin | Priority | Ordering rule |
+|---|---|---|
+| `pre-function` | 1000000 | `after: [opentelemetry]` |
+| `request-callout` | 812 | *(none)* |
+| `opentelemetry` | 14 | *(none)* |
+
+By static priority alone the order would be `pre-function → request-callout → opentelemetry`. You've
+asked for one change: run `pre-function` **after** `opentelemetry`. Here's how {{site.base_gateway}}
+builds the result:
+
+1. **Ready:** `request-callout` (812), `opentelemetry` (14). `pre-function` is *not* ready — it must
+   wait for `opentelemetry`. → Run the highest-priority ready plugin: **`request-callout`**.
+2. **Ready:** `opentelemetry` (14). → Run **`opentelemetry`**. This satisfies `pre-function`'s
+   requirement.
+3. **Ready:** `pre-function`. → Run **`pre-function`**.
+
+**Result:** `request-callout → opentelemetry → pre-function`.
+
+Notice what did **not** happen: `request-callout`, which you never configured, kept its place. You
+moved `pre-function`, and only `pre-function` moved.
+
+## New vs. legacy ordering
+
+{{site.base_gateway}} includes two ordering algorithms, selected by the
+[`plugin_ordering_algorithm`](/gateway/reference/configuration/#plugin_ordering_algorithm)
+configuration parameter:
+
+* **`new`** — the algorithm described above. Only the configured plugin moves; unconfigured plugins
+  keep their priority slots; `before` and `after` can differ.
+* **`legacy`** — the original algorithm, kept so upgrades don't change behavior unexpectedly. It
+  treats `before` and `after` as the same relationship, and repositioning one plugin can pull
+  unrelated plugins out of their priority slots.
+
+The scenario above shows the difference plainly:
+
+| | `new` | `legacy` |
+|---|---|---|
+| Result | `request-callout, opentelemetry, pre-function` | `opentelemetry, pre-function, request-callout` |
+| What moved | only `pre-function` (as configured) | `opentelemetry` jumped to the front and `request-callout` was pushed to the end — **neither was configured** |
+
+Under `legacy`, moving `pre-function` displaced `opentelemetry` and `request-callout` even though
+you never mentioned them. That surprise — an unrelated plugin changing position — is exactly what
+`new` removes.
+
+### `before` ≠ `after` under `new`
+
+Take five plugins in natural priority order `e(500), d(400), c(300), b(200), a(100)` and express
+the same relationship two ways:
+
+| Configuration | `new` result | `legacy` result |
+|---|---|---|
+| `b` with `before: [d]` | `e, b, d, c, a` | `e, b, d, c, a` |
+| `d` with `after: [b]` | `e, c, b, d, a` | `e, b, d, c, a` |
+
+Under `new`, `d after b` moves only `d` (down to just after `b`), so `c` and `e` stay put. Under
+`legacy`, `before` and `after` are identical, so both forms produce the same order — and to get
+there `legacy` lifts `b`, the plugin you only *referenced*.
+
+## Why `new` is easier to work with
+
+* **Predictable.** Only the plugin you configure moves. You never have to reason about side effects
+  on plugins you didn't touch.
+* **Deterministic.** The same configuration always produces the same order — on every node, every
+  time. Whatever you see in testing is what you get in production.
+* **Expressive.** Because `before` and `after` move different plugins, you can say precisely which
+  plugin should relocate.
+
+### What {{site.base_gateway}} guarantees (both algorithms)
+
+* **Your rules are always honored, or the config is rejected.** Every `before`/`after` you set is
+  satisfied. If your rules contradict each other (for example `A before B` *and* `B before A`),
+  {{site.base_gateway}} reports a **circular dependency** error instead of guessing.
+* **The result is deterministic.** It never depends on load order or timing.
+
+### What it does not promise
+
+* **Exact adjacency when rules interact.** If a plugin is both a mover and an anchor, or sits on a
+  chain of rules, it lands as close to its anchor as *all* your rules allow — which may not be
+  immediately adjacent. The order is still correct; it just reflects the whole set of rules, not one
+  rule in isolation.
+* **A priority-looking result when you constrain many plugins.** If you order most of your plugins
+  explicitly, the output is dictated by those rules and can look nothing like priority order. That's
+  expected — you asked for it.
+
+## Scoping and the request path
+
+Dynamic ordering runs per request. A plugin scoped to a specific Route, Service, or Consumer only
+takes part in ordering for requests that match its scope. A scoped plugin that doesn't match the
+current request still counts as an **anchor** (so another plugin's `before`/`after` that points at
+it is preserved), but it contributes no rules of its own and does not execute. This is why the
+resulting order can differ from one request path to another.
+
+<!-- TODO(productionize): embed the interactive plugin ordering simulator include here
+     (app/_includes/components/plugin_ordering_simulator.html). A validated standalone
+     prototype of this tool exists; the Vue component wiring is a follow-up. -->
+
+## Choosing an algorithm on upgrade
+
+`plugin_ordering_algorithm` defaults to `legacy`, so **upgrading does not change your current
+access-phase order**. When you're ready to adopt the clearer `new` behavior:
+
+1. Set `plugin_ordering_algorithm = new` in `kong.conf` (or the `KONG_PLUGIN_ORDERING_ALGORITHM`
+   environment variable) on your data planes.
+2. Re-test any Workspace that uses `ordering` — the access-phase order of those Workspaces may
+   change (that's the fix taking effect). Workspaces with no `ordering` are unaffected either way.
+
+The setting is read per node, so you can roll it out one data plane at a time.
+
+## Known limitations
+
+If you use dynamic ordering, test your configurations and handle the feature with care:
+
+* **Cascading deletes**: {{site.base_gateway}} does not detect an `ordering` rule that points at a
+  deleted plugin.
+* **Performance**: sorting plugins during a request adds a small amount of latency. Reordering any
+  plugin in a Workspace or control plane affects all plugins in that environment.
+* **Validation**: {{site.base_gateway}} catches basic mistakes (such as circular rules) but cannot
+  validate that an order makes sense for your business logic.


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Add standalone explainers for both dynamic plugin ordering algorithms and document the new
`plugin_ordering_algorithm` option that selects which one runs.

  * `app/gateway/plugins/plugin-ordering-legacy.md` (new): the `legacy` algorithm on its own terms
    -- its real DFS post-order mechanism (a plugin's whole dependency chain is placed immediately
    before it, however far the chain reaches), a hand-worked trace, why `before` and `after` build
    the identical dependency edge under this algorithm, and its pros, cons, and corner cases.
  * `app/gateway/plugins/plugin-ordering-priority-preserving.md` (new, replaces
    `plugin-ordering.md`): the principle behind `priority_preserving` ("at each step, run the
    highest-priority plugin whose `after` requirements are already met"), a hand-worked
    step-by-step example so readers can predict the exact order, a `priority_preserving`-vs-`legacy`
    comparison on the identical configuration (the FTI-7177 displacement and the `before` !=
    `after` asymmetry, with concrete sorted results attributed to whichever algorithm produced
    them), the guarantees and non-guarantees (including the non-optimal-placement case and its
    fix), how request scope changes the result, and how to adopt `priority_preserving` on upgrade.
  * `app/_gateway_entities/plugin.md`: point the "Dynamic plugin ordering" reference callout and
    the `plugin_ordering_algorithm` known-limitations bullet at both new pages instead of the one
    merged page.
  * `app/_indices/gateway.yaml`: replace the single "How Gateway Works" navigation entry with one
    per page.
  * `app/_redirects`: redirect the old `/gateway/plugins/plugin-ordering/` URL to the
    `priority_preserving` page.
  * `.github/styles/base/Dictionary.txt`: add `priority_preserving` so Vale's spelling check
    accepts it outside of code spans (frontmatter descriptions, table keys) -- same convention as
    the other snake_case config values already in that file.

Fixes FTI-7177

## Preview Links

https://deploy-preview-5936--kongdeveloper.netlify.app/gateway/plugins/plugin-ordering-priority-preserving/
https://deploy-preview-5936--kongdeveloper.netlify.app/gateway/plugins/plugin-ordering-legacy/
https://deploy-preview-5936--kongdeveloper.netlify.app/gateway/entities/plugin/#dynamic-plugin-ordering

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
