### PR TITLE
Pull AI Gateway get-started fixes from ko-ai-gw

### DIFF
--- a/app/_how-tos/operator/operator-get-started-ai-gateway-1-install.md
+++ b/app/_how-tos/operator/operator-get-started-ai-gateway-1-install.md
@@ -79,7 +79,30 @@ kubectl create namespace kong
 
 Install {{site.operator_product_name}} with the {{ site.ai_gateway }} data plane controller enabled:
 
-{% include prereqs/products/operator.md raw=true v_maj=2 %}
+<!-- TEMPORARY: pinned to a preview build for docs review. Revert to
+     {% include prereqs/products/operator.md raw=true v_maj=2 %}
+     once {{site.operator_product_name}} 1.4.0 is released. -->
+
+1. Add the Kong Helm charts:
+
+   ```bash
+   helm repo add kong https://charts.konghq.com
+   helm repo update
+   ```
+
+1. Install {{ site.operator_product_name }} using Helm:
+
+   ```bash
+   helm upgrade --install kong-operator kong/kong-operator -n kong-system \
+     --create-namespace \
+     --version 1.4.0-rc.1 \
+     --set env.ENABLE_CONTROLLER_KONNECT=true \
+     --set env.ENABLE_CONTROLLER_AIGATEWAYDATAPLANE=true
+   ```
+
+{% include k8s/cert-manager.md %}
+
+{% include k8s/ca-cert.md %}
 
 ## Verify {{ site.ai_gateway }} CRDs
 

--- a/app/_how-tos/operator/operator-get-started-ai-gateway-3-policy.md
+++ b/app/_how-tos/operator/operator-get-started-ai-gateway-3-policy.md
@@ -38,7 +38,7 @@ tldr:
   a: |
     Create an `AIGatewayPolicy` resource pointing to your `KonnectAIGateway` via `spec.aiGatewayRef`.
     Set `spec.apiSpec.global` to `Enabled` to apply the Policy to every model on the gateway, or `Disabled` to target a specific model.
-    Use a single Policy resource to combine `deny_patterns` (block injection attempts) and `allow_patterns` (restrict to a topic list). The gateway evaluates deny patterns first, then checks that the request matches at least one allow pattern.
+    Set `spec.apiSpec.config.type` to `inline` and nest the plugin configuration under `spec.apiSpec.config.value`. Use a single Policy resource to combine `deny_patterns` (block injection attempts) and `allow_patterns` (restrict to a topic list). The gateway evaluates deny patterns first, then checks that the request matches at least one allow pattern.
 
 next_steps:
   - text: Add AI Consumers and credentials
@@ -99,16 +99,18 @@ export AIGW_HOST=$(kubectl get service my-ai-gateway-dp-ingress -n kong \
        enabled: Enabled
        global: Enabled
        config:
-         deny_patterns:
-           - "(?i).*ignore (all )?previous instructions.*"
-           - "(?i).*you are now (DAN|jailbroken).*"
-           - "(?i).*disregard (your|all) (previous |prior )?instructions.*"
-           - "(?i).*what (is|was) your (system|initial) prompt.*"
-           - "(?i).*(reveal|show|print|repeat) (your )?(system prompt|instructions).*"
-         allow_patterns:
-           - "(?i).*(what is|how do i|how to|configure|install|troubleshoot|debug|explain|difference between).*"
-           - "(?i).*(kubernetes|docker|helm|terraform|kong|api|service|microservice|container|pod|namespace).*"
-           - "(?i).*(code|function|script|query|yaml|json|bash|python|go|javascript).*"
+         type: inline
+         value:
+           deny_patterns:
+             - "(?i).*ignore (all )?previous instructions.*"
+             - "(?i).*you are now (DAN|jailbroken).*"
+             - "(?i).*disregard (your|all) (previous |prior )?instructions.*"
+             - "(?i).*what (is|was) your (system|initial) prompt.*"
+             - "(?i).*(reveal|show|print|repeat) (your )?(system prompt|instructions).*"
+           allow_patterns:
+             - "(?i).*(what is|how do i|how to|configure|install|troubleshoot|debug|explain|difference between).*"
+             - "(?i).*(kubernetes|docker|helm|terraform|kong|api|service|microservice|container|pod|namespace).*"
+             - "(?i).*(code|function|script|query|yaml|json|bash|python|go|javascript).*"
    ' | kubectl apply -f -
    ```
 

--- a/app/_how-tos/operator/operator-get-started-ai-gateway-4-consumers.md
+++ b/app/_how-tos/operator/operator-get-started-ai-gateway-4-consumers.md
@@ -236,9 +236,11 @@ curl -s -o /dev/null -w "%{http_code}\n" \
 
 `AIGatewayConsumerGroup` is a named set of AI Consumers that you can target as a unit. Use groups to:
 
-- Apply shared Policies to a team by listing Policy names in `spec.apiSpec.policies`. This is useful for policies scoped with `global: Disabled` that should only apply to specific groups
+- Apply shared Policies to a team via `spec.apiSpec.policies` on the group — each entry is an object with a `name` field referencing an `AIGatewayPolicy` by its Kubernetes resource name, useful for policies scoped with `global: Disabled`
 - Restrict or allow group access to individual AI Models via `spec.apiSpec.model.access.acls` on the `AIGatewayModel`
 - Attribute usage across multiple AI Consumers to a single group in {{ site.konnect_short_name }} analytics
+
+Consumer membership is declared on the `AIGatewayConsumer`, not on the group. Use `spec.consumerGroups` on the AI Consumer to reference the groups it belongs to.
 
 1. Create an AI Consumer Group:
 
@@ -265,6 +267,22 @@ curl -s -o /dev/null -w "%{http_code}\n" \
 
    ```bash
    kubectl wait aigatewayconsumergroup/platform-team-group -n kong \
+     --for=condition=Programmed=True \
+     --timeout=5m
+   ```
+
+1. Enroll the AI Consumer in the group by patching the consumer resource:
+
+   ```bash
+   kubectl patch aigatewayconsumer team-platform -n kong \
+     --type=merge \
+     -p '{"spec":{"consumerGroups":[{"name":"platform-team-group"}]}}'
+   ```
+
+1. Wait for the AI Consumer to reconcile with the updated group membership:
+
+   ```bash
+   kubectl wait aigatewayconsumer/team-platform -n kong \
      --for=condition=Programmed=True \
      --timeout=5m
    ```


### PR DESCRIPTION
## Summary
- Ports the install/policy/consumers corrections from ko-ai-gw commit 6c2d70548ea297c6ebbf73699345935121fe3926, adapted to this branch's existing frontmatter and terminology conventions
- install: temporarily pin the operator Helm chart to `1.4.0-rc.1` for preview docs review (revert once 1.4.0 ships)
- policy: nest `AIGatewayPolicy` config under `type: inline` / `value`
- consumers: add the missing consumer-group enrollment steps (`kubectl patch` + `kubectl wait`)

## Test plan
- [ ] Verify rendered install/policy/consumers pages under `KONG_PRODUCTS=operator make run`
- [ ] Revert the temporary Helm version pin on install.md once 1.4.0 is released