### PR TITLE
fix(konnect-platform): Update Deployer role description

### DIFF
--- a/app/konnect-platform/teams-and-roles.md
+++ b/app/konnect-platform/teams-and-roles.md
@@ -513,7 +513,7 @@ rows:
       * Create, read, list and delete debug sessions.
       * Read and list control planes and all configurations within them.
   - role: "`Deployer`"
-    description: "This role grants full write access to administer services, routes and plugins necessary to deploy services in Service Catalog."
+    description: "This role grants full write access to administer services, routes and plugins necessary to deploy services in Service Catalog. This role cannot write partials."
     permissions: |
       * List and read control planes.
       * Create, read, edit, delete, and list plugins and custom plugins.


### PR DESCRIPTION
Clarified Deployer role description to specify that it cannot write partials.

<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes #3824 

## Preview Links
/konnect-platform/teams-and-roles/#control-planes

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
