### PR TITLE
fix(saml): clarify signature validation behavior (CVE-2026-14917)

### DIFF
--- a/app/_how-tos/gateway/enable-saml-authentication-with-microsoft-entra.md
+++ b/app/_how-tos/gateway/enable-saml-authentication-with-microsoft-entra.md
@@ -109,9 +109,10 @@ We also need to provide a value for [`config.session_secret`](/plugins/saml/refe
 {:.danger}
 > This example keeps [`validate_assertion_signature`](/plugins/saml/reference/#schema--config-validate-assertion-signature) at its default value of `true`, which requires a valid `idp_certificate`.
 > The plugin validates the SAML response signature whenever you configure an `idp_certificate`, even if you set `validate_assertion_signature` to `false`.
+> <br><br>
 > The plugin skips signature validation only when `validate_assertion_signature` is `false` and no `idp_certificate` is set. It then accepts unsigned responses and logs a warning.
-> This state is **not secure** — an attacker can impersonate any user. Always set `idp_certificate`. Never disable signature validation in production.
-
+> This state is **not secure**, as an attacker can impersonate any user. 
+> Always set `idp_certificate`. Never disable signature validation in production.
 {% entity_examples %}
 entities:
     plugins:

--- a/app/_how-tos/gateway/enable-saml-authentication-with-microsoft-entra.md
+++ b/app/_how-tos/gateway/enable-saml-authentication-with-microsoft-entra.md
@@ -107,9 +107,10 @@ Enable the [SAML plugin](/plugins/saml/) and provide the information to connect 
 We also need to provide a value for [`config.session_secret`](/plugins/saml/reference/#schema--config-session-secret), which should be a random 32-character string.
 
 {:.danger}
-> This example keeps [`validate_assertion_signature`](/plugins/saml/reference/#schema--config-validate-assertion-signature) set to its default value of `true`, which requires a valid `idp_certificate`.
-> If you only want to test the authentication flow without configuring a signing certificate, you can manually set `validate_assertion_signature` to `false`.
-> Disabling signature validation is **not secure**. **Do not disable signature validation in production.**
+> This example keeps [`validate_assertion_signature`](/plugins/saml/reference/#schema--config-validate-assertion-signature) at its default value of `true`, which requires a valid `idp_certificate`.
+> The plugin validates the SAML response signature whenever you configure an `idp_certificate`, even if you set `validate_assertion_signature` to `false`.
+> The plugin skips signature validation only when `validate_assertion_signature` is `false` and no `idp_certificate` is set. It then accepts unsigned responses and logs a warning.
+> This state is **not secure** — an attacker can impersonate any user. Always set `idp_certificate`. Never disable signature validation in production.
 
 {% entity_examples %}
 entities:

--- a/app/_kong_plugins/saml/index.md
+++ b/app/_kong_plugins/saml/index.md
@@ -77,7 +77,7 @@ The minimum configuration required is:
 
 {:.warning}
 > The plugin validates the SAML response signature whenever you set `idp_certificate`, even when [`validate_assertion_signature`](/plugins/saml/reference/#schema--config-validate-assertion-signature) is `false`.
-> If you set `validate_assertion_signature` to `false` and configure no `idp_certificate`, the plugin skips signature validation and accepts unsigned responses, which is insecure. Always set `idp_certificate`.
+> If you set `validate_assertion_signature` to `false` and don't configure `idp_certificate`, the plugin skips signature validation and accepts unsigned responses, which is insecure. Always set `idp_certificate`.
 
 The plugin currently supports SAML 2.0 with Microsoft Entra. Refer to the
 [Microsoft Entra SAML documentation](https://learn.microsoft.com/en-us/entra/architecture/auth-saml)

--- a/app/_kong_plugins/saml/index.md
+++ b/app/_kong_plugins/saml/index.md
@@ -75,6 +75,10 @@ The minimum configuration required is:
   information from the IdP.
 - The issuer (`issuer`): This is the unique identifier of the IdP application.
 
+{:.warning}
+> The plugin validates the SAML response signature whenever you set `idp_certificate`, even when [`validate_assertion_signature`](/plugins/saml/reference/#schema--config-validate-assertion-signature) is `false`.
+> If you set `validate_assertion_signature` to `false` and configure no `idp_certificate`, the plugin skips signature validation and accepts unsigned responses, which is insecure. Always set `idp_certificate`.
+
 The plugin currently supports SAML 2.0 with Microsoft Entra. Refer to the
 [Microsoft Entra SAML documentation](https://learn.microsoft.com/en-us/entra/architecture/auth-saml)
 for more information about SAML authentication with Azure AD.


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Reword the Microsoft Entra how-to danger callout and add a note on the SAML overview page. The plugin now validates the SAML response signature whenever an idp_certificate is set, even when validate_assertion_signature is false. Skipping validation happens only with the flag false and no certificate, which accepts unsigned responses and logs a warning.

Fixes [KAG-9220](https://konghq.atlassian.net/browse/KAG-9220)

RFC link: https://docs.google.com/document/d/1VzqyyYIsyFFZT73MYnp1tEXPn1gaDpujgNPoUhUrID8/edit?usp=sharing
PR link: https://github.com/Kong/kong-ee/pull/20483

## Preview Links

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).


[KAG-9220]: https://konghq.atlassian.net/browse/KAG-9220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