### PR TITLE
fix(metering-and-billing): Correct meter payloads and UI steps in M&B onboarding guides [OM-426]

### DIFF
--- a/app/_how-tos/ai-gateway/meter-llm-traffic.md
+++ b/app/_how-tos/ai-gateway/meter-llm-traffic.md
@@ -235,6 +235,7 @@ Customers are the entities who pay for the consumption. In many cases, it's equa
 1. In the {{site.metering_and_billing}} sidebar, click **Billing**.
 1. Click **Create Customer**.
 1. In the **Name** field, enter `Kong Air`.
+1. In the **Key** field, enter `kong-air`.
 1. In the **Include usage from** dropdown, select "kong-air".
 1. Click **Save**.
 1. Click the **Subscriptions** tab.

--- a/app/_how-tos/ai-gateway/meter-llm-traffic.md
+++ b/app/_how-tos/ai-gateway/meter-llm-traffic.md
@@ -148,7 +148,7 @@ body:
 
 ## Configure the Metering & Billing plugin
 
-Next, configure the Metering & Billing plugin to emit LLM token usage events from {{site.ai_gateway}} to {{site.metering_and_billing}}:
+Next, configure the [{{site.metering_and_billing}} plugin](/plugins/metering-and-billing/) to emit LLM token usage events from {{site.ai_gateway}} to {{site.metering_and_billing}}:
 
 <!--vale off-->
 {% entity_examples %}

--- a/app/_how-tos/ai-gateway/meter-llm-traffic.md
+++ b/app/_how-tos/ai-gateway/meter-llm-traffic.md
@@ -133,12 +133,21 @@ url: /v3/openmeter/meters
 status_code: 201
 method: POST
 body:
-    key: tokens_total
-    name: AI Token Usage
-    event_type: prompt
+    name: LLM Tokens
+    key: llm_tokens_total
+    description: Number of input and output tokens across models
+    event_type: kong.llm_request
     aggregation: sum
     value_property: $.tokens
-    dimensions: {"model": "$.model", "type": "$.type"}
+    dimensions:
+        http_status: $.http_status
+        model: $.model
+        provider: $.provider
+        type: $.type
+        control_plane_id: $.control_plane_id
+        service_id: $.service_id
+        route_id: $.route_id
+        ai_plugin_id: $.ai_plugin_id
 {% endkonnect_api_request %}
 <!--vale on-->
 

--- a/app/_how-tos/ai-gateway/meter-llm-traffic.md
+++ b/app/_how-tos/ai-gateway/meter-llm-traffic.md
@@ -186,7 +186,7 @@ In this guide, you'll create a feature for the `example-service` you created in 
 1. In the {{site.metering_and_billing}} sidebar, click **Product Catalog**.
 1. Click **Create Feature**.
 1. In the **Name** field, enter `ai-token`.
-1. From the **Meter** dropdown menu, select "{{site.ai_gateway}} Tokens".
+1. From the **Meter** dropdown menu, select "LLM Tokens".
 1. Click **Add group by filter**.
    The group by filter ensures you only bill for LLM tokens from a specific provider.
 1. From the **Group by** dropdown menu, select "Provider".

--- a/app/_how-tos/ai-gateway/meter-llm-traffic.md
+++ b/app/_how-tos/ai-gateway/meter-llm-traffic.md
@@ -140,14 +140,9 @@ body:
     aggregation: sum
     value_property: $.tokens
     dimensions:
-        http_status: $.http_status
         model: $.model
         provider: $.provider
         type: $.type
-        control_plane_id: $.control_plane_id
-        service_id: $.service_id
-        route_id: $.route_id
-        ai_plugin_id: $.ai_plugin_id
 {% endkonnect_api_request %}
 <!--vale on-->
 

--- a/app/_how-tos/gateway/get-started-with-metering-and-billing.md
+++ b/app/_how-tos/gateway/get-started-with-metering-and-billing.md
@@ -225,12 +225,12 @@ In this guide, you'll create a feature for the `example-service` you created in 
 1. In the {{site.metering_and_billing}} sidebar, click **Product Catalog**.
 1. Click **Create Feature**.
 1. In the **Name** field, enter `example-service`.
-1. From the **Meter** dropdown menu, select "API Gateway Requests".
+1. From the **Meter** dropdown menu, select "API requests".
 1. Click **Add group by filter**.
    The group by filter ensures you only bill for traffic to `example-service`, not all {{site.base_gateway}} traffic. This lets you offer different pricing for different APIs.
 1. From the **Group by** dropdown menu, select "service_name".
 1. From the **Operator** dropdown menu, select "Equals".
