### PR TITLE
ko: clarify binding plugins

### DIFF
--- a/app/_how-tos/operator/operator-dataplane-configure-plugins-for-httproute.md
+++ b/app/_how-tos/operator/operator-dataplane-configure-plugins-for-httproute.md
@@ -1,6 +1,6 @@
 ---
 title: Configure a plugin for a specific HTTPRoute
-description: "Learn how to attach plugins to HTTPRoute resources using KongPluginBinding, ExtensionRef, or annotations."
+description: "Learn how to attach plugins to HTTPRoute resources using ExtensionRef or annotations."
 content_type: how_to
 permalink: /operator/dataplanes/how-to/configure-plugins-for-httproute/
 breadcrumbs:
@@ -30,7 +30,7 @@ prereqs:
 tldr:
   q: How do I attach a plugin to an HTTPRoute with {{ site.operator_product_name }}?
   a: |
-    Use an `ExtensionRef`, the legacy `konghq.com/plugins` annotation, or the `KongPluginBinding` resource ({{site.konnect_short_name}} only).
+    Use an `ExtensionRef` or the legacy `konghq.com/plugins` annotation.
 ---
 
 ## Create a KongPlugin
@@ -54,38 +54,6 @@ config:
 ## Apply the plugin to the HTTPRoute
 
 {% navtabs "Methods" %}
-
-{% navtab "KongPluginBinding (Konnect only)" %}
-
-The `KongPluginBinding` resource can be used when managing entities in {{site.konnect_short_name}} or when using the Hybrid mode. 
-It allows you to bind a plugin to one or more entities without modifying those entities.
-
-For more details about the `KongPluginBinding` resources, see [Understanding KongPluginBinding](/operator/konnect/kongpluginbinding/).
-
-Use this method if you need to reuse the same plugin configuration across multiple Routes without editing each Route resource, or if you do not have permission to modify the Route.
-
-```bash
-echo '
-apiVersion: configuration.konghq.com/v1alpha1
-kind: KongPluginBinding
-metadata:
-  name: bind-rate-limit-to-route
-  namespace: kong
-spec:
-  controlPlaneRef:
-    type: konnectNamespacedRef
-    konnectNamespacedRef:
-      name: gateway-control-plane
-  pluginRef:
-    name: rate-limit-example
-  targets:
-    routeRef:
-      group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      name: echo-route
-' | kubectl apply -f -
-```
-{% endnavtab %}
 
 {% navtab "ExtensionRef" %}
 

--- a/app/operator/konnect/kongpluginbinding.md
+++ b/app/operator/konnect/kongpluginbinding.md
@@ -20,7 +20,6 @@ related_resources:
 
 The `KongPluginBinding` is the CRD used to manage the binding relationship between plugins and attached {{site.konnect_short_name}} entities, including Services, Routes, Consumers, and Consumer Groups, or a supported combination of these entities.
 
-
 {% new_in 1.5 %} It can also be used to bind a plugin globally to a Control Plane when `spec.scope` is set to `GlobalInControlPlane`.
 
 Each `KongPluginBinding` represents a single plugin instance on {{ site.konnect_short_name }}.
