### PR TITLE
feat(gateway): add new debugger span attributes

### DIFF
--- a/app/observability/debugger-spans.md
+++ b/app/observability/debugger-spans.md
@@ -105,7 +105,8 @@ rows:
   - name: "`proxy.kong.upstream.status_code`"
     description: |
       Status code returned by the upstream to {{site.base_gateway}}.
-  - name: "`proxy.kong.upstream.address`"
+  - name: |
+      `proxy.kong.upstream.address` {% new_in 3.16 %}
     description: |
       DNS name and port of the selected upstream.
   - name: "`http.response.status_code`"
@@ -158,7 +159,8 @@ rows:
     description: x509 DN for cert Kong presented.
   - name: "`tls.cipher`"
     description: Negotiated cipher.
-  - name: "`tls.client.server_name`"
+  - name: |
+      `tls.client.server_name` {% new_in 3.16 %}
     description: TLS SNI value sent by the client.
 {% endtable %}
 <!--vale on-->

--- a/app/observability/debugger-spans.md
+++ b/app/observability/debugger-spans.md
@@ -105,6 +105,9 @@ rows:
   - name: "`proxy.kong.upstream.status_code`"
     description: |
       Status code returned by the upstream to {{site.base_gateway}}.
+  - name: "`proxy.kong.upstream.address`"
+    description: |
+      DNS name and port of the selected upstream.
   - name: "`http.response.status_code`"
     description: |
       Status code sent back by {{site.base_gateway}} to client.
@@ -155,6 +158,8 @@ rows:
     description: x509 DN for cert Kong presented.
   - name: "`tls.cipher`"
     description: Negotiated cipher.
+  - name: "`tls.client.server_name`"
+    description: TLS SNI value sent by the client.
 {% endtable %}
 <!--vale on-->
 ### kong.phase.certificate


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description
Added the following debugger span attributes
- roxy.kong.upstream.address
- tls.client.server_name

kong-ee PR: https://github.com/Kong/kong-ee/pull/20007

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
