### PR TITLE
fix(gateway): Links for cache endpoints

### DIFF
--- a/app/gateway/traditional-mode.md
+++ b/app/gateway/traditional-mode.md
@@ -153,7 +153,7 @@ Admin API `/cache` endpoint.
 
 
 * Inspect a cached value: [`/cache/{key}`](/api/gateway/admin-ee/#/operations/get-cache-by-key)
-* Purge a cached value: [`/cache/{cache_key}`](/api/gateway/admin-ee/#/operations/deleteCacheByKey)
+* Purge a cached value: [`/cache/{key}`](/api/gateway/admin-ee/#/operations/deleteCacheByKey)
 * Purge a node's cache: [`/cache`](/api/gateway/admin-ee/#/operations/delete-cache-entries)
   
   {:.info}

--- a/app/gateway/traditional-mode.md
+++ b/app/gateway/traditional-mode.md
@@ -152,9 +152,9 @@ invalidate a value cached by {{site.base_gateway}} (a cached hit or miss), you c
 Admin API `/cache` endpoint.
 
 
-* Inspect a cached value: [`/cache/{key}`](/api/gateway/admin-ee/#/operations/getCacheByKey)
+* Inspect a cached value: [`/cache/{key}`](/api/gateway/admin-ee/#/operations/get-cache-by-key)
 * Purge a cached value: [`/cache/{cache_key}`](/api/gateway/admin-ee/#/operations/deleteCacheByKey)
-* Purge a node's cache: [`/cache`](/api/gateway/admin-ee/#/operations/purgeAllCache)
+* Purge a node's cache: [`/cache`](/api/gateway/admin-ee/#/operations/delete-cache-entries)
   
   {:.info}
   > **Note**: Be wary of using this endpoint on a node running in production with warm cache.


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

The links to the cache endpoints on https://developer.konghq.com/gateway/traditional-mode/#interacting-with-the-cache-via-the-admin-api are wrong (however, "Purge a cached value" is still correct; the entity naming format in the spec is inconsistent).

## Preview Links

https://deploy-preview-6023--kongdeveloper.netlify.app/gateway/traditional-mode/#interacting-with-the-cache-via-the-admin-api

