### PR TITLE
fix(ai-gateway): Add ai sync command to the configure on-prem doc

### DIFF
--- a/app/ai-gateway/configure-on-prem.md
+++ b/app/ai-gateway/configure-on-prem.md
@@ -131,7 +131,7 @@ Use [`deck ai sync`](/deck/ai/sync/) to convert any {{site.ai_gateway}} 2.0 decK
 AI Model, AI MCP Server, AI Agent, and AI Policy entities need conversion, since each one generates {{site.base_gateway}} Services, Routes, or plugins.
 AI Consumers, AI Consumer Groups, and AI Vaults pass through unchanged, since they're already shaped like their [native {{site.base_gateway}} equivalents](#consumers-consumer-groups-and-vaults).
 
-The following examples walk through converting a decK `ai.yaml` file for a single AI Model, AI MCP Server, AI Agent, and AI Policy. Each example uses [`deck file ai2kong`](/deck/file/ai2kong/) to show the `kong.yaml` it generates, then syncs that configuration with `deck ai sync`.
+The following examples walk through converting a decK `ai.yaml` file for a single AI Model, AI MCP Server, AI Agent, and AI Policy. Each example uses [`deck file ai2kong`](/deck/file/ai2kong/) to show the `kong.yaml` it generates, then applies that configuration. You can either sync the generated `kong.yaml` with [`deck gateway sync`](/deck/gateway/sync/), or skip the intermediate file and let `deck ai sync` convert and sync `ai.yaml` in one step.
 
 ### Convert an AI Model
 
@@ -233,7 +233,11 @@ The following examples walk through converting a decK `ai.yaml` file for a singl
 
    {:.info}
    > The converted output uses the `alias` and `model_alias` field names from the self-hosted `ai-model-selector` and `ai-proxy-advanced` plugin schemas. These are distinct from `config.route.model` on the {{site.ai_gateway}} entity shown in the input above; `deck file ai2kong` handles the translation between the two.
-1. Sync the configuration to your self-hosted {{site.base_gateway}}. `deck ai sync` converts `ai.yaml` and syncs the result in one step, so you don't need to keep the intermediate `kong.yaml`:
+1. Apply the configuration to your self-hosted {{site.base_gateway}}. Sync the `kong.yaml` file you just generated with [`deck gateway sync`](/deck/gateway/sync/):
+   ```sh
+   deck gateway sync kong.yaml
+   ```
+   Or skip the intermediate file and let `deck ai sync` convert and sync `ai.yaml` in one step:
    ```sh
    deck ai sync ai.yaml
    ```
@@ -317,7 +321,11 @@ The following examples walk through converting a decK `ai.yaml` file for a singl
          name: ai-mcp-proxy
    ```
    {: .no-copy-code .collapsible }
-1. Sync the configuration to your self-hosted {{site.base_gateway}}. `deck ai sync` converts `ai.yaml` and syncs the result in one step, so you don't need to keep the intermediate `kong.yaml`:
+1. Apply the configuration to your self-hosted {{site.base_gateway}}. Sync the `kong.yaml` file you just generated with [`deck gateway sync`](/deck/gateway/sync/):
+   ```sh
+   deck gateway sync kong.yaml
+   ```
+   Or skip the intermediate file and let `deck ai sync` convert and sync `ai.yaml` in one step:
    ```sh
    deck ai sync ai.yaml
    ```
@@ -375,7 +383,11 @@ The following examples walk through converting a decK `ai.yaml` file for a singl
      url: https://agent.example.com
    ```
    {: .no-copy-code .collapsible }
-1. Sync the configuration to your self-hosted {{site.base_gateway}}. `deck ai sync` converts `ai.yaml` and syncs the result in one step, so you don't need to keep the intermediate `kong.yaml`:
+1. Apply the configuration to your self-hosted {{site.base_gateway}}. Sync the `kong.yaml` file you just generated with [`deck gateway sync`](/deck/gateway/sync/):
+   ```sh
+   deck gateway sync kong.yaml
+   ```
+   Or skip the intermediate file and let `deck ai sync` convert and sync `ai.yaml` in one step:
    ```sh
    deck ai sync ai.yaml
    ```
