### PR TITLE
Fix(ai-gateway): duplicate konctl prereq

### DIFF
--- a/app/_how-tos/ai-gateway/get-started-with-ai-agent.md
+++ b/app/_how-tos/ai-gateway/get-started-with-ai-agent.md
@@ -34,8 +34,6 @@ tools:
 
 prereqs:
   inline:
-    - title: Configure kongctl
-      include_content: md/ai-gateway/v2/prereqs/kongctl
     - title: OpenAI API key
       content: |
         1. [Create an OpenAI account](https://auth.openai.com/create-account).


### PR DESCRIPTION

## Description

This fix removes the duplicate kongctl instructions on [this guide](https://release-ai-gateway-2-0--kongdeveloper.netlify.app/ai-gateway/get-started-with-ai-agent/). I followed the model already in [the get started guide](https://release-ai-gateway-2-0--kongdeveloper.netlify.app/ai-gateway/get-started/) to fix it.

## Preview Links

https://deploy-preview-5970--kongdeveloper.netlify.app/ai-gateway/get-started-with-ai-agent/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
