### PR TITLE
feat(ai-gateway): Add kongctl to provider subpages

### DIFF
--- a/app/_includes/components/entity_example/format/kongctl.md
+++ b/app/_includes/components/entity_example/format/kongctl.md
@@ -15,9 +15,10 @@ The following creates a new TLS trust bundle called **{{ include.presenter.data[
 {% when 'event_gateway_policy' %}
 The following example creates a new `{{ include.presenter.data['type'] }}` policy.
 {% endcase %}
+{% endif %}
+{% if include.render_context or include.presenter.product == 'ai-gateway' %}
 {% if include.presenter.product == 'event-gateway' %}{% assign product = 'event_gateways' %}{% elsif include.presenter.product == 'ai-gateway'%}{% assign product = 'ai_gateways' %}{% endif %}
 Add this snippet to a kongctl declarative configuration file, and then [manage it with kongctl](/kongctl/declarative/#declarative-commands):
-{% else %}
 {% endif %}
 
 {% include components/entity_example/format/snippets/kongctl.md presenter=include.presenter %}

--- a/app/_includes/components/entity_example/format/kongctl.md
+++ b/app/_includes/components/entity_example/format/kongctl.md
@@ -23,6 +23,6 @@ Add this snippet to a kongctl declarative configuration file, and then [manage i
 
 {% include components/entity_example/format/snippets/kongctl.md presenter=include.presenter %}
 
-{% if include.render_context %}
+{% if include.render_context or include.presenter.product == 'ai-gateway' %}
 {% include components/entity_example/replace_variables.md missing_variables=include.presenter.missing_variables %}
 {% endif %}

--- a/app/_includes/components/entity_example/format/kongctl.md
+++ b/app/_includes/components/entity_example/format/kongctl.md
@@ -16,7 +16,7 @@ The following creates a new TLS trust bundle called **{{ include.presenter.data[
 The following example creates a new `{{ include.presenter.data['type'] }}` policy.
 {% endcase %}
 {% if include.presenter.product == 'event-gateway' %}{% assign product = 'event_gateways' %}{% elsif include.presenter.product == 'ai-gateway'%}{% assign product = 'ai_gateways' %}{% endif %}
-Add this snippet to an `{{product}}` resource in your declarative configuration file, and then [manage it with kongctl](/kongctl/declarative/#declarative-commands):
+Add this snippet to a kongctl declarative configuration file, and then [manage it with kongctl](/kongctl/declarative/#declarative-commands):
 {% else %}
 {% endif %}
 

--- a/app/_plugins/drops/entity_example/presenters/kongctl.rb
+++ b/app/_plugins/drops/entity_example/presenters/kongctl.rb
@@ -57,15 +57,8 @@ module Jekyll
 
             def build_config_hash
               if @example_drop.product == 'ai-gateway'
-                {
-                  'ai_gateways' => [
-                    {
-                      'ref' => ai_gateway_placeholder,
-                      'name' => ai_gateway_placeholder,
-                      child_key => [{ 'ref' => yaml_data['name'] }.merge(yaml_data)]
-                    }
-                  ]
-                }
+                entity_item = { 'ref' => yaml_data['name'], 'ai_gateway' => Utils::VariableReplacer::KongctlData::AI_GATEWAY_LOOKUP_SENTINEL }.merge(yaml_data.except('ref'))
+                { "ai_gateway_#{child_key}" => [entity_item] }
               else
                 {
                   'event_gateways' => [

--- a/app/_plugins/drops/entity_example/presenters/kongctl.rb
+++ b/app/_plugins/drops/entity_example/presenters/kongctl.rb
@@ -38,11 +38,21 @@ module Jekyll
             end
 
             def missing_variables
-              @missing_variables ||= if @example_drop.product == 'ai-gateway'
-                                       [formats['kongctl']['ai_gateway_variables']['ai_gateway']]
-                                     else
-                                       [formats['kongctl']['event_gateway_variables']['event_gateway']]
-                                     end
+              @missing_variables ||= begin
+                base = if @example_drop.product == 'ai-gateway'
+                         [formats['kongctl']['ai_gateway_variables']['ai_gateway']]
+                       else
+                         [formats['kongctl']['event_gateway_variables']['event_gateway']]
+                       end
+                base + variables.filter_map do |_key, var|
+                  next unless var['description']
+
+                  placeholder = Utils::VariableReplacer::KongctlData.apply_tags(
+                    Utils::VariableReplacer::KongctlData.run(data: var['value'])
+                  )
+                  { 'placeholder' => placeholder, 'description' => var['description'] }
+                end
+              end
             end
 
             def template_file
@@ -94,7 +104,7 @@ module Jekyll
             end
 
             def yaml_data
-              @yaml_data ||= Utils::VariableReplacer::KongctlData.run(data: data)
+              @yaml_data ||= Utils::VariableReplacer::KongctlData.run(data: data, variables: variables)
             end
 
             def event_gateway_placeholder

--- a/app/_plugins/drops/entity_example/utils/variable_replacer.rb
+++ b/app/_plugins/drops/entity_example/utils/variable_replacer.rb
@@ -111,6 +111,7 @@ module Jekyll
 
           class KongctlData
             SENTINEL_PATTERN = /__kongctl_env_([A-Z][A-Z0-9_]*)__/
+            AI_GATEWAY_LOOKUP_SENTINEL = '__kongctl_lookup_ai_gateway__'
             ENV_VAR_PATTERN = /\A\$([A-Z][A-Z0-9_]*)\z/
 
             def self.run(data:)
@@ -118,7 +119,9 @@ module Jekyll
             end
 
             def self.apply_tags(yaml)
-              yaml.gsub(SENTINEL_PATTERN, '!env \1')
+              yaml
+                .gsub(SENTINEL_PATTERN, '!env \1')
+                .gsub(AI_GATEWAY_LOOKUP_SENTINEL, '!lookup name:ai-gateway-name')
             end
 
             def process(data)

--- a/app/_plugins/drops/entity_example/utils/variable_replacer.rb
+++ b/app/_plugins/drops/entity_example/utils/variable_replacer.rb
@@ -114,8 +114,8 @@ module Jekyll
             AI_GATEWAY_LOOKUP_SENTINEL = '__kongctl_lookup_ai_gateway__'
             ENV_VAR_PATTERN = /\A\$([A-Z][A-Z0-9_]*)\z/
 
-            def self.run(data:)
-              new.process(data)
+            def self.run(data:, variables: {})
+              new(variables:).process(data)
             end
 
             def self.apply_tags(yaml)
@@ -124,16 +124,29 @@ module Jekyll
                 .gsub(AI_GATEWAY_LOOKUP_SENTINEL, '!lookup name:ai-gateway-name')
             end
 
+            def initialize(variables: {})
+              @variables = variables
+            end
+
             def process(data)
               case data
               when Hash  then data.transform_values { |v| process(v) }
               when Array then data.map { |item| process(item) }
-              when String then transform_env_var(data)
+              when String then transform_env_var(substitute_variables(data))
               else data
               end
             end
 
             private
+
+            def substitute_variables(str)
+              return str if @variables.empty?
+
+              keys_pattern = @variables.keys.map { |k| Regexp.escape(k.to_s) }.join('|')
+              str.gsub(/\$\{(#{keys_pattern})\}/) do
+                @variables.dig(Regexp.last_match(1), 'value') || Regexp.last_match(0)
+              end
+            end
 
             def transform_env_var(str)
               str.gsub(ENV_VAR_PATTERN, '__kongctl_env_\1__')

--- a/app/ai-gateway/ai-providers/anthropic.md
+++ b/app/ai-gateway/ai-providers/anthropic.md
@@ -17,6 +17,7 @@ products:
 
 tools:
   - konnect-api
+  - kongctl
 
 tags:
   - ai
@@ -49,14 +50,9 @@ To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model P
 
 Here's a minimal configuration for chat completions:
 
-<!--vale off-->
-{% konnect_api_request %}
-url: /v1/ai-gateways/$AI_GATEWAY_ID/model-providers
-status_code: 201
-method: POST
-headers:
-  - 'Content-Type: application/json'
-body:
+{% entity_example %}
+type: model-provider
+data:
   display_name: Anthropic Production
   name: anthropic-provider
   type: anthropic
@@ -66,6 +62,8 @@ body:
       headers:
         - name: x-api-key
           value: $ANTHROPIC_API_KEY
-{% endkonnect_api_request %}
-<!--vale on-->
+{% endentity_example %}
+
+Replace the following with your actual values:
+* `$ANTHROPIC_API_KEY`: The API key used to connect to Anthropic.
  

--- a/app/ai-gateway/ai-providers/anthropic.md
+++ b/app/ai-gateway/ai-providers/anthropic.md
@@ -61,9 +61,9 @@ data:
       type: basic
       headers:
         - name: x-api-key
-          value: $ANTHROPIC_API_KEY
+          value: ${key}
+variables:
+  key:
+    value: $ANTHROPIC_API_KEY
+    description: The API key to use to connect to Anthropic.
 {% endentity_example %}
-
-Replace the following with your actual values:
-* `$ANTHROPIC_API_KEY`: The API key used to connect to Anthropic.
- 

--- a/app/ai-gateway/ai-providers/azure.md
+++ b/app/ai-gateway/ai-providers/azure.md
@@ -66,12 +66,13 @@ data:
       type: basic
       headers:
         - name: Authorization
-          value: $AZURE_OPENAI_API_KEY
+          value: ${key}
     instance: kong-az-east
+variables:
+  key:
+    value: $AZURE_OPENAI_API_KEY
+    description: "The API key used to connect to Azure OpenAI. Include the `Bearer` prefix, for example `Bearer <your-api-key>`."
 {% endentity_example %}
-
-Replace the following with your actual values:
-* `$AZURE_OPENAI_API_KEY`: The API key used to connect to Azure OpenAI. Include the `Bearer ` prefix, for example `Bearer <your-api-key>`.
 
 ## Authentication with Azure IAM
 

--- a/app/ai-gateway/ai-providers/azure.md
+++ b/app/ai-gateway/ai-providers/azure.md
@@ -17,6 +17,7 @@ products:
 
 tools:
   - konnect-api
+  - kongctl
 
 tags:
   - ai
@@ -54,14 +55,9 @@ Here's a minimal configuration for chat completions:
 {:.info}
 > Replace `kong-az-east` with your Azure OpenAI resource instance name (the subdomain in your resource's endpoint, for example the `kong-az-east` in `https://kong-az-east.openai.azure.com`).
 
-<!--vale off-->
-{% konnect_api_request %}
-url: /v1/ai-gateways/$AI_GATEWAY_ID/model-providers
-status_code: 201
-method: POST
-headers:
-  - 'Content-Type: application/json'
-body:
+{% entity_example %}
+type: model-provider
+data:
   display_name: Azure Production
   name: my-azure-account
   type: azure
@@ -70,10 +66,12 @@ body:
       type: basic
       headers:
         - name: Authorization
-          value: Bearer $AZURE_OPENAI_API_KEY
+          value: $AZURE_OPENAI_API_KEY
     instance: kong-az-east
-{% endkonnect_api_request %}
-<!--vale on-->
+{% endentity_example %}
+
+Replace the following with your actual values:
+* `$AZURE_OPENAI_API_KEY`: The API key used to connect to Azure OpenAI. Include the `Bearer ` prefix, for example `Bearer <your-api-key>`.
 
 ## Authentication with Azure IAM
 

--- a/app/ai-gateway/ai-providers/bedrock.md
+++ b/app/ai-gateway/ai-providers/bedrock.md
@@ -74,13 +74,16 @@ data:
   config:
     auth:
       type: aws
-      access_key_id: $AWS_ACCESS_KEY_ID
-      secret_access_key: $AWS_SECRET_ACCESS_KEY
+      access_key_id: ${key_id}
+      secret_access_key: ${access_key}
+variables:
+  key_id:
+    value: $AWS_ACCESS_KEY_ID
+    description: Your AWS access key ID.
+  access_key:
+    value: $AWS_SECRET_ACCESS_KEY
+    description: Your AWS secret access key.
 {% endentity_example %}
-
-Replace the following with your actual values:
-* `$AWS_ACCESS_KEY_ID`: Your AWS access key ID.
-* `$AWS_SECRET_ACCESS_KEY`: Your AWS secret access key.
 
 ## Authentication with AWS
 

--- a/app/ai-gateway/ai-providers/bedrock.md
+++ b/app/ai-gateway/ai-providers/bedrock.md
@@ -17,6 +17,7 @@ products:
 
 tools:
   - konnect-api
+  - kongctl
 
 tags:
   - ai
@@ -64,14 +65,9 @@ To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model P
 
 Here's a minimal configuration for chat completions:
 
-<!--vale off-->
-{% konnect_api_request %}
-url: /v1/ai-gateways/$AI_GATEWAY_ID/model-providers
-status_code: 201
-method: POST
-headers:
-  - 'Content-Type: application/json'
-body:
+{% entity_example %}
+type: model-provider
+data:
   display_name: AWS Production
   name: my-aws-account
   type: bedrock
@@ -80,8 +76,11 @@ body:
       type: aws
       access_key_id: $AWS_ACCESS_KEY_ID
       secret_access_key: $AWS_SECRET_ACCESS_KEY
-{% endkonnect_api_request %}
-<!--vale on-->
+{% endentity_example %}
+
+Replace the following with your actual values:
+* `$AWS_ACCESS_KEY_ID`: Your AWS access key ID.
+* `$AWS_SECRET_ACCESS_KEY`: Your AWS secret access key.
 
 ## Authentication with AWS
 

--- a/app/ai-gateway/ai-providers/cerebras.md
+++ b/app/ai-gateway/ai-providers/cerebras.md
@@ -17,6 +17,7 @@ products:
 
 tools:
   - konnect-api
+  - kongctl
 
 tags:
   - ai
@@ -46,14 +47,9 @@ To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model P
 
 Here's a minimal configuration for chat completions:
 
-<!--vale off-->
-{% konnect_api_request %}
-url: /v1/ai-gateways/$AI_GATEWAY_ID/model-providers
-status_code: 201
-method: POST
-headers:
-  - 'Content-Type: application/json'
-body:
+{% entity_example %}
+type: model-provider
+data:
   display_name: Cerebras Production
   name: my-cerebras-account
   type: cerebras
@@ -62,6 +58,8 @@ body:
       type: basic
       headers:
         - name: Authorization
-          value: Bearer $CEREBRAS_API_KEY
-{% endkonnect_api_request %}
-<!--vale on-->
+          value: $CEREBRAS_API_KEY
+{% endentity_example %}
+
+Replace the following with your actual values:
+* `$CEREBRAS_API_KEY`: The API key used to connect to Cerebras. Include the `Bearer ` prefix, for example `Bearer <your-api-key>`.

--- a/app/ai-gateway/ai-providers/cerebras.md
+++ b/app/ai-gateway/ai-providers/cerebras.md
@@ -58,8 +58,9 @@ data:
       type: basic
       headers:
         - name: Authorization
-          value: $CEREBRAS_API_KEY
+          value: ${key}
+variables:
+  key:
+    value: $CEREBRAS_API_KEY
+    description: "The API key used to connect to Cerebras. Include the `Bearer` prefix, for example `Bearer <your-api-key>`."
 {% endentity_example %}
-
-Replace the following with your actual values:
-* `$CEREBRAS_API_KEY`: The API key used to connect to Cerebras. Include the `Bearer ` prefix, for example `Bearer <your-api-key>`.

--- a/app/ai-gateway/ai-providers/cohere.md
+++ b/app/ai-gateway/ai-providers/cohere.md
@@ -20,6 +20,7 @@ tags:
 
 tools:
   - konnect-api
+  - kongctl
 
 min_version:
   ai-gateway: '2.0'
@@ -54,14 +55,9 @@ To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model P
 
 Here's a minimal configuration for chat completions:
 
-<!--vale off-->
-{% konnect_api_request %}
-url: /v1/ai-gateways/$AI_GATEWAY_ID/model-providers
-status_code: 201
-method: POST
-headers:
-  - 'Content-Type: application/json'
-body:
+{% entity_example %}
+type: model-provider
+data:
   display_name: Cohere Production
   name: my-cohere-account
   type: cohere
@@ -70,6 +66,8 @@ body:
       type: basic
       headers:
         - name: Authorization
-          value: Bearer $COHERE_API_KEY
-{% endkonnect_api_request %}
-<!--vale on-->
+          value: $COHERE_API_KEY
+{% endentity_example %}
+
+Replace the following with your actual values:
+* `$COHERE_API_KEY`: The API key used to connect to Cohere. Include the `Bearer ` prefix, for example `Bearer <your-api-key>`.

--- a/app/ai-gateway/ai-providers/cohere.md
+++ b/app/ai-gateway/ai-providers/cohere.md
@@ -66,8 +66,9 @@ data:
       type: basic
       headers:
         - name: Authorization
-          value: $COHERE_API_KEY
+          value: ${key}
+variables:
+  key:
+    value: $COHERE_API_KEY
+    description: "The API key used to connect to Cohere. Include the `Bearer` prefix, for example `Bearer <your-api-key>`."
 {% endentity_example %}
-
-Replace the following with your actual values:
-* `$COHERE_API_KEY`: The API key used to connect to Cohere. Include the `Bearer ` prefix, for example `Bearer <your-api-key>`.

--- a/app/ai-gateway/ai-providers/dashscope.md
+++ b/app/ai-gateway/ai-providers/dashscope.md
@@ -17,6 +17,7 @@ products:
 
 tools:
   - konnect-api
+  - kongctl
 
 tags:
   - ai
@@ -47,14 +48,9 @@ To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model P
 
 Here's a minimal configuration for chat completions:
 
-<!--vale off-->
-{% konnect_api_request %}
-url: /v1/ai-gateways/$AI_GATEWAY_ID/model-providers
-status_code: 201
-method: POST
-headers:
-  - 'Content-Type: application/json'
-body:
+{% entity_example %}
+type: model-provider
+data:
   display_name: Dashscope Production
   name: my-dashscope-account
   type: dashscope
@@ -63,6 +59,8 @@ body:
       type: basic
       headers:
         - name: Authorization
-          value: Bearer $DASHSCOPE_API_KEY
-{% endkonnect_api_request %}
-<!--vale on-->
+          value: $DASHSCOPE_API_KEY
+{% endentity_example %}
+
+Replace the following with your actual values:
+* `$DASHSCOPE_API_KEY`: The API key used to connect to Dashscope. Include the `Bearer ` prefix, for example `Bearer <your-api-key>`.

--- a/app/ai-gateway/ai-providers/dashscope.md
+++ b/app/ai-gateway/ai-providers/dashscope.md
@@ -59,8 +59,9 @@ data:
       type: basic
       headers:
         - name: Authorization
-          value: $DASHSCOPE_API_KEY
+          value: ${key}
+variables:
+  key:
+    value: $DASHSCOPE_API_KEY
+    description: "The API key used to connect to Dashscope. Include the `Bearer` prefix, for example `Bearer <your-api-key>`."
 {% endentity_example %}
-
-Replace the following with your actual values:
-* `$DASHSCOPE_API_KEY`: The API key used to connect to Dashscope. Include the `Bearer ` prefix, for example `Bearer <your-api-key>`.

--- a/app/ai-gateway/ai-providers/databricks.md
+++ b/app/ai-gateway/ai-providers/databricks.md
@@ -59,11 +59,12 @@ data:
       type: basic
       headers:
         - name: Authorization
-          value: $DATABRICKS_TOKEN
+          value: ${key}
+variables:
+  key:
+    value: $DATABRICKS_TOKEN
+    description: "The access token used to connect to Databricks. Include the `Bearer` prefix, for example `Bearer <your-access-token>`."
 {% endentity_example %}
-
-Replace the following with your actual values:
-* `$DATABRICKS_TOKEN`: The access token used to connect to Databricks. Include the `Bearer ` prefix, for example `Bearer <your-access-token>`.
 
 ## Configure a model target for {{ provider.name }}
 

--- a/app/ai-gateway/ai-providers/databricks.md
+++ b/app/ai-gateway/ai-providers/databricks.md
@@ -17,6 +17,7 @@ products:
 
 tools:
   - konnect-api
+  - kongctl
 
 tags:
   - ai
@@ -47,14 +48,9 @@ To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model P
 
 Here's a minimal configuration for chat completions:
 
-<!--vale off-->
-{% konnect_api_request %}
-url: /v1/ai-gateways/$AI_GATEWAY_ID/model-providers
-status_code: 201
-method: POST
-headers:
-  - 'Content-Type: application/json'
-body:
+{% entity_example %}
+type: model-provider
+data:
   display_name: Databricks Production
   name: my-databricks-account
   type: databricks
@@ -63,9 +59,11 @@ body:
       type: basic
       headers:
         - name: Authorization
-          value: Bearer $DATABRICKS_TOKEN
-{% endkonnect_api_request %}
-<!--vale on-->
+          value: $DATABRICKS_TOKEN
+{% endentity_example %}
+
+Replace the following with your actual values:
+* `$DATABRICKS_TOKEN`: The access token used to connect to Databricks. Include the `Bearer ` prefix, for example `Bearer <your-access-token>`.
 
 ## Configure a model target for {{ provider.name }}
 

--- a/app/ai-gateway/ai-providers/deepseek.md
+++ b/app/ai-gateway/ai-providers/deepseek.md
@@ -59,8 +59,9 @@ data:
       type: basic
       headers:
         - name: Authorization
-          value: $DEEPSEEK_API_KEY
+          value: ${key}
+variables:
+  key:
+    value: $DEEPSEEK_API_KEY
+    description: "The API key used to connect to DeepSeek. Include the `Bearer` prefix, for example `Bearer <your-api-key>`."
 {% endentity_example %}
-
-Replace the following with your actual values:
-* `$DEEPSEEK_API_KEY`: The API key used to connect to DeepSeek. Include the `Bearer ` prefix, for example `Bearer <your-api-key>`.

--- a/app/ai-gateway/ai-providers/deepseek.md
+++ b/app/ai-gateway/ai-providers/deepseek.md
@@ -17,6 +17,7 @@ products:
 
 tools:
   - konnect-api
+  - kongctl
 
 tags:
   - ai
@@ -47,14 +48,9 @@ To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model P
 
 Here's a minimal configuration for chat completions:
 
-<!--vale off-->
-{% konnect_api_request %}
-url: /v1/ai-gateways/$AI_GATEWAY_ID/model-providers
-status_code: 201
-method: POST
-headers:
-  - 'Content-Type: application/json'
-body:
+{% entity_example %}
+type: model-provider
+data:
   display_name: Deepseek Production
   name: my-deepseek-account
   type: deepseek
@@ -63,6 +59,8 @@ body:
       type: basic
       headers:
         - name: Authorization
-          value: Bearer $DEEPSEEK_API_KEY
-{% endkonnect_api_request %}
-<!--vale on-->
+          value: $DEEPSEEK_API_KEY
+{% endentity_example %}
+
+Replace the following with your actual values:
+* `$DEEPSEEK_API_KEY`: The API key used to connect to DeepSeek. Include the `Bearer ` prefix, for example `Bearer <your-api-key>`.

--- a/app/ai-gateway/ai-providers/gemini.md
+++ b/app/ai-gateway/ai-providers/gemini.md
@@ -74,11 +74,12 @@ data:
       type: basic
       headers:
         - name: x-goog-api-key
-          value: $GEMINI_API_KEY
+          value: ${key}
+variables:
+  key:
+    value: $GEMINI_API_KEY
+    description: The API key used to connect to Gemini.
 {% endentity_example %}
-
-Replace the following with your actual values:
-* `$GEMINI_API_KEY`: The API key used to connect to Gemini.
 
 ## Authentication with GCP IAM
 

--- a/app/ai-gateway/ai-providers/gemini.md
+++ b/app/ai-gateway/ai-providers/gemini.md
@@ -17,6 +17,7 @@ products:
 
 tools:
   - konnect-api
+  - kongctl
 
 tags:
   - ai
@@ -62,14 +63,9 @@ To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model P
 
 Here's a minimal configuration for chat completions:
 
-<!--vale off-->
-{% konnect_api_request %}
-url: /v1/ai-gateways/$AI_GATEWAY_ID/model-providers
-status_code: 201
-method: POST
-headers:
-  - 'Content-Type: application/json'
-body:
+{% entity_example %}
+type: model-provider
+data:
   display_name: Gemini Production
   name: my-gemini-account
   type: gemini
@@ -79,8 +75,10 @@ body:
       headers:
         - name: x-goog-api-key
           value: $GEMINI_API_KEY
-{% endkonnect_api_request %}
-<!--vale on-->
+{% endentity_example %}
+
+Replace the following with your actual values:
+* `$GEMINI_API_KEY`: The API key used to connect to Gemini.
 
 ## Authentication with GCP IAM
 

--- a/app/ai-gateway/ai-providers/huggingface.md
+++ b/app/ai-gateway/ai-providers/huggingface.md
@@ -61,8 +61,9 @@ data:
       type: basic
       headers:
         - name: Authorization
-          value: $HUGGINGFACE_TOKEN
+          value: ${key}
+variables:
+  key:
+    value: $HUGGINGFACE_TOKEN
+    description: "The access token used to connect to Hugging Face. Include the `Bearer` prefix, for example `Bearer <your-access-token>`."
 {% endentity_example %}
-
-Replace the following with your actual values:
-* `$HUGGINGFACE_TOKEN`: The access token used to connect to Hugging Face. Include the `Bearer ` prefix, for example `Bearer <your-access-token>`.

--- a/app/ai-gateway/ai-providers/huggingface.md
+++ b/app/ai-gateway/ai-providers/huggingface.md
@@ -17,6 +17,7 @@ products:
 
 tools:
   - konnect-api
+  - kongctl
 
 tags:
   - ai
@@ -49,14 +50,9 @@ To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model P
 
 Here's a minimal configuration for chat completions:
 
-<!--vale off-->
-{% konnect_api_request %}
-url: /v1/ai-gateways/$AI_GATEWAY_ID/model-providers
-status_code: 201
-method: POST
-headers:
-  - 'Content-Type: application/json'
-body:
+{% entity_example %}
+type: model-provider
+data:
   display_name: Huggingface Production
   name: my-huggingface-account
   type: huggingface
@@ -65,6 +61,8 @@ body:
       type: basic
       headers:
         - name: Authorization
-          value: Bearer $HUGGINGFACE_TOKEN
-{% endkonnect_api_request %}
-<!--vale on-->
+          value: $HUGGINGFACE_TOKEN
+{% endentity_example %}
+
+Replace the following with your actual values:
+* `$HUGGINGFACE_TOKEN`: The access token used to connect to Hugging Face. Include the `Bearer ` prefix, for example `Bearer <your-access-token>`.

--- a/app/ai-gateway/ai-providers/kimi.md
+++ b/app/ai-gateway/ai-providers/kimi.md
@@ -17,6 +17,7 @@ works_on:
 
 tools:
   - konnect-api
+  - kongctl
 
 products:
   - ai-gateway
@@ -46,14 +47,9 @@ related_resources:
 
 To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model Provider](/ai-gateway/entities/ai-model-provider/) as follows:
 
-<!--vale off-->
-{% konnect_api_request %}
-url: /v1/ai-gateways/$AI_GATEWAY_ID/model-providers
-status_code: 201
-method: POST
-headers:
-  - 'Content-Type: application/json'
-body:
+{% entity_example %}
+type: model-provider
+data:
   display_name: Kimi Production
   name: my-kimi-account
   type: kimi
@@ -62,6 +58,8 @@ body:
       type: basic
       headers:
         - name: Authorization
-          value: Bearer $KIMI_TOKEN
-{% endkonnect_api_request %}
-<!--vale on-->
+          value: $KIMI_TOKEN
+{% endentity_example %}
+
+Replace the following with your actual values:
+* `$KIMI_TOKEN`: The API token used to connect to Kimi. Include the `Bearer ` prefix, for example `Bearer <your-api-token>`.

--- a/app/ai-gateway/ai-providers/kimi.md
+++ b/app/ai-gateway/ai-providers/kimi.md
@@ -58,8 +58,9 @@ data:
       type: basic
       headers:
         - name: Authorization
-          value: $KIMI_TOKEN
+          value: ${key}
+variables:
+  key:
+    value: $KIMI_TOKEN
+    description: "The API token used to connect to Kimi. Include the `Bearer` prefix, for example `Bearer <your-api-token>`."
 {% endentity_example %}
-
-Replace the following with your actual values:
-* `$KIMI_TOKEN`: The API token used to connect to Kimi. Include the `Bearer ` prefix, for example `Bearer <your-api-token>`.

--- a/app/ai-gateway/ai-providers/llama.md
+++ b/app/ai-gateway/ai-providers/llama.md
@@ -17,6 +17,7 @@ products:
 
 tools:
   - konnect-api
+  - kongctl
 
 tags:
   - ai
@@ -47,14 +48,9 @@ To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model P
 
 Here's a minimal configuration for chat completions:
 
-<!--vale off-->
-{% konnect_api_request %}
-url: /v1/ai-gateways/$AI_GATEWAY_ID/model-providers
-status_code: 201
-method: POST
-headers:
-  - 'Content-Type: application/json'
-body:
+{% entity_example %}
+type: model-provider
+data:
   display_name:  llama2 Production
   name: my-llama2-account
   type:  llama2
@@ -63,9 +59,11 @@ body:
       type: basic
       headers:
         - name: Authorization
-          value: Bearer $LLAMA_API_KEY
-{% endkonnect_api_request %}
-<!--vale on-->
+          value: $LLAMA_API_KEY
+{% endentity_example %}
+
+Replace the following with your actual values:
+* `$LLAMA_API_KEY`: The API key used to connect to your Llama2 endpoint. Include the `Bearer ` prefix, for example `Bearer <your-api-key>`.
 
 ## Configure a model target for {{ provider.name }}
 

--- a/app/ai-gateway/ai-providers/llama.md
+++ b/app/ai-gateway/ai-providers/llama.md
@@ -51,9 +51,9 @@ Here's a minimal configuration for chat completions:
 {% entity_example %}
 type: model-provider
 data:
-  display_name:  llama2 Production
+  display_name: Llama2 Production
   name: my-llama2-account
-  type:  llama2
+  type: llama2
   config:
     auth:
       type: basic

--- a/app/ai-gateway/ai-providers/llama.md
+++ b/app/ai-gateway/ai-providers/llama.md
@@ -59,11 +59,12 @@ data:
       type: basic
       headers:
         - name: Authorization
-          value: $LLAMA_API_KEY
+          value: ${key}
+variables:
+  key:
+    value: $LLAMA_API_KEY
+    description: "The API key used to connect to your Llama2 endpoint. Include the `Bearer` prefix, for example `Bearer <your-api-key>`."
 {% endentity_example %}
-
-Replace the following with your actual values:
-* `$LLAMA_API_KEY`: The API key used to connect to your Llama2 endpoint. Include the `Bearer ` prefix, for example `Bearer <your-api-key>`.
 
 ## Configure a model target for {{ provider.name }}
 

--- a/app/ai-gateway/ai-providers/mistral.md
+++ b/app/ai-gateway/ai-providers/mistral.md
@@ -59,11 +59,12 @@ data:
       type: basic
       headers:
         - name: Authorization
-          value: $MISTRAL_API_KEY
+          value: ${key}
+variables:
+  key:
+    value: $MISTRAL_API_KEY
+    description: "The API key used to connect to Mistral. Include the `Bearer` prefix, for example `Bearer <your-api-key>`."
 {% endentity_example %}
-
-Replace the following with your actual values:
-* `$MISTRAL_API_KEY`: The API key used to connect to Mistral. Include the `Bearer ` prefix, for example `Bearer <your-api-key>`.
 
 ## Configure a model target for {{ provider.name }}
 

--- a/app/ai-gateway/ai-providers/mistral.md
+++ b/app/ai-gateway/ai-providers/mistral.md
@@ -17,6 +17,7 @@ products:
 
 tools:
   - konnect-api
+  - kongctl
 
 tags:
   - ai
@@ -47,14 +48,9 @@ To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model P
 
 Here's a minimal configuration for chat completions:
 
-<!--vale off-->
-{% konnect_api_request %}
-url: /v1/ai-gateways/$AI_GATEWAY_ID/model-providers
-status_code: 201
-method: POST
-headers:
-  - 'Content-Type: application/json'
-body:
+{% entity_example %}
+type: model-provider
+data:
   display_name: Mistral Production
   name: my-mistral-account
   type: mistral
@@ -63,9 +59,11 @@ body:
       type: basic
       headers:
         - name: Authorization
-          value: Bearer $MISTRAL_API_KEY
-{% endkonnect_api_request %}
-<!--vale on-->
+          value: $MISTRAL_API_KEY
+{% endentity_example %}
+
+Replace the following with your actual values:
+* `$MISTRAL_API_KEY`: The API key used to connect to Mistral. Include the `Bearer ` prefix, for example `Bearer <your-api-key>`.
 
 ## Configure a model target for {{ provider.name }}
 

--- a/app/ai-gateway/ai-providers/ollama.md
+++ b/app/ai-gateway/ai-providers/ollama.md
@@ -17,6 +17,7 @@ products:
 
 tools:
   - konnect-api
+  - kongctl
 
 tags:
   - ai
@@ -47,19 +48,13 @@ To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model P
 
 Here's a minimal configuration for chat completions:
 
-<!--vale off-->
-{% konnect_api_request %}
-url: /v1/ai-gateways/$AI_GATEWAY_ID/model-providers
-status_code: 201
-method: POST
-headers:
-  - 'Content-Type: application/json'
-body:
+{% entity_example %}
+type: model-provider
+data:
   display_name: Ollama Production
   name: local-ollama
   type: ollama
   config:
     auth:
       type: basic
-{% endkonnect_api_request %}
-<!--vale on-->
+{% endentity_example %}

--- a/app/ai-gateway/ai-providers/openai.md
+++ b/app/ai-gateway/ai-providers/openai.md
@@ -11,6 +11,7 @@ permalink: /ai-gateway/ai-providers/openai/
 
 tools:
   - konnect-api
+  - kongctl
 
 works_on:
  - konnect
@@ -47,14 +48,9 @@ To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model P
 
 Here's a minimal configuration for chat completions:
 
-<!--vale off-->
-{% konnect_api_request %}
-url: /v1/ai-gateways/$AI_GATEWAY_ID/model-providers
-status_code: 201
-method: POST
-headers:
-  - 'Content-Type: application/json'
-body:
+{% entity_example %}
+type: model-provider
+data:
   display_name: OpenAI Production
   name: my-openai-account
   type: openai
@@ -63,6 +59,8 @@ body:
       type: basic
       headers:
         - name: Authorization
-          value: Bearer $OPENAI_API_KEY
-{% endkonnect_api_request %}
-<!--vale on-->
+          value: $OPENAI_API_KEY
+{% endentity_example %}
+
+Replace the following with your actual values:
+* `$OPENAI_API_KEY`: The API key used to connect to OpenAI. Include the `Bearer ` prefix, for example `Bearer <your-api-key>`.

--- a/app/ai-gateway/ai-providers/openai.md
+++ b/app/ai-gateway/ai-providers/openai.md
@@ -59,8 +59,9 @@ data:
       type: basic
       headers:
         - name: Authorization
-          value: $OPENAI_API_KEY
+          value: ${key}
+variables:
+  key:
+    value: $OPENAI_API_KEY
+    description: "The API key used to connect to OpenAI. Include the `Bearer` prefix, for example `Bearer <your-api-key>`."
 {% endentity_example %}
-
-Replace the following with your actual values:
-* `$OPENAI_API_KEY`: The API key used to connect to OpenAI. Include the `Bearer ` prefix, for example `Bearer <your-api-key>`.

--- a/app/ai-gateway/ai-providers/vercel.md
+++ b/app/ai-gateway/ai-providers/vercel.md
@@ -60,8 +60,9 @@ data:
       type: basic
       headers:
         - name: Authorization
-          value: $VERCEL_API_KEY
+          value: ${key}
+variables:
+  key:
+    value: $VERCEL_API_KEY
+    description: "The API key used to connect to Vercel. Include the `Bearer` prefix, for example `Bearer <your-api-key>`."
 {% endentity_example %}
-
-Replace the following with your actual values:
-* `$VERCEL_API_KEY`: The API key used to connect to Vercel. Include the `Bearer ` prefix, for example `Bearer <your-api-key>`.

--- a/app/ai-gateway/ai-providers/vercel.md
+++ b/app/ai-gateway/ai-providers/vercel.md
@@ -17,6 +17,7 @@ products:
 
 tools:
   - konnect-api
+  - kongctl
 
 tags:
   - ai
@@ -48,14 +49,9 @@ Note that, {{ site.vercel }} hosts [models](https://vercel.com/ai-gateway/models
 
 Here's a minimal configuration for chat completions:
 
-<!--vale off-->
-{% konnect_api_request %}
-url: /v1/ai-gateways/$AI_GATEWAY_ID/model-providers
-status_code: 201
-method: POST
-headers:
-  - 'Content-Type: application/json'
-body:
+{% entity_example %}
+type: model-provider
+data:
   display_name: Vercel Production
   name: my-vercel-account
   type: vercel
@@ -64,6 +60,8 @@ body:
       type: basic
       headers:
         - name: Authorization
-          value: Bearer $VERCEL_API_KEY
-{% endkonnect_api_request %}
-<!--vale on-->
+          value: $VERCEL_API_KEY
+{% endentity_example %}
+
+Replace the following with your actual values:
+* `$VERCEL_API_KEY`: The API key used to connect to Vercel. Include the `Bearer ` prefix, for example `Bearer <your-api-key>`.

--- a/app/ai-gateway/ai-providers/vertex.md
+++ b/app/ai-gateway/ai-providers/vertex.md
@@ -59,11 +59,12 @@ data:
     auth:
       type: gcp
       use_gcp_service_account: true
-      service_account_json: $GCP_ACCOUNT_JSON
+      service_account_json: ${account}
+variables:
+  account:
+    value: $GCP_ACCOUNT_JSON
+    description: The contents of your GCP service account JSON key file.
 {% endentity_example %}
-
-Replace the following with your actual values:
-* `$GCP_ACCOUNT_JSON`: The contents of your GCP service account JSON key file.
 
 ## Authentication with GCP IAM
 

--- a/app/ai-gateway/ai-providers/vertex.md
+++ b/app/ai-gateway/ai-providers/vertex.md
@@ -17,6 +17,7 @@ products:
 
 tools:
   - konnect-api
+  - kongctl
 
 tags:
   - ai
@@ -48,14 +49,9 @@ To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model P
 
 Here's a minimal configuration for chat completions:
 
-<!--vale off-->
-{% konnect_api_request %}
-url: /v1/ai-gateways/$AI_GATEWAY_ID/model-providers
-status_code: 201
-method: POST
-headers:
-  - 'Content-Type: application/json'
-body:
+{% entity_example %}
+type: model-provider
+data:
   display_name: Vertex Production
   name: my-vertex-account
   type: vertex
@@ -64,8 +60,10 @@ body:
       type: gcp
       use_gcp_service_account: true
       service_account_json: $GCP_ACCOUNT_JSON
-{% endkonnect_api_request %}
-<!--vale on-->
+{% endentity_example %}
+
+Replace the following with your actual values:
+* `$GCP_ACCOUNT_JSON`: The contents of your GCP service account JSON key file.
 
 ## Authentication with GCP IAM
 

--- a/app/ai-gateway/ai-providers/vllm.md
+++ b/app/ai-gateway/ai-providers/vllm.md
@@ -17,6 +17,7 @@ products:
 
 tools:
   - konnect-api
+  - kongctl
 
 tags:
   - ai
@@ -48,22 +49,16 @@ To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model P
 
 Here's a minimal configuration for chat completions:
 
-<!--vale off-->
-{% konnect_api_request %}
-url: /v1/ai-gateways/$AI_GATEWAY_ID/model-providers
-status_code: 201
-method: POST
-headers:
-  - 'Content-Type: application/json'
-body:
+{% entity_example %}
+type: model-provider
+data:
   display_name: vllm Production
   name: my-vllm-account
   type: vllm
   config:
     auth:
       type: basic
-{% endkonnect_api_request %}
-<!--vale on-->
+{% endentity_example %}
 
 ## Configure a model target for {{ provider.name }}
 

--- a/app/ai-gateway/ai-providers/xai.md
+++ b/app/ai-gateway/ai-providers/xai.md
@@ -61,8 +61,9 @@ data:
       type: basic
       headers:
         - name: Authorization
-          value: $XAI_API_KEY
+          value: ${key}
+variables:
+  key:
+    value: $XAI_API_KEY
+    description: "The API key used to connect to xAI. Include the `Bearer` prefix, for example `Bearer <your-api-key>`."
 {% endentity_example %}
-
-Replace the following with your actual values:
-* `$XAI_API_KEY`: The API key used to connect to xAI. Include the `Bearer ` prefix, for example `Bearer <your-api-key>`.

--- a/app/ai-gateway/ai-providers/xai.md
+++ b/app/ai-gateway/ai-providers/xai.md
@@ -17,6 +17,7 @@ products:
 
 tools:
   - konnect-api
+  - kongctl
 
 tags:
   - ai
@@ -49,14 +50,9 @@ To use {{ provider.name }} with {{site.ai_gateway}}, configure a new [AI Model P
 
 Here's a minimal configuration for chat completions:
 
-<!--vale off-->
-{% konnect_api_request %}
-url: /v1/ai-gateways/$AI_GATEWAY_ID/model-providers
-status_code: 201
-method: POST
-headers:
-  - 'Content-Type: application/json'
-body:
+{% entity_example %}
+type: model-provider
+data:
   display_name: Xai Production
   name: my-xai-account
   type: xai
@@ -65,6 +61,8 @@ body:
       type: basic
       headers:
         - name: Authorization
-          value: Bearer $XAI_API_KEY
-{% endkonnect_api_request %}
-<!--vale on-->
+          value: $XAI_API_KEY
+{% endentity_example %}
+
+Replace the following with your actual values:
+* `$XAI_API_KEY`: The API key used to connect to xAI. Include the `Bearer ` prefix, for example `Bearer <your-api-key>`.


### PR DESCRIPTION
## Description

Important things to be fixed:

Adding kongctl as a tool and using entity_example liquid doesn't render `Add this snippet to an ai_gateways resource in your declarative configuration file, and then [manage it with kongctl](http://localhost:8888/kongctl/declarative/#declarative-commands):` and `Make sure to replace the following placeholders with your own values: ai-gateway-name: The name of your AI Gateway.`

<img width="1053" height="710" alt="Screenshot 2026-07-24 at 10 39 04" src="https://github.com/user-attachments/assets/95d974d0-8887-4d7f-b71c-bb97395b4379" />

Also, these kongctl snippets would create a new ai gateway, not append this config to the existing AI Gateway.

@fabianrbz - can we fix this?

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
