### PR TITLE
fix(metering-and-billing): Correct minimum gateway version in onboarding guides

### DIFF
--- a/app/_how-tos/ai-gateway/meter-llm-traffic.md
+++ b/app/_how-tos/ai-gateway/meter-llm-traffic.md
@@ -14,6 +14,9 @@ products:
 works_on:
     - konnect
 
+min_version:
+    gateway: '3.14'
+
 tags:
     - get-started
 

--- a/app/_how-tos/gateway/get-started-with-metering-and-billing.md
+++ b/app/_how-tos/gateway/get-started-with-metering-and-billing.md
@@ -63,7 +63,7 @@ related_resources:
   - text: Get started with {{site.metering_and_billing}} generic meters
     url: /how-to/get-started-with-metering-and-billing-generic-meters/
 min_version:
-    gateway: '3.4'
+    gateway: '3.14'
 next_steps:
   - text: See all {{site.base_gateway}} tutorials
     url: /how-to/?products=gateway


### PR DESCRIPTION
## Description

### What

Sets `min_version.gateway` to `3.14` on the two Metering & Billing onboarding guides.

- `app/_how-tos/gateway/get-started-with-metering-and-billing.md` — was `3.4` (typo)
- `app/_how-tos/ai-gateway/meter-llm-traffic.md` — had no `min_version` at all

### Why

The Metering & Billing plugin was added in Kong Gateway **3.14.0.0** (see the `3.14.0.0` kong-ee entry in `app/_data/changelogs/gateway.json`: "Added a new plugin for metering and billing"). The `3.4` tag pointed readers at a release where the plugin does not exist, and the LLM guide gave no version floor even though it configures the same plugin.

### How

Frontmatter only, no content changes. Both guides now match the plugin page (`app/_kong_plugins/metering-and-billing/index.md`) and the sibling guide `meter-api-requests-by-consumer.md`, which already declare `3.14`.

The other Metering & Billing how-tos (generic meters, prepaid credits, tax codes, active users) are intentionally untouched: they are `products: [metering-and-billing]` only and carry no Kong Gateway dependency.

Verified with the frontmatter validator and Vale (both clean), checked the preview render.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).