### PR TITLE
docs(gateway): add kong.client.get_principal to sandboxing strict mode allowlist

### DIFF
--- a/app/gateway/sandboxing.md
+++ b/app/gateway/sandboxing.md
@@ -151,6 +151,7 @@ kong.client.get_jwt_token_header
 kong.client.get_jwt_token_payload
 kong.client.get_identity_realm_source
 kong.client.set_identity_realm_source
+kong.client.get_principal
 ```
 
 #### Kong Cluster PDK


### PR DESCRIPTION
## Description

Kong Gateway added a new PDK function, `kong.client.get_principal()` ([Kong/kong-ee#20892](https://github.com/Kong/kong-ee/pull/20892)), and added it to the `untrusted_lua = strict` sandbox allowlist next to `kong.client.get_consumer` (`lax` inherits it automatically). This updates the hand-maintained allowlist mirror on the [Lua sandboxing reference page](/gateway/sandboxing/) to match, per the `NOTE: Don't forget to update docs too!` comment in the gateway's `strict.lua`/`lax.lua` source.

Fixes: N/A (no doc ticket filed; internal follow-up to Kong/kong-ee#20892)

## Preview Links

N/A — single-line addition to an existing code block, no new page.

## Checklist 

- [x] Tested how-to docs. If not, note why here. — N/A, this is a reference page code-block list, not a how-to.
- [x] All pages contain metadata. — unchanged, no new page.
- [x] Any new docs link to existing docs. — N/A, no new page.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager). — N/A, no autogenerated content touched.
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly. — unchanged formatting, matches surrounding list style.
- [x] Every page has a `description` entry in frontmatter. — unchanged, no new page.
- [x] Add new pages to the product documentation index (if applicable). — N/A, no new page.