### PR TITLE
fix(aigw): Remove kongctl adopt from prereq

### DIFF
--- a/app/_includes/prereqs/tools/kongctl.md
+++ b/app/_includes/prereqs/tools/kongctl.md
@@ -3,9 +3,7 @@ kongctl &nbsp; {% new_in site.data.kongctl_latest.version %}
 {% endcapture %}
 
 {% capture details_content %}
-{% assign product=page.products[0] %}
-{% if product == 'ai-gateway' %}
-This tutorial uses [kongctl](/kongctl/) to manage {{site.ai_gateway}} configuration.
+This tutorial uses [kongctl](/kongctl/) to manage {{site.konnect_short_name}} resources programmatically.
 We recommend keeping kongctl up to date with the latest version ({{site.data.kongctl_latest.version}}).
 
 1. Install **kongctl** from [developer.konghq.com/kongctl](/kongctl/).
@@ -14,18 +12,6 @@ We recommend keeping kongctl up to date with the latest version ({{site.data.kon
    ```sh
    kongctl version
    ```
-
-If you're using an existing {{site.ai_gateway}} instead of the quickstart script, adopt it into a kongctl namespace so the apply command later in this tutorial can manage it:
-
-```sh
-kongctl adopt ai-gateway "$AI_GATEWAY_ID" \
-    --namespace ai-gateway-get-started \
-    --pat "$KONNECT_TOKEN"
-```
-{% else %}
-  kongctl is a CLI tool for managing {{site.konnect_short_name}} resources programmatically. To complete this tutorial, 
-  install [kongctl](/kongctl/).
-{% endif %}
 {% endcapture %}
 
 {% include how-tos/prereq_cleanup_item.html summary=summary details_content=details_content icon_url='/assets/icons/code.svg' %}


### PR DESCRIPTION
kongctl adopt is not necessary when managing an external resource. In our how-tos, we reference every resource as `external`, so kongctl adopt isn't doing anything.

Preview: any how-to guide, eg https://deploy-preview-6340--kongdeveloper.netlify.app/ai-gateway/get-started/