### PR TITLE
feat(aigw): Managing AI Gateway with kongctl

### DIFF
--- a/app/_includes/kongctl/commands-reference-table.md
+++ b/app/_includes/kongctl/commands-reference-table.md
@@ -1,0 +1,58 @@
+{% table %}
+columns:
+  - title: Command
+    key: command
+  - title: Description
+    key: description
+  - title: When to use
+    key: when
+rows:
+  - command: |
+      [`adopt`](/kongctl/adopt/)
+    description: |
+      Adds a namespace label to an existing {{site.konnect_short_name}} resource that was created outside of kongctl, bringing it under declarative management without modifying any other fields.
+    when: |
+      Use before your first `dump` or `plan`, when you need to bring a manually created or UI-created resource into your configuration.
+  - command: |
+      [`dump`](/kongctl/dump/)
+    description: |
+      Exports the current state of {{site.konnect_short_name}} resources to a declarative YAML configuration file.
+    when: |
+      Use when bootstrapping a new declarative configuration from existing live resources, or when generating a starting point for a new configuration file.
+  - command: |
+      [`plan`](/kongctl/plan/)
+    description: |
+      Compares your local configuration files against live {{site.konnect_short_name}} state and generates a JSON plan artifact describing the changes to be made.
+    when: |
+      Use before applying changes, especially in CI/CD pipelines, to produce a reviewable and reusable plan artifact.
+  - command: |
+      [`diff`](/kongctl/diff/)
+    description: |
+      Displays a human-readable preview of the changes between the current live state and the desired state in your configuration files, or from a saved plan artifact.
+    when: |
+      Use during development to inspect what `apply` or `sync` would change before committing.
+  - command: |
+      [`apply`](/kongctl/apply/)
+    description: |
+      Creates and updates resources to match the desired state. Does not delete resources.
+    when: |
+      Use to incrementally apply configuration without risk of deleting anything. Use `sync` instead when you want deletes as well.
+  - command: |
+      [`sync`](/kongctl/sync/)
+    description: |
+      Applies the full desired state from your configuration files. Creates, updates, and deletes resources.
+    when: |
+      Use for full reconciliation between your configuration and live state, including deletions. Use `apply` if you only want creates and updates.
+  - command: |
+      [`delete`](/kongctl/delete/)
+    description: |
+      Plans and executes deletion of all resources defined in the input configuration files.
+    when: |
+      Use for tearing down a known set of resources, such as resetting a test environment. Not a typical step in the day-to-day declarative workflow.
+  - command: |
+      [`get`](/kongctl/get/)
+    description: |
+      Retrieves {{site.konnect_short_name}} resources.
+    when: |
+      Use to inspect live state after applying configuration, or to look up resource IDs and names.
+{% endtable %}

--- a/app/_indices/ai-gateway.yaml
+++ b/app/_indices/ai-gateway.yaml
@@ -76,6 +76,12 @@ sections:
         - ai-gateway
       tags:
         - a2a
+  - title: Manage with kongctl
+    items:
+      - path: /ai-gateway/kongctl/
+      - path: /kongctl/supported-resources/#ai-gateway
+      - path: /kongctl/declarative/
+
   - title: AI load balancing
     items:
       - title: Load balancing with AI Proxy Advanced

--- a/app/_landing_pages/ai-gateway.yaml
+++ b/app/_landing_pages/ai-gateway.yaml
@@ -119,6 +119,15 @@ rows:
             cta:
               url: /ai-gateway/entities/
               align: end
+      - blocks:
+        - type: card
+          config:
+            title: Manage with kongctl
+            description: Use kongctl to create and manage {{site.ai_gateway}} resources declaratively or with imperative commands.
+            icon: /assets/icons/terminal.svg
+            cta:
+              url: /ai-gateway/kongctl/
+              align: end
   - header:
       type: h2
       text: "{{site.ai_gateway}} providers"

