### PR TITLE
Feat(aigw): Route Claude CLI traffic through {{site.ai_gateway}} and Vertex AI

### DIFF
--- a/app/_config/releases/ai-gateway/v1.yml
+++ b/app/_config/releases/ai-gateway/v1.yml
@@ -278,8 +278,7 @@ app/_how-tos/ai-gateway/v1/use-claude-code-with-ai-gateway-huggingface.md:
 app/_how-tos/ai-gateway/v1/use-claude-code-with-ai-gateway-openai.md:
   canonical_url: /ai-gateway/use-claude-code-with-ai-gateway-openai/
 app/_how-tos/ai-gateway/v1/use-claude-code-with-ai-gateway-vertex.md:
-  status: pending
-  canonical_url: /ai-gateway/ai-providers/vertex/
+  canonical_url: /ai-gateway/use-claude-code-with-ai-gateway-vertex/
 app/_how-tos/ai-gateway/v1/use-codex-with-ai-gateway.md:
   status: pending
   canonical_url: /ai-gateway/ai-providers/openai/

--- a/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-vertex.md
+++ b/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-vertex.md
@@ -30,6 +30,9 @@ tldr:
   a: Create an AI Model Provider entity to authenticate to Google Vertex AI, add a Policy to strip Anthropic-only request fields Vertex doesn't support, create an AI Model entity that accepts Anthropic-compatible requests and targets your Vertex model. Then, point Claude CLI’s `ANTHROPIC_BASE_URL` at your local {{site.ai_gateway}} endpoint so all requests are proxied for monitoring and control.
 
 prereqs:
+  konnect:
+     - name: KONG_NGINX_HTTP_CLIENT_BODY_BUFFER_SIZE
+       value: 2m
   inline:
     - title: Vertex
       content: |

--- a/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-vertex.md
+++ b/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-vertex.md
@@ -27,7 +27,7 @@ tags:
 
 tldr:
   q: How do I run Claude CLI through {{site.ai_gateway}}?
-  a: Install Claude CLI, configure its API key helper, create a Gateway Service and Route, attach the AI Proxy plugin to forward requests to Claude, enable file-log to inspect traffic, and point Claude CLI to the local proxy endpoint so all LLM requests pass through the {{site.ai_gateway}} for monitoring and control.
+  a: Create an AI Model Provider entity to authenticate to Google Vertex AI, create an AI Model entity that accepts Anthropic-compatible requests and targets your Vertex model, then point Claude CLI’s `ANTHROPIC_BASE_URL` at your local {{site.ai_gateway}} endpoint so all requests are proxied for monitoring and control.
 
 prereqs:
   inline:
@@ -80,6 +80,39 @@ EOF
 
 In this example, we're setting up the AI Model Provider with:
 
+ * `type: vertex`: Specifies that this provider connects to Google Vertex AI.
+ * `config.auth.service_account_json: !env GCP_SERVICE_ACCOUNT_JSON`: Loads the service account JSON, required to access the account, from your environment at apply time.
+
+## Create an AI Policy entity
+
+Create an [AI Policy](/ai-gateway/entities/ai-policy/) entity using [request transformer](/ai-gateway/policies/ai-request-transformer/) to remove extra headers that Azure does not support.
+
+```sh
+kongctl apply -f - --auto-approve --pat "$KONNECT_TOKEN" <<EOF
+_defaults:
+  kongctl:
+    namespace: ai-gateway-get-started
+
+ai_gateways:
+  - ref: ai-quickstart
+    name: ai-quickstart
+    display_name: "ai-quickstart"
+
+ai_gateway_policies:
+  - ref: claude-code-compat
+    name: claude-code-compat
+    ai_gateway: ai-quickstart
+    type: request-transformer-advanced
+    enabled: true
+    global: false
+    config:
+      remove:
+        headers: [anthropic-beta]
+        querystring: [beta]
+        body: [output_config, context_management, mcp_servers, container, service_tier]
+EOF
+```
+
 ## Create an AI Model entity
 
 Create an [AI Model](/ai-gateway/entities/ai-model/) entity to declare which upstream models are available, configure how client requests are routed, and specify which AI Provider to use:
@@ -97,38 +130,37 @@ ai_gateways:
 
 ai_gateway_models:
   - ref: claude-code-vertex-sonnet
-    type: model
     name: claude-code-vertex-sonnet
     display_name: "Claude Code - Vertex - Sonnet 4.6"
     ai_gateway: ai-quickstart
+    type: model
     enabled: true
+    formats: [{ type: anthropic }]
     config:
-      route:
-        paths:
-        - /
-      model:
-        alias: "claude-code-vertex-sonnet"
-    formats:
-      - type: anthropic
+      route: { paths: [/] }
+      model: { name_header: true }
+    capabilities: [generate]
+    policies: [ !ref claude-code-compat#name ]
     targets:
-      - name: claude-sonnet-4-6
+      - name: claude-sonnet-4-5@20250929
         provider: vertex-prod
         config:
           type: vertex
           upstream_url: !env VERTEX_UPSTREAM_URL
-    capabilities:
-      - generate
 EOF
 ```
 
+display_name: "Claude Code - Vertex - Sonnet 4.6"
+
 In this example, we're setting up the AI Model with:
+
+ * `formats: [type: anthropic]`: Accepts Anthropic-compatible requests (what {{ site.claude_code }} sends).
+ * `config.model.alias: claude-code-vertex-sonnet`: The model name you pass from Claude CLI.
+ * `targets[0].provider: vertex-prod`: Routes upstream requests through the Vertex AI Provider created earlier.
 
 ## Verify traffic through Kong
 
 Now, we can start a {{ site.claude_code }} session that points it to the local {{site.ai_gateway}} endpoint:
-
-{:.warning}
-> Ensure that `ANTHROPIC_MODEL` matches the model you deployed in Gemini.
 
 ```sh
 ANTHROPIC_BASE_URL=http://localhost:8000/ claude --model 'claude-code-vertex-sonnet'
@@ -148,7 +180,7 @@ This means I can:
 Learn more ( https://docs.claude.com/s/claude-code-security )
 
 ❯ 1. Yes, continue
-2. No, exit
+1. No, exit
 ```
 {:.no-copy-code}
 

--- a/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-vertex.md
+++ b/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-vertex.md
@@ -42,11 +42,8 @@ prereqs:
 
         Export these values as environment variables:
         ```sh
-        export GEMINI_API_KEY="<your_gemini_api_key>"
-        export GCP_PROJECT_ID="<your-gemini-project-id>"
-        export GEMINI_LOCATION_ID="<your-gemini-location_id>"
-        export GEMINI_API_ENDPOINT="<your_gemini_api_endpoint>"
-        export GCP_SERVICE_ACCOUNT="<your_account_json>"
+        export VERTEX_UPSTREAM_URL="<your_upstream_url>"
+        export GCP_SERVICE_ACCOUNT_JSON="<your_account_json>"
         ```
       icon_url: /assets/icons/vertex.svg
     - title: Claude Code CLI
@@ -77,7 +74,7 @@ ai_gateway_model_providers:
     config:
       auth:
         type: gcp
-        service_account_json: !env GCP_SERVICE_ACCOUNT
+        service_account_json: !env GCP_SERVICE_ACCOUNT_JSON
 EOF
 ```
 

--- a/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-vertex.md
+++ b/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-vertex.md
@@ -1,0 +1,167 @@
+---
+title: Route Claude CLI traffic through {{site.ai_gateway}} and Vertex AI
+permalink: /ai-gateway/use-claude-code-with-ai-gateway-vertex/
+content_type: how_to
+
+related_resources:
+  - text: "{{site.ai_gateway}}"
+    url: /ai-gateway/
+
+description: Configure {{site.ai_gateway}} to proxy Claude CLI traffic using Google Vertex AI models
+
+products:
+  - ai-gateway
+
+works_on:
+  - konnect
+
+tools:
+  - kongctl
+
+min_version:
+  ai-gateway: '2.0'
+
+tags:
+  - ai
+  - vertex-ai
+
+tldr:
+  q: How do I run Claude CLI through {{site.ai_gateway}}?
+  a: Install Claude CLI, configure its API key helper, create a Gateway Service and Route, attach the AI Proxy plugin to forward requests to Claude, enable file-log to inspect traffic, and point Claude CLI to the local proxy endpoint so all LLM requests pass through the {{site.ai_gateway}} for monitoring and control.
+
+prereqs:
+  inline:
+    - title: Vertex
+      content: |
+        Before you begin, you must get the following credentials from Google Cloud:
+
+        - **Service Account Key**: A JSON key file for a service account with Vertex AI permissions
+        - **Project ID**: Your Google Cloud project identifier
+        - **Location ID**: The region where your Vertex AI endpoint is deployed (for example, `us-central1`)
+        - **API Endpoint**: The Vertex AI API endpoint URL (typically `https://{location}-aiplatform.googleapis.com`)
+
+        Export these values as environment variables:
+        ```sh
+        export GEMINI_API_KEY="<your_gemini_api_key>"
+        export GCP_PROJECT_ID="<your-gemini-project-id>"
+        export GEMINI_LOCATION_ID="<your-gemini-location_id>"
+        export GEMINI_API_ENDPOINT="<your_gemini_api_endpoint>"
+        ```
+      icon_url: /assets/icons/vertex.svg
+    - title: Claude Code CLI
+      icon_url: /assets/icons/third-party/claude.svg
+      include_content: prereqs/claude-code
+
+---
+
+## Create an AI Provider entity
+
+
+## Create an AI Model entity
+
+
+## Verify traffic through Kong
+
+Now, we can start a {{ site.claude_code }} session that points it to the local {{site.ai_gateway}} endpoint:
+
+{:.warning}
+> Ensure that `ANTHROPIC_MODEL` matches the model you deployed in Gemini.
+
+```sh
+ANTHROPIC_BASE_URL=http://localhost:8000/anything \
+ANTHROPIC_MODEL=YOUR_VERTEX_MODEL \
+claude
+```
+
+{{ site.claude_code }} asks for permission before it runs tools or interacts with files:
+
+```text
+I'll need permission to work with your files.
+
+This means I can:
+- Read any file in this folder
+- Create, edit, or delete files
+- Run commands (like npm, git, tests, ls, rm)
+- Use tools defined in .mcp.json
+
+Learn more ( https://docs.claude.com/s/claude-code-security )
+
+❯ 1. Yes, continue
+2. No, exit
+```
+{:.no-copy-code}
+
+Select **Yes, continue**. The session starts. Ask a simple question to confirm that requests reach {{site.ai_gateway}}.
+
+```text
+Tell me about Anna Komnene's Alexiad.
+```
+
+{{ site.claude_code }} might prompt you approve its web search for answering the question. When you select **Yes**, {{ site.claude }} will produce a full-length response to your request:
+
+```text
+Anna Komnene (1083-1153?) was a Byzantine princess, scholar, physician,
+hospital administrator, and historian. She is known for writing the
+Alexiad, a historical account of the reign of her father, Emperor Alexios
+I Komnenos (r. 1081-1118). The Alexiad is a valuable primary source for
+understanding Byzantine history and the First Crusade.
+```
+{:.no-copy-code}
+
+Next, inspect the {{site.ai_gateway}} logs to verify that the traffic was proxied through it:
+
+```sh
+docker exec kong-quickstart-gateway cat /tmp/claude.json | jq
+```
+
+You should find an entry that shows the upstream request made by {{ site.claude_code }}. A typical log record looks like this:
+
+```json
+{
+  ...
+  "method": "POST",
+  "headers": {
+    "user-agent": "claude-cli/2.0.37 (external, cli)",
+    "content-type": "application/json"
+  },
+  ...
+  "ai": {
+    "proxy": {
+      "tried_targets": [
+        {
+          "provider": "gemini",
+          "model": "gemini-2.0-flash",
+          "port": 443,
+          "upstream_scheme": "https",
+          "host": "us-central1-aiplatform.googleapis.com",
+          "upstream_uri": "/v1/projects/example-project-id/locations/us-central1/publishers/google/models/gemini-2.0-flash:generateContent",
+          "route_type": "llm/v1/chat",
+          "ip": "xxx.xxx.xxx.xxx"
+        }
+      ],
+      "meta": {
+        "request_model": "gemini-2.5-flash",
+        "request_mode": "oneshot",
+        "response_model": "gemini-2.5-flash",
+        "provider_name": "gemini",
+        "llm_latency": 1694,
+        "plugin_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+      },
+      "usage": {
+        "completion_tokens": 19,
+        "completion_tokens_details": {},
+        "total_tokens": 11203,
+        "cost": 0,
+        "time_per_token": 85.157894736842,
+        "time_to_first_token": 2546,
+        "prompt_tokens": 11184,
+        "prompt_tokens_details": {}
+      }
+    }
+  }
+  ...
+}
+```
+{:.no-copy-code}
+
+This output confirms that {{ site.claude_code }} routed the request through {{site.ai_gateway}} using the `gemini-2.5-flash` model we selected while starting the {{ site.claude_code }} session.

--- a/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-vertex.md
+++ b/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-vertex.md
@@ -109,15 +109,15 @@ ai_gateway_models:
       model:
         alias: "claude-code-vertex-sonnet"
     formats:
-    - type: anthropic
-    target_models:
-    - name: claude-sonnet-4-6
-      provider: vertex-prod
-      config:
-        type: vertex
-        upstream_url: !env VERTEX_UPSTREAM_URL
+      - type: anthropic
+    targets:
+      - name: claude-sonnet-4-6
+        provider: vertex-prod
+        config:
+          type: vertex
+          upstream_url: !env VERTEX_UPSTREAM_URL
     capabilities:
-    - generate
+      - generate
 EOF
 ```
 

--- a/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-vertex.md
+++ b/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-vertex.md
@@ -27,7 +27,7 @@ tags:
 
 tldr:
   q: How do I run Claude CLI through {{site.ai_gateway}} for a Claude model hosted on Google Vertex AI?
-  a: Create an AI Model Provider entity to authenticate to Google Vertex AI, add a policy to strip Anthropic-only request fields Vertex doesn't support, create an AI Model entity that accepts Anthropic-compatible requests and targets your Vertex model, then point Claude CLI’s `ANTHROPIC_BASE_URL` at your local {{site.ai_gateway}} endpoint so all requests are proxied for monitoring and control.
+  a: Create an AI Model Provider entity to authenticate to Google Vertex AI, add a Policy to strip Anthropic-only request fields Vertex doesn't support, create an AI Model entity that accepts Anthropic-compatible requests and targets your Vertex model. Then, point Claude CLI’s `ANTHROPIC_BASE_URL` at your local {{site.ai_gateway}} endpoint so all requests are proxied for monitoring and control.
 
 prereqs:
   inline:
@@ -37,7 +37,7 @@ prereqs:
 
         1. In [Vertex AI Model Garden](https://console.cloud.google.com/vertex-ai/model-garden), enable a Claude model (for example, **Claude Sonnet 4.5**). Note the **location** it's enabled in. Depending on your project, Vertex may offer Claude in a specific region (for example, `us-east5`) or under `global`.
         1. Create a Google Cloud service account with Vertex AI permissions and download its JSON key file.
-        1. Export the service account JSON and the full `:rawPredict` upstream URL as environment variables. Vertex encodes your project, location, and model id directly in this URL, so there are no separate provider or target fields for them. The hostname depends on the location from step 1: a specific region uses a region-prefixed host, while `global` uses the plain host with no region prefix:
+        1. Export the service account JSON and the full `:rawPredict` upstream URL as environment variables. Vertex encodes your project, location, and model ID directly in this URL, so there are no separate provider or target fields for them. The hostname depends on the location from step 1: a specific region uses a region-prefixed host, while `global` uses the plain host with no region prefix:
 
             ```sh
             export GCP_SERVICE_ACCOUNT_JSON="$(cat /path/to/service-account.json)"
@@ -50,7 +50,7 @@ prereqs:
             ```
 
         {:.info}
-        > Vertex publisher model ids use the format `name@YYYYMMDD` (for example, `claude-sonnet-4-5@20250929`), not a plain model name. Use the exact id shown for your enabled model in Model Garden.
+        > Vertex publisher model IDs use the format `name@YYYYMMDD` (for example, `claude-sonnet-4-5@20250929`), not a plain model name. Use the exact ID shown for your enabled model in Model Garden.
       icon_url: /assets/icons/vertex.svg
     - title: Claude Code CLI
       icon_url: /assets/icons/third-party/claude.svg
@@ -58,7 +58,9 @@ prereqs:
 
 ---
 
-## Create an AI Provider entity
+## Create an AI Model Provider entity
+
+Create an [AI Model Provider](/ai-gateway/entities/ai-model-provider/) entity to define your connection to Vertex AI and store your API key:
 
 ```sh
 kongctl apply -f - --auto-approve --pat "$KONNECT_TOKEN" <<EOF
@@ -100,7 +102,7 @@ This AI Model Provider uses:
 Create an [AI Policy](/ai-gateway/entities/ai-policy/) entity using [request transformer](/ai-gateway/policies/ai-request-transformer/) to remove extra fields that Vertex AI's Claude endpoint does not support, and an [AI Model](/ai-gateway/entities/ai-model/) entity to declare which upstream model is available and attach that policy to it.
 
 {:.warning}
-> Apply the policy and the model together, in the same `kongctl apply` call, as shown below. The model's `policies` field references the policy via `!ref`, and `ref` values are local to a single `kongctl apply` call. They're never written to {{site.konnect_short_name}}. If you split this into two separate `kongctl apply` calls, the second one fails with `resource not found: claude-code-compat`, even though the policy already exists.
+> Apply the Policy and the AI Model together, in the same `kongctl apply` call, as shown below. The AI Model's `policies` field references the Policy via `!ref`, and `ref` values are local to a single `kongctl apply` call. They're never written to {{site.konnect_short_name}}. If you split this into two separate `kongctl apply` calls, the second one fails with `resource not found: claude-code-compat`, even though the Policy already exists.
 
 ```sh
 kongctl apply -f - --auto-approve --pat "$KONNECT_TOKEN" <<EOF
@@ -159,18 +161,18 @@ The AI Policy uses:
 * `config.remove.headers` / `config.remove.querystring` / `config.remove.body`: Strips fields that {{ site.claude_code }} sends but that Vertex AI's Claude endpoint rejects with a `400 Extra inputs are not permitted`: the `anthropic-beta` header, the `beta` query string, and body fields like `mcp_servers` and `container`. The list also includes `thinking`. {{ site.claude_code }} sends `thinking: {"type": "adaptive", ...}` by default, and Vertex's schema only accepts `disabled` or `enabled` for `thinking.type`, so it must be removed rather than left as-is.
 
 {:.info}
-> Unlike the Azure AI Foundry version of this how-to, you don't need to add an `anthropic-version` header here. The Vertex driver injects it into the request body automatically.
+> The Vertex driver injects the `anthropic-version` header into the request body automatically. 
 
 The AI Model uses:
 
- * `name`/`display_name: claude-code-vertex-sonnet`: The identifier you pass to `claude --model`. {{ site.claude_code }} uses this, not the upstream target id, to select the model.
+ * `name`/`display_name: claude-code-vertex-sonnet`: The identifier you pass to `claude --model`. {{ site.claude_code }} uses this, not the upstream target ID, to select the model.
  * `formats: [type: anthropic]`: Accepts Anthropic-compatible requests (what {{ site.claude_code }} sends).
  * `config.model.name_header: true`: Lets {{ site.claude_code }} select this model by sending its `name` in the request, instead of requiring a separate `alias`.
  * `capabilities: [generate]`: Enables text generation. For a model using the `anthropic` format, `generate` creates a `/messages` endpoint matching Anthropic's native Messages API.
  * `policies`: Attaches the `claude-code-compat` policy defined above, via `!ref claude-code-compat#name`, so its body-stripping transformation applies to every request sent through this model.
  * `targets[0].provider: vertex-prod`: Routes upstream requests through the Vertex AI Provider created earlier.
- * `targets[0].name: claude-sonnet-4-5@20250929`: The Vertex publisher model id, in `name@YYYYMMDD` format. It must match a model you've enabled in Vertex AI Model Garden.
- * `targets[0].config.upstream_url`: The full `:rawPredict` URL from the prerequisites, encoding your project, location, and model id.
+ * `targets[0].name: claude-sonnet-4-5@20250929`: The Vertex publisher model ID, in `name@YYYYMMDD` format. It must match a model you've enabled in Vertex AI Model Garden.
+ * `targets[0].config.upstream_url`: The full `:rawPredict` URL from the prerequisites, encoding your project, location, and model ID.
 
 ## Verify traffic through Kong
 
@@ -198,7 +200,7 @@ Learn more ( https://docs.claude.com/s/claude-code-security )
 ```
 {:.no-copy-code}
 
-Select **Yes, continue**. The session starts. Ask a simple question to confirm that requests reach {{site.ai_gateway}}.
+Select **Yes, continue**. The session starts. Ask a question to confirm that requests reach {{site.ai_gateway}}.
 
 ```text
 Tell me about Anna Komnene's Alexiad.

--- a/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-vertex.md
+++ b/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-vertex.md
@@ -26,25 +26,31 @@ tags:
   - vertex-ai
 
 tldr:
-  q: How do I run Claude CLI through {{site.ai_gateway}}?
-  a: Create an AI Model Provider entity to authenticate to Google Vertex AI, create an AI Model entity that accepts Anthropic-compatible requests and targets your Vertex model, then point Claude CLI’s `ANTHROPIC_BASE_URL` at your local {{site.ai_gateway}} endpoint so all requests are proxied for monitoring and control.
+  q: How do I run Claude CLI through {{site.ai_gateway}} for a Claude model hosted on Google Vertex AI?
+  a: Create an AI Model Provider entity to authenticate to Google Vertex AI, add a policy to strip Anthropic-only request fields Vertex doesn't support, create an AI Model entity that accepts Anthropic-compatible requests and targets your Vertex model, then point Claude CLI’s `ANTHROPIC_BASE_URL` at your local {{site.ai_gateway}} endpoint so all requests are proxied for monitoring and control.
 
 prereqs:
   inline:
     - title: Vertex
       content: |
-        Before you begin, you must get the following credentials from Google Cloud:
+        Before you begin:
 
-        - **Service Account Key**: A JSON key file for a service account with Vertex AI permissions
-        - **Project ID**: Your Google Cloud project identifier
-        - **Location ID**: The region where your Vertex AI endpoint is deployed (for example, `us-central1`)
-        - **API Endpoint**: The Vertex AI API endpoint URL (typically `https://{location}-aiplatform.googleapis.com`)
+        1. In [Vertex AI Model Garden](https://console.cloud.google.com/vertex-ai/model-garden), enable a Claude model (for example, **Claude Sonnet 4.5**). Note the **location** it's enabled in. Depending on your project, Vertex may offer Claude in a specific region (for example, `us-east5`) or under `global`.
+        1. Create a Google Cloud service account with Vertex AI permissions and download its JSON key file.
+        1. Export the service account JSON and the full `:rawPredict` upstream URL as environment variables. Vertex encodes your project, location, and model id directly in this URL, so there are no separate provider or target fields for them. The hostname depends on the location from step 1: a specific region uses a region-prefixed host, while `global` uses the plain host with no region prefix:
 
-        Export these values as environment variables:
-        ```sh
-        export VERTEX_UPSTREAM_URL="<your_upstream_url>"
-        export GCP_SERVICE_ACCOUNT_JSON="<your_account_json>"
-        ```
+            ```sh
+            export GCP_SERVICE_ACCOUNT_JSON="$(cat /path/to/service-account.json)"
+
+            # If your model is enabled in a specific region:
+            export VERTEX_UPSTREAM_URL="https://us-east5-aiplatform.googleapis.com/v1/projects/<YOUR_PROJECT_ID>/locations/us-east5/publishers/anthropic/models/claude-sonnet-4-5@20250929:rawPredict"
+
+            # If your model is enabled under "global" instead:
+            export VERTEX_UPSTREAM_URL="https://aiplatform.googleapis.com/v1/projects/<YOUR_PROJECT_ID>/locations/global/publishers/anthropic/models/claude-sonnet-4-5@20250929:rawPredict"
+            ```
+
+        {:.info}
+        > Vertex publisher model ids use the format `name@YYYYMMDD` (for example, `claude-sonnet-4-5@20250929`), not a plain model name. Use the exact id shown for your enabled model in Model Garden.
       icon_url: /assets/icons/vertex.svg
     - title: Claude Code CLI
       icon_url: /assets/icons/third-party/claude.svg
@@ -62,8 +68,10 @@ _defaults:
 
 ai_gateways:
   - ref: ai-quickstart
-    name: ai-quickstart
-    display_name: "ai-quickstart"
+    _external:
+      selector:
+        matchFields:
+          name: "ai-quickstart"
 
 ai_gateway_model_providers:
   - ref: vertex-prod
@@ -78,14 +86,21 @@ ai_gateway_model_providers:
 EOF
 ```
 
-In this example, we're setting up the AI Model Provider with:
+{:.info}
+> `ai-quickstart` references the {{site.ai_gateway}} created by the quickstart script in the prerequisites above, instead of creating a new one.
+
+This AI Model Provider uses:
 
  * `type: vertex`: Specifies that this provider connects to Google Vertex AI.
+ * `config.auth.type: gcp`: Uses Google Cloud service account authentication, rather than a bearer token or API key.
  * `config.auth.service_account_json: !env GCP_SERVICE_ACCOUNT_JSON`: Loads the service account JSON, required to access the account, from your environment at apply time.
 
-## Create an AI Policy entity
+## Create an AI Policy and AI Model
 
-Create an [AI Policy](/ai-gateway/entities/ai-policy/) entity using [request transformer](/ai-gateway/policies/ai-request-transformer/) to remove extra headers that Azure does not support.
+Create an [AI Policy](/ai-gateway/entities/ai-policy/) entity using [request transformer](/ai-gateway/policies/ai-request-transformer/) to remove extra fields that Vertex AI's Claude endpoint does not support, and an [AI Model](/ai-gateway/entities/ai-model/) entity to declare which upstream model is available and attach that policy to it.
+
+{:.warning}
+> Apply the policy and the model together, in the same `kongctl apply` call, as shown below. The model's `policies` field references the policy via `!ref`, and `ref` values are local to a single `kongctl apply` call. They're never written to {{site.konnect_short_name}}. If you split this into two separate `kongctl apply` calls, the second one fails with `resource not found: claude-code-compat`, even though the policy already exists.
 
 ```sh
 kongctl apply -f - --auto-approve --pat "$KONNECT_TOKEN" <<EOF
@@ -95,8 +110,10 @@ _defaults:
 
 ai_gateways:
   - ref: ai-quickstart
-    name: ai-quickstart
-    display_name: "ai-quickstart"
+    _external:
+      selector:
+        matchFields:
+          name: "ai-quickstart"
 
 ai_gateway_policies:
   - ref: claude-code-compat
@@ -109,24 +126,7 @@ ai_gateway_policies:
       remove:
         headers: [anthropic-beta]
         querystring: [beta]
-        body: [output_config, context_management, mcp_servers, container, service_tier]
-EOF
-```
-
-## Create an AI Model entity
-
-Create an [AI Model](/ai-gateway/entities/ai-model/) entity to declare which upstream models are available, configure how client requests are routed, and specify which AI Provider to use:
-
-```sh
-kongctl apply -f - --auto-approve --pat "$KONNECT_TOKEN" <<EOF
-_defaults:
-  kongctl:
-    namespace: ai-gateway-get-started
-
-ai_gateways:
-  - ref: ai-quickstart
-    name: ai-quickstart
-    display_name: "ai-quickstart"
+        body: [output_config, context_management, mcp_servers, container, service_tier, thinking]
 
 ai_gateway_models:
   - ref: claude-code-vertex-sonnet
@@ -150,13 +150,27 @@ ai_gateway_models:
 EOF
 ```
 
-display_name: "Claude Code - Vertex - Sonnet 4.6"
+{:.info}
+> Replace `claude-sonnet-4-5@20250929` with the id of your own enabled model in Vertex AI Model Garden.
 
-In this example, we're setting up the AI Model with:
+The AI Policy uses:
 
+* `type: request-transformer-advanced`: Modifies requests before {{site.ai_gateway}} forwards them upstream.
+* `config.remove.headers` / `config.remove.querystring` / `config.remove.body`: Strips fields that {{ site.claude_code }} sends but that Vertex AI's Claude endpoint rejects with a `400 Extra inputs are not permitted`: the `anthropic-beta` header, the `beta` query string, and body fields like `mcp_servers` and `container`. The list also includes `thinking`. {{ site.claude_code }} sends `thinking: {"type": "adaptive", ...}` by default, and Vertex's schema only accepts `disabled` or `enabled` for `thinking.type`, so it must be removed rather than left as-is.
+
+{:.info}
+> Unlike the Azure AI Foundry version of this how-to, you don't need to add an `anthropic-version` header here. The Vertex driver injects it into the request body automatically.
+
+The AI Model uses:
+
+ * `name`/`display_name: claude-code-vertex-sonnet`: The identifier you pass to `claude --model`. {{ site.claude_code }} uses this, not the upstream target id, to select the model.
  * `formats: [type: anthropic]`: Accepts Anthropic-compatible requests (what {{ site.claude_code }} sends).
- * `config.model.alias: claude-code-vertex-sonnet`: The model name you pass from Claude CLI.
+ * `config.model.name_header: true`: Lets {{ site.claude_code }} select this model by sending its `name` in the request, instead of requiring a separate `alias`.
+ * `capabilities: [generate]`: Enables text generation. For a model using the `anthropic` format, `generate` creates a `/messages` endpoint matching Anthropic's native Messages API.
+ * `policies`: Attaches the `claude-code-compat` policy defined above, via `!ref claude-code-compat#name`, so its body-stripping transformation applies to every request sent through this model.
  * `targets[0].provider: vertex-prod`: Routes upstream requests through the Vertex AI Provider created earlier.
+ * `targets[0].name: claude-sonnet-4-5@20250929`: The Vertex publisher model id, in `name@YYYYMMDD` format. It must match a model you've enabled in Vertex AI Model Garden.
+ * `targets[0].config.upstream_url`: The full `:rawPredict` URL from the prerequisites, encoding your project, location, and model id.
 
 ## Verify traffic through Kong
 
@@ -180,7 +194,7 @@ This means I can:
 Learn more ( https://docs.claude.com/s/claude-code-security )
 
 ❯ 1. Yes, continue
-1. No, exit
+2. No, exit
 ```
 {:.no-copy-code}
 
@@ -190,7 +204,7 @@ Select **Yes, continue**. The session starts. Ask a simple question to confirm t
 Tell me about Anna Komnene's Alexiad.
 ```
 
-{{ site.claude_code }} might prompt you approve its web search for answering the question. When you select **Yes**, {{ site.claude }} will produce a full-length response to your request:
+{{ site.claude_code }} might prompt you to approve its web search for answering the question. When you select **Yes**, {{ site.claude }} will produce a full-length response to your request:
 
 ```text
 Anna Komnene (1083-1153?) was a Byzantine princess, scholar, physician,

--- a/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-vertex.md
+++ b/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-vertex.md
@@ -46,6 +46,7 @@ prereqs:
         export GCP_PROJECT_ID="<your-gemini-project-id>"
         export GEMINI_LOCATION_ID="<your-gemini-location_id>"
         export GEMINI_API_ENDPOINT="<your_gemini_api_endpoint>"
+        export GCP_SERVICE_ACCOUNT="<your_account_json>"
         ```
       icon_url: /assets/icons/vertex.svg
     - title: Claude Code CLI
@@ -56,9 +57,74 @@ prereqs:
 
 ## Create an AI Provider entity
 
+```sh
+kongctl apply -f - --auto-approve --pat "$KONNECT_TOKEN" <<EOF
+_defaults:
+  kongctl:
+    namespace: ai-gateway-get-started
+
+ai_gateways:
+  - ref: ai-quickstart
+    name: ai-quickstart
+    display_name: "ai-quickstart"
+
+ai_gateway_model_providers:
+  - ref: vertex-prod
+    name: vertex-prod
+    display_name: "Google Vertex Prod"
+    ai_gateway: ai-quickstart
+    type: vertex
+    config:
+      auth:
+        type: gcp
+        service_account_json: !env GCP_SERVICE_ACCOUNT
+EOF
+```
+
+In this example, we're setting up the AI Model Provider with:
 
 ## Create an AI Model entity
 
+Create an [AI Model](/ai-gateway/entities/ai-model/) entity to declare which upstream models are available, configure how client requests are routed, and specify which AI Provider to use:
+
+```sh
+kongctl apply -f - --auto-approve --pat "$KONNECT_TOKEN" <<EOF
+_defaults:
+  kongctl:
+    namespace: ai-gateway-get-started
+
+ai_gateways:
+  - ref: ai-quickstart
+    name: ai-quickstart
+    display_name: "ai-quickstart"
+
+ai_gateway_models:
+  - ref: claude-code-vertex-sonnet
+    type: model
+    name: claude-code-vertex-sonnet
+    display_name: "Claude Code - Vertex - Sonnet 4.6"
+    ai_gateway: ai-quickstart
+    enabled: true
+    config:
+      route:
+        paths:
+        - /
+      model:
+        alias: "claude-code-vertex-sonnet"
+    formats:
+    - type: anthropic
+    target_models:
+    - name: claude-sonnet-4-6
+      provider: vertex-prod
+      config:
+        type: vertex
+        upstream_url: !env VERTEX_UPSTREAM_URL
+    capabilities:
+    - generate
+EOF
+```
+
+In this example, we're setting up the AI Model with:
 
 ## Verify traffic through Kong
 
@@ -68,9 +134,7 @@ Now, we can start a {{ site.claude_code }} session that points it to the local {
 > Ensure that `ANTHROPIC_MODEL` matches the model you deployed in Gemini.
 
 ```sh
-ANTHROPIC_BASE_URL=http://localhost:8000/anything \
-ANTHROPIC_MODEL=YOUR_VERTEX_MODEL \
-claude
+ANTHROPIC_BASE_URL=http://localhost:8000/ claude --model 'claude-code-vertex-sonnet'
 ```
 
 {{ site.claude_code }} asks for permission before it runs tools or interacts with files:
@@ -107,61 +171,3 @@ I Komnenos (r. 1081-1118). The Alexiad is a valuable primary source for
 understanding Byzantine history and the First Crusade.
 ```
 {:.no-copy-code}
-
-Next, inspect the {{site.ai_gateway}} logs to verify that the traffic was proxied through it:
-
-```sh
-docker exec kong-quickstart-gateway cat /tmp/claude.json | jq
-```
-
-You should find an entry that shows the upstream request made by {{ site.claude_code }}. A typical log record looks like this:
-
-```json
-{
-  ...
-  "method": "POST",
-  "headers": {
-    "user-agent": "claude-cli/2.0.37 (external, cli)",
-    "content-type": "application/json"
-  },
-  ...
-  "ai": {
-    "proxy": {
-      "tried_targets": [
-        {
-          "provider": "gemini",
-          "model": "gemini-2.0-flash",
-          "port": 443,
-          "upstream_scheme": "https",
-          "host": "us-central1-aiplatform.googleapis.com",
-          "upstream_uri": "/v1/projects/example-project-id/locations/us-central1/publishers/google/models/gemini-2.0-flash:generateContent",
-          "route_type": "llm/v1/chat",
-          "ip": "xxx.xxx.xxx.xxx"
-        }
-      ],
-      "meta": {
-        "request_model": "gemini-2.5-flash",
-        "request_mode": "oneshot",
-        "response_model": "gemini-2.5-flash",
-        "provider_name": "gemini",
-        "llm_latency": 1694,
-        "plugin_id": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-      },
-      "usage": {
-        "completion_tokens": 19,
-        "completion_tokens_details": {},
-        "total_tokens": 11203,
-        "cost": 0,
-        "time_per_token": 85.157894736842,
-        "time_to_first_token": 2546,
-        "prompt_tokens": 11184,
-        "prompt_tokens_details": {}
-      }
-    }
-  }
-  ...
-}
-```
-{:.no-copy-code}
-
-This output confirms that {{ site.claude_code }} routed the request through {{site.ai_gateway}} using the `gemini-2.5-flash` model we selected while starting the {{ site.claude_code }} session.


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links

[/ai-gateway/use-claude-code-with-ai-gateway-vertex/](https://deploy-preview-5952--kongdeveloper.netlify.app/ai-gateway/use-claude-code-with-ai-gateway-vertex/)

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