@@ -447,7 +459,11 @@ An AI Policy generates no object of its own. It must be attached to another enti
    ```
 
    The `model` and `route` fields on the plugin are what scope it to that AI Model's traffic instead of applying globally.
-1. Sync the configuration to your self-hosted {{site.base_gateway}}. `deck ai sync` converts `ai.yaml` and syncs the result in one step, so you don't need to keep the intermediate `kong.yaml`:
+1. Apply the configuration to your self-hosted {{site.base_gateway}}. Sync the `kong.yaml` file you just generated with [`deck gateway sync`](/deck/gateway/sync/):
+   ```sh
+   deck gateway sync kong.yaml
+   ```
+   Or skip the intermediate file and let `deck ai sync` convert and sync `ai.yaml` in one step:
    ```sh
    deck ai sync ai.yaml
    ```

--- a/app/ai-gateway/configure-on-prem.md
+++ b/app/ai-gateway/configure-on-prem.md
@@ -21,36 +21,38 @@ related_resources:
     url: /ai-gateway/entities/
   - text: "{{site.ai_gateway}} Policies"
     url: /ai-gateway/policies/
+  - text: "Migrate to {{site.ai_gateway}} 2.x"
+    url: /ai-gateway/v2-migration-guide/
+  - text: deck file ai2kong
+    url: /deck/file/ai2kong/
+  - text: deck ai sync
+    url: /deck/ai/sync/
+  - text: deck ai dump
+    url: /deck/ai/dump/
   - text: AI Proxy Advanced plugin
     url: /plugins/ai-proxy-advanced/
   - text: AI MCP Proxy plugin
     url: /plugins/ai-mcp-proxy/
   - text: AI A2A Proxy plugin
     url: /plugins/ai-a2a-proxy/
-  - text: deck ai sync
-    url: /deck/ai/sync/
-  - text: deck ai dump
-    url: /deck/ai/dump/
 ---
 
-{{site.ai_gateway}} on {{site.konnect_short_name}} is documented around its entity model.
-If you run {{site.ai_gateway}} on self-hosted {{site.base_gateway}}, this page maps each entity to the plugins and objects you already configure, so you can read {{site.ai_gateway}} docs and know how to apply them to your deployment.
-You can [convert](#convert-ai-gateway-2-0-entities-to-self-hosted-kong-gateway-config) any {{site.ai_gateway}} 2.0 decK configuration into the equivalent self-hosted config.
+The existing {{site.ai_gateway}} documentation follows the {{site.konnect_short_name}} model: AI Models, AI Model Providers, AI MCP Servers, AI Agents, and more, that you configure in {{site.konnect_short_name}}. See [{{site.ai_gateway}} entities](/ai-gateway/entities/) for the full list. Self-hosted {{site.base_gateway}} doesn't have these objects. This page shows you how to configure the same capabilities with AI plugins on [Services](/gateway/entities/service/) and [Routes](/gateway/entities/route/).
 
-On {{site.konnect_short_name}}, you configure {{site.ai_gateway}} through its entity model: [AI Models](/ai-gateway/entities/ai-model/), [AI Model Providers](/ai-gateway/entities/ai-model-provider/), [AI MCP Servers](/ai-gateway/entities/ai-mcp-server/), [AI Agents](/ai-gateway/entities/ai-agent/), [AI Identity Providers](/ai-gateway/entities/ai-identity-provider/), [AI Policies](/ai-gateway/entities/ai-policy/), [AI Consumers](/ai-gateway/entities/ai-consumer/), [AI Consumer Groups](/ai-gateway/entities/ai-consumer-group/), and [AI Vaults](/ai-gateway/entities/ai-vault/). Self-hosted {{site.base_gateway}} doesn't expose these entities. Instead, you configure the same capabilities with AI plugins on [Services](/gateway/entities/service/) and [Routes](/gateway/entities/route/).
+There are two ways to bridge that gap:
 
-Both deployments run the same {{site.base_gateway}} primitives. When you save an AI entity in {{site.konnect_short_name}}, {{site.ai_gateway}} generates the Services, Routes, Plugins, and Consumers that data planes run. On-prem, you create those primitives yourself.
+* Read [How entities translate to {{site.base_gateway}} configuration](#how-entities-translate-to-kong-gateway-configuration) to translate what you read in {{site.ai_gateway}} docs into the plugin fields you configure by hand.
+* [Convert](#convert-ai-gateway-2-0-entities-to-self-hosted-kong-gateway-config) an existing {{site.ai_gateway}} 2.0 decK configuration into the equivalent self-hosted config, instead of hand-writing the plugins.
 
-{:.info}
-> On-prem, each Policy-backed plugin's configuration maps 1:1 to an [{{site.ai_gateway}} Policy](/ai-gateway/policies/). The AI Policy fields and the plugin fields are the same.
+Both deployments run the same {{site.base_gateway}} Services, Routes, Plugins, and Consumers (what we call primitives). When you save an AI entity in {{site.konnect_short_name}}, {{site.ai_gateway}} generates the primitives that data planes run. On-prem, you produce those same primitives yourself, either by writing the plugin config directly or by converting an entity-model file.
 
 ## How entities translate to {{site.base_gateway}} configuration
 
-AI entities are a high-level abstraction. When you save one, a dedicated conversion step translates it into the same {{site.base_gateway}} building blocks classic {{site.base_gateway}} uses (Routes, Services, plugins, Consumers), and that's what data plane nodes actually run.
+AI entities are a high-level abstraction. When you save one, a dedicated conversion step translates it into the same Routes, Services, plugins, and Consumers that self-hosted {{site.base_gateway}} uses, and that's what data plane nodes actually run.
 
-The mapping isn't always 1:1. Some entities carry over almost directly while others become more than one {{site.base_gateway}} entity.
+The mapping isn't always 1:1. Some entities carry over almost directly, others become more than one {{site.base_gateway}} object, and a few have no self-hosted equivalent at all.
 
-The following table describes how {{site.konnect_short_name}} {{site.ai_gateway}} entities map to {{site.ai_gateway}} on self-hosted {{site.base_gateway}} entities.
+The following table shows how {{site.konnect_short_name}} {{site.ai_gateway}} entities map to on-prem {{site.base_gateway}} configuration.
 
 {% table %}
 columns:
@@ -64,11 +66,11 @@ rows:
   - entity: "[AI Model Provider](/ai-gateway/entities/ai-model-provider/)"
     primitives: "None of its own. Its `type` and credentials are materialized into the AI Proxy Advanced target of every AI Model that references it."
   - entity: "[AI MCP Server](/ai-gateway/entities/ai-mcp-server/)"
-    primitives: "One or more Routes carrying the AI MCP Proxy plugin. The Route topology depends on the server [mode](/ai-gateway/entities/ai-mcp-server/#server-modes)."
+    primitives: "One or more Routes carrying the AI MCP Proxy plugin, depending on the server [mode](/ai-gateway/entities/ai-mcp-server/#server-modes). The `upstream-server` mode has no self-hosted equivalent; the plugin's `mode` field doesn't support it."
   - entity: "[AI Agent](/ai-gateway/entities/ai-agent/)"
-    primitives: "A Service, a Route, and the AI A2A Proxy plugin."
+    primitives: "For `type: a2a`, a Service, a Route, and the AI A2A Proxy plugin. For `type: http`, a Service and a Route with no AI plugin, since the AI A2A Proxy plugin always applies A2A protocol handling."
   - entity: "[AI Identity Provider](/ai-gateway/entities/ai-identity-provider/)"
-    primitives: "None of its own. A `key-auth` type materializes into a Key Auth Policy, and an `openid-connect` type into an OpenID Connect Policy, on the Route of every AI Model that references it, plus a shared anonymous Consumer with a Request Termination Policy that returns 401 for unauthenticated requests."
+    primitives: "None of its own. A `key-auth` type materializes into a Key Auth Policy, and an `openid-connect` type into an OpenID Connect Policy, on the Route of every AI Model or AI Agent that references it, plus a shared anonymous Consumer with a Request Termination Policy that returns 401 for unauthenticated requests."
   - entity: "[AI Policy](/ai-gateway/entities/ai-policy/)"
     primitives: "The {{site.base_gateway}} plugin named by the policy `type` (for example, AI Prompt Guard or AI Rate Limiting Advanced), applied globally or scoped to whatever the policy is attached to."
   - entity: "[AI Consumer](/ai-gateway/entities/ai-consumer/)"
@@ -77,12 +79,15 @@ rows:
     primitives: "A [Consumer Group](/gateway/entities/consumer-group/) with its membership."
   - entity: "[AI Vault](/ai-gateway/entities/ai-vault/)"
     primitives: "A [Vault](/gateway/entities/vault/)."
+  - entity: "[AI Data Plane Certificate](/ai-gateway/entities/ai-data-plane-certificate/)"
+    primitives: "None. It authorizes {{site.konnect_short_name}}-managed data planes to connect to a specific {{site.ai_gateway}}. Self-hosted hybrid mode deployments use the standard [Certificate](/gateway/entities/certificate/) entity and [hybrid mode node configuration](/gateway/hybrid-mode/) instead."
 {% endtable %}
 
 ## On-prem request flow
 
 On-prem, a client sends requests to {{site.base_gateway}}, where a [Service](/gateway/entities/service/) and [Route](/gateway/entities/route/) carry the AI plugin. The plugin applies the AI behavior and proxies the request to the upstream, whether that's an LLM provider, an MCP server, or an agent.
 
+<!--vale off-->
 {% mermaid %}
 flowchart LR
   Client(Client)
@@ -98,25 +103,51 @@ flowchart LR
   Client --> P2 --> MCP
   Client --> P3 --> Agent
 {% endmermaid %}
+<!--vale on-->
 > _Figure 1:_ On-prem, {{site.ai_gateway}} capabilities are delivered by plugins on {{site.base_gateway}}, each proxying to its upstream.
 
 ## AI Models
 
-Use the [AI Proxy Advanced](/plugins/ai-proxy-advanced/) (`ai-proxy-advanced`) plugin to transform and proxy requests to multiple AI providers and models at the same time, and to load balance across targets. On {{site.konnect_short_name}}, an AI Model generates a Service, one Route per capability it serves (chat completions, embeddings, and so on), and the plugins on each Route (`ai-model-selector` and `ai-proxy-advanced`). On-prem, create one Route per capability you want to expose, each carrying its own `ai-proxy-advanced` plugin.
+Use the [AI Proxy Advanced](/plugins/ai-proxy-advanced/) (`ai-proxy-advanced`) plugin to transform and proxy requests to multiple AI providers and models at the same time, and to load balance across targets.
 
-The AI Provider referenced by a target has no plugin of its own. Set its `type` and `auth` in the corresponding `targets` entry of the [`ai-proxy-advanced`](/plugins/ai-proxy-advanced/) plugin.
+- **On {{site.konnect_short_name}}:** An AI Model generates a Service, one Route per capability it serves (chat completions, embeddings, and so on), and the plugins on each Route (`ai-model-selector` and `ai-proxy-advanced`).
+- **On-prem:** You create one Route per capability you want to expose, each carrying its own `ai-proxy-advanced` plugin.
 
+The AI Model Provider referenced by a target has no plugin of its own. Set its `type` and `auth` in the corresponding `targets` entry of the [`ai-proxy-advanced`](/plugins/ai-proxy-advanced/) plugin.
 
 ## AI MCP Servers
 
-Use the [AI MCP Proxy](/plugins/ai-mcp-proxy/) (`ai-mcp-proxy`) plugin to convert APIs into MCP tools, proxy MCP servers, expose MCP tools to AI clients, and observe MCP traffic. On {{site.konnect_short_name}}, an AI MCP Server generates one or more Routes, each carrying an `ai-mcp-proxy` plugin. The number of Routes, and whether the plugin converts a REST API into MCP tools or proxies an existing MCP server, depends on the server [mode](/ai-gateway/entities/ai-mcp-server/#server-modes). On-prem, configure the plugin's mode and Routes to match the topology you want.
+Use the [AI MCP Proxy](/plugins/ai-mcp-proxy/) (`ai-mcp-proxy`) plugin to convert APIs into MCP tools, proxy MCP servers, expose MCP tools to AI clients, and observe MCP traffic.
 
+- **On {{site.konnect_short_name}}:** An AI MCP Server generates one or more Routes, each carrying an `ai-mcp-proxy` plugin. The number of Routes, and whether the plugin converts a REST API into MCP tools or proxies an existing MCP server, depends on the server [mode](/ai-gateway/entities/ai-mcp-server/#server-modes).
+- **On-prem:** You configure the plugin's mode and Routes to match the topology you want.
 
 ## AI Agents
 
-Use the [AI A2A Proxy](/plugins/ai-a2a-proxy/) (`ai-a2a-proxy`) plugin to add observability and gateway control to Agent-to-Agent (A2A) protocol traffic. The plugin supports both JSON-RPC and REST bindings. On {{site.konnect_short_name}}, an AI Agent generates one Service, one Route, and one `ai-a2a-proxy` plugin, which matches what you configure on-prem.
+Use the [AI A2A Proxy](/plugins/ai-a2a-proxy/) (`ai-a2a-proxy`) plugin to add observability and gateway control to Agent-to-Agent (A2A) protocol traffic. The plugin supports both JSON-RPC and REST bindings, and always applies A2A protocol handling, agent card URL rewriting, and A2A telemetry. It has no mode to turn that off.
 
-## Consumers, Consumer Groups, and Vaults
+On {{site.konnect_short_name}}, an AI Agent with `type: a2a` generates:
+- One Service
+- One Route
+- One `ai-a2a-proxy` plugin
+
+This matches what you configure on-prem. An AI Agent with `type: http` generates a Service and Route with no AI plugin, since `type: http` is a plain transparent proxy. Replicate it on-prem with a Service and Route and no plugin attached.
+
+## AI Identity Providers
+
+Use the [Key Auth](/ai-gateway/policies/key-auth/) or [OpenID Connect](/ai-gateway/policies/openid-connect/) Policy, backed by the `key-auth` and `openid-connect` {{site.base_gateway}} plugins, to authenticate the clients calling your AI routes.
+
+- **On {{site.konnect_short_name}}:** An AI Identity Provider generates a `key-auth` or `openid-connect` plugin on the Route of every AI Model or AI Agent that references it, plus a shared anonymous Consumer carrying a `request-termination` plugin that returns `401` for requests that don't authenticate.
+- **On-prem:** You attach the corresponding plugin to each Route yourself, and configure the anonymous Consumer and `request-termination` plugin to match.
+
+## AI Policies
+
+An AI Policy applies a specific behavior, named by its `type` (for example, `ai-prompt-guard` or `ai-rate-limiting-advanced`), either globally or scoped to whatever it's attached to: an AI Model, AI Agent, AI MCP Server, AI Consumer, or AI Consumer Group. On {{site.konnect_short_name}}, an AI Policy generates the {{site.base_gateway}} plugin named by that `type`, applied at the same scope.
+
+{:.info}
+> On-prem, each Policy-backed plugin's configuration maps 1:1 to an [{{site.ai_gateway}} Policy](/ai-gateway/policies/). The AI Policy fields and the plugin fields are the same.
+
+## Consumers, Consumer Groups, Vaults, and Data Plane Certificates
 
 Access control and secret management on-prem use the same {{site.base_gateway}} objects as any other Gateway configuration, so the objects themselves need no AI-specific setup. Use the existing {{site.base_gateway}} documentation:
 
@@ -124,348 +155,348 @@ Access control and secret management on-prem use the same {{site.base_gateway}} 
 * [Consumer Groups](/gateway/entities/consumer-group/): Apply shared rate limits and policies to groups of Consumers by attaching the plugin to the Consumer Group.
 * [Vaults](/gateway/entities/vault/): Store and reference provider credentials.
 
+[AI Data Plane Certificates](/ai-gateway/entities/ai-data-plane-certificate/) have no on-prem equivalent. They authorize {{site.konnect_short_name}}-managed data planes to connect to a specific {{site.ai_gateway}}. Self-hosted hybrid mode deployments use the standard [Certificate](/gateway/entities/certificate/) entity and [hybrid mode node configuration](/gateway/hybrid-mode/) instead.
+
 ## Convert {{site.ai_gateway}} 2.0 entities to self-hosted {{site.base_gateway}} config
 
-Use [`deck ai sync`](/deck/ai/sync/) to convert any {{site.ai_gateway}} 2.0 decK configuration into {{site.ai_gateway}} on self-hosted {{site.base_gateway}} entities and apply it in one step.  When you run `deck ai sync`, you run in one step what two commands would do (`deck file ai2kong` and  `deck gateway sync`).
+AI Model, AI MCP Server, AI Agent, and AI Policy entities need conversion, since each one generates {{site.base_gateway}} Services, Routes, or plugins. AI Consumers, AI Consumer Groups, and AI Vaults pass through conversion unchanged, since they're already shaped like their [native {{site.base_gateway}} equivalents](#consumers-consumer-groups-vaults-and-data-plane-certificates).
 
-The command tags every entity it manages with `managed_by:deck-ai`. To export that configuration back out of a running {{site.base_gateway}}, use [`deck ai dump`](/deck/ai/dump/), which reverts the tagged entities to {{site.ai_gateway}} 2.0 format.
+decK's `file ai2kong`, `ai sync`, and `ai dump` all translate the same {{site.ai_gateway}} 2.x configuration between its entity-model representation and its self-hosted plugin representation. They don't change versions, only where the config runs. `kongctl convert ai-gateway` does something different: it upgrades an older {{site.ai_gateway}} running on {{site.base_gateway}} plugin configuration to the 2.x entity model, for {{site.konnect_short_name}}.
 
-AI Model, AI MCP Server, AI Agent, and AI Policy entities need conversion, since each one generates {{site.base_gateway}} Services, Routes, or plugins.
-AI Consumers, AI Consumer Groups, and AI Vaults pass through unchanged, since they're already shaped like their [native {{site.base_gateway}} equivalents](#consumers-consumer-groups-and-vaults).
+<!--vale off-->
+{% table %}
+columns:
+  - title: Command
+    key: command
+  - title: Direction
+    key: direction
+  - title: Use case
+    key: usecase
+rows:
+  - command: "[`deck file ai2kong`](/deck/file/ai2kong/)"
+    direction: "{{site.ai_gateway}} 2.x entity file → self-hosted config file"
+    usecase: "Convert an `ai.yaml` file to a `kong.yaml` file without touching a live gateway, so you can review the output or apply it separately."
+  - command: "[`deck ai sync`](/deck/ai/sync/)"
+    direction: "{{site.ai_gateway}} 2.x entity file → live self-hosted {{site.base_gateway}}"
+    usecase: "Convert and apply in one step. Equivalent to running `deck file ai2kong` followed by `deck gateway sync`."
+  - command: "[`deck ai dump`](/deck/ai/dump/)"
+    direction: "Live self-hosted {{site.base_gateway}} or {{site.konnect_short_name}} → {{site.ai_gateway}} 2.x entity file"
+    usecase: "Export configuration previously created with `deck ai sync` (tagged `managed_by:deck-ai`) back into the entity model, for backup or review."
+  - command: "[`kongctl convert ai-gateway`](/ai-gateway/v2-migration-guide/)"
+    direction: "Pre-2.0 {{site.ai_gateway}} plugin config → {{site.ai_gateway}} 2.x entity file, for {{site.konnect_short_name}}"
+    usecase: "One-time version upgrade: move an existing {{site.ai_gateway}} running on {{site.base_gateway}} configuration to a {{site.konnect_short_name}} {{site.ai_gateway}} 2.x control plane. See [Migrate to {{site.ai_gateway}} 2.x](/ai-gateway/v2-migration-guide/)."
+{% endtable %}
+<!--vale on-->
 
-The following examples walk through converting a decK `ai.yaml` file for a single AI Model, AI MCP Server, AI Agent, and AI Policy. Each example uses [`deck file ai2kong`](/deck/file/ai2kong/) to show the `kong.yaml` it generates, then applies that configuration. You can either sync the generated `kong.yaml` with [`deck gateway sync`](/deck/gateway/sync/), or skip the intermediate file and let `deck ai sync` convert and sync `ai.yaml` in one step.
+The rest of this section uses `deck file ai2kong` to show exactly what config each entity generates.
+
+### Conversion workflow
+
+Every example that follows uses the same two-step conversion, shown once here. Write your {{site.ai_gateway}} 2.0 entity configuration to `ai.yaml`, then:
+
+1. Convert it to {{site.base_gateway}} 3.x config:
+
+   ```sh
+   deck file ai2kong --source ai.yaml --output-file kong.yaml
+   ```
+1. Sync the converted config to your self-hosted {{site.base_gateway}}:
+
+   ```sh
+   deck gateway sync kong.yaml
+   ```
+
+To skip the intermediate file, run `deck ai sync ai.yaml` instead of both steps.
+
+The following sections show what `ai.yaml` and the resulting `kong.yaml` look like for each entity type.
 
 ### Convert an AI Model
 
-1. Write a decK `ai.yaml` configuration file using the {{site.ai_gateway}} 2.0 entity model. For example, the following AI Model, `gpt-5-2`, exposes the `generate` capability on `/ai` and routes to a single target backed by the `openai-prod` AI Provider:
+The following AI Model, `gpt-5-2`, exposes the `generate` capability on `/ai` and routes to a single target backed by the `openai-prod` AI Model Provider:
 
-   ```sh
-   echo '
-   models:
-     - name: gpt-5-2
-       capabilities:
-         - generate
-       formats:
-         - type: openai
-       config:
-         route:
-           paths:
-             - /ai
-           model:
-             body_param: model
-             values: ["@openai/gpt-5.2"]
-       targets:
-         - name: gpt-5.2
-           provider: openai-prod
-           config:
-             type: openai
-             temperature: 1.0
-             max_tokens: 1024
-   model_providers:
-     - name: openai-prod
-       type: openai
-       config:
-         auth:
-           type: basic
-           headers:
-             - name: Authorization
-               value: "{vault://ai/openai-token}"
-   ' > ai.yaml
-   ```
-1. Convert the {{site.ai_gateway}} entity config to {{site.base_gateway}} 3.x config:
+```yaml
+# ai.yaml (AI Gateway 2.0 entity model)
+models:
+  - name: gpt-5-2
+    capabilities:
+      - generate
+    formats:
+      - type: openai
+    config:
+      route:
+        paths:
+          - /ai
+        model:
+          body_param: model
+          values: ["@openai/gpt-5.2"]
+    targets:
+      - name: gpt-5.2
+        provider: openai-prod
+        config:
+          type: openai
+          temperature: 1.0
+          max_tokens: 1024
+model_providers:
+  - name: openai-prod
+    type: openai
+    config:
+      auth:
+        type: basic
+        headers:
+          - name: Authorization
+            value: "{vault://ai/openai-token}"
+```
+{:.collapsible}
 
-   ```sh
-   deck file ai2kong --source ai.yaml --output-file kong.yaml
-   ```
-   For this example AI Model, {{site.ai_gateway}} generates a Service, a Route, and an `ai-proxy-advanced` plugin on that Route. `kong.yaml` contains:
+Converting it generates a Service, a Route, and an `ai-proxy-advanced` plugin on that Route:
 
-   ```yaml
-   _format_version: "3.0"
-   _info:
-     select_tags:
-     - 'managed_by:deck-ai'
-   ai_models:
-   - alias: '@openai/gpt-5.2'
-     name: gpt-5-2
-   plugins:
-   - config:
-       body_path: model
-       max_request_body_size: 8388608
-       source: body
-     name: ai-model-selector
-     route: openai-chat
-   - config:
-       balancer:
-         algorithm: round-robin
-       genai_category: text/generation
-       llm_format: openai
-       targets:
-       - auth:
-           header_name: Authorization
-           header_value: '{vault://ai/openai-token}'
-         description: gpt-5.2
-         logging:
-            log_payloads: false
-            log_statistics: true
-         model:
-           model_alias: '@openai/gpt-5.2'
-           name: gpt-5.2
-           options:
-             max_tokens: 1024
-             temperature: 1
-           provider: openai
-         route_type: llm/v1/chat
-     model: gpt-5-2
-     name: ai-proxy-advanced
-     route: openai-chat
-   services:
-   - name: ai-gateway
-     routes:
-     - methods:
-       - POST
-       name: openai-chat
-       paths:
-       - /ai/chat/completions
-       strip_path: false
-     url: http://ai-gateway.upstream.local
-   ```
-   {: .no-copy-code .collapsible }
+```yaml
+# kong.yaml (self-hosted Kong Gateway 3.x)
+_format_version: "3.0"
+_info:
+  select_tags:
+  - 'managed_by:deck-ai'
+ai_models:
+- alias: '@openai/gpt-5.2'
+  name: gpt-5-2
+plugins:
+- config:
+    body_path: model
+    max_request_body_size: 8388608
+    source: body
+  name: ai-model-selector
+  route: openai-chat
+- config:
+    balancer:
+      algorithm: round-robin
+    genai_category: text/generation
+    llm_format: openai
+    targets:
+    - auth:
+        header_name: Authorization
+        header_value: '{vault://ai/openai-token}'
+      description: gpt-5.2
+      logging:
+         log_payloads: false
+         log_statistics: true
+      model:
+        model_alias: '@openai/gpt-5.2'
+        name: gpt-5.2
+        options:
+          max_tokens: 1024
+          temperature: 1
+        provider: openai
+      route_type: llm/v1/chat
+  model: gpt-5-2
+  name: ai-proxy-advanced
+  route: openai-chat
+services:
+- name: ai-gateway
+  routes:
+  - methods:
+    - POST
+    name: openai-chat
+    paths:
+    - /ai/chat/completions
+    strip_path: false
+  url: http://ai-gateway.upstream.local
+```
+{: .no-copy-code .collapsible }
 
-   The AI Provider generates no object of its own. Its `type` becomes the target's `model.provider`, and its `auth` is materialized into the same `ai-proxy-advanced` target.
+The AI Model Provider generates no object of its own. Its `type` becomes the target's `model.provider`, and its `auth` is materialized into the same `ai-proxy-advanced` target.
 
-   {:.info}
-   > The converted output uses the `alias` and `model_alias` field names from the self-hosted `ai-model-selector` and `ai-proxy-advanced` plugin schemas. These are distinct from `config.route.model` on the {{site.ai_gateway}} entity shown in the input above; `deck file ai2kong` handles the translation between the two.
-1. Apply the configuration to your self-hosted {{site.base_gateway}}. Sync the `kong.yaml` file you just generated with [`deck gateway sync`](/deck/gateway/sync/):
-   ```sh
-   deck gateway sync kong.yaml
-   ```
-   Or skip the intermediate file and let `deck ai sync` convert and sync `ai.yaml` in one step:
-   ```sh
-   deck ai sync ai.yaml
-   ```
+{:.info}
+> The converted output uses the `alias` and `model_alias` field names from the self-hosted `ai-model-selector` and `ai-proxy-advanced` plugin schemas. These are distinct from `config.route.model` on the {{site.ai_gateway}} entity shown in the input; `deck file ai2kong` handles the translation between the two.
 
 ### Convert an AI MCP Server
 
-1. Write a decK `ai.yaml` configuration file using the {{site.ai_gateway}} 2.0 entity model that defines an AI MCP Server in [conversion-listener mode](/ai-gateway/entities/ai-mcp-server/#server-modes), which converts a REST endpoint into an MCP tool. For example, the following AI MCP Server, `demo-mcp`, exposes a single `get-item` tool that proxies a REST `GET` request:
+The following AI MCP Server, `demo-mcp`, uses [conversion-listener mode](/ai-gateway/entities/ai-mcp-server/#server-modes) to expose a single `get-item` tool that proxies a REST `GET` request:
 
-   ```sh
-   echo '
-   mcp_servers:
-     - ref: demo-mcp
-       name: demo-mcp
-       display_name: "Demo MCP Server"
-       type: conversion-listener
-       enabled: true
-       access:
-         acl_attribute_type: consumer
-       config:
-         url: https://mock.example.com
-         route:
-           paths:
-             - /demo-mcp
-       tools:
-         - name: get-item
-           description: Fetch an item by id
-           annotations:
-             title: Fetch an item by id
-           method: GET
-           path: /items/{itemId}
-           parameters:
-             - name: itemId
-               in: path
-               description: The item id
-               required: true
-               schema:
-                 type: string
-   ' > ai.yaml
-   ```
-1. Convert the {{site.ai_gateway}} entity config to {{site.base_gateway}} 3.x config:
+```yaml
+# ai.yaml (AI Gateway 2.0 entity model)
+mcp_servers:
+  - ref: demo-mcp
+    name: demo-mcp
+    display_name: "Demo MCP Server"
+    type: conversion-listener
+    enabled: true
+    access:
+      acl_attribute_type: consumer
+    config:
+      url: https://mock.example.com
+      route:
+        paths:
+          - /demo-mcp
+    tools:
+      - name: get-item
+        description: Fetch an item by id
+        annotations:
+          title: Fetch an item by id
+        method: GET
+        path: /items/{itemId}
+        parameters:
+          - name: itemId
+            in: path
+            description: The item id
+            required: true
+            schema:
+              type: string
+```
+{:.collapsible}
 
-   ```sh
-   deck file ai2kong --source ai.yaml --output-file kong.yaml
-   ```
-   For this example AI MCP Server, {{site.ai_gateway}} generates a Service, a Route, and an `ai-mcp-proxy` plugin carrying the tool definition. `kong.yaml` contains:
+Converting it generates a Service, a Route, and an `ai-mcp-proxy` plugin carrying the tool definition:
 
-   ```yaml
-   _format_version: "3.0"
-   _info:
-     select_tags:
-     - 'managed_by:deck-ai'
-   services:
-   - host: localhost
-     name: demo-mcp
-     routes:
-     - name: demo-mcp-route
-       paths:
-       - /demo-mcp
-       plugins:
-       - config:
-           include_consumer_groups: true
-           logging:
-             log_audits: false
-             log_payloads: false
-             log_statistics: true
-           mode: conversion-listener
-           tools:
-           - annotations:
-               title: Fetch an item by id
-             description: Fetch an item by id
-             method: GET
-             name: get-item
-             parameters:
-             - description: The item id
-               in: path
-               name: itemId
-               required: true
-               schema:
-                 type: string
-             path: /items/{itemId}
-         name: ai-mcp-proxy
-   ```
-   {: .no-copy-code .collapsible }
-1. Apply the configuration to your self-hosted {{site.base_gateway}}. Sync the `kong.yaml` file you just generated with [`deck gateway sync`](/deck/gateway/sync/):
-   ```sh
-   deck gateway sync kong.yaml
-   ```
-   Or skip the intermediate file and let `deck ai sync` convert and sync `ai.yaml` in one step:
-   ```sh
-   deck ai sync ai.yaml
-   ```
+```yaml
+# kong.yaml (self-hosted Kong Gateway 3.x)
+_format_version: "3.0"
+_info:
+  select_tags:
+  - 'managed_by:deck-ai'
+services:
+- host: localhost
+  name: demo-mcp
+  routes:
+  - name: demo-mcp-route
+    paths:
+    - /demo-mcp
+    plugins:
+    - config:
+        include_consumer_groups: true
+        logging:
+          log_audits: false
+          log_payloads: false
+          log_statistics: true
+        mode: conversion-listener
+        tools:
+        - annotations:
+            title: Fetch an item by id
+          description: Fetch an item by id
+          method: GET
+          name: get-item
+          parameters:
+          - description: The item id
+            in: path
+            name: itemId
+            required: true
+            schema:
+              type: string
+          path: /items/{itemId}
+      name: ai-mcp-proxy
+```
+{: .no-copy-code .collapsible }
 
 ### Convert an AI Agent
 
-1. Write a decK `ai.yaml` configuration file using the {{site.ai_gateway}} 2.0 entity model that defines an AI Agent using the A2A protocol. For example, the following AI Agent, `demo-agent`, proxies Agent-to-Agent traffic to an upstream agent:
+The following AI Agent, `demo-agent`, proxies Agent-to-Agent traffic to an upstream agent:
 
-   ```sh
-   echo '
-   agents:
-     - ref: demo-agent
-       name: demo-agent
-       type: a2a
-       display_name: "Demo Agent"
-       enabled: true
-       labels:
-         team: demo
-       config:
-         url: https://agent.example.com
-         route:
-           paths:
-             - /agents/demo
-         logging:
-           max_payload_size: 524288
-   ' > ai.yaml
-   ```
-1. Convert the {{site.ai_gateway}} entity config to {{site.base_gateway}} 3.x config:
+```yaml
+# ai.yaml (AI Gateway 2.0 entity model)
+agents:
+  - ref: demo-agent
+    name: demo-agent
+    type: a2a
+    display_name: "Demo Agent"
+    enabled: true
+    labels:
+      team: demo
+    config:
+      url: https://agent.example.com
+      route:
+        paths:
+          - /agents/demo
+      logging:
+        max_payload_size: 524288
+```
+{:.collapsible}
 
-   ```sh
-   deck file ai2kong --source ai.yaml --output-file kong.yaml
-   ```
-   For this example AI Agent, {{site.ai_gateway}} generates a Service, a Route, and an `ai-a2a-proxy` plugin on that Route. `kong.yaml` contains:
+Converting it generates a Service, a Route, and an `ai-a2a-proxy` plugin on that Route:
 
-   ```yaml
-   _format_version: "3.0"
-   _info:
-     select_tags:
-     - 'managed_by:deck-ai'
-   services:
-   - name: demo-agent
-     routes:
-     - name: demo-agent-route
-       paths:
-       - /agents/demo
-       plugins:
-       - config:
-           logging:
-             log_payloads: false
-             log_statistics: true
-             max_payload_size: 524288
-         name: ai-a2a-proxy
-     tags:
-     - team:demo
-     url: https://agent.example.com
-   ```
-   {: .no-copy-code .collapsible }
-1. Apply the configuration to your self-hosted {{site.base_gateway}}. Sync the `kong.yaml` file you just generated with [`deck gateway sync`](/deck/gateway/sync/):
-   ```sh
-   deck gateway sync kong.yaml
-   ```
-   Or skip the intermediate file and let `deck ai sync` convert and sync `ai.yaml` in one step:
-   ```sh
-   deck ai sync ai.yaml
-   ```
+```yaml
+# kong.yaml (self-hosted Kong Gateway 3.x)
+_format_version: "3.0"
+_info:
+  select_tags:
+  - 'managed_by:deck-ai'
+services:
+- name: demo-agent
+  routes:
+  - name: demo-agent-route
+    paths:
+    - /agents/demo
+    plugins:
+    - config:
+        logging:
+          log_payloads: false
+          log_statistics: true
+          max_payload_size: 524288
+      name: ai-a2a-proxy
+  tags:
+  - team:demo
+  url: https://agent.example.com
+```
+{: .no-copy-code .collapsible }
+
+An AI Agent with `type: http` converts the same way, minus the `ai-a2a-proxy` plugin: just the Service and Route.
 
 ### Convert an AI Policy
 
 An AI Policy generates no object of its own. It must be attached to another entity, such as an AI Model, AI Agent, or AI MCP Server, and converts into the {{site.base_gateway}} plugin named by the policy `type`, scoped to that entity's Route.
 
-1. Add a `policies` entry to the `ai.yaml` from the [AI Model example](#convert-an-ai-model), and reference it from the model's `policies` field. For example, the following `ai-gw-prompt-guard` policy attaches to the `gpt-5-2` model:
+The following `ai.yaml` defines a minimal chat model, `gpt-5-2`, with an `ai-gw-prompt-guard` policy attached:
 
-   ```sh
-   echo '
-   models:
-     - name: gpt-5-2
-       capabilities:
-         - generate
-       formats:
-         - type: openai
-       config:
-         route:
-           paths:
-             - /ai
-           model:
-             body_param: model
-             values: ["@openai/gpt-5.2"]
-       policies:
-         - ai-gw-prompt-guard
-       targets:
-         - name: gpt-5.2
-           provider: openai-prod
-           config:
-             type: openai
-             temperature: 1.0
-             max_tokens: 1024
-   model_providers:
-     - name: openai-prod
-       type: openai
-       config:
-         auth:
-           type: basic
-           headers:
-             - name: Authorization
-               value: "{vault://ai/openai-token}"
-   policies:
-     - ref: ai-gw-prompt-guard
-       name: ai-gw-prompt-guard
-       display_name: "AI Prompt Guard"
-       type: ai-prompt-guard
-       enabled: true
-       config:
-         deny_patterns:
-           - ".*(W|w)ar.*"
-   ' > ai.yaml
-   ```
-1. Convert the {{site.ai_gateway}} entity config to {{site.base_gateway}} 3.x config:
+```yaml
+# ai.yaml (AI Gateway 2.0 entity model)
+models:
+  - name: gpt-5-2
+    capabilities:
+      - generate
+    formats:
+      - type: openai
+    config:
+      route:
+        paths:
+          - /ai
+        model:
+          body_param: model
+          values: ["@openai/gpt-5.2"]
+    policies:
+      - ai-gw-prompt-guard
+    targets:
+      - name: gpt-5.2
+        provider: openai-prod
+        config:
+          type: openai
+model_providers:
+  - name: openai-prod
+    type: openai
+    config:
+      auth:
+        type: basic
+        headers:
+          - name: Authorization
+            value: "{vault://ai/openai-token}"
+policies:
+  - ref: ai-gw-prompt-guard
+    name: ai-gw-prompt-guard
+    display_name: "AI Prompt Guard"
+    type: ai-prompt-guard
+    enabled: true
+    config:
+      deny_patterns:
+        - ".*(W|w)ar.*"
+```
+{:.collapsible}
 
-   ```sh
-   deck file ai2kong --source ai.yaml --output-file kong.yaml
-   ```
-   {{site.ai_gateway}} generates the same Service, Route, `ai-model-selector`, and `ai-proxy-advanced` plugins as the AI Model example, plus an `ai-prompt-guard` plugin on the same Route, scoped to the `gpt-5-2` model:
+Converting it generates the same Service, Route, `ai-model-selector`, and `ai-proxy-advanced` plugins as [converting an AI Model](#convert-an-ai-model), plus an `ai-prompt-guard` plugin on the same Route, scoped to the `gpt-5-2` model:
 
-   ```yaml
-   - config:
-       deny_patterns:
-       - .*(W|w)ar.*
-     model: gpt-5-2
-     name: ai-prompt-guard
-     route: openai-chat
-   ```
+```yaml
+# kong.yaml (self-hosted Kong Gateway 3.x)
+- config:
+    deny_patterns:
+    - .*(W|w)ar.*
+  model: gpt-5-2
+  name: ai-prompt-guard
+  route: openai-chat
+```
+{: .no-copy-code .collapsible }
 
-   The `model` and `route` fields on the plugin are what scope it to that AI Model's traffic instead of applying globally.
-1. Apply the configuration to your self-hosted {{site.base_gateway}}. Sync the `kong.yaml` file you just generated with [`deck gateway sync`](/deck/gateway/sync/):
-   ```sh
-   deck gateway sync kong.yaml
-   ```
-   Or skip the intermediate file and let `deck ai sync` convert and sync `ai.yaml` in one step:
-   ```sh
-   deck ai sync ai.yaml
-   ```
+The `model` and `route` fields on the plugin scope it to that AI Model's traffic instead of applying globally.

--- a/app/ai-gateway/configure-on-prem.md
+++ b/app/ai-gateway/configure-on-prem.md
@@ -27,6 +27,10 @@ related_resources:
     url: /plugins/ai-mcp-proxy/
   - text: AI A2A Proxy plugin
     url: /plugins/ai-a2a-proxy/
+  - text: deck ai sync
+    url: /deck/ai/sync/
+  - text: deck ai dump
+    url: /deck/ai/dump/
 ---
 
 {{site.ai_gateway}} on {{site.konnect_short_name}} is documented around its entity model.
@@ -122,12 +126,12 @@ Access control and secret management on-prem use the same {{site.base_gateway}} 
 
 ## Convert {{site.ai_gateway}} 2.0 entities to self-hosted {{site.base_gateway}} config
 
-Use `deck file ai2kong` to convert any {{site.ai_gateway}} 2.0 decK configuration into {{site.ai_gateway}} on self-hosted {{site.base_gateway}} entities.
+Use [`deck ai sync`](/deck/ai/sync/) to convert any {{site.ai_gateway}} 2.0 decK configuration into {{site.ai_gateway}} on self-hosted {{site.base_gateway}} entities and apply it in one step. `deck ai sync` is the equivalent of running `deck file ai2kong` followed by `deck gateway sync` on the result, and it tags every entity it manages with `managed_by:deck-ai`. To export that configuration back out of a running {{site.base_gateway}}, use [`deck ai dump`](/deck/ai/dump/), which reverts the tagged entities to {{site.ai_gateway}} 2.0 format.
 
 AI Model, AI MCP Server, AI Agent, and AI Policy entities need conversion, since each one generates {{site.base_gateway}} Services, Routes, or plugins.
-AI Consumers, AI Consumer Groups, and AI Vaults pass through `deck file ai2kong` unchanged, since they're already shaped like their [native {{site.base_gateway}} equivalents](#consumers-consumer-groups-and-vaults).
+AI Consumers, AI Consumer Groups, and AI Vaults pass through unchanged, since they're already shaped like their [native {{site.base_gateway}} equivalents](#consumers-consumer-groups-and-vaults).
 
-The following examples walk through converting a decK `ai.yaml` file for a single AI Model, AI MCP Server, AI Agent, and AI Policy.
+The following examples walk through converting a decK `ai.yaml` file for a single AI Model, AI MCP Server, AI Agent, and AI Policy. Each example uses [`deck file ai2kong`](/deck/file/ai2kong/) to show the `kong.yaml` it generates, then syncs that configuration with `deck ai sync`.
 
 ### Convert an AI Model
 
@@ -229,9 +233,9 @@ The following examples walk through converting a decK `ai.yaml` file for a singl
 
    {:.info}
    > The converted output uses the `alias` and `model_alias` field names from the self-hosted `ai-model-selector` and `ai-proxy-advanced` plugin schemas. These are distinct from `config.route.model` on the {{site.ai_gateway}} entity shown in the input above; `deck file ai2kong` handles the translation between the two.
-1. Sync the converted config to your self-hosted {{site.base_gateway}}:
+1. Sync the configuration to your self-hosted {{site.base_gateway}}. `deck ai sync` converts `ai.yaml` and syncs the result in one step, so you don't need to keep the intermediate `kong.yaml`:
    ```sh
