### PR TITLE
[DRAFT] fix(ai-gateway): update the AI Gateway V2 migration guide to use the new tooling

### DIFF
--- a/app/ai-gateway/v2-migration-guide.md
+++ b/app/ai-gateway/v2-migration-guide.md
@@ -162,7 +162,7 @@ auth_strategies:
     client_id:
     - your-client-id
     client_secret:
-    - your-client-secret
+    - !secret {source: !env OIDC_CLIENT_SECRET}
     scopes:
     - openid
     cache_tokens_salt: "a-random-string"
@@ -245,6 +245,7 @@ Open the `yaml` files in `./out` and confirm that the converter captured everyth
 - Each AI Agent points at the correct upstream URL and carries the logging settings you had configured.
 - The auth strategies you declared in `./config` were merged into `auth_strategies.yaml` and attached to the right AI Models, AI MCP Servers, and AI Agents via `access.auth_strategies`, and `vaults.yaml` and `gateway.yaml` reflect what you declared.
 - Non-auth supporting plugins were converted to AI Policies and attached to the right entities.
+- Any write-only credential field carried over as a plain string, such as an AI Model Provider's `config.auth.headers[].value`, is wrapped in a deferred `!secret` source rather than left as a literal. See [Validate AI Model converted configuration files](#converted-configuration-files).
 
 Pay particular attention to anything the converter can't infer from the config of {{site.ai_gateway}} running on {{site.base_gateway}}, such as an AI Model Provider `display_name` or an AI Model `display_name`. These are required in {{site.ai_gateway}} 2.x and may be generated from the source data, so rename them to something meaningful before you apply.
 
@@ -318,7 +319,7 @@ ai_gateway_model_providers:
       type: basic
       headers:
       - name: Authorization
