### PR TITLE
fix(kapa): Add styles for mantine-ywqy7n class

### DIFF
--- a/app/_layouts/default.html
+++ b/app/_layouts/default.html
@@ -147,6 +147,10 @@
               color: rgb(var(--color-text-primary));
               border: 1px solid rgb(var(--color-border-primary), var(--opacity-border-primary));
             }
+            .mantine-ywqy7n {
+              color: rgb(var(--color-text-primary));
+              background-color: rgb(var(--color-brand));
+            }
             #kapa-widget-root[data-mantine-color-scheme="light"] {
               --mantine-color-default-border: rgb(var(--color-border-primary), var(--opacity-border-primary));
               --mantine-color-body: rgb(var(--color-bg-secondary));


### PR DESCRIPTION
## Description

Custom styling with data attributes isn't working, so overriding a class is the only possible way.
<img width="453" height="263" alt="Screenshot 2026-08-03 at 10 45 00" src="https://github.com/user-attachments/assets/9da15dc0-2852-48ce-815d-44b9dac77036" />
<img width="474" height="199" alt="Screenshot 2026-08-03 at 10 44 56" src="https://github.com/user-attachments/assets/c439bfcf-e4d6-4416-8650-afa1f2c41ff8" />



Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
