### PR TITLE
fix(ai-gateway): replace YOUR_OPENAI_API_KEY with OPENAI_API_KEY

### DIFF
--- a/app/_how-tos/ai-gateway/get-started-with-ai-agent.md
+++ b/app/_how-tos/ai-gateway/get-started-with-ai-agent.md
@@ -34,8 +34,6 @@ tools:
 
 prereqs:
   inline:
-    - title: Configure kongctl
-      include_content: md/ai-gateway/v2/prereqs/kongctl
     - title: OpenAI API key
       content: |
         1. [Create an OpenAI account](https://auth.openai.com/create-account).

--- a/app/_includes/md/ai-gateway/v2/prereqs/a2a-agent.md
+++ b/app/_includes/md/ai-gateway/v2/prereqs/a2a-agent.md
@@ -9,7 +9,7 @@ services:
     container_name: a2a-kongair-agent
     image: ghcr.io/tomek-labuk/a2a-kongair-openai-agent:1.0.0
     environment:
-      - OPENAI_API_KEY=${YOUR_OPENAI_API_KEY}
+      - OPENAI_API_KEY=${OPENAI_API_KEY}
       - OPENAI_MODEL=gpt-5-mini
       - KONGAIR_BASE_URL=https://api.kong-air.com
       - PUBLIC_AGENT_URL=http://localhost:10000


### PR DESCRIPTION

## Description

This fix targets an include ([used only once in this file so far](https://release-ai-gateway-2-0--kongdeveloper.netlify.app/ai-gateway/get-started-with-ai-agent/#a2a-agent)) by replacing `YOUR_OPENAI_API_KEY` by `OPENAI_API_KEY`, as this is the name of the variable saved in the session [when setting up OpenAI](https://release-ai-gateway-2-0--kongdeveloper.netlify.app/ai-gateway/get-started-with-ai-agent/#a2a-agent) in how-tos.

Fixes #issue

## Preview Links

https://deploy-preview-5971--kongdeveloper.netlify.app/ai-gateway/get-started-with-ai-agent/#a2a-agent

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
