### PR TITLE
docs(KO): add How to config Store-backed TLS certificate keys for KO

### DIFF
--- a/app/_how-tos/gateway/configure-the-konnect-config-store.md
+++ b/app/_how-tos/gateway/configure-the-konnect-config-store.md
@@ -10,6 +10,8 @@ related_resources:
     url: /gateway/entities/vault/
   - text: Store a Mistral API key as a secret in Konnect Config Store
     url: /how-to/store-a-mistral-api-key-as-a-secret-in-konnect-config-store/
+  - text: Store TLS certificate private keys in a Konnect Config Store with {{site.operator_product_name}}
+    url: /operator/konnect/how-to/config-store-certificate-keys/
 
 products:
     - gateway

--- a/app/_how-tos/operator/operator-konnect-certificate-ca-cert.md
+++ b/app/_how-tos/operator/operator-konnect-certificate-ca-cert.md
@@ -25,6 +25,8 @@ related_resources:
     url: /gateway/entities/ca-certificate/
   - text: Certificate
     url: /gateway/entities/certificate/
+  - text: Store TLS certificate private keys in a {{site.konnect_short_name}} Config Store
+    url: /operator/konnect/how-to/config-store-certificate-keys/
 tags:
   - konnect-crd
  
@@ -83,6 +85,25 @@ spec:
     -----END PRIVATE KEY-----
 {% endkonnect_crd %}
 <!-- vale on -->
+
+### Reference certificate material from a Vault {% new_in 2.3 %}
+
+`spec.cert`, `spec.cert_alt`, `spec.key`, and `spec.key_alt` each independently accept either inline PEM material or a
+[Kong vault](/operator/konnect/crd/gateway/vault/) reference of the form `{vault://VAULT_PREFIX/SECRET_KEY}`. References
+are passed through unchanged and resolved from the Vault backend, so you can keep the private key out of your
+Kubernetes manifests while the public certificate stays inline:
+
+```yaml
+  cert: |
+    -----BEGIN CERTIFICATE-----
+    ...
+    -----END CERTIFICATE-----
+  key: '{vault://certvault/example-tls-key}'
+```
+
+Vault references are only supported with the default `spec.type: inline`. For a complete walkthrough, see
+[Store TLS certificate private keys in a {{site.konnect_short_name}} Config Store](/operator/konnect/how-to/config-store-certificate-keys/).
+
 ## Create a `KongCACertificate`
 
 Use the `KongCACertificate` resource to provision a CA certificate in Konnect. This certificate can be used for client authentication or mutual TLS setups.

--- a/app/_how-tos/operator/operator-konnect-certificate-ca-cert.md
+++ b/app/_how-tos/operator/operator-konnect-certificate-ca-cert.md
@@ -34,6 +34,31 @@ tldr:
   q: How do I configure TLS and CA certificates for {{site.konnect_short_name}} using KGO?
   a: Use `KongCertificate` and `KongCACertificate` to manage TLS credentials and CA Certificates
 
+faqs:
+  - q: Can I reference certificate material from a Vault?
+    a: |
+      {% new_in 2.3 %} `spec.cert`, `spec.cert_alt`, `spec.key`, and `spec.key_alt` each independently accept either
+      inline PEM material or a [Kong vault](/operator/konnect/crd/gateway/vault/) reference of the form
+      `{vault://VAULT_PREFIX/SECRET_KEY}`. References are passed through unchanged and resolved from the Vault
+      backend, so you can keep the private key out of your Kubernetes manifests while the public certificate stays
+      inline:
+
+      ```yaml
+        cert: |
+          -----BEGIN CERTIFICATE-----
+          ...
+          -----END CERTIFICATE-----
+        key: '{vault://certvault/example-tls-key}'
+      ```
+
+      Because each field is independent, you can reference only the fields that are sensitive. Malformed references
+      are rejected at admission time, so a typo in a reference fails when you apply the resource rather than at TLS
+      handshake time.
+
+      Vault references are only supported with the default `spec.type: inline`. `spec.type: secretRef` reads the
+      certificate and key from a Kubernetes `Secret`, which stores the key in etcd. For a complete walkthrough, see
+      [Store TLS certificate private keys in a {{site.konnect_short_name}} Config Store](/operator/konnect/how-to/config-store-certificate-keys/).
+
 
 prereqs:
   operator:
@@ -86,28 +111,11 @@ spec:
 {% endkonnect_crd %}
 <!-- vale on -->
 
-### Reference certificate material from a Vault {% new_in 2.3 %}
-
-`spec.cert`, `spec.cert_alt`, `spec.key`, and `spec.key_alt` each independently accept either inline PEM material or a
-[Kong vault](/operator/konnect/crd/gateway/vault/) reference of the form `{vault://VAULT_PREFIX/SECRET_KEY}`. References
-are passed through unchanged and resolved from the Vault backend, so you can keep the private key out of your
-Kubernetes manifests while the public certificate stays inline:
-
-```yaml
-  cert: |
-    -----BEGIN CERTIFICATE-----
-    ...
-    -----END CERTIFICATE-----
-  key: '{vault://certvault/example-tls-key}'
-```
-
-Vault references are only supported with the default `spec.type: inline`. For a complete walkthrough, see
-[Store TLS certificate private keys in a {{site.konnect_short_name}} Config Store](/operator/konnect/how-to/config-store-certificate-keys/).
-
 ## Create a `KongCACertificate`
 
 Use the `KongCACertificate` resource to provision a CA certificate in Konnect. This certificate can be used for client authentication or mutual TLS setups.
-<!-- vale on -->
+
+<!-- vale off -->
 {% konnect_crd %}
 kind: KongCACertificate
 apiVersion: configuration.konghq.com/v1alpha1
@@ -133,7 +141,7 @@ spec:
       qKjBs0k=
       -----END CERTIFICATE-----
 {% endkonnect_crd %}
-<!-- vale off -->
+<!-- vale on -->
 
 
 ## Validation

