### PR TITLE
feat(insomnia): set max_token in AI settings

### DIFF
--- a/app/_data/products/insomnia.yml
+++ b/app/_data/products/insomnia.yml
@@ -45,4 +45,6 @@ releases:
     version: "12.6.0"
   - release: "13.0"
     version: "13.0.0"
+  - release: "13.1"
+    version: "13.1.0"
     latest: true

--- a/app/_landing_pages/insomnia/ai-in-insomnia.yaml
+++ b/app/_landing_pages/insomnia/ai-in-insomnia.yaml
@@ -174,6 +174,10 @@ rows:
                   When deactivated, the desktop app shows an explanatory message.  
                   When activated, each user must still activate a model before toggles become available.
                   This setting is available only for Enterprise plans.
+              - q: Can I set a token limit per request from {{ site.data.products.insomnia.name }}?
+                a: |
+                  Yes. Go to **Preferences** > **AI Settings** > **LLM URL**, then enter your LLM URL and API token to open **Advanced Options**, where you can [set a maximum number of tokens per request](/insomnia/mcp-clients-in-insomnia/#set-a-token-limit-per-request). If you use a hosted provider, enter its provider URL, such as `https://api.openai.com/v1`.
+
               - q: Which transports are supported for MCP Clients?
                 a: |
                   Both **HTTP** and **STDIO** transports are supported for connecting to MCP Servers.

--- a/app/_landing_pages/insomnia/ai-in-insomnia.yaml
+++ b/app/_landing_pages/insomnia/ai-in-insomnia.yaml
@@ -174,7 +174,7 @@ rows:
                   When deactivated, the desktop app shows an explanatory message.  
                   When activated, each user must still activate a model before toggles become available.
                   This setting is available only for Enterprise plans.
-              - q: Can I set a token limit per request from {{ site.data.products.insomnia.name }}?
+              - q: Can I set a token limit per request in {{ site.data.products.insomnia.name }}?
                 a: |
                   Yes. Go to **Preferences** > **AI Settings** > **LLM URL**, then enter your LLM URL and API token to open **Advanced Options**, where you can [set a maximum number of tokens per request](/insomnia/mcp-clients-in-insomnia/#set-a-token-limit-per-request). If you use a hosted provider, enter its provider URL, such as `https://api.openai.com/v1`.
 

--- a/app/insomnia/mcp-clients-in-insomnia.md
+++ b/app/insomnia/mcp-clients-in-insomnia.md
@@ -202,7 +202,7 @@ token usage on each request and control cost, {{ site.data.products.insomnia.nam
 lets you set a maximum number of tokens per request:
 
 1. Navigate to **Preferences** > **AI Settings** > **Activate an LLM**.
-1. Select **LLM URL**
+1. Select **LLM URL**.
 1. In the **LLM URL** field, enter your custom self-hosted URL or the provider URL, such as `https://api.openai.com/v1`.
 1. In the **API Token** field, enter your API token.
 1. Click **Advanced Options**.

--- a/app/insomnia/mcp-clients-in-insomnia.md
+++ b/app/insomnia/mcp-clients-in-insomnia.md
@@ -194,3 +194,16 @@ Insomnia supports **MCP Sampling**. Sampling is a workflow where an MCP server r
 > When supported by the server, this process can continue across additional turns.
 
 For more information about sampling, go to the MCP [Sampling](https://modelcontextprotocol.io/specification/draft/client/sampling) documentation.
+
+## Set a token limit per request
+
+By default, a request can consume as many tokens as the model allows. To cap
+token usage on each request and control cost, {{ site.data.products.insomnia.name }}
+lets you set a maximum number of tokens per request:
+
+1. Navigate to **Preferences** > **AI Settings** > **Activate an LLM**
+1. Select **LLM URL**
+1. In the **LLM URL** field, enter your custom self-hosted URL or the provider URL, such as `https://api.openai.com/v1`.
+1. In the **API Token** field, enter your API token.
+1. Click **Advanced Options**.
+1. In the **Max Tokens** field, enter the maximum number of tokens allowed per request.

--- a/app/insomnia/mcp-clients-in-insomnia.md
+++ b/app/insomnia/mcp-clients-in-insomnia.md
@@ -201,7 +201,7 @@ By default, a request can consume as many tokens as the model allows. To cap
 token usage on each request and control cost, {{ site.data.products.insomnia.name }}
 lets you set a maximum number of tokens per request:
 
-1. Navigate to **Preferences** > **AI Settings** > **Activate an LLM**
+1. Navigate to **Preferences** > **AI Settings** > **Activate an LLM**.
 1. Select **LLM URL**
 1. In the **LLM URL** field, enter your custom self-hosted URL or the provider URL, such as `https://api.openai.com/v1`.
 1. In the **API Token** field, enter your API token.


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

This PR updates the Insomnia AI and MCP pages to include the `max_tokens` settings, which can be used to limit the number of tokens used per request.
 
closes #5830 


## Preview Links

https://deploy-preview-5998--kongdeveloper.netlify.app/insomnia/ai-in-insomnia/#frequently-asked-questions

https://deploy-preview-5998--kongdeveloper.netlify.app/insomnia/mcp-clients-in-insomnia/

## Testing instructions

Open Insomnia, and switch to the beta version (Preferences > General > Software Updates > Select beta > Click **Check**)

Then follow [these steps](https://deploy-preview-5998--kongdeveloper.netlify.app/insomnia/mcp-clients-in-insomnia/#set-a-token-limit-per-request)

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