--- a/app/ai-gateway/kongctl.md
+++ b/app/ai-gateway/kongctl.md
@@ -1,0 +1,189 @@
+---
+title: "Using kongctl to manage {{site.ai_gateway}}"
+content_type: reference
+layout: reference
+
+description: "Learn how to use kongctl to create and inspect {{site.ai_gateway}} resources in {{site.konnect_product_name}}."
+
+breadcrumbs:
+  - /ai-gateway/
+
+products:
+  - ai-gateway
+
+works_on:
+  - konnect
+
+tools:
+  - kongctl
+
+min_version:
+  ai-gateway: '2.0'
+
+tags:
+  - declarative-config
+  - cli
+
+related_resources:
+  - text: "Get started with {{site.ai_gateway}}"
+    url: /ai-gateway/get-started/
+  - text: "Declarative configuration with kongctl"
+    url: /kongctl/declarative/
+  - text: "kongctl and decK"
+    url: /kongctl/kongctl-and-deck/
+  - text: "{{site.ai_gateway}} v2 migration guide"
+    url: /ai-gateway/v2-migration-guide/
+  - text: "kongctl supported resources"
+    url: /kongctl/supported-resources/
+  - text: "Configuration of kongctl"
+    url: /kongctl/config/
+next_steps:
+  - text: "Get started with {{site.ai_gateway}}"
+    url: /ai-gateway/get-started/
+---
+
+kongctl is the CLI for managing [{{site.ai_gateway}} resources](/ai-gateway/entities/) in {{site.konnect_product_name}}.
+It supports two modes of operation: declarative configuration for managing resources as code, and imperative commands for one-off operations and inspection.
+
+{:.info}
+> **Note**: 
+> kongctl manages {{site.ai_gateway}} on {{site.konnect_product_name}}.
+> decK manages {{site.base_gateway}} entities (Services, Routes, Plugins, and so on) on self-managed deployments.
+> If you're coming from {{site.ai_gateway}} 1.x, which used decK and Gateway plugins, see the [v2 migration guide](/ai-gateway/v2-migration-guide/) for how to move to the kongctl-managed entity model.
+
+{{site.ai_gateway}} resources are regional.
+Make sure your active kongctl profile's `konnect.region` matches the region where your {{site.ai_gateway}} lives (`us`, `eu`, `au`, `me`, `in`, or `sg`).
+See [Configuration of kongctl](/kongctl/config/) for how to set this.
+
+## Declarative configuration
+
+In declarative mode, you describe the desired state of your resources in declarative configuration file and kongctl calculates and applies the diff.
+This is the recommended approach for most {{site.ai_gateway}} configuration because it lets you store configuration in source control and apply it safely at any time.
+
+The {{site.ai_gateway}} [how-to guides](/how-to/?products=ai-gateway) use this approach.
+
+### Workflow
+
+Use the following workflow to manage {{site.ai_gateway}} resources declaratively:
+
+1. Write a configuration file describing the resources you want.
+2. Run `kongctl plan -f example.yaml` to preview what will change (optional but recommended).
+3. Run `kongctl apply -f example.yaml` to create or update resources.
+4. Run `kongctl sync -f example.yaml` when you want kongctl to also delete resources that are no longer in the file.
+
+For example, this configuration file creates an {{site.ai_gateway}}:
+
+```yaml
+_defaults:
+  kongctl:
+    namespace: my-namespace
+
+ai_gateways:
+  - ref: my-ai-gateway
+    name: my-ai-gateway
+```
+
+Save this as `ai-gateway.yaml`, then preview what will change:
+
+```bash
+kongctl plan -f ai-gateway.yaml --pat "$KONNECT_TOKEN"
+```
+
+Then apply:
+
+```bash
+kongctl apply -f ai-gateway.yaml --pat "$KONNECT_TOKEN"
+```
+
+For a step-by-step guide, see [Get started with {{site.ai_gateway}}](/ai-gateway/get-started/), which walks through creating an AI Provider and AI Model using `kongctl apply`.
+
+For the full declarative configuration reference, see [Declarative configuration with kongctl](/kongctl/declarative/).
+
+### Resource schemas
+
+To look up field names and required fields for any resource type, use `kongctl explain`:
+
+```bash
+kongctl explain ai_gateway_model_providers
+```
+
+Use `kongctl scaffold` to generate starter YAML for a resource type:
+
+```bash
+kongctl scaffold ai_gateway_model_providers
+```
+
+See the [kongctl declarative resource reference](/kongctl/supported-resources/#ai-gateway) for all supported resource types.
+
+### Adopting an existing {{site.ai_gateway}}
+
+If you create an {{site.ai_gateway}} using declarative configuration, kongctl tracks it in the namespace automatically.
+
+If an {{site.ai_gateway}} already exists in {{site.konnect_product_name}} (for example, one provisioned outside of kongctl), use [`kongctl adopt`](/kongctl/adopt/) to bring it into a namespace before managing it declaratively:
+
+```sh
+kongctl adopt ai-gateway "$AI_GATEWAY_ID" \
+    --namespace my-namespace \
+    --pat "$KONNECT_TOKEN"
+```
+
+`adopt` registers the existing {{site.ai_gateway}} with a kongctl namespace so it can be tracked.
+Pre-existing resources need to be adopted before kongctl includes them in plan and sync operations.
+
+You can reference the {{site.ai_gateway}} in your configuration files using `_external`.
+`_external` tells kongctl to look up the resource without taking ownership of it in the current configuration.
+For example, here the gateway is managed (adopted), but not owned by this configuration file:
+
+```yaml
+ai_gateways:
+  - ref: my-ai-gateway
+    _external:
+      selector:
+        matchFields:
+          name: "my-ai-gateway"
+
+ai_gateway_model_providers:
+  - ref: openai-primary
+    ai_gateway: my-ai-gateway
+    name: openai-primary
+    type: openai
+    config:
+      auth:
+        type: basic
+        name: Authorization
+        value: "Bearer !env OPENAI_API_KEY"
+```
+
+### Commands reference
+
+These are the commands you'll use most often in a declarative workflow:
+
+{% include_cached /kongctl/commands-reference-table.md %}
+
+## Imperative commands
+
+For inspection and one-off operations, use [`kongctl get`](/kongctl/get/), [`kongctl create`](/kongctl/create/), and [`kongctl delete`](/kongctl/delete/) directly.
+These commands don't require a configuration file and take effect immediately without going through a plan.
+
+List all {{site.ai_gateway}} instances in your organization:
+
+```sh
+kongctl get ai-gateways
+```
+
+List resources scoped to a specific {{site.ai_gateway}}, for example:
+
+```sh
+kongctl get ai-gateway model-providers --gateway-name "my-ai-gateway"
+kongctl get ai-gateway models --gateway-name "my-ai-gateway"
+kongctl get ai-gateway policies --gateway-name "my-ai-gateway"
+kongctl get ai-gateway consumers --gateway-name "my-ai-gateway"
+kongctl get ai-gateway mcp-servers --gateway-name "my-ai-gateway"
+```
+
+Pass `--help` to any subcommand to see available flags and filtering options.
+For example, passing it to `kongctl get ai-gateway` will give you a list of all {{site.ai_gateway}} resources kongctl can manage:
+
+```sh
+kongctl get ai-gateway --help
+```

--- a/app/ai-gateway/kongctl.md
+++ b/app/ai-gateway/kongctl.md
@@ -57,7 +57,7 @@ See [Configuration of kongctl](/kongctl/config/) for how to set this.
 
 ## Declarative configuration
 
-In declarative mode, you describe the desired state of your resources in declarative configuration file and kongctl calculates and applies the diff.
+In declarative mode, you describe the desired state of your resources in declarative configuration files and kongctl calculates and applies the diff.
 This is the recommended approach for most {{site.ai_gateway}} configuration because it lets you store configuration in source control and apply it safely at any time.
 
 The {{site.ai_gateway}} [how-to guides](/how-to/?products=ai-gateway) use this approach.

--- a/app/kongctl/config.md
+++ b/app/kongctl/config.md
@@ -109,16 +109,20 @@ default:
 
 ## Environment variables
 
-When values are loaded via environment variables, the variable names 
-must start with the `KONGCTL_` prefix, then the desired profile, 
-and finally the config path in uppercase with underscores instead of dots. 
+When values are loaded via environment variables, the variable names
+must start with the `KONGCTL_` prefix, then the desired profile,
+and finally the config path in uppercase with underscores instead of dots.
 
-For example, to set the same region value for the default profiles, 
+For example, to set the same region value for the default profiles,
 set the following environment variable:
 
 ```text
 KONGCTL_DEFAULT_KONNECT_REGION=eu
 ```
+
+{:.info}
+> **Note**: The `KONGCTL_` prefix is for configuring the kongctl CLI itself.
+> To inject environment variable values into declarative resource configuration files, use the [`!env` YAML tag](/kongctl/declarative/#loading-values-from-environment-variables) instead.
 
 
 ## Configuration file

--- a/app/kongctl/declarative.md
+++ b/app/kongctl/declarative.md
@@ -271,6 +271,7 @@ of them support child resources underneath them.
 - `analytics.dashboards`
 - `organization.teams`
 - `event_gateways`
+- `ai_gateways`
 
 **Child resource examples**:
 
@@ -284,6 +285,12 @@ of them support child resources underneath them.
 - `portal.custom_domain`
 - `portal.email_config`
 - `portal.email_templates`
+- `ai_gateway.model_providers`
+- `ai_gateway.models`
+- `ai_gateway.policies`
+- `ai_gateway.consumers`
+- `ai_gateway.mcp_servers`
+- `ai_gateway.agents`
 
 See the [kongctl declarative resource reference](/kongctl/supported-resources/) for more details on supported resources.
 
@@ -708,61 +715,7 @@ not provide a safe observable signal for that update.
 kongctl includes many commands for declarative configuration management.
 Start with the following commands for most use cases:
 
-{% table %}
-columns:
-  - title: Command
-    key: command
-  - title: Description
-    key: description
-  - title: When to use
-    key: when
-rows:
-  - command: |
-      [`adopt`](/kongctl/adopt/)
-    description: |
-      Adds a namespace label to an existing {{site.konnect_short_name}} resource that was created outside of kongctl, bringing it under declarative management without modifying any other fields.
-    when: |
-      Use before your first `dump` or `plan`, when you need to bring manually-created or UI-created resources into your configuration set.
-  - command: |
-      [`dump`](/kongctl/dump/)
-    description: |
-      Exports the current state of {{site.konnect_short_name}} resources to a declarative YAML configuration file.
-    when: |
-      Use when bootstrapping a new declarative configuration from existing live resources, or when generating a starting point for a new configuration file.
-  - command: |
-      [`plan`](/kongctl/plan/)
-    description: |
-      Compares your local configuration files against live {{site.konnect_short_name}} state and generates a JSON plan artifact describing the changes to be made.
-    when: |
-      Use before applying changes, especially in CI/CD pipelines, to produce a reviewable and reusable plan artifact.
-  - command: |
-      [`diff`](/kongctl/diff/)
-    description: |
-      Displays a human-readable preview of the changes between the current live state and the desired state in your configuration files, or from a saved plan artifact.
-    when: |
-      Use during development or code review to inspect what `plan` or `sync` would change before committing changes.
-  - command: |
-      [`apply`](/kongctl/apply/)
-    description: |
-      Creates and updates resources to match the desired state. Doesn't delete any resources.
-    when: |
-      Use when you want to incrementally apply configuration without risk of deleting anything. 
-      Use `sync` instead when you want to apply deletes as well.
-  - command: |
-      [`sync`](/kongctl/sync/)
-    description: |
-      Applies the full desired state from your configuration files. Creates, updates, and deletes resources.
-    when: |
-      Use when you want full reconciliation between your configuration and live state, including deletions. 
-      Use `apply` instead if you only want creates and updates.
-  - command: |
-      [`delete`](/kongctl/delete/)
-    description: |
-      Plans and executes deletion of all resources defined in the input configuration files.
-    when: |
-      Use for tearing down a known set of resources, such as resetting a test environment. 
-      Not a typical step in the day-to-day declarative workflow.
-{% endtable %}
+{% include_cached /kongctl/commands-reference-table.md %}
 
 See the CLI help at `kongctl --help` for all possible commands, or check out the [kongctl CLI reference](/index/kongctl/#cli-reference) documentation.
 

--- a/app/kongctl/skills.md
+++ b/app/kongctl/skills.md
@@ -77,8 +77,7 @@ agent:
 
 - Discover supported resource fields with `kongctl explain`.
 - Generate starter YAML with `kongctl scaffold`.
-- Create manifests for APIs, Dev Portals, control planes, and other supported
-  resources.
+- Create manifests for APIs, Dev Portals, control planes, {{site.ai_gateway}} resources, and other supported resources.
 - Integrate decK Gateway state through `_deck`.
 - Generate API configuration from OpenAPI documents.
 - Work through plan, diff, apply, sync, delete, and adopt workflows.

--- a/app/kongctl/supported-resources.md
+++ b/app/kongctl/supported-resources.md
@@ -865,3 +865,428 @@ audit-logs:
           matchFields:
             name: foo
 ```
+
+## {{site.ai_gateway}}
+
+This section covers the {{site.ai_gateway}} resources supported by kongctl.
+Use `kongctl explain ai_gateways --output yaml` as the authoritative schema for nested {{site.ai_gateway}} resources and fields, and use `kongctl scaffold ai_gateways` to generate starter YAML.
+
+* [{{site.ai_gateway}} entities reference](/ai-gateway/entities/)
+* [Using kongctl to manage {{site.ai_gateway}}](/ai-gateway/kongctl/)
+* [Get started with {{site.ai_gateway}}](/ai-gateway/get-started/)
+
+### {{site.ai_gateway}}s
+
+```yaml
+ai_gateways:
+  - ref: string
+    name: string required
+    display_name: string required
+    description: string (nullable)
+    proxy_urls: array[object]
+      - host: string required
+        port: integer required
+        protocol: string required
+    labels: object [string]string
+      key: value
+    model_providers: # see AI Model Providers
+    identity_providers: # see AI Identity Providers
+    policies: # see AI Policies
+    agents: # see AI Agents
+    consumers: # see AI Consumers
+    consumer_groups: # see AI Consumer Groups
+    models: # see AI Models
+    mcp_servers: # see AI MCP Servers
+    vaults: # see AI Vaults
+    data_plane_certificates:
+      - ref: string
+        title: string required
+        description: string (nullable)
+        cert: string required # PEM-encoded certificate; prefer: !file ./certs/data-plane.pem
+```
+
+### AI Model Providers
+
+[AI Model Providers](/ai-gateway/entities/ai-model-provider/) define connections to upstream LLM services and store authentication credentials.
+The `type` field determines the provider and the shape of `config.auth`.
+
+Most providers use `type: basic` auth with a `headers` array.
+AWS Bedrock supports `type: aws` for IAM credentials.
+Azure supports `type: azure` for service principal or managed identity auth.
+Gemini and Vertex support `type: gcp` for service account auth.
+
+```yaml
+ai_gateway_model_providers:
+  - ref: string
+    ai_gateway: string required # prefer: !ref <ai-gateway-ref>
+    name: string required
+    display_name: string required
+    labels: object [string]string
+      key: value
+    # Basic auth (used by openai, anthropic, cerebras, cohere, dashscope,
+    # databricks, deepseek, huggingface, kimi, llama2, mistral, ollama,
+    # vercel, vllm, xai, and as an option for bedrock, azure, gemini, vertex)
+    type: One of (openai | anthropic | cerebras | cohere | dashscope | databricks | deepseek | huggingface | kimi | llama2 | mistral | ollama | vercel | vllm | xai | bedrock | azure | gemini | vertex) required
+    config:
+      auth:
+        type: basic required
+        headers: # at least one of headers or params
+          - name: string required
+            value: string
+        params:
+          - name: string required
+            value: string
+            location: One of (body | query)
+    # AWS Bedrock with IAM credentials (type=bedrock, auth type=aws)
+    # type: bedrock
+    # config:
+    #   auth:
+    #     type: aws
+    #     access_key_id: string # prefer: !env AWS_ACCESS_KEY_ID
+    #     secret_access_key: string # prefer: !env AWS_SECRET_ACCESS_KEY
+    #     assume_role_arn: string (nullable)
+    #     role_session_name: string (nullable)
+    #     sts_endpoint_url: string (nullable)
+    #     batch_role_arn: string (nullable)
+    # Azure with service principal (type=azure, auth type=azure)
+    # type: azure
+    # config:
+    #   auth:
+    #     type: azure
+    #     client_id: string # prefer: !env AZURE_CLIENT_ID
+    #     client_secret: string # prefer: !env AZURE_CLIENT_SECRET
+    #     tenant_id: string # prefer: !env AZURE_TENANT_ID
+    #     use_managed_identity: boolean
+    #   instance: string # Azure instance name
+    # GCP-based providers (type=gemini or type=vertex, auth type=gcp)
+    # type: gemini # or vertex
+    # config:
+    #   auth:
+    #     type: gcp
+    #     service_account_json: string # prefer: !env GCP_SERVICE_ACCOUNT_JSON
+    #     metadata_url: string (nullable)
+    #     oauth_token_url: string (nullable)
+    #     use_gcp_service_account: boolean
+```
+{:.collapsible}
+
+### AI Models
+
+[AI Models](/ai-gateway/entities/ai-model/) declare which upstream models are available, configure routing, and specify which AI Model Provider to use.
+
+```yaml
+ai_gateway_models:
+  - ref: string
+    ai_gateway: string required # prefer: !ref <ai-gateway-ref>
+    name: string required
+    display_name: string required
+    enabled: boolean
+    type: One of (model | api) required
+    formats: array[object] required
+      - type: string required (for example openai)
+    config:
+      route: object required
+        paths: array[string]
+        hosts: array[string]
+        methods: array[string]
+        protocols: array[string]
+        headers: object
+        strip_path: boolean
+        preserve_host: boolean
+        regex_priority: integer
+        https_redirect_status_code: integer
+        request_buffering: boolean
+        response_buffering: boolean
+        tags: array[string]
+      model: object
+        alias: string
+      logging: object
+        payloads: boolean
+        statistics: boolean
+      response_streaming: One of (allow | deny | always)
+      max_request_body_size: integer
+      balancer: object
+      proxy: object
+    targets: array[object] required
+      - name: string required # upstream model name (for example gpt-4o)
+        provider: string required # AI Model Provider name
+        weight: integer
+        semantic_description: string
+        allow_auth_override: boolean
+        config:
+          type: One of (openai | anthropic | azure | bedrock | cerebras | cohere | dashscope | databricks | deepseek | gemini | huggingface | kimi | llama2 | mistral | ollama | vercel | vertex | vllm | xai) required
+          upstream_url: string (nullable)
+          # anthropic
+          version: string
+          # azure
+          deployment_id: string
+          api_version: string
+          # bedrock
+          region: string
+          # and more provider-specific fields; run `kongctl explain ai_gateway_models` for full detail
+    access: object
+      acls:
+        oneOf:
+          allow: array[string] # consumer group names
+          deny: array[string]
+      identity_providers: array[string] # identity provider names
+    capabilities: array[string] # for example [generate]
+    policies: array[string] # policy names; prefer: !ref values
+    labels: object [string]string
+      key: value
+```
+{:.collapsible}
+
+### AI Identity Providers
+
+[AI Identity Providers](/ai-gateway/entities/ai-identity-provider/) configure authentication for {{site.ai_gateway}} endpoints.
+
+```yaml
+ai_gateway_identity_providers:
+  - ref: string
+    ai_gateway: string required # prefer: !ref <ai-gateway-ref>
+    name: string required
+    display_name: string required
+    labels: object [string]string
+      key: value
+    type: One of (key-auth | openid-connect) required
+    # Key auth
+    config: # if type=key-auth
+      hide_credentials: boolean
+      key_in_body: boolean
+      key_in_header: boolean
+      key_in_query: boolean
+      key_names: array[string] required
+    # OIDC
+    # config: # if type=openid-connect
+    #   issuer: string required
+    #   client_id: array[string]
+    #   client_secret: array[string] # write-only; prefer: !env
+    #   scopes: array[string]
+    #   auth_methods: array[string]
+    #   consumer_claims: array[string]
+    #   consumer_optional: boolean
+    #   cache_tokens_salt: string
+    #   ssl_verify: boolean
+```
+
+### AI Policies
+
+[AI Policies](/ai-gateway/entities/ai-policy/) apply rules to requests and responses passing through {{site.ai_gateway}}.
+
+```yaml
+ai_gateway_policies:
+  - ref: string
+    ai_gateway: string required # prefer: !ref <ai-gateway-ref>
+    name: string required
+    display_name: string required
+    type: string required # for example ai-sanitizer
+    enabled: boolean
+    global: boolean
+    config: object # policy-specific configuration
+    labels: object [string]string
+      key: value
+```
+
+### AI Consumers
+
+[AI Consumers](/ai-gateway/entities/ai-consumer/) represent clients that access {{site.ai_gateway}} endpoints.
+
+```yaml
+ai_gateway_consumers:
+  - ref: string
+    ai_gateway: string required # prefer: !ref <ai-gateway-ref>
+    name: string required
+    display_name: string required
+    type: One of (api-key) required
+    custom_id: string (nullable)
+    policies: array[string] # policy names; prefer: !ref values
+    credentials:
+      - ref: string
+        ai_gateway_consumer: string required # prefer: !ref <consumer-ref>
+        name: string required
+        display_name: string required
+        type: One of (api-key) required
+        ttl: integer
+        labels: object [string]string
+          key: value
+    labels: object [string]string
+      key: value
+```
+
+### AI Consumer Groups
+
+[AI Consumer Groups](/ai-gateway/entities/ai-consumer-group/) collect consumers so that policies can be applied to them as a set.
+
+```yaml
+ai_gateway_consumer_groups:
+  - ref: string
+    ai_gateway: string required # prefer: !ref <ai-gateway-ref>
+    name: string required
+    display_name: string required
+    consumers: array[string] # consumer names; prefer: !ref <consumer-ref>#name
+    policies: array[string] # policy names; prefer: !ref values
+    labels: object [string]string
+      key: value
+```
+
+### AI MCP Servers
+
+[AI MCP Servers](/ai-gateway/entities/ai-mcp-server/) expose Model Context Protocol tool endpoints through {{site.ai_gateway}}.
+The `type` controls how the server is exposed: `conversion-only` converts MCP to REST without a listener, `listener` creates a dedicated MCP listener, `passthrough-listener` forwards MCP traffic as-is, and `upstream-server` proxies to an upstream MCP server.
+
+```yaml
+ai_gateway_mcp_servers:
+  - ref: string
+    ai_gateway: string required # prefer: !ref <ai-gateway-ref>
+    name: string required
+    display_name: string required
+    enabled: boolean
+    type: One of (conversion-only | conversion-listener | listener | passthrough-listener | upstream-server) required
+    config:
+      url: string required # upstream MCP server URL
+      route: object
+        paths: array[string]
+        hosts: array[string]
+        methods: array[string]
+        protocols: array[string]
+        headers: object
+        strip_path: boolean
+        preserve_host: boolean
+        regex_priority: integer
+        https_redirect_status_code: integer
+        request_buffering: boolean
+        response_buffering: boolean
+        tags: array[string]
+      logging: object
+        payloads: boolean
+        statistics: boolean
+        audits: boolean
+      max_request_body_size: integer
+      server: object
+      proxy: object
+      tools_cache_ttl_seconds: integer
+    tools: array[object]
+      - name: string required
+        description: string
+        method: string required # for example GET
+        path: string required # for example /customers/{customer_id}
+        scheme: string
+        host: string
+        headers: object
+        query: object
+        request_body: object
+        responses: object
+        parameters: array[object]
+          - name: string required
+            in: One of (path | query | header) required
+            description: string
+            required: boolean
+            schema: object
+        annotations: object
+          title: string
+          read_only_hint: boolean
+          destructive_hint: boolean
+          idempotent_hint: boolean
+          open_world_hint: boolean
+        input_schema: object
+        output_schema: object
+        access: object
+          acls:
+            oneOf:
+              allow: array[string]
+              deny: array[string]
+    access: object # for listener, passthrough-listener, conversion-listener, upstream-server types
+      acl_attribute_type: One of (consumer)
+      access_token_claim_field: string
+      acls:
+        oneOf:
+          allow: array[string]
+          deny: array[string]
+      default_tool_acls:
+        oneOf:
+          allow: array[string]
+          deny: array[string]
+    policies: array[string] # policy names
+    labels: object [string]string
+      key: value
+```
+{:.collapsible}
+
+### AI Agents
+
+[AI Agents](/ai-gateway/entities/ai-agent/) expose agent-to-agent (A2A) endpoints through {{site.ai_gateway}}.
+
+```yaml
+ai_gateway_agents:
+  - ref: string
+    ai_gateway: string required # prefer: !ref <ai-gateway-ref>
+    name: string required
+    display_name: string required
+    type: One of (a2a) required
+    enabled: boolean
+    config:
+      url: string required # upstream agent URL
+      route: object
+        paths: array[string]
+        hosts: array[string]
+        methods: array[string]
+        protocols: array[string]
+        headers: object
+        strip_path: boolean
+        preserve_host: boolean
+        regex_priority: integer
+        https_redirect_status_code: integer
+        request_buffering: boolean
+        response_buffering: boolean
+        tags: array[string]
+      max_request_body_size: integer
+      logging: object
+        payloads: boolean
+        statistics: boolean
+        max_payload_size: integer
+    access: object
+      acls:
+        oneOf:
+          allow: array[string] # consumer group names
+          deny: array[string]
+    policies: array[string] # policy names; prefer: !ref values
+    labels: object [string]string
+      key: value
+```
+{:.collapsible}
+
+### AI Vaults
+
+[AI Vaults](/ai-gateway/entities/ai-vault/) store secrets and credentials for use by {{site.ai_gateway}} resources.
+The `type` field determines the backend and the shape of `config`.
+
+```yaml
+ai_gateway_vaults:
+  - ref: string
+    ai_gateway: string required # prefer: !ref <ai-gateway-ref>
+    name: string required
+    description: string (nullable)
+    type: One of (env | konnect | aws | gcp | azure | conjur | hcv) required
+    labels: object [string]string
+      key: value
+    # Environment variables (type=env)
+    config: # if type=env
+      prefix: string required
+      base64_decode: boolean
+    # Konnect Config Store (type=konnect)
+    # config: # if type=konnect
+    #   config_store_id: string required
+    # AWS Secrets Manager (type=aws)
+    # config: # if type=aws
+    #   region: string required
+    # GCP Secret Manager (type=gcp)
+    # config: # if type=gcp
+    #   project_id: string required
+    # Azure Key Vault (type=azure)
+    # config: # if type=azure
+    #   vault_uri: string required
+    # HashiCorp Vault (type=hcv) and Conjur (type=conjur)
+    # config: # provider-specific; run `kongctl explain ai_gateway_vaults` for full detail
+```
+{:.collapsible}

--- a/app/kongctl/supported-resources.md
+++ b/app/kongctl/supported-resources.md
@@ -877,6 +877,8 @@ Use `kongctl explain ai_gateways --output yaml` as the authoritative schema for 
 
 ### {{site.ai_gateway}}s
 
+[{{site.ai_gateway}}s](/ai-gateway/) are the top-level resource that contains other {{site.ai_gateway}} resources.
+
 ```yaml
 ai_gateways:
   - ref: string


### PR DESCRIPTION
## Description
* Adds a page for kongctl & ai gateway at `/ai-gateway/kongctl/`
  * I think this would fit more naturally the other way: `/kongctl/ai-gateway/`, however, I believe we need this exact URL for decK
* adds schemas for all the supported ai gateway resources (generated through `explain` and `scaffold`; we should automate this in the future and ideally add it to entity reference pages)
* adds the reference to the AIGW landing page and index
* minor edits to other pages

## Previews
https://deploy-preview-5957--kongdeveloper.netlify.app/ai-gateway/kongctl/
https://deploy-preview-5957--kongdeveloper.netlify.app/kongctl/supported-resources/
https://deploy-preview-5957--kongdeveloper.netlify.app/ai-gateway/