### PR TITLE
fix(ai-gateway): replace config.model.alias with config.route.model.body across entitiy docs and guides

### DIFF
--- a/app/_ai_gateway_entities/ai-model.md
+++ b/app/_ai_gateway_entities/ai-model.md
@@ -69,7 +69,7 @@ faqs:
   - q: Can a client override the model name from the request body?
     a: |
       By default, no. The request `model` field must match the upstream model on one of the AI Model's targets, otherwise the runtime returns a `400` error.
-      To accept a client-side alias, set [`config.model.alias`](/ai-gateway/entities/ai-model/#schema-aigateway-model-config-model-alias). Clients can then send the alias value in the request `model` field instead of the upstream AI Provider model name. See [Request routing by model alias](/ai-gateway/load-balancing/#request-routing-by-model-alias) for details and examples.
+      To accept a client-side alias, set [`config.route.model.body`](/ai-gateway/entities/ai-model/#schema-aigateway-model-config-route-model). Clients can then send the alias value in the request body field instead of the upstream AI Provider model name. See [Request routing rules](/ai-gateway/load-balancing/#request-routing-rules) for details and examples.
 
   - q: Can a client override `temperature`, `top_p`, or `top_k` from the request?
     a: |
@@ -323,11 +323,17 @@ Substitution applies to the [`name`](#schema-aigateway-model-targets-name) of ea
 
 For examples of using templating, consult the {{site.ai_gateway}} documentation and API reference.
 
-## Model aliasing
+## Request routing rules
 
-By default, applications or services making requests to the AI Model endpoint must specify the actual upstream model name (like `gpt-4o`) in the `model` field. If you want to allow them to use a different name, for abstraction, stability, or to hide implementation details, set [`config.model.alias`](#schema-aigateway-model-config-model-alias).
+By default, applications or services making requests to the AI Model endpoint must specify the actual upstream model name (like `gpt-4o`) in the `model` field. If you want to allow them to use a different name, for abstraction, stability, or to hide implementation details, configure [`config.route.model`](#schema-aigateway-model-config-route-model) with a routing rule.
 
-When an alias is set, clients can send that alias in the request `model` field instead of the upstream model name. This is useful when you want to decouple your client API from upstream provider changes. For example, you could expose an alias like `production-chat-model` while swapping the underlying upstream model from `gpt-4o` to `claude-3-sonnet` without your clients noticing.
+`config.route.model` accepts one of the following match strategies:
+
+* [`body`](#schema-aigateway-model-config-route-model): matches a value in the request body, indexed by property name. For example, `body: { model: [my-gpt-4o] }` matches when the client sends `"model": "my-gpt-4o"` in the request body.
+* [`headers`](#schema-aigateway-model-config-route-model): matches a value in the request headers, indexed by header name.
+* [`path_aliases`](#schema-aigateway-model-config-route-model): matches a value present in the request path.
+
+When a routing rule is set, clients can send the alias value (in the body, a header, or the path, depending on the strategy chosen) instead of the upstream model name. This is useful when you want to decouple your client API from upstream provider changes. For example, you could expose an alias like `production-chat-model` while swapping the underlying upstream model from `gpt-4o` to `claude-3-sonnet` without your clients noticing.
 
 ## Access control
 
@@ -393,15 +399,17 @@ data:
     route:
       paths:
         - /v1
+      model:
+        body:
+          model:
+            - my-gpt-4o
     logging:
       statistics: true
       payloads: false
-    model:
-      alias: my-gpt-4o
 {% endentity_example %}
 
 {:.info}
-> Because [`config.model.alias`](#schema-aigateway-model-config-model-alias) is set here, requests through this AI Model must send `"model": "my-gpt-4o"` (the alias) in the request body instead of the upstream target name (`gpt-4o`). Sending the upstream target name instead of the alias fails.
+> Because [`config.route.model.body`](#schema-aigateway-model-config-route-model) is set here, requests through this AI Model must send `"model": "my-gpt-4o"` (the alias) in the request body instead of the upstream target name (`gpt-4o`). Sending the upstream target name instead of the alias fails.
 
 
 ## Schema

--- a/app/_ai_gateway_entities/ai-model.md
+++ b/app/_ai_gateway_entities/ai-model.md
@@ -335,6 +335,96 @@ By default, applications or services making requests to the AI Model endpoint mu
 
 When a routing rule is set, clients can send the alias value (in the body, a header, or the path, depending on the strategy chosen) instead of the upstream model name. This is useful when you want to decouple your client API from upstream provider changes. For example, you could expose an alias like `production-chat-model` while swapping the underlying upstream model from `gpt-4o` to `claude-3-sonnet` without your clients noticing.
 
+The following examples assume the `my-openai-account` [AI Model Provider](/ai-gateway/entities/ai-model-provider/) already exists.
+{% navtabs "Model aliasing examples" %}
+{% navtab "Body" %}
+{% entity_example %}
+type: model
+data:
+  display_name: my-gpt-4o
+  name: my-gpt-4o
+  type: model
+  capabilities:
+    - generate
+  formats:
+    - type: openai
+  policies: []
+  targets:
+    - name: gpt-4o
+      provider: my-openai-account
+      config:
+        type: openai
+  config:
+    route:
+      paths:
+        - /
+      model:
+        body:
+          model:
+            - my-gpt-4o
+formats:
+  - kongctl
+{% endentity_example %}
+{% endnavtab %}
+{% navtab "Headers" %}
+{% entity_example %}
+type: model
+data:
+  display_name: my-gpt-4o
+  name: my-gpt-4o
+  type: model
+  capabilities:
+    - generate
+  formats:
+    - type: openai
+  policies: []
+  targets:
+    - name: gpt-4o
+      provider: my-openai-account
+      config:
+        type: openai
+  config:
+    route:
+      paths:
+        - /
+      model:
+        headers:
+          X-Model-Name:
+            - my-gpt-4o
+formats:
+  - kongctl
+{% endentity_example %}
+{% endnavtab %}
+{% navtab "Path aliases" %}
+{% entity_example %}
+type: model
+data:
+  display_name: my-gpt-4o
+  name: my-gpt-4o
+  type: model
+  capabilities:
+    - generate
+  formats:
+    - type: openai
+  policies: []
+  targets:
+    - name: gpt-4o
+      provider: my-openai-account
+      config:
+        type: openai
+  config:
+    route:
+      paths:
+        - /
+      model:
+        path_aliases:
+          - my-gpt-4o
+formats:
+  - kongctl
+{% endentity_example %}
+{% endnavtab %}
+{% endnavtabs %}
+
 ## Access control
 
 To limit which teams or applications can call an AI Model, use the [`access.acls`](#schema-aigateway-model-access) field to set an allow list or a deny list. Reference [AI Consumers](/ai-gateway/entities/ai-consumer/) (individual applications), [AI Consumer Groups](/ai-gateway/entities/ai-consumer-group/) (teams), or Authenticated Groups (all consumers authenticated via a specific OAuth2 scope or claim) by name.
@@ -358,19 +448,19 @@ When your data plane sits behind a corporate firewall or security boundary, conf
 Use the [`config.proxy`](#schema-aigateway-model-config-proxy) object to specify the proxy endpoint with [`http_proxy`](#schema-aigateway-model-config-proxy-http-proxy) or [`https_proxy`](#schema-aigateway-model-config-proxy-https-proxy), and optionally add [`auth`](#schema-aigateway-model-config-proxy-auth) credentials if the proxy requires authentication. Use [`no_proxy`](#schema-aigateway-model-config-proxy-no-proxy) to bypass the proxy for specific hosts that are already inside your trusted network.
 
 ## Logging and observability
-
-Enable [`statistics`](#schema-aigateway-model-config-logging-statistics) logging to track token consumption, request latency, and per-provider costs. This data flows into {{site.konnect_short_name}} analytics and any attached logging AI Policies, letting you monitor API spend, identify slow providers, and audit which AI Models drive the most usage.
-
+{{site.ai_gateway}} automatically records usage statistics, such as token consumption, request latency, and per-provider costs, for every AI Model. This data flows into [LLM traffic metrics](/ai-gateway/monitor-ai-llm-metrics/#llm-traffic-metrics-overview), [audit log entries](/ai-gateway/ai-audit-log-reference/#core-logs), and any attached logging AI Policies, letting you monitor API spend, identify slow providers, and audit which AI Models drive the most usage.
 Optionally enable [`payloads`](#schema-aigateway-model-config-logging-payloads) to capture full request and response bodies. This is useful for debugging model responses, auditing sensitive operations, or replaying requests.
 
 {:.warning}
 > Payload logging may expose sensitive data in your logging destination. Only enable it when your logging pipeline is prepared to handle request and response bodies, and verify that logging destinations comply with your data residency and privacy policies.
 
+[AI Model analytics](/ai-gateway/monitor-ai-llm-metrics/#llm-traffic-metrics-overview) display in {{site.konnect_short_name}} [Explorer](https://cloud.konghq.com/analytics/explorer) and [Dashboards](https://cloud.konghq.com/analytics/dashboards) alongside other {{site.ai_gateway}} traffic, and export through [OpenTelemetry](/ai-gateway/policies/opentelemetry/reference/).
+
 For response streaming behavior, see [Streaming](/ai-gateway/streaming/).
 
 ## Set up an AI Model
 
-Before creating an AI Model, first create an AI Model Provider to store credentials for the upstream LLM service. 
+Before creating an AI Model, first create an AI Model Provider to store credentials for the upstream LLM service.
 
 The following example:
 * Creates an OpenAI Model that exposes the `generate` capability, routed through a single OpenAI Provider, with token usage logging enabled.

--- a/app/_how-tos/ai-gateway/get-started-with-ai-gateway.md
+++ b/app/_how-tos/ai-gateway/get-started-with-ai-gateway.md
@@ -97,8 +97,10 @@ ai_gateway_models:
       route:
         paths:
           - /v1
-      model:
-        alias: my-gpt-4o
+        model:
+          body:
+            model:
+              - my-gpt-4o
     targets:
       - name: gpt-4o
         provider: generic-openai
@@ -119,7 +121,7 @@ In this example, we're setting up the AI Model with:
 * `formats: [type: openai]`: Declares that this model accepts requests in OpenAI-compatible format.
 * `config.route.paths: [/v1]`: Configures the custom base path where this model's Routes will be accessible. Clients will send requests to paths that combine this base path with capability-specific Routes.
 * `capabilities: [generate]`: Enables the text generation capability. The `generate` capability creates a `/chat/completions` endpoint, so combined with your base path, clients send chat requests to `/v1/chat/completions`.
-* `config.model.alias: my-gpt-4o`: Lets clients send `my-gpt-4o` in the request `model` field instead of the upstream model name.
+* `config.route.model.body: { model: [my-gpt-4o] }`: Lets clients send `my-gpt-4o` in the request `model` field instead of the upstream model name.
 * `targets`: Specifies which upstream AI Provider model to route requests to. Here, `provider: generic-openai` references the AI Provider we created earlier, and `name: gpt-4o` specifies which OpenAI model to call upstream.
 
 ## Validate

--- a/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-anthropic.md
+++ b/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-anthropic.md
@@ -74,8 +74,10 @@ ai_gateway_models:
       route:
         paths:
           - /
-      model:
-        alias: my-claude
+        model:
+          body:
+            model:
+              - my-claude
     targets:
       - name: claude-opus-4-8
         provider: generic-anthropic

--- a/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-azure.md
+++ b/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-azure.md
@@ -128,7 +128,7 @@ The AI Model uses:
 * `name`/`display_name: claude-code-azure-sonnet`: The identifier you pass to `claude --model`. {{ site.claude_code }} uses this, not the upstream target name, to select the model.
 * `formats: [type: anthropic]`: Declares that this model accepts requests in Anthropic-compatible format, matching what {{ site.claude_code }} sends natively.
 * `config.route.paths: [/]`: Configures the base path where this model's routes are accessible.
-* `config.model.name_header: true`: Lets {{ site.claude_code }} select this model by sending its `name` in the request, instead of requiring a separate `alias`.
+* `config.model.name_header: true`: Lets {{ site.claude_code }} select this model by sending its `name` in the request, instead of requiring a separate routing rule.
 * `capabilities: [generate]`: Enables text generation. For a model using the `anthropic` format, `generate` creates a `/messages` endpoint matching Anthropic's native Messages API, so combined with your base path, clients send requests to `/v1/messages`.
 * `policies`: Attaches the `claude-code-compat` policy created in the previous step, so its header and body transformations apply to every request sent through this model.
 * `targets`: Specifies which upstream model to route requests to. `provider: azure-claude` references the AI Provider created earlier, and `name: claude-sonnet-4-6` must match the name of your Claude deployment in Azure AI Foundry.

--- a/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-bedrock.md
+++ b/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-bedrock.md
@@ -151,8 +151,10 @@ ai_gateway_models:
       route:
         paths:
           - /
-      model:
-        alias: my-claude-bedrock
+        model:
+          body:
+            model:
+              - my-claude-bedrock
     targets:
       - name: us.anthropic.claude-haiku-4-5-20251001-v1:0
         provider: my-aws-account

--- a/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-dashscope.md
+++ b/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-dashscope.md
@@ -49,7 +49,7 @@ prereqs:
 
 ## Create the AI Model Provider and AI Model
 
-DashScope serves the Qwen model family through a native Anthropic-compatible Messages API, so {{ site.claude_code }} can talk to it natively. 
+DashScope serves the Qwen model family through a native Anthropic-compatible Messages API, so {{ site.claude_code }} can talk to it natively.
 
 Create both an [AI Model Provider](/ai-gateway/entities/ai-model-provider/) and an [AI Model](/ai-gateway/entities/ai-model/) with a single `kongctl` apply command:
 
@@ -93,7 +93,7 @@ In this example we set:
  * `type: dashscope`: Connects to the Alibaba Cloud DashScope API as an AI Model Provider.
  * `capabilities: [generate]`: For a model using the `anthropic` format, `generate` creates a `/v1/messages` endpoint matching Anthropic's native Messages API.
  * `formats: [{ type: anthropic }]`: Accepts Anthropic-format requests to the AI Model entity, matching what {{ site.claude_code }} sends.
- * `config.model.alias: qwen-plus`: The model name {{ site.claude_code }} should send in each request, which you can set with the `ANTHROPIC_MODEL` variable or `--model` option.
+ * `config.route.model.body: { model: [qwen-plus] }`: The model name {{ site.claude_code }} should send in each request, which you can set with the `ANTHROPIC_MODEL` variable or `--model` option.
  * `route.paths: [/]`: Configures the custom base path where this model's routes will be accessible. Setting this to a unique value avoids clashes when you have multiple AI Models.
  * `targets[0].config.international: true`: Uses DashScope's international endpoint (`dashscope-intl.aliyuncs.com`). This is the default. If your DashScope key belongs to a mainland China account, set this to `false` so requests reach `dashscope.aliyuncs.com` instead.
 

--- a/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-gemini.md
+++ b/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-gemini.md
@@ -151,8 +151,10 @@ ai_gateway_models:
       route:
         paths:
           - /
-      model:
-        alias: my-claude-gemini
+        model:
+          body:
+            model:
+              - my-claude-gemini
     targets:
       - name: gemini-2.5-flash
         provider: !ref my-gemini-account#name

--- a/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-huggingface.md
+++ b/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-huggingface.md
@@ -136,8 +136,10 @@ ai_gateway_models:
       route:
         paths:
           - /
-      model:
-        alias: my-huggingface
+        model:
+          body:
+            model:
+              - my-huggingface
     targets:
       - name: meta-llama/Llama-3.3-70B-Instruct
         provider: !ref my-huggingface-account#name

--- a/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-openai.md
+++ b/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-openai.md
@@ -80,8 +80,10 @@ ai_gateway_models:
       route:
         paths:
           - /
-      model:
-        alias: my-claude-openai
+        model:
+          body:
+            model:
+              - my-claude-openai
     targets:
       - name: gpt-5-mini
         provider: generic-openai

--- a/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-vertex.md
+++ b/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-vertex.md
@@ -143,7 +143,7 @@ The AI Model uses:
 
  * `name`/`display_name: claude-code-vertex-sonnet`: The identifier you pass to `claude --model`. {{ site.claude_code }} uses this, not the upstream target ID, to select the model.
  * `formats: [type: anthropic]`: Accepts Anthropic-compatible requests (what {{ site.claude_code }} sends).
- * `config.model.name_header: true`: Lets {{ site.claude_code }} select this model by sending its `name` in the request, instead of requiring a separate `alias`.
+ * `config.model.name_header: true`: Lets {{ site.claude_code }} select this model by sending its `name` in the request, instead of requiring a separate routing rule.
  * `capabilities: [generate]`: Enables text generation. For a model using the `anthropic` format, `generate` creates a `/messages` endpoint matching Anthropic's native Messages API.
  * `policies`: Attaches the `claude-code-compat` policy defined above, via `!ref claude-code-compat#name`, so its body-stripping transformation applies to every request sent through this model.
  * `targets[0].provider: vertex-prod`: Routes upstream requests through the Vertex AI Provider created earlier.

--- a/app/_how-tos/ai-gateway/use-codex-with-ai-gateway.md
+++ b/app/_how-tos/ai-gateway/use-codex-with-ai-gateway.md
@@ -92,7 +92,7 @@ In this example:
  * `type: openai`: Connects to the OpenAI API.
  * `capabilities: [agentic]`: Routes requests to the OpenAI Responses API, which the Codex CLI uses.
  * `formats: [{ type: openai }]`: Accepts OpenAI-format requests.
- * `config.model.alias: gpt-5.4`: The model name the Codex CLI sends in each request.
+ * `config.route.model.body: { model: [gpt-5.4] }`: The model name the Codex CLI sends in each request.
  * `route.paths: [/codex]`: The base path Codex points at; the Responses API is served at `/codex/responses`.
 
 ## Verify the AI Model

--- a/app/ai-gateway/configure-on-prem.md
+++ b/app/ai-gateway/configure-on-prem.md
@@ -139,8 +139,10 @@ The following steps walk through converting a decK `ai.yaml` file for a single A
          route:
            paths:
              - /ai
-         model:
-           alias: "@openai/gpt-5.2"
+           model:
+             body:
+               model:
+                 - "@openai/gpt-5.2"
        targets:
          - name: gpt-5.2
            provider: openai-prod
@@ -165,6 +167,9 @@ The following steps walk through converting a decK `ai.yaml` file for a single A
    deck file ai2kong --state ai.yaml --output-file kong.yaml
    ```
    For this example AI Model, {{site.ai_gateway}} generates a Service, a Route, and an `ai-proxy-advanced` plugin on that Route. `kong.yaml` contains:
+
+   {:.info}
+   > This converted output still shows the `alias`/`model_alias` fields used by the self-hosted `ai-proxy-advanced` plugin schema. Verify with the `deck file ai2kong` conversion tool for the current output once it supports the `config.route.model` routing rule shown in the input above.
 
    ```yaml
    _format_version: "3.0"

--- a/app/ai-gateway/load-balancing.md
+++ b/app/ai-gateway/load-balancing.md
@@ -107,11 +107,11 @@ rows:
 
 For examples of each algorithm, see [Algorithm examples](/ai-gateway/entities/ai-model/#algorithm-examples) in the [AI Model entity](/ai-gateway/entities/ai-model/) reference.
 
-### Request routing by model alias
+### Request routing rules
 
-Model aliases allow clients to send an alias instead of the actual model name in the request. This decouples the external model identifier from the internal provider model, enabling flexible routing without changing client code.
+Routing rules allow clients to send an alias instead of the actual model name in the request. This decouples the external model identifier from the internal provider model, enabling flexible routing without changing client code.
 
-Each target in a Model entity can have an optional [`model.alias`](/ai-gateway/entities/ai-model/#schema-aigateway-model-target-models-model-alias) field. When a client sends `"model": "alias-value"` in the request body, {{site.ai_gateway}} routes to the matching target. This feature works independently of load balancing algorithms — the alias determines which target (or set of targets) handles the request, and the configured load balancing algorithm selects the final backend within that set.
+An AI Model can have an optional [`config.route.model`](/ai-gateway/entities/ai-model/#schema-aigateway-model-config-route-model) field, matching on the request `body`, `headers`, or `path_aliases`. For example, when `config.route.model.body` is set to `{ model: [alias-value] }` and a client sends `"model": "alias-value"` in the request body, {{site.ai_gateway}} routes to the matching AI Model. This feature works independently of load balancing algorithms — the routing rule determines which AI Model (or target set) handles the request, and the configured load balancing algorithm selects the final backend within that set.
 
 ### Retry and fallback
 


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
