### PR TITLE
feat(gateway): Upgrade and migration pages

### DIFF
--- a/.github/styles/base/Dictionary.txt
+++ b/.github/styles/base/Dictionary.txt
@@ -107,6 +107,7 @@ callout
 callouts
 camelCase
 CDNs
+ce
 cef
 cerebras
 certificate_admin
@@ -235,6 +236,7 @@ drilldown
 dynatrace
 eason
 ecs
+ee
 ElastiCache
 elbs
 enablement

--- a/app/_how-tos/gateway/migrate-oss-to-enterprise.md
+++ b/app/_how-tos/gateway/migrate-oss-to-enterprise.md
@@ -1,0 +1,92 @@
+---
+title: "Migrate from {{site.base_gateway}} OSS to {{site.ee_product_name}}"
+permalink: /gateway/upgrade/migrate-oss-to-ee/
+
+description: "Learn how to migrate from {{site.base_gateway}} open source to {{site.ee_product_name}} using the kong migrations CLI."
+
+content_type: how_to
+
+products:
+  - gateway
+
+works_on:
+  - on-prem
+
+tags:
+  - upgrade
+  - migration
+
+search_aliases:
+  - migrate ce to ee
+  - migrate community to enterprise
+
+tldr:
+  q: How do I migrate from {{site.base_gateway}} OSS to {{site.ee_product_name}}?
+  a: |
+    Install the {{site.ee_product_name}} package that matches your OSS version, point it at the same data store, then run `kong migrations up` and `kong migrations finish`.
+
+prereqs:
+  skip_product: true
+  inline:
+    - title: Back up your data
+      content: |
+        You have backed up your {{site.base_gateway}} data.
+        See [Backing up and restoring {{site.base_gateway}}](/gateway/upgrade/backup-and-restore/).
+
+        {:.danger}
+        > **Warning:** Migration is irreversible, therefore we strongly recommend backing up your production data before migrating from {{site.base_gateway}} OSS to {{site.ee_product_name}}.
+
+      icon_url: /assets/icons/service-document.svg
+
+related_resources:
+  - text: "Upgrade and migrate {{site.base_gateway}}"
+    url: /gateway/upgrade/
+  - text: "Upgrading {{site.base_gateway}}"
+    url: /gateway/upgrade/reference/
+  - text: "Backing up and restoring {{site.base_gateway}}"
+    url: /gateway/upgrade/backup-and-restore/
+  - text: "Migrating from self-managed {{site.base_gateway}} to {{site.konnect_short_name}}"
+    url: /gateway/self-managed-migration/
+  - text: kong migrations CLI reference
+    url: /gateway/cli/reference/#kong-migrations
+next_steps:
+  - text: Upgrade to your desired version of {{site.ee_product_name}}
+    url: /gateway/upgrade/reference/
+  - text: Migrate to {{site.konnect_short_name}}
+    url: /gateway/self-managed-migration/
+---
+
+## Review deployment options
+
+Review [{{site.base_gateway}} deployment topologies](/gateway/deployment-topologies/) and choose a target deployment type.
+
+* {{site.base_gateway}} OSS supports only [traditional](/gateway/traditional-mode/) and [DB-less](/gateway/db-less-mode/) deployments.
+* {{site.ee_product_name}} supports traditional, DB-less, and also introduces [hybrid mode](/gateway/hybrid-mode/), which separates the control plane and the data plane.
+
+If you choose to migrate to hybrid mode, all data store operations will occur on the control plane.
+If you want to migrate to {{site.konnect_short_name}}, first migrate to {{site.ee_product_name}} in hybrid mode, and then migrate to {{site.konnect_short_name}}.
+
+## Download and install the Enterprise package
+
+Download and install the {{site.ee_product_name}} package that matches your installed OSS version from the [{{site.base_gateway}} install page](/gateway/install/).
+You can only migrate to an Enterprise version that supports the same OSS version.
+The latest supported OSS version is `{{site.latest_gateway_oss_version}}`.
+
+## Run database migrations
+
+Configure the new {{site.ee_product_name}} deployment to point to the same data store as your {{site.base_gateway}} OSS node.
+The [`migrations` command](/gateway/cli/reference/#kong-migrations) expects the data store to be up to date on any pending migrations.
+
+Run migrations from the new node, pointing to your existing configuration file:
+
+```bash
+kong migrations up [-c configuration_file]
+kong migrations finish [-c configuration_file]
+```
+
+{:.warning}
+> **Caution**: {% include_cached /gateway/migration-finish-warning.md %}
+
+## Confirm your entities
+
+Start your {{site.ee_product_name}} node and confirm that all entities are available.

--- a/app/_how-tos/gateway/migrate-oss-to-enterprise.md
+++ b/app/_how-tos/gateway/migrate-oss-to-enterprise.md
@@ -54,6 +54,8 @@ next_steps:
     url: /gateway/upgrade/reference/
   - text: Migrate to {{site.konnect_short_name}}
     url: /gateway/self-managed-migration/
+
+automated_tests: false
 ---
 
 ## Review deployment options

--- a/app/_landing_pages/gateway.yaml
+++ b/app/_landing_pages/gateway.yaml
@@ -304,11 +304,11 @@ rows:
       - blocks:
           - type: card
             config:
-              title: Upgrade {{site.base_gateway}}
-              description: Learn about different upgrade methods
+              title: "Upgrade or migrate {{site.base_gateway}}"
+              description: Upgrade to a newer version, migrate from OSS to Enterprise, or move to {{site.konnect_short_name}}
               icon: /assets/icons/download.svg
               cta:
-                text: See reference
+                text: See upgrade and migration options
                 url: /gateway/upgrade/
                 align: end
       - blocks:

--- a/app/_landing_pages/gateway/upgrade.yaml
+++ b/app/_landing_pages/gateway/upgrade.yaml
@@ -28,6 +28,8 @@ rows:
                     - "[Back up your data](/gateway/upgrade/backup-and-restore/): Back up your {{site.base_gateway}} configuration before upgrading so you can restore it if something goes wrong."
                     - "[Review breaking changes](/gateway/breaking-changes/): Check for breaking changes between your current version and the target version."
                     - "[Check version support](/gateway/version-support-policy/): Confirm your current and target versions are supported, and identify any required intermediate upgrade stops."
+                    - "[Review the changelog](/gateway/changelog/): Check the full changelog for every release between your current version and the target version."
+                    - "[Check performance benchmarks](/gateway/performance/benchmarks/): Review benchmark results for your target version to understand performance expectations."
 
   - header:
       type: h2

--- a/app/_landing_pages/gateway/upgrade.yaml
+++ b/app/_landing_pages/gateway/upgrade.yaml
@@ -1,0 +1,188 @@
+metadata:
+  title: "Upgrade and migrate {{site.base_gateway}}"
+  content_type: landing_page
+  description: |
+    Upgrade {{site.base_gateway}} to a newer version, or migrate from OSS to Enterprise or from self-managed to {{site.konnect_short_name}}.
+  products:
+    - gateway
+  works_on:
+    - on-prem
+    - konnect
+
+rows:
+  - header:
+      type: h1
+      text: "Upgrade and migrate {{site.base_gateway}}"
+      sub_text: |
+        Upgrade {{site.base_gateway}} to a newer version, migrate from OSS to Enterprise, or move from self-managed infrastructure to {{site.konnect_short_name}}.
+
+  - columns:
+      - blocks:
+          - type: structured_text
+            config:
+              header:
+                text: "Before you start"
+              blocks:
+                - type: unordered_list
+                  items:
+                    - "[Back up your data](/gateway/upgrade/backup-and-restore/): Back up your {{site.base_gateway}} configuration before upgrading so you can restore it if something goes wrong."
+                    - "[Review breaking changes](/gateway/breaking-changes/): Check for breaking changes between your current version and the target version."
+                    - "[Check version support](/gateway/version-support-policy/): Confirm your current and target versions are supported, and identify any required intermediate upgrade stops."
+
+  - header:
+      type: h2
+      text: "Choose an upgrade strategy"
+      description: |
+        The right strategy depends on your deployment topology and available resources.
+    columns:
+      - blocks:
+          - type: table
+            config:
+              columns:
+                - title: Deployment type
+                  key: deployment
+                - title: Recommended strategy
+                  key: strategy
+              rows:
+                - deployment: Traditional mode
+                  strategy: "[Dual-cluster upgrade](/gateway/upgrade/dual-cluster/) if resources allow; [in-place upgrade](/gateway/upgrade/in-place/) if constrained"
+                - deployment: Hybrid mode control planes
+                  strategy: "[Dual-cluster upgrade](/gateway/upgrade/dual-cluster/) if resources allow; [in-place upgrade](/gateway/upgrade/in-place/) if constrained"
+                - deployment: Hybrid mode data planes
+                  strategy: "[Rolling upgrade](/gateway/upgrade/rolling/)"
+                - deployment: DB-less mode
+                  strategy: "[Rolling upgrade](/gateway/upgrade/rolling/)"
+                - deployment: "{{site.konnect_short_name}} data plane"
+                  strategy: "[Rolling upgrade](/gateway/upgrade/rolling/)"
+          - type: structured_text
+            config:
+              blocks:
+                - type: text
+                  text: |
+                    We provide a detailed, in-depth upgrade guide that walks you through the upgrade process for each deployment type, and everything you need to know to prepare for a successful upgrade.
+                    Review this guide before you start your upgrade.
+
+          - type: button
+            config:
+              text: "Review the upgrade guide"
+              url: /gateway/upgrade/reference/
+      - blocks:
+          - type: mermaid
+            config:
+              diagram: |
+                flowchart TD
+                    A{Deployment type?} --> B(Traditional mode)
+                    A{Deployment type?} --> C(Hybrid mode)
+                    A{Deployment type?} --> D(DB-less mode)
+                    A{Deployment type?} --> E(Konnect DP)
+                    B ---> F{Enough hardware to
+                    run another cluster?}
+                    C --> G(Upgrade CP first) & H(Upgrade DP second)
+                    D ----> K([Rolling upgrade])
+                    E ----> K
+                    G --> F
+                    F ---Yes--->I([Dual-cluster upgrade])
+                    F ---No--->J([In-place upgrade])
+                    H ---> K
+                    click K "/gateway/upgrade/rolling/"
+                    click I "/gateway/upgrade/dual-cluster/"
+                    click J "/gateway/upgrade/in-place/"
+
+  - header:
+      type: h2
+      text: "Upgrade {{site.konnect_short_name}} data planes"
+      description: |
+        {{site.konnect_short_name}} data plane upgrades work differently from self-managed upgrades.
+        There are no database migrations. Instead, you provision new nodes and decommission old ones, or let Kong handle it automatically.
+    columns:
+      - blocks:
+        - type: card
+          config:
+            title: Hybrid mode data planes
+            description: |
+              Provision new data plane nodes at the target version, verify they connect to the control plane, then decommission the old nodes.
+            icon: /assets/icons/deployment.svg
+            cta:
+              text: Upgrade hybrid mode data planes
+              url: /gateway/data-plane-reference/#upgrade-data-planes
+              align: end
+      - blocks:
+        - type: card
+          config:
+            title: Dedicated Cloud Gateways
+            description: |
+              Patch releases upgrade automatically.
+              Major and minor version upgrades require you to initiate the upgrade through the Konnect API.
+            icon: /assets/icons/cloud.svg
+            cta:
+              text: Upgrade Dedicated Cloud Gateways
+              url: /dedicated-cloud-gateways/reference/#dedicated-cloud-gateway-upgrades
+              align: end
+
+  - header:
+      type: h2
+      text: "LTS version upgrades"
+    columns:
+      - blocks:
+        - type: card
+          config:
+            title: "3.10 to 3.14 LTS upgrade"
+            description: |
+              Upgrade from {{site.base_gateway}} 3.10 LTS to 3.14 LTS.
+            icon: /assets/icons/cog.svg
+            ctas:
+              - text: Upgrade guide
+                url: /gateway/upgrade/lts-upgrade-310-314/
+              - text: Convert entity configuration
+                url: /gateway/upgrade/convert-lts-310-314/
+      - blocks:
+        - type: card
+          config:
+            title: "3.4 to 3.10 LTS upgrade"
+            description: |
+              Upgrade from {{site.base_gateway}} 3.4 LTS to 3.10 LTS.
+            icon: /assets/icons/cog.svg
+            ctas:
+              - text: Upgrade guide
+                url: /gateway/upgrade/lts-upgrade-34-310/
+              - text: Convert entity configuration
+                url: /gateway/upgrade/convert-lts-34-310/
+      - blocks:
+        - type: card
+          config:
+            title: "2.8 to 3.4 LTS upgrade"
+            description: |
+              Upgrade from {{site.base_gateway}} 2.8 LTS to 3.4 LTS.
+            icon: /assets/icons/cog.svg
+            ctas:
+              - text: Upgrade guide
+                url: /gateway/upgrade/lts-upgrade-28-34/
+              - text: Convert entity configuration
+                url: /gateway/upgrade/convert-lts-28-34/
+
+  - header:
+      type: h2
+      text: "Migrate {{site.base_gateway}}"
+    columns:
+      - blocks:
+        - type: card
+          config:
+            title: "Migrate from self-managed to {{site.konnect_short_name}}"
+            description: |
+              Export your existing gateway configuration and move your data planes to a {{site.konnect_short_name}}-managed control plane.
+            icon: /assets/icons/cloud.svg
+            cta:
+              text: Migrate to {{site.konnect_short_name}}
+              url: /gateway/self-managed-migration/
+              align: end
+      - blocks:
+        - type: card
+          config:
+            title: "Migrate from OSS to {{site.ee_product_name}}"
+            description: |
+              Use the kong migrations CLI to migrate an existing {{site.base_gateway}} open source deployment to {{site.ee_product_name}}.
+            icon: /assets/icons/cog.svg
+            cta:
+              text: Migrate to Enterprise
+              url: /gateway/upgrade/migrate-oss-to-ee/
+              align: end

--- a/app/gateway/install.md
+++ b/app/gateway/install.md
@@ -19,27 +19,8 @@ breadcrumbs:
 faqs:
   - q: How do I migrate from {{site.base_gateway}} open source (OSS) to {{site.ee_product_name}}?
     a: |
-        You can migrate to {{site.ee_product_name}} using the `kong migrations` CLI commands.
-        
-        {:.danger}
-        > **Warning:** This action is irreversible, therefore we strongly recommend [backing up](/gateway/upgrade/backup-and-restore/) your production data before migrating from {{site.base_gateway}} OSS to {{site.ee_product_name}}.
-        
-        You can only migrate to a {{site.ee_product_name}} version that supports the same OSS version. The latest version of {{site.base_gateway}} OSS is {{site.latest_gateway_oss_version}}.
-
-        1. Download the {{site.ee_product_name}} package that matches your installed OSS version.
-        1. Configure it to point to the same data store as your {{site.base_gateway}} OSS node.
-           The migration command expects the data store to be up to date on any pending migration:
-
-           ```sh
-           kong migrations up [-c configuration_file]
-           kong migrations -f finish [-c configuration_file]
-           ```
-
-           {:.warning}
-           > **Caution**: {% include_cached /gateway/migration-finish-warning.md %}
-
-        1. Confirm that all of the entities are now available on your {{site.ee_product_name}} node.
-        1. (Optional) [Upgrade](/gateway/upgrade/) to your desired version of {{site.ee_product_name}}. 
+        You can migrate using the `kong migrations` CLI.
+        See the [OSS to Enterprise migration guide](/gateway/upgrade/migrate-oss-to-ee/) for step-by-step instructions.
   - q: "How do I install {{site.base_gateway}} on Windows?"
     a: |
       To install {{site.base_gateway}} on Windows, use [Docker](#docker). Kong does not provide a native Windows install method for {{site.base_gateway}}.

--- a/app/gateway/self-managed-migration.md
+++ b/app/gateway/self-managed-migration.md
@@ -13,6 +13,10 @@ works_on:
     - konnect
 
 related_resources:
+  - text: "Upgrade and migrate {{site.base_gateway}}"
+    url: /gateway/upgrade/
+  - text: "Migrate from {{site.base_gateway}} OSS to {{site.ee_product_name}}"
+    url: /gateway/upgrade/migrate-oss-to-ee/
   - text: "About {{site.konnect_short_name}}"
     url: /konnect/
   - text: Hybrid mode

--- a/app/gateway/upgrade/backup-and-restore.md
+++ b/app/gateway/upgrade/backup-and-restore.md
@@ -18,8 +18,10 @@ tags:
     - restore
 
 related_resources:
-  - text: "Upgrading {{site.base_gateway}}"
+  - text: "Upgrade and migrate {{site.base_gateway}}"
     url: /gateway/upgrade/
+  - text: "Migrate from {{site.base_gateway}} OSS to {{site.ee_product_name}}"
+    url: /gateway/upgrade/migrate-oss-to-ee/
   - text: Rolling upgrade
     url: /gateway/upgrade/rolling/
   - text: "Dual-cluster upgrade"

--- a/app/gateway/upgrade/blue-green.md
+++ b/app/gateway/upgrade/blue-green.md
@@ -20,7 +20,7 @@ search_aliases:
   - blue green upgrade
 
 related_resources:
-  - text: "Upgrading {{site.base_gateway}}"
+  - text: "Upgrade and migrate {{site.base_gateway}}"
     url: /gateway/upgrade/
   - text: "Backing up and restoring {{site.base_gateway}}"
     url: /gateway/upgrade/backup-and-restore/
@@ -108,7 +108,7 @@ The exact execution of these steps will vary depending on your environment.
 
 ### Prerequisites
 
-* Review the [general upgrade guide](/gateway/upgrade/) to prepare for the upgrade and review your options.
+* Review the [upgrade guide](/gateway/upgrade/reference/) to prepare for the upgrade and review your options.
 * You have a traditional deployment or you need to upgrade the Control Planes (CPs) in a hybrid mode deployment.
 * You have {{site.base_gateway}} 2.8.2.x or later.
 * You can't perform [dual-cluster upgrades](/gateway/upgrade/dual-cluster/) due to resource limitations.

--- a/app/gateway/upgrade/dual-cluster.md
+++ b/app/gateway/upgrade/dual-cluster.md
@@ -19,7 +19,7 @@ tags:
 
 
 related_resources:
-  - text: "Upgrading {{site.base_gateway}}"
+  - text: "Upgrade and migrate {{site.base_gateway}}"
     url: /gateway/upgrade/
   - text: "{{site.base_gateway}} breaking changes"
     url: /gateway/breaking-changes/
@@ -109,8 +109,8 @@ The exact execution of these steps will vary depending on your environment.
 
 ### Prerequisites
 
-* Review either the [general upgrade guide](/gateway/upgrade/) or one of the LTS upgrade guides 
-([2.8 -> 3.4](/gateway/upgrade/lts-upgrade-28-34/), [3.4 -> 3.10](/gateway/upgrade/lts-upgrade-34-310/), [3.10 -> 3.14](/gateway/upgrade/lts-upgrade-310-314/)) 
+* Review either the [upgrade guide](/gateway/upgrade/reference/) or one of the LTS upgrade guides
+([2.8 -> 3.4](/gateway/upgrade/lts-upgrade-28-34/), [3.4 -> 3.10](/gateway/upgrade/lts-upgrade-34-310/), [3.10 -> 3.14](/gateway/upgrade/lts-upgrade-310-314/))
 to prepare for the upgrade and review your options.
 * You have a traditional deployment or you need to upgrade the control planes (CPs) in a hybrid mode deployment.
 * You have enough resources to temporarily run an additional {{site.base_gateway}} cluster alongside your existing cluster.

--- a/app/gateway/upgrade/in-place.md
+++ b/app/gateway/upgrade/in-place.md
@@ -19,7 +19,7 @@ tags:
 
 
 related_resources:
-  - text: "Upgrading {{site.base_gateway}}"
+  - text: "Upgrade and migrate {{site.base_gateway}}"
     url: /gateway/upgrade/
   - text: "Dual-cluster upgrade"
     url: /gateway/upgrade/dual-cluster/
@@ -89,8 +89,8 @@ The exact execution of these steps will vary depending on your environment.
 
 ### Prerequisites
 
-* Review either the [general upgrade guide](/gateway/upgrade/) or one of the LTS upgrade guides 
-([2.8 -> 3.4](/gateway/upgrade/lts-upgrade-28-34/), [3.4 -> 3.10](/gateway/upgrade/lts-upgrade-34-310/), [3.10 -> 3.14](/gateway/upgrade/lts-upgrade-310-314/)) 
+* Review either the [upgrade guide](/gateway/upgrade/reference/) or one of the LTS upgrade guides
+([2.8 -> 3.4](/gateway/upgrade/lts-upgrade-28-34/), [3.4 -> 3.10](/gateway/upgrade/lts-upgrade-34-310/), [3.10 -> 3.14](/gateway/upgrade/lts-upgrade-310-314/))
 to prepare for the upgrade and review your options.
 * You have a traditional deployment or you need to upgrade the control planes (CPs) in a hybrid mode deployment.
 * You can't perform [dual-cluster upgrades](/gateway/upgrade/dual-cluster/) due to resource limitations.

--- a/app/gateway/upgrade/reference.md
+++ b/app/gateway/upgrade/reference.md
@@ -4,6 +4,7 @@ content_type: reference
 layout: reference
 breadcrumbs:
   - /gateway/
+  - /gateway/upgrade/
 products:
     - gateway
 

--- a/app/gateway/upgrade/rolling.md
+++ b/app/gateway/upgrade/rolling.md
@@ -17,7 +17,7 @@ tags:
     - versioning
 
 related_resources:
-  - text: "Upgrading {{site.base_gateway}}"
+  - text: "Upgrade and migrate {{site.base_gateway}}"
     url: /gateway/upgrade/
   - text: "Dual-cluster upgrade"
     url: /gateway/upgrade/dual-cluster/
@@ -84,8 +84,8 @@ _New nodes are gradually deployed and pointed to the `kong.yml` file, while traf
 
 ## Prerequisites
 
-* Review either the [general upgrade guide](/gateway/upgrade/) or one of the LTS upgrade guides 
-([2.8 -> 3.4](/gateway/upgrade/lts-upgrade-28-34/), [3.4 -> 3.10](/gateway/upgrade/lts-upgrade-34-310/), [3.10 -> 3.14](/gateway/upgrade/lts-upgrade-310-314/)) 
+* Review either the [upgrade guide](/gateway/upgrade/reference/) or one of the LTS upgrade guides
+([2.8 -> 3.4](/gateway/upgrade/lts-upgrade-28-34/), [3.4 -> 3.10](/gateway/upgrade/lts-upgrade-34-310/), [3.10 -> 3.14](/gateway/upgrade/lts-upgrade-310-314/))
 to prepare for the upgrade and review your options.
 * You have a [DB-less deployment](/gateway/db-less-mode/) or you need to upgrade the data planes (DPs) in a [hybrid mode deployment](/gateway/hybrid-mode/), or {{site.konnect_short_name}} DPs.
 


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes #3367 
Fixes #1330 

This started off as the CE -> EE upgrade guide and snowballed into the gateway upgrade landing page, as I was trying to add more context. It felt more natural to present this as step 1 in a migration journey to Konnect.

* Adds a how-to guide for CE -> EE; we're purposely not adding a lot of detail here as every installation is different, and we can really only provide high-level guidance. For actual upgrade, they should use the upgrade guide (and work with PS).
* Adds a landing page for `/gateway/upgrade/`. This link takes over the old reference page link, which moves to `/gateway/upgrade/reference/`. We don't need a redirect since the original link still exists.

## Preview Links
https://deploy-preview-6672--kongdeveloper.netlify.app/gateway/upgrade/
https://deploy-preview-6672--kongdeveloper.netlify.app/gateway/upgrade/reference/
https://deploy-preview-6672--kongdeveloper.netlify.app/gateway/upgrade/migrate-oss-to-ee/
https://deploy-preview-6672--kongdeveloper.netlify.app/gateway/install/#how-do-i-migrate-from-kong-gateway-open-source-oss-to-kong-gateway-enterprise


