### PR TITLE
docs(forward-proxy): correct https_verify changelog wording

### DIFF
--- a/app/_data/changelogs/gateway.json
+++ b/app/_data/changelogs/gateway.json
@@ -16997,7 +16997,7 @@
         "scope": "Core"
       },
       {
-        "message": "**forward-proxy**: the `https_verify` option to validate the `https_proxy_host`\nserver certificate is now enabled by default.",
+        "message": "**forward-proxy**: `https_verify` is now enabled by default. This option\nverifies the upstream server certificate presented after the plugin\nestablishes a `CONNECT` tunnel through the proxy.",
         "type": "feature",
         "scope": "Plugin"
       },

--- a/app/_kong_plugins/forward-proxy/changelog.json
+++ b/app/_kong_plugins/forward-proxy/changelog.json
@@ -8,7 +8,7 @@
   ],
   "3.14.0.0": [
     {
-      "message": "the `https_verify` option to validate the `https_proxy_host`\nserver certificate is now enabled by default.\n",
+      "message": "`https_verify` is now enabled by default. This option\nverifies the upstream server certificate presented after the plugin\nestablishes a `CONNECT` tunnel through the proxy.\n",
       "type": "feature",
       "scope": "Plugin"
     }


### PR DESCRIPTION
### Summary

The 3.14.0.0 changelog entry for `https_verify` said it validates the `https_proxy_host` server certificate. That's misleading: the connection to the forward proxy is always plain HTTP, so the proxy never presents a certificate to Kong. `https_verify` actually validates the upstream's certificate, seen after the plugin establishes a `CONNECT` tunnel through the proxy.

This mirrors the wording fix in [Kong/kong-ee#20923](https://github.com/Kong/kong-ee/pull/20923).

Note: these two files are normally auto-synced from kong-ee source, so this is a manual stopgap to get the correction live now rather than waiting on the next sync job.

Related to FTI-7808.

🤖 Generated with [Claude Code](https://claude.com/claude-code)