### PR TITLE
fix(ai-gateway): Correct Vertex API paths

### DIFF
--- a/app/_data/ai-gateway/v2/providers.yaml
+++ b/app/_data/ai-gateway/v2/providers.yaml
@@ -629,7 +629,7 @@ providers:
       embeddings:
         supported: true
         streaming: false
-        upstream_path: 'Uses `generateContent` API'
+        upstream_path: 'Uses `predict` API'
         model_example: 'text-embedding-004'
         min_version: '2.0'
       files:
@@ -691,11 +691,11 @@ providers:
     native_formats:
       - llm_format: 'gemini'
         supported_apis:
-          - '/v1/projects/{project_id}/locations/{location}/models/{model_name}:generateContent'
-          - '/v1/projects/{project_id}/locations/{location}/models/{model_name}:streamGenerateContent'
-          - '/v1/projects/{project_id}/locations/{location}/models/{model_name}:embedContent'
-          - '/v1/projects/{project_id}/locations/{location}/models/{model_name}:batchEmbedContent'
-          - '/v1/projects/{project_id}/locations/{location}/models/{model_name}:predictLongRunning'
+          - '/v1/projects/{project_id}/locations/{location}/publishers/{publisher}/models/{model_name}:generateContent'
+          - '/v1/projects/{project_id}/locations/{location}/publishers/{publisher}/models/{model_name}:streamGenerateContent'
+          - '/v1/projects/{project_id}/locations/{location}/publishers/{publisher}/models/{model_name}:embedContent'
+          - '/v1/projects/{project_id}/locations/{location}/publishers/{publisher}/models/{model_name}:predict'
+          - '/v1/projects/{project_id}/locations/{location}/publishers/{publisher}/models/{model_name}:predictLongRunning'
           - '/v1/projects/{project_id}/locations/{location}/rankingConfigs/{config_name}:rank'
           - '/v1/projects/{project_id}/locations/{location}/batchPredictionJobs'
     limitations:


### PR DESCRIPTION
## Description

Correct the Gemini Vertex provider reference to match the Vertex AI publisher-model routes used by the data plane. Normalized embeddings use the `predict` API, and native model paths require the publisher resource segment.

The native API list removes the invalid `batchEmbedContent` entry and includes the `predict` route used for embeddings. These are independent corrections; `predict` is not a replacement name for `batchEmbedContent`.

## References

- [Vertex AI text embeddings](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/embeddings/get-text-embeddings)
- [Vertex publisher model REST methods](https://cloud.google.com/vertex-ai/generative-ai/docs/reference/rest/v1beta1/projects.locations.publishers.models)
- [Kong data-plane embedding routing](https://github.com/Kong/kong-ee/pull/19257)

## Preview Links

- `/ai-gateway/ai-providers/vertex/`

## Checklist

- [x] Tested how-to docs. Not applicable; this updates provider reference data. `KONG_PRODUCTS=ai-gateway make run` completes the site build.
- [x] All pages contain metadata. No page metadata changed.
- [x] Any new docs link to existing docs. No new docs were added.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). No autogenerated instructions changed.
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter. No page frontmatter changed.
- [x] Add new pages to the product documentation index (if applicable). No pages were added.