### PR TITLE
feat(gateway) Custom 404 HTML example for Exit Transformer

### DIFF
--- a/app/_kong_plugins/exit-transformer/examples/customize-404-message.yaml
+++ b/app/_kong_plugins/exit-transformer/examples/customize-404-message.yaml
@@ -1,6 +1,10 @@
 description: Configure the Exit Transformer plugin to transform 404 responses and add a custom error message.
 extended_description: |
   Configure the plugin to transform 404 responses and add a custom error message.
+  
+  This example uses the `handle_unknown` parameter, which only takes effect on a globally configured instance of the plugin when a 404 error occurs.
+  If you're running this plugin on-prem, you must configure it in the default Workspace.
+
   See [Transform a 404 response message](/how-to/transform-a-404-response-message/) for a full how-to guide with this example.
 
 title: 'Customize the 404 error message'

--- a/app/_kong_plugins/exit-transformer/examples/customize-404-message.yaml
+++ b/app/_kong_plugins/exit-transformer/examples/customize-404-message.yaml
@@ -2,7 +2,7 @@ description: Configure the Exit Transformer plugin to transform 404 responses an
 extended_description: |
   Configure the plugin to transform 404 responses and add a custom error message.
   
-  This example uses the `handle_unknown` parameter, which only takes effect on a globally configured instance of the plugin when a 404 error occurs.
+  This example uses the [`handle_unknown`](/plugins/exit-transformer/reference/#schema--config-handle-unknown) parameter, which only takes effect on a globally configured instance of the plugin when a 404 error occurs.
   If you're running this plugin on-prem, you must configure it in the default Workspace.
 
   See [Transform a 404 response message](/how-to/transform-a-404-response-message/) for a full how-to guide with this example.

--- a/app/_kong_plugins/exit-transformer/examples/customize-html-404-message.yaml
+++ b/app/_kong_plugins/exit-transformer/examples/customize-html-404-message.yaml
@@ -2,7 +2,7 @@ description: Configure the Exit Transformer plugin to transform 404 responses in
 extended_description: |
   Configure the plugin to transform 404 responses into custom HTML and add a custom error message.
 
-  This example uses the `handle_unknown` parameter, which only takes effect on a globally configured instance of the plugin when a 404 error occurs.
+  This example uses the [`handle_unknown`](/plugins/exit-transformer/reference/#schema--config-handle-unknown) parameter, which only takes effect on a globally configured instance of the plugin when a 404 error occurs.
   If you're running this plugin on-prem, you must configure it in the default Workspace.
 
   For a full walkthrough, see [Transform a 404 response message](/how-to/transform-a-404-response-message/).

--- a/app/_kong_plugins/exit-transformer/examples/customize-html-404-message.yaml
+++ b/app/_kong_plugins/exit-transformer/examples/customize-html-404-message.yaml
@@ -1,0 +1,49 @@
+description: Configure the Exit Transformer plugin to transform 404 responses into custom HTML.
+extended_description: |
+  Configure the plugin to transform 404 responses into custom HTML and add a custom error message.
+
+  This example uses the `handle_unknown` parameter, which only takes effect on a globally configured instance of the plugin when a 404 error occurs.
+  If you're running this plugin on-prem, you must configure it in the default Workspace.
+
+  For a full walkthrough, see [Transform a 404 response message](/how-to/transform-a-404-response-message/).
+  Use the following example in place of the one in the guide.
+
+title: 'Return custom 404 error in HTML'
+
+targets:
+  - global
+
+weight: 900
+
+requirements: 
+ - "[`untrusted_lua`](/gateway/configuration/#untrusted-lua) must be set to either `on` or `sandbox` in your `kong.conf` file for this plugin to work."
+
+config: 
+  handle_unknown: true
+  functions:
+    - |-
+      return function(status, body, headers)
+        if status == 404 then
+          body = [[
+      <!DOCTYPE html>
+      <html lang="en">
+      <head>
+      <meta charset="utf-8">
+      <title>404 Not Found</title>
+      </head>
+      <body>
+      <h1>404</h1>
+      <p>Sorry, nothing to see here!</p>
+      </body>
+      </html>
+      ]]
+      end
+        return status, body, headers
+      end
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Example provided on Slack: https://kongstrong.slack.com/archives/C046SPHV6AH/p1785453646565689?thread_ts=1785446197.871469&cid=C046SPHV6AH

Tested this with the how-to guide by subbing in the example, it works.
Added a bit of info about the `global` requirement to this example and the other 404 error one, since I ran into the `target` limiter in the example and couldn't figure out why it was limited at first.

## Preview Links
https://deploy-preview-6585--kongdeveloper.netlify.app/plugins/exit-transformer/examples/customize-html-404-message/