-        value: Bearer {vault://openai-vault/api-key}
+        value: !secret {source: !env OPENAI_API_KEY}
 
 # models.yaml (AI Gateway v2 entity model)
 ai_gateway_models:
@@ -364,6 +365,24 @@ ai_gateway_models:
 {:.collapsible}
 <!--vale on-->
 
+AI Model Provider credential fields, such as `config.auth.headers[].value` for basic auth, or the equivalents for other auth types (for example `secret_access_key`, `client_secret`), are write-only in {{site.ai_gateway}} 2.x. 
+The converter carries over whatever value was in the v1 target's `auth` block as a plain string, whether that was a hardcoded literal or `{vault://...}` syntax. 
+A plain string in a write-only field makes `kongctl apply`/`plan` fail:
+
+```
+Error: failed to load configuration: failed to process !secret tags in out/providers.yaml:
+resource ai_gateway_model_provider "openai-1" field /config/auth/headers/0/value
+is write-only and requires !secret with a deferred source
+```
+
+After the converter runs, find each plain string value in a write-only credential field in `providers.yaml` and wrap it in a deferred `!secret` source as shown above, then set the real value out of band:
+
+```sh
+export OPENAI_API_KEY="YOUR CREDENTIAL"
+```
+
+The environment variable name is your own choice. It doesn't need to match anything you declared in `config/auth_strategies.yaml` or any other file in `./config`.
+
 ##### Verify AI Models entity configuration
 
 To verify your AI Models entity migration, be sure to check the following:
@@ -374,7 +393,6 @@ To verify your AI Models entity migration, be sure to check the following:
 - Auth override: If you relied on `config.targets.auth.allow_override` when running {{site.ai_gateway}} on {{site.base_gateway}}, set `allow_auth_override: true` on the corresponding target in version 2.x.
 - Identity: AI Models have no route auth after conversion. Confirm the auth strategies you added previously are attached via `access.auth_strategies`.
 - Vector database and embeddings: `config.vectordb` and `config.embeddings` settings carry over onto the AI Model config under the `balancer` config, keeping the same Redis or pgvector strategy.
-
 
 #### Validate MCP Servers
 
@@ -630,6 +648,40 @@ To verify your AI Agent entity migration, be sure to check the following:
 - Logging field names: As with AI MCP Servers, `log_payloads` becomes `payloads` under `config.logging`, and `log_statistics` is dropped (no {{site.ai_gateway}} 2.x equivalent).
 - Identity: Like AI Models, an AI Agent has no route auth after conversion. If the agent needs authentication, confirm the auth strategy you declared is attached via `access.auth_strategies`.
 - Analytics: A2A metrics flow into {{site.konnect_short_name}} analytics. View them under Agentic usage analytics in {{site.konnect_short_name}} [Explorer](/observability/explorer/) and [Dashboards](/observability/#dashboard).
+
+{% comment %}
+_Leaving this out of the rendered guide since it may get fixed in a later extension release. Re-check before publishing a fix for this._
+#### Validate Auth Strategies
+
+**Known converter issue (kong/ai-gateway-converter v0.5.0):** 
+The `!secret`/`!env`
+tags on `client_secret` in `config/auth_strategies.yaml` don't survive the
+merge into `./out`. Instead of preserving `client_secret: - !secret {source:
+!env OIDC_CLIENT_SECRET}`, the converter emits a plain, untagged map in
+`out/auth_strategies.yaml`:
+
+```yaml
+client_secret:
+  - source: OIDC_CLIENT_SECRET
+```
+
+`kongctl apply`/`plan` then fails with an error like the following:
+
+```
+Error: failed to load configuration: failed to process !secret tags in out/auth_strategies.yaml:
+... incompatible plan change ... for CREATE ai_gateway_auth_strategy: failed to decode AI Gateway
+Auth Strategy create payload: the current SDK rejected the payload ...
+```
+
+**Workaround:**
+Manually fix `out/auth_strategies.yaml` after conversion so the
+array element is itself the tagged value, not an object with a `source:` key:
+
+```yaml
+client_secret:
+- !secret {source: !env OIDC_CLIENT_SECRET}
+```
+{% endcomment %}
 
 ### Step 6: Authenticate kongctl
 

--- a/app/ai-gateway/v2-migration-guide.md
+++ b/app/ai-gateway/v2-migration-guide.md
@@ -98,8 +98,9 @@ The resulting `kong.yaml` contains your Services, Routes, plugins (including `ai
 
 {:.warning}
 > **Converter requirements:** 
-> * Each `ai-proxy` or `ai-proxy-advanced` plugin you're migrating needs a real model name (for example `gpt-4o`) configured. The converter can't generate one for you, and a converted AI Model with no model name fails validation when you apply it. If any of your plugins are missing one, set it on the {{site.base_gateway}} 3.x control plane before you export.
-> * `ai-proxy-advanced`, `ai-mcp-proxy`, and `ai-a2a-proxy` plugins **must** be scoped to a Service and Route to convert to the {{site.ai_gateway}} 2.x entity model.
+> * Each `ai-proxy` or `ai-proxy-advanced` plugin you're migrating needs a model name (for example `gpt-4o`) configured. The converter can't generate one for you, and a converted AI Model with no model name fails validation when you apply it. If any of your plugins are missing one, set it on the {{site.base_gateway}} 3.x control plane before you export.
+> * Each `ai-proxy` or `ai-proxy-advanced` plugin's target needs authentication (`auth`) configured if the upstream provider requires it. The converter carries this into the {{site.ai_gateway}} Model Provider's `config.auth`. If the target has no `auth` configured, the converted provider is missing `config` entirely and fails validation when you apply it.
+> * `ai-proxy-advanced`, `ai-mcp-proxy`, and `ai-a2a-proxy` plugins can be attached to a Service or a Route, but the Service they're attached to **must** have at least one Route attached, or the plugin won't convert to the {{site.ai_gateway}} 2.x entity model.
 
 ### Step 3: Prepare the configuration directory
 
@@ -170,7 +171,7 @@ identity_providers:
 
 The `openid-connect` entry above shows only the fields {{site.ai_gateway}} requires at minimum. Add any other fields your identity provider actually uses (additional scopes, claims, cookie settings, and so on). Don't copy fields straight from your v1 `openid-connect` plugin config if they're unset (`null`) there. {{site.ai_gateway}} 2.x rejects explicit `null` values for most fields, so it's easier to start minimal and add only what you need.
 
-At most two identity providers are allowed (at most one `key-auth` and one `openid-connect`), and at most one may use the `"*"` wildcard per entity kind. The converter attaches each provider to the listed entities via their `access.identity_providers`.
+At most, two identity providers are allowed (one `key-auth` and one `openid-connect`), and at only one provider can use the `"*"` wildcard per entity kind. The converter attaches each provider to the listed entities via their `access.identity_providers`.
 
 #### Vaults
 
@@ -181,17 +182,27 @@ Add a `config/vaults.yaml` with an entry for any secret store your migrated conf
 # config/vaults.yaml
 vaults:
 - ref: ai-vault
-  name: ai-vault
+  name: hashicorp
   display_name: AI Gateway Vault
-  type: konnect
-  description: Credential store for AI Gateway
+  type: hcv
+  description: HCV vault for AI Gateway
+  prefix: "my-vault"
   config:
-    config_store_id: "$KONNECT_CONFIG_STORE_ID"
+    auth_method: token
+    base64_decode: false
+    host: "127.0.0.1"
+    kv: "v1"
+    mount: "secret"
+    port: 8200
+    protocol: "http"
+    ssl_verify: true
+    token: "*********"
 ```
 <!--vale on-->
 
-{:.info}
-> **Note:** For a [{{site.konnect_short_name}} Config Store vault](/how-to/configure-the-konnect-config-store/) (`type: konnect`), the Config Store you reference must already exist in {{site.konnect_short_name}} before you apply the configuration. `kongctl` does not create it for you. If you created the Config Store through the {{site.konnect_short_name}} UI, it's created without a `name`. Set one with the [Update Config Store API](/api/konnect/control-planes-config/v2/#/operations/update-config-store) before you apply the configuration.
+{% comment %}
+If you're using a {{site.konnect_short_name}} Config Store, you must [manually migrate](#manually-migrate-konnect-config-store-vault) that after using the conversion tool.
+{% endcomment %}
 
 #### Per-model ACLs
 
@@ -241,6 +252,34 @@ Open the `yaml` files in `./out` and confirm that the converter captured everyth
 - Non-auth supporting plugins were converted to AI Policies and attached to the right entities.
 
 Pay particular attention to anything the converter can't infer from the config of {{site.ai_gateway}} running on {{site.base_gateway}}, such as an AI Model Provider `display_name` or an AI Model `display_name`. These are required in {{site.ai_gateway}} 2.x and may be generated from the source data, so rename them to something meaningful before you apply.
+
+{% comment %}
+
+#### Manually migrate {{site.konnect_short_name}} Config Store vault 
+
+If you're using a {{site.konnect_short_name}} Config Store vault, you must manually migrate it.
+The converter doesn't correctly convert a v1 vault with `type: konnect`. It emits the Config Store's UUID as a literal value under the vault's `config.config_store_id`, which Konnect rejects. Until this is fixed, migrate this vault manually instead of using the converter's output for it.
+
+Declare an `ai_gateway_config_stores` entry for the Config Store, and reference its `id` from the vault's `config.config_store_id` with `!ref`, instead of hardcoding the Config Store's UUID:
+
+```yaml
+ai_gateway_config_stores:
+- ref: ai-config-store
+  ai_gateway: !ref ai-gateway#id
+  name: "your-config-store-name"
+
+ai_gateway_vaults:
+- ref: ai-vault
+  ai_gateway: !ref ai-gateway#id
+  name: ai-vault
+  type: konnect
+  config:
+    config_store_id: !ref ai-config-store#id
+```
+
+{:.info}
+> **Note:** For a [{{site.konnect_short_name}} Config Store vault](/how-to/configure-the-konnect-config-store/) (`type: konnect`), the Config Store you reference must already exist in {{site.konnect_short_name}} before you apply the configuration. `kongctl` does not create it for you. If you created the Config Store through the {{site.konnect_short_name}} UI, it's created without a `name`. Set one with the [Update Config Store API](/api/konnect/control-planes-config/v2/#/operations/update-config-store) before you apply the configuration.
+{% endcomment %}
 
 #### Validate AI Models
 

--- a/app/ai-gateway/v2-migration-guide.md
+++ b/app/ai-gateway/v2-migration-guide.md
@@ -44,7 +44,7 @@ Before migrating, make sure you have:
 - A [{{site.konnect_short_name}} Personal Access Token (PAT) or System Account Access Token](/konnect-api/#konnect-api-authentication) with permission to read the source control plane and write to the {{site.ai_gateway}} control plane.
 - The [`deck` CLI](/deck/#install-deck) for exporting your current configuration.
 - The [`kongctl` CLI](/kongctl/) for applying the converted configuration to the {{site.ai_gateway}} control plane.
-- The identity providers, Vaults, and per-model ACLs you want the migrated AI Models, AI MCP Servers, and AI Agents to use. The converter cannot recover these from the decK export, so you declare them manually.
+- The auth strategies, Vaults, and per-model ACLs you want the migrated AI Models, AI MCP Servers, and AI Agents to use. The converter cannot recover these from the decK export, so you declare them manually.
 
 ## Migration overview
 
@@ -52,7 +52,7 @@ Migration uses the `kongctl convert ai-gateway extension` to translate your exis
 
 1. Install the `kongctl convert ai-gateway` extension.
 1. Export the declarative configuration from your existing {{site.base_gateway}} control plane with decK.
-1. Prepare a `./config` directory with the target control plane, identity providers, Vaults, and per-model ACLs the converter cannot recover from the decK export.
+1. Prepare a `./config` directory with the target control plane, auth strategies, Vaults, and per-model ACLs the converter cannot recover from the decK export.
 1. Run the converter to merge `./config` and produce a directory of {{site.ai_gateway}} entity configuration files.
 1. Validate that the output includes all of your AI Models, AI MCP Servers, and AI Agents.
 1. Authenticate `kongctl` with a {{site.konnect_short_name}} PAT or System Account Access Token.
@@ -69,7 +69,7 @@ sequenceDiagram
     participant E as {{site.ai_gateway}} CP<br/>{{site.ai_gateway}} v2
 
     A->>B: deck gateway dump
-    Note over C: add control plane, identity<br/>providers, vaults, and ACLs
+    Note over C: add control plane, auth<br/>strategies, vaults, and ACLs
     B->>D: kongctl convert ai-gateway
     C-->>D: merged on conversion
     D->>D: review and validate
@@ -104,8 +104,7 @@ The resulting `kong.yaml` contains your Services, Routes, plugins (including `ai
 
 ### Step 3: Prepare the configuration directory
 
-The converter cannot recover some configuration from the decK export, such as the target {{site.ai_gateway}} 2.x control plane, identity providers, Vaults, and per-model ACLs. Declare these in a `./config` directory before you run the converter, and it will merge them into the output. 
-Create the directory:
+The converter cannot recover some configuration from the decK export: the target {{site.ai_gateway}} 2.x control plane, auth strategies, Vaults, and per-model ACLs. Declare these in a `./config` directory before you run the converter, and it merges them into the output. Create the directory:
 
 ```sh
 mkdir -p ./config
@@ -127,16 +126,16 @@ ai_gateways:
 ```
 <!--vale on-->
 
-#### Identity providers
+#### Auth strategies
 
-Authentication works differently in version 2.x. Route auth plugins are **not** carried over onto AI Models, AI MCP Servers, or AI Agents. Instead you declare identity providers here, and the converter attaches them to the entities you list. AI Models, AI MCP Servers, and AI Agents all support identity providers the same way, referenced from the entity's `access.identity_providers`.
+Authentication works differently in version 2.x. Route auth plugins are **not** carried over onto AI Models, AI MCP Servers, or AI Agents. Instead you declare auth strategies here, and the converter attaches them to the entities you list. AI Models, AI MCP Servers, and AI Agents all support auth strategies the same way, referenced from the entity's `access.auth_strategies`.
 
-Add a `config/identity_providers.yaml` with an entry for each authentication method (`key-auth` or `openid-connect`). Each entry may optionally list the `models`, `agents`, and `mcp_servers` it attaches to by name, or `"*"` to attach to every entity of that kind:
+Add a `config/auth_strategies.yaml` with an entry for each authentication method (`key-auth` or `openid-connect`). Each entry may optionally list the `models`, `agents`, and `mcp_servers` it attaches to by name, or `"*"` to attach to every entity of that kind:
 
 <!--vale off-->
 ```yaml
-# config/identity_providers.yaml
-identity_providers:
+# config/auth_strategies.yaml
+auth_strategies:
 - ref: key-auth-prod
   name: key-auth-prod
   display_name: Key Auth
@@ -161,7 +160,7 @@ identity_providers:
     scopes:
     - openid
     cache_tokens_salt: "a-random-string"
-  # Only one identity provider per entity kind can use the '*' wildcard,
+  # Only one auth strategy per entity kind can use the '*' wildcard,
   # so name the specific models, MCP servers, and agents that use OIDC.
   models: ['my-model']
   mcp_servers: ['my-mcp-server']
@@ -171,7 +170,7 @@ identity_providers:
 
 The `openid-connect` entry above shows only the fields {{site.ai_gateway}} requires at minimum. Add any other fields your identity provider actually uses (additional scopes, claims, cookie settings, and so on). Don't copy fields straight from your v1 `openid-connect` plugin config if they're unset (`null`) there. {{site.ai_gateway}} 2.x rejects explicit `null` values for most fields, so it's easier to start minimal and add only what you need.
 
-At most, two identity providers are allowed (one `key-auth` and one `openid-connect`), and at only one provider can use the `"*"` wildcard per entity kind. The converter attaches each provider to the listed entities via their `access.identity_providers`.
+At most two auth strategies are allowed (at most one `key-auth` and one `openid-connect`), and at most one may use the `"*"` wildcard per entity kind. The converter attaches each strategy to the listed entities via their `access.auth_strategies`. An AI Agent or AI MCP Server accepts at most **one** auth strategy, so linkage that would attach two to the same agent or MCP server fails the run; AI Models are uncapped.
 
 #### Vaults
 
@@ -182,66 +181,17 @@ Add a `config/vaults.yaml` with an entry for any secret store your migrated conf
 # config/vaults.yaml
 vaults:
 - ref: ai-vault
-  name: hashicorp
+  name: ai-vault
   display_name: AI Gateway Vault
-  type: hcv
-  description: HCV vault for AI Gateway
-  prefix: "my-vault"
-  config:
-    auth_method: token
-    base64_decode: false
-    host: "127.0.0.1"
-    kv: "v1"
-    mount: "secret"
-    port: 8200
-    protocol: "http"
-    ssl_verify: true
-    token: "*********"
-```
-<!--vale on-->
-
-{% comment %}
-UNCOMMENT THIS IF THE TOOL **IS** FIXED TO CORRECTLY CONVERT KONNECT CONFIG STORE VAULTS (and replace the vault example above with this)
-
-<!--vale off-->
-```yaml
-# config/vaults.yaml
-vaults:
-- ref: ai-vault
-  name: hashicorp
-  display_name: AI Gateway Hashicorp Vault
-  type: hcv
-  description: HCV vault for AI Gateway
-  prefix: "my-vault"
-  config:
-    auth_method: token
-    base64_decode: false
-    host: "127.0.0.1"
-    kv: "v1"
-    mount: "secret"
-    port: 8200
-    protocol: "http"
-    ssl_verify: true
-    token: "*********"
-- ref: ai-konnect-vault
-  name: ai-konnect-vault
-  display_name: AI Gateway Konnect Vault
   type: konnect
   description: Credential store for AI Gateway
   config:
-    config_store_id: "00c45ss6-d6a0-4aeb-b535-e4b6def3ea25"
+    config_store_id: "${KONNECT_CONFIG_STORE_ID}"
 ```
 <!--vale on-->
 
 {:.info}
-> **Note:** For a [{{site.konnect_short_name}} Config Store vault](/how-to/configure-the-konnect-config-store/) (`type: konnect`), the Config Store you reference must already exist in {{site.konnect_short_name}} before you apply the configuration. `kongctl` does not create it for you. If you created the Config Store through the {{site.konnect_short_name}} UI, it's created without a `name`. Set one with the [Update Config Store API](/api/konnect/control-planes-config/v2/#/operations/update-config-store) before you apply the configuration.
-{% endcomment %}
-
-{% comment %}
-UNCOMMENT THIS IF THE TOOL **ISN'T** FIXED TO CORRECTLY CONVERT KONNECT CONFIG STORE VAULTS 
-
-If you're using a {{site.konnect_short_name}} Config Store, you must [manually migrate](#manually-migrate-konnect-config-store-vault) that after using the conversion tool.
-{% endcomment %}
+> **Note:** For a [{{site.konnect_short_name}} Config Store vault](/how-to/configure-the-konnect-config-store/) (`type: konnect`), you can either reference an existing Config Store by its ID, or leave `config_store_id: ""` empty and let the converter create one for you: it emits an empty AI Gateway Config Store and wires the vault to it. Either way, populating real secret values into the store is a manual step after you apply.
 
 #### Per-model ACLs
 
@@ -277,7 +227,7 @@ The `--out` flag sets the output directory for the converted files, which the co
 - Each `ai-mcp-proxy` plugin becomes an [AI MCP Server](/ai-gateway/entities/ai-mcp-server/) whose type matches the plugin mode.
 - Each `ai-a2a-proxy` plugin becomes an [AI Agent](/ai-gateway/entities/ai-agent/).
 - Non-auth supporting plugins on the same Service or Route become [AI Policies](/ai-gateway/entities/ai-policy/) attached to the relevant entity.
-- Authentication plugins (`key-auth`, `openid-connect`) on **any** AI route (AI Model, AI MCP Server, or AI Agent) are stripped; identity comes from the [identity providers](/ai-gateway/entities/ai-identity-provider/) you declared in `./config`, attached to each entity's `access.identity_providers`.
+- Authentication plugins (`key-auth`, `openid-connect`) on **any** AI route (AI Model, AI MCP Server, or AI Agent) are stripped; identity comes from the auth strategies you declared in `./config`, attached to each entity's `access.auth_strategies`.
 
 ### Step 5: Validate the converted configuration
 
@@ -285,41 +235,12 @@ Open the `yaml` files in `./out` and confirm that the converter captured everyth
 
 - Every AI Proxy plugin-based model has a corresponding AI Model entry in `models.yaml`, with the right `capabilities`, `formats`, and `targets`.
 - Provider credentials were extracted correctly, and each `targets[].provider` reference resolves to a declared AI Model Provider in `providers.yaml`.
-- Every AI MCP Server in `mcp_servers.yaml` has the correct `type` for its original plugin mode, and that `conversion-only` and `listener` pairs are linked by matching tags.
+- Every AI MCP Server in `mcp_servers.yaml` has the correct `type` for its original plugin mode, and that each `listener` names its toolsets in `sources`.
 - Each AI Agent points at the correct upstream URL and carries the logging settings you had configured.
-- The identity providers you declared in `./config` were merged into `identity_providers.yaml` and attached to the right AI Models, AI MCP Servers, and AI Agents via `access.identity_providers`, and `vaults.yaml` and `gateway.yaml` reflect what you declared.
+- The auth strategies you declared in `./config` were merged into `auth_strategies.yaml` and attached to the right AI Models, AI MCP Servers, and AI Agents via `access.auth_strategies`, and `vaults.yaml` and `gateway.yaml` reflect what you declared.
 - Non-auth supporting plugins were converted to AI Policies and attached to the right entities.
 
 Pay particular attention to anything the converter can't infer from the config of {{site.ai_gateway}} running on {{site.base_gateway}}, such as an AI Model Provider `display_name` or an AI Model `display_name`. These are required in {{site.ai_gateway}} 2.x and may be generated from the source data, so rename them to something meaningful before you apply.
-
-{% comment %}
-UNCOMMENT THIS IF THE TOOL ISN'T FIXED TO CORRECTLY CONVERT KONNECT CONFIG STORE VAULTS 
-
-#### Manually migrate {{site.konnect_short_name}} Config Store vault 
-
-If you're using a {{site.konnect_short_name}} Config Store vault, you must manually migrate it.
-The converter doesn't correctly convert a v1 vault with `type: konnect`. It emits the Config Store's UUID as a literal value under the vault's `config.config_store_id`, which Konnect rejects. Until this is fixed, migrate this vault manually instead of using the converter's output for it.
-
-Declare an `ai_gateway_config_stores` entry for the Config Store, and reference its `id` from the vault's `config.config_store_id` with `!ref`, instead of hardcoding the Config Store's UUID:
-
-```yaml
-ai_gateway_config_stores:
-- ref: ai-config-store
-  ai_gateway: !ref ai-gateway#id
-  name: "your-config-store-name"
-
-ai_gateway_vaults:
-- ref: ai-vault
-  ai_gateway: !ref ai-gateway#id
-  name: ai-vault
-  type: konnect
-  config:
-    config_store_id: !ref ai-config-store#id
-```
-
-{:.info}
-> **Note:** For a [{{site.konnect_short_name}} Config Store vault](/how-to/configure-the-konnect-config-store/) (`type: konnect`), the Config Store you reference must already exist in {{site.konnect_short_name}} before you apply the configuration. `kongctl` does not create it for you. If you created the Config Store through the {{site.konnect_short_name}} UI, it's created without a `name`. Set one with the [Update Config Store API](/api/konnect/control-planes-config/v2/#/operations/update-config-store) before you apply the configuration.
-{% endcomment %}
 
 #### Validate AI Models
 
@@ -445,7 +366,7 @@ To verify your AI Models entity migration, be sure to check the following:
 - Provider reuse: If several {{site.ai_gateway}} running on {{site.base_gateway}} targets shared the same provider and credentials, the converter should produce a single AI Model Provider that all targets reference. Deduplicate any near-identical AI Model Providers it couldn't merge.
 - Model options: Per-target options such as `max_tokens`, `temperature`, `top_p`, and `top_k` move into each `targets[].config`, keyed by the provider `type`.
 - Auth override: If you relied on `config.targets.auth.allow_override` when running {{site.ai_gateway}} on {{site.base_gateway}}, set `allow_auth_override: true` on the corresponding target in version 2.x.
-- Identity: AI Models have no route auth after conversion. Confirm the identity providers you added previously are attached via `access.identity_providers`.
+- Identity: AI Models have no route auth after conversion. Confirm the auth strategies you added previously are attached via `access.auth_strategies`.
 - Vector database and embeddings: `config.vectordb` and `config.embeddings` settings carry over onto the AI Model config under the `balancer` config, keeping the same Redis or pgvector strategy.
 
 
@@ -477,6 +398,50 @@ rows:
   - mode: "(no V1 equivalent)"
     type: "`upstream-server`"
 {% endtable %}
+
+##### Authentication moves from `ai-mcp-oauth2` to an auth strategy
+
+The [AI MCP OAuth2](/plugins/ai-mcp-oauth2/) plugin has no direct {{site.ai_gateway}} 2.x Policy equivalent, so the converter splits its config in two:
+
+* The OAuth2/OIDC token-verification fields (`client_id`, `client_secret`, `introspection_endpoint`, `jwks_endpoint`, `consumer_claim`, and similar) become an `openid-connect` auth strategy, referenced from the server's `access.auth_strategies`, the same way a `key-auth` or `openid-connect` plugin is handled.
+* The OAuth 2.0 Protected Resource Metadata fields (`authorization_servers`, `metadata_discovery_endpoint`, `metadata_endpoint`, `resource`, `scopes_supported`) become the server's `access.metadata` block, which the AI Gateway advertises to OAuth clients per [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728).
+
+Fields with no equivalent in either destination are dropped, with a warning naming them. Proxy authorization headers (`http_proxy_authorization`, `https_proxy_authorization`) have no migratable equivalent and need to be reconfigured manually.
+
+{:.info}
+> **Note:** If your `config/auth_strategies.yaml` linkage attaches a different (non-`openid-connect`) auth strategy to this MCP server, for example a `key-auth` wildcard, the synthesized `access.metadata` is dropped instead of being carried through: the {{site.ai_gateway}} API only accepts Protected Resource Metadata paired with an `openid-connect` auth strategy.
+
+##### Listener aggregation moves from tags to `sources`
+
+In version 1.x, a `listener` plugin aggregated toolsets implicitly: `config.server.tag` named a decK plugin tag, and every `ai-mcp-proxy` plugin carrying that tag contributed its tools. Version 2.x replaces this with an explicit `sources` list of AI MCP Server names, which is **required** on a `listener`.
+
+The converter resolves this for you: it matches `config.server.tag` against the plugin tags of the other MCP proxies and writes the resulting AI MCP Server names into `sources`, dropping the now-unsupported `config.server.tag`.
+
+<!--vale off-->
+```yaml
+# V1: aggregation by tag
+- name: ai-mcp-proxy
+  tags: [aigw610:tools]        # the toolset
+  config:
+    mode: conversion-only
+- name: ai-mcp-proxy           # the aggregator
+  config:
+    mode: listener
+    server:
+      tag: aigw610:tools
+
+# V2: aggregation by name
+ai_gateway_mcp_servers:
+- name: reports-mcp
+  type: conversion-only
+- name: aggregate-mcp
+  type: listener
+  sources:
+  - reports-mcp
+```
+<!--vale on-->
+
+A `sources` entry must name a `conversion-only` toolset or an `upstream-server`. If a tag matched a `conversion-listener` instead, the converter still lists it and warns; split that entity into a `conversion-only` toolset (plus its own listener, if it also served a route) before you apply. If a `listener` declared no `config.server.tag`, or the tag matched nothing, the converter warns and emits no `sources`; add them by hand.
 
 ##### Converted configuration files
 
@@ -516,15 +481,15 @@ services:
 Converting the example to use the version 2.x model:
 * Moves the upstream URL, route, tools, and logging settings onto a single AI MCP Server entity
 * Copies the value from the plugin `mode` into the MCP Server `type` 
-* Strips the `key-auth` plugin. Like AI Models, an AI MCP Server declares identity separately: add an identity provider manually and reference it from the server's `access.identity_providers`.
+* Strips the `key-auth` plugin. Like AI Models, an AI MCP Server declares identity separately: add an auth strategy manually and reference it from the server's `access.auth_strategies`.
 * Renames `default_acl` to `default_tool_acls` and sets the ACL evaluation mode explicitly with `acl_attribute_type`
 * Renames the `config.logging` fields: `log_audits` becomes `audits` and `log_payloads` becomes `payloads`. `log_statistics` has no AI Gateway 2.x equivalent and is dropped.
 
 <!--vale off-->
 ```yaml
-# identity_providers.yaml (in ./out — generated from the provider you declared
+# auth_strategies.yaml (in ./out, generated from the strategy you declared
 # in ./config in Step 3; the v1 key-auth plugin itself is stripped on conversion)
-ai_gateway_identity_providers:
+ai_gateway_auth_strategies:
 - ref: flights-key-auth
   ai_gateway: !ref ai-gateway#id
   type: key-auth
@@ -551,7 +516,7 @@ ai_gateway_mcp_servers:
       allow:
       - flight-operators
       deny: []
-    identity_providers:
+    auth_strategies:
     - flights-key-auth
   config:
     url: https://flights.internal.kongair.com
@@ -573,11 +538,12 @@ ai_gateway_mcp_servers:
 To verify your AI MCP Servers entity migration, be sure to check the following:
 
 - Mode and type: Confirm the `type` matches the original mode. The `conversion-only` and `conversion-listener` modes require Route information, so make sure the converted entity includes a `config.route`.
-- Listener aggregation: If you used `conversion-only` plugins feeding a `listener` plugin via tags, confirm the converter preserved the tags so the version 2.x listener AI MCP Server still aggregates the right tools.
+- Listener aggregation: If you used `conversion-only` plugins feeding a `listener` plugin via tags, confirm the version 2.x listener AI MCP Server lists each of those toolsets by name in `sources`. `sources` is required on a listener, so any converter warning about it must be resolved before you apply.
 - ACL mode: Version 2.x makes the ACL subject explicit. Use `acl_attribute_type: consumer` to evaluate against Consumers and Consumer Groups, or `acl_attribute_type: oauth_access_token` with `access_token_claim_field` to evaluate against a claim in an OAuth2 access token.
 - Per-tool ACLs: A per-tool `acl` replaces the default for that tool and does not merge with `default_tool_acls`. Ensure every allowed subject is listed on the tool explicitly.
 - Logging field names: `log_payloads` and `log_audits` become `payloads` and `audits` under `config.logging`. `log_statistics` has no AI Gateway 2.x equivalent and is dropped.
-- Authentication: Like AI Models, auth plugins on MCP routes (like the `key-auth` example above) are stripped on conversion. Declare the identity provider manually and reference it from the server's `access.identity_providers`.
+- Authentication: Like AI Models, auth plugins on MCP routes (like the `key-auth` example above) are stripped on conversion. Declare the auth strategy manually and reference it from the server's `access.auth_strategies`.
+- `ai-mcp-oauth2` servers: confirm the generated `openid-connect` auth strategy is attached via `access.auth_strategies` and that `access.metadata` carries the Protected Resource Metadata fields you expect. Review any converter warnings naming dropped config fields, and reconfigure proxy authorization headers manually if you used them.
 
 #### Validate AI Agents
 
@@ -618,7 +584,7 @@ Converting the example to use the version 2.x model:
 * Moves the upstream URL, route, request-size limit, and logging settings onto a single AI Agent entity.
 * Renames the `config.logging` fields: `log_payloads` becomes `payloads`. `log_statistics` has no AI Gateway 2.x equivalent and is dropped.
 
-Like AI Models and AI MCP Servers, any authentication plugin on the agent's route is stripped on conversion. If the agent needs auth, declare an identity provider manually and reference it from the agent's `access.identity_providers`.
+Like AI Models and AI MCP Servers, any authentication plugin on the agent's route is stripped on conversion. If the agent needs auth, declare an auth strategy manually and reference it from the agent's `access.auth_strategies`.
 
 <!--vale off-->
 ```yaml
@@ -655,7 +621,7 @@ To verify your AI Agent entity migration, be sure to check the following:
 - Agent type: Most A2A workloads use `type: a2a`. Use `type: http` for plain HTTP agent traffic that does not follow the A2A protocol bindings.
 - URL rewriting: The AI Agent entity rewrites the agent card `url` and `additionalInterfaces[].url` fields to the gateway address automatically, the same behavior the older plugin provided. No extra configuration is needed.
 - Logging field names: As with AI MCP Servers, `log_payloads` becomes `payloads` under `config.logging`, and `log_statistics` is dropped (no AI Gateway 2.x equivalent).
-- Identity: Like AI Models, an AI Agent has no route auth after conversion. If the agent needs authentication, confirm the identity provider you declared is attached via `access.identity_providers`.
+- Identity: Like AI Models, an AI Agent has no route auth after conversion. If the agent needs authentication, confirm the auth strategy you declared is attached via `access.auth_strategies`.
 - Analytics: A2A metrics flow into {{site.konnect_short_name}} analytics. View them under Agentic usage analytics in {{site.konnect_short_name}} [Explorer](/observability/explorer/) and [Dashboards](/observability/#dashboard).
 
 ### Step 6: Authenticate kongctl

--- a/app/ai-gateway/v2-migration-guide.md
+++ b/app/ai-gateway/v2-migration-guide.md
@@ -44,29 +44,34 @@ Before migrating, make sure you have:
 - A [{{site.konnect_short_name}} Personal Access Token (PAT) or System Account Access Token](/konnect-api/#konnect-api-authentication) with permission to read the source control plane and write to the {{site.ai_gateway}} control plane.
 - The [`deck` CLI](/deck/#install-deck) for exporting your current configuration.
 - The [`kongctl` CLI](/kongctl/) for applying the converted configuration to the {{site.ai_gateway}} control plane.
-- The `kong/kongctl-ext-aigw-converter` extension for translating the exported config to the version 2.x entity model.
-- The identity providers, vaults, and per-model ACLs you want the migrated AI Models to use. The converter cannot recover these from the decK export, so you declare them by hand in Step 4.
+- The `kong/kongctl-ext-aigw-converter` extension for translating the exported config to the version 2.x entity model. Install it with `kongctl install extension Kong/kongctl-ext-aigw-converter`.
+- The identity providers, Vaults, and per-model ACLs you want the migrated AI Models to use. The converter cannot recover these from the decK export, so you declare them manually in Step 4.
 
 ## Migration overview
 
-Migration uses the `kongctl convert ai-gateway extension` to translate your existing declarative configuration into the {{site.ai_gateway}} 2.x entity model, then applies it with `kongctl`. The flow has six steps:
+Migration uses the `kongctl convert ai-gateway extension` to translate your existing declarative configuration into the {{site.ai_gateway}} 2.x entity model, then applies it with `kongctl`.
 
 1. Export the declarative configuration from your existing {{site.base_gateway}} control plane with decK.
 1. Run the converter to produce an {{site.ai_gateway}} entity configuration file.
 1. Validate that the output includes all of your AI Models, AI MCP Servers, and AI Agents.
-1. Add identity providers, vaults, and per-model ACLs by hand, since the converter cannot recover these from the decK export.
+1. Add identity providers, Vaults, and per-model ACLs manually, since the converter cannot recover these from the decK export.
 1. Add your {{site.ai_gateway}} control plane ID to the `kongctl` configuration.
 1. Apply the converted configuration to the new {{site.ai_gateway}} control plane.
 
 The diagram below shows where each tool sits in the flow:
 
 {% mermaid %}
-flowchart LR
-    A["API Gateway CP<br/>{{site.ai_gateway}} v1"] -->|deck gateway dump| B["kong.yaml"]
-    B -->|ai-deck-converter| C["ai-gateway.yaml"]
-    C -->|add identity providers,<br/>vaults, and ACLs| C
-    C -->|review and validate| C
-    C -->|kongctl apply| D["{{site.ai_gateway}} CP<br/>{{site.ai_gateway}} v2"]
+sequenceDiagram
+    participant A as API Gateway CP<br/>{{site.ai_gateway}} v1
+    participant B as kong.yaml
+    participant C as ai-gateway.yaml
+    participant D as {{site.ai_gateway}} CP<br/>{{site.ai_gateway}} v2
+
+    A->>B: deck gateway dump
+    B->>C: ai-deck-converter
+    C->>C: add identity providers,<br/>vaults, and ACLs
+    C->>C: review and validate
+    C->>D: kongctl apply
 {% endmermaid %}
 
 ### Step 1: Export your current configuration
@@ -115,9 +120,9 @@ Open `ai-gateway.yaml` and confirm that the converter captured everything you ex
 
 Pay particular attention to anything the converter can't infer from the config of {{site.ai_gateway}} running on {{site.base_gateway}}, such as an AI Model Provider `display_name` or an AI Model `display_name`. These are required in {{site.ai_gateway}} 2.x and may be generated from the source data, so rename them to something meaningful before you apply.
 
-### Step 4: Add identity providers, vaults, and ACLs
+### Step 4: Add identity providers, Vaults, and ACLs
 
-Authentication for AI Models works differently in version 2.x. Route auth plugins are **not** carried over onto AI Models, so you add identity, secret, and access-control config to `ai-gateway.yaml` by hand before you apply it. Auth plugins on AI MCP Server and AI Agent routes are unaffected; they were already converted to AI Policies in Step 2.
+Authentication for AI Models works differently in version 2.x. Route auth plugins are **not** carried over onto AI Models, so you must add identity, secret, and access-control config to `ai-gateway.yaml` manually before you apply it. Auth plugins on AI MCP Server and AI Agent routes are unaffected. They are converted to AI Policies in Step 2.
 
 Add an `identity_providers` entry for each authentication method your AI Models need (for example `key-auth` or `openid-connect`), then reference it from each AI Model's `access.identity_providers`:
 
@@ -155,9 +160,10 @@ vaults:
 ```
 <!--vale on-->
 
-> **Note:** for a vault of `type: konnect`, the referenced config store must already exist in {{site.konnect_short_name}} before you apply. `kongctl` does not create it for you.
+{:.info}
+> **Note:** For a [{{site.konnect_short_name}} Config Store vaults](/how-to/configure-the-konnect-config-store/) (`type: konnect`), the Config Store you reference must already exist in {{site.konnect_short_name}} before you apply the configuration. `kongctl` does not create it for you.
 
-Finally, set `allow` or `deny` under each AI Model's `access.acls` to control which Consumers or Consumer Groups can reach it:
+Finally, set `allow` or `deny` under each AI Model's `access.acls` to control which AI Consumers or AI Consumer Groups can reach it:
 
 <!--vale off-->
 ```yaml
@@ -449,7 +455,7 @@ To verify your AI MCP Servers entity migration, be sure to check the following:
 - ACL mode: Version 2.x makes the ACL subject explicit. Use `acl_attribute_type: consumer` to evaluate against Consumers and Consumer Groups, or `acl_attribute_type: oauth_access_token` with `access_token_claim_field` to evaluate against a claim in an OAuth2 access token.
 - Per-tool ACLs: A per-tool `acl` replaces the default for that tool and does not merge with `default_tool_acls`. Ensure every allowed subject is listed on the tool explicitly.
 - Logging field names: The older `log_statistics`, `log_payloads`, and `log_audits` fields become `statistics`, `payloads`, and `audits` under `config.logging`.
-- Authentication: Unlike AI Models, auth plugins on MCP routes (like the `key-auth` example above) are carried over automatically as AI Policies; you don't need to redeclare them in Step 4.
+- Authentication: Unlike AI Models, auth plugins on MCP routes (like the `key-auth` example above) are carried over automatically as AI Policies. You don't need to declare them again in Step 4.
 
 ### Migrate agents
 

--- a/app/ai-gateway/v2-migration-guide.md
+++ b/app/ai-gateway/v2-migration-guide.md
@@ -44,13 +44,13 @@ Before migrating, make sure you have:
 - A [{{site.konnect_short_name}} Personal Access Token (PAT) or System Account Access Token](/konnect-api/#konnect-api-authentication) with permission to read the source control plane and write to the {{site.ai_gateway}} control plane.
 - The [`deck` CLI](/deck/#install-deck) for exporting your current configuration.
 - The [`kongctl` CLI](/kongctl/) for applying the converted configuration to the {{site.ai_gateway}} control plane.
-- The `kong/kongctl-ext-aigw-converter` extension for translating the exported config to the version 2.x entity model. Install it with `kongctl install extension Kong/kongctl-ext-aigw-converter`.
-- The identity providers, Vaults, and per-model ACLs you want the migrated AI Models to use. The converter cannot recover these from the decK export, so you declare them manually in Step 4.
+- The identity providers, Vaults, and per-model ACLs you want the migrated AI Models to use. The converter cannot recover these from the decK export, so you declare them manually.
 
 ## Migration overview
 
 Migration uses the `kongctl convert ai-gateway extension` to translate your existing declarative configuration into the {{site.ai_gateway}} 2.x entity model, then applies it with `kongctl`.
 
+1. Install the `kongctl convert ai-gateway` extension.
 1. Export the declarative configuration from your existing {{site.base_gateway}} control plane with decK.
 1. Run the converter to produce an {{site.ai_gateway}} entity configuration file.
 1. Validate that the output includes all of your AI Models, AI MCP Servers, and AI Agents.
@@ -74,7 +74,13 @@ sequenceDiagram
     C->>D: kongctl apply
 {% endmermaid %}
 
-### Step 1: Export your current configuration
+### Step 1: Install the `kongctl-ext-aigw-converter` extension
+
+The `kongctl-ext-aigw-converter` extension is used to translate your existing declarative configuration into the {{site.ai_gateway}} 2.x entity model.
+
+Install it with `kongctl install extension Kong/kongctl-ext-aigw-converter` and type `yes` when prompted by the terminal.
+
+### Step 2: Export your current configuration
 
 Use `deck` to dump the declarative configuration from the {{site.base_gateway}} control plane that currently runs your AI plugins. Replace the placeholders with your {{site.konnect_short_name}} PAT and the name of the source control plane.
 
@@ -88,7 +94,7 @@ deck gateway dump \
 
 The resulting `kong.yaml` contains your Services, Routes, plugins (including `ai-proxy-advanced`, `ai-mcp-proxy`, and `ai-a2a-proxy`), Consumers, and Vaults.
 
-### Step 2: Run the converter
+### Step 3: Run the converter
 
 Run `kongctl convert ai-gateway` against the exported `kong.yaml` file. The tool reads the {{site.ai_gateway}} running on {{site.base_gateway}} plugin configuration and emits an {{site.ai_gateway}} 2.x entity configuration.
 
@@ -106,9 +112,9 @@ The `-o` flag sets the output file. The converter inspects each AI plugin and tr
 - Each `ai-mcp-proxy` plugin becomes an [AI MCP Server](/ai-gateway/entities/ai-mcp-server/) whose type matches the plugin mode.
 - Each `ai-a2a-proxy` plugin becomes an [AI Agent](/ai-gateway/entities/ai-agent/).
 - Supporting plugins on the same Service or Route become [AI Policies](/ai-gateway/entities/ai-policy/) attached to the relevant entity.
-- Authentication plugins (`key-auth`, `openid-connect`) on AI Model routes are stripped, since AI Model identity is declared separately in version 2.x. See Step 4.
+- Authentication plugins (`key-auth`, `openid-connect`) on AI Model routes are stripped, since AI Model identity is declared separately in version 2.x.
 
-### Step 3: Validate the converted configuration
+### Step 4: Validate the converted configuration
 
 Open `ai-gateway.yaml` and confirm that the converter captured everything you expect. At minimum, check that:
 
@@ -120,9 +126,9 @@ Open `ai-gateway.yaml` and confirm that the converter captured everything you ex
 
 Pay particular attention to anything the converter can't infer from the config of {{site.ai_gateway}} running on {{site.base_gateway}}, such as an AI Model Provider `display_name` or an AI Model `display_name`. These are required in {{site.ai_gateway}} 2.x and may be generated from the source data, so rename them to something meaningful before you apply.
 
-### Step 4: Add identity providers, Vaults, and ACLs
+### Step 5: Add identity providers, Vaults, and ACLs
 
-Authentication for AI Models works differently in version 2.x. Route auth plugins are **not** carried over onto AI Models, so you must add identity, secret, and access-control config to `ai-gateway.yaml` manually before you apply it. Auth plugins on AI MCP Server and AI Agent routes are unaffected. They are converted to AI Policies in Step 2.
+Authentication for AI Models works differently in version 2.x. Route auth plugins are **not** carried over onto AI Models, so you must add identity, secret, and access-control config to `ai-gateway.yaml` manually before you apply it. Auth plugins on AI MCP Server and AI Agent routes are unaffected. They are converted to AI Policies in a previous step.
 
 Add an `identity_providers` entry for each authentication method your AI Models need (for example `key-auth` or `openid-connect`), then reference it from each AI Model's `access.identity_providers`:
 
@@ -179,7 +185,7 @@ models:
 ```
 <!--vale on-->
 
-### Step 5: Add your control plane ID to kongctl
+### Step 6: Add your control plane ID to kongctl
 
 `kongctl` needs to know which {{site.ai_gateway}} control plane to target. Add your control plane name to the `kongctl` configuration file so that `kongctl apply` writes to the correct control plane.
 
@@ -197,7 +203,7 @@ ai_gateways:
 
 Keep one source of truth so that repeated applies always target the same control plane.
 
-### Step 6: Apply the configuration
+### Step 7: Apply the configuration
 
 Sync the converted configuration to the {{site.ai_gateway}} control plane:
 
@@ -330,7 +336,7 @@ To verify your AI Models entity migration, be sure to check the following:
 - Provider reuse: If several {{site.ai_gateway}} running on {{site.base_gateway}} targets shared the same provider and credentials, the converter should produce a single AI Model Provider that all targets reference. Deduplicate any near-identical AI Model Providers it couldn't merge.
 - Model options: Per-target options such as `max_tokens`, `temperature`, `top_p`, and `top_k` move into each `targets[].config`, keyed by the provider `type`.
 - Auth override: If you relied on `config.targets.auth.allow_override` when running {{site.ai_gateway}} on {{site.base_gateway}}, set `allow_auth_override: true` on the corresponding target in version 2.x.
-- Identity: AI Models have no route auth after conversion. Confirm the identity providers you added in Step 4 are attached via `access.identity_providers`.
+- Identity: AI Models have no route auth after conversion. Confirm the identity providers you added previously are attached via `access.identity_providers`.
 - Vector database and embeddings: `config.vectordb` and `config.embeddings` settings carry over onto the AI Model config under the `balancer` config, keeping the same Redis or pgvector strategy.
 
 
@@ -455,7 +461,7 @@ To verify your AI MCP Servers entity migration, be sure to check the following:
 - ACL mode: Version 2.x makes the ACL subject explicit. Use `acl_attribute_type: consumer` to evaluate against Consumers and Consumer Groups, or `acl_attribute_type: oauth_access_token` with `access_token_claim_field` to evaluate against a claim in an OAuth2 access token.
 - Per-tool ACLs: A per-tool `acl` replaces the default for that tool and does not merge with `default_tool_acls`. Ensure every allowed subject is listed on the tool explicitly.
 - Logging field names: The older `log_statistics`, `log_payloads`, and `log_audits` fields become `statistics`, `payloads`, and `audits` under `config.logging`.
-- Authentication: Unlike AI Models, auth plugins on MCP routes (like the `key-auth` example above) are carried over automatically as AI Policies. You don't need to declare them again in Step 4.
+- Authentication: Unlike AI Models, auth plugins on MCP routes (like the `key-auth` example above) are carried over automatically as AI Policies. You don't need to declare them again.
 
 ### Migrate agents
 
@@ -543,6 +549,8 @@ After you apply the converted configuration, verify the new control plane before
 - Compare entity counts. The number of AI Models, MCP Servers, and Agents in the control plane should match the number of corresponding plugins in your {{site.ai_gateway}} running on {{site.base_gateway}} export.
 
 Run the old and new configurations in parallel during cutover so you can roll back by routing traffic to the original control plane if needed.
+
+Once you've successfully generated the `kongctl` config, applied it to your environment, and tested the configuration, you can uninstall the `kongctl-ext-aigw-converter` extension with `kongctl uninstall extension kong/ai-gateway-converter`.
 
 ## Troubleshooting
 

--- a/app/ai-gateway/v2-migration-guide.md
+++ b/app/ai-gateway/v2-migration-guide.md
@@ -104,7 +104,13 @@ The resulting `kong.yaml` contains your Services, Routes, plugins (including `ai
 
 ### Step 3: Prepare the configuration directory
 
-The converter cannot recover some configuration from the decK export: the target {{site.ai_gateway}} 2.x control plane, auth strategies, Vaults, and per-model ACLs. Declare these in a `./config` directory before you run the converter, and it merges them into the output. Create the directory:
+The converter cannot recover some configuration from the decK export: 
+* The target {{site.ai_gateway}} 2.x control plane 
+* Auth strategies 
+* Vaults
+* Per-model ACLs
+
+Declare these in a `./config` directory before you run the converter, and it merges them into the output. Create the directory:
 
 ```sh
 mkdir -p ./config
@@ -191,7 +197,7 @@ vaults:
 <!--vale on-->
 
 {:.info}
-> **Note:** For a [{{site.konnect_short_name}} Config Store vault](/how-to/configure-the-konnect-config-store/) (`type: konnect`), you can either reference an existing Config Store by its ID, or leave `config_store_id: ""` empty and let the converter create one for you: it emits an empty AI Gateway Config Store and wires the vault to it. Either way, populating real secret values into the store is a manual step after you apply.
+> **Note:** For a [{{site.konnect_short_name}} Config Store vault](/how-to/configure-the-konnect-config-store/) (`type: konnect`), you can either reference an existing Config Store by its ID, or leave `config_store_id: ""` empty and let the converter create one for you: it emits an empty {{site.ai_gateway}} Config Store and wires the vault to it. Either way, populating real secret values into the store is a manual step after you apply.
 
 #### Per-model ACLs
 
@@ -235,7 +241,7 @@ Open the `yaml` files in `./out` and confirm that the converter captured everyth
 
 - Every AI Proxy plugin-based model has a corresponding AI Model entry in `models.yaml`, with the right `capabilities`, `formats`, and `targets`.
 - Provider credentials were extracted correctly, and each `targets[].provider` reference resolves to a declared AI Model Provider in `providers.yaml`.
-- Every AI MCP Server in `mcp_servers.yaml` has the correct `type` for its original plugin mode, and that each `listener` names its toolsets in `sources`.
+- Every AI MCP Server in `mcp_servers.yaml` has the correct `type` for its original plugin mode, and that each `listener` names its tool sets in `sources`.
 - Each AI Agent points at the correct upstream URL and carries the logging settings you had configured.
 - The auth strategies you declared in `./config` were merged into `auth_strategies.yaml` and attached to the right AI Models, AI MCP Servers, and AI Agents via `access.auth_strategies`, and `vaults.yaml` and `gateway.yaml` reflect what you declared.
 - Non-auth supporting plugins were converted to AI Policies and attached to the right entities.
@@ -404,16 +410,16 @@ rows:
 The [AI MCP OAuth2](/plugins/ai-mcp-oauth2/) plugin has no direct {{site.ai_gateway}} 2.x Policy equivalent, so the converter splits its config in two:
 
 * The OAuth2/OIDC token-verification fields (`client_id`, `client_secret`, `introspection_endpoint`, `jwks_endpoint`, `consumer_claim`, and similar) become an `openid-connect` auth strategy, referenced from the server's `access.auth_strategies`, the same way a `key-auth` or `openid-connect` plugin is handled.
-* The OAuth 2.0 Protected Resource Metadata fields (`authorization_servers`, `metadata_discovery_endpoint`, `metadata_endpoint`, `resource`, `scopes_supported`) become the server's `access.metadata` block, which the AI Gateway advertises to OAuth clients per [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728).
+* The OAuth 2.0 Protected Resource Metadata fields (`authorization_servers`, `metadata_discovery_endpoint`, `metadata_endpoint`, `resource`, `scopes_supported`) become the server's `access.metadata` block, which the {{site.ai_gateway}} advertises to OAuth clients per [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728).
 
-Fields with no equivalent in either destination are dropped, with a warning naming them. Proxy authorization headers (`http_proxy_authorization`, `https_proxy_authorization`) have no migratable equivalent and need to be reconfigured manually.
+Fields with no equivalent in either destination are dropped, with a warning naming them. Proxy authorization headers (`http_proxy_authorization`, `https_proxy_authorization`) have no migrated equivalent and need to be reconfigured manually.
 
 {:.info}
 > **Note:** If your `config/auth_strategies.yaml` linkage attaches a different (non-`openid-connect`) auth strategy to this MCP server, for example a `key-auth` wildcard, the synthesized `access.metadata` is dropped instead of being carried through: the {{site.ai_gateway}} API only accepts Protected Resource Metadata paired with an `openid-connect` auth strategy.
 
 ##### Listener aggregation moves from tags to `sources`
 
-In version 1.x, a `listener` plugin aggregated toolsets implicitly: `config.server.tag` named a decK plugin tag, and every `ai-mcp-proxy` plugin carrying that tag contributed its tools. Version 2.x replaces this with an explicit `sources` list of AI MCP Server names, which is **required** on a `listener`.
+In version 1.x, a `listener` plugin aggregated tool sets implicitly: `config.server.tag` named a decK plugin tag, and every `ai-mcp-proxy` plugin carrying that tag contributed its tools. Version 2.x replaces this with an explicit `sources` list of AI MCP Server names, which is **required** on a `listener`.
 
 The converter resolves this for you: it matches `config.server.tag` against the plugin tags of the other MCP proxies and writes the resulting AI MCP Server names into `sources`, dropping the now-unsupported `config.server.tag`.
 
@@ -421,7 +427,7 @@ The converter resolves this for you: it matches `config.server.tag` against the 
 ```yaml
 # V1: aggregation by tag
 - name: ai-mcp-proxy
-  tags: [aigw610:tools]        # the toolset
+  tags: [aigw610:tools]        # the tool set
   config:
     mode: conversion-only
 - name: ai-mcp-proxy           # the aggregator
@@ -441,7 +447,8 @@ ai_gateway_mcp_servers:
 ```
 <!--vale on-->
 
-A `sources` entry must name a `conversion-only` toolset or an `upstream-server`. If a tag matched a `conversion-listener` instead, the converter still lists it and warns; split that entity into a `conversion-only` toolset (plus its own listener, if it also served a route) before you apply. If a `listener` declared no `config.server.tag`, or the tag matched nothing, the converter warns and emits no `sources`; add them by hand.
+A `sources` entry must name a `conversion-only` tool set or an `upstream-server`. If a tag matched a `conversion-listener` instead, the converter still lists it and displays a warning.
+Split that entity into a `conversion-only` tool set (plus its own listener, if it also served a route) before you apply. If a `listener` declared no `config.server.tag`, or the tag matched nothing, the converter warns and emits no `sources`; add them manually.
 
 ##### Converted configuration files
 
@@ -483,7 +490,7 @@ Converting the example to use the version 2.x model:
 * Copies the value from the plugin `mode` into the MCP Server `type` 
 * Strips the `key-auth` plugin. Like AI Models, an AI MCP Server declares identity separately: add an auth strategy manually and reference it from the server's `access.auth_strategies`.
 * Renames `default_acl` to `default_tool_acls` and sets the ACL evaluation mode explicitly with `acl_attribute_type`
-* Renames the `config.logging` fields: `log_audits` becomes `audits` and `log_payloads` becomes `payloads`. `log_statistics` has no AI Gateway 2.x equivalent and is dropped.
+* Renames the `config.logging` fields: `log_audits` becomes `audits` and `log_payloads` becomes `payloads`. `log_statistics` has no {{site.ai_gateway}} 2.x equivalent and is dropped.
 
 <!--vale off-->
 ```yaml
@@ -538,12 +545,12 @@ ai_gateway_mcp_servers:
 To verify your AI MCP Servers entity migration, be sure to check the following:
 
 - Mode and type: Confirm the `type` matches the original mode. The `conversion-only` and `conversion-listener` modes require Route information, so make sure the converted entity includes a `config.route`.
-- Listener aggregation: If you used `conversion-only` plugins feeding a `listener` plugin via tags, confirm the version 2.x listener AI MCP Server lists each of those toolsets by name in `sources`. `sources` is required on a listener, so any converter warning about it must be resolved before you apply.
+- Listener aggregation: If you used `conversion-only` plugins feeding a `listener` plugin via tags, confirm the version 2.x listener AI MCP Server lists each of those tool sets by name in `sources`. `sources` is required on a listener, so any converter warning about it must be resolved before you apply.
 - ACL mode: Version 2.x makes the ACL subject explicit. Use `acl_attribute_type: consumer` to evaluate against Consumers and Consumer Groups, or `acl_attribute_type: oauth_access_token` with `access_token_claim_field` to evaluate against a claim in an OAuth2 access token.
 - Per-tool ACLs: A per-tool `acl` replaces the default for that tool and does not merge with `default_tool_acls`. Ensure every allowed subject is listed on the tool explicitly.
-- Logging field names: `log_payloads` and `log_audits` become `payloads` and `audits` under `config.logging`. `log_statistics` has no AI Gateway 2.x equivalent and is dropped.
+- Logging field names: `log_payloads` and `log_audits` become `payloads` and `audits` under `config.logging`. `log_statistics` has no {{site.ai_gateway}} 2.x equivalent and is dropped.
 - Authentication: Like AI Models, auth plugins on MCP routes (like the `key-auth` example above) are stripped on conversion. Declare the auth strategy manually and reference it from the server's `access.auth_strategies`.
-- `ai-mcp-oauth2` servers: confirm the generated `openid-connect` auth strategy is attached via `access.auth_strategies` and that `access.metadata` carries the Protected Resource Metadata fields you expect. Review any converter warnings naming dropped config fields, and reconfigure proxy authorization headers manually if you used them.
+- `ai-mcp-oauth2` servers: Confirm the generated `openid-connect` auth strategy is attached via `access.auth_strategies` and that `access.metadata` carries the Protected Resource Metadata fields you expect. Review any converter warnings naming dropped config fields, and reconfigure proxy authorization headers manually if you used them.
 
 #### Validate AI Agents
 
@@ -582,7 +589,7 @@ services:
 
 Converting the example to use the version 2.x model:
 * Moves the upstream URL, route, request-size limit, and logging settings onto a single AI Agent entity.
-* Renames the `config.logging` fields: `log_payloads` becomes `payloads`. `log_statistics` has no AI Gateway 2.x equivalent and is dropped.
+* Renames the `config.logging` fields: `log_payloads` becomes `payloads`. `log_statistics` has no {{site.ai_gateway}} 2.x equivalent and is dropped.
 
 Like AI Models and AI MCP Servers, any authentication plugin on the agent's route is stripped on conversion. If the agent needs auth, declare an auth strategy manually and reference it from the agent's `access.auth_strategies`.
 
@@ -620,7 +627,7 @@ To verify your AI Agent entity migration, be sure to check the following:
 
 - Agent type: Most A2A workloads use `type: a2a`. Use `type: http` for plain HTTP agent traffic that does not follow the A2A protocol bindings.
 - URL rewriting: The AI Agent entity rewrites the agent card `url` and `additionalInterfaces[].url` fields to the gateway address automatically, the same behavior the older plugin provided. No extra configuration is needed.
-- Logging field names: As with AI MCP Servers, `log_payloads` becomes `payloads` under `config.logging`, and `log_statistics` is dropped (no AI Gateway 2.x equivalent).
+- Logging field names: As with AI MCP Servers, `log_payloads` becomes `payloads` under `config.logging`, and `log_statistics` is dropped (no {{site.ai_gateway}} 2.x equivalent).
 - Identity: Like AI Models, an AI Agent has no route auth after conversion. If the agent needs authentication, confirm the auth strategy you declared is attached via `access.auth_strategies`.
 - Analytics: A2A metrics flow into {{site.konnect_short_name}} analytics. View them under Agentic usage analytics in {{site.konnect_short_name}} [Explorer](/observability/explorer/) and [Dashboards](/observability/#dashboard).
 

--- a/app/ai-gateway/v2-migration-guide.md
+++ b/app/ai-gateway/v2-migration-guide.md
@@ -45,14 +45,16 @@ Before migrating, make sure you have:
 - The [`deck` CLI](/deck/#install-deck) for exporting your current configuration.
 - The [`kongctl` CLI](/kongctl/) for applying the converted configuration to the {{site.ai_gateway}} control plane.
 - The `kong/kongctl-ext-aigw-converter` extension for translating the exported config to the version 2.x entity model.
+- The identity providers, vaults, and per-model ACLs you want the migrated AI Models to use. The converter cannot recover these from the decK export, so you declare them by hand in Step 4.
 
 ## Migration overview
 
-Migration uses the `kongctl convert ai-gateway extension` to translate your existing declarative configuration into the {{site.ai_gateway}} 2.x entity model, then applies it with `kongctl`. The flow has five steps:
+Migration uses the `kongctl convert ai-gateway extension` to translate your existing declarative configuration into the {{site.ai_gateway}} 2.x entity model, then applies it with `kongctl`. The flow has six steps:
 
 1. Export the declarative configuration from your existing {{site.base_gateway}} control plane with decK.
 1. Run the converter to produce an {{site.ai_gateway}} entity configuration file.
 1. Validate that the output includes all of your AI Models, AI MCP Servers, and AI Agents.
+1. Add identity providers, vaults, and per-model ACLs by hand, since the converter cannot recover these from the decK export.
 1. Add your {{site.ai_gateway}} control plane ID to the `kongctl` configuration.
 1. Apply the converted configuration to the new {{site.ai_gateway}} control plane.
 
@@ -62,6 +64,7 @@ The diagram below shows where each tool sits in the flow:
 flowchart LR
     A["API Gateway CP<br/>{{site.ai_gateway}} v1"] -->|deck gateway dump| B["kong.yaml"]
     B -->|ai-deck-converter| C["ai-gateway.yaml"]
+    C -->|add identity providers,<br/>vaults, and ACLs| C
     C -->|review and validate| C
     C -->|kongctl apply| D["{{site.ai_gateway}} CP<br/>{{site.ai_gateway}} v2"]
 {% endmermaid %}
@@ -98,6 +101,7 @@ The `-o` flag sets the output file. The converter inspects each AI plugin and tr
 - Each `ai-mcp-proxy` plugin becomes an [AI MCP Server](/ai-gateway/entities/ai-mcp-server/) whose type matches the plugin mode.
 - Each `ai-a2a-proxy` plugin becomes an [AI Agent](/ai-gateway/entities/ai-agent/).
 - Supporting plugins on the same Service or Route become [AI Policies](/ai-gateway/entities/ai-policy/) attached to the relevant entity.
+- Authentication plugins (`key-auth`, `openid-connect`) on AI Model routes are stripped, since AI Model identity is declared separately in version 2.x. See Step 4.
 
 ### Step 3: Validate the converted configuration
 
@@ -111,7 +115,65 @@ Open `ai-gateway.yaml` and confirm that the converter captured everything you ex
 
 Pay particular attention to anything the converter can't infer from the config of {{site.ai_gateway}} running on {{site.base_gateway}}, such as an AI Model Provider `display_name` or an AI Model `display_name`. These are required in {{site.ai_gateway}} 2.x and may be generated from the source data, so rename them to something meaningful before you apply.
 
-### Step 4: Add your control plane ID to kongctl
+### Step 4: Add identity providers, vaults, and ACLs
+
+Authentication for AI Models works differently in version 2.x. Route auth plugins are **not** carried over onto AI Models, so you add identity, secret, and access-control config to `ai-gateway.yaml` by hand before you apply it. Auth plugins on AI MCP Server and AI Agent routes are unaffected; they were already converted to AI Policies in Step 2.
+
+Add an `identity_providers` entry for each authentication method your AI Models need (for example `key-auth` or `openid-connect`), then reference it from each AI Model's `access.identity_providers`:
+
+<!--vale off-->
+```yaml
+# ai-gateway.yaml (AI Gateway v2 entity model)
+identity_providers:
+- name: key-auth-prod
+  display_name: Key Auth
+  type: key-auth
+  config:
+    key_names:
+    - x-api-key
+
+models:
+- name: openai-chat
+  # ...
+  access:
+    identity_providers:
+    - key-auth-prod
+```
+<!--vale on-->
+
+Add a `vaults` entry for any secret store your migrated config references with `{vault://...}` syntax:
+
+<!--vale off-->
+```yaml
+vaults:
+- name: ai-vault
+  display_name: AI Gateway Vault
+  type: konnect
+  description: Credential store for AI Gateway
+  config:
+    config_store_id: "55c2c6a4-7973-420c-909e-a16959714f5b"
+```
+<!--vale on-->
+
+> **Note:** for a vault of `type: konnect`, the referenced config store must already exist in {{site.konnect_short_name}} before you apply. `kongctl` does not create it for you.
+
+Finally, set `allow` or `deny` under each AI Model's `access.acls` to control which Consumers or Consumer Groups can reach it:
+
+<!--vale off-->
+```yaml
+models:
+- name: azure-gpt-4o
+  # ...
+  access:
+    acls:
+      allow:
+      - Azure-OpenAI-Gold
+      - Azure-OpenAI-Silver
+      deny: []
+```
+<!--vale on-->
+
+### Step 5: Add your control plane ID to kongctl
 
 `kongctl` needs to know which {{site.ai_gateway}} control plane to target. Add your control plane name to the `kongctl` configuration file so that `kongctl apply` writes to the correct control plane.
 
@@ -129,7 +191,7 @@ ai_gateways:
 
 Keep one source of truth so that repeated applies always target the same control plane.
 
-### Step 5: Apply the configuration
+### Step 6: Apply the configuration
 
 Sync the converted configuration to the {{site.ai_gateway}} control plane:
 
@@ -262,6 +324,7 @@ To verify your AI Models entity migration, be sure to check the following:
 - Provider reuse: If several {{site.ai_gateway}} running on {{site.base_gateway}} targets shared the same provider and credentials, the converter should produce a single AI Model Provider that all targets reference. Deduplicate any near-identical AI Model Providers it couldn't merge.
 - Model options: Per-target options such as `max_tokens`, `temperature`, `top_p`, and `top_k` move into each `targets[].config`, keyed by the provider `type`.
 - Auth override: If you relied on `config.targets.auth.allow_override` when running {{site.ai_gateway}} on {{site.base_gateway}}, set `allow_auth_override: true` on the corresponding target in version 2.x.
+- Identity: AI Models have no route auth after conversion. Confirm the identity providers you added in Step 4 are attached via `access.identity_providers`.
 - Vector database and embeddings: `config.vectordb` and `config.embeddings` settings carry over onto the AI Model config under the `balancer` config, keeping the same Redis or pgvector strategy.
 
 
@@ -386,6 +449,7 @@ To verify your AI MCP Servers entity migration, be sure to check the following:
 - ACL mode: Version 2.x makes the ACL subject explicit. Use `acl_attribute_type: consumer` to evaluate against Consumers and Consumer Groups, or `acl_attribute_type: oauth_access_token` with `access_token_claim_field` to evaluate against a claim in an OAuth2 access token.
 - Per-tool ACLs: A per-tool `acl` replaces the default for that tool and does not merge with `default_tool_acls`. Ensure every allowed subject is listed on the tool explicitly.
 - Logging field names: The older `log_statistics`, `log_payloads`, and `log_audits` fields become `statistics`, `payloads`, and `audits` under `config.logging`.
+- Authentication: Unlike AI Models, auth plugins on MCP routes (like the `key-auth` example above) are carried over automatically as AI Policies; you don't need to redeclare them in Step 4.
 
 ### Migrate agents
 

--- a/app/ai-gateway/v2-migration-guide.md
+++ b/app/ai-gateway/v2-migration-guide.md
@@ -44,7 +44,7 @@ Before migrating, make sure you have:
 - A [{{site.konnect_short_name}} Personal Access Token (PAT) or System Account Access Token](/konnect-api/#konnect-api-authentication) with permission to read the source control plane and write to the {{site.ai_gateway}} control plane.
 - The [`deck` CLI](/deck/#install-deck) for exporting your current configuration.
 - The [`kongctl` CLI](/kongctl/) for applying the converted configuration to the {{site.ai_gateway}} control plane.
-- The identity providers, Vaults, and per-model ACLs you want the migrated AI Models to use. The converter cannot recover these from the decK export, so you declare them manually.
+- The identity providers, Vaults, and per-model ACLs you want the migrated AI Models, AI MCP Servers, and AI Agents to use. The converter cannot recover these from the decK export, so you declare them manually.
 
 ## Migration overview
 
@@ -52,10 +52,9 @@ Migration uses the `kongctl convert ai-gateway extension` to translate your exis
 
 1. Install the `kongctl convert ai-gateway` extension.
 1. Export the declarative configuration from your existing {{site.base_gateway}} control plane with decK.
-1. Run the converter to produce a directory of {{site.ai_gateway}} entity configuration files.
+1. Prepare a `./config` directory with the target control plane, identity providers, Vaults, and per-model ACLs the converter cannot recover from the decK export.
+1. Run the converter to merge `./config` and produce a directory of {{site.ai_gateway}} entity configuration files.
 1. Validate that the output includes all of your AI Models, AI MCP Servers, and AI Agents.
-1. Add identity providers, Vaults, and per-model ACLs manually, since the converter cannot recover these from the decK export.
-1. Point the converted configuration at your {{site.ai_gateway}} 2.x control plane.
 1. Authenticate `kongctl` with a {{site.konnect_short_name}} PAT or System Account Access Token.
 1. Apply the converted configuration to the new {{site.ai_gateway}} control plane.
 
@@ -65,14 +64,16 @@ The diagram below shows where each tool sits in the flow:
 sequenceDiagram
     participant A as API Gateway CP<br/>{{site.ai_gateway}} v1
     participant B as kong.yaml
-    participant C as ./out (entity files)
-    participant D as {{site.ai_gateway}} CP<br/>{{site.ai_gateway}} v2
+    participant C as ./config (manual config)
+    participant D as ./out (entity files)
+    participant E as {{site.ai_gateway}} CP<br/>{{site.ai_gateway}} v2
 
     A->>B: deck gateway dump
-    B->>C: kongctl convert ai-gateway
-    C->>C: add identity providers,<br/>vaults, and ACLs
-    C->>C: review and validate
-    C->>D: kongctl apply
+    Note over C: add control plane, identity<br/>providers, vaults, and ACLs
+    B->>D: kongctl convert ai-gateway
+    C-->>D: merged on conversion
+    D->>D: review and validate
+    D->>E: kongctl apply
 {% endmermaid %}
 
 ### Step 1: Install the `kongctl-ext-aigw-converter` extension
@@ -95,15 +96,94 @@ deck gateway dump \
 
 The resulting `kong.yaml` contains your Services, Routes, plugins (including `ai-proxy-advanced`, `ai-mcp-proxy`, and `ai-a2a-proxy`), Consumers, and Vaults.
 
-### Step 3: Run the converter
+### Step 3: Prepare the configuration directory
 
-Before you can convert `kong.yaml`, create the `./config` and `./out` directories that the converter will use for the converted files:
+The converter cannot recover some configuration from the decK export: the target {{site.ai_gateway}} 2.x control plane, identity providers, Vaults, and per-model ACLs. Declare these in a `./config` directory before you run the converter, and it merges them into the output. Create the directory:
 
 ```sh
-mkdir -p ./config ./out
+mkdir -p ./config
 ```
 
-Run `kongctl convert ai-gateway` against the exported `kong.yaml` file. The tool reads the {{site.ai_gateway}} running on {{site.base_gateway}} plugin configuration and emits an {{site.ai_gateway}} 2.x entity and Policy configuration.
+#### Target control plane
+
+Add a `config/gateway.yaml` that points at the {{site.ai_gateway}} 2.x control plane you created in the [prerequisites](#prerequisites). Use an `_external` selector to reference the existing control plane by name so `kongctl` does not create a new one:
+
+<!--vale off-->
+```yaml
+# config/gateway.yaml
+ai_gateways:
+- ref: ai-gateway
+  display_name: AI Gateway
+  name: ai-gateway
+  description: AI Gateway
+```
+<!--vale on-->
+
+#### Identity providers
+
+Authentication works differently in version 2.x. Route auth plugins are **not** carried over onto AI Models, AI MCP Servers, or AI Agents. Instead you declare identity providers here, and the converter attaches them to the entities you list. AI Models, AI MCP Servers, and AI Agents all support identity providers the same way, referenced from the entity's `access.identity_providers`.
+
+Add a `config/identity_providers.yaml` with an entry for each authentication method (`key-auth` or `openid-connect`). Each entry may optionally list the `models`, `agents`, and `mcp_servers` it attaches to by name, or `"*"` to attach to every entity of that kind:
+
+<!--vale off-->
+```yaml
+# config/identity_providers.yaml
+identity_providers:
+- ref: key-auth-prod
+  name: key-auth-prod
+  display_name: Key Auth
+  type: key-auth
+  config:
+    key_names:
+    - x-api-key
+  # Optional entity selectors
+  models: ['*']
+  mcp_servers: ['*']
+  agents: ['*']
+```
+<!--vale on-->
+
+At most two identity providers are allowed (at most one `key-auth` and one `openid-connect`), and at most one may use the `"*"` wildcard per entity kind. The converter attaches each provider to the listed entities via their `access.identity_providers`.
+
+#### Vaults
+
+Add a `config/vaults.yaml` with an entry for any secret store your migrated config references with `{vault://...}` syntax:
+
+<!--vale off-->
+```yaml
+# config/vaults.yaml
+vaults:
+- ref: ai-vault
+  name: ai-vault
+  display_name: AI Gateway Vault
+  type: konnect
+  description: Credential store for AI Gateway
+  config:
+    config_store_id: "${KONNECT_CONFIG_STORE_ID}"
+```
+<!--vale on-->
+
+{:.info}
+> **Note:** For a [{{site.konnect_short_name}} Config Store vault](/how-to/configure-the-konnect-config-store/) (`type: konnect`), the Config Store you reference must already exist in {{site.konnect_short_name}} before you apply the configuration. `kongctl` does not create it for you.
+
+#### Per-model ACLs
+
+Optionally, add a `config/model_acls.yaml` to control which AI Consumers or AI Consumer Groups can reach each AI Model. Each entry names a model and sets `allow` or `deny`:
+
+<!--vale off-->
+```yaml
+# config/model_acls.yaml
+acls:
+- name: azure-gpt-4o
+  allow:
+  - Azure-OpenAI-Gold
+  - Azure-OpenAI-Silver
+```
+<!--vale on-->
+
+### Step 4: Run the converter
+
+Run `kongctl convert ai-gateway` against the exported `kong.yaml` file and your `./config` directory. The tool reads the {{site.ai_gateway}} running on {{site.base_gateway}} plugin configuration, merges the manual config, and emits an {{site.ai_gateway}} 2.x entity and Policy configuration to `./out`.
 
 ```sh
 kongctl convert ai-gateway \
@@ -112,15 +192,15 @@ kongctl convert ai-gateway \
   --out ./out
 ```
 
-The `--out` flag sets the output directory for the converted files. The converter inspects each AI plugin and translates it into the matching version 2.x entity or Policy:
+The `--out` flag sets the output directory for the converted files, which the converter creates for you. It inspects each AI plugin and translates it into the matching version 2.x entity or Policy:
 
 - Each `ai-proxy-advanced` plugin becomes an [AI Model](/ai-gateway/entities/ai-model/) (and one [AI Model Provider](/ai-gateway/entities/ai-model-provider/) per distinct upstream provider and credential set).
 - Each `ai-mcp-proxy` plugin becomes an [AI MCP Server](/ai-gateway/entities/ai-mcp-server/) whose type matches the plugin mode.
 - Each `ai-a2a-proxy` plugin becomes an [AI Agent](/ai-gateway/entities/ai-agent/).
-- Supporting plugins on the same Service or Route become [AI Policies](/ai-gateway/entities/ai-policy/) attached to the relevant entity.
-- Authentication plugins (`key-auth`, `openid-connect`) on AI Model routes are stripped, since AI Model identity is declared separately in version 2.x.
+- Non-auth supporting plugins on the same Service or Route become [AI Policies](/ai-gateway/entities/ai-policy/) attached to the relevant entity.
+- Authentication plugins (`key-auth`, `openid-connect`) on **any** AI route (AI Model, AI MCP Server, or AI Agent) are stripped; identity comes from the [identity providers](/ai-gateway/entities/ai-identity-provider/) you declared in `./config`, attached to each entity's `access.identity_providers`.
 
-### Step 4: Validate the converted configuration
+### Step 5: Validate the converted configuration
 
 Open the `yaml` files in `./out` and confirm that the converter captured everything you expect. At minimum, check that:
 
@@ -128,96 +208,12 @@ Open the `yaml` files in `./out` and confirm that the converter captured everyth
 - Provider credentials were extracted correctly, and each `targets[].provider` reference resolves to a declared AI Model Provider in `providers.yaml`.
 - Every AI MCP Server in `mcp_servers.yaml` has the correct `type` for its original plugin mode, and that `conversion-only` and `listener` pairs are linked by matching tags.
 - Each AI Agent points at the correct upstream URL and carries the logging settings you had configured.
-- Supporting plugins were converted to AI Policies and attached to the right entities.
+- The identity providers you declared in `./config` were merged into `identity_providers.yaml` and attached to the right AI Models, AI MCP Servers, and AI Agents via `access.identity_providers`, and `vaults.yaml` and `gateway.yaml` reflect what you declared.
+- Non-auth supporting plugins were converted to AI Policies and attached to the right entities.
 
 Pay particular attention to anything the converter can't infer from the config of {{site.ai_gateway}} running on {{site.base_gateway}}, such as an AI Model Provider `display_name` or an AI Model `display_name`. These are required in {{site.ai_gateway}} 2.x and may be generated from the source data, so rename them to something meaningful before you apply.
 
-### Step 5: Add identity providers, Vaults, and ACLs
-
-Authentication for AI Models works differently in version 2.x. Route auth plugins are **not** carried over onto AI Models, so you must add identity, secret, and access-control config to the converted `yaml` files manually before you apply it. Auth plugins on AI MCP Server and AI Agent routes are unaffected. They are converted to AI Policies in a previous step.
-
-Add an `identity_providers` entry in `models.yaml` for each authentication method your AI Models need (for example `key-auth` or `openid-connect`), then reference it from each AI Model's `access.identity_providers`:
-
-<!--vale off-->
-```yaml
-# models.yaml (AI Gateway v2 entity model)
-ai_gateway_identity_providers:
-- ref: key-auth-prod
-  ai_gateway: !ref ai-gateway#id
-  name: key-auth-prod
-  display_name: Key Auth
-  type: key-auth
-  config:
-    key_names:
-    - x-api-key
-
-ai_gateway_models:
-- ref: openai-chat
-  ai_gateway: !ref ai-gateway#id
-  name: openai-chat
-  # ...
-  access:
-    identity_providers:
-    - key-auth-prod
-```
-<!--vale on-->
-
-Create a `vaults.yaml` file in the `./out` directory and add a `vaults` entry for any secret store your migrated config references with `{vault://...}` syntax:
-
-<!--vale off-->
-```yaml
-ai_gateway_vaults:
-- ref: ai-vault
-  ai_gateway: !ref ai-gateway#id
-  name: ai-vault
-  display_name: AI Gateway Vault
-  type: konnect
-  description: Credential store for AI Gateway
-  config:
-    config_store_id: "55c2c6a4-7973-420c-909e-a16959714f5b"
-```
-<!--vale on-->
-
-{:.info}
-> **Note:** For a [{{site.konnect_short_name}} Config Store vaults](/how-to/configure-the-konnect-config-store/) (`type: konnect`), the Config Store you reference must already exist in {{site.konnect_short_name}} before you apply the configuration. `kongctl` does not create it for you.
-
-Finally, set `allow` or `deny` under each AI Model's `access.acls` to control which AI Consumers or AI Consumer Groups can reach it:
-
-<!--vale off-->
-```yaml
-ai_gateway_models:
-- ref: azure-gpt-4o
-  ai_gateway: !ref ai-gateway#id
-  name: azure-gpt-4o
-  # ...
-  access:
-    acls:
-      allow:
-      - Azure-OpenAI-Gold
-      - Azure-OpenAI-Silver
-      deny: []
-```
-<!--vale on-->
-
-### Step 6: Point the configuration at your control plane
-
-The converter has no way to know about the {{site.ai_gateway}} 2.x control plane you created in the [prerequisites](#prerequisites), so it generates `gateway.yaml` with a placeholder `ai_gateways` entry that would create a new control plane on apply. Edit that entry so it references your existing control plane by name instead:
-
-<!--vale off-->
-```yaml
-# gateway.yaml (AI Gateway v2 entity model)
-ai_gateways:
-- ref: ai-gateway
-  _external:
-    selector:
-      matchFields:
-        name: "ai-gateway"
-```
-<!--vale on-->
-
-Replace `ai-gateway` in `matchFields.name` with the control plane name you noted in the prerequisites. Keep the `ref` value (`ai-gateway`) as is, since every other converted file links back to this entry with `ai_gateway: !ref ai-gateway#id`.
-
-### Step 7: Authenticate kongctl
+### Step 6: Authenticate kongctl
 
 `kongctl apply` needs a {{site.konnect_short_name}} PAT or System Account Access Token to reach your control plane. Reuse the token from the [prerequisites](#prerequisites) with one of the following:
 
@@ -225,7 +221,7 @@ Replace `ai-gateway` in `matchFields.name` with the control plane name you noted
 - Pass the token with the `--pat` flag on the `apply` command.
 - Set the `KONGCTL_DEFAULT_KONNECT_PAT` environment variable.
 
-### Step 8: Apply the configuration
+### Step 7: Apply the configuration
 
 Sync the converted configuration to the {{site.ai_gateway}} control plane:
 
@@ -308,8 +304,10 @@ ai_gateway_model_providers:
   config:
     auth:
       # Carried over from the v1 target auth block.
-      header_name: Authorization
-      header_value: Bearer {vault://openai-vault/api-key}
+      type: basic
+      headers:
+      - name: Authorization
+        value: Bearer {vault://openai-vault/api-key}
 
 # models.yaml (AI Gateway v2 entity model)
 ai_gateway_models:
@@ -434,20 +432,23 @@ services:
 Converting the example to use the version 2.x model:
 * Moves the upstream URL, route, tools, and logging settings onto a single AI MCP Server entity
 * Copies the value from the plugin `mode` into the MCP Server `type` 
-* Converts the `key-auth` plugin into a Policy and attaches it to the MCP Server
+* Strips the `key-auth` plugin. Like AI Models, an AI MCP Server declares identity separately: add an identity provider manually and reference it from the server's `access.identity_providers`.
 * Renames `default_acl` to `default_tool_acls` and sets the ACL evaluation mode explicitly with `acl_attribute_type`
-* Renames the `config.logging` fields: `log_statistics` becomes `statistics`, and `log_audits` becomes `audits`
+* Renames the `config.logging` fields: `log_audits` becomes `audits` and `log_payloads` becomes `payloads`. `log_statistics` has no AI Gateway 2.x equivalent and is dropped.
 
 <!--vale off-->
 ```yaml
-# policies.yaml (AI Gateway v2 entity model)
-ai_gateway_policies:
+# identity_providers.yaml (in ./out — generated from the provider you declared
+# in ./config in Step 3; the v1 key-auth plugin itself is stripped on conversion)
+ai_gateway_identity_providers:
 - ref: flights-key-auth
   ai_gateway: !ref ai-gateway#id
   type: key-auth
   name: flights-key-auth
   display_name: Flights Key Auth
-  config: {}
+  config:
+    key_names:
+    - apikey
 
 # mcp_servers.yaml (AI Gateway v2 entity model)
 ai_gateway_mcp_servers:
@@ -466,15 +467,14 @@ ai_gateway_mcp_servers:
       allow:
       - flight-operators
       deny: []
-  policies:
-  - flights-key-auth
+    identity_providers:
+    - flights-key-auth
   config:
     url: https://flights.internal.kongair.com
     route:
       paths:
       - /flights-mcp
     logging:
-      statistics: true
       audits: true
   tools:
   - name: search_flights
@@ -492,8 +492,8 @@ To verify your AI MCP Servers entity migration, be sure to check the following:
 - Listener aggregation: If you used `conversion-only` plugins feeding a `listener` plugin via tags, confirm the converter preserved the tags so the version 2.x listener AI MCP Server still aggregates the right tools.
 - ACL mode: Version 2.x makes the ACL subject explicit. Use `acl_attribute_type: consumer` to evaluate against Consumers and Consumer Groups, or `acl_attribute_type: oauth_access_token` with `access_token_claim_field` to evaluate against a claim in an OAuth2 access token.
 - Per-tool ACLs: A per-tool `acl` replaces the default for that tool and does not merge with `default_tool_acls`. Ensure every allowed subject is listed on the tool explicitly.
-- Logging field names: The older `log_statistics`, `log_payloads`, and `log_audits` fields become `statistics`, `payloads`, and `audits` under `config.logging`.
-- Authentication: Unlike AI Models, auth plugins on MCP routes (like the `key-auth` example above) are carried over automatically as AI Policies. You don't need to declare them again.
+- Logging field names: `log_payloads` and `log_audits` become `payloads` and `audits` under `config.logging`. `log_statistics` has no AI Gateway 2.x equivalent and is dropped.
+- Authentication: Like AI Models, auth plugins on MCP routes (like the `key-auth` example above) are stripped on conversion. Declare the identity provider manually and reference it from the server's `access.identity_providers`.
 
 ### Migrate agents
 
@@ -532,7 +532,9 @@ services:
 
 Converting the example to use the version 2.x model:
 * Moves the upstream URL, route, request-size limit, and logging settings onto a single AI Agent entity.
-* Renames the `config.logging` fields: `log_statistics` becomes `statistics`, and `log_payloads` becomes `payloads`
+* Renames the `config.logging` fields: `log_payloads` becomes `payloads`. `log_statistics` has no AI Gateway 2.x equivalent and is dropped.
+
+Like AI Models and AI MCP Servers, any authentication plugin on the agent's route is stripped on conversion. If the agent needs auth, declare an identity provider manually and reference it from the agent's `access.identity_providers`.
 
 <!--vale off-->
 ```yaml
@@ -556,7 +558,6 @@ ai_gateway_agents:
       - /booking-agent
     max_request_body_size: 8388608
     logging:
-      statistics: true
       payloads: false
       max_payload_size: 1048576
 ```
@@ -569,8 +570,9 @@ To verify your AI Agent entity migration, be sure to check the following:
 
 - Agent type: Most A2A workloads use `type: a2a`. Use `type: http` for plain HTTP agent traffic that does not follow the A2A protocol bindings.
 - URL rewriting: The AI Agent entity rewrites the agent card `url` and `additionalInterfaces[].url` fields to the gateway address automatically, the same behavior the older plugin provided. No extra configuration is needed.
-- Logging field names: As with AI MCP Servers, `log_statistics` and `log_payloads` become `statistics` and `payloads` under `config.logging`.
-- Analytics: When `statistics` is enabled, A2A metrics flow into {{site.konnect_short_name}} analytics. View them under Agentic usage analytics in {{site.konnect_short_name}} [Explorer](/observability/explorer/) and [Dashboards](/observability/#dashboard).
+- Logging field names: As with AI MCP Servers, `log_payloads` becomes `payloads` under `config.logging`, and `log_statistics` is dropped (no AI Gateway 2.x equivalent).
+- Identity: Like AI Models, an AI Agent has no route auth after conversion. If the agent needs authentication, confirm the identity provider you declared is attached via `access.identity_providers`.
+- Analytics: A2A metrics flow into {{site.konnect_short_name}} analytics. View them under Agentic usage analytics in {{site.konnect_short_name}} [Explorer](/observability/explorer/) and [Dashboards](/observability/#dashboard).
 
 ## Verify your migration
 

--- a/app/ai-gateway/v2-migration-guide.md
+++ b/app/ai-gateway/v2-migration-guide.md
@@ -96,9 +96,15 @@ deck gateway dump \
 
 The resulting `kong.yaml` contains your Services, Routes, plugins (including `ai-proxy-advanced`, `ai-mcp-proxy`, and `ai-a2a-proxy`), Consumers, and Vaults.
 
+{:.warning}
+> **Converter requirements:** 
+> * Each `ai-proxy` or `ai-proxy-advanced` plugin you're migrating needs a real model name (for example `gpt-4o`) configured. The converter can't generate one for you, and a converted AI Model with no model name fails validation when you apply it. If any of your plugins are missing one, set it on the {{site.base_gateway}} 3.x control plane before you export.
+> * `ai-proxy-advanced`, `ai-mcp-proxy`, and `ai-a2a-proxy` plugins **must** be scoped to a Service and Route to convert to the {{site.ai_gateway}} 2.x entity model.
+
 ### Step 3: Prepare the configuration directory
 
-The converter cannot recover some configuration from the decK export: the target {{site.ai_gateway}} 2.x control plane, identity providers, Vaults, and per-model ACLs. Declare these in a `./config` directory before you run the converter, and it merges them into the output. Create the directory:
+The converter cannot recover some configuration from the decK export, such as the target {{site.ai_gateway}} 2.x control plane, identity providers, Vaults, and per-model ACLs. Declare these in a `./config` directory before you run the converter, and it will merge them into the output. 
+Create the directory:
 
 ```sh
 mkdir -p ./config
@@ -113,9 +119,10 @@ Add a `config/gateway.yaml` that points at the {{site.ai_gateway}} 2.x control p
 # config/gateway.yaml
 ai_gateways:
 - ref: ai-gateway
-  display_name: AI Gateway
-  name: ai-gateway
-  description: AI Gateway
+  _external:
+    selector:
+      matchFields:
+        name: "your-ai-gateway-name"
 ```
 <!--vale on-->
 
@@ -140,8 +147,28 @@ identity_providers:
   models: ['*']
   mcp_servers: ['*']
   agents: ['*']
+- ref: oidc-prod
+  name: oidc-prod
+  display_name: OIDC
+  type: openid-connect
+  config:
+    issuer: "https://your-idp.example.com"
+    client_id:
+    - your-client-id
+    client_secret:
+    - your-client-secret
+    scopes:
+    - openid
+    cache_tokens_salt: "a-random-string"
+  # Only one identity provider per entity kind can use the '*' wildcard,
+  # so name the specific models, MCP servers, and agents that use OIDC.
+  models: ['my-model']
+  mcp_servers: ['my-mcp-server']
+  agents: ['my-agent']
 ```
 <!--vale on-->
+
+The `openid-connect` entry above shows only the fields {{site.ai_gateway}} requires at minimum. Add any other fields your identity provider actually uses (additional scopes, claims, cookie settings, and so on). Don't copy fields straight from your v1 `openid-connect` plugin config if they're unset (`null`) there. {{site.ai_gateway}} 2.x rejects explicit `null` values for most fields, so it's easier to start minimal and add only what you need.
 
 At most two identity providers are allowed (at most one `key-auth` and one `openid-connect`), and at most one may use the `"*"` wildcard per entity kind. The converter attaches each provider to the listed entities via their `access.identity_providers`.
 
@@ -159,12 +186,12 @@ vaults:
   type: konnect
   description: Credential store for AI Gateway
   config:
-    config_store_id: "${KONNECT_CONFIG_STORE_ID}"
+    config_store_id: "$KONNECT_CONFIG_STORE_ID"
 ```
 <!--vale on-->
 
 {:.info}
-> **Note:** For a [{{site.konnect_short_name}} Config Store vault](/how-to/configure-the-konnect-config-store/) (`type: konnect`), the Config Store you reference must already exist in {{site.konnect_short_name}} before you apply the configuration. `kongctl` does not create it for you.
+> **Note:** For a [{{site.konnect_short_name}} Config Store vault](/how-to/configure-the-konnect-config-store/) (`type: konnect`), the Config Store you reference must already exist in {{site.konnect_short_name}} before you apply the configuration. `kongctl` does not create it for you. If you created the Config Store through the {{site.konnect_short_name}} UI, it's created without a `name`. Set one with the [Update Config Store API](/api/konnect/control-planes-config/v2/#/operations/update-config-store) before you apply the configuration.
 
 #### Per-model ACLs
 
@@ -180,6 +207,8 @@ acls:
   - Azure-OpenAI-Silver
 ```
 <!--vale on-->
+
+`name` must match the AI Model's converted name, which the converter derives from the v1 **Route** name the `ai-proxy`/`ai-proxy-advanced` plugin is attached to, not from any field inside the plugin itself. If you're not sure what a model will be named, run the converter once without `model_acls.yaml`, check the `ref`/`name` values in `models.yaml` in `./out`, then add your ACLs and re-run.
 
 ### Step 4: Run the converter
 
@@ -213,38 +242,14 @@ Open the `yaml` files in `./out` and confirm that the converter captured everyth
 
 Pay particular attention to anything the converter can't infer from the config of {{site.ai_gateway}} running on {{site.base_gateway}}, such as an AI Model Provider `display_name` or an AI Model `display_name`. These are required in {{site.ai_gateway}} 2.x and may be generated from the source data, so rename them to something meaningful before you apply.
 
-### Step 6: Authenticate kongctl
-
-`kongctl apply` needs a {{site.konnect_short_name}} PAT or System Account Access Token to reach your control plane. Reuse the token from the [prerequisites](#prerequisites) with one of the following:
-
-- Run `kongctl login` to authenticate interactively through the browser.
-- Pass the token with the `--pat` flag on the `apply` command.
-- Set the `KONGCTL_DEFAULT_KONNECT_PAT` environment variable.
-
-### Step 7: Apply the configuration
-
-Sync the converted configuration to the {{site.ai_gateway}} control plane:
-
-```sh
-kongctl apply -f ./out
-```
-
-`kongctl` creates the AI Model Providers, Models, MCP Servers, Agents, and Policies defined in the files. Because the configuration is declarative, you can re-run to apply after edits and `kongctl` will reconcile the control plane to match the files.
-
-After the apply succeeds, the {{site.ai_gateway}} exposes its configuration and telemetry endpoints. Send a representative request to each migrated AI Model, MCP server, and Agent to confirm behavior matches {{site.ai_gateway}} running on {{site.base_gateway}} before you transfer traffic over.
-
-## Entity specific advice
-
-The following sections provide migration advice for the different AI entities.
-
-### Migrate models
+#### Validate AI Models
 
 In {{site.ai_gateway}} running on {{site.base_gateway}}, a model is an [AI Proxy Advanced](/plugins/ai-proxy-advanced/) plugin attached to a Service and Route. The plugin holds the provider, credentials, route type, model options, and load balancer all in one place. 
 
 In {{site.ai_gateway}} version 2.x, that single plugin becomes two entities: an [AI Model Provider](/ai-gateway/entities/ai-model-provider) that holds the upstream connection and credentials, and an [AI Model](/ai-gateway/entities/ai-model/) that holds routing, capabilities, format, load balancing, and one or more `targets` that each reference an AI Model Provider.
 This allows you to reuse AI Model Providers in multiple AI Models.
 
-#### Convert configuration files
+##### Converted configuration files
 
 The following `deck` snippet defines a chat model that load balances across two OpenAI models using round-robin:
 
@@ -353,7 +358,7 @@ ai_gateway_models:
 {:.collapsible}
 <!--vale on-->
 
-#### Verify AI Models entity configuration
+##### Verify AI Models entity configuration
 
 To verify your AI Models entity migration, be sure to check the following:
 
@@ -365,7 +370,7 @@ To verify your AI Models entity migration, be sure to check the following:
 - Vector database and embeddings: `config.vectordb` and `config.embeddings` settings carry over onto the AI Model config under the `balancer` config, keeping the same Redis or pgvector strategy.
 
 
-### Migrate MCP servers
+#### Validate MCP Servers
 
 In {{site.ai_gateway}} running on {{site.base_gateway}}, an MCP server is an [AI MCP Proxy](/plugins/ai-mcp-proxy/) plugin attached to a Service and Route. The plugin runs in one of four modes and holds the tools, Access Control Lists (ACLs), and logging settings in its config.
 
@@ -394,7 +399,7 @@ rows:
     type: "`upstream-server`"
 {% endtable %}
 
-#### Convert configuration files
+##### Converted configuration files
 
 The following {{site.ai_gateway}} running on {{site.base_gateway}} example config:
 * Converts a REST flights API into MCP tools
@@ -484,7 +489,7 @@ ai_gateway_mcp_servers:
 {:.collapsible}
 <!--vale on-->
 
-#### Verify AI MCP Servers entity configuration
+##### Verify AI MCP Servers entity configuration
 
 To verify your AI MCP Servers entity migration, be sure to check the following:
 
@@ -495,7 +500,7 @@ To verify your AI MCP Servers entity migration, be sure to check the following:
 - Logging field names: `log_payloads` and `log_audits` become `payloads` and `audits` under `config.logging`. `log_statistics` has no AI Gateway 2.x equivalent and is dropped.
 - Authentication: Like AI Models, auth plugins on MCP routes (like the `key-auth` example above) are stripped on conversion. Declare the identity provider manually and reference it from the server's `access.identity_providers`.
 
-### Migrate agents
+#### Validate AI Agents
 
 In {{site.ai_gateway}} running on {{site.base_gateway}}, an agent is an [AI A2A Proxy](/plugins/ai-a2a-proxy/) plugin attached to a Service and Route. The plugin is a transparent proxy that adds observability and agent card URL rewriting to Agent-to-Agent (A2A) traffic (where the gateway automatically changes the agent's address so clients connect through the gateway instead of directly to the agent.)
 
@@ -504,7 +509,7 @@ In {{site.ai_gateway}} version 2.x, that plugin becomes an [AI Agent](/ai-gatewa
 * Routing
 * Logging
 
-#### Convert configuration files
+##### Converted configuration files
 
 The following example for {{site.ai_gateway}} running on {{site.base_gateway}} defines an A2A agent that proxies an upstream agent that handles flight bookings:
 
@@ -564,7 +569,7 @@ ai_gateway_agents:
 {:.collapsible}
 <!--vale on-->
 
-#### Verify AI Agent entity configuration
+##### Verify AI Agent entity configuration
 
 To verify your AI Agent entity migration, be sure to check the following:
 
@@ -573,6 +578,32 @@ To verify your AI Agent entity migration, be sure to check the following:
 - Logging field names: As with AI MCP Servers, `log_payloads` becomes `payloads` under `config.logging`, and `log_statistics` is dropped (no AI Gateway 2.x equivalent).
 - Identity: Like AI Models, an AI Agent has no route auth after conversion. If the agent needs authentication, confirm the identity provider you declared is attached via `access.identity_providers`.
 - Analytics: A2A metrics flow into {{site.konnect_short_name}} analytics. View them under Agentic usage analytics in {{site.konnect_short_name}} [Explorer](/observability/explorer/) and [Dashboards](/observability/#dashboard).
+
+### Step 6: Authenticate kongctl
+
+`kongctl apply` needs a {{site.konnect_short_name}} PAT or System Account Access Token to reach your control plane. Reuse the token from the [prerequisites](#prerequisites) with one of the following:
+
+- Run `kongctl login` to authenticate interactively through the browser.
+- Pass the token with the `--pat` flag on the `apply` command.
+- Set the `KONGCTL_DEFAULT_KONNECT_PAT` environment variable.
+
+### Step 7: Apply the configuration
+
+Preview the changes before applying them:
+
+```sh
+kongctl diff -f ./out
+```
+
+Review the plan, then sync the converted configuration to the {{site.ai_gateway}} control plane:
+
+```sh
+kongctl apply -f ./out
+```
+
+`kongctl` creates the AI Model Providers, Models, MCP Servers, Agents, and Policies defined in the files. Because the configuration is declarative, you can re-run to apply after edits and `kongctl` will reconcile the control plane to match the files.
+
+After the apply succeeds, the {{site.ai_gateway}} exposes its configuration and telemetry endpoints. Send a representative request to each migrated AI Model, MCP server, and Agent to confirm behavior matches {{site.ai_gateway}} running on {{site.base_gateway}} before you transfer traffic over.
 
 ## Verify your migration
 
@@ -589,6 +620,17 @@ Run the old and new configurations in parallel during cutover so you can roll ba
 Once you've successfully generated the `kongctl` config, applied it to your environment, and tested the configuration, you can uninstall the `kongctl-ext-aigw-converter` extension with `kongctl uninstall extension kong/ai-gateway-converter`.
 
 ## Troubleshooting
+
+### Recover from a failed apply
+
+If `kongctl apply` fails partway through, `kongctl` skips every remaining resource in that run as "blocked by failed dependencies," even resources that don't actually depend on the one that failed. 
+You may hit several different failures in sequence as you fix each one and re-run, since a later error can't surface until an earlier one is resolved.
+
+To recover:
+
+1. Fix the underlying issue. Depending on the error, this might mean editing a file in `./config`, editing `kong.yaml`, or fixing configuration on the source {{site.base_gateway}} control plane (for example, setting a missing model name) and re-exporting with `deck gateway dump`.
+1. Delete `./out` and regenerate it from scratch with `kongctl convert ai-gateway`, rather than editing the partially generated files directly.
+1. Run `kongctl diff -f ./out` again to confirm the plan looks correct before re-running `kongctl apply -f ./out`.
 
 ### Drive kongctl extensions from the converter output
 

--- a/app/ai-gateway/v2-migration-guide.md
+++ b/app/ai-gateway/v2-migration-guide.md
@@ -52,10 +52,11 @@ Migration uses the `kongctl convert ai-gateway extension` to translate your exis
 
 1. Install the `kongctl convert ai-gateway` extension.
 1. Export the declarative configuration from your existing {{site.base_gateway}} control plane with decK.
-1. Run the converter to produce an {{site.ai_gateway}} entity configuration file.
+1. Run the converter to produce a directory of {{site.ai_gateway}} entity configuration files.
 1. Validate that the output includes all of your AI Models, AI MCP Servers, and AI Agents.
 1. Add identity providers, Vaults, and per-model ACLs manually, since the converter cannot recover these from the decK export.
-1. Add your {{site.ai_gateway}} control plane ID to the `kongctl` configuration.
+1. Point the converted configuration at your {{site.ai_gateway}} 2.x control plane.
+1. Authenticate `kongctl` with a {{site.konnect_short_name}} PAT or System Account Access Token.
 1. Apply the converted configuration to the new {{site.ai_gateway}} control plane.
 
 The diagram below shows where each tool sits in the flow:
@@ -64,11 +65,11 @@ The diagram below shows where each tool sits in the flow:
 sequenceDiagram
     participant A as API Gateway CP<br/>{{site.ai_gateway}} v1
     participant B as kong.yaml
-    participant C as ai-gateway.yaml
+    participant C as ./out (entity files)
     participant D as {{site.ai_gateway}} CP<br/>{{site.ai_gateway}} v2
 
     A->>B: deck gateway dump
-    B->>C: ai-deck-converter
+    B->>C: kongctl convert ai-gateway
     C->>C: add identity providers,<br/>vaults, and ACLs
     C->>C: review and validate
     C->>D: kongctl apply
@@ -140,8 +141,10 @@ Add an `identity_providers` entry in `models.yaml` for each authentication metho
 <!--vale off-->
 ```yaml
 # models.yaml (AI Gateway v2 entity model)
-identity_providers:
-- name: key-auth-prod
+ai_gateway_identity_providers:
+- ref: key-auth-prod
+  ai_gateway: !ref ai-gateway#id
+  name: key-auth-prod
   display_name: Key Auth
   type: key-auth
   config:
@@ -149,7 +152,9 @@ identity_providers:
     - x-api-key
 
 ai_gateway_models:
-- name: openai-chat
+- ref: openai-chat
+  ai_gateway: !ref ai-gateway#id
+  name: openai-chat
   # ...
   access:
     identity_providers:
@@ -161,8 +166,10 @@ Create a `vaults.yaml` file in the `./out` directory and add a `vaults` entry fo
 
 <!--vale off-->
 ```yaml
-vaults:
-- name: ai-vault
+ai_gateway_vaults:
+- ref: ai-vault
+  ai_gateway: !ref ai-gateway#id
+  name: ai-vault
   display_name: AI Gateway Vault
   type: konnect
   description: Credential store for AI Gateway
@@ -179,7 +186,9 @@ Finally, set `allow` or `deny` under each AI Model's `access.acls` to control wh
 <!--vale off-->
 ```yaml
 ai_gateway_models:
-- name: azure-gpt-4o
+- ref: azure-gpt-4o
+  ai_gateway: !ref ai-gateway#id
+  name: azure-gpt-4o
   # ...
   access:
     acls:
@@ -190,25 +199,33 @@ ai_gateway_models:
 ```
 <!--vale on-->
 
-### Step 6: Add your control plane ID to kongctl
+### Step 6: Point the configuration at your control plane
 
-`kongctl` needs to know which {{site.ai_gateway}} control plane to target. Add your control plane name to the `kongctl` configuration file so that `kongctl apply` writes to the correct control plane.
+The converter has no way to know about the {{site.ai_gateway}} 2.x control plane you created in the [prerequisites](#prerequisites), so it generates `gateway.yaml` with a placeholder `ai_gateways` entry that would create a new control plane on apply. Edit that entry so it references your existing control plane by name instead:
 
 <!--vale off-->
-```sh
-# Set the AI Gateway control plane that kongctl will apply to.
+```yaml
+# gateway.yaml (AI Gateway v2 entity model)
 ai_gateways:
 - ref: ai-gateway
   _external:
     selector:
-        matchFields:
-          name: "ai-gateway"
+      matchFields:
+        name: "ai-gateway"
 ```
 <!--vale on-->
 
-Keep one source of truth so that repeated applies always target the same control plane.
+Replace `ai-gateway` in `matchFields.name` with the control plane name you noted in the prerequisites. Keep the `ref` value (`ai-gateway`) as is, since every other converted file links back to this entry with `ai_gateway: !ref ai-gateway#id`.
 
-### Step 7: Apply the configuration
+### Step 7: Authenticate kongctl
+
+`kongctl apply` needs a {{site.konnect_short_name}} PAT or System Account Access Token to reach your control plane. Reuse the token from the [prerequisites](#prerequisites) with one of the following:
+
+- Run `kongctl login` to authenticate interactively through the browser.
+- Pass the token with the `--pat` flag on the `apply` command.
+- Set the `KONGCTL_DEFAULT_KONNECT_PAT` environment variable.
+
+### Step 8: Apply the configuration
 
 Sync the converted configuration to the {{site.ai_gateway}} control plane:
 
@@ -281,9 +298,11 @@ The converter splits the credentials into an AI Model Provider and the routing a
 
 <!--vale off-->
 ```yaml
-# ai-gateway.yaml (AI Gateway v2 entity model)
-providers:
-- type: openai
+# providers.yaml (AI Gateway v2 entity model)
+ai_gateway_model_providers:
+- ref: openai-prod
+  ai_gateway: !ref ai-gateway#id
+  type: openai
   name: openai-prod
   display_name: OpenAI Production
   config:
@@ -292,8 +311,11 @@ providers:
       header_name: Authorization
       header_value: Bearer {vault://openai-vault/api-key}
 
-models:
-- type: model
+# models.yaml (AI Gateway v2 entity model)
+ai_gateway_models:
+- ref: openai-chat
+  ai_gateway: !ref ai-gateway#id
+  type: model
   name: openai-chat
   display_name: OpenAI Chat
   enabled: true
@@ -418,15 +440,20 @@ Converting the example to use the version 2.x model:
 
 <!--vale off-->
 ```yaml
-# ai-gateway.yaml (AI Gateway v2 entity model)
-policies:
-- type: key-auth
+# policies.yaml (AI Gateway v2 entity model)
+ai_gateway_policies:
+- ref: flights-key-auth
+  ai_gateway: !ref ai-gateway#id
+  type: key-auth
   name: flights-key-auth
   display_name: Flights Key Auth
   config: {}
 
-mcp-servers:
-- type: conversion-listener
+# mcp_servers.yaml (AI Gateway v2 entity model)
+ai_gateway_mcp_servers:
+- ref: kongair-flights
+  ai_gateway: !ref ai-gateway#id
+  type: conversion-listener
   name: kongair-flights
   display_name: Kong Air Flights
   enabled: true
@@ -509,9 +536,11 @@ Converting the example to use the version 2.x model:
 
 <!--vale off-->
 ```yaml
-# ai-gateway.yaml (AI Gateway v2 entity model)
-agents:
-- type: a2a
+# agents.yaml (AI Gateway v2 entity model)
+ai_gateway_agents:
+- ref: kongair-flight-booking-agent
+  ai_gateway: !ref ai-gateway#id
+  type: a2a
   name: kongair-flight-booking-agent
   display_name: Kong Air Flight Booking Agent
   enabled: true
@@ -561,7 +590,7 @@ Once you've successfully generated the `kongctl` config, applied it to your envi
 
 ### Drive kongctl extensions from the converter output
 
-The `ai-gateway.yaml` produced by the converter is a declarative artifact, which makes it a useful input to `kongctl` extensions. `kongctl` ships installable skills for coding agents, including a declarative skill for plan, apply, sync, delete, and adopt flows, and an extension builder for creating local CLI extensions.
+The `./out` directory produced by the converter is a declarative artifact, which makes it a useful input to `kongctl` extensions. `kongctl` ships installable skills for coding agents, including a declarative skill for plan, apply, sync, delete, and adopt flows, and an extension builder for creating local CLI extensions.
 
 Install the skills from the root of the repository where your agent works:
 
@@ -573,8 +602,8 @@ By default, this writes skill files to `.kongctl/skills/` and symlinks them for 
 
 With the converter output and these skills in place, you can build extensions that:
 
-- Diff a freshly converted `ai-gateway.yaml` against the live {{site.ai_gateway}} control plane and surface drift before an apply.
-- Wrap the full `deck gateway dump`, `ai-deck-converter`, and `kongctl apply` sequence into a single repeatable command for many control planes.
+- Diff the freshly converted files in `./out` against the live {{site.ai_gateway}} control plane and surface drift before an apply.
+- Wrap the full `deck gateway dump`, `kongctl convert ai-gateway`, and `kongctl apply` sequence into a single repeatable command for many control planes.
 - Validate that every `targets[].provider` reference resolves and that required fields such as `display_name` are populated, as a pre-apply gate.
 
 This lets you treat {{site.ai_gateway}} migration as a versioned, reviewable, and automated pipeline rather than a one-time manual conversion.

--- a/app/ai-gateway/v2-migration-guide.md
+++ b/app/ai-gateway/v2-migration-guide.md
@@ -96,17 +96,22 @@ The resulting `kong.yaml` contains your Services, Routes, plugins (including `ai
 
 ### Step 3: Run the converter
 
+Before you can convert `kong.yaml`, create the `./config` and `./out` directories that the converter will use for the converted files:
+
+```sh
+mkdir -p ./config ./out
+```
+
 Run `kongctl convert ai-gateway` against the exported `kong.yaml` file. The tool reads the {{site.ai_gateway}} running on {{site.base_gateway}} plugin configuration and emits an {{site.ai_gateway}} 2.x entity configuration.
 
 ```sh
-kongctl convert ai-gateway deck.yaml \
-  --from deck \
-  --to kongctl \
-  --gateway-name support-ai \
-  --output-file ai-gateway.yaml
+kongctl convert ai-gateway \
+  --input kong.yaml \
+  --config ./config \
+  --out ./out
 ```
 
-The `-o` flag sets the output file. The converter inspects each AI plugin and translates it into the matching version 2.x entity:
+The `--out` flag sets the output directory for the converted files. The converter inspects each AI plugin and translates it into the matching version 2.x entity:
 
 - Each `ai-proxy-advanced` plugin becomes an [AI Model](/ai-gateway/entities/ai-model/) (and one [AI Model Provider](/ai-gateway/entities/ai-model-provider/) per distinct upstream provider and credential set).
 - Each `ai-mcp-proxy` plugin becomes an [AI MCP Server](/ai-gateway/entities/ai-mcp-server/) whose type matches the plugin mode.
@@ -116,7 +121,7 @@ The `-o` flag sets the output file. The converter inspects each AI plugin and tr
 
 ### Step 4: Validate the converted configuration
 
-Open `ai-gateway.yaml` and confirm that the converter captured everything you expect. At minimum, check that:
+Open the `yaml` files in `./out` and confirm that the converter captured everything you expect. At minimum, check that:
 
 - Every AI Proxy plugin-based model has a corresponding AI Model entry, with the right `capabilities`, `formats`, and `targets`.
 - Provider credentials were extracted correctly, and each `targets[].provider` reference resolves to a declared AI Model Provider.
@@ -128,13 +133,13 @@ Pay particular attention to anything the converter can't infer from the config o
 
 ### Step 5: Add identity providers, Vaults, and ACLs
 
-Authentication for AI Models works differently in version 2.x. Route auth plugins are **not** carried over onto AI Models, so you must add identity, secret, and access-control config to `ai-gateway.yaml` manually before you apply it. Auth plugins on AI MCP Server and AI Agent routes are unaffected. They are converted to AI Policies in a previous step.
+Authentication for AI Models works differently in version 2.x. Route auth plugins are **not** carried over onto AI Models, so you must add identity, secret, and access-control config to the converted `yaml` files manually before you apply it. Auth plugins on AI MCP Server and AI Agent routes are unaffected. They are converted to AI Policies in a previous step.
 
-Add an `identity_providers` entry for each authentication method your AI Models need (for example `key-auth` or `openid-connect`), then reference it from each AI Model's `access.identity_providers`:
+Add an `identity_providers` entry in `models.yaml` for each authentication method your AI Models need (for example `key-auth` or `openid-connect`), then reference it from each AI Model's `access.identity_providers`:
 
 <!--vale off-->
 ```yaml
-# ai-gateway.yaml (AI Gateway v2 entity model)
+# models.yaml (AI Gateway v2 entity model)
 identity_providers:
 - name: key-auth-prod
   display_name: Key Auth
@@ -143,7 +148,7 @@ identity_providers:
     key_names:
     - x-api-key
 
-models:
+ai_gateway_models:
 - name: openai-chat
   # ...
   access:
@@ -152,7 +157,7 @@ models:
 ```
 <!--vale on-->
 
-Add a `vaults` entry for any secret store your migrated config references with `{vault://...}` syntax:
+Create a `vaults.yaml` file in the `./out` directory and add a `vaults` entry for any secret store your migrated config references with `{vault://...}` syntax:
 
 <!--vale off-->
 ```yaml
@@ -173,7 +178,7 @@ Finally, set `allow` or `deny` under each AI Model's `access.acls` to control wh
 
 <!--vale off-->
 ```yaml
-models:
+ai_gateway_models:
 - name: azure-gpt-4o
   # ...
   access:
@@ -208,10 +213,10 @@ Keep one source of truth so that repeated applies always target the same control
 Sync the converted configuration to the {{site.ai_gateway}} control plane:
 
 ```sh
-kongctl apply -f ai-gateway.yaml
+kongctl apply -f ./out
 ```
 
-`kongctl` creates the AI Model Providers, Models, MCP Servers, Agents, and Policies defined in the file. Because the configuration is declarative, you can re-run to apply after edits and `kongctl` will reconcile the control plane to match the file.
+`kongctl` creates the AI Model Providers, Models, MCP Servers, Agents, and Policies defined in the files. Because the configuration is declarative, you can re-run to apply after edits and `kongctl` will reconcile the control plane to match the files.
 
 After the apply succeeds, the {{site.ai_gateway}} exposes its configuration and telemetry endpoints. Send a representative request to each migrated AI Model, MCP server, and Agent to confirm behavior matches {{site.ai_gateway}} running on {{site.base_gateway}} before you transfer traffic over.
 

--- a/app/ai-gateway/v2-migration-guide.md
+++ b/app/ai-gateway/v2-migration-guide.md
@@ -201,6 +201,45 @@ vaults:
 <!--vale on-->
 
 {% comment %}
+UNCOMMENT THIS IF THE TOOL **IS** FIXED TO CORRECTLY CONVERT KONNECT CONFIG STORE VAULTS (and replace the vault example above with this)
+
+<!--vale off-->
+```yaml
+# config/vaults.yaml
+vaults:
+- ref: ai-vault
+  name: hashicorp
+  display_name: AI Gateway Hashicorp Vault
+  type: hcv
+  description: HCV vault for AI Gateway
+  prefix: "my-vault"
+  config:
+    auth_method: token
+    base64_decode: false
+    host: "127.0.0.1"
+    kv: "v1"
+    mount: "secret"
+    port: 8200
+    protocol: "http"
+    ssl_verify: true
+    token: "*********"
+- ref: ai-konnect-vault
+  name: ai-konnect-vault
+  display_name: AI Gateway Konnect Vault
+  type: konnect
+  description: Credential store for AI Gateway
+  config:
+    config_store_id: "00c45ss6-d6a0-4aeb-b535-e4b6def3ea25"
+```
+<!--vale on-->
+
+{:.info}
+> **Note:** For a [{{site.konnect_short_name}} Config Store vault](/how-to/configure-the-konnect-config-store/) (`type: konnect`), the Config Store you reference must already exist in {{site.konnect_short_name}} before you apply the configuration. `kongctl` does not create it for you. If you created the Config Store through the {{site.konnect_short_name}} UI, it's created without a `name`. Set one with the [Update Config Store API](/api/konnect/control-planes-config/v2/#/operations/update-config-store) before you apply the configuration.
+{% endcomment %}
+
+{% comment %}
+UNCOMMENT THIS IF THE TOOL **ISN'T** FIXED TO CORRECTLY CONVERT KONNECT CONFIG STORE VAULTS 
+
 If you're using a {{site.konnect_short_name}} Config Store, you must [manually migrate](#manually-migrate-konnect-config-store-vault) that after using the conversion tool.
 {% endcomment %}
 
@@ -254,6 +293,7 @@ Open the `yaml` files in `./out` and confirm that the converter captured everyth
 Pay particular attention to anything the converter can't infer from the config of {{site.ai_gateway}} running on {{site.base_gateway}}, such as an AI Model Provider `display_name` or an AI Model `display_name`. These are required in {{site.ai_gateway}} 2.x and may be generated from the source data, so rename them to something meaningful before you apply.
 
 {% comment %}
+UNCOMMENT THIS IF THE TOOL ISN'T FIXED TO CORRECTLY CONVERT KONNECT CONFIG STORE VAULTS 
 
 #### Manually migrate {{site.konnect_short_name}} Config Store vault 
 

--- a/app/ai-gateway/v2-migration-guide.md
+++ b/app/ai-gateway/v2-migration-guide.md
@@ -87,8 +87,8 @@ Use `deck` to dump the declarative configuration from the {{site.base_gateway}} 
 
 ```sh
 deck gateway dump \
-  --konnect-token $YOUR_KONNECT_PAT \
-  --konnect-control-plane-name $YOUR_KONNECT_API_GATEWAY_CONTROL_PLANE_NAME \
+  --konnect-token $KONNECT_TOKEN \
+  --konnect-control-plane-name $KONNECT_API_GATEWAY_CONTROL_PLANE_NAME \
   > kong.yaml
 
 ```
@@ -103,7 +103,7 @@ Before you can convert `kong.yaml`, create the `./config` and `./out` directorie
 mkdir -p ./config ./out
 ```
 
-Run `kongctl convert ai-gateway` against the exported `kong.yaml` file. The tool reads the {{site.ai_gateway}} running on {{site.base_gateway}} plugin configuration and emits an {{site.ai_gateway}} 2.x entity configuration.
+Run `kongctl convert ai-gateway` against the exported `kong.yaml` file. The tool reads the {{site.ai_gateway}} running on {{site.base_gateway}} plugin configuration and emits an {{site.ai_gateway}} 2.x entity and Policy configuration.
 
 ```sh
 kongctl convert ai-gateway \
@@ -112,7 +112,7 @@ kongctl convert ai-gateway \
   --out ./out
 ```
 
-The `--out` flag sets the output directory for the converted files. The converter inspects each AI plugin and translates it into the matching version 2.x entity:
+The `--out` flag sets the output directory for the converted files. The converter inspects each AI plugin and translates it into the matching version 2.x entity or Policy:
 
 - Each `ai-proxy-advanced` plugin becomes an [AI Model](/ai-gateway/entities/ai-model/) (and one [AI Model Provider](/ai-gateway/entities/ai-model-provider/) per distinct upstream provider and credential set).
 - Each `ai-mcp-proxy` plugin becomes an [AI MCP Server](/ai-gateway/entities/ai-mcp-server/) whose type matches the plugin mode.
@@ -124,10 +124,10 @@ The `--out` flag sets the output directory for the converted files. The converte
 
 Open the `yaml` files in `./out` and confirm that the converter captured everything you expect. At minimum, check that:
 
-- Every AI Proxy plugin-based model has a corresponding AI Model entry, with the right `capabilities`, `formats`, and `targets`.
-- Provider credentials were extracted correctly, and each `targets[].provider` reference resolves to a declared AI Model Provider.
-- Every AI MCP Server has the correct `type` for its original plugin mode, and that `conversion-only` and `listener` pairs are linked by matching tags.
-- Each AI Agent points at the correct upstream url and carries the logging settings you had configured.
+- Every AI Proxy plugin-based model has a corresponding AI Model entry in `models.yaml`, with the right `capabilities`, `formats`, and `targets`.
+- Provider credentials were extracted correctly, and each `targets[].provider` reference resolves to a declared AI Model Provider in `providers.yaml`.
+- Every AI MCP Server in `mcp_servers.yaml` has the correct `type` for its original plugin mode, and that `conversion-only` and `listener` pairs are linked by matching tags.
+- Each AI Agent points at the correct upstream URL and carries the logging settings you had configured.
 - Supporting plugins were converted to AI Policies and attached to the right entities.
 
 Pay particular attention to anything the converter can't infer from the config of {{site.ai_gateway}} running on {{site.base_gateway}}, such as an AI Model Provider `display_name` or an AI Model `display_name`. These are required in {{site.ai_gateway}} 2.x and may be generated from the source data, so rename them to something meaningful before you apply.


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes #6026 

- Added a prerequisite noting identity providers, vaults, and per-model ACLs must be prepared by hand (converter can't recover them from decK)
- Expanded migration overview from 5 to 6 steps and updated the mermaid diagram to show the new manual step
- Added a note to Step 2 that auth plugins (key-auth, openid-connect) on AI Model routes are stripped during conversion
- Inserted a new Step 4: Add identity providers, vaults, and ACLs with YAML examples for identity_providers, vaults (plus a config-store caveat), and access.acls
- Renumbered old Step 4 → Step 5 (kongctl control plane config) and old Step 5 → Step 6 (apply)
- Added an "Identity" bullet to the AI Models verification checklist
- Added an "Authentication" bullet to the AI MCP Servers verification checklist clarifying their auth plugins do convert automatically (unlike AI Models)

## Preview Links
https://deploy-preview-6457--kongdeveloper.netlify.app/ai-gateway/v2-migration-guide/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
