### PR TITLE
fix(cgw): Notes about file system vault and custom plugin streaming support

### DIFF
--- a/app/_gateway_entities/vault.md
+++ b/app/_gateway_entities/vault.md
@@ -1225,6 +1225,8 @@ rows:
 {% new_in 3.15 %} The file system vault reads secrets from files on the {{site.base_gateway}} data plane's local filesystem.
 The file system vault doesn't require any external services or credentials.
 
+{% include /gateway/file-system-vault-cloud-unsupported.md %}
+
 Secrets can be plain text files or JSON files. Set `vaults.config.prefix` to the directory containing your secret files, then reference secrets relative to that directory:
 
 <!--vale off-->

--- a/app/_gateway_entities/vault.md
+++ b/app/_gateway_entities/vault.md
@@ -1225,7 +1225,7 @@ rows:
 {% new_in 3.15 %} The file system vault reads secrets from files on the {{site.base_gateway}} data plane's local filesystem.
 The file system vault doesn't require any external services or credentials.
 
-{% include /gateway/file-system-vault-cloud-unsupported.md %}
+{% include_cached /gateway/file-system-vault-cloud-unsupported.md %}
 
 Secrets can be plain text files or JSON files. Set `vaults.config.prefix` to the directory containing your secret files, then reference secrets relative to that directory:
 

--- a/app/_how-tos/gateway/configure-file-system-as-a-vault-backend.md
+++ b/app/_how-tos/gateway/configure-file-system-as-a-vault-backend.md
@@ -118,7 +118,7 @@ next_steps:
 automated_tests: false
 ---
 
-{% include /gateway/file-system-vault-cloud-unsupported.md %}
+{% include_cached /gateway/file-system-vault-cloud-unsupported.md %}
 
 ## Create a Vault entity for the file system vault
 

--- a/app/_how-tos/gateway/configure-file-system-as-a-vault-backend.md
+++ b/app/_how-tos/gateway/configure-file-system-as-a-vault-backend.md
@@ -118,6 +118,8 @@ next_steps:
 automated_tests: false
 ---
 
+{% include /gateway/file-system-vault-cloud-unsupported.md %}
+
 ## Create a Vault entity for the file system vault
 
 Using decK, create a [Vault](/gateway/entities/vault/) entity that points to your secrets directory:

--- a/app/_how-tos/gateway/stream-custom-plugins.md
+++ b/app/_how-tos/gateway/stream-custom-plugins.md
@@ -66,15 +66,15 @@ Normally, deploying a custom plugin requires uploading Lua files to every data p
 With streaming plugins, you define the plugin schema and handler directly in your {{site.base_gateway}} entity configuration. 
 The control plane becomes the single source of truth and distributes the plugin to all connected data planes automatically, with no file management or restarts needed.
 
-{:.warning}
-> Custom plugin streaming isn't supported on Serverless Gateways. It's supported on Dedicated Cloud Gateways and self-managed hybrid-mode deployments.
-
 In this guide, you'll define two plugins inline to demonstrate how streaming works:
 
 * `replaceme`: Substitutes a target word in the request body with a replacement word before forwarding to the upstream.
 * `reflector`: Returns the request body directly to the caller, bypassing the upstream. This lets you inspect the modified body without needing an external service.
 
 You'll apply `replaceme` globally with a condition so it only runs when the request path does not contain the word `skip`, then validate both cases.
+
+{:.warning}
+> Custom plugin streaming isn't supported on Serverless Gateways. It's supported on Dedicated Cloud Gateways and self-managed hybrid-mode deployments.
 
 ## Create the first plugin
 

--- a/app/_how-tos/gateway/stream-custom-plugins.md
+++ b/app/_how-tos/gateway/stream-custom-plugins.md
@@ -66,6 +66,9 @@ Normally, deploying a custom plugin requires uploading Lua files to every data p
 With streaming plugins, you define the plugin schema and handler directly in your {{site.base_gateway}} entity configuration. 
 The control plane becomes the single source of truth and distributes the plugin to all connected data planes automatically, with no file management or restarts needed.
 
