### PR TITLE
fix(gateway): Note about StatsD Advanced plugin

### DIFF
--- a/app/_kong_plugins/statsd/index.md
+++ b/app/_kong_plugins/statsd/index.md
@@ -53,7 +53,7 @@ It should be less than 65507, according to UDP protocol. Consider the MTU of the
 
 {:.info}
 > **Note**: As of {{site.base_gateway}} 3.0.0.0, all capabilities of StatsD Advanced are bundled in the StatsD plugin.
-> StatsD Advanced will be removed in an upcoming major version.
+> StatsD Advanced has been deprecated and will be removed in 4.0.
 > If you're still using StatsD Advanced, the StatsD reference documentation also applies to that plugin.
 
 ## Metrics

--- a/app/_kong_plugins/statsd/index.md
+++ b/app/_kong_plugins/statsd/index.md
@@ -34,6 +34,7 @@ categories:
 
 search_aliases:
   - collectd
+  - statsd-advanced
 
 related_resources:
   - text: Collect {{site.base_gateway}} metrics with the StatsD plugin
@@ -49,6 +50,11 @@ It can also be used to log metrics on the [Collectd](https://collectd.org/) daem
 
 By default, the plugin sends a packet for each metric it observes. The [`config.udp_packet_size`](/plugins/statsd/reference/#schema--config-udp-packet-size) option configures the greatest datagram size the plugin can combine. 
 It should be less than 65507, according to UDP protocol. Consider the MTU of the network when setting this parameter.
+
+{:.info}
+> **Note**: As of {{site.base_gateway}} 3.0.0.0, all capabilities of StatsD Advanced are bundled in the StatsD plugin.
+> StatsD Advanced will be removed in an upcoming major version.
+> If you're still using StatsD Advanced, the StatsD reference documentation also applies to that plugin.
 
 ## Metrics
 


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Adds note to statsd plugin about parity with statsd advanced, which is not documented, as it was deprecated long before dev site migration.

Issue reported on Slack.

## Preview Links
https://deploy-preview-6005--kongdeveloper.netlify.app/plugins/statsd/