### PR TITLE
fix(docs-improvements): Border opacity on entities prereq

### DIFF
--- a/app/_includes/components/prereqs.html
+++ b/app/_includes/components/prereqs.html
@@ -124,7 +124,7 @@
   {% endif %}
 
   {% if prereqs.entities? %}
-    <div class="flex flex-col gap-1.5 border-b border-primary/5 accordion-item last:border-b-0">
+    <div class="flex flex-col gap-1.5 border-b border-primary accordion-item last:border-b-0">
       {% assign prereq_path = "prereqs/entities/" | append: prereqs.entities_product | append: ".md" %}
       {% include {{ prereq_path }} data=prereqs.data %}
     </div>


### PR DESCRIPTION
When the entities prereq isn't last, it's missing a bottom border before the following prereq:

<img width="964" height="340" alt="Screenshot 2026-08-14 at 9 40 15 AM" src="https://github.com/user-attachments/assets/2168875b-cf58-410f-894f-ef35ed5ef415" />

This is because the opacity was set too low. The fix should make it look like this:
<img width="945" height="336" alt="Screenshot 2026-08-14 at 10 04 32 AM" src="https://github.com/user-attachments/assets/636625d4-ada8-4a95-83db-5d2fccc36142" />

## Preview

Any guide with an entities prereq, eg /metering-and-billing/get-started/

Current: http://developer.konghq.com/metering-and-billing/get-started/
Fixed: https://deploy-preview-6680--kongdeveloper.netlify.app/metering-and-billing/get-started/