+{:.warning}
+> Custom plugin streaming isn't supported on Serverless Gateways. It's supported on Dedicated Cloud Gateways and self-managed hybrid-mode deployments.
+
 In this guide, you'll define two plugins inline to demonstrate how streaming works:
 
 * `replaceme`: Substitutes a target word in the request body with a replacement word before forwarding to the upstream.

--- a/app/_how-tos/gateway/stream-custom-plugins.md
+++ b/app/_how-tos/gateway/stream-custom-plugins.md
@@ -73,8 +73,7 @@ In this guide, you'll define two plugins inline to demonstrate how streaming wor
 
 You'll apply `replaceme` globally with a condition so it only runs when the request path does not contain the word `skip`, then validate both cases.
 
-{:.warning}
-> Custom plugin streaming isn't supported on Serverless Gateways. It's supported on Dedicated Cloud Gateways and self-managed hybrid-mode deployments.
+{% include_cached /gateway/custom-plugin-streaming-serverless-unsupported.md %}
 
 ## Create the first plugin
 

--- a/app/_includes/gateway/custom-plugin-streaming-serverless-unsupported.md
+++ b/app/_includes/gateway/custom-plugin-streaming-serverless-unsupported.md
@@ -1,0 +1,2 @@
+{:.warning}
+> Custom plugin streaming isn't supported on Serverless Gateways. It's supported on Dedicated Cloud Gateways and self-managed {{site.base_gateway}} deployments (hybrid mode, traditional, and DB-less).

--- a/app/_includes/gateway/file-system-vault-cloud-unsupported.md
+++ b/app/_includes/gateway/file-system-vault-cloud-unsupported.md
@@ -1,0 +1,2 @@
+{:.warning}
+> **Cloud Gateway limitations:** The file system vault backend **is not** supported on Dedicated Cloud Gateways or Serverless Gateways: Cloud Gateways don't provide access to the data plane's local filesystem, so secret files can't be stored there.

--- a/app/_includes/gateway/file-system-vault-cloud-unsupported.md
+++ b/app/_includes/gateway/file-system-vault-cloud-unsupported.md
@@ -1,2 +1,2 @@
 {:.warning}
-> **Cloud Gateway limitations:** The file system vault backend **is not** supported on Dedicated Cloud Gateways or Serverless Gateways. Cloud Gateways don't provide access to the data plane's local filesystem, so secret files can't be stored there.
+> **Cloud Gateway limitations:** The file system vault backend **is not** supported on Dedicated Cloud Gateways or Serverless Gateways. These gateways don't provide access to the data plane's local filesystem, so secret files can't be stored there.

--- a/app/_includes/gateway/file-system-vault-cloud-unsupported.md
+++ b/app/_includes/gateway/file-system-vault-cloud-unsupported.md
@@ -1,2 +1,2 @@
 {:.warning}
-> **Cloud Gateway limitations:** The file system vault backend **is not** supported on Dedicated Cloud Gateways or Serverless Gateways: Cloud Gateways don't provide access to the data plane's local filesystem, so secret files can't be stored there.
+> **Cloud Gateway limitations:** The file system vault backend **is not** supported on Dedicated Cloud Gateways or Serverless Gateways. Cloud Gateways don't provide access to the data plane's local filesystem, so secret files can't be stored there.

--- a/app/custom-plugins/streaming-plugins.md
+++ b/app/custom-plugins/streaming-plugins.md
@@ -33,6 +33,9 @@ related_resources:
 
 You can define a custom plugin directly in Kong entity configuration.
 
+{:.warning}
+> Custom plugin streaming isn't supported on Serverless Gateways. It's supported on Dedicated Cloud Gateways and self-managed hybrid-mode deployments.
+
 ## How does custom plugin streaming work? 
 
 {{site.base_gateway}} can stream custom plugins from the control plane to the data plane. 

--- a/app/custom-plugins/streaming-plugins.md
+++ b/app/custom-plugins/streaming-plugins.md
@@ -34,7 +34,7 @@ related_resources:
 You can define a custom plugin directly in Kong entity configuration.
 
 {:.warning}
