### PR TITLE
fix(aigw): deck's `managed-by` is now `managed_by`

### DIFF
--- a/app/ai-gateway/configure-on-prem.md
+++ b/app/ai-gateway/configure-on-prem.md
@@ -170,7 +170,7 @@ The following steps walk through converting a decK `ai.yaml` file for a single A
    _format_version: "3.0"
    _info:
      select_tags:
-     - 'managed-by: deck-ai'
+     - 'managed_by: deck-ai'
    ai_models:
    - alias: '@openai/gpt-5.2'
      name: gpt-5-2


### PR DESCRIPTION
## Description

Fix `managed_by` in deck config, there was a breaking change to `model-alias` and the select-tags added by deck were updated. - Previously, it was `managed-by`.

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
