### PR TITLE
feat(identity): how to rotate a client secret

### DIFF
--- a/app/_how-tos/gateway/rotate-auth-server-client-secrets.md
+++ b/app/_how-tos/gateway/rotate-auth-server-client-secrets.md
@@ -1,0 +1,187 @@
+---
+title: Rotate secrets for an authorization server client
+permalink: /how-to/rotate-auth-server-client-secrets/
+content_type: how_to
+related_resources:
+  - text: Authentication
+    url: /gateway/authentication/
+  - text: Principals and directories
+    url: /identity/principals/ 
+  
+
+description: Learn how to rotate the client secrets for an authorization server client with no downtime.
+products:
+  - identity
+
+works_on:
+    - konnect
+
+min_version:
+  gateway: '3.15'
+
+
+tags:
+    - authentication
+
+tldr:
+  q: How do I rotate the secrets for an authorization server client?
+  a: |
+    Create a second secret for the client, validate that it works, then delete the original secret.
+
+prereqs:
+  
+  inline:
+    - title: Kong Identity authorization server
+      icon_url: /assets/icons/identity.svg
+      content: |
+        Create an authorization server using the [`/v1/auth-servers` endpoint](/api/konnect/kong-identity/v1/#/operations/createAuthServer), and save the `AUTH_SERVER_ID` and `ISSUER_URL` variables:
+
+        <!--vale off-->
+        {% konnect_api_request %}
+        url: /v1/auth-servers
+        status_code: 201
+        method: POST
+        headers:
+          - 'Content-Type: application/json'
+        body:
+          name: "Auth server example"
+          description: "Auth server example"
+          audience: "api://default"
+        capture:
+          - variable: AUTH_SERVER_ID
+            jq: ".id"
+          - variable: ISSUER_URL
+            jq: ".issuer"
+        {% endkonnect_api_request %}
+        <!--vale on-->
+    - title: Kong Identity authorization server client
+      icon_url: /assets/icons/identity.svg
+      content: |
+        Create a client in the authorization server using the [`/v1/auth-servers/{authServerId}/clients` endpoint](/api/konnect/kong-identity/v1/#/operations/createAuthServerClient), and save the `CLIENT_ID` and `CLIENT_SECRET` variables:
+
+        <!--vale off-->
+        {% konnect_api_request %}
+        url: /v1/auth-servers/$AUTH_SERVER_ID/clients
+        status_code: 201
+        method: POST
+        headers:
+          - 'Content-Type: application/json'
+        body:
+          name: "Client"
+          grant_types:
+            - client_credentials
+          allow_all_scopes: true
+          response_types:
+            - token
+          token_endpoint_auth_method: client_secret_post
+        capture:
+          - variable: CLIENT_ID
+            jq: ".id"
+          - variable: CLIENT_SECRET
+            jq: ".client_secret"
+        {% endkonnect_api_request %}
+        <!--vale on-->
+---
+
+## Validate the current secret
+
+Before rotating, confirm the client can authenticate with its current secret by requesting a token from the authorization server's token endpoint using the client credentials grant.
+A successful response returns an `access_token`:
+
+```sh
+curl -s -X POST "$ISSUER_URL/oauth/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  -d "client_id=$CLIENT_ID" \
+  -d "client_secret=$CLIENT_SECRET"
+```
+
+## Get the ID of the current secret
+
+The disable and delete operations identify a secret by its ID, not its value.
+List the client's secrets and store the current secret's ID as `$OLD_SECRET_ID`.
+Do this before you create the new secret, while the client still has only one secret:
+
+{% capture list-client-secrets %}
+<!--vale off-->
+{% konnect_api_request %}
+url: /v1/auth-servers/$AUTH_SERVER_ID/clients/$CLIENT_ID/secrets
+method: GET
+status_code: 200
+capture:
+  - variable: OLD_SECRET_ID
+    jq: ".data[0].id"
+{% endkonnect_api_request %}
+<!--vale on-->
+{% endcapture %}
+{{list-client-secrets | indent: 3}}
+
+## Create a new secret
+
+Send a POST request to the `/auth-servers/{authServerId}/clients/{clientId}/secrets` endpoint with the secret value you want to use. In this example, you:
+
+1. Create a new client secret with the value `new-secret`
+1. Store the value as `$NEW_SECRET`
+
+{% capture create-client-secret %}
+<!--vale off-->
+{% konnect_api_request %}
+url: /v1/auth-servers/$AUTH_SERVER_ID/clients/$CLIENT_ID/secrets
+method: POST
+status_code: 201
+body:
+  secret: new-secret
+  enabled: true
+capture:
+  - variable: NEW_SECRET
+    jq: ".secret"
+{% endkonnect_api_request %}
+<!--vale on-->
+{% endcapture %}
+{{create-client-secret | indent: 3}}
+
+This adds a new active secret along to the existing secret. The previous secret is still active.
+
+## Validate the new secret
+
+with the new secret (`$NEW_SECRET`) to confirm the rotated secret authenticates before you disable the old one.
+A successful response returns an `access_token`:
+
+```sh
+curl -s -X POST "$ISSUER_URL/oauth/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  -d "client_id=$CLIENT_ID" \
+  -d "client_secret=$NEW_SECRET"
+```
+
+## Delete the old secret
+
+After you've verified the new secret works as expected, you can delete the old secret in the API by sending a DELETE request: 
+
+{% capture delete-client-secret %}
+<!--vale off-->
+{% konnect_api_request %}
+url: /v1/auth-servers/$AUTH_SERVER_ID/clients/$CLIENT_ID/secrets/$OLD_SECRET_ID
+method: DELETE
+status_code: 204
+{% endkonnect_api_request %}
+<!--vale on-->
+{% endcapture %}
+{{delete-client-secret | indent: 3}}
+
+
+{% comment %}
+## {{site.identity}} authorization code flow
+
+In the authorization code flow:
+1. (Optional) The client application displays the user consent page and authenticates the user (this part is handled outside {{site.base_gateway}}). When the user clicks **Authorize**, the client app calls the `/authorize` endpoint created by attaching the OAuth2 plugin to a service.
+
+   {:.info}
+   > If an app requires user authentication, the authorization step must happen outside of {{site.konnect_short_name}}.
+   
+3. The client makes a request that includes the client ID, secret, and scopes the user consented to.
+4. The authorization server ({{site.base_gateway}} with OAuth2 plugin) validates the client credentials and returns an authorization code.
+5. The client exchanges this code at the `/oauth/token` endpoint for access tokens.
+6. The client uses the access token to call protected APIs.
+{% endcomment %}

--- a/app/_how-tos/gateway/rotate-auth-server-client-secrets.md
+++ b/app/_how-tos/gateway/rotate-auth-server-client-secrets.md
@@ -152,7 +152,6 @@ curl -s -X POST "$ISSUER_URL/oauth/token" \
 
 After you've verified the new secret works as expected, you can delete the old secret in the API by sending a DELETE request: 
 
-{% capture delete-client-secret %}
 <!--vale off-->
 {% konnect_api_request %}
 url: /v1/auth-servers/$AUTH_SERVER_ID/clients/$CLIENT_ID/secrets/$OLD_SECRET_ID
@@ -160,7 +159,5 @@ method: DELETE
 status_code: 204
 {% endkonnect_api_request %}
 <!--vale on-->
-{% endcapture %}
-{{delete-client-secret | indent: 3}}
 
 

--- a/app/_how-tos/gateway/rotate-auth-server-client-secrets.md
+++ b/app/_how-tos/gateway/rotate-auth-server-client-secrets.md
@@ -102,7 +102,6 @@ The disable and delete operations identify a secret by its ID, not its value.
 List the client's secrets and store the current secret's ID as `$OLD_SECRET_ID`.
 Do this before you create the new secret, while the client still has only one secret:
 
-{% capture list-client-secrets %}
 <!--vale off-->
 {% konnect_api_request %}
 url: /v1/auth-servers/$AUTH_SERVER_ID/clients/$CLIENT_ID/secrets
@@ -113,17 +112,13 @@ capture:
     jq: ".data[0].id"
 {% endkonnect_api_request %}
 <!--vale on-->
-{% endcapture %}
-{{list-client-secrets | indent: 3}}
 
 ## Create a new secret
 
 Send a POST request to the `/auth-servers/{authServerId}/clients/{clientId}/secrets` endpoint with the secret value you want to use. In this example, you:
 
-1. Create a new client secret with the value `new-secret`
-1. Store the value as `$NEW_SECRET`
+Create a new client secret with the value `new-secret` and store the value as `$NEW_SECRET`:
 
-{% capture create-client-secret %}
 <!--vale off-->
 {% konnect_api_request %}
 url: /v1/auth-servers/$AUTH_SERVER_ID/clients/$CLIENT_ID/secrets
@@ -137,14 +132,12 @@ capture:
     jq: ".secret"
 {% endkonnect_api_request %}
 <!--vale on-->
-{% endcapture %}
-{{create-client-secret | indent: 3}}
 
 This adds a new active secret along to the existing secret. The previous secret is still active.
 
 ## Validate the new secret
 
-with the new secret (`$NEW_SECRET`) to confirm the rotated secret authenticates before you disable the old one.
+Send a request with the new secret (`$NEW_SECRET`) to confirm the rotated secret authenticates before you disable the old one.
 A successful response returns an `access_token`:
 
 ```sh

--- a/app/_how-tos/gateway/rotate-auth-server-client-secrets.md
+++ b/app/_how-tos/gateway/rotate-auth-server-client-secrets.md
@@ -164,17 +164,3 @@ status_code: 204
 {{delete-client-secret | indent: 3}}
 
 
-{% comment %}
-## {{site.identity}} authorization code flow
-
-In the authorization code flow:
-1. (Optional) The client application displays the user consent page and authenticates the user (this part is handled outside {{site.base_gateway}}). When the user clicks **Authorize**, the client app calls the `/authorize` endpoint created by attaching the OAuth2 plugin to a service.
-
-   {:.info}
-   > If an app requires user authentication, the authorization step must happen outside of {{site.konnect_short_name}}.
-   
-3. The client makes a request that includes the client ID, secret, and scopes the user consented to.
-4. The authorization server ({{site.base_gateway}} with OAuth2 plugin) validates the client credentials and returns an authorization code.
-5. The client exchanges this code at the `/oauth/token` endpoint for access tokens.
-6. The client uses the access token to call protected APIs.
-{% endcomment %}


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

This how-to guide shows how to rotate a client secret using the auth-server API.

closes #6339  

## Testing instructions

Replace `.com` by `tech` on the API calls.

## Preview Links

https://deploy-preview-6463--kongdeveloper.netlify.app/how-to/rotate-auth-server-client-secrets/

## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
