### PR TITLE
fix(ai-gateway): Correct Gemini API paths

### DIFF
--- a/app/_data/ai-gateway/v2/providers.yaml
+++ b/app/_data/ai-gateway/v2/providers.yaml
@@ -600,9 +600,9 @@ providers:
           - '/v1beta/models/{model_name}:generateContent'
           - '/v1beta/models/{model_name}:streamGenerateContent'
           - '/v1beta/models/{model_name}:embedContent'
-          - '/v1beta/models/{model_name}:batchEmbedContent'
+          - '/v1beta/models/{model_name}:batchEmbedContents'
           - '/v1beta/batches'
-          - '/upload/{file_id}/files'
+          - '/upload/v1beta/files'
           - '/v1beta/files'
     limitations:
       provider_specific:


### PR DESCRIPTION
## Description

Correct the Gemini native API list to use the first-party `batchEmbedContents` method and `/upload/v1beta/files` upload path. The previous entries used a misspelled method and treated the upload API version as a file ID, which could send users to invalid endpoints.

References:

- https://ai.google.dev/api/embeddings
- https://ai.google.dev/gemini-api/docs/files

## Preview Links

- `/ai-gateway/ai-providers/gemini/`

## Checklist

- [x] Tested how-to docs. Not applicable; this updates provider reference data. `KONG_PRODUCTS=ai-gateway make run` completes the site build.
- [x] All pages contain metadata. No page metadata changed.
- [x] Any new docs link to existing docs. No new docs were added.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). No autogenerated instructions changed.
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter. No page frontmatter changed.
- [x] Add new pages to the product documentation index (if applicable). No pages were added.