### PR TITLE
fix(operator): Datadog autoscaling how-to

### DIFF
--- a/app/_how-tos/operator/operator-dataplane-autoscale-datadog.md
+++ b/app/_how-tos/operator/operator-dataplane-autoscale-datadog.md
@@ -70,7 +70,7 @@ The `DataPlaneMetricsExtension` allows {{ site.operator_product_name }} to monit
     ' | kubectl apply -f -
     ```
 
-1. Create a GatewayConfiguration that uses it:
+1. Create a `GatewayConfiguration` that uses it:
 
     ```bash
     echo '
@@ -87,7 +87,7 @@ The `DataPlaneMetricsExtension` allows {{ site.operator_product_name }} to monit
     ' | kubectl apply -f -
     ```
 
-1. Patch the GatewayClass to use the config:
+1. Patch the `GatewayClass` to use the config:
 
     ```bash
     kubectl patch -n kong --type=json gatewayclass kong -p='[
@@ -104,7 +104,7 @@ The `DataPlaneMetricsExtension` allows {{ site.operator_product_name }} to monit
     ]'
     ```
 
-{{ site.operator_product_name }} can be integrated with [Datadog Metrics](https://docs.datadoghq.com/metrics/) in order to use {{ site.base_gateway }} latency metrics to autoscale workloads based on their metrics.
+You can integrate {{ site.operator_product_name }} with [Datadog Metrics](https://docs.datadoghq.com/metrics/) to use {{ site.base_gateway }} latency metrics to autoscale workloads based on their metrics.
 
 ## Install Datadog in your Kubernetes cluster
 
@@ -162,7 +162,7 @@ To trigger autoscaling, run the following command in a new terminal window. This
 while curl -k "http://$(kubectl get gateway kong -o custom-columns='name:.status.addresses[0].value' --no-headers -n kong)/command/shell?cmd=sleep%200.1" ; do sleep 1; done
 ```
 
-Keep this running while we move on to next steps.
+Keep this running while you move on to the next steps.
 
 ## Annotate {{ site.operator_product_name }} with Datadog checks config
 
