### PR TITLE
feat(ai-gateway): Add SaladCloud AI Proxy how-to

### DIFF
--- a/app/_how-tos/ai-gateway/set-up-ai-proxy-with-saladcloud.md
+++ b/app/_how-tos/ai-gateway/set-up-ai-proxy-with-saladcloud.md
@@ -1,0 +1,93 @@
+---
+title: Set up AI Proxy with SaladCloud AI Gateway
+permalink: /how-to/set-up-ai-proxy-with-saladcloud/
+content_type: how_to
+related_resources:
+  - text: "{{site.ai_gateway}}"
+    url: /ai-gateway/
+  - text: AI Proxy
+    url: /plugins/ai-proxy/
+
+description: Configure the AI Proxy plugin to create a chat route using SaladCloud AI Gateway.
+
+products:
+  - gateway
+  - ai-gateway
+
+works_on:
+  - on-prem
+  - konnect
+
+min_version:
+  gateway: '3.14'
+
+plugins:
+  - ai-proxy
+
+entities:
+  - service
+  - route
+  - plugin
+
+tags:
+  - ai
+  - openai
+
+tldr:
+  q: How do I use the AI Proxy plugin with SaladCloud AI Gateway?
+  a: Create a Gateway Service and a Route, then enable the AI Proxy plugin with the OpenAI provider, the SaladCloud upstream URL, and your SaladCloud API key.
+
+tools:
+  - deck
+
+prereqs:
+  inline:
+    - title: SaladCloud AI Gateway
+      include_content: prereqs/saladcloud
+      icon_url: /assets/icons/saladcloud.svg
+  entities:
+    services:
+      - example-service
+    routes:
+      - example-route
+
+cleanup:
+  inline:
+    - title: Clean up Konnect environment
+      include_content: cleanup/platform/konnect
+      icon_url: /assets/icons/gateway.svg
+    - title: Destroy the {{site.base_gateway}} container
+      include_content: cleanup/products/gateway
+      icon_url: /assets/icons/gateway.svg
+---
+
+## Configure the plugin
+
+SaladCloud AI Gateway supports the OpenAI chat completions API. Configure the AI Proxy plugin with the `openai` provider and the SaladCloud chat completions URL.
+
+This example uses the `qwen3.6-35b-a3b` model:
+
+{% entity_examples %}
+entities:
+  plugins:
+    - name: ai-proxy
+      config:
+        route_type: llm/v1/chat
+        auth:
+          header_name: Authorization
+          header_value: Bearer ${api_key}
+        model:
+          provider: openai
+          name: qwen3.6-35b-a3b
+          options:
+            upstream_url: https://ai.salad.cloud/v1/chat/completions
+            max_tokens: 512
+            temperature: 1.0
+variables:
+  api_key:
+    value: $SALADCLOUD_API_KEY
+{% endentity_examples %}
+
+## Validate
+
+{% include how-tos/steps/ai-proxy-validate.md %}

--- a/app/_includes/prereqs/saladcloud.md
+++ b/app/_includes/prereqs/saladcloud.md
@@ -1,0 +1,9 @@
+This tutorial requires access to SaladCloud AI Gateway and a SaladCloud API key.
+
+1. [Request access to SaladCloud AI Gateway](https://salad.com/ai-gateway).
+1. Retrieve your API key from the [SaladCloud Portal](https://portal.salad.com/).
+1. Create a decK variable with the API key:
+
+   ```sh
+   export DECK_SALADCLOUD_API_KEY='YOUR SALADCLOUD API KEY'
+   ```

--- a/app/assets/icons/saladcloud.svg
+++ b/app/assets/icons/saladcloud.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-7 0 100 100" fill="currentColor">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M64.4991 37.5006L85.9991 25.0006L64.4991 12.5006V37.5006Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M21.4996 62.4996L42.9996 75.0005L21.4996 87.4996V62.4996Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M42.9996 50.0004L21.4996 62.5004L42.9996 75.0004V50.0004Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M21.4995 87.5005L42.9986 99.9996H42.9995V75.0005L21.4995 87.5005Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M0 74.9996V75.0005L21.4991 87.4996V62.4996L0 74.9996Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M64.4991 62.5005L85.9991 75.0005V50.0005L64.4991 62.5005Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M42.9996 25.0004L64.4996 37.5004L42.9996 50.0004V25.0004Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M0 49.9997V50.0006L21.4991 62.5006V37.5006L0 49.9997Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M42.9998 100H43.0015L64.4989 87.5009L42.9998 75V100Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M64.4991 87.5004L85.9991 75.0004L64.4991 62.5004V87.5004Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M42.9998 0.000358582L21.4998 12.5004L42.9998 25.0004V0.000358582Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M64.4996 37.5004L42.9996 50.0004L64.4996 62.5004V37.5004Z"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M64.4996 62.4996L42.9996 75.0005L64.4996 87.4996V62.4996Z"/>
+</svg>


### PR DESCRIPTION
## Description

Adds a how-to for routing `qwen3.6-35b-a3b` requests to SaladCloud AI Gateway with the AI Proxy plugin's OpenAI-compatible provider configuration. The change includes the reusable SaladCloud prerequisite and the approved SaladCloud icon.

## Preview Links

https://deploy-preview-6628--kongdeveloper.netlify.app/how-to/set-up-ai-proxy-with-saladcloud/

## Checklist

- [x] Tested how-to docs locally with `PAGE_PATHS="/how-to/set-up-ai-proxy-with-saladcloud/" make run`; the page and generated decK instructions rendered successfully.
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [x] Add new pages to the product documentation index (not applicable; how-to pages are indexed from frontmatter).
