### PR TITLE
chore(aigw): Add version to kongctl prereq

### DIFF
--- a/app/_includes/prereqs/tools/kongctl.md
+++ b/app/_includes/prereqs/tools/kongctl.md
@@ -1,11 +1,12 @@
 {% capture summary %}
-kongctl
+kongctl &nbsp; {% new_in site.data.kongctl_latest.version %}
 {% endcapture %}
 
 {% capture details_content %}
 {% assign product=page.products[0] %}
 {% if product == 'ai-gateway' %}
 This tutorial uses [kongctl](/kongctl/) to manage {{site.ai_gateway}} configuration.
+We recommend keeping kongctl up to date with the latest version ({{site.data.kongctl_latest.version}}).
 
 1. Install **kongctl** from [developer.konghq.com/kongctl](/kongctl/).
 1. Verify the installation:


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Adds a version requirement to the kongctl prereq, similar to decK. 
For decK, we just tell them it's best to use the latest version; I went with the same approach. We could set a specific version for when AIGW launched on kongctl (1.5.0), but realistically subsequent kongctl versions will continue to have improvements and introduce new resources, etc. So it's better to just keep it up to date.

## Preview Links


https://deploy-preview-6008--kongdeveloper.netlify.app/ai-gateway/get-started/