### PR TITLE
feat(catalog): Revamp

### DIFF
--- a/api-specs/konnect/ai-builder/v1/openapi.yaml
+++ b/api-specs/konnect/ai-builder/v1/openapi.yaml
@@ -1,0 +1,1643 @@
+openapi: 3.0.3
+info:
+  title: Konnect AI Catalog
+  version: 1.10.2
+  description: |
+    Konnect AI Catalog is the API for creating and managing AI interfaces in the Konnect Catalog.
+  contact:
+    name: Kong
+    url: 'https://cloud.konghq.com'
+servers:
+  - url: 'https://us.api.konghq.com/v1'
+    description: United-States Production region
+  - url: 'https://eu.api.konghq.com/v1'
+    description: Europe Production region
+  - url: 'https://au.api.konghq.com/v1'
+    description: Australia Production region
+  - url: 'https://me.api.konghq.com/v1'
+    description: Middle-East Production region
+  - url: 'https://in.api.konghq.com/v1'
+    description: India Production region
+  - url: 'https://sg.api.konghq.com/v1'
+    description: Singapore Production region
+paths:
+  /ai-models:
+    get:
+      operationId: list-ai-models
+      summary: List AI Models
+      description: |
+        Returns a paginated list of AI Models for the current organization. Each row includes a `managed_by` object derived from whether the model is linked to an AI Gateway model.
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+        - name: filter
+          in: query
+          description: Filter AI Models returned in the response.
+          required: false
+          schema:
+            $ref: '#/components/schemas/AiModelFilterParameters'
+          style: deepObject
+        - $ref: '#/components/parameters/AiModelSort'
+      responses:
+        '200':
+          description: A paginated list of AI Models
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AiModelList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+      tags:
+        - Catalog AI Models
+    post:
+      operationId: create-ai-model
+      summary: Create AI Model
+      description: |
+        Creates a bare AI Model. No `target_models` are accepted here — create the version separately with `POST /ai-models/{aiModelId}/versions`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AiModelCreate'
+      responses:
+        '201':
+          description: The created AI Model
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AiModel'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '409':
+          $ref: '#/components/responses/Conflict'
+      tags:
+        - Catalog AI Models
+  '/ai-models/{aiModelId}':
+    parameters:
+      - $ref: '#/components/parameters/AiModelIdPath'
+    get:
+      operationId: get-ai-model
+      summary: Get AI Model
+      description: Returns a single AI Model.
+      responses:
+        '200':
+          description: AI Model details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AiModel'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Catalog AI Models
+    patch:
+      operationId: update-ai-model
+      summary: Update AI Model
+      description: |
+        Partially updates an AI Model.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AiModelUpdate'
+      responses:
+        '200':
+          description: The updated AI Model
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AiModel'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+      tags:
+        - Catalog AI Models
+    put:
+      operationId: upsert-ai-model
+      summary: Replace AI Model
+      description: |
+        Replaces an AI Model.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AiModelReplace'
+      responses:
+        '200':
+          description: The replaced AI Model
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AiModel'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+      tags:
+        - Catalog AI Models
+    delete:
+      operationId: delete-ai-model
+      summary: Delete AI Model
+      description: |
+        Deletes an AI Model.
+      responses:
+        '204':
+          description: Successfully deleted the AI Model
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Catalog AI Models
+  '/ai-models/{aiModelId}/versions':
+    parameters:
+      - $ref: '#/components/parameters/AiModelIdPath'
+    get:
+      operationId: list-ai-model-versions
+      summary: List AI Model versions
+      description: |
+        Returns the AI Model's versions.
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+      responses:
+        '200':
+          description: The AI Model's versions
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AiModelVersionList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Catalog AI Model Versions
+    post:
+      operationId: create-ai-model-version
+      summary: Create AI Model version
+      description: |
+        Creates the `latest` version with its `target_models`. Currently, a model only has a single version. Returns `409` if a version already exists.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AiModelVersionCreate'
+      responses:
+        '201':
+          description: The created version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AiModelVersion'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+      tags:
+        - Catalog AI Model Versions
+  '/ai-models/{aiModelId}/versions/latest':
+    parameters:
+      - $ref: '#/components/parameters/AiModelIdPath'
+    get:
+      operationId: get-latest-ai-model-version
+      summary: Get latest AI Model version
+      description: |
+        Returns the AI Model's `latest` version, including its `target_models`.
+      responses:
+        '200':
+          description: The latest version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AiModelVersion'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Catalog AI Model Versions
+    patch:
+      operationId: update-latest-ai-model-version
+      summary: Update latest AI Model version
+      description: |
+        Partially updates the `latest` version. `target_models`, when supplied, is a full-array replacement.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AiModelVersionUpdate'
+      responses:
+        '200':
+          description: The updated version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AiModelVersion'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Catalog AI Model Versions
+    put:
+      operationId: upsert-latest-ai-model-version
+      summary: Replace latest AI Model version
+      description: |
+        Replaces the `latest` version.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AiModelVersionReplace'
+      responses:
+        '200':
+          description: The replaced version
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AiModelVersion'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Catalog AI Model Versions
+    delete:
+      operationId: delete-latest-ai-model-version
+      summary: Delete latest AI Model version
+      description: |
+        Deletes the AI Model's `latest` version. Returns `404` if no version exists yet.
+      responses:
+        '204':
+          description: Successfully deleted the version
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Catalog AI Model Versions
+  '/ai-models/{aiModelId}/versions/latest/spec':
+    parameters:
+      - $ref: '#/components/parameters/AiModelIdPath'
+    get:
+      operationId: get-ai-model-version-spec
+      summary: Get AI Model version spec
+      description: |
+        Returns the `latest` version's oas specification contents along with metadata.
+      responses:
+        '200':
+          description: The version's oas specification
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AiModelVersionSpec'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Catalog AI Model Specs
+    put:
+      operationId: upsert-ai-model-version-spec
+      summary: Upsert AI Model version spec
+      description: |
+        Creates or replaces the `latest` version's oas specification (upsert).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AiModelVersionSpecWrite'
+      responses:
+        '200':
+          description: The replaced spec
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AiModelVersionSpec'
+        '201':
+          description: The created spec
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AiModelVersionSpec'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Catalog AI Model Specs
+    delete:
+      operationId: delete-ai-model-version-spec
+      summary: Delete AI Model version spec
+      description: |
+        Deletes the `latest` version's oas specification.
+      responses:
+        '204':
+          description: Successfully deleted the spec
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Catalog AI Model Specs
+  '/ai-models/{aiModelId}/implementations':
+    parameters:
+      - $ref: '#/components/parameters/AiModelIdPath'
+    get:
+      operationId: list-ai-model-implementations
+      summary: List AI Model implementations
+      description: |
+        Returns a paginated list of the AI Model's implementation records.
+      parameters:
+        - $ref: '#/components/parameters/PageSize'
+        - $ref: '#/components/parameters/PageNumber'
+      responses:
+        '200':
+          description: The AI Model's implementations
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AiModelImplementationList'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Catalog AI Model Implementations
+    post:
+      operationId: create-ai-model-implementation
+      summary: Create AI Model implementation
+      description: |
+        Creates an implementation record for the AI Model. Returns `409` if the model has an existing implementation.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AiModelImplementationCreate'
+      responses:
+        '201':
+          description: The created implementation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AiModelImplementation'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/Conflict'
+      tags:
+        - Catalog AI Model Implementations
+  '/ai-models/{aiModelId}/implementations/{implementationId}':
+    parameters:
+      - $ref: '#/components/parameters/AiModelIdPath'
+      - $ref: '#/components/parameters/AiModelImplementationIdPath'
+    get:
+      operationId: get-ai-model-implementation
+      summary: Get AI Model implementation
+      description: Returns a single AI Model implementation record.
+      responses:
+        '200':
+          description: AI Model implementation details
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AiModelImplementation'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Catalog AI Model Implementations
+    delete:
+      operationId: delete-ai-model-implementation
+      summary: Delete AI Model implementation
+      description: Removes a single AI Model implementation (link) record by identifier.
+      responses:
+        '204':
+          description: Successfully deleted the AI Model implementation
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Catalog AI Model Implementations
+  '/ai-models/{aiModelId}/spec':
+    parameters:
+      - $ref: '#/components/parameters/AiModelIdPath'
+    get:
+      operationId: get-ai-model-spec
+      summary: Get AI Model spec
+      description: |
+        Convenience shortcut to the `latest` version's oas specification. Returns `404`  if either the version or the specification is missing, distinguished by error code in the response body (`ai_model_version_not_found` / `ai_model_spec_not_found`).
+      responses:
+        '200':
+          description: The latest version's spec
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AiModelVersionSpec'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+      tags:
+        - Catalog AI Model Specs
+components:
+  parameters:
+    AiModelIdPath:
+      name: aiModelId
+      in: path
+      required: true
+      description: The unique identifier of the AI Model.
+      schema:
+        type: string
+        format: uuid
+        example: 123e4567-e89b-12d3-a456-426614174000
+    AiModelImplementationIdPath:
+      name: implementationId
+      in: path
+      required: true
+      description: The unique identifier of the AI Model implementation.
+      schema:
+        type: string
+        format: uuid
+        example: d2e1f0a9-8b7c-6d5e-4f3a-2b1c0d9e8f7a
+    AiModelSort:
+      name: sort
+      description: |
+        Sort AI Models by specified fields. Supported sort attributes are:
+        - `display_name`
+        - `name`
+        - `created_at`
+        - `updated_at`
+
+        Default sort is `display_name` in ascending order.
+      required: false
+      in: query
+      schema:
+        $ref: '#/components/schemas/SortQuery'
+    PageNumber:
+      name: 'page[number]'
+      description: Determines which page of the entities to retrieve.
+      required: false
+      in: query
+      allowEmptyValue: true
+      schema:
+        type: integer
+        example: 1
+    PageSize:
+      name: 'page[size]'
+      description: The maximum number of items to include per page. The last page of a collection may include fewer items.
+      required: false
+      in: query
+      allowEmptyValue: true
+      schema:
+        type: integer
+        example: 10
+  schemas:
+    TargetModel:
+      description: An upstream LLM target the AI Model proxies.
+      type: object
+      properties:
+        provider:
+          description: The upstream model provider.
+          type: string
+          example: openai
+        name:
+          description: The upstream model name for the given provider.
+          type: string
+          example: gpt-4o
+      required:
+        - provider
+        - name
+    AiModel:
+      description: An AI Model catalog resource.
+      type: object
+      properties:
+        id:
+          description: The unique identifier of the AI Model.
+          type: string
+          format: uuid
+          example: 123e4567-e89b-12d3-a456-426614174000
+        name:
+          description: |
+            The machine name of the AI Model that uniquely identifies it within the catalog.
+          type: string
+          example: my-ai-model
+          maxLength: 120
+          minLength: 1
+          pattern: '^[0-9a-z.-]+$'
+        display_name:
+          description: The display name of the AI Model.
+          type: string
+          example: My AI Model
+          maxLength: 120
+          minLength: 1
+        description:
+          description: A description of the AI Model.
+          type: string
+          example: Customer support triage model
+          maxLength: 2048
+          nullable: true
+        labels:
+          $ref: '#/components/schemas/Labels'
+        managed_by:
+          $ref: '#/components/schemas/ManagedBy'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+      required:
+        - id
+        - name
+        - display_name
+        - description
+        - labels
+        - managed_by
+        - created_at
+        - updated_at
+    AiModelCreate:
+      description: Request body for creating or replacing an AI Model.
+      type: object
+      properties:
+        name:
+          description: |
+            The machine name of the AI Model that uniquely identifies it within the catalog.
+          type: string
+          example: my-ai-model
+          maxLength: 120
+          minLength: 1
+          pattern: '^[0-9a-z.-]+$'
+        display_name:
+          description: The display name of the AI Model.
+          type: string
+          example: My AI Model
+          maxLength: 120
+          minLength: 1
+        description:
+          description: Optionally provide a description of the AI Model.
+          type: string
+          example: Customer support triage model
+          maxLength: 2048
+          nullable: true
+        labels:
+          $ref: '#/components/schemas/Labels'
+      additionalProperties: false
+      required:
+        - name
+        - display_name
+    AiModelReplace:
+      description: Request body for creating or replacing an AI Model.
+      type: object
+      properties:
+        name:
+          description: |
+            The machine name of the AI Model that uniquely identifies it within the catalog.
+          type: string
+          example: my-ai-model
+          maxLength: 120
+          minLength: 1
+          pattern: '^[0-9a-z.-]+$'
+        display_name:
+          description: The display name of the AI Model.
+          type: string
+          example: My AI Model
+          maxLength: 120
+          minLength: 1
+        description:
+          description: Optionally provide a description of the AI Model.
+          type: string
+          example: Customer support triage model
+          maxLength: 2048
+          nullable: true
+        labels:
+          $ref: '#/components/schemas/Labels'
+      additionalProperties: false
+      required:
+        - name
+        - display_name
+    AiModelUpdate:
+      description: |
+        Request body for partially updating an AI Model (merge-patch). All fields are optional; omitted fields are left unchanged.
+      type: object
+      properties:
+        name:
+          description: |
+            The machine name of the AI Model that uniquely identifies it within the catalog.
+          type: string
+          example: my-ai-model
+          maxLength: 120
+          minLength: 1
+          pattern: '^[0-9a-z.-]+$'
+        display_name:
+          description: The display name of the AI Model.
+          type: string
+          example: My AI Model
+          maxLength: 120
+          minLength: 1
+        description:
+          description: Optionally provide a description of the AI Model.
+          type: string
+          example: Customer support triage model
+          maxLength: 2048
+          nullable: true
+        labels:
+          $ref: '#/components/schemas/LabelsUpdate'
+      additionalProperties: false
+    AiModelList:
+      description: A paginated page of AI Models.
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/AiModel'
+        meta:
+          $ref: '#/components/schemas/PaginatedMeta'
+      required:
+        - data
+        - meta
+    AiModelVersion:
+      description: |
+        A version of an AI Model, holding its `target_models`. Currently only exactly one version (`latest`) per model exists.
+      type: object
+      properties:
+        id:
+          description: The unique identifier of the version.
+          type: string
+          format: uuid
+          example: 9c4a1b2c-3d4e-5f60-7182-93a4b5c6d7e8
+        ai_model_id:
+          description: The identifier of the parent AI Model.
+          type: string
+          format: uuid
+          example: 123e4567-e89b-12d3-a456-426614174000
+        version:
+          description: An optional user-supplied version label. `null` when unset.
+          type: string
+          example: 1.0.0
+          maxLength: 120
+          minLength: 1
+          nullable: true
+          pattern: .*\S.*
+        target_models:
+          description: The upstream LLM targets for this version.
+          type: array
+          items:
+            $ref: '#/components/schemas/TargetModel'
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+      required:
+        - id
+        - ai_model_id
+        - version
+        - target_models
+        - created_at
+        - updated_at
+    AiModelVersionCreate:
+      description: Request body for creating an AI Model Version.
+      type: object
+      properties:
+        version:
+          description: |
+            An optional user-supplied version label.
+          type: string
+          example: 1.0.0
+          maxLength: 120
+          minLength: 1
+          nullable: true
+          pattern: .*\S.*
+        target_models:
+          description: The upstream LLM targets (full set).
+          type: array
+          items:
+            $ref: '#/components/schemas/TargetModel'
+      additionalProperties: false
+      required:
+        - target_models
+    AiModelVersionUpdate:
+      description: |
+        Request body for partially updating an AI Model Version.
+      type: object
+      properties:
+        version:
+          description: |
+            An optional user-supplied version label. Omit it to leave the version unchanged, or send `null` to clear it.
+          type: string
+          example: 1.0.0
+          maxLength: 120
+          minLength: 1
+          nullable: true
+          pattern: .*\S.*
+        target_models:
+          description: The upstream LLM targets.
+          type: array
+          items:
+            $ref: '#/components/schemas/TargetModel'
+      additionalProperties: false
+    AiModelVersionReplace:
+      description: Request body for replacing an AI Model Version.
+      allOf:
+        - $ref: '#/components/schemas/AiModelVersionCreate'
+    AiModelVersionList:
+      description: A paginated page of an AI Model's versions.
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/AiModelVersion'
+        meta:
+          $ref: '#/components/schemas/PaginatedMeta'
+      required:
+        - data
+        - meta
+    SpecProvider:
+      description: |
+        Client-supplied provenance for the oas specification. Omit it (or send `null`) for a user-uploaded spec. `{ "source": "ai_gateway" }` indicates the content came from the linked AI Gateway model, and is rejected with `400` (`invalid_parameters`) if the model is not linked. `{ "source": "provider" }` is reserved for provider/target-model generation.
+      type: object
+      properties:
+        source:
+          type: string
+          example: ai_gateway
+          enum:
+            - ai_gateway
+            - provider
+      required:
+        - source
+    AiModelVersionSpec:
+      description: The oas specification document for an AI Model version.
+      type: object
+      properties:
+        spec_content:
+          description: |
+            The raw content of the oas specification, in json or yaml format (for example, an
+            OpenAPI document).
+          type: string
+          example: '{"openapi":"3.1.0","info":{"title":"My AI Model","version":"1.0.0"},"paths":{}}'
+        spec_type:
+          description: |
+            The type of specification document. Currently always `oas` (OpenAPI Specification).
+          type: string
+          example: oas
+          enum:
+            - oas
+          readOnly: true
+        spec_provider:
+          description: |
+            Provenance of the specification. `null` (or absent) for a user-uploaded specification.
+          type: object
+          nullable: true
+          properties:
+            source:
+              type: string
+              example: ai_gateway
+              enum:
+                - ai_gateway
+                - provider
+          required:
+            - source
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+      required:
+        - spec_content
+        - spec_type
+        - created_at
+        - updated_at
+    AiModelVersionSpecWrite:
+      description: |
+        Request body for creating or replacing a version's spec (upsert). The request body has a maximum size limit of 8MB.
+      type: object
+      properties:
+        spec_content:
+          description: |
+            The raw content of the oas specification, in json or yaml format (for example, an
+            OpenAPI document).
+          type: string
+          example: '{"openapi":"3.1.0","info":{"title":"My AI Model","version":"1.0.0"},"paths":{}}'
+        spec_provider:
+          description: |
+            Optional provenance. Omit (or `null`) for a user-uploaded specification.
+          allOf:
+            - $ref: '#/components/schemas/SpecProvider'
+          nullable: true
+      additionalProperties: false
+      required:
+        - spec_content
+    AiModelImplementation:
+      description: AI Model Implementation.
+      type: object
+      properties:
+        id:
+          description: The unique identifier of the implementation (link) record.
+          type: string
+          format: uuid
+          example: d2e1f0a9-8b7c-6d5e-4f3a-2b1c0d9e8f7a
+        ai_model_id:
+          description: The identifier of the parent AI Model.
+          type: string
+          format: uuid
+          example: 123e4567-e89b-12d3-a456-426614174000
+        gateway_control_plane_id:
+          description: The AI Gateway control plane uuid the linked model belongs to.
+          type: string
+          format: uuid
+          example: 223e4567-e89b-12d3-a456-426614174999
+        gateway_model_id:
+          description: The text or uuid identifier of the linked AI Gateway model.
+          type: string
+          example: gw-model-abc
+        created_at:
+          $ref: '#/components/schemas/CreatedAt'
+        updated_at:
+          $ref: '#/components/schemas/UpdatedAt'
+      required:
+        - id
+        - ai_model_id
+        - gateway_control_plane_id
+        - gateway_model_id
+        - created_at
+        - updated_at
+    AiModelImplementationCreate:
+      description: Request body for linking an AI Model to an AI Gateway model.
+      type: object
+      properties:
+        gateway_control_plane_id:
+          description: The AI Gateway control plane uuid the model belongs to.
+          type: string
+          format: uuid
+          example: 223e4567-e89b-12d3-a456-426614174999
+        gateway_model_id:
+          description: The text or uuid identifier of the AI Gateway model to link.
+          type: string
+          example: gw-model-abc
+      additionalProperties: false
+      required:
+        - gateway_control_plane_id
+        - gateway_model_id
+    AiModelImplementationList:
+      description: |
+        A paginated page of an AI Model's implementation records.
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            $ref: '#/components/schemas/AiModelImplementation'
+        meta:
+          $ref: '#/components/schemas/PaginatedMeta'
+      required:
+        - data
+        - meta
+    AiModelFilterParameters:
+      description: Filter parameters for the AI Model list endpoint.
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/UuidFieldFilter'
+        name:
+          $ref: '#/components/schemas/StringFieldFilter'
+        display_name:
+          $ref: '#/components/schemas/StringFieldFilter'
+        labels:
+          $ref: '#/components/schemas/LabelsFieldFilter'
+        created_at:
+          $ref: '#/components/schemas/DateTimeFieldFilter'
+        updated_at:
+          $ref: '#/components/schemas/DateTimeFieldFilter'
+      title: AiModelFilterParameters
+    UuidFieldFilter:
+      description: 'Filter using **one** of the following operators: `eq`, `oeq`, `neq`'
+      type: object
+      properties:
+        eq:
+          description: The field exactly matches the provided value.
+          type: string
+          example: '?filter[field_name_here][eq]=foo'
+        oeq:
+          description: The field matches any of the provided values.
+          type: string
+          example: '?filter[field_name_here][oeq]=foo,bar'
+        neq:
+          description: The field does not match the provided value.
+          type: string
+          example: '?filter[field_name_here][neq]=bar'
+      additionalProperties: false
+      x-examples:
+        example-1:
+          oeq: 'some-value,some-other-value'
+          neq: not-this-value
+        example-2:
+          eq: some-value
+    StringFieldFilter:
+      oneOf:
+        - title: Filter by operator
+          description: 'Filter using **one** of the following operators: `eq`, `oeq`, `neq`, `contains`, `ocontains`'
+          x-examples:
+            example-1:
+              contains: some-value
+              ocontains: 'this-value,or-that-value'
+              oeq: 'some-value,some-other-value'
+              neq: not-this-value
+            example-2:
+              eq: some-value
+          properties:
+            eq:
+              description: The field exactly matches the provided value.
+              type: string
+              example: '?filter[field_name_here][eq]=foo'
+            contains:
+              description: The field contains the provided value.
+              type: string
+              example: '?filter[field_name_here][contains]=foo'
+            ocontains:
+              description: The field contains any of the provided values.
+              type: string
+              example: '?filter[field_name_here][ocontains]=foo,bar'
+            oeq:
+              description: The field matches any of the provided values.
+              type: string
+              example: '?filter[field_name_here][oeq]=foo,bar'
+            neq:
+              description: The field does not match the provided value.
+              type: string
+              example: '?filter[field_name_here][neq]=bar'
+          type: object
+          additionalProperties: false
+        - title: Filter by exact string match
+          type: string
+          description: The field exactly matches the provided value.
+          example: '?filter[title]=foo'
+    LabelsFieldFilter:
+      allOf:
+        - title: LabelsFieldFilter
+          description: |
+            Filters on the resource's `labels` field. Filters must use dot-notation to identify
+            the label key that will be used to filter the results. For example:
+              - `filter[labels.owner]`
+              - `filter[labels.owner][neq]=kong`
+              - `filter[labels.env]=dev`
+              - `filter[labels.env][ocontains]=dev,test`
+        - $ref: '#/components/schemas/StringFieldFilter'
+    DateTimeFieldFilter:
+      description: Filters on the given datetime (RFC-3339) field value.
+      oneOf:
+        - type: string
+          title: DateTimeFieldImplicitEqualsFilter
+          format: date-time
+          description: Value strictly equals given RFC-3339 formatted timestamp in UTC
+          example: '2022-03-30T07:20:50Z'
+        - type: object
+          title: DateTimeFieldEqualsFilter
+          additionalProperties: false
+          properties:
+            eq:
+              description: Value strictly equals given RFC-3339 formatted timestamp in UTC
+              type: string
+              format: date-time
+              example: '2022-03-30T07:20:50Z'
+          required:
+            - eq
+        - type: object
+          title: DateTimeFieldLTFilter
+          additionalProperties: false
+          properties:
+            lt:
+              description: Value is less than the given RFC-3339 formatted timestamp in UTC
+              type: string
+              format: date-time
+              example: '2022-03-30T07:20:50Z'
+          required:
+            - lt
+        - type: object
+          title: DateTimeFieldLTEFilter
+          additionalProperties: false
+          properties:
+            lte:
+              description: Value is less than or equal to the given RFC-3339 formatted timestamp in UTC
+              type: string
+              format: date-time
+              example: '2022-03-30T07:20:50Z'
+          required:
+            - lte
+        - type: object
+          title: DateTimeFieldGTFilter
+          additionalProperties: false
+          properties:
+            gt:
+              description: Value is greater than the given RFC-3339 formatted timestamp in UTC
+              type: string
+              format: date-time
+              example: '2022-03-30T07:20:50Z'
+          required:
+            - gt
+        - type: object
+          title: DateTimeFieldGTEFilter
+          additionalProperties: false
+          properties:
+            gte:
+              description: Value is greater than or equal to the given RFC-3339 formatted timestamp in UTC
+              type: string
+              format: date-time
+              example: '2022-03-30T07:20:50Z'
+          required:
+            - gte
+      title: DateTimeFieldFilter
+      x-examples:
+        datetime_field_1: '2022-03-30T07:20:50Z'
+        datetime_field_2:
+          eq: '2022-03-30T07:20:50Z'
+        datetime_field_3:
+          lt: '2022-03-30T07:20:50Z'
+        datetime_field_4:
+          lte: '2022-03-30T07:20:50Z'
+        datetime_field_5:
+          gt: '2022-03-30T07:20:50Z'
+        datetime_field_6:
+          gte: '2022-03-30T07:20:50Z'
+    SortQuery:
+      description: |
+        The `asc` suffix is optional as the default sort order is ascending.
+        The `desc` suffix is used to specify a descending order.
+        Multiple sort attributes may be provided via a comma separated list.
+        JSONPath notation may be used to specify a sub-attribute (eg: 'foo.bar desc').
+      type: string
+      example: created_at desc
+      title: SortQuery
+    Labels:
+      description: |
+        Labels store metadata of an entity that can be used for filtering an entity list or for searching across entity types. 
+
+        Keys must be of length 1-63 characters, and cannot start with "kong", "konnect", "mesh", "kic", or "_".
+      type: object
+      example:
+        env: test
+      additionalProperties:
+        type: string
+        pattern: '^[a-z0-9A-Z]{1}([a-z0-9A-Z-._]*[a-z0-9A-Z]+)?$'
+        minLength: 1
+        maxLength: 63
+      maxProperties: 50
+      title: Labels
+    ManagedBy:
+      description: |
+        Stores information about what manages this entity, such as the tool or system responsible for its lifecycle (for example, `terraform`).
+
+        Keys must be 1–63 characters long and start with an alphanumeric character.
+      type: object
+      example:
+        owner: terraform
+      additionalProperties:
+        type: string
+        pattern: '^[a-z0-9A-Z]{1}([a-z0-9A-Z-._]*[a-z0-9A-Z]+)?$'
+        minLength: 1
+        maxLength: 63
+      maxProperties: 5
+      title: ManagedBy
+    CreatedAt:
+      description: An ISO-8601 timestamp representation of entity creation date.
+      type: string
+      format: date-time
+      example: '2022-11-04T20:10:06.927Z'
+      readOnly: true
+    UpdatedAt:
+      description: An ISO-8601 timestamp representation of entity update date.
+      type: string
+      format: date-time
+      example: '2022-11-04T20:10:06.927Z'
+      readOnly: true
+    PageMeta:
+      description: Contains pagination query parameters and the total number of objects returned.
+      type: object
+      properties:
+        number:
+          type: number
+          example: 1
+        size:
+          type: number
+          example: 10
+        total:
+          type: number
+          example: 100
+      required:
+        - number
+        - size
+        - total
+    PaginatedMeta:
+      description: returns the pagination information
+      type: object
+      properties:
+        page:
+          $ref: '#/components/schemas/PageMeta'
+      required:
+        - page
+      title: PaginatedMeta
+    BaseError:
+      description: standard error
+      type: object
+      properties:
+        status:
+          description: |
+            The HTTP status code of the error. Useful when passing the response
+            body to child properties in a frontend UI. Must be returned as an integer.
+          type: integer
+          readOnly: true
+        title:
+          description: |
+            A short, human-readable summary of the problem. It should not
+            change between occurences of a problem, except for localization.
+            Should be provided as "Sentence case" for direct use in the UI.
+          type: string
+          readOnly: true
+        type:
+          description: The error type.
+          type: string
+          readOnly: true
+        instance:
+          description: |
+            Used to return the correlation ID back to the user, in the format
+            kong:trace:<correlation_id>. This helps us find the relevant logs
+            when a customer reports an issue.
+          type: string
+          readOnly: true
+        detail:
+          description: |
+            A human readable explanation specific to this occurence of the problem.
+            This field may contain request/entity data to help the user understand
+            what went wrong. Enclose variable values in square brackets. Should be
+            provided as "Sentence case" for direct use in the UI.
+          type: string
+          readOnly: true
+      required:
+        - status
+        - title
+        - instance
+        - detail
+      title: Error
+    InvalidRules:
+      description: invalid parameters rules
+      type: string
+      enum:
+        - required
+        - is_array
+        - is_base64
+        - is_boolean
+        - is_date_time
+        - is_integer
+        - is_null
+        - is_number
+        - is_object
+        - is_string
+        - is_uuid
+        - is_fqdn
+        - is_arn
+        - unknown_property
+        - missing_reference
+        - is_label
+        - matches_regex
+        - invalid
+        - is_supported_network_availability_zone_list
+        - is_supported_network_cidr_block
+        - is_supported_provider_region
+        - type
+      nullable: true
+      readOnly: true
+    InvalidParameterStandard:
+      type: object
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          $ref: '#/components/schemas/InvalidRules'
+        source:
+          type: string
+          example: body
+        reason:
+          type: string
+          example: is a required field
+          readOnly: true
+      additionalProperties: false
+      required:
+        - field
+        - reason
+    InvalidParameterMinimumLength:
+      type: object
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          description: invalid parameters rules
+          type: string
+          enum:
+            - min_length
+            - min_digits
+            - min_lowercase
+            - min_uppercase
+            - min_symbols
+            - min_items
+            - min
+          nullable: false
+          readOnly: true
+        minimum:
+          type: integer
+          example: 8
+        source:
+          type: string
+          example: body
+        reason:
+          type: string
+          example: must have at least 8 characters
+          readOnly: true
+      additionalProperties: false
+      required:
+        - field
+        - reason
+        - rule
+        - minimum
+    InvalidParameterMaximumLength:
+      type: object
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          description: invalid parameters rules
+          type: string
+          enum:
+            - max_length
+            - max_items
+            - max
+          nullable: false
+          readOnly: true
+        maximum:
+          type: integer
+          example: 8
+        source:
+          type: string
+          example: body
+        reason:
+          type: string
+          example: must not have more than 8 characters
+          readOnly: true
+      additionalProperties: false
+      required:
+        - field
+        - reason
+        - rule
+        - maximum
+    InvalidParameterChoiceItem:
+      type: object
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          description: invalid parameters rules
+          type: string
+          enum:
+            - enum
+          nullable: false
+          readOnly: true
+        reason:
+          type: string
+          example: is a required field
+          readOnly: true
+        choices:
+          type: array
+          items: {}
+          minItems: 1
+          nullable: false
+          readOnly: true
+          uniqueItems: true
+        source:
+          type: string
+          example: body
+      additionalProperties: false
+      required:
+        - field
+        - reason
+        - rule
+        - choices
+    InvalidParameterDependentItem:
+      type: object
+      properties:
+        field:
+          type: string
+          example: name
+          readOnly: true
+        rule:
+          description: invalid parameters rules
+          type: string
+          enum:
+            - dependent_fields
+          nullable: true
+          readOnly: true
+        reason:
+          type: string
+          example: is a required field
+          readOnly: true
+        dependents:
+          type: array
+          items: {}
+          nullable: true
+          readOnly: true
+          uniqueItems: true
+        source:
+          type: string
+          example: body
+      additionalProperties: false
+      required:
+        - field
+        - rule
+        - reason
+        - dependents
+    InvalidParameters:
+      description: invalid parameters
+      type: array
+      items:
+        oneOf:
+          - $ref: '#/components/schemas/InvalidParameterStandard'
+          - $ref: '#/components/schemas/InvalidParameterMinimumLength'
+          - $ref: '#/components/schemas/InvalidParameterMaximumLength'
+          - $ref: '#/components/schemas/InvalidParameterChoiceItem'
+          - $ref: '#/components/schemas/InvalidParameterDependentItem'
+      minItems: 1
+      nullable: false
+      uniqueItems: true
+    BadRequestError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          required:
+            - invalid_parameters
+          properties:
+            invalid_parameters:
+              $ref: '#/components/schemas/InvalidParameters'
+    UnauthorizedError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 401
+            title:
+              example: Unauthorized
+            type:
+              example: 'https://httpstatuses.com/401'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Invalid credentials
+    ForbiddenError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 403
+            title:
+              example: Forbidden
+            type:
+              example: 'https://httpstatuses.com/403'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Forbidden
+    ConflictError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 409
+            title:
+              example: Conflict
+            type:
+              example: 'https://httpstatuses.com/409'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Conflict
+    NotFoundError:
+      allOf:
+        - $ref: '#/components/schemas/BaseError'
+        - type: object
+          properties:
+            status:
+              example: 404
+            title:
+              example: Not Found
+            type:
+              example: 'https://httpstatuses.com/404'
+            instance:
+              example: 'kong:trace:1234567890'
+            detail:
+              example: Not found
+    LabelsUpdate:
+      description: |
+        Labels store metadata of an entity that can be used for filtering an entity list or for searching across entity types. 
+
+        Labels are intended to store **INTERNAL** metadata.
+
+        Keys must be of length 1-63 characters, and cannot start with "kong", "konnect", "mesh", "kic", or "_".
+      type: object
+      example:
+        env: test
+      additionalProperties:
+        type: string
+        pattern: '^[a-z0-9A-Z]{1}([a-z0-9A-Z-._]*[a-z0-9A-Z]+)?$'
+        minLength: 1
+        maxLength: 63
+        nullable: true
+      maxProperties: 50
+      nullable: true
+      writeOnly: true
+  examples:
+    UnauthorizedExample:
+      value:
+        status: 401
+        title: Unauthorized
+        instance: 'kong:trace:8347343766220159418'
+        detail: Unauthorized
+    ForbiddenExample:
+      value:
+        status: 403
+        title: Forbidden
+        instance: 'kong:trace:2723154947768991354'
+        detail: You do not have permission to perform this action
+    NotFoundExample:
+      value:
+        status: 404
+        title: Not Found
+        instance: 'kong:trace:6816496025408232265'
+        detail: Not Found
+  responses:
+    BadRequest:
+      description: Bad Request
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/BadRequestError'
+    Unauthorized:
+      description: Unauthorized
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/UnauthorizedError'
+          examples:
+            UnauthorizedExample:
+              $ref: '#/components/examples/UnauthorizedExample'
+    Forbidden:
+      description: Forbidden
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ForbiddenError'
+          examples:
+            UnauthorizedExample:
+              $ref: '#/components/examples/ForbiddenExample'
+    Conflict:
+      description: Conflict
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/ConflictError'
+    NotFound:
+      description: Not Found
+      content:
+        application/problem+json:
+          schema:
+            $ref: '#/components/schemas/NotFoundError'
+          examples:
+            NotFoundExample:
+              $ref: '#/components/examples/NotFoundExample'
+  securitySchemes:
+    konnectAccessToken:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+      description: |
+        The Konnect access token is meant to be used by the Konnect dashboard and the decK CLI authenticate with.
+    personalAccessToken:
+      type: http
+      scheme: bearer
+      bearerFormat: Token
+      description: |
+        The personal access token is meant to be used as an alternative to basic-auth when accessing Konnect via APIs.
+        You can generate a Personal Access Token (PAT) from the [personal access token page](https://cloud.konghq.com/global/account/tokens/) in the Konnect dashboard.
+        The PAT token must be passed in the header of a request, for example:
+        `curl -X GET 'https://global.api.konghq.com/v2/users/' --header 'Authorization: Bearer kpat_xgfT...'`
+    systemAccountAccessToken:
+      type: http
+      scheme: bearer
+      bearerFormat: Token
+      description: |
+        The system account access token is meant for automations and integrations that are not directly associated with a human identity.
+        You can generate a system account Access Token by creating a system account and then obtaining a system account access token for that account.
+        The access token must be passed in the header of a request, for example:
+        `curl -X GET 'https://global.api.konghq.com/v2/users/' --header 'Authorization: Bearer spat_i2Ej...'`
+tags:
+  - name: Catalog AI Models
+    description: Manage AI Models - a catalogable proxy for AI Gateway models
+  - name: Catalog AI Model Versions
+    description: Manage an AI Model's version.
+  - name: Catalog AI Model Specs
+    description: Manage an AI Model version's oas specification.
+  - name: Catalog AI Model Implementations
+    description: Link an AI Model to an AI Gateway model.
+security:
+  - konnectAccessToken: []
+  - personalAccessToken: []
+  - systemAccountAccessToken: []

--- a/app/_api/konnect/ai-builder/_index.md
+++ b/app/_api/konnect/ai-builder/_index.md
@@ -1,0 +1,3 @@
+---
+konnect_product_id: be747e64-83cd-4b4c-b0bf-8ddb0a89528e
+---

--- a/app/_data/konnect_oas_data.json
+++ b/app/_data/konnect_oas_data.json
@@ -354,6 +354,27 @@
     ]
   },
   {
+    "id": "be747e64-83cd-4b4c-b0bf-8ddb0a89528e",
+    "title": "Konnect AI Catalog",
+    "latestVersion": {
+      "name": "1.10.2",
+      "id": "f79cb260-fb92-456a-b927-c8b6d8eee834"
+    },
+    "description": "Konnect AI Catalog is the API for creating and managing AI interfaces in the Konnect Catalog.",
+    "documentCount": 0,
+    "versionCount": 1,
+    "versions": [
+      {
+        "id": "f79cb260-fb92-456a-b927-c8b6d8eee834",
+        "created_at": "2026-08-31T20:50:42.170Z",
+        "updated_at": "2026-08-31T20:52:50.044Z",
+        "name": "1.10.2",
+        "deprecated": false,
+        "registration_configs": []
+      }
+    ]
+  },
+  {
     "id": "5e0005b9-232b-4808-8bdf-9560d4596080",
     "title": "Konnect AI Gateway",
     "latestVersion": {

--- a/app/_how-tos/catalog/connect-azure-devops-to-the-konnect-catalog-with-the-konnect-api.md
+++ b/app/_how-tos/catalog/connect-azure-devops-to-the-konnect-catalog-with-the-konnect-api.md
@@ -1,8 +1,8 @@
 ---
-title: Connect Azure DevOps repositories to Catalog with the {{site.konnect_short_name}} API
+title: Connect Azure DevOps repositories to {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} API
 permalink: /how-to/connect-azure-devops-to-the-konnect-catalog-with-the-konnect-api/
 content_type: how_to
-description: Learn how to connect Azure DevOps repositories to your {{site.konnect_catalog}} services in {{site.konnect_short_name}} using the Konnect API.
+description: Learn how to connect Azure DevOps repositories to your {{site.konnect_catalog}} Classic services in {{site.konnect_short_name}} using the Konnect API.
 products:
   - catalog
 works_on:
@@ -17,8 +17,8 @@ search_aliases:
   - devops
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: Azure DevOps reference
@@ -48,6 +48,8 @@ prereqs:
            export AZUREDEVOPS_PAT='YOUR-AZURE-DEV-OPS-PERSONAL-ACCESS-TOKEN'
            ```
 ---
+
+{% include_cached catalog/catalog-classic-banner.md %}
 
 ## Configure the Azure DevOps integration
 
@@ -97,7 +99,7 @@ body:
 
 Once authorized, resources from your Azure DevOps account are discoverable in the UI.
 
-## Create a Service in Catalog
+## Create a Service in {{site.konnect_catalog}} Classic
 
 Create a service to map to your Azure DevOps resources:
 
@@ -120,7 +122,7 @@ capture:
 
 ## List Azure DevOps resources
 
-Before you map Azure DevOps resources to a service in Catalog, locate the resources that {{site.konnect_short_name}} ingests from Azure DevOps:
+Before you map Azure DevOps resources to a service in {{site.konnect_catalog}} Classic, locate the resources that {{site.konnect_short_name}} ingests from Azure DevOps:
 
 <!--vale off-->
 {% konnect_api_request %}

--- a/app/_how-tos/catalog/connect-azure-devops-to-the-konnect-catalog-with-the-konnect-ui.md
+++ b/app/_how-tos/catalog/connect-azure-devops-to-the-konnect-catalog-with-the-konnect-ui.md
@@ -1,8 +1,8 @@
 ---
-title: Connect Azure DevOps repositories to Catalog with the {{site.konnect_short_name}} UI
+title: Connect Azure DevOps repositories to {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} UI
 permalink: /how-to/connect-azure-devops-to-the-konnect-catalog-with-the-konnect-ui/
 content_type: how_to
-description: Learn how to connect Azure DevOps repositories to your {{site.konnect_catalog}} services in {{site.konnect_short_name}} using the UI.
+description: Learn how to connect Azure DevOps repositories to your {{site.konnect_catalog}} Classic services in {{site.konnect_short_name}} using the UI.
 products:
   - catalog
 works_on:
@@ -14,8 +14,8 @@ search_aliases:
   - azure repos
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: Azure DevOps reference
@@ -26,7 +26,7 @@ related_resources:
 automated_tests: false
 tldr:
   q: How do I connect an Azure DevOps repository to a service in {{site.konnect_short_name}}?
-  a: Configure the Azure DevOps integration with your organization name and PAT, create a {{site.konnect_catalog}} service, then map the discovered Azure DevOps repository resource to that {{site.konnect_catalog}} service.
+  a: Configure the Azure DevOps integration with your organization name and PAT, create a {{site.konnect_catalog}} Classic service, then map the discovered Azure DevOps repository resource to that {{site.konnect_catalog}} Classic service.
 prereqs:
   skip_product: true
   inline:
@@ -43,9 +43,11 @@ prereqs:
         > Your PAT can be created with an expiration period of your choice, up to a maximum of one year. Make sure to renew the PAT before it expires to avoid interruptions.
 ---
 
+{% include_cached catalog/catalog-classic-banner.md %}
+
 ## Configure the Azure DevOps integration
 
-Before you can discover Azure DevOps repositories in {{site.konnect_catalog}}, you must configure the integration:
+Before you can discover Azure DevOps repositories in {{site.konnect_catalog}} Classic, you must configure the integration:
 
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
 1. In the {{site.konnect_catalog}} sidebar, click **Integrations**.
@@ -60,9 +62,9 @@ Before you can discover Azure DevOps repositories in {{site.konnect_catalog}}, y
 
 If you don't immediately see resources, try manually syncing your Azure DevOps integration. From the {{site.konnect_short_name}} UI, navigate to the Azure DevOps integration that you just installed. Then, from the  **Actions** dropdown menu, select **Sync Now**.
 
-## Create a {{site.konnect_catalog}} service and map the Azure DevOps resources
+## Create a {{site.konnect_catalog}} Classic service and map the Azure DevOps resources
 
-After you configure the Azure DevOps integration, create a service in {{site.konnect_catalog}} and map an Azure DevOps repository resource to it.
+After you configure the Azure DevOps integration, create a service in {{site.konnect_catalog}} Classic and map an Azure DevOps repository resource to it.
 
 {:.info}
 > In this tutorial, we’ll refer to your Azure DevOps repository as `azure-devops-repository`.

--- a/app/_how-tos/catalog/discover-and-govern-apis-with-service-catalog.md
+++ b/app/_how-tos/catalog/discover-and-govern-apis-with-service-catalog.md
@@ -1,8 +1,8 @@
 ---
-title: Discover and govern APIs with Catalog
+title: Discover and govern APIs with {{site.konnect_catalog}} Classic
 permalink: /how-to/discover-and-govern-apis-with-service-catalog/
 content_type: how_to
-description: Learn how to discover APIs in AWS API Gateway, SwaggerHub, and GitHub with {{site.konnect_catalog}} and govern them with scorecards.
+description: Learn how to discover APIs in AWS API Gateway, SwaggerHub, and GitHub with {{site.konnect_catalog}} Classic and govern them with scorecards.
 products:
   - catalog
 works_on:
@@ -15,8 +15,8 @@ entities:
 search_aliases:
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: AWS API Gateway reference
@@ -27,12 +27,12 @@ automated_tests: false
 tldr:
   q: How do I discover and govern third-party APIs in {{site.konnect_short_name}}?
   a: |
-    {{site.konnect_catalog}} allows you to find and centrally view all APIs from these integrations and map them to a {{site.konnect_catalog}} service. First, authorize the integrations in {{site.konnect_catalog}} for AWS API Gateway, GitHub, and SwaggerHub. Then, create a {{site.konnect_catalog}} service and map resources from the integrations to the service. Finally, add a service documentation scorecard to your service to govern API documentation standards.
+    {{site.konnect_catalog}} Classic allows you to find and centrally view all APIs from these integrations and map them to a {{site.konnect_catalog}} Classic service. First, authorize the integrations in {{site.konnect_catalog}} Classic for AWS API Gateway, GitHub, and SwaggerHub. Then, create a {{site.konnect_catalog}} Classic service and map resources from the integrations to the service. Finally, add a service documentation scorecard to your service to govern API documentation standards.
 prereqs:
   inline:
     - title: "{{site.konnect_short_name}} roles"
       content: |
-        To configure {{site.konnect_catalog}} integrations, services, and scorecards, you need the following [roles in {{site.konnect_short_name}}](/konnect-platform/teams-and-roles/#service-catalog):
+        To configure {{site.konnect_catalog}} Classic integrations, services, and scorecards, you need the following [roles in {{site.konnect_short_name}}](/konnect-platform/teams-and-roles/#service-catalog):
         * Integration Admin
         * Scorecard Admin
         * Service Admin
@@ -47,7 +47,7 @@ prereqs:
       icon_url: /assets/icons/third-party/swaggerhub.svg
     - title: GitHub
       content: |
-        To integrate GitHub with {{site.konnect_catalog}}, you need the following:
+        To integrate GitHub with {{site.konnect_catalog}} Classic, you need the following:
         * Sufficient permissions in GitHub to authorize third-party applications and install the {{site.konnect_short_name}} GitHub App
         * A GitHub organization
         * A repository that you want to pull in to {{site.konnect_short_name}}. You can grant access to either all repositories or selected repositories during the authorization process. You can name your GitHub repository whatever you'd like. In this tutorial, we'll refer to your GitHub repository as `github-repo`.
@@ -58,11 +58,13 @@ tools:
   - deck
 ---
 
+{% include_cached catalog/catalog-classic-banner.md %}
+
 ## Configure the AWS API Gateway, GitHub, and SwaggerHub integrations
 
-In this tutorial, we'll be discovering APIs and API specs from AWS API Gateway, GitHub, and SwaggerHub in {{site.konnect_catalog}}. {{site.konnect_catalog}} allows you to find and centrally view all APIs from these integrations and map them to a {{site.konnect_catalog}} service. 
+In this tutorial, we'll be discovering APIs and API specs from AWS API Gateway, GitHub, and SwaggerHub in {{site.konnect_catalog}} Classic. {{site.konnect_catalog}} Classic allows you to find and centrally view all APIs from these integrations and map them to a {{site.konnect_catalog}} Classic service. 
 
-Before you can discover APIs in {{site.konnect_catalog}}, you must configure the third-party integrations.
+Before you can discover APIs in {{site.konnect_catalog}} Classic, you must configure the third-party integrations.
 
 ### Configure the AWS API Gateway integration
 
@@ -91,9 +93,9 @@ The {{site.konnect_short_name}} application can be managed from GitHub as a [Git
 1. In the **Instance name** field, enter `swaggerhub-test`.
 1. Click **Save**. 
 
-## Create a {{site.konnect_catalog}} service and map the API resources
+## Create a {{site.konnect_catalog}} Classic service and map the API resources
 
-Now that your integrations are configured, you can create a {{site.konnect_catalog}} service to map the ingested APIs.
+Now that your integrations are configured, you can create a {{site.konnect_catalog}} Classic service to map the ingested APIs.
 
 {:.info}
 > In this tutorial, we'll refer to your ingested resources like the following:
@@ -113,11 +115,11 @@ Now that your integrations are configured, you can create a {{site.konnect_catal
 1. Select `github-repo`. 
 1. Click **Map 3 Resources**.
 
-Your integration APIs are now discoverable from one {{site.konnect_catalog}} service.
+Your integration APIs are now discoverable from one {{site.konnect_catalog}} Classic service.
 
 ## Govern the APIs with scorecards
 
-Now that you've discovered and mapped the APIs to a {{site.konnect_catalog}} service, you can govern the service documentation of these ingested APIs with a [scorecard](/catalog/scorecards/). The built-in service documentation scorecard will alert you when your APIs don't adhere to [API documentation best practices](/catalog/scorecards/#service-documentation-linting).
+Now that you've discovered and mapped the APIs to a {{site.konnect_catalog}} Classic service, you can govern the service documentation of these ingested APIs with a [scorecard](/catalog/scorecards/). The built-in service documentation scorecard will alert you when your APIs don't adhere to [API documentation best practices](/catalog/scorecards/#service-documentation-linting).
 
 1. In the {{site.konnect_short_name}} sidebar, click [**Catalog**](https://cloud.konghq.com/service-catalog/).
 1. In the Catalog sidebar, click **Scorecards**.

--- a/app/_how-tos/catalog/discover-and-govern-apis-with-service-catalog.md
+++ b/app/_how-tos/catalog/discover-and-govern-apis-with-service-catalog.md
@@ -73,7 +73,7 @@ Before you can discover APIs in {{site.konnect_catalog}} Classic, you must confi
 ### Configure the GitHub integration
 
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. In the Catalog sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**.
+1. In the Catalog sidebar, click **Integrations**.
 2. Click **GitHub**.
 1. Click **Add GitHub Instance**.
 1. Click **Authorize in GitHub**. This will take you to GitHub, where you can grant {{site.konnect_short_name}} access to either **All Repositories** or **Select repositories**. 
@@ -86,7 +86,7 @@ The {{site.konnect_short_name}} application can be managed from GitHub as a [Git
 ### Configure the SwaggerHub integration
 
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. In the Catalog sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**.
+1. In the Catalog sidebar, click **Integrations**.
 2. Click **Add SwaggerHub Instance**.
 1. In the **SwaggerHub API Key** field, enter your SwaggerHub API key. For example: `04403e83-1a66-4366-9f08-7cecaba73e20`.
 1. In the **Display name** field, enter `SwaggerHub-test`.
@@ -103,7 +103,7 @@ Now that your integrations are configured, you can create a {{site.konnect_catal
 * GitHub repository: `github-repo`
 * SwaggerHub API version: `swaggerhub-api`
 
-1. In the {{site.konnect_short_name}} sidebar, click [**Catalog**](https://cloud.konghq.com/service-catalog/).
+1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
 1. In the Catalog sidebar, click **Services**.
 1. Click **New service**.
 1. In the **Display Name** field, enter `APIs`.
@@ -121,7 +121,7 @@ Your integration APIs are now discoverable from one {{site.konnect_catalog}} Cla
 
 Now that you've discovered and mapped the APIs to a {{site.konnect_catalog}} Classic service, you can govern the service documentation of these ingested APIs with a [scorecard](/catalog/scorecards/). The built-in service documentation scorecard will alert you when your APIs don't adhere to [API documentation best practices](/catalog/scorecards/#service-documentation-linting).
 
-1. In the {{site.konnect_short_name}} sidebar, click [**Catalog**](https://cloud.konghq.com/service-catalog/).
+1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
 1. In the Catalog sidebar, click **Scorecards**.
 1. Click **New scorecard**.
 1. From the **Scorecard template** dropdown menu, select "Service Documentation".

--- a/app/_how-tos/catalog/discover-aws-gateway-apis-using-konnect-api.md
+++ b/app/_how-tos/catalog/discover-aws-gateway-apis-using-konnect-api.md
@@ -1,8 +1,8 @@
 ---
-title: Discover AWS Gateway APIs in Catalog with the Konnect API
+title: Discover AWS Gateway APIs in {{site.konnect_catalog}} Classic with the Konnect API
 permalink: /how-to/discover-aws-gateway-apis-using-konnect-api/
 content_type: how_to
-description: Learn how to connect an AWS Gateway API to your {{site.konnect_catalog}} service in {{site.konnect_short_name}} using the API.
+description: Learn how to connect an AWS Gateway API to your {{site.konnect_catalog}} Classic service in {{site.konnect_short_name}} using the API.
 products:
   - catalog
 works_on:
@@ -15,20 +15,20 @@ tags:
 search_aliases:
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: AWS API Gateway reference
     url: /catalog/integrations/aws-api-gateway/
-  - text: "Discover AWS Gateway APIs in {{site.konnect_catalog}} with the {{site.konnect_short_name}} UI"
+  - text: "Discover AWS Gateway APIs in {{site.konnect_catalog}} Classic with the Konnect UI"
     url: /how-to/discover-aws-gateway-apis-using-konnect-ui/
   - text: Discover and govern APIs with {{site.konnect_catalog}}
     url: /how-to/discover-and-govern-apis-with-service-catalog/
 automated_tests: false
 tldr:
   q: How do I discover AWS API Gateway API in {{site.konnect_short_name}}?
-  a: Install the AWS API Gateway integration in {{site.konnect_short_name}} and authorize access with your {{site.konnect_catalog}} role ARN, then link an API to your {{site.konnect_catalog}} service.
+  a: Install the AWS API Gateway integration in {{site.konnect_short_name}} and authorize access with your {{site.konnect_catalog}} Classic role ARN, then link an API to your {{site.konnect_catalog}} Classic service.
 prereqs:
   inline:
     - title: "{{site.konnect_short_name}} roles"
@@ -39,13 +39,15 @@ prereqs:
       icon_url: /assets/icons/aws.svg
 ---
 
+{% include_cached catalog/catalog-classic-banner.md %}
+
 ## Configure the AWS API Gateway integration
 
-Before you can discover APIs in {{site.konnect_catalog}}, you must configure the AWS API Gateway integration.
+Before you can discover APIs in {{site.konnect_catalog}} Classic, you must configure the AWS API Gateway integration.
 
 {% include /catalog/aws-api-gateway-integration.md %}
 
-## Create a service in {{site.konnect_catalog}}
+## Create a service in {{site.konnect_catalog}} Classic
 
 Create a service that you'll map to your AWS API Gateway resources:
 
@@ -69,7 +71,7 @@ export AWS_SERVICE_ID='YOUR-SERVICE-ID'
 
 ## List AWS API Gateway resources
 
-Before you can map your AWS API Gateway resources to a service in {{site.konnect_catalog}}, you first need to find the resources that are pulled in from AWS API Gateway:
+Before you can map your AWS API Gateway resources to a service in {{site.konnect_catalog}} Classic, you first need to find the resources that are pulled in from AWS API Gateway:
 
 <!--vale off-->
 {% konnect_api_request %}

--- a/app/_how-tos/catalog/discover-aws-gateway-apis-using-konnect-ui.md
+++ b/app/_how-tos/catalog/discover-aws-gateway-apis-using-konnect-ui.md
@@ -1,8 +1,8 @@
 ---
-title: Discover AWS Gateway APIs in Catalog with the Konnect UI
+title: Discover AWS Gateway APIs in {{site.konnect_catalog}} Classic with the Konnect UI
 permalink: /how-to/discover-aws-gateway-apis-using-konnect-ui/
 content_type: how_to
-description: Learn how to connect an AWS Gateway API to your {{site.konnect_catalog}} service in {{site.konnect_short_name}} using the UI.
+description: Learn how to connect an AWS Gateway API to your {{site.konnect_catalog}} Classic service in {{site.konnect_short_name}} using the UI.
 products:
   - catalog
 works_on:
@@ -15,20 +15,20 @@ tags:
 search_aliases:
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: AWS API Gateway reference
     url: /catalog/integrations/aws-api-gateway/
-  - text: "Discover AWS Gateway APIs in {{site.konnect_catalog}} with the {{site.konnect_short_name}} API"
+  - text: "Discover AWS Gateway APIs in {{site.konnect_catalog}} Classic with the Konnect API"
     url: /how-to/discover-aws-gateway-apis-using-konnect-api/
   - text: Discover and govern APIs with {{site.konnect_catalog}}
     url: /how-to/discover-and-govern-apis-with-service-catalog/
 automated_tests: false
 tldr:
   q: How do I discover AWS API Gateway API in {{site.konnect_short_name}}?
-  a: Install the AWS API Gateway integration in {{site.konnect_short_name}} and authorize access with your {{site.konnect_catalog}} role ARN, then link an API to your {{site.konnect_catalog}} service.
+  a: Install the AWS API Gateway integration in {{site.konnect_short_name}} and authorize access with your {{site.konnect_catalog}} Classic role ARN, then link an API to your {{site.konnect_catalog}} Classic service.
 prereqs:
   inline:
     - title: "{{site.konnect_short_name}} roles"
@@ -39,15 +39,17 @@ prereqs:
       icon_url: /assets/icons/aws.svg
 ---
 
+{% include_cached catalog/catalog-classic-banner.md %}
+
 ## Configure the AWS API Gateway integration
 
-Before you can discover APIs in {{site.konnect_catalog}}, you must configure the AWS API Gateway integration.
+Before you can discover APIs in {{site.konnect_catalog}} Classic, you must configure the AWS API Gateway integration.
 
 {% include /catalog/aws-api-gateway-integration.md %}
 
-## Create a {{site.konnect_catalog}} service and map the API resources
+## Create a {{site.konnect_catalog}} Classic service and map the API resources
 
-Now that your integration is configured, you can create a {{site.konnect_catalog}} service to map the ingested APIs.
+Now that your integration is configured, you can create a {{site.konnect_catalog}} Classic service to map the ingested APIs.
 
 {:.info}
 > In this tutorial, we'll refer to your ingested AWS API Gateway API as `aws-api`.
@@ -62,7 +64,7 @@ Now that your integration is configured, you can create a {{site.konnect_catalog
 1. Select `aws-api`. 
 1. Click **Map 1 Resource**.
 
-Your integration APIs are now discoverable from one {{site.konnect_catalog}} service.
+Your integration APIs are now discoverable from one {{site.konnect_catalog}} Classic service.
 
 {:.info}
 > You might need to manually sync your AWS API Gateway integration for resources to appear. In the {{site.konnect_short_name}} UI, by navigate to the AWS API Gateway integration you just installed and select **Sync Now** from the **Actions** dropdown menu.

--- a/app/_how-tos/catalog/discover-aws-gateway-apis-using-konnect-ui.md
+++ b/app/_how-tos/catalog/discover-aws-gateway-apis-using-konnect-ui.md
@@ -54,7 +54,7 @@ Now that your integration is configured, you can create a {{site.konnect_catalog
 {:.info}
 > In this tutorial, we'll refer to your ingested AWS API Gateway API as `aws-api`.
 
-1. In the {{site.konnect_short_name}} sidebar, click [**{{site.konnect_catalog}}**](https://cloud.konghq.com/service-catalog/).
+1. In the {{site.konnect_short_name}} sidebar, click **{{site.konnect_catalog}}**.
 1. In the Catalog sidebar, click **Services**.
 1. Click **New service**.
 1. In the **Display Name** field, enter `APIs`.
@@ -73,7 +73,7 @@ Your integration APIs are now discoverable from one {{site.konnect_catalog}} Cla
 
 To confirm that the AWS API Gateway resource is now mapped to the intended service, navigate to the service:
 
-1. In the {{site.konnect_short_name}} sidebar, click [**{{site.konnect_catalog}}**](https://cloud.konghq.com/service-catalog/).
+1. In the {{site.konnect_short_name}} sidebar, click **{{site.konnect_catalog}}**.
 1. In the {{site.konnect_catalog}} sidebar, click **Services**.
 1. Click the **APIs** service.
 1. Click the **Resources** tab.

--- a/app/_how-tos/catalog/discover-azure-apis-with-konnect-api.md
+++ b/app/_how-tos/catalog/discover-azure-apis-with-konnect-api.md
@@ -49,7 +49,7 @@ prereqs:
 Before you can discover APIs in {{site.konnect_catalog}} Classic, you must configure the Azure API Management integration.
 
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. In the Catalog sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
+1. In the Catalog sidebar, click **Integrations**. 
 1. Click **Azure API Management**.
 1. Click **Add Azure API Management instance**.
 1. In the **Subscription ID** field, enter your Azure API subscription ID.

--- a/app/_how-tos/catalog/discover-azure-apis-with-konnect-api.md
+++ b/app/_how-tos/catalog/discover-azure-apis-with-konnect-api.md
@@ -1,8 +1,8 @@
 ---
-title: "Discover Azure API Management APIs in Catalog with the {{site.konnect_short_name}} API"
+title: "Discover Azure API Management APIs in {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} API"
 permalink: /how-to/discover-azure-apis-with-konnect-api/
 content_type: how_to
-description: Learn how to connect an Azure API Management API to your {{site.konnect_catalog}} service in {{site.konnect_short_name}} using the API.
+description: Learn how to connect an Azure API Management API to your {{site.konnect_catalog}} Classic service in {{site.konnect_short_name}} using the API.
 products:
   - catalog
 works_on:
@@ -15,18 +15,18 @@ tags:
 search_aliases:
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: Azure API Management reference
     url: /catalog/integrations/azure-api-management/
-  - text: "Discover Azure API Management APIs with the {{site.konnect_short_name}} UI"
+  - text: "Discover Azure API Management APIs in {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} UI"
     url: /how-to/discover-azure-apis-with-konnect-ui/
 automated_tests: false
 tldr:
   q: How do I discover Azure API Management APIs in {{site.konnect_short_name}}?
-  a: Install the Azure API Management integration in {{site.konnect_short_name}} and authorize access with OAuth, then link an Azure API to your {{site.konnect_catalog}} service.
+  a: Install the Azure API Management integration in {{site.konnect_short_name}} and authorize access with OAuth, then link an Azure API to your {{site.konnect_catalog}} Classic service.
 prereqs:
   inline:
     - title: "{{site.konnect_short_name}} roles"
@@ -39,12 +39,14 @@ prereqs:
       icon_url: /assets/icons/azure.svg
 ---
 
+{% include_cached catalog/catalog-classic-banner.md %}
+
 ## Configure the Azure API Management integration
 
 {:.info}
 > **Note:** The Azure API Management integration uses OAuth for authentication and can only be configured through the {{site.konnect_short_name}} UI.
 
-Before you can discover APIs in {{site.konnect_catalog}}, you must configure the Azure API Management integration.
+Before you can discover APIs in {{site.konnect_catalog}} Classic, you must configure the Azure API Management integration.
 
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
 1. In the Catalog sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
@@ -59,7 +61,7 @@ Before you can discover APIs in {{site.konnect_catalog}}, you must configure the
 1. In the **Instance name** field, enter `azure-api-management-test`.
 1. Click **Save**. 
 
-## Create a service in {{site.konnect_catalog}}
+## Create a service in {{site.konnect_catalog}} Classic
 
 Create a service that you'll map to your Azure API Management resources:
 
@@ -82,7 +84,7 @@ export AZURE_SERVICE_ID='YOUR-SERVICE-ID'
 
 ## List Azure API Management resources
 
-Before you can map your Azure API Management resources to a service in {{site.konnect_catalog}}, you first need to find the resources that are pulled in from Azure API Management:
+Before you can map your Azure API Management resources to a service in {{site.konnect_catalog}} Classic, you first need to find the resources that are pulled in from Azure API Management:
 
 <!--vale off-->
 {% konnect_api_request %}

--- a/app/_how-tos/catalog/discover-azure-apis-with-konnect-ui.md
+++ b/app/_how-tos/catalog/discover-azure-apis-with-konnect-ui.md
@@ -1,8 +1,8 @@
 ---
-title: "Discover Azure API Management APIs in Catalog with the {{site.konnect_short_name}} UI"
+title: "Discover Azure API Management APIs in {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} UI"
 permalink: /how-to/discover-azure-apis-with-konnect-ui/
 content_type: how_to
-description: Learn how to connect an Azure API Management API to your {{site.konnect_catalog}} service in {{site.konnect_short_name}} using the UI.
+description: Learn how to connect an Azure API Management API to your {{site.konnect_catalog}} Classic service in {{site.konnect_short_name}} using the UI.
 products:
   - catalog
 works_on:
@@ -13,18 +13,18 @@ tags:
 search_aliases:
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: Azure API Management reference
     url: /catalog/integrations/azure-api-management/
-  - text: "Discover Azure API Management APIs in {{site.konnect_catalog}} with the {{site.konnect_short_name}} API"
+  - text: "Discover Azure API Management APIs in {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} API"
     url: /how-to/discover-azure-apis-with-konnect-api/
 automated_tests: false
 tldr:
   q: How do I discover Azure API Management APIs in {{site.konnect_short_name}}?
-  a: Install the Azure API Management integration in {{site.konnect_short_name}} and authorize access with OAuth, then link an Azure API to your {{site.konnect_catalog}} service.
+  a: Install the Azure API Management integration in {{site.konnect_short_name}} and authorize access with OAuth, then link an Azure API to your {{site.konnect_catalog}} Classic service.
 prereqs:
   inline:
     - title: "{{site.konnect_short_name}} roles"
@@ -37,12 +37,14 @@ prereqs:
       icon_url: /assets/icons/azure.svg
 ---
 
+{% include_cached catalog/catalog-classic-banner.md %}
+
 ## Configure the Azure API Management integration
 
 {:.info}
 > **Note:** The Azure API Management integration uses OAuth for authentication and can only be configured through the {{site.konnect_short_name}} UI.
 
-Before you can discover APIs in {{site.konnect_catalog}}, you must configure the Azure API Management integration.
+Before you can discover APIs in {{site.konnect_catalog}} Classic, you must configure the Azure API Management integration.
 
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
 1. In the Catalog sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
@@ -57,9 +59,9 @@ Before you can discover APIs in {{site.konnect_catalog}}, you must configure the
 1. In the **Instance name** field, enter `azure-api-management-test`.
 1. Click **Save**. 
 
-## Create a {{site.konnect_catalog}} service and map the API resources
+## Create a {{site.konnect_catalog}} Classic service and map the API resources
 
-Now that your integration is configured, you can create a {{site.konnect_catalog}} service to map the ingested APIs.
+Now that your integration is configured, you can create a {{site.konnect_catalog}} Classic service to map the ingested APIs.
 
 {:.info}
 > In this tutorial, we'll refer to your ingested Azure API Management API as `billing-api`.
@@ -73,7 +75,7 @@ Now that your integration is configured, you can create a {{site.konnect_catalog
 1. Select `billing-api`. 
 1. Click **Map 1 Resource**.
 
-Your integration APIs are now discoverable from one {{site.konnect_catalog}} service.
+Your integration APIs are now discoverable from one {{site.konnect_catalog}} Classic service.
 
 {:.info}
 > You might need to manually sync your Azure API Management integration for resources to appear. In the {{site.konnect_short_name}} UI, by navigate to the Azure API Management integration you just installed and select **Sync Now** from the **Actions** dropdown menu.

--- a/app/_how-tos/catalog/discover-azure-apis-with-konnect-ui.md
+++ b/app/_how-tos/catalog/discover-azure-apis-with-konnect-ui.md
@@ -47,7 +47,7 @@ prereqs:
 Before you can discover APIs in {{site.konnect_catalog}} Classic, you must configure the Azure API Management integration.
 
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. In the Catalog sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
+1. In the Catalog sidebar, click **Integrations**. 
 1. Click **Azure API Management**.
 1. Click **Add Azure API Management instance**.
 1. In the **Subscription ID** field, enter your Azure API subscription ID.
@@ -66,7 +66,7 @@ Now that your integration is configured, you can create a {{site.konnect_catalog
 {:.info}
 > In this tutorial, we'll refer to your ingested Azure API Management API as `billing-api`.
 
-1. In the {{site.konnect_short_name}} sidebar, click [**{{site.konnect_catalog}}**](https://cloud.konghq.com/service-catalog/).
+1. In the {{site.konnect_short_name}} sidebar, click **{{site.konnect_catalog}}**.
 1. In the Catalog sidebar, click **Services**.
 1. Click **New service**.
 1. In the **Display Name** field, enter `Billing Service`.
@@ -84,7 +84,7 @@ Your integration APIs are now discoverable from one {{site.konnect_catalog}} Cla
 
 To confirm that the Azure API Management resource is now mapped to the intended service, navigate to the service:
 
-1. In the {{site.konnect_short_name}} sidebar, click [**{{site.konnect_catalog}}**](https://cloud.konghq.com/service-catalog/).
+1. In the {{site.konnect_short_name}} sidebar, click **{{site.konnect_catalog}}**.
 1. In the {{site.konnect_catalog}} sidebar, click **Services**.
 1. Click the **Billing Service** service.
 1. Click the **Resources** tab.

--- a/app/_how-tos/catalog/install-and-map-datadog-resources.md
+++ b/app/_how-tos/catalog/install-and-map-datadog-resources.md
@@ -1,8 +1,8 @@
 ---
-title: Install and map Datadog resources in Catalog
+title: Install and map Datadog resources in {{site.konnect_catalog}} Classic
 permalink: /how-to/install-and-map-datadog-resources/
 content_type: how_to
-description: Learn how to connect Datadog monitors and dashboards to your {{site.konnect_catalog}} service in {{site.konnect_short_name}}.
+description: Learn how to connect Datadog monitors and dashboards to your {{site.konnect_catalog}} Classic service in {{site.konnect_short_name}}.
 products:
   - catalog
 works_on:
@@ -13,15 +13,15 @@ automated_tests: false
 search_aliases:
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: Datadog reference
     url: /catalog/integrations/datadog/
 tldr:
-  q: How do I view Datadog monitors and dashboards in {{site.konnect_catalog}}?
-  a: Install the Datadog integration in {{site.konnect_short_name}} and authorize it using your API and app keys. Create a {{site.konnect_catalog}} service and associate it with your Datadog resources to display metadata and enable event tracking.
+  q: How do I view Datadog monitors and dashboards in {{site.konnect_catalog}} Classic?
+  a: Install the Datadog integration in {{site.konnect_short_name}} and authorize it using your API and app keys. Create a {{site.konnect_catalog}} Classic service and associate it with your Datadog resources to display metadata and enable event tracking.
 prereqs:
   inline:
     - title: "{{site.konnect_short_name}} roles"
@@ -49,6 +49,8 @@ prereqs:
         ```
       icon_url: /assets/icons/datadog.svg
 ---
+
+{% include_cached catalog/catalog-classic-banner.md %}
 
 ## Install and authorize the Datadog integration
 
@@ -99,7 +101,7 @@ body:
 
 Once authorized, monitor and dashboard resources from your Datadog account will be discoverable in the UI.
 
-## Create a service in {{site.konnect_catalog}}
+## Create a service in {{site.konnect_catalog}} Classic
 
 Create a service that you'll map to your Datadog resources:
 
@@ -123,7 +125,7 @@ export DATADOG_SERVICE_ID='YOUR-SERVICE-ID'
 
 ## List Datadog resources
 
-Before you can map your Datadog resources to a service in {{site.konnect_catalog}}, you first need to find the resources that are pulled in from Datadog:
+Before you can map your Datadog resources to a service in {{site.konnect_catalog}} Classic, you first need to find the resources that are pulled in from Datadog:
 
 <!--vale off-->
 {% konnect_api_request %}

--- a/app/_how-tos/catalog/install-and-map-github-resources.md
+++ b/app/_how-tos/catalog/install-and-map-github-resources.md
@@ -1,8 +1,8 @@
 ---
-title: Install and map GitHub resources in Catalog
+title: Install and map GitHub resources in {{site.konnect_catalog}} Classic
 permalink: /how-to/install-and-map-github-resources/
 content_type: how_to
-description: Learn how to connect a GitHub repository to your {{site.konnect_catalog}} service in {{site.konnect_short_name}}.
+description: Learn how to connect a GitHub repository to your {{site.konnect_catalog}} Classic service in {{site.konnect_short_name}}.
 products:
   - catalog
 works_on:
@@ -15,16 +15,16 @@ tags:
   - integrations
   - github
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: GitHub reference
     url: /catalog/integrations/github/
 automated_tests: false
 tldr:
-  q: How do I connect a GitHub repository to my {{site.konnect_catalog}} service?
-  a: Install the GitHub integration in {{site.konnect_short_name}} and authorize access to one or more repositories, then link a repository to your {{site.konnect_catalog}} service to display metadata and enable event tracking.
+  q: How do I connect a GitHub repository to my {{site.konnect_catalog}} Classic service?
+  a: Install the GitHub integration in {{site.konnect_short_name}} and authorize access to one or more repositories, then link a repository to your {{site.konnect_catalog}} Classic service to display metadata and enable event tracking.
 prereqs:
   inline:
     - title: "{{site.konnect_short_name}} roles"
@@ -32,7 +32,7 @@ prereqs:
       icon_url: /assets/icons/kogo-white.svg
     - title: GitHub access
       content: |
-        To integrate GitHub with {{site.konnect_catalog}}, you need the following:
+        To integrate GitHub with {{site.konnect_catalog}} Classic, you need the following:
         * Sufficient permissions in GitHub to authorize third-party applications and install the {{site.konnect_short_name}} GitHub App
         * A GitHub organization
         * A repository that you want to pull in to {{site.konnect_short_name}}. You can grant access to either all repositories or selected repositories during the authorization process. 
@@ -40,6 +40,8 @@ prereqs:
         The {{site.konnect_short_name}} app can be managed in your GitHub account under **Applications > GitHub Apps**.
       icon_url: /assets/icons/github.svg
 ---
+
+{% include_cached catalog/catalog-classic-banner.md %}
 
 ## Install and authorize the GitHub integration
 
@@ -50,7 +52,7 @@ prereqs:
 
 The {{site.konnect_short_name}} application can be managed from GitHub as a [GitHub Application](https://docs.github.com/en/apps/using-github-apps/authorizing-github-apps).
 
-## Create a service in {{site.konnect_catalog}}
+## Create a service in {{site.konnect_catalog}} Classic
 
 Create a service that you'll map to your GitHub resources:
 
@@ -74,7 +76,7 @@ export GITHUB_SERVICE_ID='YOUR-SERVICE-ID'
 
 ## List GitHub resources
 
-Before you can map your GitHub resources to a service in {{site.konnect_catalog}}, you first need to find the resources that are pulled in from GitHub:
+Before you can map your GitHub resources to a service in {{site.konnect_catalog}} Classic, you first need to find the resources that are pulled in from GitHub:
 
 <!--vale off-->
 {% konnect_api_request %}

--- a/app/_how-tos/catalog/install-and-map-github-resources.md
+++ b/app/_how-tos/catalog/install-and-map-github-resources.md
@@ -45,7 +45,7 @@ prereqs:
 
 ## Install and authorize the GitHub integration
 
-1. From the **Catalog** in {{site.konnect_short_name}}, select **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
+1. From the **Catalog** in {{site.konnect_short_name}}, select **Integrations**. 
 2. Click **GitHub**, then click **Add GitHub Instance**.
 3. Authorize the GitHub integration. This will take you to GitHub, where you can grant {{site.konnect_short_name}} access to either **All Repositories** or **Select repositories**. 
 1. Enter `github` as your instance name.

--- a/app/_how-tos/catalog/install-and-map-gitlab-resources.md
+++ b/app/_how-tos/catalog/install-and-map-gitlab-resources.md
@@ -1,8 +1,8 @@
 ---
-title: Install and map self-hosted GitLab resources in Catalog
+title: Install and map self-hosted GitLab resources in {{site.konnect_catalog}} Classic
 permalink: /how-to/install-and-map-gitlab-resources/
 content_type: how_to
-description: Learn how to connect a GitLab project to your {{site.konnect_catalog}} service in {{site.konnect_short_name}}.
+description: Learn how to connect a GitLab project to your {{site.konnect_catalog}} Classic service in {{site.konnect_short_name}}.
 products:
   - catalog
 works_on:
@@ -15,8 +15,8 @@ tags:
 search_aliases:
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: GitLab reference
@@ -25,8 +25,8 @@ related_resources:
     url: /how-to/install-and-map-gitlab-saas-resources/
 automated_tests: false
 tldr:
-  q: How do I view a self-hosted GitLab project in {{site.konnect_catalog}}?
-  a: Authorize the GitLab integration in the {{site.konnect_short_name}} UI using self-hosted setup. Create a {{site.konnect_catalog}} service and associate it with your project resource to display metadata and enable event tracking.
+  q: How do I view a self-hosted GitLab project in {{site.konnect_catalog}} Classic?
+  a: Authorize the GitLab integration in the {{site.konnect_short_name}} UI using self-hosted setup. Create a {{site.konnect_catalog}} Classic service and associate it with your project resource to display metadata and enable event tracking.
 prereqs:
   inline:
     - title: "{{site.konnect_short_name}} roles"
@@ -49,6 +49,8 @@ prereqs:
       icon_url: /assets/icons/gitlab.svg
 ---
 
+{% include_cached catalog/catalog-classic-banner.md %}
+
 ## Authorize the self-managed GitLab integration
 
 1. In the {{site.konnect_short_name}} UI, navigate to the [GitLab integration](https://cloud.konghq.com/service-catalog/integrations/gitlab/instances) and click **Add GitLab instance**.
@@ -63,7 +65,7 @@ prereqs:
 
 Once authorized, resources from your GitLab account will be discoverable in the UI.
 
-## Create a service in {{site.konnect_catalog}}
+## Create a service in {{site.konnect_catalog}} Classic
 
 Create a service that you'll map to your GitLab resources:
 
@@ -87,7 +89,7 @@ export GITLAB_SERVICE_ID='YOUR-SERVICE-ID'
 
 ## List GitLab resources
 
-Before you can map your GitLab resources to a service in {{site.konnect_catalog}}, you first need to find the resources that are pulled in from GitLab:
+Before you can map your GitLab resources to a service in {{site.konnect_catalog}} Classic, you first need to find the resources that are pulled in from GitLab:
 
 <!--vale off-->
 {% konnect_api_request %}

--- a/app/_how-tos/catalog/install-and-map-gitlab-resources.md
+++ b/app/_how-tos/catalog/install-and-map-gitlab-resources.md
@@ -53,7 +53,7 @@ prereqs:
 
 ## Authorize the self-managed GitLab integration
 
-1. In the {{site.konnect_short_name}} UI, navigate to the [GitLab integration](https://cloud.konghq.com/service-catalog/integrations/gitlab/instances) and click **Add GitLab instance**.
+1. In the {{site.konnect_short_name}} UI, navigate to the GitLab integration and click **Add GitLab instance**.
 1. Select **GitLab Dedicated or Self-managed**, and enter the full URL to your GitLab API in the **GitLab API Base URL** field, ending in `/api/v4`.  For example: `https://$GITLAB_HOST/api/v4`
 1. Fill out the authorization fields using the values from your GitLab OAuth application:
    * Application ID: The Application ID from your GitLab app

--- a/app/_how-tos/catalog/install-and-map-gitlab-saas-resources.md
+++ b/app/_how-tos/catalog/install-and-map-gitlab-saas-resources.md
@@ -1,8 +1,8 @@
 ---
-title: Install and map SaaS GitLab resources in Catalog
+title: Install and map SaaS GitLab resources in {{site.konnect_catalog}} Classic
 permalink: /how-to/install-and-map-gitlab-saas-resources/
 content_type: how_to
-description: Learn how to connect a SaaS GitLab project to your {{site.konnect_catalog}} service in {{site.konnect_short_name}}.
+description: Learn how to connect a SaaS GitLab project to your {{site.konnect_catalog}} Classic service in {{site.konnect_short_name}}.
 products:
   - catalog
 works_on:
@@ -15,8 +15,8 @@ tags:
 search_aliases:
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: GitLab reference
@@ -25,8 +25,8 @@ related_resources:
     url: /how-to/install-and-map-gitlab-resources/
 automated_tests: false
 tldr:
-  q: How do I view a SaaS GitLab project in {{site.konnect_catalog}}?
-  a: Install and authorize the SaaS GitLab integration in the {{site.konnect_short_name}} UI. Create a {{site.konnect_catalog}} service and associate it with your GitLab project to display metadata and enable event tracking.
+  q: How do I view a SaaS GitLab project in {{site.konnect_catalog}} Classic?
+  a: Install and authorize the SaaS GitLab integration in the {{site.konnect_short_name}} UI. Create a {{site.konnect_catalog}} Classic service and associate it with your GitLab project to display metadata and enable event tracking.
 prereqs:
   inline:
     - title: "{{site.konnect_short_name}} roles"
@@ -38,13 +38,15 @@ prereqs:
       icon_url: /assets/icons/gitlab.svg
 ---
 
+{% include_cached catalog/catalog-classic-banner.md %}
+
 ## Authorize the GitLab integration
 
 1. From the **Catalog** in {{site.konnect_short_name}}, select **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**.
 2. Click **GitLab**, then click **Add GitLab instance**.
 3. Select **GitLab (SaaS)**, authorize GitLab to connect your account, and enter `gitlab` for your instance name.
 
-## Create a service in {{site.konnect_catalog}}
+## Create a service in {{site.konnect_catalog}} Classic
 
 Create a service that you'll map to your GitLab resources:
 
@@ -68,7 +70,7 @@ export GITLAB_SERVICE_ID='YOUR-SERVICE-ID'
 
 ## List GitLab resources
 
-Before you can map your GitLab resources to a service in {{site.konnect_catalog}}, you first need to find the resources that are pulled in from GitLab:
+Before you can map your GitLab resources to a service in {{site.konnect_catalog}} Classic, you first need to find the resources that are pulled in from GitLab:
 
 <!--vale off-->
 {% konnect_api_request %}

--- a/app/_how-tos/catalog/install-and-map-gitlab-saas-resources.md
+++ b/app/_how-tos/catalog/install-and-map-gitlab-saas-resources.md
@@ -42,7 +42,7 @@ prereqs:
 
 ## Authorize the GitLab integration
 
-1. From the **Catalog** in {{site.konnect_short_name}}, select **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**.
+1. From the **Catalog** in {{site.konnect_short_name}}, select **Integrations**.
 2. Click **GitLab**, then click **Add GitLab instance**.
 3. Select **GitLab (SaaS)**, authorize GitLab to connect your account, and enter `gitlab` for your instance name.
 

--- a/app/_how-tos/catalog/install-and-map-pagerduty-resources.md
+++ b/app/_how-tos/catalog/install-and-map-pagerduty-resources.md
@@ -40,7 +40,7 @@ prereqs:
 
 ## Authenticate the PagerDuty integration
 
-1. From the **Catalog** in {{site.konnect_short_name}}, select **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
+1. From the **Catalog** in {{site.konnect_short_name}}, select **Integrations**. 
 2. Click **PagerDuty**, and then click **Add PagerDuty Instance**.
 3. Configure the region, grant authorization, and name the instance. 
    PagerDuty will ask you to grant consent to {{site.konnect_short_name}}. **Both Read and Write scopes are required.**

--- a/app/_how-tos/catalog/install-and-map-pagerduty-resources.md
+++ b/app/_how-tos/catalog/install-and-map-pagerduty-resources.md
@@ -1,8 +1,8 @@
 ---
-title: Import and map PagerDuty resources in Catalog
+title: Import and map PagerDuty resources in {{site.konnect_catalog}} Classic
 permalink: /how-to/install-and-map-pagerduty-resources/
 content_type: how_to
-description: Learn how to connect PagerDuty services to your {{site.konnect_catalog}} service in {{site.konnect_short_name}}.
+description: Learn how to connect PagerDuty services to your {{site.konnect_catalog}} Classic service in {{site.konnect_short_name}}.
 products:
   - catalog
 works_on:
@@ -15,16 +15,16 @@ tags:
 search_aliases:
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: PagerDuty reference
     url: /catalog/integrations/pagerduty/
 automated_tests: false
 tldr:
-  q: How do I view PagerDuty services in {{site.konnect_catalog}}?
-  a: Install the PagerDuty integration in {{site.konnect_short_name}} and authorize it with both read and write scopes. Create a {{site.konnect_catalog}} service and associate it with your PagerDuty services to display metadata and enable event tracking. 
+  q: How do I view PagerDuty services in {{site.konnect_catalog}} Classic?
+  a: Install the PagerDuty integration in {{site.konnect_short_name}} and authorize it with both read and write scopes. Create a {{site.konnect_catalog}} Classic service and associate it with your PagerDuty services to display metadata and enable event tracking. 
 prereqs:
   inline:
     - title: "{{site.konnect_short_name}} roles"
@@ -36,6 +36,8 @@ prereqs:
       icon_url: /assets/icons/pagerduty.svg
 ---
 
+{% include_cached catalog/catalog-classic-banner.md %}
+
 ## Authenticate the PagerDuty integration
 
 1. From the **Catalog** in {{site.konnect_short_name}}, select **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
@@ -45,7 +47,7 @@ prereqs:
 
 Once authorized, resources from your PagerDuty account will be discoverable in the UI.
 
-## Create a service in {{site.konnect_catalog}}
+## Create a service in {{site.konnect_catalog}} Classic
 
 Create a service that you'll map to your PagerDuty resources:
 
@@ -69,7 +71,7 @@ export PAGERDUTY_SERVICE_ID='YOUR-SERVICE-ID'
 
 ## List PagerDuty resources
 
-Before you can map your PagerDuty resources to a service in {{site.konnect_catalog}}, you first need to find the resources that are pulled in from PagerDuty:
+Before you can map your PagerDuty resources to a service in {{site.konnect_catalog}} Classic, you first need to find the resources that are pulled in from PagerDuty:
 
 <!--vale off-->
 {% konnect_api_request %}

--- a/app/_how-tos/catalog/install-and-map-slack-resources.md
+++ b/app/_how-tos/catalog/install-and-map-slack-resources.md
@@ -42,7 +42,7 @@ prereqs:
 
 ## Authorize the Slack integration
 
-1. From the **Catalog** in {{site.konnect_short_name}}, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**.
+1. From the **Catalog** in {{site.konnect_short_name}}, click **Integrations**.
 2. Click **Slack**, then click **Add Slack instance**.
 3. Name your integration `slack` and authorize the Slack instance. Slack will prompt you to grant read and write permissions to {{site.konnect_short_name}}. Only Slack administrators can authorize the integration.
 

--- a/app/_how-tos/catalog/install-and-map-slack-resources.md
+++ b/app/_how-tos/catalog/install-and-map-slack-resources.md
@@ -1,8 +1,8 @@
 ---
-title: Import and map Slack resources in Catalog
+title: Import and map Slack resources in {{site.konnect_catalog}} Classic
 permalink: /how-to/install-and-map-slack-resources/
 content_type: how_to
-description: Learn how to connect Slack channels to your {{site.konnect_catalog}} service in {{site.konnect_short_name}}.
+description: Learn how to connect Slack channels to your {{site.konnect_catalog}} Classic service in {{site.konnect_short_name}}.
 products:
   - catalog
 works_on:
@@ -15,8 +15,8 @@ tags:
 search_aliases:
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: Traceable plugin
@@ -25,8 +25,8 @@ related_resources:
     url: /catalog/integrations/slack/
 automated_tests: false
 tldr:
-  q: How do I view a Slack channel in {{site.konnect_catalog}}?
-  a: Install the Slack integration in {{site.konnect_short_name}} and authorize it using Slack admin credentials. Create a {{site.konnect_catalog}} service and associate it with your Slack channel to improve visibility and ownership.
+  q: How do I view a Slack channel in {{site.konnect_catalog}} Classic?
+  a: Install the Slack integration in {{site.konnect_short_name}} and authorize it using Slack admin credentials. Create a {{site.konnect_catalog}} Classic service and associate it with your Slack channel to improve visibility and ownership.
 prereqs:
   inline:
     - title: "{{site.konnect_short_name}} roles"
@@ -38,6 +38,8 @@ prereqs:
       icon_url: /assets/icons/third-party/slack.svg
 ---
 
+{% include_cached catalog/catalog-classic-banner.md %}
+
 ## Authorize the Slack integration
 
 1. From the **Catalog** in {{site.konnect_short_name}}, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**.
@@ -47,7 +49,7 @@ prereqs:
 Once authorized, resources from your Slack account will be discoverable in the UI.
 
 
-## Create a service in {{site.konnect_catalog}}
+## Create a service in {{site.konnect_catalog}} Classic
 
 Create a service that you'll map to your Slack resources:
 
@@ -71,7 +73,7 @@ export SLACK_SERVICE_ID='YOUR-SERVICE-ID'
 
 ## List Slack resources
 
-Before you can map your Slack resources to a service in {{site.konnect_catalog}}, you first need to find the resources that are pulled in from Slack:
+Before you can map your Slack resources to a service in {{site.konnect_catalog}} Classic, you first need to find the resources that are pulled in from Slack:
 
 <!--vale off-->
 {% konnect_api_request %}

--- a/app/_how-tos/catalog/install-and-map-swaggerhub-resources.md
+++ b/app/_how-tos/catalog/install-and-map-swaggerhub-resources.md
@@ -1,8 +1,8 @@
 ---
-title: Import and map SwaggerHub resources in Catalog
+title: Import and map SwaggerHub resources in {{site.konnect_catalog}} Classic
 permalink: /how-to/install-and-map-swaggerhub-resources/
 content_type: how_to
-description: Learn how to connect SwaggerHub API versions to your {{site.konnect_catalog}} service in {{site.konnect_short_name}}.
+description: Learn how to connect SwaggerHub API versions to your {{site.konnect_catalog}} Classic service in {{site.konnect_short_name}}.
 products:
   - catalog
 works_on:
@@ -15,16 +15,16 @@ tags:
 search_aliases:
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: SwaggerHub reference
     url: /catalog/integrations/swaggerhub/
 automated_tests: false
 tldr:
-  q: How do I view SwaggerHub API specs in {{site.konnect_catalog}}?
-  a: Install the SwaggerHub integration in {{site.konnect_short_name}} and authorize using your SwaggerHub API key. Create a {{site.konnect_catalog}} service and associate it with your SwaggerHub API versions to display metadata and enable event tracking. 
+  q: How do I view SwaggerHub API specs in {{site.konnect_catalog}} Classic?
+  a: Install the SwaggerHub integration in {{site.konnect_short_name}} and authorize using your SwaggerHub API key. Create a {{site.konnect_catalog}} Classic service and associate it with your SwaggerHub API versions to display metadata and enable event tracking. 
 prereqs:
   inline:
     - title: "{{site.konnect_short_name}} roles"
@@ -40,6 +40,8 @@ prereqs:
 
         Additionally, you'll need an [API version](https://support.smartbear.com/swaggerhub/docs/en/manage-apis/versioning.html?sbsearch=API%20Versions0) in SwaggerHub to pull into {{site.konnect_short_name}} as a resource.
 ---
+
+{% include_cached catalog/catalog-classic-banner.md %}
 
 ## Install and authorize the SwaggerHub integration
 
@@ -86,7 +88,7 @@ body:
 
 Once authorized, resources from your SwaggerHub account will be discoverable in the UI.
 
-## Create a service in {{site.konnect_catalog}}
+## Create a service in {{site.konnect_catalog}} Classic
 
 Create a service that you'll map to your SwaggerHub resources:
 
@@ -110,7 +112,7 @@ export SWAGGERHUB_SERVICE_ID='YOUR-SERVICE-ID'
 
 ## List SwaggerHub resources
 
-Before you can map your SwaggerHub resources to a service in {{site.konnect_catalog}}, you first need to find the resources that are pulled in from SwaggerHub:
+Before you can map your SwaggerHub resources to a service in {{site.konnect_catalog}} Classic, you first need to find the resources that are pulled in from SwaggerHub:
 
 <!--vale off-->
 {% konnect_api_request %}

--- a/app/_how-tos/catalog/install-and-map-traceable-resources.md
+++ b/app/_how-tos/catalog/install-and-map-traceable-resources.md
@@ -1,8 +1,8 @@
 ---
-title: Import and map Traceable resources in Catalog
+title: Import and map Traceable resources in {{site.konnect_catalog}} Classic
 permalink: /how-to/install-and-map-traceable-resources/
 content_type: how_to
-description: Learn how to connect Traceable services to your {{site.konnect_catalog}} service in {{site.konnect_short_name}}.
+description: Learn how to connect Traceable services to your {{site.konnect_catalog}} Classic service in {{site.konnect_short_name}}.
 products:
   - catalog
 works_on:
@@ -15,8 +15,8 @@ tags:
 search_aliases:
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: Traceable plugin
@@ -25,8 +25,8 @@ related_resources:
     url: /catalog/integrations/traceable/
 automated_tests: false
 tldr:
-  q: How do I view Traceable services in {{site.konnect_catalog}}?
-  a: Install the Traceable integration in {{site.konnect_short_name}} and authorize it with your Traceable API key. Create a {{site.konnect_catalog}} service and associate it with your Traceable services to display metadata and enable event tracking. 
+  q: How do I view Traceable services in {{site.konnect_catalog}} Classic?
+  a: Install the Traceable integration in {{site.konnect_short_name}} and authorize it with your Traceable API key. Create a {{site.konnect_catalog}} Classic service and associate it with your Traceable services to display metadata and enable event tracking. 
 prereqs:
   inline:
     - title: "{{site.konnect_short_name}} roles"
@@ -34,7 +34,7 @@ prereqs:
       icon_url: /assets/icons/kogo-white.svg
     - title: Traceable access
       content: |
-        You must have an active [Traceable account](https://www.traceable.ai/) and valid API access to connect Traceable services to your {{site.konnect_catalog}} service. You also need a [Traceable Service](https://docs.traceable.ai/docs/domains-services-backends) you can pull into {{site.konnect_short_name}}.
+        You must have an active [Traceable account](https://www.traceable.ai/) and valid API access to connect Traceable services to your {{site.konnect_catalog}} Classic service. You also need a [Traceable Service](https://docs.traceable.ai/docs/domains-services-backends) you can pull into {{site.konnect_short_name}}.
         
         Export your Traceable API key:
         ```sh
@@ -42,6 +42,8 @@ prereqs:
         ```
       icon_url: /assets/icons/traceable.svg
 ---
+
+{% include_cached catalog/catalog-classic-banner.md %}
 
 ## Install and authorize the Traceable integration
 
@@ -89,7 +91,7 @@ body:
 
 Once authorized, resources from your Traceable account will be discoverable in the UI.
 
-## Create a service in {{site.konnect_catalog}}
+## Create a service in {{site.konnect_catalog}} Classic
 
 Create a service that you'll map to your Traceable resources:
 
@@ -113,7 +115,7 @@ export TRACEABLE_SERVICE_ID='YOUR-SERVICE-ID'
 
 ## List Traceable resources
 
-Before you can map your Traceable resources to a service in {{site.konnect_catalog}}, you first need to find the resources that are pulled in from Traceable:
+Before you can map your Traceable resources to a service in {{site.konnect_catalog}} Classic, you first need to find the resources that are pulled in from Traceable:
 
 <!--vale off-->
 {% konnect_api_request %}

--- a/app/_how-tos/catalog/map-analytics-resources.md
+++ b/app/_how-tos/catalog/map-analytics-resources.md
@@ -1,8 +1,8 @@
 ---
-title: Map {{site.observability}} reports in Catalog
+title: Map {{site.observability}} reports in {{site.konnect_catalog}} Classic
 permalink: /how-to/map-analytics-resources/
 content_type: how_to
-description: Learn how to map {{site.konnect_short_name}} analytics resources in {{site.konnect_catalog}} to visualize {{site.observability}} Reports.
+description: Learn how to map {{site.konnect_short_name}} analytics resources in {{site.konnect_catalog}} Classic to visualize {{site.observability}} Reports.
 products:
   - catalog
 works_on:
@@ -12,26 +12,28 @@ search_aliases:
   - service catalog
   - konnect analytics
 tldr:
-  q: How do I map {{site.observability}} reports in {{site.konnect_catalog}}?
-  a: Create a {{site.konnect_catalog}} service and associate it with your {{site.konnect_short_name}} analytics resources to visualize {{site.observability}} Reports.
+  q: How do I map {{site.observability}} reports in {{site.konnect_catalog}} Classic?
+  a: Create a {{site.konnect_catalog}} Classic service and associate it with your {{site.konnect_short_name}} analytics resources to visualize {{site.observability}} Reports.
 prereqs:
   inline:
     - title: "{{site.observability}} reports"
       content: |
-        You'll need a [{{site.observability}} report](https://cloud.konghq.com/analytics/reports) to ingest in {{site.konnect_catalog}} as resources.
+        You'll need a [{{site.observability}} report](https://cloud.konghq.com/analytics/reports) to ingest in {{site.konnect_catalog}} Classic as resources.
       icon_url: /assets/icons/analytics.svg
 related_resources:
   - text: "{{site.observability}} integration"
     url: /catalog/integrations/konnect-analytics/
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: "{{site.konnect_catalog}} integrations"
     url: /catalog/integrations/
 ---
 
-## Create a service in {{site.konnect_catalog}}
+{% include_cached catalog/catalog-classic-banner.md %}
 
-In this tutorial, you'll map Reports from {{site.observability}} to a service in {{site.konnect_catalog}}. Because the {{site.observability}} integration is built-in, you don't need to install or authorize it like other {{site.konnect_catalog}} integrations.
+## Create a service in {{site.konnect_catalog}} Classic
+
+In this tutorial, you'll map Reports from {{site.observability}} to a service in {{site.konnect_catalog}} Classic. Because the {{site.observability}} integration is built-in, you don't need to install or authorize it like other {{site.konnect_catalog}} Classic integrations.
 
 Create a service that you'll map to your {{site.observability}} resources:
 
@@ -47,7 +49,7 @@ body:
 {% endkonnect_api_request %}
 <!--vale on-->
 
-Export the {{site.konnect_catalog}} service ID:
+Export the {{site.konnect_catalog}} Classic service ID:
 
 ```sh
 export SERVICE_ID='YOUR-SERVICE-ID'
@@ -55,7 +57,7 @@ export SERVICE_ID='YOUR-SERVICE-ID'
 
 ## List {{site.observability}} resources
 
-Before you can map a resource to {{site.konnect_catalog}}, you first need to find the resources that are pulled in from {{site.observability}}:
+Before you can map a resource to {{site.konnect_catalog}} Classic, you first need to find the resources that are pulled in from {{site.observability}}:
 
 <!--vale off-->
 {% konnect_api_request %}
@@ -72,7 +74,7 @@ Export the resource ID you want to map to the service:
 export ANALYTICS_RESOURCE_ID='YOUR-RESOURCE-ID'
 ```
 
-## Map resources to a {{site.konnect_catalog}} service
+## Map resources to a {{site.konnect_catalog}} Classic service
 
 Now, you can map the {{site.observability}} resource to the service:
 

--- a/app/_how-tos/catalog/map-api-gateway-resources.md
+++ b/app/_how-tos/catalog/map-api-gateway-resources.md
@@ -1,8 +1,8 @@
 ---
-title: Map API Gateway Services in Catalog
+title: Map API Gateway Services in {{site.konnect_catalog}} Classic
 permalink: /how-to/map-api-gateway-resources/
 content_type: how_to
-description: Learn how to map Gateway Services from {{site.konnect_short_name}} API Gateway in {{site.konnect_catalog}} to visualize services across multiple Control Planes.
+description: Learn how to map Gateway Services from {{site.konnect_short_name}} API Gateway in {{site.konnect_catalog}} Classic to visualize services across multiple Control Planes.
 products:
   - gateway
   - catalog
@@ -15,8 +15,8 @@ entities:
 search_aliases:
   - service catalog
 tldr:
-  q: How do I map Gateway Services in {{site.konnect_catalog}}?
-  a: Create a {{site.konnect_catalog}} service and associate it with your API Gateway resources to visualize Services across multiple Control Planes.
+  q: How do I map Gateway Services in {{site.konnect_catalog}} Classic?
+  a: Create a {{site.konnect_catalog}} Classic service and associate it with your API Gateway resources to visualize Services across multiple Control Planes.
 prereqs:
   entities:
     services:
@@ -24,15 +24,17 @@ prereqs:
 related_resources:
   - text: API Gateway integration
     url: /catalog/integrations/api-gateway/
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: "{{site.konnect_catalog}} integrations"
     url: /catalog/integrations/
 ---
 
-## Create a service in {{site.konnect_catalog}}
+{% include_cached catalog/catalog-classic-banner.md %}
 
-In this tutorial, you'll map Gateway Services from API Gateway to a service in {{site.konnect_catalog}}. Because the API Gateway integration is built-in, you don't need to install or authorize it like other {{site.konnect_catalog}} integrations. 
+## Create a service in {{site.konnect_catalog}} Classic
+
+In this tutorial, you'll map Gateway Services from API Gateway to a service in {{site.konnect_catalog}} Classic. Because the API Gateway integration is built-in, you don't need to install or authorize it like other {{site.konnect_catalog}} Classic integrations. 
 
 Create a service that you'll map to your API Gateway resources:
 
@@ -48,7 +50,7 @@ body:
 {% endkonnect_api_request %}
 <!--vale on-->
 
-Export the {{site.konnect_catalog}} service ID:
+Export the {{site.konnect_catalog}} Classic service ID:
 
 ```sh
 export SERVICE_ID='YOUR-SERVICE-ID'
@@ -56,7 +58,7 @@ export SERVICE_ID='YOUR-SERVICE-ID'
 
 ## List API Gateway resources
 
-Before you can map a resource to {{site.konnect_catalog}}, you first need to find the resources that are pulled in from API Gateway:
+Before you can map a resource to {{site.konnect_catalog}} Classic, you first need to find the resources that are pulled in from API Gateway:
 
 <!--vale off-->
 {% konnect_api_request %}
@@ -73,7 +75,7 @@ Export the resource ID you want to map to the service:
 export API_GATEWAY_RESOURCE_ID='YOUR-RESOURCE-ID'
 ```
 
-## Map resources to a {{site.konnect_catalog}} service
+## Map resources to a {{site.konnect_catalog}} Classic service
 
 Now, you can map the API Gateway resource to the service:
 

--- a/app/_how-tos/catalog/map-service-mesh-resources.md
+++ b/app/_how-tos/catalog/map-service-mesh-resources.md
@@ -1,8 +1,8 @@
 ---
-title: Map Service Mesh services in Catalog
+title: Map Service Mesh services in {{site.konnect_catalog}} Classic
 permalink: /how-to/map-service-mesh-resources/
 content_type: how_to
-description: Learn how to map Service Mesh resources in {{site.konnect_catalog}} to gain visibility into how the service is deployed across meshes and zones.
+description: Learn how to map Service Mesh resources in {{site.konnect_catalog}} Classic to gain visibility into how the service is deployed across meshes and zones.
 products:
   - catalog
 works_on:
@@ -12,26 +12,28 @@ entities: []
 search_aliases:
   - service catalog
 tldr:
-  q: How do I map Service Mesh services in {{site.konnect_catalog}}?
-  a: Create a {{site.konnect_catalog}} service and associate it with your Service Mesh resources to visualize meshes.
+  q: How do I map Service Mesh services in {{site.konnect_catalog}} Classic?
+  a: Create a {{site.konnect_catalog}} Classic service and associate it with your Service Mesh resources to visualize meshes.
 prereqs:
   inline:
     - title: "{{site.mesh_product_name}} services"
       content: |
-        You'll need a [Service Mesh service](https://cloud.konghq.com/mesh-manager) to ingest in {{site.konnect_catalog}} as resources.
+        You'll need a [Service Mesh service](https://cloud.konghq.com/mesh-manager) to ingest in {{site.konnect_catalog}} Classic as resources.
       icon_url: /assets/icons/mesh.svg
 related_resources:
   - text: "Service Mesh integration"
     url: /catalog/integrations/service-mesh/
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: "{{site.konnect_catalog}} integrations"
     url: /catalog/integrations/
 ---
 
-## Create a service in {{site.konnect_catalog}}
+{% include_cached catalog/catalog-classic-banner.md %}
 
-In this tutorial, you'll map services from {{site.mesh_product_name}} to a service in {{site.konnect_catalog}}. Because the Service Mesh integration is built-in, you don't need to install or authorize it like other {{site.konnect_catalog}} integrations. 
+## Create a service in {{site.konnect_catalog}} Classic
+
+In this tutorial, you'll map services from {{site.mesh_product_name}} to a service in {{site.konnect_catalog}} Classic. Because the Service Mesh integration is built-in, you don't need to install or authorize it like other {{site.konnect_catalog}} Classic integrations. 
 
 Create a service that you'll map to your Service Mesh resources:
 
@@ -47,7 +49,7 @@ body:
 {% endkonnect_api_request %}
 <!--vale on-->
 
-Export the {{site.konnect_catalog}} service ID:
+Export the {{site.konnect_catalog}} Classic service ID:
 
 ```sh
 export SERVICE_ID='YOUR-SERVICE-ID'
@@ -55,7 +57,7 @@ export SERVICE_ID='YOUR-SERVICE-ID'
 
 ## List Service Mesh resources
 
-Before you can map a resource to {{site.konnect_catalog}}, you first need to find the resources that are pulled in:
+Before you can map a resource to {{site.konnect_catalog}} Classic, you first need to find the resources that are pulled in:
 
 <!--vale off-->
 {% konnect_api_request %}
@@ -72,7 +74,7 @@ Export the resource ID you want to map to the service:
 export MESH_RESOURCE_ID='YOUR-RESOURCE-ID'
 ```
 
-## Map resources to a {{site.konnect_catalog}} service
+## Map resources to a {{site.konnect_catalog}} Classic service
 
 Now, you can map the Service Mesh resource to the service:
 

--- a/app/_how-tos/catalog/monitor-dynatrace-slos-with-konnect-api.md
+++ b/app/_how-tos/catalog/monitor-dynatrace-slos-with-konnect-api.md
@@ -1,8 +1,8 @@
 ---
-title: Monitor Dynatrace classic SLOs in Catalog with the Konnect API
+title: Monitor Dynatrace classic SLOs in {{site.konnect_catalog}} Classic with the Konnect API
 permalink: /how-to/monitor-dynatrace-slos-with-konnect-api/
 content_type: how_to
-description: Learn how to connect a Dynatrace classic SLO to your {{site.konnect_catalog}} service in {{site.konnect_short_name}} using the API.
+description: Learn how to connect a Dynatrace classic SLO to your {{site.konnect_catalog}} Classic service in {{site.konnect_short_name}} using the API.
 products:
   - catalog
 works_on:
@@ -17,20 +17,20 @@ search_aliases:
   - SLO
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: Dynatrace reference
     url: /catalog/integrations/dynatrace/
-  - text: "Monitor Dynatrace classic SLOs {{site.konnect_catalog}} with the {{site.konnect_short_name}} UI"
+  - text: "Monitor Dynatrace classic SLOs in {{site.konnect_catalog}} Classic with the Konnect UI"
     url: /how-to/monitor-dynatrace-slos-with-konnect-ui/
   - text: Set up Dynatrace with OpenTelemetry
     url: /how-to/set-up-dynatrace-with-otel/
 automated_tests: false
 tldr:
   q: How do I monitor Dynatrace classic service-level objects in {{site.konnect_short_name}}?
-  a: Install the Dynatrace integration in {{site.konnect_short_name}} and authorize access with your Dynatrace URL and personal access token (with `slo.read` permissions), then link an SLO to your {{site.konnect_catalog}} service.
+  a: Install the Dynatrace integration in {{site.konnect_short_name}} and authorize access with your Dynatrace URL and personal access token (with `slo.read` permissions), then link an SLO to your {{site.konnect_catalog}} Classic service.
 prereqs:
   inline:
     - title: "{{site.konnect_short_name}} roles"
@@ -54,9 +54,11 @@ prereqs:
       icon_url: /assets/icons/third-party/dynatrace.png
 ---
 
+{% include_cached catalog/catalog-classic-banner.md %}
+
 ## Configure the Dynatrace integration
 
-Before you can discover SLOs in {{site.konnect_catalog}}, you must configure the Dynatrace integration.
+Before you can discover SLOs in {{site.konnect_catalog}} Classic, you must configure the Dynatrace integration.
 
 First, install the Dynatrace integration:
 
@@ -100,7 +102,7 @@ body:
 
 Once authorized, resources from your Dynatrace account will be discoverable in the UI.
 
-## Create a service in {{site.konnect_catalog}}
+## Create a service in {{site.konnect_catalog}} Classic
 
 Create a service that you'll map to your Dynatrace resources:
 
@@ -124,7 +126,7 @@ export DYNATRACE_SERVICE_ID='YOUR-SERVICE-ID'
 
 ## List Dynatrace resources
 
-Before you can map your Dynatrace resources to a service in {{site.konnect_catalog}}, you first need to find the resources that are pulled in from Dynatrace:
+Before you can map your Dynatrace resources to a service in {{site.konnect_catalog}} Classic, you first need to find the resources that are pulled in from Dynatrace:
 
 <!--vale off-->
 {% konnect_api_request %}

--- a/app/_how-tos/catalog/monitor-dynatrace-slos-with-konnect-ui.md
+++ b/app/_how-tos/catalog/monitor-dynatrace-slos-with-konnect-ui.md
@@ -1,8 +1,8 @@
 ---
-title: Monitor Dynatrace classic SLOs in Catalog with the Konnect UI
+title: Monitor Dynatrace classic SLOs in {{site.konnect_catalog}} Classic with the Konnect UI
 permalink: /how-to/monitor-dynatrace-slos-with-konnect-ui/
 content_type: how_to
-description: Learn how to connect a Dynatrace classic SLO to your {{site.konnect_catalog}} service in {{site.konnect_short_name}} using the UI.
+description: Learn how to connect a Dynatrace classic SLO to your {{site.konnect_catalog}} Classic service in {{site.konnect_short_name}} using the UI.
 products:
   - catalog
 works_on:
@@ -15,20 +15,20 @@ search_aliases:
   - SLO
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: Dynatrace reference
     url: /catalog/integrations/dynatrace/
-  - text: "Monitor Dynatrace classic SLOs {{site.konnect_catalog}} with the {{site.konnect_short_name}} API"
+  - text: "Monitor Dynatrace classic SLOs in {{site.konnect_catalog}} Classic with the Konnect API"
     url: /how-to/monitor-dynatrace-slos-with-konnect-api/
   - text: Set up Dynatrace with OpenTelemetry
     url: /how-to/set-up-dynatrace-with-otel/
 automated_tests: false
 tldr:
   q: How do I monitor Dynatrace classic service-level objects in {{site.konnect_short_name}}?
-  a: Install the Dynatrace integration in {{site.konnect_short_name}} and authorize access with your Dynatrace URL and personal access token (with `slo.read` permissions), then link an SLO to your {{site.konnect_catalog}} service.
+  a: Install the Dynatrace integration in {{site.konnect_short_name}} and authorize access with your Dynatrace URL and personal access token (with `slo.read` permissions), then link an SLO to your {{site.konnect_catalog}} Classic service.
 prereqs:
   inline:
     - title: "{{site.konnect_short_name}} roles"
@@ -46,9 +46,11 @@ prereqs:
       icon_url: /assets/icons/third-party/dynatrace.png
 ---
 
+{% include_cached catalog/catalog-classic-banner.md %}
+
 ## Configure the Dynatrace integration
 
-Before you can discover APIs in {{site.konnect_catalog}}, you must configure the Dynatrace integration.
+Before you can discover APIs in {{site.konnect_catalog}} Classic, you must configure the Dynatrace integration.
 
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
 1. In the Catalog sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
@@ -60,9 +62,9 @@ Before you can discover APIs in {{site.konnect_catalog}}, you must configure the
 1. In the **Instance name** field, enter `dynatrace`.
 1. Click **Save**.
 
-## Create a {{site.konnect_catalog}} service and map the SLO resources
+## Create a {{site.konnect_catalog}} Classic service and map the SLO resources
 
-Now that your integration is configured, you can create a {{site.konnect_catalog}} service to map the ingested SLOs.
+Now that your integration is configured, you can create a {{site.konnect_catalog}} Classic service to map the ingested SLOs.
 
 {:.info}
 > In this tutorial, we'll refer to your ingested Dynatrace SLO as `billing-slo`.
@@ -77,7 +79,7 @@ Now that your integration is configured, you can create a {{site.konnect_catalog
 1. Select `billing-slo`. 
 1. Click **Map 1 Resource**.
 
-Your integration SLOs are now discoverable from one {{site.konnect_catalog}} service.
+Your integration SLOs are now discoverable from one {{site.konnect_catalog}} Classic service.
 
 {:.info}
 > You might need to manually sync your Dynatrace integration for resources to appear. From the {{site.konnect_short_name}} UI by navigating to the Dynatrace integration you just installed and selecting **Sync Now** from the **Actions** dropdown menu.

--- a/app/_how-tos/catalog/monitor-dynatrace-slos-with-konnect-ui.md
+++ b/app/_how-tos/catalog/monitor-dynatrace-slos-with-konnect-ui.md
@@ -53,7 +53,7 @@ prereqs:
 Before you can discover APIs in {{site.konnect_catalog}} Classic, you must configure the Dynatrace integration.
 
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. In the Catalog sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
+1. In the Catalog sidebar, click **Integrations**. 
 1. Click **Dynatrace**.
 1. Click **Add Dynatrace instance**.
 1. In the **Dynatrace API Base URL** field, enter your Dynatrace URL without the trailing `/`. For example: `https://whr42363.apps.dynatrace.com`
@@ -69,7 +69,7 @@ Now that your integration is configured, you can create a {{site.konnect_catalog
 {:.info}
 > In this tutorial, we'll refer to your ingested Dynatrace SLO as `billing-slo`.
 
-1. In the {{site.konnect_short_name}} sidebar, click [**{{site.konnect_catalog}}**](https://cloud.konghq.com/service-catalog/).
+1. In the {{site.konnect_short_name}} sidebar, click **{{site.konnect_catalog}}**.
 1. In the Catalog sidebar, click **Services**.
 1. Click **New service**.
 1. In the **Display Name** field, enter `Billing Service`.
@@ -88,7 +88,7 @@ Your integration SLOs are now discoverable from one {{site.konnect_catalog}} Cla
 
 To confirm that the Dynatrace resource is now mapped to the intended service, navigate to the service:
 
-1. In the {{site.konnect_short_name}} sidebar, click [**{{site.konnect_catalog}}**](https://cloud.konghq.com/service-catalog/).
+1. In the {{site.konnect_short_name}} sidebar, click **{{site.konnect_catalog}}**.
 1. In the {{site.konnect_catalog}} sidebar, click **Services**.
 1. Click the **Billing Service** service.
 1. Click the **Resources** tab.

--- a/app/_how-tos/catalog/monitor-sonarqube-projects-with-konnect-api.md
+++ b/app/_how-tos/catalog/monitor-sonarqube-projects-with-konnect-api.md
@@ -1,8 +1,8 @@
 ---
-title: Monitor SonarQube projects in Catalog with the Konnect API
+title: Monitor SonarQube projects in {{site.konnect_catalog}} Classic with the Konnect API
 permalink: /how-to/monitor-sonarqube-projects-with-konnect-api/
 content_type: how_to
-description: Learn how to connect a SonarQube project to your {{site.konnect_catalog}} service in {{site.konnect_short_name}} using the API.
+description: Learn how to connect a SonarQube project to your {{site.konnect_catalog}} Classic service in {{site.konnect_short_name}} using the API.
 products:
   - catalog
 works_on:
@@ -16,18 +16,18 @@ search_aliases:
   - projects
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: SonarQube reference
     url: /catalog/integrations/sonarqube/
-  - text: "Monitor SonarQube projects {{site.konnect_catalog}} with the {{site.konnect_short_name}} UI"
+  - text: "Monitor SonarQube projects in {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} UI"
     url: /how-to/monitor-sonarqube-projects-with-konnect-ui/
 automated_tests: false
 tldr:
   q: How do I monitor SonarQube projects in {{site.konnect_short_name}}?
-  a: Install the SonarQube integration in {{site.konnect_short_name}} and authorize access with your SonarQube personal access token, then link a project to your {{site.konnect_catalog}} service.
+  a: Install the SonarQube integration in {{site.konnect_short_name}} and authorize access with your SonarQube personal access token, then link a project to your {{site.konnect_catalog}} Classic service.
 prereqs:
   inline:
     - title: "{{site.konnect_short_name}} roles"
@@ -48,9 +48,11 @@ prereqs:
       icon_url: /assets/icons/third-party/sonarqube.svg
 ---
 
+{% include_cached catalog/catalog-classic-banner.md %}
+
 ## Configure the SonarQube integration
 
-Before you can discover [SonarQube projects](https://docs.sonarsource.com/sonarqube-cloud/managing-your-projects) in {{site.konnect_catalog}}, you must configure the SonarQube integration.
+Before you can discover [SonarQube projects](https://docs.sonarsource.com/sonarqube-cloud/managing-your-projects) in {{site.konnect_catalog}} Classic, you must configure the SonarQube integration.
 
 First, install the SonarQube integration:
 
@@ -93,7 +95,7 @@ body:
 
 Once authorized, resources from your SonarQube account will be discoverable in the UI.
 
-## Create a service in {{site.konnect_catalog}}
+## Create a service in {{site.konnect_catalog}} Classic
 
 Create a service that you'll map to your SonarQube resources:
 
@@ -117,7 +119,7 @@ export SONARQUBE_SERVICE_ID='YOUR-SERVICE-ID'
 
 ## List SonarQube resources
 
-Before you can map your SonarQube resources to a service in {{site.konnect_catalog}}, you first need to find the resources that are pulled in from SonarQube:
+Before you can map your SonarQube resources to a service in {{site.konnect_catalog}} Classic, you first need to find the resources that are pulled in from SonarQube:
 
 <!--vale off-->
 {% konnect_api_request %}

--- a/app/_how-tos/catalog/monitor-sonarqube-projects-with-konnect-ui.md
+++ b/app/_how-tos/catalog/monitor-sonarqube-projects-with-konnect-ui.md
@@ -1,8 +1,8 @@
 ---
-title: Monitor SonarQube projects in Catalog with the {{site.konnect_short_name}} UI
+title: Monitor SonarQube projects in {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} UI
 permalink: /how-to/monitor-sonarqube-projects-with-konnect-ui/
 content_type: how_to
-description: Learn how to connect a SonarQube project to your {{site.konnect_catalog}} service in {{site.konnect_short_name}} using the UI.
+description: Learn how to connect a SonarQube project to your {{site.konnect_catalog}} Classic service in {{site.konnect_short_name}} using the UI.
 products:
   - catalog
 works_on:
@@ -14,18 +14,18 @@ search_aliases:
   - project
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: SonarQube reference
     url: /catalog/integrations/sonarqube/
-  - text: "Monitor SonarQube projects {{site.konnect_catalog}} with the {{site.konnect_short_name}} API"
+  - text: "Monitor SonarQube projects in {{site.konnect_catalog}} Classic with the Konnect API"
     url: /how-to/monitor-sonarqube-projects-with-konnect-api/
 automated_tests: false
 tldr:
   q: How do I monitor SonarQube projects in {{site.konnect_short_name}}?
-  a: Install the SonarQube integration in {{site.konnect_short_name}} and authorize access with your SonarQube personal access token, then link a project to your {{site.konnect_catalog}} service.
+  a: Install the SonarQube integration in {{site.konnect_short_name}} and authorize access with your SonarQube personal access token, then link a project to your {{site.konnect_catalog}} Classic service.
 prereqs:
   inline:
     - title: "{{site.konnect_short_name}} roles"
@@ -41,9 +41,11 @@ prereqs:
       icon_url: /assets/icons/third-party/sonarqube.svg
 ---
 
+{% include_cached catalog/catalog-classic-banner.md %}
+
 ## Configure the SonarQube integration
 
-Before you can discover [SonarQube projects](https://docs.sonarsource.com/sonarqube-cloud/managing-your-projects) in {{site.konnect_catalog}}, you must configure the SonarQube integration.
+Before you can discover [SonarQube projects](https://docs.sonarsource.com/sonarqube-cloud/managing-your-projects) in {{site.konnect_catalog}} Classic, you must configure the SonarQube integration.
 
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
 1. In the Catalog sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
@@ -54,9 +56,9 @@ Before you can discover [SonarQube projects](https://docs.sonarsource.com/sonarq
 1. In the **Instance name** field, enter `sonarqube`.
 1. Click **Save**.
 
-## Create a {{site.konnect_catalog}} service and map the SLO resources
+## Create a {{site.konnect_catalog}} Classic service and map the SLO resources
 
-Now that your integration is configured, you can create a {{site.konnect_catalog}} service to map the ingested projects.
+Now that your integration is configured, you can create a {{site.konnect_catalog}} Classic service to map the ingested projects.
 
 {:.info}
 > In this tutorial, we'll refer to your ingested SonarQube project as `billing-project`.
@@ -71,7 +73,7 @@ Now that your integration is configured, you can create a {{site.konnect_catalog
 1. Select `billing-project`. 
 1. Click **Map 1 Resource**.
 
-Your integration projects are now discoverable from one {{site.konnect_catalog}} service.
+Your integration projects are now discoverable from one {{site.konnect_catalog}} Classic service.
 
 {:.info}
 > You may need to manually sync your SonarQube integration for resources to appear. From the {{site.konnect_short_name}} UI by navigating to the SonarQube integration you just installed and selecting **Sync Now** from the **Actions** dropdown menu.

--- a/app/_how-tos/catalog/monitor-sonarqube-projects-with-konnect-ui.md
+++ b/app/_how-tos/catalog/monitor-sonarqube-projects-with-konnect-ui.md
@@ -48,7 +48,7 @@ prereqs:
 Before you can discover [SonarQube projects](https://docs.sonarsource.com/sonarqube-cloud/managing-your-projects) in {{site.konnect_catalog}} Classic, you must configure the SonarQube integration.
 
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. In the Catalog sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
+1. In the Catalog sidebar, click **Integrations**. 
 1. Click **SonarQube**.
 1. Click **Add SonarQube instance**.
 1. In the **SonarQube API key** field, enter your SonarQube personal access token.
@@ -63,7 +63,7 @@ Now that your integration is configured, you can create a {{site.konnect_catalog
 {:.info}
 > In this tutorial, we'll refer to your ingested SonarQube project as `billing-project`.
 
-1. In the {{site.konnect_short_name}} sidebar, click [**{{site.konnect_catalog}}**](https://cloud.konghq.com/service-catalog/).
+1. In the {{site.konnect_short_name}} sidebar, click **{{site.konnect_catalog}}**.
 1. In the Catalog sidebar, click **Services**.
 1. Click **New service**.
 1. In the **Display Name** field, enter `Billing Service`.
@@ -82,7 +82,7 @@ Your integration projects are now discoverable from one {{site.konnect_catalog}}
 
 To confirm that the SonarQube resource is now mapped to the intended service, navigate to the service:
 
-1. In the {{site.konnect_short_name}} sidebar, click [**{{site.konnect_catalog}}**](https://cloud.konghq.com/service-catalog/).
+1. In the {{site.konnect_short_name}} sidebar, click **{{site.konnect_catalog}}**.
 1. In the {{site.konnect_catalog}} sidebar, click **Services**.
 1. Click the **Billing Service** service.
 1. Click the **Resources** tab.

--- a/app/_how-tos/dev-portal/package-apis-with-dev-portal.md
+++ b/app/_how-tos/dev-portal/package-apis-with-dev-portal.md
@@ -53,7 +53,7 @@ prereqs:
            
            {:.info}
            > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **APIs** in the sidebar instead.
-        1. Click [**New API**](https://cloud.konghq.com/apis/create).
+        1. Click **New API**.
         1. In the **API name** field, enter `MyAPI`.
         1. Click **Create**.
       icon_url: /assets/icons/dev-portal.svg
@@ -280,7 +280,7 @@ To allow developers to consume your API, you must first link an API Gateway and 
 
 Operations from your API's OpenAPI spec should overlap with Routes to ensure requests will be routed to the correct Service. Gateway routing configuration isn't directly modified by adding operations.
 
-1. In the {{site.konnect_short_name}} sidebar, click [**Catalog**](https://cloud.konghq.com/apis/).
+1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
    
    {:.info}
    > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **APIs** in the sidebar instead.

--- a/app/_how-tos/dev-portal/package-apis-with-dev-portal.md
+++ b/app/_how-tos/dev-portal/package-apis-with-dev-portal.md
@@ -47,7 +47,12 @@ prereqs:
     - title: Dev Portal APIs
       content: |
         To complete this guide, you'll need an API in Catalog:
+
         1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
+        1. Click the **APIs** tab.
+           
+           {:.info}
+           > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **APIs** in the sidebar instead.
         1. Click [**New API**](https://cloud.konghq.com/apis/create).
         1. In the **API name** field, enter `MyAPI`.
         1. Click **Create**.
@@ -274,7 +279,12 @@ You can compose [API packages](/catalog/api-packaging/) from existing APIs in De
 To allow developers to consume your API, you must first link an API Gateway and control plane to your API.
 
 Operations from your API's OpenAPI spec should overlap with Routes to ensure requests will be routed to the correct Service. Gateway routing configuration isn't directly modified by adding operations.
+
 1. In the {{site.konnect_short_name}} sidebar, click [**Catalog**](https://cloud.konghq.com/apis/).
+   
+   {:.info}
+   > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **APIs** in the sidebar instead.
+   
 1. Click **MyAPI**.
 1. Click the **Gateway** tab.
 1. Click **Link gateway**.
@@ -295,6 +305,9 @@ The Gateway configuration isn't directly modified, so any unmatched operations w
 
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
 1. Click the **API packages** tab.
+   
+   {:.info}
+   > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **API packages** in the sidebar instead.
 1. Click **Create API package**.
 1. In the **API package name** field, enter `Company package`.
 1. Enable the Package rate limit.
@@ -312,8 +325,12 @@ The Gateway configuration isn't directly modified, so any unmatched operations w
 
 ## Publish API packages to Dev Portal
 Now you can make the API packages available to developers by publishing them to a Dev Portal.
+
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
 1. Click the **API packages** tab.
+   
+   {:.info}
+   > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **API packages** in the sidebar instead.
 1. Click **Company package**.
 1. Click **Publish API**.
 1. From the **Portal** dropdown menu, select your Dev Portal.

--- a/app/_how-tos/dev-portal/package-apis-with-dev-portal.md
+++ b/app/_how-tos/dev-portal/package-apis-with-dev-portal.md
@@ -304,11 +304,10 @@ Now, you can create an API package by picking operations from your API. Operatio
 The Gateway configuration isn't directly modified, so any unmatched operations will be highlighted to indicate that a user needs API Gateway permissions to perform an action.
 
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. Click the **API packages** tab.
+1. From the **New** dropdown menu, select "API package".
    
    {:.info}
    > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **API packages** in the sidebar instead.
-1. Click **Create API package**.
 1. In the **API package name** field, enter `Company package`.
 1. Enable the Package rate limit.
 1. For the rate limit, enter `5` and select "Minute".

--- a/app/_includes/catalog/catalog-classic-banner.md
+++ b/app/_includes/catalog/catalog-classic-banner.md
@@ -1,0 +1,2 @@
+{:.warning}
+> You're viewing the {{site.konnect_catalog}} Classic docs. To see the new {{site.konnect_catalog}} experience, see the [{{site.konnect_catalog}} documentation](/catalog/).

--- a/app/_includes/faqs/mcp-server-vs-registry.md
+++ b/app/_includes/faqs/mcp-server-vs-registry.md
@@ -1,0 +1,15 @@
+{% if include.section == "question" %}
+
+Should I create an MCP server or MCP registry in the new {{site.konnect_catalog}}?
+{% elsif include.section == "answer" %}
+
+If you're creating a new MCP definition, create an [MCP server](/catalog/mcp-servers/). 
+It's the preferred object going forward, and is additive to the MCP registry's server object.
+It captures remotes and packages like an MCP registry, but also supports the server's tools, resources, and prompts.
+You can also [link an MCP server to {{site.ai_gateway}} 2.0](/catalog/mcp-servers/#create-an-mcp-server) as its source.
+
+If you're already using MCP registries, we recommend migrating to MCP server so you can use these additional capabilities.
+You can automate this by writing a script that iterates through each MCP registry and the MCP servers nested under it, then creates a new MCP server using the new object model for each one, including its remotes and packages.
+You won't lose any information in the process, since the new object model is additive.
+
+{% endif %}

--- a/app/_indices/catalog.yaml
+++ b/app/_indices/catalog.yaml
@@ -34,4 +34,6 @@ groups:
         auto_exclude: true
       - title: How-tos
         items:
-          - path: /how-to/discover-and-govern-apis-with-service-catalog/
+          - type: how-to
+            products:
+              - catalog

--- a/app/_indices/catalog.yaml
+++ b/app/_indices/catalog.yaml
@@ -12,6 +12,12 @@ groups:
           - path: /how-to/automate-api-catalog/
           - path: /how-to/automate-api-catalog-with-terraform/
           - path: /how-to/package-apis-with-dev-portal/
+      - title: AI Models
+        items:
+          - path: /catalog/ai-models/
+      - title: MCP Registry
+        items:
+          - path: /catalog/mcp-registry/
   - title: "{{site.konnect_catalog}} Classic"
     sections:
       - title: Overview
@@ -29,6 +35,3 @@ groups:
       - title: How-tos
         items:
           - path: /how-to/discover-and-govern-apis-with-service-catalog/
-      - title: MCP Registry
-        items:
-          - path: /catalog/mcp-registry/

--- a/app/_indices/catalog.yaml
+++ b/app/_indices/catalog.yaml
@@ -18,6 +18,9 @@ groups:
       - title: MCP Registry
         items:
           - path: /catalog/mcp-registry/
+      - title: Agents
+        items:
+          - path: /catalog/agents/
   - title: "{{site.konnect_catalog}} Classic"
     sections:
       - title: Overview

--- a/app/_indices/catalog.yaml
+++ b/app/_indices/catalog.yaml
@@ -1,23 +1,34 @@
 title: "Catalog Documentation"
 description: Index containing all documentation for {{site.konnect_catalog}}.
-sections:
-  - title: Overview
-    items:
-      - path: /catalog/
-  - title: APIs
-    items:
-      - path: /service-catalog/apis/
-      - path: /catalog/api-packaging/
-      - path: /how-to/automate-api-catalog/
-      - path: /how-to/automate-api-catalog-with-terraform/
-      - path: /how-to/discover-and-govern-apis-with-service-catalog/
-      - path: /how-to/package-apis-with-dev-portal/
-  - title: Services and scorecards
-    items:
-      - path: /catalog/scorecards/
-      - path: /catalog/services/
-  - title: Integrations
-    items:
-      - path: /catalog/integrations/
-      - path: /catalog/integrations/**/*
-    auto_exclude: true
+groups:
+  - sections:
+      - title: Overview
+        items:
+          - path: /catalog/
+      - title: APIs
+        items:
+          - path: /service-catalog/apis/
+          - path: /catalog/api-packaging/
+          - path: /how-to/automate-api-catalog/
+          - path: /how-to/automate-api-catalog-with-terraform/
+          - path: /how-to/package-apis-with-dev-portal/
+  - title: "{{site.konnect_catalog}} Classic"
+    sections:
+      - title: Overview
+        items:
+          - path: /catalog-classic/
+      - title: Services and scorecards
+        items:
+          - path: /catalog/scorecards/
+          - path: /catalog/services/
+      - title: Integrations
+        items:
+          - path: /catalog/integrations/
+          - path: /catalog/integrations/**/*
+        auto_exclude: true
+      - title: How-tos
+        items:
+          - path: /how-to/discover-and-govern-apis-with-service-catalog/
+      - title: MCP Registry
+        items:
+          - path: /catalog/mcp-registry/

--- a/app/_indices/catalog.yaml
+++ b/app/_indices/catalog.yaml
@@ -15,8 +15,9 @@ groups:
       - title: AI Models
         items:
           - path: /catalog/ai-models/
-      - title: MCP Registry
+      - title: MCP
         items:
+          - path: /catalog/mcp-servers/
           - path: /catalog/mcp-registry/
       - title: Agents
         items:

--- a/app/_landing_pages/catalog-classic.yaml
+++ b/app/_landing_pages/catalog-classic.yaml
@@ -1,0 +1,144 @@
+metadata:
+  title: "{{site.konnect_short_name}} {{site.konnect_catalog}} Classic"
+  content_type: landing_page
+  products:
+    - catalog
+  description: Learn how to track and manage services across your organization with the {{site.konnect_short_name}} {{site.konnect_catalog}} Classic.
+  tags:
+    - governance
+  search_aliases:
+    - service catalog
+
+rows:
+  - header:
+      type: h1
+      text: "{{site.konnect_short_name}} {{site.konnect_catalog}} Classic"
+      sub_text: "A centralized catalog of all services running in your {{site.konnect_short_name}} organization"
+  
+  - columns:
+      - blocks:
+          - type: structured_text
+            config:
+              blocks:
+                - type: text
+                  text: |
+                    {% include_cached catalog/catalog-classic-banner.md %}
+
+  - columns:
+      - blocks:
+          - type: structured_text
+            config:
+              header:
+                text: "What is the {{site.konnect_short_name}} {{site.konnect_catalog}} Classic?"
+              blocks:
+                - type: text
+                  text: |
+                    {{site.konnect_catalog}} Classic provides a centralized catalog of all services and APIs running in your organization. 
+                    By integrating with internal applications, like API Gateway and Service Mesh, and external tools, like GitHub and PagerDuty, 
+                    it offers a 360-degree overview of your services, including:
+                - type: unordered_list
+                  items:
+                    - Service ownership details
+                    - Upstream and downstream dependencies
+                    - Associated code repositories and CI/CD pipelines
+                    - API gateway and service mesh mappings
+                    - Comprehensive API and MCP server catalog
+
+  - header:
+        type: h2
+        text: "Create your catalog"
+    columns:
+      - blocks:
+        - type: card
+          config:
+            title: APIs
+            description: |
+              Create, discover, and govern APIs and specs.
+              Catalog serves as a central repository for your APIs, services, and the documentation files associated with them.
+            icon: /assets/icons/api.svg
+            ctas:
+              - text: APIs reference
+                url: "/catalog/apis/"
+              - text: API packages
+                url: /catalog/api-packaging/
+              - text: Create an API catalog with the {{site.konnect_short_name}} API
+                url: "/how-to/automate-api-catalog/"
+              - text: Create an API catalog with Terraform
+                url: "/how-to/automate-api-catalog-with-terraform/"
+              - text: Discover and govern APIs
+                url: /how-to/discover-and-govern-apis-with-service-catalog/
+      - blocks:
+          - type: card
+            config:
+              title: "Services"
+              description: |
+                Discover the systems that power your APIs—like microservices or backends—and centralize them for a complete view of your API infrastructure.
+              icon: /assets/icons/linked-services.svg
+              cta:
+                text: Learn about {{site.konnect_catalog}} services
+                url: /catalog/services/
+      - blocks:
+          - type: card
+            config:
+              title: MCP Registry (tech preview)
+              description: |
+                Discover and connect MCP servers to {{site.konnect_short_name}} {{site.konnect_catalog}}.
+              icon: /assets/icons/mcp.svg
+              cta:
+                text: Enable in {{site.konnect_short_name}} Labs.
+                url: /catalog/mcp-registry/
+  - header:
+      type: h2
+      text: "Explore more features"
+    columns:
+      - blocks:
+          - type: card
+            config:
+              title: Integrations
+              description: |
+                Connect external tools like GitHub, PagerDuty, and CI/CD pipelines to map services, dependencies, and metadata.
+              icon: /assets/icons/plug.svg
+              cta:
+                text: See all integrations
+                url: /catalog/integrations/
+      - blocks:
+          - type: card
+            config:
+              title: Scorecards
+              description: |
+                Monitor compliance, security, and best practices across services using automated scorecards.
+              icon: /assets/icons/data-object.svg
+              cta:
+                text: Learn about scorecards
+                url: /catalog/scorecards/
+  - header:
+      type: h2
+      text: "Migrate to the new Catalog"
+    columns:
+      - blocks:
+          - type: structured_text
+            config:
+              blocks:
+                - type: text
+                  text: |
+                    An Org Admin can migrate to the new {{site.konnect_catalog}} experience by enabling the New Catalog
+                    in **Manage organization** > **Settings** > **Catalog**.
+
+                    Your APIs and API packages migrate to the new {{site.konnect_catalog}}. Services, Scorecards, and Integrations data isn't deleted,
+                    but becomes inaccessible in the UI after migrating. You can still manage these and access their data by using the API. 
+
+  - header:
+      type: h2
+      text: "Frequently asked questions"
+    columns:
+      - blocks:
+          - type: faqs
+            config:
+              - q: "How do I view service health and status?"
+                a: "Go to **Services** in {{site.konnect_catalog}} Classic and select a service to view detailed health and status information."
+              - q: "How can I identify available resources for mapping?"
+                a: "Visit the **Resources** page in {{site.konnect_catalog}} Classic to see all available ingested resources."
+              - q: "What if I notice discrepancies in {{site.konnect_catalog}} data?"
+                a: "Check integration settings, verify connected tools, and ensure data synchronization is working correctly."
+              - q: "Can I control access to specific {{site.konnect_catalog}} data?"
+                a: "Yes, access can be managed through [teams and roles](/konnect-platform/teams-and-roles/)."

--- a/app/_landing_pages/catalog-classic.yaml
+++ b/app/_landing_pages/catalog-classic.yaml
@@ -121,8 +121,8 @@ rows:
                     The [new {{site.konnect_catalog}} experience](/catalog/) is a unified, platform-level home for your interfaces. Here's how it compares
                     to {{site.konnect_catalog}} Classic:
 
-                    * **AI Models**: The new {{site.konnect_catalog}} adds support for AI Models as a first-class interface, with more interface
-                      types coming.
+                    * **AI Models**: The new {{site.konnect_catalog}} adds support for AI Models as a first-class interface. You can opt to link these to {{site.ai_gateway}} 2.0 AI Model entities.
+                    * **Agents (beta)**: The new {{site.konnect_catalog}} introduces Agents as a first-class interface. You can opt to link these to {{site.ai_gateway}} 2.0 AI Agent entities.
                     * **Continued support for APIs, API packages, and MCP Registries**: APIs, API packages, and MCP Registries (tech preview) work the same way in both experiences. APIs and API packages migrate over.
 
                     Services, Scorecards, and Integrations are only compatible with {{site.konnect_catalog}} Classic.

--- a/app/_landing_pages/catalog-classic.yaml
+++ b/app/_landing_pages/catalog-classic.yaml
@@ -17,12 +17,9 @@ rows:
   
   - columns:
       - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    {% include_cached catalog/catalog-classic-banner.md %}
+          - type: text
+            config: |
+              {% include_cached catalog/catalog-classic-banner.md %}
 
   - columns:
       - blocks:
@@ -121,11 +118,20 @@ rows:
               blocks:
                 - type: text
                   text: |
+                    The [new {{site.konnect_catalog}} experience](/catalog/) is a unified, platform-level home for your interfaces. Here's how it compares
+                    to {{site.konnect_catalog}} Classic:
+
+                    * **AI Models**: The new {{site.konnect_catalog}} adds support for AI Models as a first-class interface, with more interface
+                      types coming. 
+                    * **Continued support for APIs**: APIs and API packages work the same way in both experiences, APIs and API packages migrate over.
+
+                    Services, Scorecards, Integrations, and the MCP Registry are only compatible with {{site.konnect_catalog}} Classic.
+                    
                     An Org Admin can migrate to the new {{site.konnect_catalog}} experience by enabling the New Catalog
                     in **Manage organization** > **Settings** > **Catalog**.
 
                     Your APIs and API packages migrate to the new {{site.konnect_catalog}}. Services, Scorecards, and Integrations data isn't deleted,
-                    but becomes inaccessible in the UI after migrating. You can still manage these and access their data by using the API. 
+                    but becomes inaccessible in the UI after migrating. You can still manage these and access their data by using the API.
 
   - header:
       type: h2

--- a/app/_landing_pages/catalog-classic.yaml
+++ b/app/_landing_pages/catalog-classic.yaml
@@ -122,10 +122,10 @@ rows:
                     to {{site.konnect_catalog}} Classic:
 
                     * **AI Models**: The new {{site.konnect_catalog}} adds support for AI Models as a first-class interface, with more interface
-                      types coming. 
-                    * **Continued support for APIs**: APIs and API packages work the same way in both experiences, APIs and API packages migrate over.
+                      types coming.
+                    * **Continued support for APIs, API packages, and MCP Registries**: APIs, API packages, and MCP Registries (tech preview) work the same way in both experiences. APIs and API packages migrate over.
 
-                    Services, Scorecards, Integrations, and the MCP Registry are only compatible with {{site.konnect_catalog}} Classic.
+                    Services, Scorecards, and Integrations are only compatible with {{site.konnect_catalog}} Classic.
                     
                     An Org Admin can migrate to the new {{site.konnect_catalog}} experience by enabling the New Catalog
                     in **Manage organization** > **Settings** > **Catalog**.

--- a/app/_landing_pages/catalog.yaml
+++ b/app/_landing_pages/catalog.yaml
@@ -3,37 +3,44 @@ metadata:
   content_type: landing_page
   products:
     - catalog
-  description: Learn how to track and manage services across your organization with the {{site.konnect_short_name}} {{site.konnect_catalog}}.
+  description: Learn how to create, discover, and govern the interfaces your organization publishes and consumes with {{site.konnect_short_name}} {{site.konnect_catalog}}.
   tags:
     - governance
   search_aliases:
     - service catalog
+    - api catalog
 
 rows:
   - header:
       type: h1
       text: "{{site.konnect_short_name}} {{site.konnect_catalog}}"
-      sub_text: "A centralized catalog of all services running in your {{site.konnect_short_name}} organization"
-  
+      sub_text: "A platform-level home for the interfaces your organization publishes and consumes"
+
+  - columns:
+      - blocks:
+          - type: structured_text
+            config:
+              blocks:
+                - type: text
+                  text: |
+                    {:.info}
+                    > Looking for {{site.konnect_catalog}} Classic? 
+                    > See the [{{site.konnect_catalog}} Classic documentation](/catalog-classic/).
+
   - columns:
       - blocks:
           - type: structured_text
             config:
               header:
-                text: "What is the {{site.konnect_short_name}} {{site.konnect_catalog}}?"
+                text: "What is {{site.konnect_short_name}} {{site.konnect_catalog}}?"
               blocks:
                 - type: text
                   text: |
-                    {{site.konnect_catalog}} provides a centralized catalog of all services and APIs running in your organization. 
-                    By integrating with internal applications, like API Gateway and Service Mesh, and external tools, like GitHub and PagerDuty, 
-                    it offers a 360-degree overview of your services, including:
-                - type: unordered_list
-                  items:
-                    - Service ownership details
-                    - Upstream and downstream dependencies
-                    - Associated code repositories and CI/CD pipelines
-                    - API gateway and service mesh mappings
-                    - Comprehensive API and MCP server catalog
+                    {{site.konnect_catalog}} is where your organization's interfaces live: APIs, API packages, and AI Models today, with more interface types
+                    coming. Instead of digging through individual products to find what already exists, {{site.konnect_catalog}} gives you a
+                    platform-level home for creating, describing, and governing them.
+
+                    <!-- TODO: add screenshot of the {{site.konnect_catalog}} view -->
 
   - header:
         type: h2
@@ -45,63 +52,35 @@ rows:
             title: APIs
             description: |
               Create, discover, and govern APIs and specs.
-              Catalog serves as a central repository for your APIs, services, and the documentation files associated with them.
+              Catalog serves as a central repository for your APIs and the documentation files associated with them.
             icon: /assets/icons/api.svg
             ctas:
               - text: APIs reference
                 url: "/catalog/apis/"
-              - text: API packages
-                url: /catalog/api-packaging/
               - text: Create an API catalog with the {{site.konnect_short_name}} API
                 url: "/how-to/automate-api-catalog/"
               - text: Create an API catalog with Terraform
                 url: "/how-to/automate-api-catalog-with-terraform/"
-              - text: Discover and govern APIs
-                url: /how-to/discover-and-govern-apis-with-service-catalog/
       - blocks:
           - type: card
             config:
-              title: "Services"
+              title: "API packages"
               description: |
-                Discover the systems that power your APIs—like microservices or backends—and centralize them for a complete view of your API infrastructure.
-              icon: /assets/icons/linked-services.svg
+                Compose API packages from existing operations to serve specific partners or use cases.
+              icon: /assets/icons/api.svg
               cta:
-                text: Learn about {{site.konnect_catalog}} services
-                url: /catalog/services/
+                text: API packages reference
+                url: /catalog/api-packaging/
       - blocks:
           - type: card
             config:
-              title: MCP Registry (tech preview)
+              title: "AI Models"
               description: |
-                Discover and connect MCP servers to {{site.konnect_short_name}} {{site.konnect_catalog}}.
-              icon: /assets/icons/mcp.svg
+                Model your organization's AI models as first-class interfaces in {{site.konnect_catalog}}.
+              icon: /assets/icons/brain.svg
               cta:
-                text: Enable in {{site.konnect_short_name}} Labs.
-                url: /catalog/mcp-registry/
-  - header:
-      type: h2
-      text: "Explore more features"
-    columns:
-      - blocks:
-          - type: card
-            config:
-              title: Integrations
-              description: |
-                Connect external tools like GitHub, PagerDuty, and CI/CD pipelines to map services, dependencies, and metadata.
-              icon: /assets/icons/plug.svg
-              cta:
-                text: See all integrations
-                url: /catalog/integrations/
-      - blocks:
-          - type: card
-            config:
-              title: Scorecards
-              description: |
-                Monitor compliance, security, and best practices across services using automated scorecards.
-              icon: /assets/icons/data-object.svg
-              cta:
-                text: Learn about scorecards
-                url: /catalog/scorecards/
+                text: Learn about AI Models
+                url: /catalog/ai-models/
   - header:
       type: h2
       text: "Frequently asked questions"
@@ -109,11 +88,7 @@ rows:
       - blocks:
           - type: faqs
             config:
-              - q: "How do I view service health and status?"
-                a: "Go to **Services** in the {{site.konnect_catalog}} and select a service to view detailed health and status information."
-              - q: "How can I identify available resources for mapping?"
-                a: "Visit the **Resources** page in the {{site.konnect_catalog}} to see all available ingested resources."
-              - q: "What if I notice discrepancies in {{site.konnect_catalog}} data?"
-                a: "Check integration settings, verify connected tools, and ensure data synchronization is working correctly."
+              - q: "What happened to Services, Integrations, and Scorecards?"
+                a: "Those features are compatible with {{site.konnect_catalog}} Classic. See the [{{site.konnect_catalog}} Classic documentation](/catalog-classic/)."
               - q: "Can I control access to specific {{site.konnect_catalog}} data?"
                 a: "Yes, access can be managed through [teams and roles](/konnect-platform/teams-and-roles/)."

--- a/app/_landing_pages/catalog.yaml
+++ b/app/_landing_pages/catalog.yaml
@@ -115,10 +115,10 @@ rows:
                     - solution: |
                         [AI Models](/catalog/ai-models/), browsable with their providers and target models visible
                 - usecase: |
-                    You need to see which AI Models are actually connected to a real {{site.ai_gateway}} deployment, versus just defined on paper
+                    You need to see which AI Models are actually connected to a real {{site.ai_gateway}} 2.0 deployment, versus just defined on paper
                   outcomes:
                     - solution: |
-                        Filter AI Models by whether they're linked to {{site.ai_gateway}}
+                        Filter AI Models by whether they're linked to {{site.ai_gateway}} 2.0
                 - usecase: |
                     Your teams are building MCP servers for AI agents, but they're scattered across repos and local configs with no shared place to register them
                   outcomes:

--- a/app/_landing_pages/catalog.yaml
+++ b/app/_landing_pages/catalog.yaml
@@ -18,14 +18,11 @@ rows:
 
   - columns:
       - blocks:
-          - type: structured_text
-            config:
-              blocks:
-                - type: text
-                  text: |
-                    {:.info}
-                    > Looking for {{site.konnect_catalog}} Classic? 
-                    > See the [{{site.konnect_catalog}} Classic documentation](/catalog-classic/).
+          - type: text
+            config: |
+              {:.info}
+              > Looking for {{site.konnect_catalog}} Classic?
+              > See the [{{site.konnect_catalog}} Classic documentation](/catalog-classic/).
 
   - columns:
       - blocks:
@@ -88,6 +85,8 @@ rows:
       - blocks:
           - type: faqs
             config:
+              - q: "What's different between {{site.konnect_catalog}} and {{site.konnect_catalog}} Classic?"
+                a: "{{site.konnect_catalog}} is the unified, platform-level experience for APIs, API packages, and AI Models today, with more interface types coming. {{site.konnect_catalog}} Classic remains available with Services, Scorecards, Integrations, and MCP Registry. See [Migrate to the new Catalog](/catalog-classic/#migrate-to-the-new-catalog) for how to move to the new experience."
               - q: "What happened to Services, Integrations, and Scorecards?"
                 a: "Those features are compatible with {{site.konnect_catalog}} Classic. See the [{{site.konnect_catalog}} Classic documentation](/catalog-classic/)."
               - q: "Can I control access to specific {{site.konnect_catalog}} data?"

--- a/app/_landing_pages/catalog.yaml
+++ b/app/_landing_pages/catalog.yaml
@@ -33,7 +33,11 @@ rows:
               blocks:
                 - type: text
                   text: |
-                    {{site.konnect_catalog}} is where your organization's interfaces live: APIs, API packages, and AI Models today, with more interface types
+                    Teams build APIs and configure AI models independently, each in their own tools, with no shared record of what already exists.
+                    An API might be well documented within its own team, but invisible to everyone else.
+                    An LLM integration might work fine until someone in security asks which providers you're actually sending data to, and there's no fast way to answer.
+
+                    {{site.konnect_catalog}} is where these interfaces live instead: APIs, API packages, and AI Models today, with more interface types
                     coming. Instead of digging through individual products to find what already exists, {{site.konnect_catalog}} gives you a
                     platform-level home for creating, describing, and governing them.
 
@@ -43,6 +47,26 @@ rows:
         type: h2
         text: "Create your catalog"
     columns:
+      - blocks:
+          - type: card
+            config:
+              title: "AI Models"
+              description: |
+                Model your organization's AI models as first-class interfaces in {{site.konnect_catalog}}.
+              icon: /assets/icons/brain.svg
+              cta:
+                text: Learn about AI Models
+                url: /catalog/ai-models/
+      - blocks:
+          - type: card
+            config:
+              title: "MCP Registries (tech preview)"
+              description: |
+                Register and discover MCP servers as first-class interfaces in {{site.konnect_catalog}}.
+              icon: /assets/icons/mcp.svg
+              cta:
+                text: Learn about MCP Registries
+                url: /catalog/mcp-registry/
       - blocks:
         - type: card
           config:
@@ -68,16 +92,49 @@ rows:
               cta:
                 text: API packages reference
                 url: /catalog/api-packaging/
+  - header:
+      type: h2
+      text: "Use cases for {{site.konnect_catalog}}"
+    columns:
       - blocks:
-          - type: card
+          - type: use_case_table
             config:
-              title: "AI Models"
-              description: |
-                Model your organization's AI models as first-class interfaces in {{site.konnect_catalog}}.
-              icon: /assets/icons/brain.svg
-              cta:
-                text: Learn about AI Models
-                url: /catalog/ai-models/
+              usecase_title: "**Use case**"
+              columns:
+                - title: "**Then use...**"
+                  key: solution
+              rows:
+                - usecase: |
+                    You need to know every AI model, API, and MCP server your org has built, without checking each team's tools individually
+                  outcomes:
+                    - solution: |
+                        {{site.konnect_catalog}} as one inventory across APIs, API packages, AI Models, and MCP Registries
+                - usecase: |
+                    Before building a new LLM integration, you want to check whether another team already has one you can reuse
+                  outcomes:
+                    - solution: |
+                        [AI Models](/catalog/ai-models/), browsable with their providers and target models visible
+                - usecase: |
+                    You need to see which AI Models are actually connected to a real {{site.ai_gateway}} deployment, versus just defined on paper
+                  outcomes:
+                    - solution: |
+                        Filter AI Models by whether they're linked to {{site.ai_gateway}}
+                - usecase: |
+                    Your teams are building MCP servers for AI agents, but they're scattered across repos and local configs with no shared place to register them
+                  outcomes:
+                    - solution: |
+                        [MCP Registries](/catalog/mcp-registry/), where you publish MCP servers with their packages and remote endpoints
+                - usecase: |
+                    A partner or internal team needs access to a specific slice of your APIs, not everything, without creating separate infrastructure for it
+                  outcomes:
+                    - solution: |
+                        [API packages](/catalog/api-packaging/), composed from existing API operations for that audience
+                - usecase: |
+                    You want developers to register their own applications and get credentials for an API without provisioning each one manually
+                  outcomes:
+                    - solution: |
+                        Publish an [API](/catalog/apis/#publish-your-api-to-dev-portal) to a Dev Portal with an authentication strategy
+
   - header:
       type: h2
       text: "Frequently asked questions"
@@ -86,7 +143,7 @@ rows:
           - type: faqs
             config:
               - q: "What's different between {{site.konnect_catalog}} and {{site.konnect_catalog}} Classic?"
-                a: "{{site.konnect_catalog}} is the unified, platform-level experience for APIs, API packages, and AI Models today, with more interface types coming. {{site.konnect_catalog}} Classic remains available with Services, Scorecards, Integrations, and MCP Registry. See [Migrate to the new Catalog](/catalog-classic/#migrate-to-the-new-catalog) for how to move to the new experience."
+                a: "{{site.konnect_catalog}} is the unified, platform-level experience for APIs, API packages, AI Models, and MCP Registries (tech preview) today, with more interface types coming. {{site.konnect_catalog}} Classic remains available with Services, Scorecards, and Integrations. See [Migrate to the new Catalog](/catalog-classic/#migrate-to-the-new-catalog) for how to move to the new experience."
               - q: "What happened to Services, Integrations, and Scorecards?"
                 a: "Those features are compatible with {{site.konnect_catalog}} Classic. See the [{{site.konnect_catalog}} Classic documentation](/catalog-classic/)."
               - q: "Can I control access to specific {{site.konnect_catalog}} data?"

--- a/app/_landing_pages/catalog.yaml
+++ b/app/_landing_pages/catalog.yaml
@@ -86,7 +86,17 @@ rows:
       - blocks:
           - type: card
             config:
-              title: "MCP Registries (tech preview)"
+              title: "MCP servers"
+              description: |
+                Model individual MCP servers as first-class interfaces in {{site.konnect_catalog}}.
+              icon: /assets/icons/mcp.svg
+              cta:
+                text: Learn about MCP servers
+                url: /catalog/mcp-servers/
+      - blocks:
+          - type: card
+            config:
+              title: "MCP registries (tech preview)"
               description: |
                 Register and discover MCP servers as first-class interfaces in {{site.konnect_catalog}}.
               icon: /assets/icons/mcp.svg
@@ -119,7 +129,7 @@ rows:
                     You need to know every API, AI Model, agent, and MCP server your org has built, without checking each team's tools individually
                   outcomes:
                     - solution: |
-                        {{site.konnect_catalog}} as one inventory across APIs, API packages, AI Models, MCP Registries, and Agents
+                        {{site.konnect_catalog}} as one inventory across APIs, API packages, AI Models, MCP servers, and agents
                 - usecase: |
                     Before building a new LLM integration, you want to check whether another team already has one you can reuse
                   outcomes:
@@ -134,7 +144,7 @@ rows:
                     Your teams are building MCP servers for AI agents, but they're scattered across repos and local configs with no shared place to register them
                   outcomes:
                     - solution: |
-                        [MCP Registries](/catalog/mcp-registry/), where you publish MCP servers with their packages and remote endpoints
+                        [MCP servers](/catalog/mcp-servers/), where you publish MCP servers with their packages and remote endpoints
                 - usecase: |
                     Your teams are building agents across different frameworks, with no shared place to see what already exists and whether it's safe to reuse
                   outcomes:
@@ -159,7 +169,7 @@ rows:
           - type: faqs
             config:
               - q: "What's different between {{site.konnect_catalog}} and {{site.konnect_catalog}} Classic?"
-                a: "{{site.konnect_catalog}} is the unified, platform-level experience for APIs, API packages, AI Models, MCP Registries (tech preview), and Agents (beta) today, with more interface types coming. {{site.konnect_catalog}} Classic remains available with Services. See [Migrate to the new Catalog](/catalog-classic/#migrate-to-the-new-catalog) for how to move to the new experience."
+                a: "{{site.konnect_catalog}} is the unified, platform-level experience for APIs, API packages, AI Models, MCP servers, Agents (beta), and MCP registries (tech preview) today, with more interface types coming. {{site.konnect_catalog}} Classic remains available with Services. See [Migrate to the new Catalog](/catalog-classic/#migrate-to-the-new-catalog) for how to move to the new experience."
               - q: "What happens to Integrations and Scorecards?"
                 a: "Integrations and Scorecards are compatible with [{{site.konnect_catalog}} Classic](/catalog-classic/) today. Kong plans to bring them into the new {{site.konnect_catalog}} experience in the future, with a focus on APIs and AI interfaces rather than Services."
               - q: "Can I control access to specific {{site.konnect_catalog}} data?"

--- a/app/_landing_pages/catalog.yaml
+++ b/app/_landing_pages/catalog.yaml
@@ -37,8 +37,8 @@ rows:
                     An API might be well documented within its own team, but invisible to everyone else.
                     An LLM integration might work fine until someone in security asks which providers you're actually sending data to, and there's no fast way to answer.
 
-                    {{site.konnect_catalog}} is where these interfaces live instead: APIs, API packages, and AI Models today, with more interface types
-                    coming. Instead of digging through individual products to find what already exists, {{site.konnect_catalog}} gives you a
+                    {{site.konnect_catalog}} is where these interfaces live instead: APIs, AI Models, and more. Instead of digging through individual products
+                    to find what already exists, {{site.konnect_catalog}} gives you a
                     platform-level home for creating, describing, and governing them.
 
                     <!-- TODO: add screenshot of the {{site.konnect_catalog}} view -->
@@ -46,6 +46,7 @@ rows:
   - header:
         type: h2
         text: "Create your catalog"
+  - column_count: 3
     columns:
       - blocks:
         - type: card
@@ -92,6 +93,16 @@ rows:
               cta:
                 text: Learn about MCP Registries
                 url: /catalog/mcp-registry/
+      - blocks:
+          - type: card
+            config:
+              title: Agents (beta)
+              description: |
+                Register agents your organization builds or consumes as first-class interfaces in {{site.konnect_catalog}}. 
+              icon: /assets/icons/ai.svg
+              cta:
+                text: Learn about Agents
+                url: /catalog/agents/
   - header:
       type: h2
       text: "Use cases for {{site.konnect_catalog}}"
@@ -105,10 +116,10 @@ rows:
                   key: solution
               rows:
                 - usecase: |
-                    You need to know every API, AI Model, and MCP server your org has built, without checking each team's tools individually
+                    You need to know every API, AI Model, agent, and MCP server your org has built, without checking each team's tools individually
                   outcomes:
                     - solution: |
-                        {{site.konnect_catalog}} as one inventory across APIs, API packages, AI Models, and MCP Registries
+                        {{site.konnect_catalog}} as one inventory across APIs, API packages, AI Models, MCP Registries, and Agents
                 - usecase: |
                     Before building a new LLM integration, you want to check whether another team already has one you can reuse
                   outcomes:
@@ -124,6 +135,11 @@ rows:
                   outcomes:
                     - solution: |
                         [MCP Registries](/catalog/mcp-registry/), where you publish MCP servers with their packages and remote endpoints
+                - usecase: |
+                    Your teams are building agents across different frameworks, with no shared place to see what already exists and whether it's safe to reuse
+                  outcomes:
+                    - solution: |
+                        [Agents](/catalog/agents/), inventoried alongside APIs, AI Models, and MCP Registries, with an optional link to {{site.ai_gateway}} 2.0 AI Agent entities
                 - usecase: |
                     A partner or internal team needs access to a specific slice of your APIs, not everything, without creating separate infrastructure for it
                   outcomes:
@@ -143,7 +159,7 @@ rows:
           - type: faqs
             config:
               - q: "What's different between {{site.konnect_catalog}} and {{site.konnect_catalog}} Classic?"
-                a: "{{site.konnect_catalog}} is the unified, platform-level experience for APIs, API packages, AI Models, and MCP Registries (tech preview) today, with more interface types coming. {{site.konnect_catalog}} Classic remains available with Services. See [Migrate to the new Catalog](/catalog-classic/#migrate-to-the-new-catalog) for how to move to the new experience."
+                a: "{{site.konnect_catalog}} is the unified, platform-level experience for APIs, API packages, AI Models, MCP Registries (tech preview), and Agents (beta) today, with more interface types coming. {{site.konnect_catalog}} Classic remains available with Services. See [Migrate to the new Catalog](/catalog-classic/#migrate-to-the-new-catalog) for how to move to the new experience."
               - q: "What happens to Integrations and Scorecards?"
                 a: "Integrations and Scorecards are compatible with [{{site.konnect_catalog}} Classic](/catalog-classic/) today. Kong plans to bring them into the new {{site.konnect_catalog}} experience in the future, with a focus on APIs and AI interfaces rather than Services."
               - q: "Can I control access to specific {{site.konnect_catalog}} data?"

--- a/app/_landing_pages/catalog.yaml
+++ b/app/_landing_pages/catalog.yaml
@@ -136,7 +136,7 @@ rows:
                     - solution: |
                         [AI Models](/catalog/ai-models/), browsable with their providers and target models visible
                 - usecase: |
-                    You need to see which AI Models are actually connected to a real {{site.ai_gateway}} 2.0 deployment, versus just defined on paper
+                    You need to see which AI Models are actually connected to a real [{{site.ai_gateway}} 2.0](/ai-gateway/) deployment, versus just defined on paper
                   outcomes:
                     - solution: |
                         Filter AI Models by whether they're linked to {{site.ai_gateway}} 2.0
@@ -149,7 +149,8 @@ rows:
                     Your teams are building agents across different frameworks, with no shared place to see what already exists and whether it's safe to reuse
                   outcomes:
                     - solution: |
-                        [Agents](/catalog/agents/), inventoried alongside APIs, AI Models, and MCP Registries, with an optional link to {{site.ai_gateway}} 2.0 AI Agent entities
+                        [Agents](/catalog/agents/), inventoried alongside APIs, AI Models, and MCP Registries 
+                        {% comment %} with an optional link to {{site.ai_gateway}} 2.0 AI Agent entities {% endcomment %}
                 - usecase: |
                     A partner or internal team needs access to a specific slice of your APIs, not everything, without creating separate infrastructure for it
                   outcomes:

--- a/app/_landing_pages/catalog.yaml
+++ b/app/_landing_pages/catalog.yaml
@@ -48,26 +48,6 @@ rows:
         text: "Create your catalog"
     columns:
       - blocks:
-          - type: card
-            config:
-              title: "AI Models"
-              description: |
-                Model your organization's AI models as first-class interfaces in {{site.konnect_catalog}}.
-              icon: /assets/icons/brain.svg
-              cta:
-                text: Learn about AI Models
-                url: /catalog/ai-models/
-      - blocks:
-          - type: card
-            config:
-              title: "MCP Registries (tech preview)"
-              description: |
-                Register and discover MCP servers as first-class interfaces in {{site.konnect_catalog}}.
-              icon: /assets/icons/mcp.svg
-              cta:
-                text: Learn about MCP Registries
-                url: /catalog/mcp-registry/
-      - blocks:
         - type: card
           config:
             title: APIs
@@ -92,6 +72,26 @@ rows:
               cta:
                 text: API packages reference
                 url: /catalog/api-packaging/
+      - blocks:
+          - type: card
+            config:
+              title: "AI Models"
+              description: |
+                Model your organization's AI models as first-class interfaces in {{site.konnect_catalog}}.
+              icon: /assets/icons/brain.svg
+              cta:
+                text: Learn about AI Models
+                url: /catalog/ai-models/
+      - blocks:
+          - type: card
+            config:
+              title: "MCP Registries (tech preview)"
+              description: |
+                Register and discover MCP servers as first-class interfaces in {{site.konnect_catalog}}.
+              icon: /assets/icons/mcp.svg
+              cta:
+                text: Learn about MCP Registries
+                url: /catalog/mcp-registry/
   - header:
       type: h2
       text: "Use cases for {{site.konnect_catalog}}"
@@ -105,7 +105,7 @@ rows:
                   key: solution
               rows:
                 - usecase: |
-                    You need to know every AI model, API, and MCP server your org has built, without checking each team's tools individually
+                    You need to know every API, AI Model, and MCP server your org has built, without checking each team's tools individually
                   outcomes:
                     - solution: |
                         {{site.konnect_catalog}} as one inventory across APIs, API packages, AI Models, and MCP Registries
@@ -143,8 +143,8 @@ rows:
           - type: faqs
             config:
               - q: "What's different between {{site.konnect_catalog}} and {{site.konnect_catalog}} Classic?"
-                a: "{{site.konnect_catalog}} is the unified, platform-level experience for APIs, API packages, AI Models, and MCP Registries (tech preview) today, with more interface types coming. {{site.konnect_catalog}} Classic remains available with Services, Scorecards, and Integrations. See [Migrate to the new Catalog](/catalog-classic/#migrate-to-the-new-catalog) for how to move to the new experience."
-              - q: "What happened to Services, Integrations, and Scorecards?"
-                a: "Those features are compatible with {{site.konnect_catalog}} Classic. See the [{{site.konnect_catalog}} Classic documentation](/catalog-classic/)."
+                a: "{{site.konnect_catalog}} is the unified, platform-level experience for APIs, API packages, AI Models, and MCP Registries (tech preview) today, with more interface types coming. {{site.konnect_catalog}} Classic remains available with Services. See [Migrate to the new Catalog](/catalog-classic/#migrate-to-the-new-catalog) for how to move to the new experience."
+              - q: "What happens to Integrations and Scorecards?"
+                a: "Integrations and Scorecards are compatible with [{{site.konnect_catalog}} Classic](/catalog-classic/) today. Kong plans to bring them into the new {{site.konnect_catalog}} experience in the future, with a focus on APIs and AI interfaces rather than Services."
               - q: "Can I control access to specific {{site.konnect_catalog}} data?"
                 a: "Yes, access can be managed through [teams and roles](/konnect-platform/teams-and-roles/)."

--- a/app/_landing_pages/catalog/integrations.yaml
+++ b/app/_landing_pages/catalog/integrations.yaml
@@ -4,7 +4,7 @@ metadata:
   products:
     - catalog
   breadcrumbs:
-    - /catalog/
+    - /catalog-classic/
   description: Integrate third-party applications into your {{site.konnect_short_name}} organization.
   tags:
     - integrations

--- a/app/catalog/agents.md
+++ b/app/catalog/agents.md
@@ -1,0 +1,98 @@
+---
+title: "Agents in {{site.konnect_catalog}}"
+content_type: reference
+layout: reference
+beta: true
+products:
+    - catalog
+    - ai-gateway
+
+breadcrumbs:
+  - /catalog/
+
+works_on:
+  - konnect
+
+search_aliases:
+  - A2A
+  - agent card
+  - AI agent
+
+description: An Agent is an interface in {{site.konnect_catalog}} that represents an A2A-compatible agent your organization builds or consumes. Learn how to create and manage Agents.
+
+related_resources:
+  - text: "{{site.konnect_catalog}}"
+    url: /catalog/
+  - text: "{{site.ai_gateway}}"
+    url: /ai-gateway/
+  - text: "MCP Registries (tech preview)"
+    url: /catalog/mcp-registry/
+  - text: "AI Models"
+    url: /catalog/ai-models/
+---
+
+An Agent is an interface in {{site.konnect_catalog}} modeled on the [A2A protocol's](https://a2a-protocol.org/v1.0.0/specification/#441-agentcard) AgentCard, representing an agent that your organization builds or consumes.
+{{site.konnect_catalog}} gives you a single place to see every agent across your organization, whether it's registered from a pasted card, discovered from a remote host, or linked to {{site.ai_gateway}} 2.0 AI Agent entities, so teams don't have to track agents individually in separate tools.
+
+You can create an Agent in three ways:
+* Paste the agent's A2A card directly as JSON.
+* (Coming soon) Import it from a remote host that serves an A2A card at a well-known URL.
+* (Coming soon) Link it to an AI Agent entity from {{site.ai_gateway}} 2.0.
+
+{{site.konnect_catalog}} Agents represent the agents available across your organization, regardless of where they are defined or run. 
+When an Agent is also configured in {{site.ai_gateway}}, you can link the {{site.konnect_catalog}} Agent to its corresponding {{site.ai_gateway}} representation. 
+That relationship identifies {{site.ai_gateway}} as an implementation of the Agent, which indicates that the Agent is served or protected through {{site.ai_gateway}}.
+
+## Create an Agent
+
+1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
+1. From the **New** dropdown menu, select **Agent**.
+1. Under **Data source**, select **Paste JSON**.
+1. In the **Agent card JSON** field, paste the agent's A2A card. The card must include a `name`, `description`, and `version`. A live preview of the card renders under **Card preview**.
+1. In the **Display name** field, enter a name for your Agent, for example `My Agent`.
+1. In the **Name** field, enter a unique identifier for the Agent, for example `my-agent`. This is derived from the display name until you edit it. Only use lowercase letters, numbers, hyphens, and periods.
+1. (Optional) In the **Description** field, describe the purpose of your Agent. Leave this blank to use the description from the agent card.
+1. (Optional) Click **Add labels**, and do the following:
+   1. In the **Key** field, enter a label key.
+   1. In the **Value** field, enter a label value.
+   1. (Optional) Click **Add another label** to add more labels.
+1. Click **Create**.
+
+{% comment %}
+{% navtabs "create-agent" %}
+{% navtab "{{site.konnect_short_name}} API" %}
+Creating an Agent from a remote URL or linking one to {{site.ai_gateway}} 2.0 is coming soon. Today, send a POST request to the `/agents` endpoint with `source_type: manual` and the agent's A2A card. The card must include a `name`, `description`, and `version`:
+<!--vale off-->
+{% konnect_api_request %}
+url: /v1/agents
+status_code: 201
+method: POST
+body:
+    source_type: manual
+    display_name: My Agent
+    agent_card:
+        name: my-agent
+        description: Handles customer support triage
+        version: 1.0.0
+extract_body:
+    - name: 'id'
+      variable: AGENT_ID
+{% endkonnect_api_request %}
+<!--vale on-->
+{% endnavtab %}
+{% navtab "{{site.konnect_short_name}} UI" %}
+1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
+1. From the **New** dropdown menu, select **Agent**.
+1. Under **Data source**, select **Paste JSON**.
+1. In the **Agent card JSON** field, paste the agent's A2A card. The card must include a `name`, `description`, and `version`. A live preview of the card renders under **Card preview**.
+1. In the **Display name** field, enter a name for your Agent, for example `My Agent`.
+1. In the **Name** field, enter a unique identifier for the Agent, for example `my-agent`. This is derived from the display name until you edit it. Only use lowercase letters, numbers, hyphens, and periods.
+1. (Optional) In the **Description** field, describe the purpose of your Agent. Leave this blank to use the description from the agent card.
+1. (Optional) Click **Add labels**, and do the following:
+   1. In the **Key** field, enter a label key.
+   1. In the **Value** field, enter a label value.
+   1. (Optional) Click **Add another label** to add more labels.
+1. Click **Create**.
+{% endnavtab %}
+{% endnavtabs %}
+{% endcomment %}

--- a/app/catalog/ai-models.md
+++ b/app/catalog/ai-models.md
@@ -32,6 +32,10 @@ You can create an AI Model in two ways:
 * Add it manually by defining its providers and target models yourself.
 * Import it from {{site.ai_gateway}}, by linking an existing {{site.ai_gateway}} AI Model as the source. This allows teams to discover, understand, and use it securely.
 
+When an AI Model is linked to {{site.ai_gateway}}, traffic to that AI Model is protected by {{site.ai_gateway}}.
+The link is a snapshot, not a live sync.
+If you later change the linked model's configuration in {{site.ai_gateway}}, the AI Model in {{site.konnect_catalog}} isn't automatically updated to match.
+
 ## Create an AI Model
 
 {% navtabs "create-ai-model" %}
@@ -88,6 +92,7 @@ url: /v1/ai-models/$AI_MODEL_ID/versions
 status_code: 201
 method: POST
 body:
+    version: 1.0.0
     target_models:
       - provider: openai
         name: gpt-4o
@@ -108,6 +113,8 @@ body:
 {% endnavtab %}
 {% endnavtabs %}
 
+
+{% comment %}
 ## AI Model analytics
 
 When you create an AI Model in {{site.konnect_catalog}}, you can see analytics for that model in addition to the details you configured. 
@@ -118,3 +125,4 @@ The analytics you can see are:
 * Estimated cost
 
 These analytics are collected for the past 30 days.
+{% endcomment %}

--- a/app/catalog/ai-models.md
+++ b/app/catalog/ai-models.md
@@ -1,0 +1,120 @@
+---
+title: "AI Models in {{site.konnect_catalog}}"
+content_type: reference
+layout: reference
+
+products:
+    - catalog
+    - ai-gateway
+
+breadcrumbs:
+  - /catalog/
+
+works_on:
+  - konnect
+
+search_aliases:
+  - LLM
+  - model
+
+description: An AI Model is an interface in {{site.konnect_catalog}} that represents the providers and target models your organization routes requests to. Learn how to create and manage AI Models.
+
+related_resources:
+  - text: "{{site.konnect_catalog}}"
+    url: /catalog/
+  - text: "{{site.ai_gateway}}"
+    url: /ai-gateway/
+---
+
+An AI Model is an interface in {{site.konnect_catalog}} that represents the providers and target models your organization routes requests to, along with the OpenAPI spec that describes how to call it.
+
+You can create an AI Model in two ways:
+* Add it manually by defining its providers and target models yourself.
+* Import it from {{site.ai_gateway}}, by linking an existing {{site.ai_gateway}} AI Model as the source. This allows teams to discover, understand, and use it securely.
+
+## Create an AI Model
+
+{% navtabs "create-ai-model" %}
+{% navtab "{{site.konnect_short_name}} UI" %}
+1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
+1. Click the **AI models** tab.
+1. From the **New** dropdown menu, select "AI model".
+1. Under **Data source**, do one of the following:
+   1. To manually define providers and models, select **Add manually**.
+   1. To import an existing gateway-defined model, select **Import from AI gateway**, then:
+      1. From the **AI gateway** dropdown menu, select your {{site.ai_gateway}} control plane.
+      1. From the **Model from AI gateway** dropdown menu, select the model you want to import.
+1. (Optional) Under **Target models**, add the providers and models this AI Model routes to:
+   1. From the **Provider** dropdown menu, select a provider, for example "OpenAI".
+   1. From the **Target model** dropdown menu, select a model, for example "gpt-3.5-turbo".
+   1. (Optional) Click **Add target model** to add another provider and target model pair.
+1. In the **Display name** field, enter a name for your AI Model, for example `My AI Model`.
+1. In the **Name** field, enter a unique identifier for the AI Model, for example `my-ai-model`. This must contain only lowercase letters, numbers, hyphens, and periods.
+1. (Optional) In the **Version** field, enter a version for your AI Model.
+1. (Optional) In the **Description** field, describe the purpose of your AI Model.
+1. (Optional) Click **Show labels**, and do the following:
+   1. In the **Key** field, enter a label key.
+   1. In the **Value** field, enter a label value.
+   1. (Optional) Click **Add another label** to add more labels.
+1. Click **Create**.
+
+
+You can also link AI Models that you've manually created in {{site.konnect_catalog}} to a model on {{site.ai_gateway}} by clicking the **Gateway** tab on a {{site.konnect_catalog}} AI Model's details page and clicking **Link AI gateway**.
+{% endnavtab %}
+{% navtab "{{site.konnect_short_name}} API" %}
+Send a POST request to the `/ai-models` endpoint to create an empty AI Model:
+<!--vale off-->
+{% konnect_api_request %}
+url: /v1/ai-models
+status_code: 201
+method: POST
+body:
+    name: my-ai-model
+    display_name: My AI Model
+    description: Customer support triage model
+extract_body:
+    - name: 'id'
+      variable: AI_MODEL_ID
+capture:
+  - variable: AI_MODEL_ID
+    jq: ".id"
+{% endkonnect_api_request %}
+<!--vale on-->
+
+Add the providers and target models that this AI Model routes to by sending a POST request to the `/ai-models/{aiModelId}/versions` endpoint:
+<!--vale off-->
+{% konnect_api_request %}
+url: /v1/ai-models/$AI_MODEL_ID/versions
+status_code: 201
+method: POST
+body:
+    target_models:
+      - provider: openai
+        name: gpt-4o
+{% endkonnect_api_request %}
+<!--vale on-->
+
+Link the AI Model to a model on {{site.ai_gateway}} by sending a POST request to the `/ai-models/{aiModelId}/implementations` endpoint:
+<!--vale off-->
+{% konnect_api_request %}
+url: /v1/ai-models/$AI_MODEL_ID/implementations
+status_code: 201
+method: POST
+body:
+    gateway_control_plane_id: $CONTROL_PLANE_ID
+    gateway_model_id: $GATEWAY_MODEL_ID
+{% endkonnect_api_request %}
+<!--vale on-->
+{% endnavtab %}
+{% endnavtabs %}
+
+## AI Model analytics
+
+When you create an AI Model in {{site.konnect_catalog}}, you can see analytics for that model in addition to the details you configured. 
+The analytics you can see are:
+* Number of requests
+* Error rate
+* Token usage
+* Estimated cost
+
+These analytics are collected for the past 30 days.

--- a/app/catalog/ai-models.md
+++ b/app/catalog/ai-models.md
@@ -30,7 +30,7 @@ An AI Model is an interface in {{site.konnect_catalog}} that represents the prov
 
 You can create an AI Model in two ways:
 * Add it manually by defining its providers and target models yourself.
-* Import it from [{{site.ai_gateway}} 2.0](/ai-gateway/), by linking an existing {{site.ai_gateway}} 2.0 AI Model as the source. This allows teams to discover, understand, and use it securely.
+* Import it from [{{site.ai_gateway}} 2.0](/ai-gateway/), by linking an existing {{site.ai_gateway}} 2.0 [AI Model](/ai-gateway/entities/ai-model/) as the source. This allows teams to discover, understand, and use it securely.
 
 When an AI Model is linked to {{site.ai_gateway}} 2.0, traffic to that AI Model is protected by {{site.ai_gateway}}.
 The link is a snapshot, not a live sync.

--- a/app/catalog/ai-models.md
+++ b/app/catalog/ai-models.md
@@ -30,23 +30,22 @@ An AI Model is an interface in {{site.konnect_catalog}} that represents the prov
 
 You can create an AI Model in two ways:
 * Add it manually by defining its providers and target models yourself.
-* Import it from {{site.ai_gateway}}, by linking an existing {{site.ai_gateway}} AI Model as the source. This allows teams to discover, understand, and use it securely.
+* Import it from [{{site.ai_gateway}} 2.0](/ai-gateway/), by linking an existing {{site.ai_gateway}} 2.0 AI Model as the source. This allows teams to discover, understand, and use it securely.
 
-When an AI Model is linked to {{site.ai_gateway}}, traffic to that AI Model is protected by {{site.ai_gateway}}.
+When an AI Model is linked to {{site.ai_gateway}} 2.0, traffic to that AI Model is protected by {{site.ai_gateway}}.
 The link is a snapshot, not a live sync.
-If you later change the linked model's configuration in {{site.ai_gateway}}, the AI Model in {{site.konnect_catalog}} isn't automatically updated to match.
+If you later change the linked model's configuration in {{site.ai_gateway}} 2.0, the AI Model in {{site.konnect_catalog}} isn't automatically updated to match.
 
 ## Create an AI Model
 
 {% navtabs "create-ai-model" %}
 {% navtab "{{site.konnect_short_name}} UI" %}
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. Click the **AI models** tab.
 1. From the **New** dropdown menu, select "AI model".
 1. Under **Data source**, do one of the following:
    1. To manually define providers and models, select **Add manually**.
    1. To import an existing gateway-defined model, select **Import from AI gateway**, then:
-      1. From the **AI gateway** dropdown menu, select your {{site.ai_gateway}} control plane.
+      1. From the **AI gateway** dropdown menu, select your {{site.ai_gateway}} 2.0 control plane.
       1. From the **Model from AI gateway** dropdown menu, select the model you want to import.
 1. (Optional) Under **Target models**, add the providers and models this AI Model routes to:
    1. From the **Provider** dropdown menu, select a provider, for example "OpenAI".
@@ -63,7 +62,7 @@ If you later change the linked model's configuration in {{site.ai_gateway}}, the
 1. Click **Create**.
 
 
-You can also link AI Models that you've manually created in {{site.konnect_catalog}} to a model on {{site.ai_gateway}} by clicking the **Gateway** tab on a {{site.konnect_catalog}} AI Model's details page and clicking **Link AI gateway**.
+You can also link AI Models that you've manually created in {{site.konnect_catalog}} to a model on {{site.ai_gateway}} 2.0 by clicking the **Gateway** tab on a {{site.konnect_catalog}} AI Model's details page and clicking **Link AI gateway**.
 {% endnavtab %}
 {% navtab "{{site.konnect_short_name}} API" %}
 Send a POST request to the `/ai-models` endpoint to create an empty AI Model:

--- a/app/catalog/api-packaging.md
+++ b/app/catalog/api-packaging.md
@@ -166,12 +166,11 @@ To package APIs with Dev Portal, you need:
 
 ### Create an API package
 
-1. In {{site.konnect_short_name}}, click **Catalog**.
-1. Click the **API packages** tab.
+1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
+1. From the **New** dropdown menu, select "API package".
    
    {:.info}
    > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **API packages** in the sidebar instead.
-1. Click **Create API package**.
 1. In the **API package name** field, enter a name for your package.
 1. Enable the Package rate limit and configure your rate limit.
 1. Click **Add operations from APIs** in the API operations settings.

--- a/app/catalog/api-packaging.md
+++ b/app/catalog/api-packaging.md
@@ -168,6 +168,9 @@ To package APIs with Dev Portal, you need:
 
 1. In {{site.konnect_short_name}}, click **Catalog**.
 1. Click the **API packages** tab.
+   
+   {:.info}
+   > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **API packages** in the sidebar instead.
 1. Click **Create API package**.
 1. In the **API package name** field, enter a name for your package.
 1. Enable the Package rate limit and configure your rate limit.
@@ -184,6 +187,9 @@ The image must be a PNG, JPG, or SVG image under 500 KB that’s no larger than 
 
 1. In {{site.konnect_short_name}}, click **Catalog**.
 1. Click the **API packages** tab.
+   
+   {:.info}
+   > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **API packages** in the sidebar instead.
 1. Click your API package.
 1. Click **Publish API**.
 1. From the **Portal** dropdown menu, select your Dev Portal.

--- a/app/catalog/apis.md
+++ b/app/catalog/apis.md
@@ -75,7 +75,10 @@ Additionally, you can link your API to a Gateway Service to allow developers to 
 To create an API, do one of the following:
 {% navtabs "create-api" %}
 {% navtab "{{site.konnect_short_name}} UI" %}
-Navigate to **Catalog > APIs** in the sidebar, and then click [**New API**](https://cloud.konghq.com/apis/create).
+Navigate to **Catalog** in the sidebar, click the **APIs** tab, and then click [**New API**](https://cloud.konghq.com/apis/create).
+
+{:.info}
+> If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **APIs** in the sidebar instead.
 {% endnavtab %}
 {% navtab "{{site.konnect_short_name}} API" %}
 Send a POST request to the [`/apis` endpoint](/api/konnect/api-builder/v3/#/operations/create-api):
@@ -131,11 +134,17 @@ To version an API, do one of the following:
 {% navtabs "api-version" %}
 {% navtab "{{site.konnect_short_name}} UI" %}
 1. In the {{site.konnect_short_name}} sidebar, click [**{{site.konnect_catalog}}**](https://cloud.konghq.com/service-catalog/).
+   
+   {:.info}
+   > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **Catalog > APIs** in the sidebar instead.
 1. Click [**New API**](https://cloud.konghq.com/apis/create).
 1. Enter a version in the **API version** field, or upload an API specification, which will set the version to match the API spec version. 
 
 You can also add versions to existing APIs when you edit them if they aren't associated with an API specification. To manage multiple versions of the API specification, do the following:
 1. In the {{site.konnect_short_name}} sidebar, click [**{{site.konnect_catalog}}**](https://cloud.konghq.com/service-catalog/). 
+   
+   {:.info}
+   > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **Catalog > APIs** in the sidebar instead.
 1. Click your API. 
 1. Click the **API specification** tab.
 1. From the Actions dropdown menu, select "Add or update API spec". 
@@ -196,7 +205,10 @@ While you are creating or editing an API document, you can also choose to publis
 To create a new API document, do one of the following:
 {% navtabs "link-service" %}
 {% navtab "{{site.konnect_short_name}} UI" %}
-1. Navigate to [**Catalog > APIs**](https://cloud.konghq.com/apis) in the sidebar and click your API. 
+1. Navigate to [**Catalog**](https://cloud.konghq.com/apis) in the sidebar and click your API. 
+   
+   {:.info}
+   > If you're using {{site.konnect_catalog}} Classic, click ****Catalog > APIs**** in the sidebar instead.
 1. Click the **Documentation** tab, and then click **New document** to create a new Markdown document. 
 
 If you want to upload an existing Markdown documentation file, use the API or Terraform.
@@ -261,7 +273,10 @@ The image must be a PNG, JPG, or SVG image under 500 KB that’s no larger than 
 
 To upload an API image, do the following:
 1. In the {{site.konnect_short_name}} sidebar, click **{{site.konnect_catalog}}**.
-1. In the {{site.konnect_catalog}} sidebar, click **[APIs](https://cloud.konghq.com/apis)**. 
+1. Click the **[APIs](https://cloud.konghq.com/apis)** tab. 
+   
+   {:.info}
+   > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **APIs** in the sidebar instead.
 1. Click the API you want to add the image to.
 1. From the action menu, select "Edit".
 1. Click **Upload image** and upload an image.
@@ -449,7 +464,10 @@ rows:
 To publish your API, do one of the following:
 {% navtabs "link-service" %}
 {% navtab "{{site.konnect_short_name}} UI" %}
-Navigate to [**Catalog > APIs**](https://cloud.konghq.com/apis) and click your API. Click the **Portals** tab, and then click **Publish API**.
+Navigate to **Catalog**, click the **APIs** tab, and then click your API. Click the **Portals** tab, and then click **Publish API**.
+
+{:.info}
+> If you're using [{{site.konnect_catalog}} Classic](/catalog-classic), click **APIs** in the sidebar instead.
 {% endnavtab %}
 {% navtab "{{site.konnect_short_name}} API" %}
 Send a PUT request to the [`/apis/{apiId}/publications/{portalId}` endpoint](/api/konnect/api-builder/v3/#/operations/publish-api-to-portal):

--- a/app/catalog/apis.md
+++ b/app/catalog/apis.md
@@ -75,7 +75,7 @@ Additionally, you can link your API to a Gateway Service to allow developers to 
 To create an API, do one of the following:
 {% navtabs "create-api" %}
 {% navtab "{{site.konnect_short_name}} UI" %}
-Navigate to **Catalog** in the sidebar, click the **APIs** tab, and then click [**New API**](https://cloud.konghq.com/apis/create).
+Navigate to **Catalog** in the sidebar, click the **APIs** tab, and then click **New API**.
 
 {:.info}
 > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **APIs** in the sidebar instead.
@@ -133,15 +133,15 @@ The API entity's `version` property is treated as "current", meaning it is the v
 To version an API, do one of the following:
 {% navtabs "api-version" %}
 {% navtab "{{site.konnect_short_name}} UI" %}
-1. In the {{site.konnect_short_name}} sidebar, click [**{{site.konnect_catalog}}**](https://cloud.konghq.com/service-catalog/).
+1. In the {{site.konnect_short_name}} sidebar, click **{{site.konnect_catalog}}**.
    
    {:.info}
    > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **Catalog > APIs** in the sidebar instead.
-1. Click [**New API**](https://cloud.konghq.com/apis/create).
+1. Click **New API**.
 1. Enter a version in the **API version** field, or upload an API specification, which will set the version to match the API spec version. 
 
 You can also add versions to existing APIs when you edit them if they aren't associated with an API specification. To manage multiple versions of the API specification, do the following:
-1. In the {{site.konnect_short_name}} sidebar, click [**{{site.konnect_catalog}}**](https://cloud.konghq.com/service-catalog/). 
+1. In the {{site.konnect_short_name}} sidebar, click **{{site.konnect_catalog}}**. 
    
    {:.info}
    > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **Catalog > APIs** in the sidebar instead.
@@ -205,10 +205,10 @@ While you are creating or editing an API document, you can also choose to publis
 To create a new API document, do one of the following:
 {% navtabs "link-service" %}
 {% navtab "{{site.konnect_short_name}} UI" %}
-1. Navigate to [**Catalog**](https://cloud.konghq.com/apis) in the sidebar and click your API. 
+1. Navigate to **Catalog** in the sidebar and click your API. 
    
    {:.info}
-   > If you're using {{site.konnect_catalog}} Classic, click ****Catalog > APIs**** in the sidebar instead.
+   > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **Catalog > APIs** in the sidebar instead.
 1. Click the **Documentation** tab, and then click **New document** to create a new Markdown document. 
 
 If you want to upload an existing Markdown documentation file, use the API or Terraform.
@@ -273,7 +273,7 @@ The image must be a PNG, JPG, or SVG image under 500 KB that’s no larger than 
 
 To upload an API image, do the following:
 1. In the {{site.konnect_short_name}} sidebar, click **{{site.konnect_catalog}}**.
-1. Click the **[APIs](https://cloud.konghq.com/apis)** tab. 
+1. Click the **APIs** tab. 
    
    {:.info}
    > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **APIs** in the sidebar instead.
@@ -353,7 +353,7 @@ If you want the Gateway Service or control plane to restrict access to the API, 
 To link your API to a Gateway Service or control plane, do one of the following:
 {% navtabs "link-service" %}
 {% navtab "{{site.konnect_short_name}} UI" %}
-1. In the {{site.konnect_short_name}} sidebar, click [**Catalog**](https://cloud.konghq.com/catalog).
+1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
 1. From the Catalog sidebar, click **APIs**.
 1. Click your API. 
 1. Click the **Gateway** tab.
@@ -467,7 +467,7 @@ To publish your API, do one of the following:
 Navigate to **Catalog**, click the **APIs** tab, and then click your API. Click the **Portals** tab, and then click **Publish API**.
 
 {:.info}
-> If you're using [{{site.konnect_catalog}} Classic](/catalog-classic), click **APIs** in the sidebar instead.
+> If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **APIs** in the sidebar instead.
 {% endnavtab %}
 {% navtab "{{site.konnect_short_name}} API" %}
 Send a PUT request to the [`/apis/{apiId}/publications/{portalId}` endpoint](/api/konnect/api-builder/v3/#/operations/publish-api-to-portal):

--- a/app/catalog/integrations/api-gateway.md
+++ b/app/catalog/integrations/api-gateway.md
@@ -18,22 +18,24 @@ search_aliases:
   - gateway manager integration
 works_on:
     - konnect
-description: The API Gateway integration is built directly into {{site.konnect_catalog}}, so no additional authorization is needed.
+description: The API Gateway integration is built directly into {{site.konnect_catalog}} Classic, so no additional authorization is needed.
 
 related_resources:
   - text: Map API Gateway Services in {{site.konnect_catalog}}
     url: /how-to/map-api-gateway-resources/
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
 discovery_support: true
 bindable_entities: "Gateway Service"
 ---
 
-This integration allows you to associate your {{site.konnect_catalog}} service to one or more Gateway Services registered in {{site.konnect_short_name}}’s API Gateway application.
+{% include_cached catalog/catalog-classic-banner.md %}
+
+This integration allows you to associate your {{site.konnect_catalog}} Classic service to one or more Gateway Services registered in {{site.konnect_short_name}}’s API Gateway application.
 
 ## Authorize the API Gateway integration
 
-The API Gateway integration is built directly into {{site.konnect_catalog}}. No additional authorization is required. As new Gateway Services are created in API Gateway, they are automatically discovered by {{site.konnect_catalog}} and surfaced as Resources.
+The API Gateway integration is built directly into {{site.konnect_catalog}} Classic. No additional authorization is required. As new Gateway Services are created in API Gateway, they are automatically discovered by {{site.konnect_catalog}} Classic and surfaced as Resources.
 
 ## Resources
 

--- a/app/catalog/integrations/api-gateway.md
+++ b/app/catalog/integrations/api-gateway.md
@@ -11,7 +11,7 @@ tags:
   - integrations
 
 breadcrumbs:
-  - /catalog/
+  - /catalog-classic/
   - /catalog/integrations/
 search_aliases:
   - service catalog

--- a/app/catalog/integrations/aws-api-gateway.md
+++ b/app/catalog/integrations/aws-api-gateway.md
@@ -18,11 +18,11 @@ search_aliases:
   - service catalog
 works_on:
     - konnect
-description: The AWS API Gateway integration allows you to associate your {{site.konnect_catalog}} service with one or more AWS API Gateway APIs. 
+description: The AWS API Gateway integration allows you to associate your {{site.konnect_catalog}} Classic service with one or more AWS API Gateway APIs. 
 
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Import and map AWS API Gateway resources in {{site.konnect_catalog}}
     url: /how-to/install-and-map-aws-gateway-apis/
   - text: "Discover AWS Gateway APIs in {{site.konnect_catalog}} with the {{site.konnect_short_name}} API"
@@ -35,27 +35,29 @@ discovery_support: true
 bindable_entities: "APIs"
 ---
 
-The AWS API Gateway integration allows you to associate your {{site.konnect_catalog}} service with one or more AWS API Gateway APIs.
+{% include_cached catalog/catalog-classic-banner.md %}
+
+The AWS API Gateway integration allows you to associate your {{site.konnect_catalog}} Classic service with one or more AWS API Gateway APIs.
 
 {% include /catalog/multi-resource.md %}
 
 For complete tutorials, see the following:
-* [Discover and govern APIs with {{site.konnect_catalog}}](/how-to/discover-and-govern-apis-with-service-catalog/)
-* [Discover AWS Gateway APIs in {{site.konnect_catalog}} with the {{site.konnect_short_name}} API](/how-to/discover-aws-gateway-apis-using-konnect-api/)
-* [Discover AWS Gateway APIs in {{site.konnect_catalog}} with the {{site.konnect_short_name}} UI](/how-to/discover-aws-gateway-apis-using-konnect-ui/)
+* [Discover and govern APIs with {{site.konnect_catalog}} Classic](/how-to/discover-and-govern-apis-with-service-catalog/)
+* [Discover AWS Gateway APIs in {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} API](/how-to/discover-aws-gateway-apis-using-konnect-api/)
+* [Discover AWS Gateway APIs in {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} UI](/how-to/discover-aws-gateway-apis-using-konnect-ui/)
 
-## Configure an IAM role in AWS for {{site.konnect_catalog}}
+## Configure an IAM role in AWS for {{site.konnect_catalog}} Classic
 
 {% include /prereqs/service-catalog-iam.md %}
 
 ## Authorize the AWS API Gateway integration
 
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. In the Catalog sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
+1. In the {{site.konnect_catalog}} sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
 1. Click **AWS API Gateway**.
 1. Click **Add AWS API Gateway instance**.
 1. From the **AWS region** dropdown, select your AWS region.
-1. In the **IAM role ARN** field, enter the [IAM role you configured for {{site.konnect_catalog}}](#configure-an-iam-role-in-aws-for-service-catalog).
+1. In the **IAM role ARN** field, enter the [IAM role you configured for {{site.konnect_catalog}} Classic](#configure-an-iam-role-in-aws-for-service-catalog).
 1. In the **Display name** field, enter a name for your AWS API Gateway instance.
 1. In the **Instance name** field, enter a unique identifier for your AWS API Gateway instance.
 1. Click **Save**. 
@@ -73,7 +75,7 @@ columns:
     key: description
 rows:
   - entity: API
-    description: An AWS API Gateway API that relates to the {{site.konnect_catalog}} service.
+    description: An AWS API Gateway API that relates to the {{site.konnect_catalog}} Classic service.
 {% endtable %}
 <!--vale on-->
 

--- a/app/catalog/integrations/aws-api-gateway.md
+++ b/app/catalog/integrations/aws-api-gateway.md
@@ -12,7 +12,7 @@ tags:
   - aws
 
 breadcrumbs:
-  - /catalog/
+  - /catalog-classic/
   - /catalog/integrations/
 search_aliases:
   - service catalog

--- a/app/catalog/integrations/aws-api-gateway.md
+++ b/app/catalog/integrations/aws-api-gateway.md
@@ -53,7 +53,7 @@ For complete tutorials, see the following:
 ## Authorize the AWS API Gateway integration
 
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. In the {{site.konnect_catalog}} sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
+1. In the {{site.konnect_catalog}} sidebar, click **Integrations**. 
 1. Click **AWS API Gateway**.
 1. Click **Add AWS API Gateway instance**.
 1. From the **AWS region** dropdown, select your AWS region.

--- a/app/catalog/integrations/azure-api-management.md
+++ b/app/catalog/integrations/azure-api-management.md
@@ -50,7 +50,7 @@ Before you configure the Azure API Management integration, ensure the following:
 > **Note:** The Azure API Management integration uses OAuth for authentication and can only be configured through the {{site.konnect_short_name}} UI.
 
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. In the {{site.konnect_catalog}} sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
+1. In the {{site.konnect_catalog}} sidebar, click **Integrations**. 
 1. Click **Azure API Management**.
 1. Click **Add Azure API Management instance**.
 1. In the **Subscription ID** field, enter your Azure API subscription ID.

--- a/app/catalog/integrations/azure-api-management.md
+++ b/app/catalog/integrations/azure-api-management.md
@@ -12,7 +12,7 @@ tags:
   - azure
 
 breadcrumbs:
-  - /catalog/
+  - /catalog-classic/
   - /catalog/integrations/
 search_aliases:
   - service catalog

--- a/app/catalog/integrations/azure-api-management.md
+++ b/app/catalog/integrations/azure-api-management.md
@@ -21,19 +21,21 @@ works_on:
 description: placeholder
 
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
 discovery_support: true
 bindable_entities: "APIs"
 ---
 
-The Azure API Management integration allows you to associate your {{site.konnect_catalog}} service with one or more Azure API Management APIs.
+{% include_cached catalog/catalog-classic-banner.md %}
+
+The Azure API Management integration allows you to associate your {{site.konnect_catalog}} Classic service with one or more Azure API Management APIs.
 
 {% include /catalog/multi-resource.md %}
 
 For complete tutorials, see the following:
-* [Discover Azure API Management APIs in {{site.konnect_catalog}} with the {{site.konnect_short_name}} API](/how-to/discover-azure-apis-with-konnect-api/)
-* [Discover Azure API Management APIs in {{site.konnect_catalog}} with the {{site.konnect_short_name}} UI](/how-to/discover-azure-apis-with-konnect-ui/)
+* [Discover Azure API Management APIs in {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} API](/how-to/discover-azure-apis-with-konnect-api/)
+* [Discover Azure API Management APIs in {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} UI](/how-to/discover-azure-apis-with-konnect-ui/)
 
 ## Prerequisites
 
@@ -48,7 +50,7 @@ Before you configure the Azure API Management integration, ensure the following:
 > **Note:** The Azure API Management integration uses OAuth for authentication and can only be configured through the {{site.konnect_short_name}} UI.
 
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. In the Catalog sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
+1. In the {{site.konnect_catalog}} sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
 1. Click **Azure API Management**.
 1. Click **Add Azure API Management instance**.
 1. In the **Subscription ID** field, enter your Azure API subscription ID.
@@ -72,7 +74,7 @@ columns:
     key: description
 rows:
   - entity: API
-    description: An Azure API Management API that relates to the {{site.konnect_catalog}} service. Only HTTP specs can be added via the **API Specs** tab on a service. gRPC, WebSocket, and GraphQL specifications aren't supported.
+    description: An Azure API Management API that relates to the {{site.konnect_catalog}} Classic service. Only HTTP specs can be added via the the **API Specs** tab on a service. gRPC, WebSocket, and GraphQL specifications aren't supported.
 {% endtable %}
 <!--vale on-->
 

--- a/app/catalog/integrations/azure-api-management.md
+++ b/app/catalog/integrations/azure-api-management.md
@@ -21,19 +21,21 @@ works_on:
 description: placeholder
 
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
 discovery_support: true
 bindable_entities: "APIs"
 ---
 
-The Azure API Management integration allows you to associate your {{site.konnect_catalog}} service with one or more Azure API Management APIs.
+{% include_cached catalog/catalog-classic-banner.md %}
+
+The Azure API Management integration allows you to associate your {{site.konnect_catalog}} Classic service with one or more Azure API Management APIs.
 
 {% include /catalog/multi-resource.md %}
 
 For complete tutorials, see the following:
-* [Discover Azure API Management APIs in {{site.konnect_catalog}} with the {{site.konnect_short_name}} API](/how-to/discover-azure-apis-with-konnect-api/)
-* [Discover Azure API Management APIs in {{site.konnect_catalog}} with the {{site.konnect_short_name}} UI](/how-to/discover-azure-apis-with-konnect-ui/)
+* [Discover Azure API Management APIs in {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} API](/how-to/discover-azure-apis-with-konnect-api/)
+* [Discover Azure API Management APIs in {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} UI](/how-to/discover-azure-apis-with-konnect-ui/)
 
 ## Prerequisites
 
@@ -48,7 +50,7 @@ Before you configure the Azure API Management integration, ensure the following:
 > **Note:** The Azure API Management integration uses OAuth for authentication and can only be configured through the {{site.konnect_short_name}} UI.
 
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. In the Catalog sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
+1. In the {{site.konnect_catalog}} sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
 1. Click **Azure API Management**.
 1. Click **Add Azure API Management instance**.
 1. In the **Subscription ID** field, enter your Azure API subscription ID.
@@ -72,7 +74,7 @@ columns:
     key: description
 rows:
   - entity: API
-    description: An Azure API Management API that relates to the {{site.konnect_catalog}} service. Only HTTP specs can be added via the the **API Specs** tab on a service. gRPC, WebSocket, and GraphQL specifications aren't supported.
+    description: An Azure API Management API that relates to the {{site.konnect_catalog}} Classic service. Only HTTP specs can be added via the the **API Specs** tab on a service. gRPC, WebSocket, and GraphQL specifications aren't supported.
 {% endtable %}
 <!--vale on-->
 

--- a/app/catalog/integrations/azure-devops.md
+++ b/app/catalog/integrations/azure-devops.md
@@ -22,23 +22,25 @@ bindable_entities: "Repositories"
 
 works_on:
     - konnect
-description: "description: Provides information about the Azure DevOps integration, which lets the Konnect {{site.konnect_catalog}} read repository metadata from Azure DevOps and use it for service mapping and governance workflows."
+description: "description: Provides information about the Azure DevOps integration, which lets the Konnect {{site.konnect_catalog}} Classic read repository metadata from Azure DevOps and use it for service mapping and governance workflows."
 
 
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
-  - text: "Connect Azure DevOps repositories to Catalog with the Konnect API"
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
+  - text: "Connect Azure DevOps repositories to {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} API"
     url: /how-to/connect-azure-devops-to-the-konnect-catalog-with-the-konnect-api/
-  - text: "Connect Azure DevOps repositories to Catalog with the Konnect UI"
+  - text: "Connect Azure DevOps repositories to {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} UI"
     url: /how-to/connect-azure-devops-to-the-konnect-catalog-with-the-konnect-ui/
 ---
 
-The Azure DevOps integration lets Konnect {{site.konnect_catalog}} securely read and ingest repository metadata from Azure DevOps using a PAT with `Code:Read` access. Teams can reference and manage their source-code assets inside {{site.konnect_catalog}} and prepare for future governance and scorecard workflows.
+{% include_cached catalog/catalog-classic-banner.md %}
+
+The Azure DevOps integration lets Konnect {{site.konnect_catalog}} Classic securely read and ingest repository metadata from Azure DevOps using a PAT with `Code:Read` access. Teams can reference and manage their source-code assets inside {{site.konnect_catalog}} Classic and prepare for future governance and scorecard workflows.
 
 For a complete tutorial, choose one of the following:
-- [Connect Azure DevOps repositories to Catalog with the Konnect API](/how-to/connect-azure-devops-to-the-konnect-catalog-with-the-konnect-api/)
-- [Connect Azure DevOps repositories to Catalog with the Konnect UI](/how-to/connect-azure-devops-to-the-konnect-catalog-with-the-konnect-ui/)
+- [Connect Azure DevOps repositories to {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} API](/how-to/connect-azure-devops-to-the-konnect-catalog-with-the-konnect-api/)
+- [Connect Azure DevOps repositories to {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} UI](/how-to/connect-azure-devops-to-the-konnect-catalog-with-the-konnect-ui/)
 
 ### Prerequisites
 You need to configure the following:
@@ -63,7 +65,7 @@ You need to configure the following:
 {% endnavtab %}
 {% navtab "API" %}
 
-Before you can discover Azure DevOps repositories in {{site.konnect_catalog}}, export your Azure organization name exactly as it appears in Azure DevOps:
+Before you can discover Azure DevOps repositories in {{site.konnect_catalog}} Classic, export your Azure organization name exactly as it appears in Azure DevOps:
 
 ```sh
 export AZURE_DEVOPS_ORG_NAME="YOUR-ORG-NAME"

--- a/app/catalog/integrations/azure-devops.md
+++ b/app/catalog/integrations/azure-devops.md
@@ -14,7 +14,7 @@ tags:
 search_aliases:
   - service catalog
 breadcrumbs:
-  - /catalog/
+  - /catalog-classic/
   - /catalog/integrations/
 
 discovery_support: true

--- a/app/catalog/integrations/datadog.md
+++ b/app/catalog/integrations/datadog.md
@@ -19,21 +19,23 @@ breadcrumbs:
 
 works_on:
     - konnect
-description: The Datadog integration lets you connect Datadog entities directly to your {{site.konnect_catalog}} services.
+description: The Datadog integration lets you connect Datadog entities directly to your {{site.konnect_catalog}} Classic services.
 discovery_support: true
 bindable_entities: "Datadog Monitor, Datadog Dashboard"
 
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Import and map Datadog resources in {{site.konnect_catalog}}
     url: /how-to/install-and-map-datadog-resources/
 ---
 
-The Datadog integration lets you connect Datadog entities directly to your {{site.konnect_catalog}} services.
+{% include_cached catalog/catalog-classic-banner.md %}
+
+The Datadog integration lets you connect Datadog entities directly to your {{site.konnect_catalog}} Classic services.
 {% include /catalog/multi-resource.md %}
 
-For a complete tutorial using the {{site.konnect_short_name}} API, see [Import and map Datadog resources in {{site.konnect_catalog}}](/how-to/install-and-map-datadog-resources/).
+For a complete tutorial using the {{site.konnect_short_name}} API, see [Import and map Datadog resources in {{site.konnect_catalog}} Classic](/how-to/install-and-map-datadog-resources/).
 
 ## Prerequisites
 

--- a/app/catalog/integrations/datadog.md
+++ b/app/catalog/integrations/datadog.md
@@ -50,7 +50,7 @@ Your Datadog instance application key must either have no scopes or the followin
 
 {% navtabs "datadog-integration" %}
 {% navtab "UI" %}
-1. From the **Catalog** in {{site.konnect_short_name}}, select **[Integrations](https://cloud.konghq.com/service-catalog/integrations)**. 
+1. From the **Catalog** in {{site.konnect_short_name}}, select **Integrations**. 
 1. Select **Add Datadog Instance**.
 1. Select your Datadog region and enter your [Datadog API and application keys](https://docs.datadoghq.com/account_management/api-app-keys/). 
 1. Select **Authorize**. 

--- a/app/catalog/integrations/datadog.md
+++ b/app/catalog/integrations/datadog.md
@@ -14,7 +14,7 @@ tags:
 search_aliases:
   - service catalog
 breadcrumbs:
-  - /catalog/
+  - /catalog-classic/
   - /catalog/integrations/
 
 works_on:

--- a/app/catalog/integrations/dynatrace.md
+++ b/app/catalog/integrations/dynatrace.md
@@ -19,13 +19,13 @@ breadcrumbs:
 
 works_on:
     - konnect
-description: The Dynatrace integration lets you connect Dynatrace classic service-level objects directly to your {{site.konnect_catalog}} services.
+description: The Dynatrace integration lets you connect Dynatrace classic service-level objects directly to your {{site.konnect_catalog}} Classic services.
 discovery_support: true
 bindable_entities: "Classic service-level object"
 
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: "Monitor Dynatrace SLOs {{site.konnect_catalog}} with the {{site.konnect_short_name}} UI"
     url: /how-to/monitor-dynatrace-slos-with-konnect-ui/
   - text: "Monitor Dynatrace SLOs {{site.konnect_catalog}} with the {{site.konnect_short_name}} API"
@@ -34,12 +34,14 @@ related_resources:
     url: /how-to/set-up-dynatrace-with-otel/
 ---
 
-The Dynatrace integration lets you connect Dynatrace classic service-level objects directly to your {{site.konnect_catalog}} services.
+{% include_cached catalog/catalog-classic-banner.md %}
+
+The Dynatrace integration lets you connect Dynatrace classic service-level objects directly to your {{site.konnect_catalog}} Classic services.
 {% include /catalog/multi-resource.md %}
 
 For a complete tutorial, see the following:
-* [Monitor Dynatrace SLOs {{site.konnect_catalog}} with the {{site.konnect_short_name}} UI](/how-to/monitor-dynatrace-slos-with-konnect-ui/)
-* [Monitor Dynatrace SLOs {{site.konnect_catalog}} with the {{site.konnect_short_name}} API](/how-to/monitor-dynatrace-slos-with-konnect-api/)
+* [Monitor Dynatrace SLOs {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} UI](/how-to/monitor-dynatrace-slos-with-konnect-ui/)
+* [Monitor Dynatrace SLOs {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} API](/how-to/monitor-dynatrace-slos-with-konnect-api/)
 
 ## Prerequisites
 
@@ -56,7 +58,7 @@ You need to configure the following in Dynatrace SaaS:
 {% navtabs "dynatrace-integration" %}
 {% navtab "UI" %}
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. In the Catalog sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
+1. In the {{site.konnect_catalog}} sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
 1. Click **Dynatrace**.
 1. Click **Add Dynatrace instance**.
 1. In the **Dynatrace API Base URL** field, enter your Dynatrace URL without the trailing `/`. For example: `https://whr42363.apps.dynatrace.com`

--- a/app/catalog/integrations/dynatrace.md
+++ b/app/catalog/integrations/dynatrace.md
@@ -58,7 +58,7 @@ You need to configure the following in Dynatrace SaaS:
 {% navtabs "dynatrace-integration" %}
 {% navtab "UI" %}
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. In the {{site.konnect_catalog}} sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
+1. In the {{site.konnect_catalog}} sidebar, click **Integrations**. 
 1. Click **Dynatrace**.
 1. Click **Add Dynatrace instance**.
 1. In the **Dynatrace API Base URL** field, enter your Dynatrace URL without the trailing `/`. For example: `https://whr42363.apps.dynatrace.com`

--- a/app/catalog/integrations/dynatrace.md
+++ b/app/catalog/integrations/dynatrace.md
@@ -14,7 +14,7 @@ tags:
 search_aliases:
   - service catalog
 breadcrumbs:
-  - /catalog/
+  - /catalog-classic/
   - /catalog/integrations/
 
 works_on:

--- a/app/catalog/integrations/github.md
+++ b/app/catalog/integrations/github.md
@@ -12,7 +12,7 @@ tags:
   - github
 
 breadcrumbs:
-  - /catalog/
+  - /catalog-classic/
   - /catalog/integrations/
 
 works_on:

--- a/app/catalog/integrations/github.md
+++ b/app/catalog/integrations/github.md
@@ -17,24 +17,26 @@ breadcrumbs:
 
 works_on:
     - konnect
-description: The GitHub integration allows you to associate your {{site.konnect_catalog}} service to one or more GitHub repositories. 
+description: The GitHub integration allows you to associate your {{site.konnect_catalog}} Classic service to one or more GitHub repositories. 
 search_aliases:
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Import and map GitHub resources in {{site.konnect_catalog}}
     url: /how-to/install-and-map-github-resources/
 discovery_support: true
 bindable_entities: "Repositories"
 ---
 
-The GitHub integration allows you to associate your {{site.konnect_catalog}} service to one or more GitHub repositories.
+{% include_cached catalog/catalog-classic-banner.md %}
+
+The GitHub integration allows you to associate your {{site.konnect_catalog}} Classic service to one or more GitHub repositories.
 
 For each linked repository, the UI can show a **Repository Summary** with simple data pulled from the GitHub API, such as the number of open issues, open pull requests, most recently closed pull requests, languages, and more.
 {% include /catalog/multi-resource.md %}
 
-For a complete tutorial using the {{site.konnect_short_name}} API, see [Import and map GitHub resources in {{site.konnect_catalog}}](/how-to/install-and-map-github-resources/).
+For a complete tutorial using the {{site.konnect_short_name}} API, see [Import and map GitHub resources in {{site.konnect_catalog}} Classic](/how-to/install-and-map-github-resources/).
 
 ## Authorize the GitHub integration
 
@@ -59,7 +61,7 @@ columns:
     key: description
 rows:
   - entity: Repository
-    description: A GitHub repository relating to the {{site.konnect_catalog}} service.
+    description: A GitHub repository relating to the {{site.konnect_catalog}} Classic service.
 {% endtable %}
 <!--vale on-->
 

--- a/app/catalog/integrations/github.md
+++ b/app/catalog/integrations/github.md
@@ -40,7 +40,7 @@ For a complete tutorial using the {{site.konnect_short_name}} API, see [Import a
 
 ## Authorize the GitHub integration
 
-1. From the **Catalog** in {{site.konnect_short_name}}, select **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
+1. From the **Catalog** in {{site.konnect_short_name}}, select **Integrations**. 
 2. Select **GitHub**, then **Add GitHub Instance**.
 3. Select **Authorize**. 
 

--- a/app/catalog/integrations/gitlab.md
+++ b/app/catalog/integrations/gitlab.md
@@ -17,12 +17,12 @@ breadcrumbs:
 works_on:
     - konnect
 
-description: The GitLab integration allows you to associate your {{site.konnect_catalog}} Service to one or more GitLab projects
+description: The GitLab integration allows you to associate your {{site.konnect_catalog}} Classic Service to one or more GitLab projects
 search_aliases:
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: Import and map self-managed GitLab resources in {{site.konnect_catalog}}
@@ -32,14 +32,17 @@ related_resources:
 discovery_support: true
 bindable_entities: "Projects"
 ---
-The GitLab integration allows you to associate your {{site.konnect_catalog}} service to one or more [GitLab projects](https://docs.gitlab.com/ee/user/get_started/get_started_projects.html).
+
+{% include_cached catalog/catalog-classic-banner.md %}
+
+The GitLab integration allows you to associate your {{site.konnect_catalog}} Classic service to one or more [GitLab projects](https://docs.gitlab.com/ee/user/get_started/get_started_projects.html).
 {% include /catalog/multi-resource.md %}
 
 For each linked project, the UI can show a **Project Summary** with simple data pulled from the GitLab API, such as the number of open issues, open merge requests, contributors, languages, and latest releases.
 
 For a complete tutorial using the {{site.konnect_short_name}} API, see the following:
-* [Import and map self-managed GitLab resources in {{site.konnect_catalog}}](/how-to/install-and-map-gitlab-resources/)
-* [Import and map SaaS GitLab resources in {{site.konnect_catalog}}](/how-to/install-and-map-gitlab-saas-resources/)
+* [Import and map self-managed GitLab resources in {{site.konnect_catalog}} Classic](/how-to/install-and-map-gitlab-resources/)
+* [Import and map SaaS GitLab resources in {{site.konnect_catalog}} Classic](/how-to/install-and-map-gitlab-saas-resources/)
 
 ## Prerequisites
 
@@ -82,7 +85,7 @@ columns:
     key: description
 rows:
   - entity: Projects
-    description: "Organizes all the data for a specific development project that relates to a {{site.konnect_catalog}} service."
+    description: "Organizes all the data for a specific development project that relates to a {{site.konnect_catalog}} Classic service."
 {% endtable %}
 <!--vale on-->
 

--- a/app/catalog/integrations/gitlab.md
+++ b/app/catalog/integrations/gitlab.md
@@ -58,7 +58,7 @@ To use the GitLab integration in a self-hosted environment:
 1. [Create a group-owned application](https://docs.gitlab.com/integration/oauth_provider/#create-a-group-owned-application) in your GitLab instance. This is required to enable OAuth access for your organization.
    * Set the redirect URI in GitLab to `https://cloud.konghq.com/$KONNECT_REGION/service-catalog/integrations/gitlab`
    * Make sure the application has the `api` scope.
-1. In the {{site.konnect_short_name}} UI, navigate to the [GitLab integration](https://cloud.konghq.com/service-catalog/integrations/gitlab/configuration)
+1. In the {{site.konnect_short_name}} UI, navigate to the GitLab integration.
 1. In the **GitLab API Base URL** field, enter the full URL to your GitLab API, ending in `/api/v4`.  
    For example: `https://gitlab.example.com/api/v4`
 1. Fill out the authorization fields using the values from your GitLab OAuth application:
@@ -69,7 +69,7 @@ To use the GitLab integration in a self-hosted environment:
 1. Click **Authorize** to complete the connection.
 {% endnavtab %}
 {% navtab "SaaS" %}
-1. From the **Catalog** in {{site.konnect_short_name}}, select **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
+1. From the **Catalog** in {{site.konnect_short_name}}, select **Integrations**. 
 1. Select **GitLab**, then **Install GitLab**.
 1. Click **Authorize**. 
 {% endnavtab %}

--- a/app/catalog/integrations/gitlab.md
+++ b/app/catalog/integrations/gitlab.md
@@ -11,7 +11,7 @@ tags:
   - gitlab
 
 breadcrumbs:
-  - /catalog/
+  - /catalog-classic/
   - /catalog/integrations/
 
 works_on:

--- a/app/catalog/integrations/konnect-analytics.md
+++ b/app/catalog/integrations/konnect-analytics.md
@@ -23,18 +23,20 @@ search_aliases:
 related_resources:
   - text: "Map {{site.observability}} reports in {{site.konnect_catalog}}"
     url: /how-to/map-analytics-resources/
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
 discovery_support: true
 discovery_default: true
 bindable_entities: "Report"
 ---
 
+{% include_cached catalog/catalog-classic-banner.md %}
+
 The {{site.observability}} integration will allow users to connect Reports from the {{site.observability}} product directly to their services. Users browsing the catalog will be able to see what reports are important to that service, and be brought directly to the report by clicking through.
 
 ## Authorize the {{site.observability}} integration
 
-The {{site.observability}} integration is built directly into {{site.konnect_catalog}}. No additional authorization is required.
+The {{site.observability}} integration is built directly into {{site.konnect_catalog}} Classic. No additional authorization is required.
 
 
 ## Resources

--- a/app/catalog/integrations/konnect-analytics.md
+++ b/app/catalog/integrations/konnect-analytics.md
@@ -11,7 +11,7 @@ tags:
   - integrations
 
 breadcrumbs:
-  - /catalog/
+  - /catalog-classic/
   - /catalog/integrations/
 
 works_on:

--- a/app/catalog/integrations/pagerduty.md
+++ b/app/catalog/integrations/pagerduty.md
@@ -12,7 +12,7 @@ tags:
   - pagerduty
 
 breadcrumbs:
-  - /catalog/
+  - /catalog-classic/
   - /catalog/integrations/
 search_aliases:
   - service catalog

--- a/app/catalog/integrations/pagerduty.md
+++ b/app/catalog/integrations/pagerduty.md
@@ -20,20 +20,22 @@ works_on:
     - konnect
 description: The PagerDuty integration allows you to provide a way to alert on information about current open incidents to consumers of the service directory.
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Import and map PagerDuty resources in {{site.konnect_catalog}}
     url: /how-to/install-and-map-pagerduty-resources/
 discovery_support: true
 bindable_entities: "PagerDuty Service"
 ---
 
+{% include_cached catalog/catalog-classic-banner.md %}
+
 The PagerDuty integration allows you to provide a way to alert the service team (via PagerDuty services), as well as provide information on current open incidents to consumers of the service directory.
 {% include /catalog/multi-resource.md %}
 
-For each linked PagerDuty service, a summary will be provided on the {{site.konnect_catalog}} service's details page, showing current unresolved incidents and the current on-call user.
+For each linked PagerDuty service, a summary will be provided on the {{site.konnect_catalog}} Classic service's details page, showing current unresolved incidents and the current on-call user.
 
-For a complete tutorial using the {{site.konnect_short_name}} API, see [Import and map PagerDuty resources in {{site.konnect_catalog}}](/how-to/install-and-map-pagerduty-resources/).
+For a complete tutorial using the {{site.konnect_short_name}} API, see [Import and map PagerDuty resources in {{site.konnect_catalog}} Classic](/how-to/install-and-map-pagerduty-resources/).
 
 ## Authenticate the PagerDuty integration
 

--- a/app/catalog/integrations/pagerduty.md
+++ b/app/catalog/integrations/pagerduty.md
@@ -39,7 +39,7 @@ For a complete tutorial using the {{site.konnect_short_name}} API, see [Import a
 
 ## Authenticate the PagerDuty integration
 
-1. From the **Catalog** in {{site.konnect_short_name}}, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
+1. From the **Catalog** in {{site.konnect_short_name}}, click **Integrations**. 
 2. Select **Add PagerDuty Instance**
 3. Configure the **Region**, add **authorization**, and name the instance `pagerduty`. PagerDuty will ask you to grant consent to {{site.konnect_short_name}}. Both Read and Write scopes are required.
 

--- a/app/catalog/integrations/service-mesh.md
+++ b/app/catalog/integrations/service-mesh.md
@@ -22,18 +22,20 @@ search_aliases:
 related_resources:
   - text: Map Service Mesh services in {{site.konnect_catalog}}
     url: /how-to/map-service-mesh-resources/
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
 discovery_support: true
 discovery_default: true
 bindable_entities: "Mesh Service"
 ---
 
+{% include_cached catalog/catalog-classic-banner.md %}
+
 The {{site.konnect_short_name}} Mesh integration allows users gain visibility into how their service is deployed across meshes and zones, determine whether their deployment is healthy, and (if used in conjunction with other built-in integrations) to identify links between their mesh services and other {{site.konnect_short_name}} resources.
 
 ## Authorize the Service Mesh integration
 
-The Service Mesh integration is built directly into {{site.konnect_catalog}}. No additional authorization is required. As new Mesh Services are created, they are automatically discovered by {{site.konnect_catalog}} and surfaced as Resources.
+The Service Mesh integration is built directly into {{site.konnect_catalog}} Classic. No additional authorization is required. As new Mesh Services are created, they are automatically discovered by {{site.konnect_catalog}} Classic and surfaced as Resources.
 
 ## Resources
 

--- a/app/catalog/integrations/service-mesh.md
+++ b/app/catalog/integrations/service-mesh.md
@@ -11,7 +11,7 @@ tags:
   - integrations
 
 breadcrumbs:
-  - /catalog/
+  - /catalog-classic/
   - /catalog/integrations/
 
 works_on:

--- a/app/catalog/integrations/slack.md
+++ b/app/catalog/integrations/slack.md
@@ -18,11 +18,11 @@ search_aliases:
   - service catalog
 works_on:
     - konnect
-description: The Slack integration allows you to see Slack communication channels that are relevant to a {{site.konnect_catalog}} service.
+description: The Slack integration allows you to see Slack communication channels that are relevant to a {{site.konnect_catalog}} Classic service.
 
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Integrations
     url: /catalog/integrations/
   - text: Import and map Slack resources in {{site.konnect_catalog}}
@@ -33,11 +33,12 @@ bindable_entities: "Slack Channel"
 mechanism: "pull/ingestion model"
 ---
 
+{% include_cached catalog/catalog-classic-banner.md %}
 
-The Slack integration allows you to see communication channels (via [Slack channels](https://slack.com/help/articles/360017938993-What-is-a-channel)) that are relevant to a {{site.konnect_catalog}} service.
+The Slack integration allows you to see communication channels (via [Slack channels](https://slack.com/help/articles/360017938993-What-is-a-channel)) that are relevant to a {{site.konnect_catalog}} Classic service.
 {% include /catalog/multi-resource.md %}
 
-For a complete tutorial using the {{site.konnect_short_name}} API, see [Import and map Slack resources in {{site.konnect_catalog}}](/how-to/install-and-map-slack-resources/).
+For a complete tutorial using the {{site.konnect_short_name}} API, see [Import and map Slack resources in {{site.konnect_catalog}} Classic](/how-to/install-and-map-slack-resources/).
 
 ## Prerequisites
 
@@ -64,7 +65,7 @@ columns:
 rows:
   - entity: Slack Channel 
     description: 
-       A Slack channel that indicates who owns the {{site.konnect_catalog}} service. Ideally, this helps users identify who they can contact if they have questions about a service.
+       A Slack channel that indicates who owns the {{site.konnect_catalog}} Classic service. Ideally, this helps users identify who they can contact if they have questions about a service.
 {% endtable %}
 <!--vale on-->
 

--- a/app/catalog/integrations/slack.md
+++ b/app/catalog/integrations/slack.md
@@ -46,7 +46,7 @@ For a complete tutorial using the {{site.konnect_short_name}} API, see [Import a
 
 ## Authenticate the Slack integration
 
-1. From the **Catalog** in {{site.konnect_short_name}}, select **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**.
+1. From the **Catalog** in {{site.konnect_short_name}}, select **Integrations**.
 2. Select **Add Slack Instance**.
 3. Select **Authorize in Slack**, and name the instance.
    Only Slack admins can authorize the integration.

--- a/app/catalog/integrations/slack.md
+++ b/app/catalog/integrations/slack.md
@@ -12,7 +12,7 @@ tags:
   - slack
 
 breadcrumbs:
-  - /catalog/
+  - /catalog-classic/
   - /catalog/integrations/
 search_aliases:
   - service catalog

--- a/app/catalog/integrations/sonarqube.md
+++ b/app/catalog/integrations/sonarqube.md
@@ -19,25 +19,27 @@ breadcrumbs:
 
 works_on:
     - konnect
-description: The SonarQube integration lets you connect SonarQube SaaS projects directly to your {{site.konnect_catalog}} services.
+description: The SonarQube integration lets you connect SonarQube SaaS projects directly to your {{site.konnect_catalog}} Classic services.
 discovery_support: true
 bindable_entities: "Projects"
 
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: "Monitor SonarQube projects {{site.konnect_catalog}} with the {{site.konnect_short_name}} UI"
     url: /how-to/monitor-sonarqube-projects-with-konnect-ui/
   - text: "Monitor SonarQube projects {{site.konnect_catalog}} with the {{site.konnect_short_name}} API"
     url: /how-to/monitor-sonarqube-projects-with-konnect-api/
 ---
 
-The SonarQube integration lets you connect [SonarQube projects](https://docs.sonarsource.com/sonarqube-cloud/managing-your-projects) directly to your {{site.konnect_catalog}} services.
+{% include_cached catalog/catalog-classic-banner.md %}
+
+The SonarQube integration lets you connect [SonarQube projects](https://docs.sonarsource.com/sonarqube-cloud/managing-your-projects) directly to your {{site.konnect_catalog}} Classic services.
 {% include /catalog/multi-resource.md %}
 
 For a complete tutorial, see the following:
-* [Monitor SonarQube projects {{site.konnect_catalog}} with the {{site.konnect_short_name}} UI](/how-to/monitor-sonarqube-projects-with-konnect-ui/)
-* [Monitor SonarQube projects {{site.konnect_catalog}} with the {{site.konnect_short_name}} API](/how-to/monitor-sonarqube-projects-with-konnect-api/)
+* [Monitor SonarQube projects {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} UI](/how-to/monitor-sonarqube-projects-with-konnect-ui/)
+* [Monitor SonarQube projects {{site.konnect_catalog}} Classic with the {{site.konnect_short_name}} API](/how-to/monitor-sonarqube-projects-with-konnect-api/)
 
 ## Prerequisites
 
@@ -52,7 +54,7 @@ You need to configure the following in SonarQube SaaS:
 {% navtabs "sonarqube-integration" %}
 {% navtab "UI" %}
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. In the Catalog sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
+1. In the {{site.konnect_catalog}} sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
 1. Click **SonarQube**.
 1. Click **Add SonarQube instance**.
 1. In the **SonarQube API key** field, enter your SonarQube personal access token.

--- a/app/catalog/integrations/sonarqube.md
+++ b/app/catalog/integrations/sonarqube.md
@@ -54,7 +54,7 @@ You need to configure the following in SonarQube SaaS:
 {% navtabs "sonarqube-integration" %}
 {% navtab "UI" %}
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. In the {{site.konnect_catalog}} sidebar, click **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
+1. In the {{site.konnect_catalog}} sidebar, click **Integrations**. 
 1. Click **SonarQube**.
 1. Click **Add SonarQube instance**.
 1. In the **SonarQube API key** field, enter your SonarQube personal access token.

--- a/app/catalog/integrations/sonarqube.md
+++ b/app/catalog/integrations/sonarqube.md
@@ -14,7 +14,7 @@ tags:
 search_aliases:
   - service catalog
 breadcrumbs:
-  - /catalog/
+  - /catalog-classic/
   - /catalog/integrations/
 
 works_on:

--- a/app/catalog/integrations/swaggerhub.md
+++ b/app/catalog/integrations/swaggerhub.md
@@ -18,20 +18,22 @@ search_aliases:
   - service catalog
 works_on:
     - konnect
-description: The SwaggerHub integration lets you connect SwaggerHub API specs directly to your {{site.konnect_catalog}} services.
+description: The SwaggerHub integration lets you connect SwaggerHub API specs directly to your {{site.konnect_catalog}} Classic services.
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Import and map SwaggerHub resources in {{site.konnect_catalog}}
     url: /how-to/install-and-map-swaggerhub-resources/
 discovery_support: true
 bindable_entities: "SwaggerHub API version"
 ---
 
-The SwaggerHub integration lets you connect SwaggerHub API specs directly to your {{site.konnect_catalog}} services.
+{% include_cached catalog/catalog-classic-banner.md %}
+
+The SwaggerHub integration lets you connect SwaggerHub API specs directly to your {{site.konnect_catalog}} Classic services.
 {% include /catalog/multi-resource.md %}
 
-For a complete tutorial using the {{site.konnect_short_name}} API, see [Import and map SwaggerHub resources in {{site.konnect_catalog}}](/how-to/install-and-map-swaggerhub-resources/).
+For a complete tutorial using the {{site.konnect_short_name}} API, see [Import and map SwaggerHub resources in {{site.konnect_catalog}} Classic](/how-to/install-and-map-swaggerhub-resources/).
 
 ## Prerequisites
 

--- a/app/catalog/integrations/swaggerhub.md
+++ b/app/catalog/integrations/swaggerhub.md
@@ -12,7 +12,7 @@ tags:
   - swaggerhub
 
 breadcrumbs:
-  - /catalog/
+  - /catalog-classic/
   - /catalog/integrations/
 search_aliases:
   - service catalog

--- a/app/catalog/integrations/swaggerhub.md
+++ b/app/catalog/integrations/swaggerhub.md
@@ -44,7 +44,7 @@ You need a [SwaggerHub API key](https://swagger.io/docs/specification/v3_0/authe
 
 {% navtabs "swaggerhub-integration" %}
 {% navtab "UI" %}
-1. From the **Catalog** in {{site.konnect_short_name}}, select **[Integrations](https://cloud.konghq.com/service-catalog/integrations)**. 
+1. From the **Catalog** in {{site.konnect_short_name}}, select **Integrations**. 
 2. Select **Add SwaggerHub Instance**.
 3. Add your Swaggerhub API key and name the instance.
 {% endnavtab %}

--- a/app/catalog/integrations/traceable.md
+++ b/app/catalog/integrations/traceable.md
@@ -18,11 +18,11 @@ search_aliases:
   - service catalog
 works_on:
     - konnect
-description: The Traceable integration lets you connect Traceable entities directly to your {{site.konnect_catalog}} services.
+description: The Traceable integration lets you connect Traceable entities directly to your {{site.konnect_catalog}} Classic services.
 
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Traceable plugin
     url: /plugins/traceable/
   - text: Import and map Traceable resources in {{site.konnect_catalog}}
@@ -31,10 +31,12 @@ discovery_support: true
 bindable_entities: "Traceable Service"
 ---
 
-The Traceable integration lets you connect Traceable Services directly to your {{site.konnect_catalog}} services.
+{% include_cached catalog/catalog-classic-banner.md %}
+
+The Traceable integration lets you connect Traceable Services directly to your {{site.konnect_catalog}} Classic services.
 {% include /catalog/multi-resource.md %}
 
-For a complete tutorial using the {{site.konnect_short_name}} API, see [Import and map Traceable resources in {{site.konnect_catalog}}](/how-to/install-and-map-traceable-resources/).
+For a complete tutorial using the {{site.konnect_short_name}} API, see [Import and map Traceable resources in {{site.konnect_catalog}} Classic](/how-to/install-and-map-traceable-resources/).
 
 ## Authenticate the Traceable integration
 

--- a/app/catalog/integrations/traceable.md
+++ b/app/catalog/integrations/traceable.md
@@ -12,7 +12,7 @@ tags:
   - traceable
 
 breadcrumbs:
-  - /catalog/
+  - /catalog-classic/
   - /catalog/integrations/
 search_aliases:
   - service catalog

--- a/app/catalog/integrations/traceable.md
+++ b/app/catalog/integrations/traceable.md
@@ -42,7 +42,7 @@ For a complete tutorial using the {{site.konnect_short_name}} API, see [Import a
 
 {% navtabs "traceable-integration" %}
 {% navtab "UI" %}
-1. From the **Catalog** in {{site.konnect_short_name}}, select **[Integrations](https://cloud.konghq.com/us/service-catalog/integrations)**. 
+1. From the **Catalog** in {{site.konnect_short_name}}, select **Integrations**. 
 2. Select **Add Traceable Instance**.
 3. Configure the instance, add authorization and name the instance. 
 {% endnavtab %}

--- a/app/catalog/mcp-registry.md
+++ b/app/catalog/mcp-registry.md
@@ -194,6 +194,7 @@ Remotes describe hosted MCP server endpoints that agents can connect to over the
 
 An MCP server can define multiple packages and multiple remotes simultaneously. This allows organizations to support different runtime environments without duplicating server definitions.
 
+{% comment %}
 ## Publish an MCP Registry to Dev Portal
 
 You can publish an MCP Registry to a Dev Portal to expose it to a broader audience.
@@ -204,6 +205,7 @@ You can publish an MCP Registry to a Dev Portal to expose it to a broader audien
 1. Click **Publish to portal**.
 1. From the **Portal** dropdown menu, select the {{site.dev_portal}} you want to publish to.
 1. Click **Publish MCP registry**.
+{% endcomment %}
 
 ## Access and authentication
 

--- a/app/catalog/mcp-registry.md
+++ b/app/catalog/mcp-registry.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP Registries in {{site.konnect_catalog}}"
+title: "MCP registries in {{site.konnect_catalog}} (tech preview)"
 content_type: reference
 layout: reference
 tech_preview: true
@@ -30,6 +30,10 @@ faqs:
         This feature is built on top of Anthropic’s MCP Registry API specification, which is still rapidly evolving. Because the underlying standard continues to change, we cannot responsibly commit to GA timelines or long-term stability guarantees at this time.
 
         We are actively iterating in partnership with customers who are exploring MCP-based agent architectures and will evaluate GA readiness as the specification matures.
+    - q: |
+        {% include faqs/mcp-server-vs-registry.md section='question' %}
+      a: |
+        {% include faqs/mcp-server-vs-registry.md section='answer' %}
 ---
 
 ## What is an MCP Registry?

--- a/app/catalog/mcp-registry.md
+++ b/app/catalog/mcp-registry.md
@@ -60,6 +60,7 @@ You can access MCP Registries by doing the following:
 
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
 1. Click the **MCP registries** tab.
+   
    {:.info}
    > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **MCP Registries** in the sidebar instead.
 
@@ -68,11 +69,10 @@ You can access MCP Registries by doing the following:
 {% navtabs "create-mcp-registry" %}
 {% navtab "{{site.konnect_short_name}} UI" %}
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. Click the **MCP registries** tab.
+1. From the **New** dropdown menu, select "MCP registry".
    
    {:.info}
    > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **MCP Registries** in the sidebar instead.
-1. From the **New** dropdown menu, select "MCP registry".
 1. In the **Display Name** field, enter a name for your registry, for example `Production Registry`.
 1. In the **Name** field, enter a unique identifier for the registry, for example `production-registry`. This must be lowercase and alphanumeric, and can include hyphens.
 1. (Optional) In the **Description** field, describe the purpose of this registry.
@@ -194,19 +194,6 @@ Remotes describe hosted MCP server endpoints that agents can connect to over the
 
 An MCP server can define multiple packages and multiple remotes simultaneously. This allows organizations to support different runtime environments without duplicating server definitions.
 
-{% comment %}
-## Publish an MCP Registry to Dev Portal
-
-You can publish an MCP Registry to a Dev Portal to expose it to a broader audience.
-
-1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. Click the **MCP registries** tab.
-1. Click your MCP registry.
-1. Click **Publish to portal**.
-1. From the **Portal** dropdown menu, select the {{site.dev_portal}} you want to publish to.
-1. Click **Publish MCP registry**.
-{% endcomment %}
-
 ## Access and authentication
 
 Registry endpoints assume a {{site.konnect_short_name}} authentication context. Only authenticated clients with appropriate [access tokens](/konnect-api/#konnect-api-authentication) can query the registry URL:
@@ -222,7 +209,7 @@ We are continuing to evolve MCP Registries alongside the broader MCP ecosystem.
 
 Planned enhancements include:
 
-* Linking {{site.konnect_catalog}} MCP servers to MCP servers created in {{site.ai_gateway}}
+* Linking {{site.konnect_catalog}} MCP servers to MCP servers created in [{{site.ai_gateway}} 2.0](/ai-gateway/)
 * Additional governance and lifecycle controls
 
 Because the MCP specification is still evolving, we are committed to iterating in partnership with customers who have already begun developing MCP servers and experimenting with agent-based workflows.

--- a/app/catalog/mcp-registry.md
+++ b/app/catalog/mcp-registry.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP Registries in {{site.konnect_catalog}} Classic"
+title: "MCP Registries in {{site.konnect_catalog}}"
 content_type: reference
 layout: reference
 tech_preview: true
@@ -8,16 +8,16 @@ products:
 works_on:
   - konnect
 
-description: An MCP Registry is a centralized publishing and discovery endpoint for MCP servers within your organization. Learn how to register your MCP servers in {{site.konnect_short_name}} {{site.konnect_catalog}} Classic.
+description: An MCP Registry is a centralized publishing and discovery endpoint for MCP servers within your organization. Learn how to register your MCP servers in {{site.konnect_short_name}} {{site.konnect_catalog}}.
 
 breadcrumbs:
-  - /catalog-classic/
+  - /catalog/
 search_aliases:
   - service catalog
   - mcp
 related_resources:
-  - text: "{{site.konnect_catalog}} Classic"
-    url: /catalog-classic/
+  - text: "{{site.konnect_catalog}}"
+    url: /catalog/
   - text: "MCP traffic gateway"
     url: /mcp/
   - text: "MCP clients in Insomnia"
@@ -25,14 +25,12 @@ related_resources:
 faqs:
     - q: Is the MCP Registry feature GA?
       a: |
-        No, MCP Registries in {{site.konnect_catalog}} Classic is only available in Tech Preview via {{site.konnect_short_name}} Labs.
+        No, MCP Registries in {{site.konnect_catalog}} is only available in Tech Preview via {{site.konnect_short_name}} Labs.
 
         This feature is built on top of Anthropic’s MCP Registry API specification, which is still rapidly evolving. Because the underlying standard continues to change, we cannot responsibly commit to GA timelines or long-term stability guarantees at this time.
 
         We are actively iterating in partnership with customers who are exploring MCP-based agent architectures and will evaluate GA readiness as the specification matures.
 ---
-
-{% include_cached catalog/catalog-classic-banner.md %}
 
 ## What is an MCP Registry?
 
@@ -44,24 +42,43 @@ As organizations experiment with AI agents, MCP servers are often embedded direc
 * Which agents should use which servers  
 * How those servers should be governed
 
-MCP Registries extend {{site.konnect_short_name}} {{site.konnect_catalog}} Classic to provide a structured, standards-based way to register and manage MCP servers, helping Platform Teams maintain visibility and control as AI adoption scales.
+MCP Registries extend {{site.konnect_short_name}} {{site.konnect_catalog}} to provide a structured, standards-based way to register and manage MCP servers, helping Platform Teams maintain visibility and control as AI adoption scales.
 
 This feature is built on top of the MCP Registry API specification defined by {{ site.anthropic }}’s [open source project](https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/api/openapi.yaml). The specification allows flexibility in how registries are structured, so you can model them according to your organization’s governance needs.
 
 
-## Enable MCP Registries in {{site.konnect_catalog}} Classic
+## Enable MCP Registries in {{site.konnect_catalog}}
 
-MCP Registries in {{site.konnect_catalog}} Classic are currently available in tech preview via {{site.konnect_short_name}} Labs.
+MCP Registries in {{site.konnect_catalog}} are currently available in tech preview via {{site.konnect_short_name}} Labs.
 
-1. In the {{site.konnect_short_name}} sidebar, navigate to **Organizations**.
-1. In the Organization sidebar, click **Labs**.
+1. In {{site.konnect_short_name}}, click your organization dropdown and select "Manage organizations".
+1. Click the **Labs** tab.
 1. Click **Catalog - MCP Registry**.
-1. Click the toggle at the top right to enable the integration.
+1. Click **Enable feature**.
 
-You can access the MCP Registry by navigating to **Catalog** > **MCP Registries** in the sidebar.
+You can access MCP Registries by doing the following:
+
+1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
+1. Click the **MCP registries** tab.
+   {:.info}
+   > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **MCP Registries** in the sidebar instead.
 
 ## Create an MCP Registry
 
+{% navtabs "create-mcp-registry" %}
+{% navtab "{{site.konnect_short_name}} UI" %}
+1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
+1. Click the **MCP registries** tab.
+   
+   {:.info}
+   > If you're using [{{site.konnect_catalog}} Classic](/catalog-classic/), click **MCP Registries** in the sidebar instead.
+1. From the **New** dropdown menu, select "MCP registry".
+1. In the **Display Name** field, enter a name for your registry, for example `Production Registry`.
+1. In the **Name** field, enter a unique identifier for the registry, for example `production-registry`. This must be lowercase and alphanumeric, and can include hyphens.
+1. (Optional) In the **Description** field, describe the purpose of this registry.
+1. Click **Create**.
+{% endnavtab %}
+{% navtab "{{site.konnect_short_name}} API" %}
 Send a POST request to the `/mcp-registries` endpoint:
 
 ```sh
@@ -73,8 +90,10 @@ curl -X POST "https://klabs.us.api.konghq.com/v0/mcp-registries" \
     "description": "Registry for MCP servers approved for internal AI agents"
   }'
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
-## Publish an MCP server
+## Add an MCP server
 
 An MCP server represents an agent-facing service definition. It describes:
 
@@ -82,6 +101,45 @@ An MCP server represents an agent-facing service definition. It describes:
 * Its version  
 * How agents can connect to it
 
+{% navtabs "publish-mcp-server" %}
+{% navtab "{{site.konnect_short_name}} UI" %}
+1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
+1. Click the **MCP registries** tab.
+1. Click your MCP registry.
+1. From your MCP Registry's detail page, click **New MCP Server**.
+1. (Optional) In the **Title** field, enter a short, descriptive name for the server, for example `Filesystem Server`.
+1. In the **Name** field, enter a unique identifier in reverse-DNS format, for example `io.example/filesystem`. This must contain exactly one forward slash.
+1. In the **Version** field, enter a version number using semantic versioning, for example `1.0.0`.
+1. In the **Description** field, enter a description of what the server does.
+1. (Optional) Click **Show optional fields**, and do the following:
+   1. (Optional) In the **Schema URI** field, enter a URI, for example `https://example.com/schemas/server.json`.
+   1. (Optional) In the **GitHub repository URL** field, enter a URL, for example `https://github.com/owner/repo`.
+   1. (Optional) In the **Website URL** field, enter a URL, for example `https://example.com`.
+   1. (Optional) In the **Metadata** field, enter a JSON object, for example `{"license": "MIT", "author": "Example Corp", "certified": true}`.
+1. (Optional) To describe a run-it-yourself distribution option, such as an npm or PyPI package, click **Add Package** and do the following:
+   1. From the **Transport type** dropdown menu, select an option. 
+      If you select "Streamable-HTTP" or "SSE", also enter the transport URL.
+   1. From the **Registry type** dropdown menu, select how you want users to download packages.
+   1. In the **Registry base URL** field, enter `https://registry.npmjs.org`.
+   1. In the **Package identifier** field, enter the base URL of the package registry, for example `@modelcontextprotocol/mcp-server`.
+   1. (Optional) In the **Package version** field, enter a version, for example `1.0.0`.
+   1. Click **Save**.
+1. (Optional) To add a remote to describe a hosted MCP server endpoint that agents can connect to over the network, click **Add Remote** and do the following:
+   1. From the **Transport type** dropdown menu, select "Streamable-HTTP" or "SSE".
+   1. In the **Remote URL** field, enter the MCP server's endpoint, for example `https://example.com/mcp`.
+   1. (Optional) In the **Headers** field, enter headers as a JSON array of objects, for example, to pass an authorization token:
+   ```json
+   [
+     {
+       "name": "Authorization",
+       "value": "Bearer ${token}"
+     }
+   ]
+   ```
+   1. Click **Save**.
+1. Click **Publish**.
+{% endnavtab %}
+{% navtab "{{site.konnect_short_name}} API" %}
 To add an MCP server, send a POST request to the `/mcp-registries/{registryIdentifier}/v0.1/publish` endpoint:
 
 ```sh
@@ -109,6 +167,8 @@ curl -X POST "https://klabs.us.api.konghq.com/v0/mcp-registries/internal-mcp-reg
     ]
   }'
 ```
+{% endnavtab %}
+{% endnavtabs %}
 
 
 ## Packages and remotes
@@ -134,6 +194,16 @@ Remotes describe hosted MCP server endpoints that agents can connect to over the
 
 An MCP server can define multiple packages and multiple remotes simultaneously. This allows organizations to support different runtime environments without duplicating server definitions.
 
+## Publish an MCP Registry to Dev Portal
+
+You can publish an MCP Registry to a Dev Portal to expose it to a broader audience.
+
+1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
+1. Click the **MCP registries** tab.
+1. Click your MCP registry.
+1. Click **Publish to portal**.
+1. From the **Portal** dropdown menu, select the {{site.dev_portal}} you want to publish to.
+1. Click **Publish MCP registry**.
 
 ## Access and authentication
 
@@ -144,17 +214,13 @@ curl -X GET "https://klabs.us.api.konghq.com/v0/mcp-registries/internal-mcp-regi
   -H "Authorization: Bearer $KONNECT_TOKEN"
 ```
 
-Future enhancements will allow publishing MCP servers to Dev Portal, enabling controlled exposure to broader audiences, including users and agents outside of {{site.konnect_short_name}}.
-
-
 ## What’s next
 
 We are continuing to evolve MCP Registries alongside the broader MCP ecosystem.
 
 Planned enhancements include:
 
-* Publishing MCP servers to Dev Portal  
-* Auto-registration of MCP servers created via {{site.konnect_short_name}}-native workflows such as {{site.ai_gateway}} 
+* Linking {{site.konnect_catalog}} MCP servers to MCP servers created in {{site.ai_gateway}}
 * Additional governance and lifecycle controls
 
 Because the MCP specification is still evolving, we are committed to iterating in partnership with customers who have already begun developing MCP servers and experimenting with agent-based workflows.

--- a/app/catalog/mcp-registry.md
+++ b/app/catalog/mcp-registry.md
@@ -11,7 +11,7 @@ works_on:
 description: An MCP Registry is a centralized publishing and discovery endpoint for MCP servers within your organization. Learn how to register your MCP servers in {{site.konnect_short_name}} {{site.konnect_catalog}} Classic.
 
 breadcrumbs:
-  - /catalog/
+  - /catalog-classic/
 search_aliases:
   - service catalog
   - mcp

--- a/app/catalog/mcp-registry.md
+++ b/app/catalog/mcp-registry.md
@@ -1,5 +1,5 @@
 ---
-title: "MCP Registries in {{site.konnect_catalog}}"
+title: "MCP Registries in {{site.konnect_catalog}} Classic"
 content_type: reference
 layout: reference
 tech_preview: true
@@ -8,7 +8,7 @@ products:
 works_on:
   - konnect
 
-description: An MCP Registry is a centralized publishing and discovery endpoint for MCP servers within your organization. Learn how to register your MCP servers in {{site.konnect_short_name}} {{site.konnect_catalog}}.
+description: An MCP Registry is a centralized publishing and discovery endpoint for MCP servers within your organization. Learn how to register your MCP servers in {{site.konnect_short_name}} {{site.konnect_catalog}} Classic.
 
 breadcrumbs:
   - /catalog/
@@ -16,8 +16,8 @@ search_aliases:
   - service catalog
   - mcp
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: "MCP traffic gateway"
     url: /mcp/
   - text: "MCP clients in Insomnia"
@@ -25,12 +25,14 @@ related_resources:
 faqs:
     - q: Is the MCP Registry feature GA?
       a: |
-        No, MCP Registries in Catalog is only available in Tech Preview via {{site.konnect_short_name}} Labs.
+        No, MCP Registries in {{site.konnect_catalog}} Classic is only available in Tech Preview via {{site.konnect_short_name}} Labs.
 
         This feature is built on top of Anthropic’s MCP Registry API specification, which is still rapidly evolving. Because the underlying standard continues to change, we cannot responsibly commit to GA timelines or long-term stability guarantees at this time.
 
         We are actively iterating in partnership with customers who are exploring MCP-based agent architectures and will evaluate GA readiness as the specification matures.
 ---
+
+{% include_cached catalog/catalog-classic-banner.md %}
 
 ## What is an MCP Registry?
 
@@ -42,14 +44,14 @@ As organizations experiment with AI agents, MCP servers are often embedded direc
 * Which agents should use which servers  
 * How those servers should be governed
 
-MCP Registries extend {{site.konnect_short_name}} {{site.konnect_catalog}} to provide a structured, standards-based way to register and manage MCP servers, helping Platform Teams maintain visibility and control as AI adoption scales.
+MCP Registries extend {{site.konnect_short_name}} {{site.konnect_catalog}} Classic to provide a structured, standards-based way to register and manage MCP servers, helping Platform Teams maintain visibility and control as AI adoption scales.
 
 This feature is built on top of the MCP Registry API specification defined by {{ site.anthropic }}’s [open source project](https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/api/openapi.yaml). The specification allows flexibility in how registries are structured, so you can model them according to your organization’s governance needs.
 
 
-## Enable MCP Registries in {{site.konnect_catalog}}
+## Enable MCP Registries in {{site.konnect_catalog}} Classic
 
-MCP Registries in {{site.konnect_catalog}} are currently available in tech preview via {{site.konnect_short_name}} Labs.
+MCP Registries in {{site.konnect_catalog}} Classic are currently available in tech preview via {{site.konnect_short_name}} Labs.
 
 1. In the {{site.konnect_short_name}} sidebar, navigate to **Organizations**.
 1. In the Organization sidebar, click **Labs**.

--- a/app/catalog/mcp-servers.md
+++ b/app/catalog/mcp-servers.md
@@ -53,6 +53,60 @@ The link is a snapshot, not a live sync: if you change the linked server's confi
 
 ## Create an MCP server
 
+1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
+1. From the **New** dropdown menu, select **MCP server**.
+1. Under **Data source**, select one of the following:
+   1. To fill out the server's details yourself, select **Define manually**.
+   1. To populate details from an existing server's definition, select **Paste JSON**, then in the **Version, capabilities, and access methods** field, paste the definition. Only `version` is required.
+   1. To create the server from an MCP interface already configured in {{site.ai_gateway}} 2.0, select **Import from AI gateway**, then:
+      1. From the **AI gateway** dropdown menu, select your {{site.ai_gateway}} control plane.
+      1. From the **MCP server** dropdown menu, select the server you want to import.
+1. In the **Display name** field, enter a name for your MCP server, for example `My MCP server`.
+1. In the **Name** field, enter a unique identifier for the MCP server, for example `my-new-mcp-server`. This must contain only lowercase letters, numbers, hyphens, and periods.
+1. (Optional) In the **Description** field, describe the purpose of your MCP server.
+1. (Optional) Click **Add labels**, and do the following:
+   1. In the **Key** field, enter a label key.
+   1. In the **Value** field, enter a label value.
+   1. (Optional) Click **Add another label** to add more labels.
+1. Click **Next**.
+1. If you didn't select **Paste JSON**, in the **Version** field, enter a version number for your MCP server, for example `1.0.0`.
+1. (Optional) Under **Capabilities**, click **New capability**, and select one of the following:
+   * **Tool**: Outlines how your server takes actions. 
+     1. In the **Name** field, enter a unique identifier for the tool. 
+     1. In the **Input schema** field, enter the JSON schema defining the tool's expected parameters. 
+     1. (Optional) Fill in **Title**, **Description**, **Output schema**, and **Annotations**.
+     1. Click **Add**, then repeat to add more capabilities.
+   * **Resource**: To share server context through documents, logs, and other data. 
+     1. In the **URI** field, enter a unique identifier for the resource, for example `file://example.txt`. 
+     1. In the **Name** field, enter a name for the resource. 
+     1. (Optional) Fill in **Title**, **Description**, **mimeType**, and **Size (bytes)**.
+     1. Click **Add**, then repeat to add more capabilities.
+   * **Prompt**: Define a reusable workflow with preset inputs. 
+     1. In the **Name** field, enter a unique identifier for the prompt. 
+     1. (Optional) Fill in **Title**, **Description**, and a comma-separated list of **Arguments**, for example `language, focus_area, severity_threshold`.
+     1. Click **Add**, then repeat to add more capabilities.
+1. (Optional) Under **Access methods**, click **New access method**, and select one of the following:
+   * **Remote**: Describes a hosted MCP server endpoint. 
+     1. In the **Remote URL** field, enter the server's endpoint, for example `https://example.com/mcp`. 
+     1. From the **Transport type** dropdown menu, select a transport type. 
+     1. (Optional) In the **Headers** field, enter headers as a JSON array of objects, for example, to pass an authorization token:
+        ```json
+        [
+          {
+            "name": "Authorization",
+            "value": "Bearer ${token}"
+          }
+        ]
+        ```
+     1. Click **Add**, then repeat to add more access methods.
+   * **Package**, to describe a run-it-yourself distribution option. 
+      1. In the **Package identifier** field, enter the package name or URL, for example `@modelcontextprotocol/mcp-server`. 
+      1. From the **Transport type** and **Package type** dropdown menus, select the applicable types. 
+      1. (Optional) Fill in **Registry base URL** and **Package version**. If you leave **Package version** blank, the package uses the server's version.
+      1. Click **Add**, then repeat to add more access methods.
+1. Click **Save**.
+
+{% comment %}
 {% navtabs "create-mcp-server" %}
 {% navtab "{{site.konnect_short_name}} API" %}
 Send a POST request to the `/mcp-servers` endpoint to create an empty MCP server:
@@ -182,6 +236,7 @@ body:
 1. Click **Save**.
 {% endnavtab %}
 {% endnavtabs %}
+{% endcomment %}
 
 {% comment %}
 ## MCP server analytics

--- a/app/catalog/mcp-servers.md
+++ b/app/catalog/mcp-servers.md
@@ -1,0 +1,190 @@
+---
+title: "MCP servers in {{site.konnect_catalog}}"
+content_type: reference
+layout: reference
+
+products:
+    - catalog
+    - ai-gateway
+
+breadcrumbs:
+  - /catalog/
+
+works_on:
+  - konnect
+
+search_aliases:
+  - mcp
+
+description: An MCP server is an interface in {{site.konnect_catalog}} that represents an MCP server your organization builds or consumes. Learn how to create and manage MCP servers.
+
+related_resources:
+  - text: "{{site.konnect_catalog}}"
+    url: /catalog/
+  - text: "{{site.ai_gateway}}"
+    url: /ai-gateway/
+  - text: "MCP registries (tech preview)"
+    url: /catalog/mcp-registry/
+  - text: "AI Models"
+    url: /catalog/ai-models/
+
+faqs:
+  - q: |
+      {% include faqs/mcp-server-vs-registry.md section='question' %}
+    a: |
+      {% include faqs/mcp-server-vs-registry.md section='answer' %}
+---
+
+As teams build MCP servers for AI agents, those servers are often embedded directly in agent code, defined in local configuration files, or scattered across repositories, with no shared record of what already exists.
+{{site.konnect_catalog}} gives you a single place to see every MCP server across your organization, so you don't have to track each one down in a separate tool to know what it does or how to connect to it.
+An MCP server is an interface in {{site.konnect_catalog}} that represents an MCP server your organization builds or consumes.
+
+You can create an MCP server in {{site.konnect_catalog}} in a few ways:
+* Define it manually, filling out its details yourself.
+* Paste an existing server's JSON definition.
+* Import it from [{{site.ai_gateway}} 2.0](/ai-gateway/), by linking an existing {{site.ai_gateway}} MCP server as the source.
+* (Coming soon) Connect to a running MCP server, and have {{site.konnect_short_name}} fetch its definition directly.
+
+When an MCP server is linked to {{site.ai_gateway}} 2.0, the link indicates that {{site.ai_gateway}} is protecting and proxying that server.
+An MCP server that isn't linked can still exist in {{site.konnect_catalog}} as part of your organization's inventory. 
+The absence of a link can also help you identify MCP servers that aren't yet protected by {{site.ai_gateway}} and could be candidates to govern with it.
+
+The link is a snapshot, not a live sync: if you change the linked server's configuration in {{site.ai_gateway}}, the MCP server in {{site.konnect_catalog}} isn't automatically updated to match.
+
+## Create an MCP server
+
+{% navtabs "create-mcp-server" %}
+{% navtab "{{site.konnect_short_name}} API" %}
+Send a POST request to the `/mcp-servers` endpoint to create an empty MCP server:
+<!--vale off-->
+{% konnect_api_request %}
+url: /v1/mcp-servers
+status_code: 201
+method: POST
+body:
+    name: my-mcp
+    display_name: My MCP
+    description: Customer support triage MCP server
+extract_body:
+    - name: 'id'
+      variable: MCP_ID
+capture:
+  - variable: MCP_ID
+    jq: ".id"
+{% endkonnect_api_request %}
+<!--vale on-->
+
+Add the MCP server's capabilities and access methods by sending a POST request to the `/mcp-servers/{mcpId}/versions` endpoint:
+<!--vale off-->
+{% konnect_api_request %}
+url: /v1/mcp-servers/$MCP_ID/versions
+status_code: 201
+method: POST
+body:
+    version: 1.0.0
+    tools:
+      - name: get_forecast
+        description: Multi-day forecast for a location.
+        input_schema:
+            type: object
+    resources:
+      - name: forecast-docs
+        uri: file://forecast-docs.txt
+        description: Reference documentation describing forecast data fields and units.
+        mime_type: text/plain
+    prompts:
+      - name: summarize_forecast
+        description: Summarize the forecast for a location over a date range.
+        arguments:
+          - name: location
+            description: The location to summarize the forecast for.
+            required: true
+    remotes:
+      - type: streamable-http
+        url: https://mcp.example.com/weather
+    packages:
+      - registry:
+            type: npm
+        identifier: "@example/weather-mcp-server"
+        version: 1.0.0
+        transport:
+            type: stdio
+{% endkonnect_api_request %}
+<!--vale on-->
+
+(Optional) Link the MCP server to a server on {{site.ai_gateway}} by sending a POST request to the `/mcp-servers/{mcpId}/implementations` endpoint:
+<!--vale off-->
+{% konnect_api_request %}
+url: /v1/mcp-servers/$MCP_ID/implementations
+status_code: 201
+method: POST
+body:
+    implementation:
+        type: ai-gateway
+        config:
+            gateway_control_plane_id: $CONTROL_PLANE_ID
+            gateway_mcp_server_id: $GATEWAY_MCP_SERVER_ID
+{% endkonnect_api_request %}
+<!--vale on-->
+{% endnavtab %}
+{% navtab "{{site.konnect_short_name}} UI" %}
+1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
+1. From the **New** dropdown menu, select **MCP server**.
+1. Under **Data source**, select one of the following:
+   1. To fill out the server's details yourself, select **Define manually**.
+   1. To populate details from an existing server's definition, select **Paste JSON**, then in the **Version, capabilities, and access methods** field, paste the definition. Only `version` is required.
+   1. To create the server from an MCP interface already configured in {{site.ai_gateway}} 2.0, select **Import from AI gateway**, then:
+      1. From the **AI gateway** dropdown menu, select your {{site.ai_gateway}} control plane.
+      1. From the **MCP server** dropdown menu, select the server you want to import.
+1. In the **Display name** field, enter a name for your MCP server, for example `My MCP server`.
+1. In the **Name** field, enter a unique identifier for the MCP server, for example `my-new-mcp-server`. This must contain only lowercase letters, numbers, hyphens, and periods.
+1. (Optional) In the **Description** field, describe the purpose of your MCP server.
+1. (Optional) Click **Add labels**, and do the following:
+   1. In the **Key** field, enter a label key.
+   1. In the **Value** field, enter a label value.
+   1. (Optional) Click **Add another label** to add more labels.
+1. Click **Next**.
+1. If you didn't select **Paste JSON**, in the **Version** field, enter a version number for your MCP server, for example `1.0.0`.
+1. (Optional) Under **Capabilities**, click **New capability**, and select one of the following:
+   * **Tool**: Outlines how your server takes actions. 
+     1. In the **Name** field, enter a unique identifier for the tool. 
+     1. In the **Input schema** field, enter the JSON schema defining the tool's expected parameters. 
+     1. (Optional) Fill in **Title**, **Description**, **Output schema**, and **Annotations**.
+     1. Click **Add**, then repeat to add more capabilities.
+   * **Resource**: To share server context through documents, logs, and other data. 
+     1. In the **URI** field, enter a unique identifier for the resource, for example `file://example.txt`. 
+     1. In the **Name** field, enter a name for the resource. 
+     1. (Optional) Fill in **Title**, **Description**, **mimeType**, and **Size (bytes)**.
+     1. Click **Add**, then repeat to add more capabilities.
+   * **Prompt**: Define a reusable workflow with preset inputs. 
+     1. In the **Name** field, enter a unique identifier for the prompt. 
+     1. (Optional) Fill in **Title**, **Description**, and a comma-separated list of **Arguments**, for example `language, focus_area, severity_threshold`.
+     1. Click **Add**, then repeat to add more capabilities.
+1. (Optional) Under **Access methods**, click **New access method**, and select one of the following:
+   * **Remote**: Describes a hosted MCP server endpoint. 
+     1. In the **Remote URL** field, enter the server's endpoint, for example `https://example.com/mcp`. 
+     1. From the **Transport type** dropdown menu, select a transport type. 
+     1. (Optional) In the **Headers** field, enter headers as a JSON array of objects, for example, to pass an authorization token:
+        ```json
+        [
+          {
+            "name": "Authorization",
+            "value": "Bearer ${token}"
+          }
+        ]
+        ```
+     1. Click **Add**, then repeat to add more access methods.
+   * **Package**, to describe a run-it-yourself distribution option. 
+      1. In the **Package identifier** field, enter the package name or URL, for example `@modelcontextprotocol/mcp-server`. 
+      1. From the **Transport type** and **Package type** dropdown menus, select the applicable types. 
+      1. (Optional) Fill in **Registry base URL** and **Package version**. If you leave **Package version** blank, the package uses the server's version.
+      1. Click **Add**, then repeat to add more access methods.
+1. Click **Save**.
+{% endnavtab %}
+{% endnavtabs %}
+
+{% comment %}
+## MCP server analytics
+
+When you create an MCP server in {{site.konnect_catalog}}, you can see analytics for that server in addition to the details you configured.
+{% endcomment %}

--- a/app/catalog/migrate-api-specs-to-apis.md
+++ b/app/catalog/migrate-api-specs-to-apis.md
@@ -23,6 +23,8 @@ related_resources:
     url: /catalog/integrations/
 ---
 
+{% include_cached catalog/catalog-classic-banner.md %}
+
 APIs can be associated with {{site.konnect_catalog}} services, which replaces the legacy API spec linking. We recommend migrating API specs that are associated with a {{site.konnect_catalog}} service to APIs because this allows API consumers and service owners to see which APIs and services are associated with each other. 
 
 {% include_cached /catalog/note-api-spec-snapshot.md %}

--- a/app/catalog/migrate-api-specs-to-apis.md
+++ b/app/catalog/migrate-api-specs-to-apis.md
@@ -15,8 +15,8 @@ breadcrumbs:
 search_aliases:
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Scorecards
     url: /catalog/scorecards/
   - text: "{{site.konnect_catalog}} integrations"

--- a/app/catalog/scorecards.md
+++ b/app/catalog/scorecards.md
@@ -11,7 +11,7 @@ works_on:
 description: Scorecards in {{site.konnect_catalog}} Classic allow platform teams to monitor services for compliance with Kong-recommended and industry-defined best practices in {{site.konnect_short_name}}.
 
 breadcrumbs:
-  - /catalog/
+  - /catalog-classic/
 search_aliases:
   - service catalog
 related_resources:

--- a/app/catalog/scorecards.md
+++ b/app/catalog/scorecards.md
@@ -8,22 +8,24 @@ products:
 works_on:
   - konnect
 
-description: Scorecards in {{site.konnect_catalog}} allow platform teams to monitor services for compliance with Kong-recommended and industry-defined best practices in {{site.konnect_short_name}}.
+description: Scorecards in {{site.konnect_catalog}} Classic allow platform teams to monitor services for compliance with Kong-recommended and industry-defined best practices in {{site.konnect_short_name}}.
 
 breadcrumbs:
   - /catalog/
 search_aliases:
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: "{{site.konnect_catalog}} services"
     url: /catalog/services/
   - text: Catalog integrations
     url: /catalog/integrations/
 ---
 
-A {{site.konnect_catalog}} scorecard helps you evaluate services based on validation criteria. Scorecards help you detect issues, like whether there are services in the catalog that don't have an on-call engineer assigned, or if you have GitHub repositories with stale pull requests that aren't getting reviewed or closed. 
+{% include_cached catalog/catalog-classic-banner.md %}
+
+A {{site.konnect_catalog}} Classic scorecard helps you evaluate services based on validation criteria. Scorecards help you detect issues, like whether there are services in the catalog that don't have an on-call engineer assigned, or if you have GitHub repositories with stale pull requests that aren't getting reviewed or closed. 
 
 From the scorecard view, you can view details on either a per-service or per-criteria basis.
 
@@ -31,7 +33,7 @@ You can use a prebuilt scorecard template that includes criteria from Kong and i
 
 ## Scorecard templates
 
-{{site.konnect_short_name}} provides several scorecard templates to help ensure your {{site.konnect_catalog}} services adhere to industry best practices.
+{{site.konnect_short_name}} provides several scorecard templates to help ensure your {{site.konnect_catalog}} Classic services adhere to industry best practices.
 
 <!--vale off-->
 {% table %}
@@ -59,7 +61,7 @@ To enable a scorecard on a service:
 {% navtabs "scorecards" %}
 {% navtab "UI" %}
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. In the Catalog sidebar, click **[Scorecards](https://cloud.konghq.com/service-catalog/scorecards)**.
+1. In the {{site.konnect_catalog}} sidebar, click **[Scorecards](https://cloud.konghq.com/service-catalog/scorecards)**.
 1. Click **New Scorecard**.
 1. From the **Scorecard template** dropdown menu, select your template or select custom scorecard.
 1. (Optional) If you want to add an additional section or criteria, click **Add criteria** or **Add section**.

--- a/app/catalog/scorecards.md
+++ b/app/catalog/scorecards.md
@@ -61,7 +61,7 @@ To enable a scorecard on a service:
 {% navtabs "scorecards" %}
 {% navtab "UI" %}
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. In the {{site.konnect_catalog}} sidebar, click **[Scorecards](https://cloud.konghq.com/service-catalog/scorecards)**.
+1. In the {{site.konnect_catalog}} sidebar, click **Scorecards**.
 1. Click **New Scorecard**.
 1. From the **Scorecard template** dropdown menu, select your template or select custom scorecard.
 1. (Optional) If you want to add an additional section or criteria, click **Add criteria** or **Add section**.

--- a/app/catalog/services.md
+++ b/app/catalog/services.md
@@ -11,7 +11,7 @@ works_on:
 description: Learn about services in {{site.konnect_catalog}} Classic and how to configure them.
 
 breadcrumbs:
-  - /catalog/
+  - /catalog-classic/
 search_aliases:
   - service catalog
 related_resources:

--- a/app/catalog/services.md
+++ b/app/catalog/services.md
@@ -1,5 +1,5 @@
 ---
-title: "{{site.konnect_catalog}} services"
+title: "{{site.konnect_catalog}} Classic services"
 content_type: reference
 layout: reference
 
@@ -8,15 +8,15 @@ products:
 works_on:
   - konnect
 
-description: Learn about services in {{site.konnect_catalog}} and how to configure them.
+description: Learn about services in {{site.konnect_catalog}} Classic and how to configure them.
 
 breadcrumbs:
   - /catalog/
 search_aliases:
   - service catalog
 related_resources:
-  - text: "{{site.konnect_catalog}}"
-    url: /catalog/
+  - text: "{{site.konnect_catalog}} Classic"
+    url: /catalog-classic/
   - text: Scorecards
     url: /catalog/scorecards/
   - text: Traceable integration
@@ -32,33 +32,35 @@ related_resources:
   - text: PagerDuty integration
     url: /catalog/integrations/pagerduty/
 faqs:
-  - q: What's the difference between a Gateway Service and a {{site.konnect_catalog}} service?
+  - q: What's the difference between a Gateway Service and a {{site.konnect_catalog}} Classic service?
     a: |
-      A [Gateway Service](/gateway/entities/service/) is a {{site.base_gateway}} entity that represents an upstream service in your system and is the business logic component that's responsible for responding to requests. A {{site.konnect_catalog}} service is a collection of one or more resources from {{site.konnect_catalog}} integrations.
+      A [Gateway Service](/gateway/entities/service/) is a {{site.base_gateway}} entity that represents an upstream service in your system and is the business logic component that's responsible for responding to requests. A {{site.konnect_catalog}} Classic service is a collection of one or more resources from {{site.konnect_catalog}} Classic integrations.
 ---
 
-A {{site.konnect_catalog}} service is a collection of one or more resources from integrations.
+{% include_cached catalog/catalog-classic-banner.md %}
 
-A {{site.konnect_catalog}} service represents the following:
+A {{site.konnect_catalog}} Classic service is a collection of one or more resources from integrations.
+
+A {{site.konnect_catalog}} Classic service represents the following:
 * A unit of software that is typically owned by a single team
 * Exposes one or more APIs 
-* May be dependent on other {{site.konnect_catalog}} services (as either upstream or downstream)  
+* May be dependent on other {{site.konnect_catalog}} Classic services (as either upstream or downstream)  
 
-{{site.konnect_catalog}} services allow you to gain visibility into all resources in your organization, including what teams or people own them. 
+{{site.konnect_catalog}} Classic services allow you to gain visibility into all resources in your organization, including what teams or people own them. 
 
-To create a {{site.konnect_catalog}} service, do one of the following:
+To create a {{site.konnect_catalog}} Classic service, do one of the following:
 
 {% navtabs "service" %}
 {% navtab "UI" %}
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. In the Catalog sidebar, click **Services**. 
+1. In the {{site.konnect_catalog}} sidebar, click **Services**. 
 1. Click **New service** and configure the details about your service. 
 1. Map the service to an integration: 
    1. Click the service.
    1.  Select "Map resources" from the **Action** dropdown menu.
 {% endnavtab %}
 {% navtab "API" %}
-1. Create a {{site.konnect_catalog}} service by sending a POST request to the [`/catalog-services` endpoint](/api/konnect/service-catalog/v1/#/operations/create-catalog-service):
+1. Create a {{site.konnect_catalog}} Classic service by sending a POST request to the [`/catalog-services` endpoint](/api/konnect/service-catalog/v1/#/operations/create-catalog-service):
 <!--vale off-->
 {% capture service %}
 {% konnect_api_request %}
@@ -128,13 +130,13 @@ resource "konnect_catalog_service" "my_catalogservice" {
 {% endnavtab %}
 {% endnavtabs %}
 
-## Map APIs to a service in {{site.konnect_catalog}}
+## Map APIs to a service in {{site.konnect_catalog}} Classic
 
-APIs can be associated with {{site.konnect_catalog}} services, which allows API consumers and service owners to see which APIs and services are associated with each other. If you've already assigned API specs to a service from integrations, [migrate them to APIs](/catalog/migrate-api-specs-to-apis/). 
+APIs can be associated with {{site.konnect_catalog}} Classic services, which allows API consumers and service owners to see which APIs and services are associated with each other. If you've already assigned API specs to a service from integrations, [migrate them to APIs](/catalog/migrate-api-specs-to-apis/). 
 
 {% include_cached /catalog/note-api-spec-snapshot.md %}
 
-To link APIs with a {{site.konnect_catalog}} service, you need the following [{{site.konnect_short_name}} roles](/konnect-platform/teams-and-roles/#catalog) at a minimum for the services and APIs:
+To link APIs with a {{site.konnect_catalog}} Classic service, you need the following [{{site.konnect_short_name}} roles](/konnect-platform/teams-and-roles/#catalog) at a minimum for the services and APIs:
 * API viewer
 * Service viewer
 * Service admin
@@ -143,14 +145,14 @@ To link APIs to a service, do the following:
 {% navtabs "map-apis" %}
 {% navtab "UI" %}
 1. In the {{site.konnect_short_name}} sidebar, click **Catalog**.
-1. In the Catalog sidebar, click **Services**. 
+1. In the {{site.konnect_catalog}} sidebar, click **Services**. 
 1. Click a service you want to associate an API with.
 1. Click the **APIs** tab.
 1. Click **Link API**.
 1. Select the APIs you want to link.
 1. Click **Link APIs**.
 
-You will now see the API with your API spec linked to the {{site.konnect_catalog}} service. Users who view APIs will also be able to see any linked {{site.konnect_catalog}} services.
+You will now see the API with your API spec linked to the {{site.konnect_catalog}} Classic service. Users who view APIs will also be able to see any linked {{site.konnect_catalog}} Classic services.
 {% endnavtab %}
 {% navtab "API" %}
 


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes #5413 

TODO:

- [x] app/_landing_pages/catalog.yaml: FAQ about migration, banner currently renders weird don't use the include and create a separate one for just this page that is text that is all a link similar to /dev-portal.yaml
- [x] app/_landing_pages/catalog-classic.yaml: probably also needs the same fix for the note as the other landing page.
- [x] app/_landing_pages/catalog.yaml: and app/_landing_pages/catalog-classic.yaml: FAQ that's an include about the difference between classic and new catalog with a link to the migraiton content
- [x] all the classic pages will need their breadcrumbs and permalinks looked at. Ex. the GitHub integration one is using /catalog/ in the breadcrumbs and that should probably be /catalog-classic/, which also means I think that we're going to need redirects.
- [x] _indices/catalog.yaml: the Classic pages should be moved to their own Classic section but retain the subsections that they are currently in (ex. Services and scorecards will move to the Classic section), also be sure to add the Classic landing page
- [x] app/_how-tos/catalog/monitor-sonarqube-projects-with-konnect-ui.md check this one
- [x] new UI means we have to change some things as MCP registries is included in this release
- [x] complete AI Models page https://docs.google.com/document/d/1W17b_7OJTsEnw_FoYVun2JOk55ipYlwl4vyHRYfMn3A/edit?tab=t.0#heading=h.gfoe2totyqbx
- [x] index with how tos in catalog classic section may need to be combed through
- [ ] (if AIGW deadline moves) comment out/unpublish AI models stuff just in case

Open questions:
* when you link to an AI gateway model, you can add any provider, even if the linked Model doesn't have that provider in it's config
* MCP registry publishing?

## Preview Links
- https://deploy-preview-6586--kongdeveloper.netlify.app/catalog/
- https://deploy-preview-6586--kongdeveloper.netlify.app/catalog-classic/
- https://deploy-preview-6586--kongdeveloper.netlify.app/catalog/mcp-registry/ (new UI steps)
- https://deploy-preview-6586--kongdeveloper.netlify.app/catalog/ai-models/
- https://deploy-preview-6586--kongdeveloper.netlify.app/catalog/agents/
- https://deploy-preview-6586--kongdeveloper.netlify.app/catalog/mcp-servers/
- https://deploy-preview-6586--kongdeveloper.netlify.app/api/konnect/ai-builder/ (new spec for AI models)
- Classic Catalog only how tos ([for example](https://deploy-preview-6586--kongdeveloper.netlify.app/how-to/connect-azure-devops-to-the-konnect-catalog-with-the-konnect-api/)) have Catalog updated to "Catalog Classic" and a banner denoting that this is catalog classic

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
