### PR TITLE
feat(gateway): Add TLS termination for Helm deployment

### DIFF
--- a/app/_how-tos/gateway/gateway-install-helm-onprem.md
+++ b/app/_how-tos/gateway/gateway-install-helm-onprem.md
@@ -415,7 +415,7 @@ The proxy TLS certificate is a second secret, mounted alongside the clustering c
 {% include /k8s/create-certificate.md namespace='kong' hostname='demo.example.com' secret_name='demo-example-com' cert_required=true %}
 
 {:.info}
-> The secret name can't contain dots. The Helm chart uses each `secretVolumes` entry as a Kubernetes volume name, and volume names must be a DNS label. This is why the secret is named `demo-example-com` rather than after the `demo.example.com` hostname.
+> The secret name can't contain dots. The Helm chart uses each `secretVolumes` entry as a Kubernetes volume name, and volume names must be a DNS label. This is why the secret is named `demo-example-com` rather than matching the `demo.example.com` hostname exactly.
 
 ### Load the certificate on the data plane
 

--- a/app/_how-tos/gateway/gateway-install-helm-onprem.md
+++ b/app/_how-tos/gateway/gateway-install-helm-onprem.md
@@ -412,7 +412,10 @@ The proxy TLS certificate is a second secret, mounted alongside the clustering c
 
 ### Generate a TLS certificate
 
-{% include /k8s/create-certificate.md namespace='kong' hostname='demo.example.com' cert_required=true %}
+{% include /k8s/create-certificate.md namespace='kong' hostname='demo.example.com' secret_name='demo-example-com' cert_required=true %}
+
+{:.info}
+> The secret name can't contain dots. The Helm chart uses each `secretVolumes` entry as a Kubernetes volume name, and volume names must be a DNS label. This is why the secret is named `demo-example-com` rather than after the `demo.example.com` hostname.
 
 ### Load the certificate on the data plane
 
@@ -422,15 +425,15 @@ The proxy TLS certificate is a second secret, mounted alongside the clustering c
    # Mount the clustering cert and the proxy TLS cert
    secretVolumes:
      - kong-cluster-cert
-     - demo.example.com
+     - demo-example-com
 
    env:
      # Serve this certificate for proxy HTTPS traffic
-     ssl_cert: /etc/secrets/demo.example.com/tls.crt
-     ssl_cert_key: /etc/secrets/demo.example.com/tls.key
+     ssl_cert: /etc/secrets/demo-example-com/tls.crt
+     ssl_cert_key: /etc/secrets/demo-example-com/tls.key
    ```
 
-   `secretVolumes` mounts each secret at `/etc/secrets/<secret-name>/`. The certificate you created in the previous step is stored in a secret named after its hostname, so its files are at `/etc/secrets/demo.example.com/tls.crt` and `/etc/secrets/demo.example.com/tls.key`.
+   `secretVolumes` mounts each secret at `/etc/secrets/<secret-name>/`, so the certificate you created in the previous step is at `/etc/secrets/demo-example-com/tls.crt` and `/etc/secrets/demo-example-com/tls.key`.
 
 1. Apply the updated values file:
 
@@ -438,8 +441,18 @@ The proxy TLS certificate is a second secret, mounted alongside the clustering c
    helm upgrade kong-dp kong/kong -n kong --values ./values-dp.yaml
    ```
 
-1. Verify that the proxy serves your certificate over HTTPS. Use `-k` because this is a self-signed test certificate:
+1. Verify that the proxy serves your certificate over HTTPS. Use `-v` to print the certificate the proxy presents, and `-k` to accept it, because this is a self-signed test certificate:
 
    ```bash
-   curl -ik https://$PROXY_IP/mock/anything -H "Host: demo.example.com"
+   curl -skv -o /dev/null https://$PROXY_IP/mock/anything 2>&1 | grep -E "subject:|issuer:"
    ```
+
+   You should see your certificate rather than the built-in {{ site.base_gateway }} default:
+
+   ```text
+   *   subject: CN=demo.example.com
+   *   issuer: CN=demo.example.com
+   ```
+
+   {:.info}
+   > `ssl_cert` sets the default certificate for the proxy listener, so {{ site.base_gateway }} presents it on every HTTPS connection, whatever hostname the client requests. To serve different certificates per hostname, create [Certificate](/gateway/entities/certificate/) and [SNI](/gateway/entities/sni/) entities instead.

--- a/app/_how-tos/gateway/gateway-install-helm-onprem.md
+++ b/app/_how-tos/gateway/gateway-install-helm-onprem.md
@@ -403,3 +403,43 @@ manager:
    ```bash
    curl -i $PROXY_IP/mock/anything
    ```
+
+## Terminate TLS at the proxy
+
+By default, the data plane serves a built-in {{ site.base_gateway }} certificate for HTTPS traffic. To present your own certificate for a hostname, generate a certificate, mount it into the data plane, and tell {{ site.base_gateway }} which certificate and key to load.
+
+The proxy TLS certificate is a second secret, mounted alongside the clustering certificate you created earlier.
+
+### Generate a TLS certificate
+
+{% include /k8s/create-certificate.md namespace='kong' hostname='demo.example.com' cert_required=true %}
+
+### Load the certificate on the data plane
+
+1. In `values-dp.yaml`, add the certificate secret to `secretVolumes` and set `ssl_cert` and `ssl_cert_key` in `env`:
+
+   ```yaml
+   # Mount the clustering cert and the proxy TLS cert
+   secretVolumes:
+     - kong-cluster-cert
+     - demo.example.com
+
+   env:
+     # Serve this certificate for proxy HTTPS traffic
+     ssl_cert: /etc/secrets/demo.example.com/tls.crt
+     ssl_cert_key: /etc/secrets/demo.example.com/tls.key
+   ```
+
+   `secretVolumes` mounts each secret at `/etc/secrets/<secret-name>/`. The certificate you created in the previous step is stored in a secret named after its hostname, so its files are at `/etc/secrets/demo.example.com/tls.crt` and `/etc/secrets/demo.example.com/tls.key`.
+
+1. Apply the updated values file:
+
+   ```bash
+   helm upgrade kong-dp kong/kong -n kong --values ./values-dp.yaml
+   ```
+
+1. Verify that the proxy serves your certificate over HTTPS. Use `-k` because this is a self-signed test certificate:
+
+   ```bash
+   curl -ik https://$PROXY_IP/mock/anything -H "Host: demo.example.com"
+   ```

--- a/app/_includes/k8s/create-certificate.md
+++ b/app/_includes/k8s/create-certificate.md
@@ -1,4 +1,4 @@
-{% unless include.cert_required %}
+{% assign secret_name = include.secret_name | default: include.hostname %}{% unless include.cert_required %}
 The routing configuration can include a certificate to present when clients connect
 over HTTPS. This is not required, as {{site.base_gateway}} will serve a default
 certificate if it cannot find another, but including TLS configuration along
@@ -37,6 +37,6 @@ openssl req -subj '/CN={{ include.hostname }}' -new -newkey rsa:2048 -sha256 \
 
 1. Create a Secret containing the certificate:
     ```bash
-    kubectl create secret{% if include.namespace %} -n {{ include.namespace }}{% endif %} tls {{ include.hostname }} --cert=./server.crt --key=./server.key
+    kubectl create secret{% if include.namespace %} -n {{ include.namespace }}{% endif %} tls {{ secret_name }} --cert=./server.crt --key=./server.key
     ```
     {: data-test-step="block"}


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes #2347 

## Preview Links

https://deploy-preview-6591--kongdeveloper.netlify.app/gateway/install/kubernetes/on-prem/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
