### PR TITLE
fix(gateway): Add Gateway 3.15 to konnect support table

### DIFF
--- a/app/_data/support/gateway.yml
+++ b/app/_data/support/gateway.yml
@@ -1,3 +1,9 @@
+- release: "3.15"
+  konnect: true
+  beginning: "3.15.0.0"
+  release_date: "2026-07-02"
+  eol: "2027-07-02"
+  sunset: "2028-07-02"
 - release: "3.14"
   konnect: true
   lts: true


### PR DESCRIPTION
Adding the missing entry for 3.15 to the Konnect version compatibility table.

https://deploy-preview-6341--kongdeveloper.netlify.app/konnect-platform/compatibility/