-> Custom plugin streaming isn't supported on Serverless Gateways. It's supported on Dedicated Cloud Gateways and self-managed hybrid-mode deployments.
+> Custom plugin streaming isn't supported on Serverless Gateways. It's supported on Dedicated Cloud Gateways and self-managed {{site.base_gateway}} deployments (hybrid mode, traditional, and DB-less).
 
 ## How does custom plugin streaming work? 
 

--- a/app/custom-plugins/streaming-plugins.md
+++ b/app/custom-plugins/streaming-plugins.md
@@ -33,8 +33,7 @@ related_resources:
 
 You can define a custom plugin directly in Kong entity configuration.
 
-{:.warning}
-> Custom plugin streaming isn't supported on Serverless Gateways. It's supported on Dedicated Cloud Gateways and self-managed {{site.base_gateway}} deployments (hybrid mode, traditional, and DB-less).
+{% include_cached /gateway/custom-plugin-streaming-serverless-unsupported.md %}
 
 ## How does custom plugin streaming work? 
 

--- a/app/dedicated-cloud-gateways/reference.md
+++ b/app/dedicated-cloud-gateways/reference.md
@@ -81,6 +81,9 @@ faqs:
 
       {:.warning}
       > **Azure Key Vault is not supported as a Vault backend on Dedicated Cloud Gateways:** Azure Key Vault's client secret has no Vault entity equivalent. It's only read from an environment variable. Since Dedicated Cloud Gateways can't set that environment variable and don't support Azure managed identity as an alternative, Azure Key Vault can't be used as a Vault backend on Dedicated Cloud Gateways.
+  - q: Can I use the file system vault backend with Dedicated Cloud Gateways?
+    a: |
+      No. The file system vault backend isn't supported on Dedicated Cloud Gateways, since Dedicated Cloud Gateways don't provide access to the data plane's filesystem to store secret files.
 
 related_resources:
   - text: Dedicated Cloud Gateways 

--- a/app/dedicated-cloud-gateways/reference.md
+++ b/app/dedicated-cloud-gateways/reference.md
@@ -83,7 +83,7 @@ faqs:
       > **Azure Key Vault is not supported as a Vault backend on Dedicated Cloud Gateways:** Azure Key Vault's client secret has no Vault entity equivalent. It's only read from an environment variable. Since Dedicated Cloud Gateways can't set that environment variable and don't support Azure managed identity as an alternative, Azure Key Vault can't be used as a Vault backend on Dedicated Cloud Gateways.
   - q: Can I use the file system vault backend with Dedicated Cloud Gateways?
     a: |
-      No. The file system vault backend isn't supported on Dedicated Cloud Gateways, since Dedicated Cloud Gateways don't provide access to the data plane's filesystem to store secret files.
+      No. The file system vault backend isn't supported on Dedicated Cloud Gateways because they don't provide access to the data plane's local filesystem for storing secret files.
 
 related_resources:
   - text: Dedicated Cloud Gateways 

--- a/app/serverless-gateways/reference.md
+++ b/app/serverless-gateways/reference.md
@@ -295,4 +295,6 @@ The Serverless V1 egress IPs are:
 Serverless Gateways have the following limits:
 * Request rate limit: Serverless Gateways support up to 100 requests per second (RPS) per gateway.
 * Maximum request size: Incoming requests are limited to a maximum payload size of 10MB.
+* File system vault: The file system vault backend is not supported on Serverless Gateways.
+* Custom plugin streaming: Custom plugin streaming is not supported on Serverless Gateways.
 For workloads that exceed these limits, consider using [Dedicated Cloud Gateways](/dedicated-cloud-gateways/) for higher throughput and larger request sizes.


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes https://kongstrong.slack.com/archives/CDSTDSG9J/p1784123561228059

## Preview Links
- /gateway/entities/vault/#vault-provider-specific-configuration-parameters
- /how-to/configure-file-system-as-a-vault-backend/
- /how-to/stream-custom-plugins/
- /custom-plugins/streaming-plugins/
- /dedicated-cloud-gateways/reference/#can-i-use-the-file-system-vault-backend-with-dedicated-cloud-gateways
- /serverless-gateways/reference/#limits

**Note for reviewer:** It seems like `topologies:` isn't supported on reference, how-to, or landing pages. Would that be a better fix than the notes? Sometimes the info box is easy to miss.

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
