### PR TITLE
Update API spec reference in documentation

### DIFF
--- a/app/kong-identity/principals-and-directories.md
+++ b/app/kong-identity/principals-and-directories.md
@@ -7,7 +7,7 @@ products:
   - identity
   - konnect
 api_specs:
-    - konnect/kong-identity
+    - konnect/kong-identity-principals
 works_on:
   - konnect
 


### PR DESCRIPTION
Incorrectly pointed to the auth server API, should point to the principals API

<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

This page incorrectly links to the Auth Server API spec, should link to the Principal spec.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
