### PR TITLE
fix(dcgw): Clarify REP upstream service domain name

### DIFF
--- a/app/_how-tos/dedicated-cloud-gateways/aws-resource-endpoints.md
+++ b/app/_how-tos/dedicated-cloud-gateways/aws-resource-endpoints.md
@@ -40,11 +40,13 @@ prereqs:
         * A [resource gateway](https://docs.aws.amazon.com/vpc-lattice/latest/ug/create-resource-gateway.html)
         * A [resource configuration group](https://docs.aws.amazon.com/vpc-lattice/latest/ug/create-resource-configuration.html)
 
-        Copy and save the resource configuration ID and [upstream service domain name](https://docs.aws.amazon.com/vpc-lattice/latest/ug/service-custom-domain-name.html) (generated or custom) for each resource configuration. {{site.konnect_short_name}} will use these to create a mapping of upstream domain names and resource configuration IDs.
+        Copy and save the resource configuration ID for each resource configuration.
 
-        Export your AWS upstream service domain name:
+        Choose a domain name for each resource configuration, for example `myupstream.internal`. This domain doesn't need to exist in AWS. {{site.konnect_short_name}} uses it to create a mapping between the domain name and the resource configuration ID, and creates a CNAME record pointing your chosen domain to the resource configuration.
+
+        Export your chosen domain name:
         ```sh
-        export UPSTREAM_SERVICE_DOMAIN_NAME='http://YOUR-UPSTREAM-SERVICE-DOMAIN-NAME/anything'
+        export UPSTREAM_DOMAIN_NAME='http://YOUR-UPSTREAM-DOMAIN-NAME/anything'
         ```
         We'll use this to connect to our Dedicated Cloud Gateway service.
       icon_url: /assets/icons/aws.svg
@@ -56,7 +58,7 @@ prereqs:
         1. Click your Dedicated Cloud Gateway.
         1. Click the **Gateway Services** tab.
         1. Click **New gateway service**.
-        1. In the **Full URL** field, enter your upstream service domain, appended with `/anything`. For example: `http://YOUR-UPSTREAM-SERVICE-DOMAIN-NAME/anything`
+        1. In the **Full URL** field, enter the domain name you chose in the prerequisites, appended with `/anything`. For example: `http://YOUR-UPSTREAM-DOMAIN-NAME/anything`
         1. In the **Name** field, enter `example-service`.
         1. Click **Save**.
         1. Click the **Routes** tab.
@@ -138,7 +140,7 @@ Now that the resource share is configured in AWS, you can connect it with {{site
    
    {:.info}
    > **Note:** If your resource configuration has a child resource configuration, use the ID from the child resource.
-1. In the **Domain name** field, enter your resource configuration domain name from AWS.
+1. In the **Domain name** field, enter the domain name you chose in the prerequisites.
    
    {:.info}
    > **Note:** If your resource configuration has a child resource configuration, use the domain name from the child resource.
@@ -153,7 +155,7 @@ Once the resource configuration mapping displays as `Ready`, your resource endpo
 Additionally, you can validate that the resource endpoint connections in {{site.konnect_short_name}} are working correctly by navigating to your [Gateway Service configured in the prerequisites](/dedicated-cloud-gateways/aws-resource-endpoints/#required-entities):
 
 ```sh
-curl -i -X GET "$UPSTREAM_SERVICE_DOMAIN_NAME"
+curl -i -X GET "$UPSTREAM_DOMAIN_NAME"
 ```
 
 ## Configure VPC security group inbound rules

--- a/app/_how-tos/dedicated-cloud-gateways/aws-resource-endpoints.md
+++ b/app/_how-tos/dedicated-cloud-gateways/aws-resource-endpoints.md
@@ -40,7 +40,7 @@ prereqs:
         * A [resource gateway](https://docs.aws.amazon.com/vpc-lattice/latest/ug/create-resource-gateway.html)
         * A [resource configuration group](https://docs.aws.amazon.com/vpc-lattice/latest/ug/create-resource-configuration.html)
 
-        Copy and save the resource configuration ID and resource definition domain name for each resource configuration. {{site.konnect_short_name}} will use these to create a mapping of upstream domain names and resource configuration IDs.
+        Copy and save the resource configuration ID and [upstream service domain name](https://docs.aws.amazon.com/vpc-lattice/latest/ug/service-custom-domain-name.html) (generated or custom) for each resource configuration. {{site.konnect_short_name}} will use these to create a mapping of upstream domain names and resource configuration IDs.
 
         Export your AWS resource configuration domain name:
         ```sh

--- a/app/_how-tos/dedicated-cloud-gateways/aws-resource-endpoints.md
+++ b/app/_how-tos/dedicated-cloud-gateways/aws-resource-endpoints.md
@@ -42,9 +42,9 @@ prereqs:
 
         Copy and save the resource configuration ID and [upstream service domain name](https://docs.aws.amazon.com/vpc-lattice/latest/ug/service-custom-domain-name.html) (generated or custom) for each resource configuration. {{site.konnect_short_name}} will use these to create a mapping of upstream domain names and resource configuration IDs.
 
-        Export your AWS resource configuration domain name:
+        Export your AWS upstream service domain name:
         ```sh
-        export RESOURCE_DOMAIN_NAME='http://YOUR-RESOURCE-DOMAIN-NAME/anything'
+        export UPSTREAM_SERVICE_DOMAIN_NAME='http://YOUR-UPSTREAM-SERVICE-DOMAIN-NAME/anything'
         ```
         We'll use this to connect to our Dedicated Cloud Gateway service.
       icon_url: /assets/icons/aws.svg
@@ -56,7 +56,7 @@ prereqs:
         1. Click your Dedicated Cloud Gateway.
         1. Click the **Gateway Services** tab.
         1. Click **New gateway service**.
-        1. In the **Full URL** field, enter your resource domain, appended with `/anything`. For example: `http://YOUR-RESOURCE-DOMAIN-NAME/anything`
+        1. In the **Full URL** field, enter your upstream service domain, appended with `/anything`. For example: `http://YOUR-UPSTREAM-SERVICE-DOMAIN-NAME/anything`
         1. In the **Name** field, enter `example-service`.
         1. Click **Save**.
         1. Click the **Routes** tab.
@@ -153,7 +153,7 @@ Once the resource configuration mapping displays as `Ready`, your resource endpo
 Additionally, you can validate that the resource endpoint connections in {{site.konnect_short_name}} are working correctly by navigating to your [Gateway Service configured in the prerequisites](/dedicated-cloud-gateways/aws-resource-endpoints/#required-entities):
 
 ```sh
-curl -i -X GET "$RESOURCE_DOMAIN_NAME"
+curl -i -X GET "$UPSTREAM_SERVICE_DOMAIN_NAME"
 ```
 
 ## Configure VPC security group inbound rules


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes https://kongstrong.slack.com/archives/C070FKK6GBT/p1784625812687919?thread_ts=1784618061.332219&cid=C070FKK6GBT

## Preview Links
/dedicated-cloud-gateways/aws-resource-endpoints/

Is this link better? https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-vpc-lattice-service.html

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
