### PR TITLE
fix(identity): Remove `on-prem` from Identity principal how tos

### DIFF
--- a/app/_how-tos/gateway/authenticate-principals-with-basic-authentication.md
+++ b/app/_how-tos/gateway/authenticate-principals-with-basic-authentication.md
@@ -17,7 +17,6 @@ plugins:
   - basic-auth
 
 works_on:
-    - on-prem
     - konnect
 
 min_version:

--- a/app/_how-tos/gateway/authenticate-principals-with-key-auth.md
+++ b/app/_how-tos/gateway/authenticate-principals-with-key-auth.md
@@ -16,7 +16,6 @@ products:
 plugins:
   - key-auth
 works_on:
-    - on-prem
     - konnect
 
 min_version:

--- a/app/kong-identity/principals-and-directories.md
+++ b/app/kong-identity/principals-and-directories.md
@@ -322,6 +322,7 @@ Before using them, you need an [existing principal](#configure-a-principal) in a
 ### Basic auth
 
 Add a username and password credential to a principal so clients can authenticate at {{site.base_gateway}} with basic auth. 
+For a complete end-to-end tutorial, see [Authenticate Principals with basic authentication](/how-to/authenticate-principals-with-basic-authentication/).
 
 {% navtabs "basic-auth" %}
 {% navtab "API" %}
@@ -369,6 +370,7 @@ body:
 ### Key auth
 
 Add an API key credential to a principal so clients can authenticate at {{site.base_gateway}} with key auth. 
+For a complete end-to-end tutorial, see [Authenticate Principals with the Key Authentication plugin](/how-to/authenticate-principals-with-key-auth/).
 
 {% navtabs "key-auth" %}
 {% navtab "API" %}
@@ -402,6 +404,7 @@ body:
 ### OpenID Connect
 
 Reference a principal authenticated by an external IdP such as Okta or Cognito. 
+For a complete end-to-end tutorial, see [Authenticate OAuth clients with a Kong Identity authorization server](/how-to/authenticate-oauth-clients-with-kong-identity/).
 
 {% navtabs "oidc" %}
 {% navtab "API" %}


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

principals aren't supported on-prem.

## Preview Links
- /how-to/authenticate-principals-with-basic-authentication/
- /how-to/authenticate-principals-with-key-auth/
- Added links to the how tos:
  - /identity/principals/#basic-auth
  - /identity/principals/#key-auth
  - /identity/principals/#openid-connect

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