-   deck gateway sync kong.yaml
+   deck ai sync ai.yaml
    ```
 
 ### Convert an AI MCP Server
@@ -313,9 +317,9 @@ The following examples walk through converting a decK `ai.yaml` file for a singl
          name: ai-mcp-proxy
    ```
    {: .no-copy-code .collapsible }
-1. Sync the converted config to your self-hosted {{site.base_gateway}}:
+1. Sync the configuration to your self-hosted {{site.base_gateway}}. `deck ai sync` converts `ai.yaml` and syncs the result in one step, so you don't need to keep the intermediate `kong.yaml`:
    ```sh
-   deck gateway sync kong.yaml
+   deck ai sync ai.yaml
    ```
 
 ### Convert an AI Agent
@@ -371,9 +375,9 @@ The following examples walk through converting a decK `ai.yaml` file for a singl
      url: https://agent.example.com
    ```
    {: .no-copy-code .collapsible }
-1. Sync the converted config to your self-hosted {{site.base_gateway}}:
+1. Sync the configuration to your self-hosted {{site.base_gateway}}. `deck ai sync` converts `ai.yaml` and syncs the result in one step, so you don't need to keep the intermediate `kong.yaml`:
    ```sh
-   deck gateway sync kong.yaml
+   deck ai sync ai.yaml
    ```
 
 ### Convert an AI Policy
@@ -443,7 +447,7 @@ An AI Policy generates no object of its own. It must be attached to another enti
    ```
 
    The `model` and `route` fields on the plugin are what scope it to that AI Model's traffic instead of applying globally.