--- a/app/_how-tos/operator/operator-konnect-config-store-certificate-keys.md
+++ b/app/_how-tos/operator/operator-konnect-config-store-certificate-keys.md
@@ -1,0 +1,398 @@
+---
+title: Store TLS certificate private keys in a {{site.konnect_short_name}} Config Store
+description: "Keep TLS private keys out of Kubernetes and out of your certificate objects by referencing them from a KonnectConfigStore-backed KongVault."
+content_type: how_to
+
+permalink: /operator/konnect/how-to/config-store-certificate-keys/
+breadcrumbs:
+  - /operator/
+  - index: operator
+    group: Konnect
+
+products:
+  - operator
+
+works_on:
+  - konnect
+
+search_aliases:
+  - kgo config store
+  - kgo vault certificate key
+  - KonnectConfigStore
+
+tags:
+  - konnect-crd
+  - secrets-management
+  - certificates
+
+related_resources:
+  - text: Create a Vault
+    url: /operator/konnect/crd/gateway/vault/
+  - text: Create a Certificate and CA Certificate
+    url: /operator/konnect/crd/gateway/certificate-ca-cert/
+  - text: Cross namespace references
+    url: /operator/konnect/cross-namespace-references/
+  - text: Configure the {{site.konnect_short_name}} Config Store vault
+    url: /how-to/configure-the-konnect-config-store/
+
+tldr:
+  q: How do I keep a TLS private key out of my Kubernetes manifests and out of my certificate objects?
+  a: |
+    Create a `KonnectConfigStore`, point a `KongVault` with `backend: konnect` at it using `spec.configStoreRef`,
+    write the private key directly into the Config Store, and then set `KongCertificate.spec.key` to a
+    `{vault://PREFIX/KEY}` reference instead of the key material.
+
+min_version:
+  operator: '2.3'
+
+next_steps:
+  - text: Map hostnames to the certificate with SNIs
+    url: /gateway/entities/sni/
+  - text: Review what else can be stored as a secret
+    url: /gateway/entities/vault/#what-can-be-stored-as-a-secret
+
+prereqs:
+  operator:
+    konnect:
+      auth: true
+      control_plane: true
+---
+
+A `KongCertificate` normally carries the private key as PEM material in `spec.key`, which means the key is stored in
+your Kubernetes manifests, in etcd, and in the {{site.konnect_short_name}} certificate object. Anyone who can read the
+`KongCertificate` or the {{site.konnect_short_name}} certificate can read the key.
+
+Instead, you can store the key in a [{{site.konnect_short_name}} Config Store](/how-to/configure-the-konnect-config-store/)
+and reference it from `spec.key` with a Kong vault reference. The reference is passed through unchanged, so the key
+material never enters your cluster and never appears in the certificate object.
+
+## How the pieces fit together
+
+Four Kubernetes resources describe the setup:
+
+{% table %}
+columns:
+  - title: Resource
+    key: resource
+  - title: Purpose
+    key: purpose
+rows:
+  - resource: "`KonnectConfigStore`"
+    purpose: |
+      Creates the Config Store container in {{site.konnect_short_name}} that holds the secret entries. It manages the
+      container only, never the secret values inside it.
+  - resource: "`KongReferenceGrant`"
+    purpose: |
+      Authorizes the cluster-scoped `KongVault` to reference the namespaced `KonnectConfigStore`.
+  - resource: "`KongVault`"
+    purpose: |
+      Creates a Vault with the `konnect` backend and resolves `spec.configStoreRef` into the `config_store_id` of the
+      Vault configuration sent to {{site.konnect_short_name}}.
+  - resource: "`KongCertificate`"
+    purpose: |
+      Holds the public certificate inline and a vault reference in place of the private key.
+{% endtable %}
+
+The secret value itself is the one step that isn't declarative: it's written straight to {{site.konnect_short_name}},
+out-of-band. That's deliberate. If the key were passed through a Kubernetes resource, it would be stored in etcd, which
+is exactly what this setup avoids.
+
+## Create a `KonnectConfigStore`
+
+Use the `KonnectConfigStore` resource to create the Config Store container in {{site.konnect_short_name}}. It must
+reference the `KonnectGatewayControlPlane` that owns the Config Store:
+
+<!-- vale off -->
+{% konnect_crd %}
+kind: KonnectConfigStore
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: cert-keys
+spec:
+  controlPlaneRef:
+    type: namespacedRef
+    namespacedRef:
+      name: gateway-control-plane
+  apiSpec:
+    name: cert-keys
+{% endkonnect_crd %}
+<!-- vale on -->
+
+## Allow the `KongVault` to reference the Config Store
+
+`KongVault` is cluster-scoped and `KonnectConfigStore` is namespaced, so the reference always crosses a namespace
+boundary and the namespace that holds the Config Store must allow it with a `KongReferenceGrant`. Because a
+`KongVault` has no namespace of its own, the grant must list `namespace: ""` in its `from` entry.
+
+The same grant also covers the `KongVault` reference to the `KonnectGatewayControlPlane`, which crosses a namespace
+boundary for the same reason:
+
+```sh
+echo '
+apiVersion: configuration.konghq.com/{{ site.operator_kongreferencegrant_api_version }}
+kind: KongReferenceGrant
+metadata:
+  name: allow-kongvault-to-konnect-resources
+  namespace: kong
+spec:
+  from:
+    - group: configuration.konghq.com
+      kind: KongVault
+      namespace: ""
+  to:
+    - group: konnect.konghq.com
+      kind: KonnectConfigStore
+    - group: konnect.konghq.com
+      kind: KonnectGatewayControlPlane' | kubectl apply -f -
+```
+
+## Create a `KongVault` backed by the Config Store
+
+Create a `KongVault` with `backend: konnect` and point `spec.configStoreRef` at the `KonnectConfigStore`. {{site.operator_product_name}}
+resolves the reference into the `config_store_id` of the Vault configuration, so you never have to copy the
+{{site.konnect_short_name}} Config Store ID by hand:
+
+<!-- vale off -->
+{% konnect_crd %}
+kind: KongVault
+apiVersion: configuration.konghq.com/v1alpha1
+metadata:
+  name: certvault
+spec:
+  backend: konnect
+  prefix: certvault
+  description: TLS certificate private keys
+  configStoreRef:
+    kind: KonnectConfigStore
+    name: cert-keys
+    namespace: kong
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: gateway-control-plane
+      namespace: kong
+{% endkonnect_crd %}
+<!-- vale on -->
+
+`spec.prefix` is what you use in vault references later, and it's immutable after creation.
+
+{:.info}
+> **Note:** `spec.configStoreRef` is only supported with `backend: konnect`, and it's mutually exclusive with setting
+> `config_store_id` under `spec.config`. Set one or the other, not both.
+
+## Write the private key into the Config Store
+
+Generate a self-signed certificate and key to work with:
+
+```sh
+openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout tls.key -out tls.crt -subj "/CN=example.localdomain.dev"
+```
+
+Fetch the {{site.konnect_short_name}} IDs of the control plane and of the Config Store that {{site.operator_product_name}}
+created. The Config Store ID is published on the `KonnectConfigStore` status, so you don't have to look it up in the
+{{site.konnect_short_name}} UI:
+
+```sh
+export CONTROL_PLANE_ID=$(kubectl get -n kong konnectgatewaycontrolplanes.konnect.konghq.com gateway-control-plane -o jsonpath='{.status.id}')
+export CONFIG_STORE_ID=$(kubectl get -n kong konnectconfigstores.konnect.konghq.com cert-keys -o jsonpath='{.status.id}')
+```
+
+Build the request body, using `jq` to embed the PEM file as a JSON string:
+
+```sh
+jq -n --arg key example-tls-key --rawfile value tls.key '{key: $key, value: $value}' > secret.json
+```
+
+Store the private key as a secret entry in the Config Store:
+
+<!--vale off-->
+{% konnect_api_request %}
+url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores/$CONFIG_STORE_ID/secrets
+status_code: 201
+method: POST
+body_cmd: $(cat secret.json)
+{% endkonnect_api_request %}
+<!--vale on-->
+
+You can also store the secret from the {{site.konnect_short_name}} UI:
+
+1. In {{site.konnect_short_name}}, navigate to [**API Gateway**](https://cloud.konghq.com/gateway-manager/) in the sidebar.
+1. Click your control plane.
+1. Navigate to **Vaults** in the sidebar, then click the `certvault` Vault.
+1. Click **Store New Secret**.
+1. Enter `example-tls-key` in the **Key** field and paste the contents of `tls.key` in the **Value** field.
+1. Click **Save**.
+
+Delete the local copies of the key once it's stored:
+
+```sh
+rm tls.key secret.json
+```
+
+## Create a `KongCertificate` that references the key
+
+Set `spec.key` to a vault reference of the form `{vault://PREFIX/KEY}`, where `PREFIX` is the `spec.prefix` of the
+`KongVault` and `KEY` is the Config Store entry you created. The public certificate isn't sensitive, so it stays
+inline:
+
+```sh
+echo "
+kind: KongCertificate
+apiVersion: configuration.konghq.com/{{ site.operator_kongcertificate_api_version }}
+metadata:
+  name: cert-with-vault-key
+  namespace: kong
+spec:
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: gateway-control-plane
+  cert: |
+$(sed 's/^/    /' tls.crt)
+  key: '{vault://certvault/example-tls-key}'" | kubectl apply -f -
+```
+
+`spec.cert`, `spec.cert_alt`, `spec.key`, and `spec.key_alt` each independently accept either inline material or a
+vault reference, so you can reference only the fields that are sensitive. Malformed references are rejected at
+admission time, so a typo in a reference fails when you apply the resource rather than at TLS handshake time.
+
+{:.warning}
+> **Vault references and `type: secretRef`:** vault references are only supported with the default
+> `spec.type: inline`. `spec.type: secretRef` reads the certificate and key from a Kubernetes `Secret`, which stores
+> the key in etcd.
+
+## Validate
+
+Check that all three resources are programmed in {{site.konnect_short_name}}:
+
+<!-- vale off -->
+{% validation kubernetes-resource %}
+kind: KonnectConfigStore
+name: cert-keys
+{% endvalidation %}
+
+{% validation kubernetes-resource %}
+kind: KongVault
+name: certvault
+{% endvalidation %}
+
+{% validation kubernetes-resource %}
+kind: KongCertificate
+name: cert-with-vault-key
+{% endvalidation %}
+<!-- vale on -->
+
+Confirm that the `KongVault` accepted the Config Store reference:
+
+<!-- vale off -->
+{% validation kubernetes-resource-property %}
+kind: kongvault
+name: certvault
+path: |
+  .status.conditions[] | select(.type == "ConfigStoreRefValid") | .status
+expected: "True"
+{% endvalidation %}
+<!-- vale on -->
+
+Finally, confirm that the certificate stored in {{site.konnect_short_name}} holds the vault reference rather than the
+key material:
+
+<!--vale off-->
+{% konnect_api_request %}
+url: /v2/control-planes/$CONTROL_PLANE_ID/core-entities/certificates
+status_code: 200
+method: GET
+{% endkonnect_api_request %}
+<!--vale on-->
+
+The `key` field in the response is `{vault://certvault/example-tls-key}`. The reference is resolved after
+{{site.base_gateway}} connects to the control plane, so the certificate object itself never contains the key.
+
+## Security boundary
+
+This setup moves the private key out of every place you manage with GitOps, but it doesn't remove it from
+{{site.konnect_short_name}}:
+
+{% table %}
+columns:
+  - title: Location
+    key: location
+  - title: Holds the private key?
+    key: holds
+rows:
+  - location: Git repository and Kubernetes manifests
+    holds: No, only the vault reference.
+  - location: Kubernetes API and etcd
+    holds: No, only the vault reference.
+  - location: "{{site.konnect_short_name}} certificate object"
+    holds: No, only the vault reference.
+  - location: "{{site.konnect_short_name}} Config Store"
+    holds: Yes. Access is controlled by {{site.konnect_short_name}} roles and permissions.
+  - location: "{{site.base_gateway}} data plane memory"
+    holds: |
+      Yes, while the certificate is in use. {{site.konnect_short_name}} resolves the reference after the data plane
+      connects to the control plane.
+{% endtable %}
+
+Anyone who can write secrets into the Config Store can replace the key that your listener serves, so treat Config
+Store write access as equivalent to certificate issuance rights.
+
+## Lifecycle and deletion
+
+* Deleting the `KonnectConfigStore` deletes the Config Store in {{site.konnect_short_name}} **along with every secret
+  stored in it**, including keys that other Vaults or certificates still reference. Delete it only when you're sure
+  nothing depends on its contents.
+* `spec.configStoreRef` is mutable. Removing it clears the `ConfigStoreRefValid` condition and leaves any
+  `config_store_id` you set directly under `spec.config` untouched.
+* Removing the `KongReferenceGrant` stops further updates to a programmed `KongVault`, but the Vault that already
+  exists in {{site.konnect_short_name}}, including its `config_store_id`, isn't rolled back or removed.
+* Rotating a key is a Config Store operation: update the secret value in place, and the vault reference keeps
+  resolving without any change to your Kubernetes resources.
+
+## Troubleshooting
+
+The `KongVault` reports the outcome of the reference in the `ConfigStoreRefValid` condition:
+
+```sh
+kubectl get kongvault certvault -o jsonpath-as-json="{.status.conditions[?(@.type=='ConfigStoreRefValid')]}"
+```
+
+{% table %}
+columns:
+  - title: Reason
+    key: reason
+  - title: Meaning
+    key: meaning
+rows:
+  - reason: "`Valid`"
+    meaning: |
+      The referenced `KonnectConfigStore` is programmed and its ID was used as the `config_store_id`.
+  - reason: "`NotProgrammed`"
+    meaning: |
+      The `KonnectConfigStore` exists but hasn't been created in {{site.konnect_short_name}} yet, so its ID isn't
+      known. This resolves on its own once the Config Store is programmed.
+  - reason: "`RefNotPermitted`"
+    meaning: |
+      No `KongReferenceGrant` in the Config Store's namespace allows the reference. Check that the grant's `from`
+      entry names the `KongVault` kind with an empty namespace.
+  - reason: "`Invalid`"
+    meaning: |
+      The reference can't be used at all, for example because the `KonnectConfigStore` doesn't exist, the vault
+      backend isn't `konnect`, or `spec.config` also sets `config_store_id`. The condition message names the cause,
+      and fixing it requires a spec change.
+{% endtable %}
+
+While the reference is unresolved, {{site.operator_product_name}} doesn't push the `KongVault` to
+{{site.konnect_short_name}}, so that a Vault is never created with a missing or wrong Config Store ID.
+
+If the Vault is programmed but {{site.base_gateway}} fails the TLS handshake, the reference itself is usually fine and
+the secret entry is the problem. Confirm that the key exists in the Config Store and that its name matches the vault
+reference:
+
+<!--vale off-->
+{% konnect_api_request %}
+url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores/$CONFIG_STORE_ID/secrets
+status_code: 200
+method: GET
+{% endkonnect_api_request %}
+<!--vale on-->

--- a/app/_how-tos/operator/operator-konnect-config-store-certificate-keys.md
+++ b/app/_how-tos/operator/operator-konnect-config-store-certificate-keys.md
@@ -38,7 +38,7 @@ related_resources:
 tldr:
   q: How do I keep a TLS private key out of my Kubernetes manifests and out of my certificate objects?
   a: |
-    Create a `KonnectConfigStore`, point a `KongVault` with `backend: konnect` at it using `spec.configStoreRef`,
+    Create a `KonnectConfigStore`, point to a `KongVault` with `backend: konnect` at it using `spec.configStoreRef`,
     write the private key directly into the Config Store, and then set `KongCertificate.spec.key` to a
     `{vault://PREFIX/KEY}` reference instead of the key material.
 

--- a/app/_how-tos/operator/operator-konnect-config-store-certificate-keys.md
+++ b/app/_how-tos/operator/operator-konnect-config-store-certificate-keys.md
@@ -280,7 +280,6 @@ indent: 3
 1. Enter `example-tls-key` in the **Key** field and paste the contents of `tls.key` in the **Value** field.
 1. Click **Save**.
 
-{{delete}}
 {% endnavtab %}
 {% endnavtabs %}
 

--- a/app/_how-tos/operator/operator-konnect-config-store-certificate-keys.md
+++ b/app/_how-tos/operator/operator-konnect-config-store-certificate-keys.md
@@ -30,20 +30,72 @@ related_resources:
     url: /operator/konnect/crd/gateway/vault/
   - text: Create a Certificate and CA Certificate
     url: /operator/konnect/crd/gateway/certificate-ca-cert/
+  - text: Config Store-backed Vaults
+    url: /operator/konnect/config-store/
   - text: Cross namespace references
     url: /operator/konnect/cross-namespace-references/
+  - text: Status fields
+    url: /operator/konnect/troubleshooting/status/
   - text: Configure the {{site.konnect_short_name}} Config Store vault
     url: /how-to/configure-the-konnect-config-store/
 
 tldr:
   q: How do I keep a TLS private key out of my Kubernetes manifests and out of my certificate objects?
   a: |
-    Create a `KonnectConfigStore`, point to a `KongVault` with `backend: konnect` at it using `spec.configStoreRef`,
+    Create a `KonnectConfigStore`, point a `KongVault` to it with `backend: konnect` using `spec.configStoreRef`,
     write the private key directly into the Config Store, and then set `KongCertificate.spec.key` to a
     `{vault://PREFIX/KEY}` reference instead of the key material.
 
 min_version:
   operator: '2.3'
+
+faqs:
+  - q: Why isn't the secret value stored declaratively?
+    a: |
+      The purpose of this guide is to avoid storing the secret in etcd, which would be the case if the key was passed through a Kubernetes resource. Instead, we pass it directly to {{site.konnect_short_name}} using either the API or the UI.
+  - q: Who can replace the private key once it's in the Config Store?
+    a: |
+      Anyone who can write secrets into the Config Store can replace the key that your listener serves, so treat
+      Config Store write access as equivalent to certificate issuance rights. For a full breakdown of where the key
+      does and doesn't exist, see the [security boundary](/operator/konnect/config-store/#security-boundary) of a
+      Config Store-backed Vault.
+  - q: What happens if I delete the `KonnectConfigStore`?
+    a: |
+      Deleting the `KonnectConfigStore` deletes the Config Store in {{site.konnect_short_name}} **along with every
+      secret stored in it**, including keys that other Vaults or certificates still reference. Delete it only when
+      you're sure nothing depends on its contents. For more information, see
+      [lifecycle and deletion](/operator/konnect/config-store/#lifecycle-and-deletion).
+  - q: How do I rotate a key that's stored in the Config Store?
+    a: |
+      Rotating a key is a Config Store operation: update the secret value in place, and the vault reference keeps
+      resolving without any change to your Kubernetes resources.
+  - q: "Can I use vault references with `spec.type: secretRef`?"
+    a: |
+      No. Vault references are only supported with the default `spec.type: inline`. `spec.type: secretRef` reads the
+      certificate and key from a Kubernetes `Secret`, which stores the key in etcd.
+  - q: Why isn't my `KongVault` programmed in {{site.konnect_short_name}}?
+    a: |
+      If the `KongVault` isn't programmed in {{site.konnect_short_name}}, check the `ConfigStoreRefValid` condition:
+
+      ```sh
+      kubectl get kongvault certvault -o jsonpath-as-json="{.status.conditions[?(@.type=='ConfigStoreRefValid')]}"
+      ```
+
+      For the meaning of each condition reason, see
+      [`ConfigStoreRefValid` on `KongVault`](/operator/konnect/troubleshooting/status/#configstorerefvalid-on-kongvault).
+  - q: The Vault is programmed, but {{site.base_gateway}} fails the TLS handshake. What should I check?
+    a: |
+      If the Vault is programmed but {{site.base_gateway}} fails the TLS handshake, the reference itself is usually
+      fine and the secret entry is the problem. Confirm that the key exists in the Config Store and that its name
+      matches the vault reference:
+
+      <!--vale off-->
+      {% konnect_api_request %}
+      url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores/$CONFIG_STORE_ID/secrets
+      status_code: 200
+      method: GET
+      {% endkonnect_api_request %}
+      <!--vale on-->
 
 next_steps:
   - text: Map hostnames to the certificate with SNIs
@@ -66,36 +118,7 @@ Instead, you can store the key in a [{{site.konnect_short_name}} Config Store](/
 and reference it from `spec.key` with a Kong vault reference. The reference is passed through unchanged, so the key
 material never enters your cluster and never appears in the certificate object.
 
-## How the pieces fit together
-
-Four Kubernetes resources describe the setup:
-
-{% table %}
-columns:
-  - title: Resource
-    key: resource
-  - title: Purpose
-    key: purpose
-rows:
-  - resource: "`KonnectConfigStore`"
-    purpose: |
-      Creates the Config Store container in {{site.konnect_short_name}} that holds the secret entries. It manages the
-      container only, never the secret values inside it.
-  - resource: "`KongReferenceGrant`"
-    purpose: |
-      Authorizes the cluster-scoped `KongVault` to reference the namespaced `KonnectConfigStore`.
-  - resource: "`KongVault`"
-    purpose: |
-      Creates a Vault with the `konnect` backend and resolves `spec.configStoreRef` into the `config_store_id` of the
-      Vault configuration sent to {{site.konnect_short_name}}.
-  - resource: "`KongCertificate`"
-    purpose: |
-      Holds the public certificate inline and a vault reference in place of the private key.
-{% endtable %}
-
-The secret value itself is the one step that isn't declarative: it's written straight to {{site.konnect_short_name}},
-out-of-band. That's deliberate. If the key were passed through a Kubernetes resource, it would be stored in etcd, which
-is exactly what this setup avoids.
+For more information, see [Config Store-backed Vaults](/operator/konnect/config-store/).
 
 ## Create a `KonnectConfigStore`
 
@@ -116,6 +139,11 @@ spec:
   apiSpec:
     name: cert-keys
 {% endkonnect_crd %}
+
+{% validation kubernetes-resource %}
+kind: KonnectConfigStore
+name: cert-keys
+{% endvalidation %}
 <!-- vale on -->
 
 ## Allow the `KongVault` to reference the Config Store
@@ -148,9 +176,8 @@ spec:
 
 ## Create a `KongVault` backed by the Config Store
 
-Create a `KongVault` with `backend: konnect` and point `spec.configStoreRef` at the `KonnectConfigStore`. {{site.operator_product_name}}
-resolves the reference into the `config_store_id` of the Vault configuration, so you never have to copy the
-{{site.konnect_short_name}} Config Store ID by hand:
+Create a `KongVault` with `backend: konnect` and point `spec.configStoreRef` to the `KonnectConfigStore`. {{site.operator_product_name}}
+resolves the reference into the `config_store_id` of the Vault configuration:
 
 <!-- vale off -->
 {% konnect_crd %}
@@ -172,15 +199,28 @@ spec:
       name: gateway-control-plane
       namespace: kong
 {% endkonnect_crd %}
+
+{% validation kubernetes-resource %}
+kind: KongVault
+name: certvault
+{% endvalidation %}
 <!-- vale on -->
 
-`spec.prefix` is what you use in vault references later, and it's immutable after creation.
+Confirm that the `KongVault` accepted the Config Store reference:
+<!-- vale off -->
+{% validation kubernetes-resource-property %}
+kind: kongvault
+name: certvault
+path: |
+  .status.conditions[] | select(.type == "ConfigStoreRefValid") | .status
+expected: "True"
+{% endvalidation %}
+<!-- vale on -->
 
-{:.info}
-> **Note:** `spec.configStoreRef` is only supported with `backend: konnect`, and it's mutually exclusive with setting
-> `config_store_id` under `spec.config`. Set one or the other, not both.
+For more information about `spec.configStoreRef` and `spec.prefix`, see
+[Config Store-backed Vaults](/operator/konnect/config-store/#field-behavior).
 
-## Write the private key into the Config Store
+## Generate a certificate
 
 Generate a self-signed certificate and key to work with:
 
@@ -188,46 +228,61 @@ Generate a self-signed certificate and key to work with:
 openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout tls.key -out tls.crt -subj "/CN=example.localdomain.dev"
 ```
 
-Fetch the {{site.konnect_short_name}} IDs of the control plane and of the Config Store that {{site.operator_product_name}}
-created. The Config Store ID is published on the `KonnectConfigStore` status, so you don't have to look it up in the
-{{site.konnect_short_name}} UI:
+## Write the private key into the Config Store
 
-```sh
-export CONTROL_PLANE_ID=$(kubectl get -n kong konnectgatewaycontrolplanes.konnect.konghq.com gateway-control-plane -o jsonpath='{.status.id}')
-export CONFIG_STORE_ID=$(kubectl get -n kong konnectconfigstores.konnect.konghq.com cert-keys -o jsonpath='{.status.id}')
-```
+{% navtabs "store-certificate-key" %}
+{% navtab "{{site.konnect_short_name}} API" %}
+1. Fetch the {{site.konnect_short_name}} IDs of the control plane and of the Config Store that {{site.operator_product_name}}
+   created. The Config Store ID is published on the `KonnectConfigStore` status, so you don't have to look it up in the
+   {{site.konnect_short_name}} UI:
 
-Build the request body, using `jq` to embed the PEM file as a JSON string:
+   ```sh
+   export CONTROL_PLANE_ID=$(kubectl get -n kong konnectgatewaycontrolplanes.konnect.konghq.com gateway-control-plane -o jsonpath='{.status.id}')
+   echo $CONTROL_PLANE_ID
+   export CONFIG_STORE_ID=$(kubectl get -n kong konnectconfigstores.konnect.konghq.com cert-keys -o jsonpath='{.status.id}')
+   echo $CONFIG_STORE_ID
+   ```
 
-```sh
-jq -n --arg key example-tls-key --rawfile value tls.key '{key: $key, value: $value}' > secret.json
-```
+1. Build the request body, using `jq` to embed the PEM file as a JSON string:
 
-Store the private key as a secret entry in the Config Store:
+   ```sh
+   jq -n --arg key example-tls-key --rawfile value tls.key '{key: $key, value: $value}' > secret.json
+   ```
 
+1. Store the private key as a secret entry in the Config Store:
+{% capture command %}
 <!--vale off-->
 {% konnect_api_request %}
 url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores/$CONFIG_STORE_ID/secrets
 status_code: 201
 method: POST
 body_cmd: $(cat secret.json)
+indent: 3
 {% endkonnect_api_request %}
 <!--vale on-->
+{% endcapture %}
+{{command | indent}}
 
-You can also store the secret from the {{site.konnect_short_name}} UI:
+{% capture delete %}
+1. Delete the local copies of the key once it's stored:
 
+   ```sh
+   rm tls.key secret.json
+   ```
+{% endcapture %}
+{{delete}}
+{% endnavtab %}
+{% navtab "{{site.konnect_short_name}} UI" %}
 1. In {{site.konnect_short_name}}, navigate to [**API Gateway**](https://cloud.konghq.com/gateway-manager/) in the sidebar.
 1. Click your control plane.
 1. Navigate to **Vaults** in the sidebar, then click the `certvault` Vault.
-1. Click **Store New Secret**.
+1. Click **Store new secret**.
 1. Enter `example-tls-key` in the **Key** field and paste the contents of `tls.key` in the **Value** field.
 1. Click **Save**.
 
-Delete the local copies of the key once it's stored:
-
-```sh
-rm tls.key secret.json
-```
+{{delete}}
+{% endnavtab %}
+{% endnavtabs %}
 
 ## Create a `KongCertificate` that references the key
 
@@ -252,49 +307,19 @@ $(sed 's/^/    /' tls.crt)
   key: '{vault://certvault/example-tls-key}'" | kubectl apply -f -
 ```
 
-`spec.cert`, `spec.cert_alt`, `spec.key`, and `spec.key_alt` each independently accept either inline material or a
-vault reference, so you can reference only the fields that are sensitive. Malformed references are rejected at
-admission time, so a typo in a reference fails when you apply the resource rather than at TLS handshake time.
-
-{:.warning}
-> **Vault references and `type: secretRef`:** vault references are only supported with the default
-> `spec.type: inline`. `spec.type: secretRef` reads the certificate and key from a Kubernetes `Secret`, which stores
-> the key in etcd.
-
-## Validate
-
-Check that all three resources are programmed in {{site.konnect_short_name}}:
-
 <!-- vale off -->
-{% validation kubernetes-resource %}
-kind: KonnectConfigStore
-name: cert-keys
-{% endvalidation %}
-
-{% validation kubernetes-resource %}
-kind: KongVault
-name: certvault
-{% endvalidation %}
-
 {% validation kubernetes-resource %}
 kind: KongCertificate
 name: cert-with-vault-key
 {% endvalidation %}
 <!-- vale on -->
 
-Confirm that the `KongVault` accepted the Config Store reference:
+For more information about which certificate fields accept vault references, see
+[Can I reference certificate material from a Vault?](/operator/konnect/crd/gateway/certificate-ca-cert/#can-i-reference-certificate-material-from-a-vault).
 
-<!-- vale off -->
-{% validation kubernetes-resource-property %}
-kind: kongvault
-name: certvault
-path: |
-  .status.conditions[] | select(.type == "ConfigStoreRefValid") | .status
-expected: "True"
-{% endvalidation %}
-<!-- vale on -->
+## Validate
 
-Finally, confirm that the certificate stored in {{site.konnect_short_name}} holds the vault reference rather than the
+Confirm that the certificate stored in {{site.konnect_short_name}} holds the vault reference rather than the
 key material:
 
 <!--vale off-->
@@ -305,94 +330,5 @@ method: GET
 {% endkonnect_api_request %}
 <!--vale on-->
 
-The `key` field in the response is `{vault://certvault/example-tls-key}`. The reference is resolved after
+The value of the `key` field in the response is `{vault://certvault/example-tls-key}`. The reference is resolved after
 {{site.base_gateway}} connects to the control plane, so the certificate object itself never contains the key.
-
-## Security boundary
-
-This setup moves the private key out of every place you manage with GitOps, but it doesn't remove it from
-{{site.konnect_short_name}}:
-
-{% table %}
-columns:
-  - title: Location
-    key: location
-  - title: Holds the private key?
-    key: holds
-rows:
-  - location: Git repository and Kubernetes manifests
-    holds: No, only the vault reference.
-  - location: Kubernetes API and etcd
-    holds: No, only the vault reference.
-  - location: "{{site.konnect_short_name}} certificate object"
-    holds: No, only the vault reference.
-  - location: "{{site.konnect_short_name}} Config Store"
-    holds: Yes. Access is controlled by {{site.konnect_short_name}} roles and permissions.
-  - location: "{{site.base_gateway}} data plane memory"
-    holds: |
-      Yes, while the certificate is in use. {{site.konnect_short_name}} resolves the reference after the data plane
-      connects to the control plane.
-{% endtable %}
-
-Anyone who can write secrets into the Config Store can replace the key that your listener serves, so treat Config
-Store write access as equivalent to certificate issuance rights.
-
-## Lifecycle and deletion
-
-* Deleting the `KonnectConfigStore` deletes the Config Store in {{site.konnect_short_name}} **along with every secret
-  stored in it**, including keys that other Vaults or certificates still reference. Delete it only when you're sure
-  nothing depends on its contents.
-* `spec.configStoreRef` is mutable. Removing it clears the `ConfigStoreRefValid` condition and leaves any
-  `config_store_id` you set directly under `spec.config` untouched.
-* Removing the `KongReferenceGrant` stops further updates to a programmed `KongVault`, but the Vault that already
-  exists in {{site.konnect_short_name}}, including its `config_store_id`, isn't rolled back or removed.
-* Rotating a key is a Config Store operation: update the secret value in place, and the vault reference keeps
-  resolving without any change to your Kubernetes resources.
-
-## Troubleshooting
-
-The `KongVault` reports the outcome of the reference in the `ConfigStoreRefValid` condition:
-
-```sh
-kubectl get kongvault certvault -o jsonpath-as-json="{.status.conditions[?(@.type=='ConfigStoreRefValid')]}"
-```
-
-{% table %}
-columns:
-  - title: Reason
-    key: reason
-  - title: Meaning
-    key: meaning
-rows:
-  - reason: "`Valid`"
-    meaning: |
-      The referenced `KonnectConfigStore` is programmed and its ID was used as the `config_store_id`.
-  - reason: "`NotProgrammed`"
-    meaning: |
-      The `KonnectConfigStore` exists but hasn't been created in {{site.konnect_short_name}} yet, so its ID isn't
-      known. This resolves on its own once the Config Store is programmed.
-  - reason: "`RefNotPermitted`"
-    meaning: |
-      No `KongReferenceGrant` in the Config Store's namespace allows the reference. Check that the grant's `from`
-      entry names the `KongVault` kind with an empty namespace.
-  - reason: "`Invalid`"
-    meaning: |
-      The reference can't be used at all, for example because the `KonnectConfigStore` doesn't exist, the vault
-      backend isn't `konnect`, or `spec.config` also sets `config_store_id`. The condition message names the cause,
-      and fixing it requires a spec change.
-{% endtable %}
-
-While the reference is unresolved, {{site.operator_product_name}} doesn't push the `KongVault` to
-{{site.konnect_short_name}}, so that a Vault is never created with a missing or wrong Config Store ID.
-
-If the Vault is programmed but {{site.base_gateway}} fails the TLS handshake, the reference itself is usually fine and
-the secret entry is the problem. Confirm that the key exists in the Config Store and that its name matches the vault
-reference:
-
-<!--vale off-->
-{% konnect_api_request %}
-url: /v2/control-planes/$CONTROL_PLANE_ID/config-stores/$CONFIG_STORE_ID/secrets
-status_code: 200
-method: GET
-{% endkonnect_api_request %}
-<!--vale on-->

--- a/app/_how-tos/operator/operator-konnect-vault.md
+++ b/app/_how-tos/operator/operator-konnect-vault.md
@@ -26,6 +26,8 @@ tags:
 related_resources:
   - text: Vault
     url: /gateway/entities/vault/
+  - text: Store TLS certificate private keys in a {{site.konnect_short_name}} Config Store
+    url: /operator/konnect/how-to/config-store-certificate-keys/
 tldr:
   q: How do I create and configure a Vault in Konnect using KGO?
   a: Define a `KongVault` resource and associate it with your `KonnectGatewayControlPlane` to manage secrets using a configured backend.
@@ -61,11 +63,100 @@ spec:
 {% endkonnect_crd %}
 <!-- vale on -->
 
+## Create a {{site.konnect_short_name}} Config Store-backed `KongVault` {% new_in 2.3 %}
+
+The `konnect` backend stores secrets in a {{site.konnect_short_name}} Config Store, which is identified by a
+`config_store_id`. Instead of creating the Config Store out-of-band and copying its ID into `spec.config`, you can
+manage the Config Store with a `KonnectConfigStore` resource and reference it from `spec.configStoreRef`:
+
+<!-- vale off -->
+{% konnect_crd %}
+kind: KonnectConfigStore
+apiVersion: konnect.konghq.com/v1alpha1
+metadata:
+  name: konnect-config-store
+spec:
+  controlPlaneRef:
+    type: namespacedRef
+    namespacedRef:
+      name: gateway-control-plane
+  apiSpec:
+    name: konnect-config-store
+{% endkonnect_crd %}
+<!-- vale on -->
+
+`KongVault` is cluster-scoped and `KonnectConfigStore` is namespaced, so the reference always crosses a namespace
+boundary. The namespace holding the `KonnectConfigStore` must allow it with a
+[`KongReferenceGrant`](/operator/konnect/cross-namespace-references/#vault-config-store-configuration), and because a
+`KongVault` has no namespace of its own, the grant lists `namespace: ""` in its `from` entry:
+
+```sh
+echo '
+apiVersion: configuration.konghq.com/{{ site.operator_kongreferencegrant_api_version }}
+kind: KongReferenceGrant
+metadata:
+  name: allow-kongvault-to-konnect-resources
+  namespace: kong
+spec:
+  from:
+    - group: configuration.konghq.com
+      kind: KongVault
+      namespace: ""
+  to:
+    - group: konnect.konghq.com
+      kind: KonnectConfigStore
+    - group: konnect.konghq.com
+      kind: KonnectGatewayControlPlane' | kubectl apply -f -
+```
+
+Now create the `KongVault`:
+
+<!-- vale off -->
+{% konnect_crd %}
+kind: KongVault
+apiVersion: configuration.konghq.com/v1alpha1
+metadata:
+  name: konnect-vault
+spec:
+  backend: konnect
+  prefix: konnect-vault
+  configStoreRef:
+    kind: KonnectConfigStore
+    name: konnect-config-store
+    namespace: kong
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: gateway-control-plane
+      namespace: kong
+{% endkonnect_crd %}
+<!-- vale on -->
+
+{{ site.operator_product_name }} resolves the reference to the {{site.konnect_short_name}} ID of the
+`KonnectConfigStore`, uses it as the `config_store_id` of the Vault configuration, and reports the outcome in the
+`ConfigStoreRefValid` condition.
+
+`spec.configStoreRef` is only supported with `backend: konnect`, and it's mutually exclusive with setting
+`config_store_id` under `spec.config`.
+
+For an end-to-end example that keeps TLS private keys out of Kubernetes entirely, see
+[Store TLS certificate private keys in a {{site.konnect_short_name}} Config Store](/operator/konnect/how-to/config-store-certificate-keys/).
+
 ## Validation
 
 <!-- vale off -->
 {% validation kubernetes-resource %}
 kind: KongVault
 name: env-vault
+{% endvalidation %}
+
+{% validation kubernetes-resource %}
+kind: KonnectConfigStore
+name: konnect-config-store
+{% endvalidation %}
+
+{% validation kubernetes-resource %}
+kind: KongVault
+name: konnect-vault
 {% endvalidation %}
 <!-- vale on -->

--- a/app/_how-tos/operator/operator-konnect-vault.md
+++ b/app/_how-tos/operator/operator-konnect-vault.md
@@ -28,6 +28,8 @@ related_resources:
     url: /gateway/entities/vault/
   - text: Store TLS certificate private keys in a {{site.konnect_short_name}} Config Store
     url: /operator/konnect/how-to/config-store-certificate-keys/
+  - text: Config Store-backed Vaults
+    url: /operator/konnect/config-store/
 tldr:
   q: How do I create and configure a Vault in Konnect using KGO?
   a: Define a `KongVault` resource and associate it with your `KonnectGatewayControlPlane` to manage secrets using a configured backend.
@@ -63,84 +65,8 @@ spec:
 {% endkonnect_crd %}
 <!-- vale on -->
 
-## Create a {{site.konnect_short_name}} Config Store-backed `KongVault` {% new_in 2.3 %}
-
-The `konnect` backend stores secrets in a {{site.konnect_short_name}} Config Store, which is identified by a
-`config_store_id`. Instead of creating the Config Store out-of-band and copying its ID into `spec.config`, you can
-manage the Config Store with a `KonnectConfigStore` resource and reference it from `spec.configStoreRef`:
-
-<!-- vale off -->
-{% konnect_crd %}
-kind: KonnectConfigStore
-apiVersion: konnect.konghq.com/v1alpha1
-metadata:
-  name: konnect-config-store
-spec:
-  controlPlaneRef:
-    type: namespacedRef
-    namespacedRef:
-      name: gateway-control-plane
-  apiSpec:
-    name: konnect-config-store
-{% endkonnect_crd %}
-<!-- vale on -->
-
-`KongVault` is cluster-scoped and `KonnectConfigStore` is namespaced, so the reference always crosses a namespace
-boundary. The namespace holding the `KonnectConfigStore` must allow it with a
-[`KongReferenceGrant`](/operator/konnect/cross-namespace-references/#vault-config-store-configuration), and because a
-`KongVault` has no namespace of its own, the grant lists `namespace: ""` in its `from` entry:
-
-```sh
-echo '
-apiVersion: configuration.konghq.com/{{ site.operator_kongreferencegrant_api_version }}
-kind: KongReferenceGrant
-metadata:
-  name: allow-kongvault-to-konnect-resources
-  namespace: kong
-spec:
-  from:
-    - group: configuration.konghq.com
-      kind: KongVault
-      namespace: ""
-  to:
-    - group: konnect.konghq.com
-      kind: KonnectConfigStore
-    - group: konnect.konghq.com
-      kind: KonnectGatewayControlPlane' | kubectl apply -f -
-```
-
-Now create the `KongVault`:
-
-<!-- vale off -->
-{% konnect_crd %}
-kind: KongVault
-apiVersion: configuration.konghq.com/v1alpha1
-metadata:
-  name: konnect-vault
-spec:
-  backend: konnect
-  prefix: konnect-vault
-  configStoreRef:
-    kind: KonnectConfigStore
-    name: konnect-config-store
-    namespace: kong
-  controlPlaneRef:
-    type: konnectNamespacedRef
-    konnectNamespacedRef:
-      name: gateway-control-plane
-      namespace: kong
-{% endkonnect_crd %}
-<!-- vale on -->
-
-{{ site.operator_product_name }} resolves the reference to the {{site.konnect_short_name}} ID of the
-`KonnectConfigStore`, uses it as the `config_store_id` of the Vault configuration, and reports the outcome in the
-`ConfigStoreRefValid` condition.
-
-`spec.configStoreRef` is only supported with `backend: konnect`, and it's mutually exclusive with setting
-`config_store_id` under `spec.config`.
-
-For an end-to-end example that keeps TLS private keys out of Kubernetes entirely, see
-[Store TLS certificate private keys in a {{site.konnect_short_name}} Config Store](/operator/konnect/how-to/config-store-certificate-keys/).
+To store secrets in a {{site.konnect_short_name}} Config Store that {{site.operator_product_name}} manages for you,
+see [Store TLS certificate private keys in a {{site.konnect_short_name}} Config Store](/operator/konnect/how-to/config-store-certificate-keys/).
 
 ## Validation
 
@@ -148,15 +74,5 @@ For an end-to-end example that keeps TLS private keys out of Kubernetes entirely
 {% validation kubernetes-resource %}
 kind: KongVault
 name: env-vault
-{% endvalidation %}
-
-{% validation kubernetes-resource %}
-kind: KonnectConfigStore
-name: konnect-config-store
-{% endvalidation %}
-
-{% validation kubernetes-resource %}
-kind: KongVault
-name: konnect-vault
 {% endvalidation %}
 <!-- vale on -->

--- a/app/_indices/operator.yaml
+++ b/app/_indices/operator.yaml
@@ -113,6 +113,7 @@ groups:
           - path: /operator/konnect/labelling/
           - path: /operator/konnect/kongpluginbinding/
           - path: /operator/konnect/cross-namespace-references/
+          - path: /operator/konnect/config-store/
       - title: "Konnect CRDs: Control Planes"
         items:
           - path: /operator/konnect/crd/control-planes/**/*

--- a/app/_indices/operator.yaml
+++ b/app/_indices/operator.yaml
@@ -126,6 +126,7 @@ groups:
         items:
           - path: /operator/konnect/how-to/auth-cross-namespace-reference/
           - path: /operator/konnect/how-to/secret-cross-namespace-reference/
+          - path: /operator/konnect/how-to/config-store-certificate-keys/
           - path: /operator/konnect/how-to/static-naming/
       - title: Troubleshooting
         items:

--- a/app/operator/konnect/config-store.md
+++ b/app/operator/konnect/config-store.md
@@ -1,0 +1,119 @@
+---
+title: "Config Store-backed Vaults"
+description: "How does a KongVault reference a KonnectConfigStore, and where do the secrets it holds actually live?"
+content_type: reference
+layout: reference
+products:
+  - operator
+works_on:
+  - konnect
+search_aliases:
+  - kgo config store
+  - KonnectConfigStore
+breadcrumbs:
+  - /operator/
+  - index: operator
+    group: Konnect
+  - index: operator
+    group: Konnect
+    section: Key Concepts
+related_resources:
+  - text: Create a Vault
+    url: /operator/konnect/crd/gateway/vault/
+  - text: Cross namespace references
+    url: /operator/konnect/cross-namespace-references/
+  - text: Store TLS certificate private keys in a {{site.konnect_short_name}} Config Store
+    url: /operator/konnect/how-to/config-store-certificate-keys/
+  - text: Status fields
+    url: /operator/konnect/troubleshooting/status/
+  - text: "{{site.konnect_short_name}} Config Store vault"
+    url: /gateway/entities/vault/konnect-config-store/
+min_version:
+  operator: '2.3'
+
+---
+
+A `KongVault` with `backend: konnect` stores its secrets in a {{site.konnect_short_name}} Config Store, which is
+identified by a `config_store_id`. Instead of creating the Config Store out-of-band and copying its ID into
+`spec.config`, you can manage the Config Store with a `KonnectConfigStore` resource and reference it from
+`spec.configStoreRef`.
+
+## Resources involved
+
+Four Kubernetes resources describe the setup:
+
+{% table %}
+columns:
+  - title: Resource
+    key: resource
+  - title: Purpose
+    key: purpose
+rows:
+  - resource: "`KonnectConfigStore`"
+    purpose: |
+      Creates the Config Store container in {{site.konnect_short_name}} that holds the secret entries. It manages the
+      container only, never the secret values inside it.
+  - resource: "`KongReferenceGrant`"
+    purpose: |
+      Authorizes the cluster-scoped `KongVault` to reference the namespaced `KonnectConfigStore`.
+  - resource: "`KongVault`"
+    purpose: |
+      Creates a Vault with the `konnect` backend and resolves `spec.configStoreRef` into the `config_store_id` of the
+      Vault configuration sent to {{site.konnect_short_name}}.
+  - resource: "`KongCertificate`"
+    purpose: |
+      Holds the public certificate inline and a vault reference in place of the private key.
+{% endtable %}
+
+The secret value itself is the one step that isn't declarative: it's written straight to {{site.konnect_short_name}}, out-of-band, to avoid storing the secret value in etcd.
+
+## Field behavior
+
+* `spec.configStoreRef` is only supported with `backend: konnect`, and it's mutually exclusive with setting
+  `config_store_id` under `spec.config`.
+* `spec.prefix` is what you use in vault references later, and it's immutable after creation.
+* `KongVault` is cluster-scoped and `KonnectConfigStore` is namespaced, so the reference always crosses a namespace
+  boundary and requires a
+  [`KongReferenceGrant`](/operator/konnect/cross-namespace-references/#vault-config-store-configuration).
+* {{site.operator_product_name}} reports the outcome of the reference in the
+  [`ConfigStoreRefValid`](/operator/konnect/troubleshooting/status/#configstorerefvalid-on-kongvault) condition.
+
+## Security boundary
+
+Referencing a secret from a Config Store moves it out of every place you manage with GitOps, but it doesn't remove it
+from {{site.konnect_short_name}}:
+
+{% table %}
+columns:
+  - title: Location
+    key: location
+  - title: Holds the secret?
+    key: holds
+rows:
+  - location: Git repository and Kubernetes manifests
+    holds: No, only the vault reference.
+  - location: Kubernetes API and etcd
+    holds: No, only the vault reference.
+  - location: "{{site.konnect_short_name}} certificate object"
+    holds: No, only the vault reference.
+  - location: "{{site.konnect_short_name}} Config Store"
+    holds: Yes. Access is controlled by {{site.konnect_short_name}} roles and permissions.
+  - location: "{{site.base_gateway}} data plane memory"
+    holds: |
+      Yes, while the secret is in use. {{site.konnect_short_name}} resolves the reference after the data plane
+      connects to the control plane.
+{% endtable %}
+
+Anyone who can write secrets into the Config Store can replace the key that your listener serves, so treat Config Store write access as equivalent to certificate issuance rights.
+
+## Lifecycle and deletion
+
+* Deleting the `KonnectConfigStore` deletes the Config Store in {{site.konnect_short_name}} along with every secret
+  stored in it, including keys that other Vaults or certificates still reference. Delete it only when you're sure
+  nothing depends on its contents.
+* `spec.configStoreRef` is mutable. Removing it clears the `ConfigStoreRefValid` condition and leaves any
+  `config_store_id` you set directly under `spec.config` untouched.
+* Removing the `KongReferenceGrant` stops further updates to a programmed `KongVault`, but the Vault that already
+  exists in {{site.konnect_short_name}}, including its `config_store_id`, isn't rolled back or removed.
+* Rotating a key is a Config Store operation: update the secret value in place, and the vault reference keeps
+  resolving without any change to your Kubernetes resources.

--- a/app/operator/konnect/cross-namespace-references.md
+++ b/app/operator/konnect/cross-namespace-references.md
@@ -250,6 +250,64 @@ spec:
 
 Without a valid grant, the `KonnectAPIAuthConfiguration` reports `ResolvedRefs=False` with reason `RefNotPermitted` and `APIAuthValid=False`. Once a permitting `KongReferenceGrant` is created, the object is reconciled and the reference becomes valid.
 
+## Vault Config Store configuration {% new_in 2.3 %}
+
+When configuring a `KongVault` with `spec.backend: konnect`, you can reference the `KonnectConfigStore` that backs the
+Vault instead of copying the {{site.konnect_short_name}} Config Store ID into `spec.config.config_store_id`.
+
+You can do this with the `spec.configStoreRef` field. `KongVault` is cluster-scoped and `KonnectConfigStore` is
+namespaced, so `spec.configStoreRef.namespace` is required and the reference always crosses a namespace boundary:
+
+```yaml
+apiVersion: configuration.konghq.com/v1alpha1
+kind: KongVault
+metadata:
+  name: certvault
+spec:
+  backend: konnect
+  prefix: certvault
+  configStoreRef:
+    kind: KonnectConfigStore
+    name: cert-keys
+    namespace: kong
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: my-control-plane
+      namespace: kong
+```
+
+In order to protect cross-namespace references, the `KonnectConfigStore` resource must explicitly allow references from
+other namespaces using `KongReferenceGrant` resources. Because a `KongVault` is cluster-scoped and has no namespace of
+its own, the `from` entry must set `namespace: ""`:
+
+```yaml
+apiVersion: configuration.konghq.com/{{ site.operator_kongreferencegrant_api_version }}
+kind: KongReferenceGrant
+metadata:
+  name: allow-kongvault-to-konnect-config-store
+  namespace: kong
+spec:
+  from:
+    - group: configuration.konghq.com
+      kind: KongVault
+      namespace: ""
+  to:
+    - group: konnect.konghq.com
+      kind: KonnectConfigStore
+      # Optionally specify a specific KonnectConfigStore name to allow
+      # only this specific resource to be referenced.
+      # name: cert-keys
+```
+
+Without a valid grant, the `KongVault` reports `ConfigStoreRefValid=False` with reason `RefNotPermitted` and isn't
+pushed to {{site.konnect_short_name}}, so that a Vault is never created with a missing Config Store ID. If the grant is
+removed after the `KongVault` has been programmed, subsequent updates stop, but the Vault that already exists in
+{{site.konnect_short_name}} isn't rolled back or removed.
+
+The denial is reported on `ConfigStoreRefValid` rather than on `ResolvedRefs`, which the control plane reference already
+uses for this resource.
+
 ## Troubleshooting
 
 If you're having issues with cross namespace references, you can always check your

--- a/app/operator/konnect/troubleshooting/status.md
+++ b/app/operator/konnect/troubleshooting/status.md
@@ -70,3 +70,42 @@ id: 7dcf6756-b2e7-4067-a19b-111111111111
 organizationID: 5ca26716-02f7-4430-9117-111111111111
 serverURL: https://us.api.konghq.com
 ```
+
+## Status conditions
+
+Resources also report `status.conditions`, where each condition carries a `reason` that explains the current state.
+
+### `ConfigStoreRefValid` on `KongVault` {% new_in 2.3 %}
+
+The `KongVault` reports the outcome of the reference in the `ConfigStoreRefValid` condition:
+
+```sh
+kubectl get kongvault <vault_prefix> -o jsonpath-as-json="{.status.conditions[?(@.type=='ConfigStoreRefValid')]}"
+```
+
+{% table %}
+columns:
+  - title: Reason
+    key: reason
+  - title: Meaning
+    key: meaning
+rows:
+  - reason: "`Valid`"
+    meaning: |
+      The referenced `KonnectConfigStore` is programmed and its ID was used as the `config_store_id`.
+  - reason: "`NotProgrammed`"
+    meaning: |
+      The `KonnectConfigStore` exists but hasn't been created in {{site.konnect_short_name}} yet, so its ID is unknown. This resolves on its own once the Config Store is programmed.
+  - reason: "`RefNotPermitted`"
+    meaning: |
+      No `KongReferenceGrant` in the Config Store's namespace allows the reference. Check that the grant's `from`
+      entry names the `KongVault` kind with an empty namespace.
+  - reason: "`Invalid`"
+    meaning: |
+      The reference can't be used at all, for example because the `KonnectConfigStore` doesn't exist, the vault
+      backend isn't `konnect`, or `spec.config` also sets `config_store_id`. The condition message names the cause,
+      and fixing it requires a spec change.
+{% endtable %}
+
+While the reference is unresolved, {{site.operator_product_name}} doesn't push the `KongVault` to
+{{site.konnect_short_name}}, so that a Vault is never created with a missing or wrong Config Store ID.


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes https://github.com/Kong/kong-operator/issues/5169

## Preview Links

https://deploy-preview-6652--kongdeveloper.netlify.app/operator/konnect/how-to/config-store-certificate-keys/

## Checklist 

- [x] Tested how-to docs. If not, note why here. 
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [x] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [x] Add new pages to the product documentation index (if applicable).
