### PR TITLE
fix(gateway): Mocking plugin supports all HTTP status codes since 3.1.0

### DIFF
--- a/app/_kong_plugins/mocking/index.md
+++ b/app/_kong_plugins/mocking/index.md
@@ -49,11 +49,13 @@ You need an API spec you want to mock the endpoints of for the Mocking plugin to
 
 ## Mocked responses
 
-The Mocking plugin can mock the following responses: 
+By default, the Mocking plugin selects and returns the minimum HTTP status code defined for the matched operation in your API specification. In older versions of the plugin, this meant only `200`, `201`, and `204` responses could be mocked.
 
-* **`200`**
-* **`201`**
-* **`204`**
+{% new_in 3.1 %} The plugin can mock any HTTP status code defined in your API specification, not just `200`, `201`, and `204`. You can change which status code is returned using the following options:
+
+* [`config.included_status_codes`](/plugins/mocking/reference/#schema--config-included-status-codes): A global list of the only HTTP status codes that the plugin can select and return.
+* [`config.random_status_code`](/plugins/mocking/reference/#schema--config-random-status-code): When enabled, the plugin randomly selects a status code from the responses defined for the matched operation, instead of always returning the minimum status code.
+* The [`X-Kong-Mocking-Status-Code`](#x-kong-mocking-status-code) behavioral header, which lets a client request a specific status code that's defined for the matched operation.
 
 ## Behavioral headers
 


### PR DESCRIPTION
## Description

Fixes #5825

The **Mocked responses** section of the Mocking plugin docs said the plugin could only mock `200`, `201`, and `204` responses. That's no longer accurate: the `3.1.0.0` changelog added `config.included_status_codes`, `config.random_status_code`, and the `X-Kong-Mocking-Status-Code` behavioral header, all of which let the plugin mock **any** HTTP status code defined in the API spec.

This was misleading users into picking the Request Termination plugin for 4xx/5xx mocks when the Mocking plugin already supports them.

Changes:
- Clarified that the `200`/`201`/`204` limitation only applied before `3.1.0.0`.
- Added a `{% new_in 3.1 %}` badge and explained the three ways to control which status code is returned: `config.included_status_codes`, `config.random_status_code`, and the `X-Kong-Mocking-Status-Code` header (which was already documented further down the page, now cross-linked).
- Linked `config.included_status_codes` / `config.random_status_code` to their autogenerated schema reference entries, matching the pattern used on other plugin pages (e.g. `ai-azure-content-safety`).

## Preview Links

N/A (docs-only content change, no new pages)

## Checklist

- [x] Tested how-to docs. If not, note why here. — N/A, this is a reference page edit, not a how-to.
- [x] All pages contain metadata. — Frontmatter unchanged.
- [x] Any new docs link to existing docs. — Links to the plugin's own autogenerated schema reference and existing `X-Kong-Mocking-Status-Code` section.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). — N/A, no entity examples changed.
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly. — Ran `vale` locally against the changed file: 0 errors, 0 warnings, 0 suggestions.
- [x] Every page has a `description` entry in frontmatter. — Unchanged, already present.
- [x] Add new pages to the product documentation index (if applicable). — N/A, no new pages.