### PR TITLE
feat(insomnia): remove default browser mention in MCP auth flow

### DIFF
--- a/app/insomnia/mcp-clients-in-insomnia.md
+++ b/app/insomnia/mcp-clients-in-insomnia.md
@@ -38,9 +38,6 @@ faqs:
   - q: Can I use a Personal Access Token (PAT) instead of OAuth?
     a: |
       Yes. Select **Auth > Bearer Token** and enter your PAT in the **Token** field.
-  - q: Why doesn’t my browser open during OAuth sign-in?
-    a: |
-      The MCP Auth Flow uses your system’s default browser. Ensure that Insomnia can open URLs using your system browser. The MCP Auth Flow only supports browser-based OAuth.
   - q: Why is MCP Auth Flow not listed under OAuth 2.0?
     a: |
       The MCP Server’s metadata may not include a valid authorization endpoint. Use a **Personal Access Token (PAT)** or **Basic Auth** instead.


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Insomnia doesn't use the default browser anymore to start an MCP auth workflow. A dialog should pop up to allow th user to choose a browser. 

For example: 

1. MCP URL: `https://mcp.atlassian.com/v1/mcp` 
2. In **Auth** select **OAuth 2.0** > **Grant Type**: **MCP Auth Flow**.
3. Click **Connect**
 
- closes #6578 

### How to test

[Create an MCP client](https://developer.konghq.com/insomnia/mcp-clients-in-insomnia/#create-an-mcp-client) that requires authentication in Insomnia, and check if the browser selection dialog pops up.
   
## Preview Links

https://deploy-preview-6625--kongdeveloper.netlify.app/insomnia/mcp-clients-in-insomnia/#faqs
## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
