### PR TITLE
chore(gateway): Distroless 3.13 changelog + note

### DIFF
--- a/app/_data/changelogs/gateway.json
+++ b/app/_data/changelogs/gateway.json
@@ -24757,6 +24757,11 @@
         "message": "Improved router update performance during incremental sync by updating service data in place instead of triggering a full router rebuild when only service attributes change.",
         "type": "performance",
         "scope": "Core"
+      },
+      {
+        "message": "Added a Distroless Docker image variant for Kong API Gateway. The Distroless image ships only the Kong binary and its runtime dependencies, with no package managers, no shells or any other programs you would expect to find in a standard Linux distribution.",
+        "type": "feature",
+        "scope": "Core"
       }
     ]
   },

--- a/app/_how-tos/gateway/docker-compose.md
+++ b/app/_how-tos/gateway/docker-compose.md
@@ -48,7 +48,7 @@ automated_tests: false
 
 ## Set up the Docker Compose file
 
-Run the following command to create `docker-compose.yml`:
+Run the following command to create `docker-compose.yml`, replacing `{{ site.data.gateway_latest.ee-version }}` with your own version of {{site.base_gateway}}:
 
 <!-- vale off -->
 ```bash

--- a/app/_how-tos/gateway/gateway-install-helm-konnect.md
+++ b/app/_how-tos/gateway/gateway-install-helm-konnect.md
@@ -117,7 +117,7 @@ CONTROL_PLANE_ENDPOINT=$(echo $CONTROL_PLANE_DETAILS | jq -r '.config.control_pl
 CONTROL_PLANE_TELEMETRY=$(echo $CONTROL_PLANE_DETAILS | jq -r '.config.telemetry_endpoint | sub("https://";"")')
 ```
 
-Create a `values-dp.yaml` file with the following content:
+Create a `values-dp.yaml` file with the following content, replacing `{{ site.data.gateway_latest.release }}` with your own version of {{site.base_gateway}}:
 
 ```yaml
 echo '

--- a/app/_how-tos/gateway/gateway-install-helm-onprem.md
+++ b/app/_how-tos/gateway/gateway-install-helm-onprem.md
@@ -180,7 +180,7 @@ If you want to deploy a PostgreSQL database within the cluster for testing purpo
 
 The control plane contains all {{ site.base_gateway }} configurations. The configuration is stored in a PostgreSQL database.
 
-1. Create a `values-cp.yaml` file.
+1. Create a `values-cp.yaml` file, replacing `{{ site.data.gateway_latest.release }}` with your own version of {{site.base_gateway}}:
 
 {% capture values_file %}
 

--- a/app/_how-tos/gateway/install-gateway-distroless.md
+++ b/app/_how-tos/gateway/install-gateway-distroless.md
@@ -79,7 +79,7 @@ automated_tests: false
 
 ## Pull the distroless image
 
-Pull the {{site.base_gateway}} distroless image from Docker Hub:
+Pull the {{site.base_gateway}} distroless image from Docker Hub, replacing `{{ site.data.gateway_latest.ee-version }}` with your own version of {{site.base_gateway}}:
 
 ```sh
 docker pull kong/kong-gateway:{{ site.data.gateway_latest.ee-version }}-distroless

--- a/app/_how-tos/gateway/install-gateway-read-only.md
+++ b/app/_how-tos/gateway/install-gateway-read-only.md
@@ -84,7 +84,7 @@ Now we need to configure our {{site.base_gateway}} Docker Compose stack.
 In this configuration file, we're going to mount a Docker volume to the locations where {{site.base_gateway}} needs to write data, which includes the `/declarative` directory.
 This default configuration requires write access to `/tmp` and to the prefix path.
 
-Run the following command to create a Docker Compose file at `docker-compose.yml` with `read_only` set to `true`:
+Run the following command to create a Docker Compose file at `docker-compose.yml` with `read_only` set to `true`, replacing `{{ site.data.gateway_latest.ee-version }}` with your own version of {{site.base_gateway}}:
 
 <!-- vale off -->
 ```bash


### PR DESCRIPTION
* Changelog entry for distroless in 3.13
* In install guides, telling users to substitute their own version (per request)
  * Note that some guides use `{{ site.data.gateway_latest.ee-version }}` and some use `{{ site.data.gateway_latest.release }}` - this is intentional, the kubernetes installs use the short version number.

https://deploy-preview-6567--kongdeveloper.netlify.app/gateway/changelog/#3-13-0-8
install pages like https://deploy-preview-6567--kongdeveloper.netlify.app/gateway/install/docker-distroless/