### PR TITLE
feat(AIGW): Extend existing callout to mention spacy repo

### DIFF
--- a/.github/styles/base/Dictionary.txt
+++ b/.github/styles/base/Dictionary.txt
@@ -745,6 +745,7 @@ SLT_Enc
 sni
 snis
 sonarqube
+spaCy
 Speedscope
 Splunk
 sse

--- a/app/_ai_gateway_policies/ai-sanitizer/index.md
+++ b/app/_ai_gateway_policies/ai-sanitizer/index.md
@@ -184,7 +184,7 @@ The following language-specific images are currently available:
 * `-tr` (Turkish)
 
 {:.info}
-> The PII Anonymizer service loads one NLP model by default. Ensure at least **600MB of free memory** is available when running the container.
+> The PII Anonymizer service loads one NLP model by default. Ensure at least **600MB of free memory** is available when running the container. If a user specifies a model that isn’t bundled with the deployed image, it will be downloaded at startup from the [spaCy models](https://github.com/explosion/spacy-models/) repository.
 
 ### Image configuration options
 

--- a/app/_ai_gateway_policies/ai-sanitizer/index.md
+++ b/app/_ai_gateway_policies/ai-sanitizer/index.md
@@ -183,8 +183,7 @@ The following language-specific images are currently available:
 * `-pt` (Portuguese)
 * `-tr` (Turkish)
 
-{:.info}
-> The PII Anonymizer service loads one NLP model by default. Ensure at least **600MB of free memory** is available when running the container. If a user specifies a model that isn’t bundled with the deployed image, it will be downloaded at startup from the [spaCy models](https://github.com/explosion/spacy-models/) repository.
+{% include /md/ai-gateway/v2/policies/spacy-pii-note.md %}
 
 ### Image configuration options
 

--- a/app/_includes/md/ai-gateway/v2/policies/spacy-pii-note.md
+++ b/app/_includes/md/ai-gateway/v2/policies/spacy-pii-note.md
@@ -1,0 +1,2 @@
+{:.info}
+> The PII Anonymizer service loads one NLP model by default. Ensure at least **600MB of free memory** is available when running the container. If a user specifies a model that isn’t bundled with the deployed image, it will be downloaded at startup from the [spaCy models](https://github.com/explosion/spacy-models/) repository.

--- a/app/_kong_plugins/ai-sanitizer/index.md
+++ b/app/_kong_plugins/ai-sanitizer/index.md
@@ -185,8 +185,7 @@ The following language-specific images are currently available:
 * `-pt` (Portuguese)
 * `-tr` (Turkish)
 
-{:.info}
-> The PII Anonymizer service loads one NLP model by default. Ensure at least **600MB of free memory** is available when running the container. If a user specifies a model that isn’t bundled with the deployed image, it will be downloaded at startup from the [spaCy models](https://github.com/explosion/spacy-models/) repository.
+{% include /md/ai-gateway/v2/policies/spacy-pii-note.md %}
 
 ### Image configuration options
 

--- a/app/_kong_plugins/ai-sanitizer/index.md
+++ b/app/_kong_plugins/ai-sanitizer/index.md
@@ -186,7 +186,7 @@ The following language-specific images are currently available:
 * `-tr` (Turkish)
 
 {:.info}
-> The PII Anonymizer service loads one NLP model by default. Ensure at least **600MB of free memory** is available when running the container.
+> The PII Anonymizer service loads one NLP model by default. Ensure at least **600MB of free memory** is available when running the container. If a user specifies a model that isn’t bundled with the deployed image, it will be downloaded at startup from the [spaCy models](https://github.com/explosion/spacy-models/) repository.
 
 ### Image configuration options
 


### PR DESCRIPTION
## Description

Fixes [Add spacy model download to PII sanitiser overview](https://github.com/Kong/developer.konghq.com/issues/6584)

Related to https://kongstrong.slack.com/archives/CDSTDSG9J/p1785991171667759

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