@@ -32,10 +31,14 @@ This CRD has the following fields:
 
 You can refer to the Custom Resource [API](/operator/reference/custom-resources/#kongpluginbinding) to see all the available fields.
 
+{:.info}
+> **Note:** KongPluginBinding models 1:1 Konnect's Plugin API hence it only allows to interact with Kong entities like Service, Route, Consumer, and ConsumerGroup.
+> To attach a plugin to an HTTPRoute see the supported methods in [this guide](/operator/dataplanes/how-to/configure-plugins-for-httproute/).
+
 ## Using an unmanaged `KongPluginBinding`
 
-You can directly create a `KongPluginBinding` to bind your plugin to a Konnect entity. For a end-to-end tutorial, see [Enable a Plugin with KGO](/operator/konnect/crd/gateway/plugin/).
-
+You can directly create a `KongPluginBinding` to bind your plugin to a {{ site.konnect_short_name }} entity.
+For an end-to-end tutorial, see [Enable a Plugin with {{ site.operator_product_name_short }}](/operator/konnect/crd/gateway/plugin/).
 
 Assuming that you have an existing and programmed `KonnectGatewayControlPlane` with the name `cp` in the `default` namespace, first, create a Gateway Service and a plugin with the `KongService` and `KongPlugin` CRDs:
 
@@ -97,33 +100,6 @@ spec:
 ```
 
 Then the plugin will be successfully attached to the Service in {{ site.konnect_short_name }}.
-
-### Binding to an HTTPRoute
-
-You can also bind a plugin to a specific `HTTPRoute` resource. This is useful when you want to apply a plugin to a specific path or rule within your Gateway configuration:
-
-```shell
-echo '
-kind: KongPluginBinding
-apiVersion: configuration.konghq.com/v1alpha1
-metadata:
-  namespace: default
-  name: binding-route-example-rate-limiting
-spec:
-  pluginRef:
-    kind: KongPlugin
-    name: rate-limiting-minute-10
-  targets:
-    routeRef:
-      group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      name: my-route
-  controlPlaneRef:
-    type: konnectNamespacedRef
-    konnectNamespacedRef:
-      name: cp
-' | kubectl apply -f -
-```
 
 ### Attaching plugins to multiple entities
 

--- a/app/operator/konnect/kongpluginbinding.md
+++ b/app/operator/konnect/kongpluginbinding.md
@@ -32,8 +32,8 @@ This CRD has the following fields:
 You can refer to the Custom Resource [API](/operator/reference/custom-resources/#kongpluginbinding) to see all the available fields.
 
 {:.info}
-> **Note:** KongPluginBinding models 1:1 Konnect's Plugin API hence it only allows to interact with Kong entities like Service, Route, Consumer, and ConsumerGroup.
-> To attach a plugin to an HTTPRoute see the supported methods in [this guide](/operator/dataplanes/how-to/configure-plugins-for-httproute/).
+> **Note:** `KongPluginBinding` models Konnect's Plugin API 1:1, so it only supports Kong entities such as Service, Route, Consumer, and Consumer Group.
+> To attach a plugin to an `HTTPRoute`, see the supported methods in [this guide](/operator/dataplanes/how-to/configure-plugins-for-httproute/).
 
 ## Using an unmanaged `KongPluginBinding`
 

--- a/app/operator/konnect/kongpluginbinding.md
+++ b/app/operator/konnect/kongpluginbinding.md
@@ -32,13 +32,13 @@ This CRD has the following fields:
 You can refer to the Custom Resource [API](/operator/reference/custom-resources/#kongpluginbinding) to see all the available fields.
 
 {:.info}
-> **Note:** `KongPluginBinding` models Konnect's Plugin API 1:1, so it only supports Kong entities such as Service, Route, Consumer, and Consumer Group.
+> **Note:** `KongPluginBinding` models {{ site.konnect_short_name }}'s Plugin API 1:1, so it only supports Kong entities such as Service, Route, Consumer, and Consumer Group.
 > To attach a plugin to an `HTTPRoute`, see the supported methods in [this guide](/operator/dataplanes/how-to/configure-plugins-for-httproute/).
 
 ## Using an unmanaged `KongPluginBinding`
 
 You can directly create a `KongPluginBinding` to bind your plugin to a {{ site.konnect_short_name }} entity.
-For an end-to-end tutorial, see [Enable a Plugin with {{ site.operator_product_name_short }}](/operator/konnect/crd/gateway/plugin/).
+For an end-to-end tutorial, see [Enable a plugin with {{ site.operator_product_name_short }}](/operator/konnect/crd/gateway/plugin/).
 
 Assuming that you have an existing and programmed `KonnectGatewayControlPlane` with the name `cp` in the `default` namespace, first, create a Gateway Service and a plugin with the `KongService` and `KongPlugin` CRDs:
 


### PR DESCRIPTION
## Description

Clarify binding plugins to e.g. `HTTPRoute` with KO. Specifically remove the section saying that KO supports binding `HTTPRoute`s with `KongPluginBinding`.

Related FTI: https://konghq.atlassian.net/browse/FTI-7759

## Preview Links

https://deploy-preview-6131--kongdeveloper.netlify.app/operator/konnect/kongpluginbinding/#binding-to-an-httproute
https://deploy-preview-6131--kongdeveloper.netlify.app/operator/dataplanes/how-to/configure-plugins-for-httproute/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
