### PR TITLE
fix(ai-gateway): Correct OpenAI video path

### DIFF
--- a/app/_data/ai-gateway/v2/providers.yaml
+++ b/app/_data/ai-gateway/v2/providers.yaml
@@ -1099,7 +1099,7 @@ providers:
       video:
         supported: true
         streaming: false
-        upstream_path: 'Use the LLM `/v1/images/generations` upstream path'
+        upstream_path: '`/v1/videos`'
         model_example: 'sora-2'
         min_version: '2.0'
       rerank:


### PR DESCRIPTION
## Description

Correct the OpenAI video capability to use the `/v1/videos` upstream path. The previous `/v1/images/generations` value was carried over from the legacy provider table; the data plane has routed OpenAI video requests to `/v1/videos` since video support was introduced and does not provide an image-path compatibility fallback.

## References

- [OpenAI Videos API](https://platform.openai.com/docs/api-reference/videos)
- [Initial data-plane video support](https://github.com/Kong/kong-ee/pull/14756)

## Preview Links

- `/ai-gateway/ai-providers/openai/`

## Checklist

- [x] Tested how-to docs. Not applicable; this updates provider reference data. `KONG_PRODUCTS=ai-gateway make run` completes the site build.
- [x] All pages contain metadata. No page metadata changed.
- [x] Any new docs link to existing docs. No new docs were added.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). No autogenerated instructions changed.
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter. No page frontmatter changed.
- [x] Add new pages to the product documentation index (if applicable). No pages were added.