-1. Sync the converted config to your self-hosted {{site.base_gateway}}:
+1. Sync the configuration to your self-hosted {{site.base_gateway}}. `deck ai sync` converts `ai.yaml` and syncs the result in one step, so you don't need to keep the intermediate `kong.yaml`:
    ```sh
-   deck gateway sync kong.yaml
+   deck ai sync ai.yaml
    ```

--- a/app/ai-gateway/configure-on-prem.md
+++ b/app/ai-gateway/configure-on-prem.md
@@ -126,7 +126,9 @@ Access control and secret management on-prem use the same {{site.base_gateway}} 
 
 ## Convert {{site.ai_gateway}} 2.0 entities to self-hosted {{site.base_gateway}} config
 
-Use [`deck ai sync`](/deck/ai/sync/) to convert any {{site.ai_gateway}} 2.0 decK configuration into {{site.ai_gateway}} on self-hosted {{site.base_gateway}} entities and apply it in one step. `deck ai sync` is the equivalent of running `deck file ai2kong` followed by `deck gateway sync` on the result, and it tags every entity it manages with `managed_by:deck-ai`. To export that configuration back out of a running {{site.base_gateway}}, use [`deck ai dump`](/deck/ai/dump/), which reverts the tagged entities to {{site.ai_gateway}} 2.0 format.
+Use [`deck ai sync`](/deck/ai/sync/) to convert any {{site.ai_gateway}} 2.0 decK configuration into {{site.ai_gateway}} on self-hosted {{site.base_gateway}} entities and apply it in one step.  When you run `deck ai sync`, you run in one step what two commands would do (`deck file ai2kong` and  `deck gateway sync`).
+
+The command tags every entity it manages with `managed_by:deck-ai`. To export that configuration back out of a running {{site.base_gateway}}, use [`deck ai dump`](/deck/ai/dump/), which reverts the tagged entities to {{site.ai_gateway}} 2.0 format.
 
 AI Model, AI MCP Server, AI Agent, and AI Policy entities need conversion, since each one generates {{site.base_gateway}} Services, Routes, or plugins.
 AI Consumers, AI Consumer Groups, and AI Vaults pass through unchanged, since they're already shaped like their [native {{site.base_gateway}} equivalents](#consumers-consumer-groups-and-vaults).


### PR DESCRIPTION
## Description

Fixes #issue

## Preview Links

https://deploy-preview-6650--kongdeveloper.netlify.app/ai-gateway/configure-on-prem/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