-1. From the **Value** dropdown menu, select "example-service".
+1. In the **Value** dropdown menu, enter "example-service".
 1. Click **Save**.
 
 ## Create a Premium plan

--- a/app/_how-tos/gateway/get-started-with-metering-and-billing.md
+++ b/app/_how-tos/gateway/get-started-with-metering-and-billing.md
@@ -265,13 +265,14 @@ Customers are the entities who pay for the consumption. In many cases, it's equa
 1. In the {{site.metering_and_billing}} sidebar, click **Billing**.
 1. Click **Create Customer**.
 1. In the **Name** field, enter `Kong Air`.
+1. In the **Key** field, enter `kong-air`.
 1. In the **Include usage from** dropdown, select "kong-air".
 1. Click **Save**.
 1. Click the **Subscriptions** tab.
 1. Click **Create a Subscription**.
 1. From the **Subscribed Plan** dropdown, select "Premium".
 1. Click **Next Step**.
-1. Click **Create Subscription**.
+1. Click **Start Subscription**.
 
 <!--Note: Want to delete a customer? Cancel their subscription first and then you can delete them.-->
 

--- a/app/_how-tos/gateway/get-started-with-metering-and-billing.md
+++ b/app/_how-tos/gateway/get-started-with-metering-and-billing.md
@@ -173,19 +173,9 @@ body:
   event_type: kong.api_request
   aggregation: count
   dimensions:
-    request_host: $.request_host
     request_method: $.request_method
-    request_uri: $.request_uri
-    response_http_status: $.response_http_status
     route_name: $.route_name
-    client_ip: $.client_ip
-    upstream_status: $.upstream_status
-    route_id: $.route_id
-    control_plane_id: $.control_plane_id
-    service_id: $.service_id
     service_name: $.service_name
-    service_port: $.service_port
-    service_protocol: $.service_protocol
 {% endkonnect_api_request %}
 <!--vale on-->
 

--- a/app/_how-tos/gateway/get-started-with-metering-and-billing.md
+++ b/app/_how-tos/gateway/get-started-with-metering-and-billing.md
@@ -167,14 +167,25 @@ Create a meter to count API requests:
 url: /v3/openmeter/meters
 method: POST
 body:
-  name: Total API requests
+  name: API requests
   key: api_requests_total
-  description: API Requests
-  event_type: request
+  description: Number of API requests
+  event_type: kong.api_request
   aggregation: count
   dimensions:
-    method: $.method
-    route: $.route
+    request_host: $.request_host
+    request_method: $.request_method
+    request_uri: $.request_uri
+    response_http_status: $.response_http_status
+    route_name: $.route_name
+    client_ip: $.client_ip
+    upstream_status: $.upstream_status
+    route_id: $.route_id
+    control_plane_id: $.control_plane_id
+    service_id: $.service_id
+    service_name: $.service_name
+    service_port: $.service_port
+    service_protocol: $.service_protocol
 {% endkonnect_api_request %}
 <!--vale on-->
 


### PR DESCRIPTION
## Description

Corrects content errors in the two Konnect Metering & Billing onboarding guides found during an onboarding audit.

### What

- **Meter payloads** in both "Create a meter" steps rewritten to match the events the M&B plugin actually emits.
  - get-started: `event_type: kong.api_request` + full dimension set.
  - LLM traffic: `event_type: kong.llm_request` + full dimension set.
- **"Create a feature" steps**: Meter dropdown now names an existing meter ("API requests" / "LLM Tokens"); Value field corrected to an entry, not a select.
- **"Create Customer" steps**: added the mandatory **Key** field.
- **get-started subscription**: button label fixed to **Start Subscription**.

### Why

The old payloads used invalid `event_type`s (`request`, `prompt`) with missing dimensions, so metering would not match plugin events and the tutorials would not produce billable usage. UI labels referenced meters and buttons that don't exist, and the mandatory Key field was omitted.

### How

Payloads verified against the plugin source `cloudevent.lua` (`kong.api_request` / `kong.llm_request` and their emitted `data` fields) and the `api_requests` / `llm_tokens` meter templates. Both pages render-checked locally at `127.0.0.1:4000`.

Files:
- `app/_how-tos/gateway/get-started-with-metering-and-billing.md`
- `app/_how-tos/ai-gateway/meter-llm-traffic.md`

Fixes https://konghq.atlassian.net/browse/OM-426

## Preview Links

- https://deploy-preview-6533--kongdeveloper.netlify.app/metering-and-billing/get-started/
- https://deploy-preview-6533--kongdeveloper.netlify.app/how-to/meter-llm-traffic/

## Checklist

- [x] Tested how-to docs. Render-verified both pages locally; not run as a full live traffic/invoice flow (`automated_tests: false`).
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable). — N/A, no new pages.