@@ -209,7 +209,7 @@ spec:
 ```
 
 {:.info}
-> **Note:** The Datadog Cluster Agent only starts refreshing a `DatadogMetric`'s status once it's referenced by a `HorizontalPodAutoscaler`. Its `ACTIVE`/`VALID`/`VALUE` fields will stay empty until you create the HPA in the next section — that's expected, not an error.
+> **Note:** The Datadog Cluster Agent only starts refreshing a `DatadogMetric`'s status once it's referenced by a `HorizontalPodAutoscaler`. Its `ACTIVE`/`VALID`/`VALUE` fields will stay empty until you create the HPA in the next section.
 
 ### Use `DatadogMetric` in `HorizontalPodAutoscaler`
 

--- a/app/_how-tos/operator/operator-dataplane-autoscale-datadog.md
+++ b/app/_how-tos/operator/operator-dataplane-autoscale-datadog.md
@@ -31,6 +31,9 @@ prereqs:
       - command-service
     routes:
       - command
+  inline:
+    - title: Get Datadog API and application keys
+      include_content: /prereqs/operator/datadog-account
 
 tldr:
   q: How can I autoscale {{site.base_gateway}} workloads using Datadog metrics?
@@ -104,18 +107,6 @@ The `DataPlaneMetricsExtension` allows {{ site.operator_product_name }} to monit
 {{ site.operator_product_name }} can be integrated with [Datadog Metrics](https://docs.datadoghq.com/metrics/) in order to use {{ site.base_gateway }} latency metrics to autoscale workloads based on their metrics.
 
 ## Install Datadog in your Kubernetes cluster
-
-To install Datadog agents in your cluster you will need:
-* An [API key](https://docs.datadoghq.com/account_management/api-app-keys/#api-keys)
-* An [application key](https://docs.datadoghq.com/account_management/api-app-keys/#application-keys)
-* The Datadog site for your region (for example `datadoghq.com` for the US1 region or `datadoghq.eu` for the EU region). 
-
-1. Export these to your environment:
-   ```bash
-   export DD_SITE='YOUR DATADOG SITE'
-   export DD_API_KEY='YOUR DATADOG API KEY'
-   export DD_APP_KEY='YOUR DATADOG APPLICATION KEY'
-   ```
 
 1. Create the following configuration file:
 

--- a/app/_how-tos/operator/operator-dataplane-autoscale-datadog.md
+++ b/app/_how-tos/operator/operator-dataplane-autoscale-datadog.md
@@ -43,8 +43,6 @@ tldr:
 
 {% assign gatewayApiVersion = "v1" %}
 
-## Autoscaling Workloads
-
 This tutorial shows how to autoscale workloads based on Service latency. The `command` service created in the prerequisites allows us to inject an artificial delay in to responses to trigger autoscaling.
 
 ## Create a `DataPlaneMetricsExtension`
@@ -107,81 +105,89 @@ The `DataPlaneMetricsExtension` allows {{ site.operator_product_name }} to monit
 
 ## Install Datadog in your Kubernetes cluster
 
-### Datadog API and application keys
+To install Datadog agents in your cluster you will need:
+* An [API key](https://docs.datadoghq.com/account_management/api-app-keys/#api-keys)
+* An [application key](https://docs.datadoghq.com/account_management/api-app-keys/#application-keys)
+* The Datadog site for your region (for example `datadoghq.com` for the US1 region or `datadoghq.eu` for the EU region). 
 
-To install Datadog agents in your cluster you will need a Datadog API key
-and an application key. Please refer to [this Datadog manual page](https://docs.datadoghq.com/account_management/api-app-keys/) to obtain those.
+1. Export these to your environment:
+   ```bash
+   export DD_SITE='YOUR DATADOG SITE'
+   export DD_API_KEY='YOUR DATADOG API KEY'
+   export DD_APP_KEY='YOUR DATADOG APPLICATION KEY'
+   ```
 
-### Installing
+1. Create the following configuration file:
 
-To install Datadog in your cluster, you can follow [this guide](https://docs.datadoghq.com/containers/kubernetes/installation/?tab=helm)
-or use the following `values.yaml`:
+   ```yaml
+   echo '
+   datadog:
+     kubelet:
+       tlsVerify: false
+   
+   clusterAgent:
+     enabled: true
+     # Enable the metricsProvider to be able to scale based on metrics in Datadog
+     metricsProvider:
+       # Set this to true to enable Metrics Provider
+       enabled: true
+       # Enable usage of DatadogMetric CRD to autoscale on arbitrary Datadog queries
+       useDatadogMetrics: true
+   
+     prometheusScrape:
+       enabled: true
+       serviceEndpoints: true
+   
+   agents:
+     containers:
+       agent:
+         env:
+         - name: DD_HOSTNAME
+           valueFrom:
+             fieldRef:
+               fieldPath: spec.nodeName
+   ' > values.yaml
+   ```
 
-```yaml
-echo '
-datadog:
-  kubelet:
-    tlsVerify: false
+1. Install [Datadog's helm chart](https://github.com/DataDog/helm-charts/tree/main/charts/datadog):
 
-clusterAgent:
-  enabled: true
-  # Enable the metricsProvider to be able to scale based on metrics in Datadog
-  metricsProvider:
-    # Set this to true to enable Metrics Provider
-    enabled: true
-    # Enable usage of DatadogMetric CRD to autoscale on arbitrary Datadog queries
-    useDatadogMetrics: true
+   ```bash
+   helm repo add datadog https://helm.datadoghq.com
+   helm repo update
+   helm install -n default datadog -f values.yaml --set datadog.apiKey=${DD_API_KEY} --set datadog.appKey=${DD_APP_KEY} --set datadog.site=${DD_SITE} datadog/datadog
+   ```
 
-  prometheusScrape:
-    enabled: true
-    serviceEndpoints: true
+1. Wait for the `DatadogMetric` CRD to be established before continuing:
 
-agents:
-  containers:
-    agent:
-      env:
-      - name: DD_HOSTNAME
-        valueFrom:
-          fieldRef:
-            fieldPath: spec.nodeName
-' > values.yaml
-```
-
-To install [Datadog's helm chart](https://github.com/DataDog/helm-charts/tree/main/charts/datadog):
-
-```bash
-helm repo add datadog https://helm.datadoghq.com
-helm repo update
-helm install -n datadog datadog --set datadog.apiKey=${DD_APIKEY} --set datadog.AppKey=${DD_APPKEY} datadog/datadog
-```
+   ```bash
+   kubectl wait --for=condition=Established crd/datadogmetrics.datadoghq.com --timeout=120s
+   ```
 
 ## Send traffic
 
 To trigger autoscaling, run the following command in a new terminal window. This will cause the underlying deployment to sleep for 100ms on each request and thus increase the average response time to that value.
 
 ```bash
-while curl -k "http://$(kubectl get gateway kong -o custom-columns='name:.status.addresses[0].value' --no-headers -n default)/echo/shell?cmd=sleep%200.1" ; do sleep 1; done
+while curl -k "http://$(kubectl get gateway kong -o custom-columns='name:.status.addresses[0].value' --no-headers -n kong)/command/shell?cmd=sleep%200.1" ; do sleep 1; done
 ```
 
 Keep this running while we move on to next steps.
 
 ## Annotate {{ site.operator_product_name }} with Datadog checks config
 
-Add the following annotation on {{ site.operator_product_name }}'s Pod to tell Datadog how to scrape {{ site.operator_product_name }}'s metrics:
+In a new terminal window, add the following annotation on {{ site.operator_product_name }}'s Pod to tell Datadog how to scrape {{ site.operator_product_name }}'s metrics:
 
 ```bash
-POD_NAME=$(kubectl get pods -n kong-system -o custom-columns='name:.metadata.name' --no-headers)
+POD_NAME=$(kubectl get pods -n kong-system -l control-plane=controller-manager -o custom-columns='name:.metadata.name' --no-headers)
 kubectl annotate -n kong-system pod $POD_NAME \
-  'ad.datadoghq.com/kube-rbac-proxy.checks={
+  'ad.datadoghq.com/manager.checks={
     "openmetrics": {
       "instances": [
         {
-          "prometheus_url": "https://%%host%%:8080/metrics",
+          "prometheus_url": "http://%%host%%:8080/metrics",
           "namespace": "autoscaling",
           "metrics": [
-            "kong_upstream_latency_ms_bucket",
-            "kong_upstream_latency_ms_sum",
-            "kong_upstream_latency_ms_count"
+            "kong_upstream_latency_ms"
           ],
           "send_histograms_buckets": true,
           "send_distribution_buckets": true
@@ -191,7 +197,7 @@ kubectl annotate -n kong-system pod $POD_NAME \
   }'
 ```
 
-After applying the above you should see `avg:autoscaling.kong_upstream_latency_ms{service:echo}` metrics in your Datadog Metrics explorer.
+After applying the above you should see `avg:autoscaling.kong_upstream_latency_ms{service:command}` metrics in your Datadog Metrics explorer.
 
 ## Expose Datadog metrics to Kubernetes
 
@@ -205,127 +211,122 @@ echo '
 apiVersion: datadoghq.com/v1alpha1
 kind: DatadogMetric
 metadata:
-  name: echo-kong-upstream-latency-ms-avg
-  namespace: default
+  name: command-kong-upstream-latency-ms-avg
+  namespace: kong
 spec:
-  query: autoscaling.kong_upstream_latency_ms{service:echo} ' | kubectl apply -f -
+  query: autoscaling.kong_upstream_latency_ms{service:command} ' | kubectl apply -f -
 ```
-
-You can check the status of `DatadogMetric` with:
-
-```bash
-kubectl get -n default datadogmetric echo-kong-upstream-latency-ms-avg -w
-```
-
-Which should look like this:
-
-```bash
-NAME                                ACTIVE   VALID   VALUE               REFERENCES         UPDATE TIME
-echo-kong-upstream-latency-ms-avg   True     True    104.46194839477539                     38s
-```
-
-You should be able to get the metric via Kubernetes External Metrics API within 30 seconds:
-
-```bash
-kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/default/datadogmetric@default:echo-kong-upstream-latency-ms-avg" | jq
-```
-
-```json
-{
-  "kind": "ExternalMetricValueList",
-  "apiVersion": "external.metrics.k8s.io/v1beta1",
-  "metadata": {},
-  "items": [
-    {
-      "metricName": "datadogmetric@default:echo-kong-upstream-latency-ms-avg",
-      "metricLabels": null,
-      "timestamp": "2024-03-08T18:03:02Z",
-      "value": "104233138021n"
-    }
-  ]
-}
-```
-{:.no-copy-code}
 
 {:.info}
-> **Note:** `104233138021n` is a Kubernetes way of expressing numbers as integers.
-> Since `value` here represents latency in milliseconds, it is approximately equivalent to 104.23ms.
+> **Note:** The Datadog Cluster Agent only starts refreshing a `DatadogMetric`'s status once it's referenced by a `HorizontalPodAutoscaler`. Its `ACTIVE`/`VALID`/`VALUE` fields will stay empty until you create the HPA in the next section — that's expected, not an error.
 
 ### Use `DatadogMetric` in `HorizontalPodAutoscaler`
 
-When we have the metric already available in Kubernetes External API we can use it in HPA like so:
+The `command-kong-upstream-latency-ms-avg` `DatadogMetric` from the `kong` namespace can be used by the Kubernetes `HorizontalPodAutoscaler` to autoscale our workload, specifically the `command` `Deployment`. The `HorizontalPodAutoscaler` must be created in the same namespace as the `command` `Deployment` it targets, which is `kong`.
 
-The `echo-kong-upstream-latency-ms-avg` `DatadogMetric` from `default` namespace can be used by the Kubernetes `HorizontalPodAutoscaler` to autoscale our workload: specifically the `echo` `Deployment`.
+1. Run the following command to scale the underlying `command` `Deployment` between 1 and 10 replicas, trying to keep the average latency across last 30s at 40ms:
 
-The following manifest will scale the underlying `echo` `Deployment` between 1 and 10 replicas, trying to keep the average latency across last 30s at 40ms.
+   ```yaml
+   echo '
+   apiVersion: autoscaling/v2
+   kind: HorizontalPodAutoscaler
+   metadata:
+     name: command
+     namespace: kong
+   spec:
+     scaleTargetRef:
+       apiVersion: apps/v1
+       kind: Deployment
+       name: command
+     minReplicas: 1
+     maxReplicas: 10
+     behavior:
+       scaleDown:
+         stabilizationWindowSeconds: 1
+         policies:
+         - type: Percent
+           value: 100
+           periodSeconds: 10
+       scaleUp:
+         stabilizationWindowSeconds: 1
+         policies:
+         - type: Percent
+           value: 100
+           periodSeconds: 2
+         - type: Pods
+           value: 4
+           periodSeconds: 2
+         selectPolicy: Max
+   
+     metrics:
+     - type: External
+       external:
+         metric:
+           name: datadogmetric@kong:command-kong-upstream-latency-ms-avg
+         target:
+           type: Value
+           value: 40 ' | kubectl apply -f -
+   ```
 
-```yaml
-echo '
-apiVersion: autoscaling/v2
-kind: HorizontalPodAutoscaler
-metadata:
-  name: echo
-  namespace: default
-spec:
-  scaleTargetRef:
-    apiVersion: apps/v1
-    kind: Deployment
-    name: echo
-  minReplicas: 1
-  maxReplicas: 10
-  behavior:
-    scaleDown:
-      stabilizationWindowSeconds: 1
-      policies:
-      - type: Percent
-        value: 100
-        periodSeconds: 10
-    scaleUp:
-      stabilizationWindowSeconds: 1
-      policies:
-      - type: Percent
-        value: 100
-        periodSeconds: 2
-      - type: Pods
-        value: 4
-        periodSeconds: 2
-      selectPolicy: Max
+1. Once the HPA is created, wait for `DatadogMetric` to become active and valid:
 
-  metrics:
-  - type: External
-    external:
-      metric:
-        name: datadogmetric@default:echo-kong-upstream-latency-ms-avg
-      target:
-        type: Value
-        value: 40 ' | kubectl apply -f -
-```
+   ```bash
+   kubectl wait --for=jsonpath='{.status.conditions[?(@.type=="Active")].status}'=True -n kong datadogmetric/command-kong-upstream-latency-ms-avg --timeout=120s
+   kubectl wait --for=jsonpath='{.status.conditions[?(@.type=="Valid")].status}'=True -n kong datadogmetric/command-kong-upstream-latency-ms-avg --timeout=120s
+   kubectl get -n kong datadogmetric command-kong-upstream-latency-ms-avg
+   ```
+   
+   You should get the following result:
+   
+   ```bash
+   NAME                                   ACTIVE   VALID   VALUE               REFERENCES          UPDATE TIME
+   command-kong-upstream-latency-ms-avg   True     True    104.46194839477539  hpa:kong/command   38s
+   ```
+   {:.no-copy-code}
 
-When everything is configured correctly, `DatadogMetric`'s status will update and it will now have a reference to the `HorizontalPodAutoscaler`:
 
-Get the `DatadogMetric` using `kubectl`:
+## Validate
 
-```bash
-kubectl get -n default datadogmetric echo-kong-upstream-latency-ms-avg -w
-```
+1. Run the following command to get the `command-kong-upstream-latency-ms-avg` metric via the Kubernetes External Metrics API:
 
-You will see the HPA reference in the output:
+   ```bash
+   kubectl get --raw "/apis/external.metrics.k8s.io/v1beta1/namespaces/kong/datadogmetric@kong:command-kong-upstream-latency-ms-avg" | jq
+   ```
 
-```bash
-NAME                                ACTIVE   VALID   VALUE               REFERENCES         UPDATE TIME
-echo-kong-upstream-latency-ms-avg   True     True    104.46194839477539  hpa:default/echo  38s
-```
-{:.no-copy-code}
+   You should get the following result:
 
-If everything went well we should see the `SuccessfulRescale` events:
+   ```json
+   {
+     "kind": "ExternalMetricValueList",
+     "apiVersion": "external.metrics.k8s.io/v1beta1",
+     "metadata": {},
+     "items": [
+       {
+         "metricName": "datadogmetric@kong:command-kong-upstream-latency-ms-avg",
+         "metricLabels": null,
+         "timestamp": "2024-03-08T18:03:02Z",
+         "value": "104233138021n"
+       }
+     ]
+   }
+   ```
+   {:.no-copy-code}
 
-```bash
-12m          Normal   SuccessfulRescale   horizontalpodautoscaler/echo   New size: 2; reason: Service metric kong_upstream_latency_ms_30s_average above target
-12m          Normal   SuccessfulRescale   horizontalpodautoscaler/echo   New size: 4; reason: Service metric kong_upstream_latency_ms_30s_average above target
-12m          Normal   SuccessfulRescale   horizontalpodautoscaler/echo   New size: 8; reason: Service metric kong_upstream_latency_ms_30s_average above target
-12m          Normal   SuccessfulRescale   horizontalpodautoscaler/echo   New size: 10; reason: Service metric kong_upstream_latency_ms_30s_average above target
+   {:.info}
+   > **Note:** `104233138021n` is a Kubernetes way of expressing numbers as integers.
+   > Since `value` here represents latency in milliseconds, it is approximately equivalent to 104.23ms.
 
-# Then when latency drops
-4s          Normal   SuccessfulRescale   horizontalpodautoscaler/echo   New size: 1; reason: All metrics below target
-```
-{:.no-copy-code}
+1. Check for `SuccessfulRescale` events:
+
+   ```bash
+   kubectl get events -n kong --field-selector involvedObject.name=command,involvedObject.kind=HorizontalPodAutoscaler,reason=SuccessfulRescale --sort-by='.lastTimestamp'
+   ```
+
+   The result should look like this:
+
+   ```bash
+   LAST SEEN   TYPE     REASON              OBJECT                            MESSAGE
+   38s         Normal   SuccessfulRescale   horizontalpodautoscaler/command   New size: 5; reason: external metric datadogmetric@kong:command-kong-upstream-latency-ms-avg(nil) above target
+   23s         Normal   SuccessfulRescale   horizontalpodautoscaler/command   New size: 10; reason: external metric datadogmetric@kong:command-kong-upstream-latency-ms-avg(nil) above target
+   ```
+   {:.no-copy-code}

--- a/app/_includes/prereqs/operator/datadog-account.md
+++ b/app/_includes/prereqs/operator/datadog-account.md
@@ -1,0 +1,12 @@
+To install Datadog agents in your cluster you will need:
+* An [API key](https://docs.datadoghq.com/account_management/api-app-keys/#api-keys)
+* An [application key](https://docs.datadoghq.com/account_management/api-app-keys/#application-keys)
+* The Datadog site for your region (for example `datadoghq.com` for the US1 region or `datadoghq.eu` for the EU region).
+
+Export these to your environment:
+
+```bash
+export DD_SITE='YOUR DATADOG SITE'
+export DD_API_KEY='YOUR DATADOG API KEY'
+export DD_APP_KEY='YOUR DATADOG APPLICATION KEY'
+```


### PR DESCRIPTION
## Description

Fixes #1447 

## Note to reviewers

You can get a free Datadog trial, otherwise my keys are in 1Password

## Preview Links

https://deploy-preview-6555--kongdeveloper.netlify.app/operator/dataplanes/how-to/autoscale-workloads/datadog/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
