### PR TITLE
Feat(insomnia): identical mock route update

### DIFF
--- a/app/_data/products/insomnia.yml
+++ b/app/_data/products/insomnia.yml
@@ -45,4 +45,6 @@ releases:
     version: "12.6.0"
   - release: "13.0"
     version: "13.0.0"
+  - release: "13.1"
+    version: "13.1.0"
     latest: true

--- a/app/_includes/how-tos/steps/mock-route.md
+++ b/app/_includes/how-tos/steps/mock-route.md
@@ -21,6 +21,3 @@ In this example, we want to create a `/flights` route based on the [KongAir Flig
     ```
 1. Update the headers and status if needed. In this example we'll keep the default values.
 1. Click **Test** to send a request to the mock.
-
-{:.info}
-> You can't define multiple responses for the same route. If you want to mock another response, you need to create a different mock server.


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Insomnia now allows identical mock routes with different methods. The previous limitation has been removed in this PR. 
 To test, create a mock server in Insomnia (you can do this from a template) and:
 
 - add a mock route with the GET method
 - add the same route with the POST method
 
 Example:
 
<img width="333" height="184" alt="Capture d’écran 2026-07-17 à 13 33 12" src="https://github.com/user-attachments/assets/6712206a-e88a-4996-8fa6-21467d5b695a" />
 

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
