### PR TITLE
feat(gateway): How-to guides for routing authenticated clients using datakit

### DIFF
--- a/app/_how-tos/gateway/configure-oidc-datakit-host-routing.md
+++ b/app/_how-tos/gateway/configure-oidc-datakit-host-routing.md
@@ -1,0 +1,260 @@
+---
+title: Dynamically set host based on the authenticated caller with Datakit
+permalink: /how-to/configure-oidc-datakit-host-routing/
+content_type: how_to
+
+related_resources:
+  - text: OpenID Connect plugin
+    url: /plugins/openid-connect/
+  - text: Datakit plugin
+    url: /plugins/datakit/
+  - text: Dynamically set upstream based on the authenticated caller
+    url: /how-to/configure-oidc-datakit-upstream-routing/
+  - text: OpenID Connect tutorials
+    url: /how-to/?query=openid-connect
+
+plugins:
+  - openid-connect
+  - datakit
+
+entities:
+  - route
+  - service
+  - plugin
+
+products:
+  - gateway
+
+works_on:
+  - on-prem
+  - konnect
+
+min_version:
+  gateway: '3.14'
+
+tools:
+  - deck
+
+prereqs:
+  entities:
+    services:
+      - example-service
+    routes:
+      - example-route
+  inline:
+    - title: Set up Keycloak
+      include_content: prereqs/auth/oidc/keycloak-oidc-routing
+      icon_url: /assets/icons/keycloak.svg
+
+tags:
+  - authentication
+  - openid-connect
+  - routing
+search_aliases:
+  - oidc
+  - datakit
+  - target routing
+
+description: Learn how to validate a bearer token with the OpenID Connect plugin, extract a claim as a credential, then use the Datakit plugin to route the request directly to a host and port based on that credential.
+
+tldr:
+  q: How do I route requests to different hosts based on who is making the request, without using Upstream entities?
+  a: |
+    Configure the OpenID Connect plugin with `credential_claim` to extract a token claim (for example, `client_id`) and set it as the authenticated credential.
+    Then, configure the Datakit plugin to read that credential, map its value to a `host:port` string, and write it to `kong.service.target`, overriding the backend directly.
+
+cleanup:
+  inline:
+    - title: Clean up Konnect environment
+      include_content: cleanup/platform/konnect
+      icon_url: /assets/icons/gateway.svg
+    - title: Destroy the {{site.base_gateway}} container
+      include_content: cleanup/products/gateway
+      icon_url: /assets/icons/gateway.svg
+automated_tests: false
+---
+
+Kong's router runs before authentication, so it can't directly route traffic based on who is making a request.
+This guide shows you how to solve that using two plugins working together in the `access` phase:
+
+1. [**OpenID Connect**](/plugins/openid-connect/) validates the bearer token and extracts a claim value (such as `client_id`) onto a virtual credential.
+2. [**Datakit**](/plugins/datakit/) reads that credential and maps its value to a `host:port` string, setting it as the backend target for that specific request.
+
+All callers share one Route and one Service, and the backend is decided dynamically after authentication.
+
+This guide routes directly to a `host:port` backend, which bypasses Upstream entities, load balancing, health checks, and retries.
+Use it when each backend is a fixed address and you don't need a pool.
+If you need load balancing or health checks, use [Upstream entities instead](/how-to/configure-oidc-datakit-upstream-routing/).
+
+{:.info}
+> **Note:** The OpenID Connect plugin has a higher [static priority](/gateway/entities/plugin/#plugin-priority) than Datakit, so it always runs first in the `access` phase.
+> No explicit plugin ordering configuration is required.
+
+## Generate salt token
+
+{% include how-tos/steps/deck-salt-token.md %}
+
+## Enable the OpenID Connect plugin
+
+Configure the OpenID Connect plugin to validate bearer tokens and extract the `client_id` claim as a virtual credential.
+The `credential_claim` field sets `credential.id` to the value of the named claim without requiring a Kong Consumer entity.
+
+{% entity_examples %}
+entities:
+  plugins:
+    - name: openid-connect
+      service: example-service
+      config:
+        issuer: ${issuer}
+        using_pseudo_issuer: true
+        jwks_endpoint: ${jwks-endpoint}
+        client_id:
+          - ${client-id}
+        client_secret:
+          - ${client-secret}
+        client_auth:
+          - client_secret_post
+        auth_methods:
+          - bearer
+        credential_claim:
+          - client_id
+        consumer_optional: true
+        cache_tokens_salt: ${salt-token}
+variables:
+  issuer:
+    value: $ISSUER
+  jwks-endpoint:
+    value: $JWKS_ENDPOINT
+  client-id:
+    value: $CLIENT_ID
+  client-secret:
+    value: $CLIENT_SECRET
+  salt-token:
+    value: $TOKEN_SALT
+{% endentity_examples %}
+
+In this configuration:
+* `issuer`: The issuer URL used to validate the `iss` claim in incoming tokens. This must match the `iss` value Keycloak stamps into its tokens (`localhost:8080`).
+* `using_pseudo_issuer: true`: Disables OIDC discovery from the `issuer` URL. This is required here because {{site.base_gateway}} runs inside Docker and can't reach `localhost:8080` directly. The `issuer` value is still used to validate the `iss` claim in incoming tokens.
+* `jwks_endpoint`: The explicit URL {{site.base_gateway}} uses to fetch Keycloak's signing keys. This uses the `keycloak` container name, which is reachable from {{site.base_gateway}} over the shared Docker network.
+* `auth_methods: bearer`: The plugin only accepts tokens in the `Authorization: Bearer` header.
+* `credential_claim: [client_id]`: Extracts the `client_id` claim from the validated token and places its value on `credential.id`.
+* `consumer_optional: true`: Prevents a `401` when no Consumer entity matches the credential. The plugin still validates the token, but it doesn't require a Consumer to exist.
+
+## Enable the Datakit plugin
+
+Configure the Datakit plugin to read the credential set by the OpenID Connect plugin and map it to a `host:port` backend.
+
+{% entity_examples %}
+entities:
+  plugins:
+    - name: datakit
+      service: example-service
+      config:
+        nodes:
+          - name: GET_CREDENTIAL
+            type: property
+            property: kong.client.credential
+          - name: PICK_TARGET
+            type: jq
+            input: GET_CREDENTIAL
+            jq: |
+              {
+                "caller-a": {"target": "httpbin.konghq.com:80", "scheme": "http"},
+                "caller-b": {"target": "httpbun.com:443", "scheme": "https"}
+              }[.id] // {"target": "httpbin.konghq.com:80", "scheme": "http"}
+          - name: EXTRACT_TARGET
+            type: jq
+            input: PICK_TARGET
+            jq: .target
+          - name: SET_TARGET
+            type: property
+            property: kong.service.target
+            input: EXTRACT_TARGET
+          - name: EXTRACT_SCHEME
+            type: jq
+            input: PICK_TARGET
+            jq: .scheme
+          - name: SET_SCHEME
+            type: property
+            property: kong.service.request.scheme
+            input: EXTRACT_SCHEME
+        debug: true
+{% endentity_examples %}
+
+In this configuration:
+* `GET_CREDENTIAL`: Reads the `kong.client.credential` object that the OpenID Connect plugin populates. No input is connected because this is a read-only (get) operation.
+* `PICK_TARGET`: Uses a jq map to look up the credential's `.id` field and return an object containing both the `host:port` address and the scheme. Returning both values from one node avoids reading the credential twice. Unknown callers fall through to a default backend.
+* `EXTRACT_TARGET`: Extracts the `.target` field from the `PICK_TARGET` output.
+* `SET_TARGET`: Writes the extracted `host:port` string to `kong.service.target`, overriding the backend for this request. This bypasses load balancing, health checks, and retries.
+* `EXTRACT_SCHEME`: Extracts the `.scheme` field from the `PICK_TARGET` output.
+* `SET_SCHEME`: Writes the extracted scheme to `kong.service.request.scheme`. This is required when backends use different protocols, so Kong uses the correct scheme when connecting.
+* `debug: true`: Enables trace output for this tutorial. Remove it before using this configuration in production.
+
+## Validate the routing
+
+To validate that routing via Datakit is working, retrieve access tokens from Keycloak using the client credentials grant, then send them as bearer tokens to verify that each caller is routed to the correct backend.
+
+In the following requests, we're setting the `X-Datakit-Debug-Trace: true` request header so that Datakit returns a JSON trace in the response body showing each node's input and output.
+
+1. Fetch a token as `caller-a`:
+
+   ```sh
+   export TOKEN_A=$(curl -s -X POST http://$KEYCLOAK_HOST:8080/realms/master/protocol/openid-connect/token \
+     -d "client_id=caller-a" \
+     -d "client_secret=$CALLER_A_SECRET" \
+     -d "grant_type=client_credentials" | jq -r .access_token)
+   ```
+
+   Send a request as `caller-a`:
+   ```sh
+   curl -si http://localhost:8000/anything \
+     -H "Authorization: Bearer $TOKEN_A" \
+     -H "X-Datakit-Debug-Trace: true"
+   ```
+
+   The response comes from `httpbin.konghq.com`.
+   In the response body, find the `complete` event for each node and check:
+   * `GET_CREDENTIAL`: `value.value.id` is `caller-a`.
+   * `PICK_TARGET`: `value.value` is `{"target":"httpbin.konghq.com:80","scheme":"http"}`.
+   * `EXTRACT_TARGET`: `value.value` is `httpbin.konghq.com:80`.
+   * `SET_TARGET`: `value.value` is `httpbin.konghq.com:80`.
+   * `EXTRACT_SCHEME`: `value.value` is `http`.
+   * `SET_SCHEME`: `value.value` is `http`.
+
+1. Fetch a token as `caller-b` and send a request:
+
+   ```sh
+   export TOKEN_B=$(curl -s -X POST http://$KEYCLOAK_HOST:8080/realms/master/protocol/openid-connect/token \
+     -d "client_id=caller-b" \
+     -d "client_secret=$CALLER_B_SECRET" \
+     -d "grant_type=client_credentials" | jq -r .access_token)
+   ```
+
+   Send a request as `caller-b`:
+   ```sh
+   curl -si http://localhost:8000/anything \
+     -H "Authorization: Bearer $TOKEN_B" \
+     -H "X-Datakit-Debug-Trace: true"
+   ```
+
+   The response comes from `httpbun.com`, confirming the request was routed to a different backend.
+   `EXTRACT_TARGET` and `SET_TARGET` should show `httpbun.com:443`, and `EXTRACT_SCHEME` and `SET_SCHEME` should show `https`.
+
+1. Fetch a token as the `kong` client to confirm the fallback:
+
+   ```sh
+   export TOKEN_FALLBACK=$(curl -s -X POST http://$KEYCLOAK_HOST:8080/realms/master/protocol/openid-connect/token \
+     -d "client_id=$DECK_CLIENT_ID" \
+     -d "client_secret=$DECK_CLIENT_SECRET" \
+     -d "grant_type=client_credentials" | jq -r .access_token)
+   ```
+
+   Send a request as the fallback client:
+   ```sh
+   curl -si http://localhost:8000/anything \
+     -H "Authorization: Bearer $TOKEN_FALLBACK" \
+     -H "X-Datakit-Debug-Trace: true"
+   ```
+
+   `GET_CREDENTIAL` should show `value.value.id` as `kong`, and `EXTRACT_TARGET` and `SET_TARGET` should resolve to `httpbin.konghq.com:80` because `kong` isn't in the routing map.

--- a/app/_how-tos/gateway/configure-oidc-datakit-upstream-routing.md
+++ b/app/_how-tos/gateway/configure-oidc-datakit-upstream-routing.md
@@ -81,7 +81,7 @@ This guide shows you how to solve that using two plugins working together in the
 1. [**OpenID Connect**](/plugins/openid-connect/) validates the bearer token and extracts a claim value (such as `client_id`) onto a virtual credential.
 2. [**Datakit**](/plugins/datakit/) reads that credential and maps its value to a named Upstream entity, overriding the backend for that specific request.
 
-All callers share one Route and one Service, and the backend is decided dynamically after authentication.
+All callers share one Route and one Service. After authentication, the backend is selected dynamically based on the client's identity.
 
 This guide uses named Upstream entities, which preserves load balancing, health checks, and retries.
 If you don't need those features and prefer to route directly to a `host:port` without a pool, see [Route requests to different targets based on the authenticated caller](/how-to/configure-oidc-datakit-host-routing/).

--- a/app/_how-tos/gateway/configure-oidc-datakit-upstream-routing.md
+++ b/app/_how-tos/gateway/configure-oidc-datakit-upstream-routing.md
@@ -1,0 +1,280 @@
+---
+title: Dynamically set upstream based on the authenticated caller with Datakit
+permalink: /how-to/configure-oidc-datakit-upstream-routing/
+content_type: how_to
+
+related_resources:
+  - text: OpenID Connect plugin
+    url: /plugins/openid-connect/
+  - text: Datakit plugin
+    url: /plugins/datakit/
+  - text: Dynamically set host based on the authenticated caller with Datakit
+    url: /how-to/configure-oidc-datakit-host-routing/
+  - text: OpenID Connect tutorials
+    url: /how-to/?query=openid-connect
+
+plugins:
+  - openid-connect
+  - datakit
+
+entities:
+  - route
+  - service
+  - upstream
+  - plugin
+
+products:
+  - gateway
+
+works_on:
+  - on-prem
+  - konnect
+
+min_version:
+  gateway: '3.14'
+
+tools:
+  - deck
+
+prereqs:
+  entities:
+    services:
+      - example-service
+    routes:
+      - example-route
+  inline:
+    - title: Set up Keycloak
+      include_content: prereqs/auth/oidc/keycloak-oidc-routing
+      icon_url: /assets/icons/keycloak.svg
+
+tags:
+  - authentication
+  - openid-connect
+  - routing
+search_aliases:
+  - oidc
+  - datakit
+  - upstream routing
+
+description: Learn how to validate a bearer token with the OpenID Connect plugin, extract a claim as a credential, then use the Datakit plugin to route the request to a different upstream based on that credential.
+
+tldr:
+  q: How do I route requests to different backends based on who is making the request?
+  a: |
+    Configure the OpenID Connect plugin with `credential_claim` to extract a token claim (for example, `client_id`) and set it as the authenticated credential.
+    Then, configure the Datakit plugin to read that credential, map its value to a named Upstream entity, and override the backend for the request.
+
+cleanup:
+  inline:
+    - title: Clean up Konnect environment
+      include_content: cleanup/platform/konnect
+      icon_url: /assets/icons/gateway.svg
+    - title: Destroy the {{site.base_gateway}} container
+      include_content: cleanup/products/gateway
+      icon_url: /assets/icons/gateway.svg
+automated_tests: false
+---
+
+Kong's router runs before authentication, so it can't directly route traffic based on who is making a request.
+This guide shows you how to solve that using two plugins working together in the `access` phase:
+
+1. [**OpenID Connect**](/plugins/openid-connect/) validates the bearer token and extracts a claim value (such as `client_id`) onto a virtual credential.
+2. [**Datakit**](/plugins/datakit/) reads that credential and maps its value to a named Upstream entity, overriding the backend for that specific request.
+
+All callers share one Route and one Service, and the backend is decided dynamically after authentication.
+
+This guide uses named Upstream entities, which preserves load balancing, health checks, and retries.
+If you don't need those features and prefer to route directly to a `host:port` without a pool, see [Route requests to different targets based on the authenticated caller](/how-to/configure-oidc-datakit-host-routing/).
+
+{:.info}
+> **Note:** The OpenID Connect plugin has a higher [static priority](/gateway/entities/plugin/#plugin-priority) than Datakit, so it always runs first in the `access` phase.
+> No explicit plugin ordering configuration is required.
+
+## Generate salt token
+
+{% include how-tos/steps/deck-salt-token.md %}
+
+## Add upstreams
+
+Create the named Upstream entities that Datakit will route to.
+Each Upstream is a pool of targets, so load balancing, health checks, and retries are preserved when Datakit overrides the backend.
+
+In this example, two callers route to separate upstreams and all other callers fall back to a default upstream.
+
+{:.info}
+> In this example, all three upstreams point at `httpbin.konghq.com` so you can run the guide end to end.
+In production, each upstream would point at a different backend host.
+
+{% entity_examples %}
+entities:
+  upstreams:
+    - name: upstream-a
+      targets:
+        - target: httpbin.konghq.com:80
+    - name: upstream-b
+      targets:
+        - target: httpbin.konghq.com:80
+    - name: upstream-default
+      targets:
+        - target: httpbin.konghq.com:80
+{% endentity_examples %}
+
+Update the `example-service` Service so that its `host` points to `upstream-default`.
+This is the default backend; Datakit overrides it per request based on the authenticated caller.
+
+{% entity_examples %}
+entities:
+  services:
+    - name: example-service
+      host: upstream-default
+      port: 80
+      protocol: http
+{% endentity_examples %}
+
+## Enable the OpenID Connect plugin
+
+Configure the OpenID Connect plugin to validate bearer tokens and extract the `client_id` claim as a virtual credential.
+The `credential_claim` field sets `credential.id` to the value of the named claim without requiring a Kong Consumer entity.
+
+{% entity_examples %}
+entities:
+  plugins:
+    - name: openid-connect
+      service: example-service
+      config:
+        issuer: ${issuer}
+        using_pseudo_issuer: true
+        jwks_endpoint: ${jwks-endpoint}
+        client_id:
+          - ${client-id}
+        client_secret:
+          - ${client-secret}
+        client_auth:
+          - client_secret_post
+        auth_methods:
+          - bearer
+        credential_claim:
+          - client_id
+        consumer_optional: true
+        cache_tokens_salt: ${salt-token}
+variables:
+  issuer:
+    value: $ISSUER
+  jwks-endpoint:
+    value: $JWKS_ENDPOINT
+  client-id:
+    value: $CLIENT_ID
+  client-secret:
+    value: $CLIENT_SECRET
+  salt-token:
+    value: $TOKEN_SALT
+{% endentity_examples %}
+
+In this configuration:
+* `issuer`: The issuer URL used to validate the `iss` claim in incoming tokens. This must match the `iss` value Keycloak stamps into its tokens (`localhost:8080`).
+* `using_pseudo_issuer: true`: Disables OIDC discovery from the `issuer` URL. This is required here because {{site.base_gateway}} runs inside Docker and can't reach `localhost:8080` directly. The `issuer` value is still used to validate the `iss` claim in incoming tokens.
+* `jwks_endpoint`: The explicit URL {{site.base_gateway}} uses to fetch Keycloak's signing keys. This uses the `keycloak` container name, which is reachable from {{site.base_gateway}} over the shared Docker network.
+* `auth_methods: bearer`: The plugin only accepts tokens in the `Authorization: Bearer` header.
+* `credential_claim: [client_id]`: Extracts the `client_id` claim from the validated token and places its value on `credential.id`.
+* `consumer_optional: true`: Prevents a `401` when no Consumer entity matches the credential. The plugin still validates the token, but it doesn't require a Consumer to exist.
+
+## Enable the Datakit plugin
+
+Configure the Datakit plugin to read the credential set by the OpenID Connect plugin and map it to an upstream name.
+
+{% entity_examples %}
+entities:
+  plugins:
+    - name: datakit
+      service: example-service
+      config:
+        nodes:
+          - name: GET_CREDENTIAL
+            type: property
+            property: kong.client.credential
+          - name: PICK_UPSTREAM
+            type: jq
+            input: GET_CREDENTIAL
+            jq: |
+              {
+                "caller-a": "upstream-a",
+                "caller-b": "upstream-b"
+              }[.id] // "upstream-default"
+          - name: SET_UPSTREAM
+            type: property
+            property: kong.service.upstream
+            input: PICK_UPSTREAM
+        debug: true
+{% endentity_examples %}
+
+In this configuration:
+* `GET_CREDENTIAL`: Reads the `kong.client.credential` object that the OpenID Connect plugin populates. No input is connected because this is a read-only (get) operation.
+* `PICK_UPSTREAM`: Uses a jq map to look up the credential's `.id` field and return the matching upstream name. 
+   The keys `caller-a` and `caller-b` match the `client_id` values in the tokens issued by the Keycloak clients you created in the prerequisites. 
+   The `// "upstream-default"` fallback handles any caller whose ID isn't in the map.
+* `SET_UPSTREAM`: Writes the resolved upstream name to `kong.service.upstream`, overriding the backend for this request. 
+* `debug: true`: Enables trace output for this tutorial. Remove it before using this configuration in production.
+
+## Validate the routing
+
+To validate that routing via Datakit is working, retreive access tokens from Keycloak using the client credentials grant, then send them as bearer tokens to verify that each caller is routed to the correct upstream.
+
+All three upstreams point at the same host in this tutorial, so each request returns an HTTP 200 from `httpbin.konghq.com`.
+In the following requests, we're setting the `X-Datakit-Debug-Trace: true` request header so that Datakit returns a JSON trace in the response body showing each node's input and output.
+
+1. Fetch a token as `caller-a` :
+
+   ```sh
+   export TOKEN_A=$(curl -s -X POST http://$KEYCLOAK_HOST:8080/realms/master/protocol/openid-connect/token \
+     -d "client_id=caller-a" \
+     -d "client_secret=$CALLER_A_SECRET" \
+     -d "grant_type=client_credentials" | jq -r .access_token)
+   ```
+  
+   Send a request as `caller-a`:
+   ```sh
+   curl -si http://localhost:8000/anything \
+     -H "Authorization: Bearer $TOKEN_A" \
+     -H "X-Datakit-Debug-Trace: true"
+   ```
+
+   In the response body, find the `complete` event for each node and check:
+   * `GET_CREDENTIAL`: `value.value.id` is `caller-a`.
+   * `PICK_UPSTREAM`: `value.value` is `upstream-a`.
+   * `SET_UPSTREAM`: `value.value` is `upstream-a`.
+
+1. Fetch a token as `caller-b` and send a request:
+
+   ```sh
+   export TOKEN_B=$(curl -s -X POST http://$KEYCLOAK_HOST:8080/realms/master/protocol/openid-connect/token \
+     -d "client_id=caller-b" \
+     -d "client_secret=$CALLER_B_SECRET" \
+     -d "grant_type=client_credentials" | jq -r .access_token)
+   ```
+  
+   Send a request as `caller-b`:
+   ```sh
+   curl -si http://localhost:8000/anything \
+     -H "Authorization: Bearer $TOKEN_B" \
+     -H "X-Datakit-Debug-Trace: true"
+   ```
+
+   `PICK_UPSTREAM` should resolve to `upstream-b`.
+
+1. Fetch a token as the `kong` client to confirm the fallback:
+
+   ```sh
+   export TOKEN_FALLBACK=$(curl -s -X POST http://$KEYCLOAK_HOST:8080/realms/master/protocol/openid-connect/token \
+     -d "client_id=$DECK_CLIENT_ID" \
+     -d "client_secret=$DECK_CLIENT_SECRET" \
+     -d "grant_type=client_credentials" | jq -r .access_token)
+   ```
+   
+   Send a request as the fallback client:
+   ```sh
+   curl -si http://localhost:8000/anything \
+     -H "Authorization: Bearer $TOKEN_FALLBACK" \
+     -H "X-Datakit-Debug-Trace: true"
+   ```
+
+   `GET_CREDENTIAL` should show `value.value.id` as `kong`, and `PICK_UPSTREAM` should be `upstream-default` because `kong` isn't in the routing map.

--- a/app/_how-tos/gateway/configure-oidc-datakit-upstream-routing.md
+++ b/app/_how-tos/gateway/configure-oidc-datakit-upstream-routing.md
@@ -217,7 +217,7 @@ In this configuration:
 
 ## Validate the routing
 
-To validate that routing via Datakit is working, retreive access tokens from Keycloak using the client credentials grant, then send them as bearer tokens to verify that each caller is routed to the correct upstream.
+To validate that routing via Datakit is working, retrieve access tokens from Keycloak using the client credentials grant, then send them as bearer tokens to verify that each caller is routed to the correct upstream.
 
 All three upstreams point at the same host in this tutorial, so each request returns an HTTP 200 from `httpbin.konghq.com`.
 In the following requests, we're setting the `X-Datakit-Debug-Trace: true` request header so that Datakit returns a JSON trace in the response body showing each node's input and output.

--- a/app/_includes/prereqs/auth/oidc/keycloak-oidc-routing.md
+++ b/app/_includes/prereqs/auth/oidc/keycloak-oidc-routing.md
@@ -1,0 +1,145 @@
+This tutorial requires an identity provider (IdP). If you don't have one, you can use [Keycloak](http://www.keycloak.org/).
+The steps will be similar in other standard identity providers.
+
+For this tutorial, you need three clients: one for the OpenID Connect plugin to use when validating tokens, and two representing the API callers that will be routed to different backends.
+
+#### Install and run Keycloak
+
+1. Install [Keycloak](https://www.keycloak.org/guides) (version 26 or later) on your platform.
+
+   For example, you can use the Keycloak Docker image. The following command attaches Keycloak to the same network as {{site.base_gateway}} so that the OIDC plugin can reach it:
+
+   ```sh
+   docker run -p 127.0.0.1:8080:8080 \
+     --name keycloak \
+     --network kong-quickstart-net \
+     -e KC_BOOTSTRAP_ADMIN_USERNAME=admin \
+     -e KC_BOOTSTRAP_ADMIN_PASSWORD=admin \
+     -e KC_HOSTNAME=http://localhost:8080 \
+     quay.io/keycloak/keycloak start-dev
+   ```
+
+   The `KC_HOSTNAME=http://localhost:8080` parameter ensures Keycloak always uses `localhost:8080` as its token issuer regardless of which URL it's accessed through.
+   This is required because {{site.base_gateway}} runs inside Docker and accesses Keycloak via the container name `keycloak:8080`, but the `iss` claim in issued tokens must use `localhost:8080` for the plugin to recognize them.
+
+1. Export your issuer URL, JWKS endpoint, and Keycloak host to environment variables.
+   For example, using Docker and the default `master` realm:
+
+   ```sh
+   export DECK_ISSUER='http://localhost:8080/realms/master'
+   export DECK_JWKS_ENDPOINT='http://keycloak:8080/realms/master/protocol/openid-connect/certs'
+   export KEYCLOAK_HOST='localhost'
+   ```
+
+   Because we're using Docker for this demo, we must configure a few networking parameters:
+   * `DECK_ISSUER` and `KEYCLOAK_HOST` use `localhost` because that's how you access Keycloak from your machine.
+   * `DECK_JWKS_ENDPOINT` uses the container name `keycloak` because {{site.base_gateway}} runs inside Docker and reaches Keycloak over the shared `kong-quickstart-net` network.
+
+   In your own setup, especially running outside of a container, you may not need `DECK_JWKS_ENDPOINT`.
+
+1. Open the admin console.
+
+   The default URL is `http://localhost:8080/admin/master/console/`.
+
+#### Create the plugin client
+
+This client is used by the OpenID Connect plugin to connect to Keycloak for token validation.
+
+1. In the sidebar, open **Clients**, then click **Create client**.
+1. Configure the client:
+
+<!--vale off-->
+{% table %}
+columns:
+  - title: Section
+    key: section
+  - title: Settings
+    key: settings
+rows:
+  - section: "**General settings**"
+    settings: |
+      * Client type: **OpenID Connect**
+      * Client ID: `kong`
+  - section: "**Capability config**"
+    settings: |
+      * Toggle **Client authentication** to **on**
+      * Make sure **Service accounts roles** is checked
+{% endtable %}
+<!--vale on-->
+
+1. Open the **Credentials** tab.
+1. Set **Client Authenticator** to **Client ID and Secret**.
+1. Copy the **Client Secret** and export it along with the client ID:
+
+   ```sh
+   export DECK_CLIENT_ID='kong'
+   export DECK_CLIENT_SECRET='YOUR-KONG-CLIENT-SECRET'
+   ```
+
+#### Create the caller clients
+
+These clients represent the API callers. Each one authenticates to Keycloak with the client credentials grant. The `client_id` claim in each token is what Datakit uses to select the upstream.
+
+Create the first caller client:
+
+1. In the sidebar, open **Clients**, then click **Create client**.
+1. Configure the client:
+
+<!--vale off-->
+{% table %}
+columns:
+  - title: Section
+    key: section
+  - title: Settings
+    key: settings
+rows:
+  - section: "**General settings**"
+    settings: |
+      * Client type: **OpenID Connect**
+      * Client ID: `caller-a`
+  - section: "**Capability config**"
+    settings: |
+      * Toggle **Client authentication** to **on**
+      * Make sure **Service accounts roles** is checked
+{% endtable %}
+<!--vale on-->
+
+1. Open the **Credentials** tab.
+1. Set **Client Authenticator** to **Client ID and Secret**.
+1. Copy the **Client Secret** and export it:
+
+   ```sh
+   export CALLER_A_SECRET='YOUR-CALLER-A-SECRET'
+   ```
+
+Create the second caller client:
+
+1. In the sidebar, open **Clients**, then click **Create client**.
+1. Configure the client:
+
+<!--vale off-->
+{% table %}
+columns:
+  - title: Section
+    key: section
+  - title: Settings
+    key: settings
+rows:
+  - section: "**General settings**"
+    settings: |
+      * Client type: **OpenID Connect**
+      * Client ID: `caller-b`
+  - section: "**Capability config**"
+    settings: |
+      * Toggle **Client authentication** to **on**
+      * Make sure **Service accounts roles** is checked
+{% endtable %}
+<!--vale on-->
+
+1. Open the **Credentials** tab.
+1. Set **Client Authenticator** to **Client ID and Secret**.
+1. Copy the **Client Secret** and export it:
+
+   ```sh
+   export CALLER_B_SECRET='YOUR-CALLER-B-SECRET'
+   ```

--- a/app/_includes/prereqs/auth/oidc/keycloak-oidc-routing.md
+++ b/app/_includes/prereqs/auth/oidc/keycloak-oidc-routing.md
@@ -7,7 +7,7 @@ For this tutorial, you need three clients: one for the OpenID Connect plugin to 
 
 1. Install [Keycloak](https://www.keycloak.org/guides) (version 26 or later) on your platform.
 
-   For example, you can use the Keycloak Docker image. The following command attaches Keycloak to the same network as {{site.base_gateway}} so that the OIDC plugin can reach it:
+   For example, you can use the Keycloak Docker image. The following command attaches Keycloak to the same network as {{site.base_gateway}} so that the OIDC plugin can reach it. Open a new session in your terminal and run:
 
    ```sh
    docker run -p 127.0.0.1:8080:8080 \
@@ -37,9 +37,7 @@ For this tutorial, you need three clients: one for the OpenID Connect plugin to 
 
    In your own setup, especially running outside of a container, you may not need `DECK_JWKS_ENDPOINT`.
 
-1. Open the admin console.
-
-   The default URL is `http://localhost:8080/admin/master/console/`.
+1. Open the admin console at default URL `http://localhost:8080/admin/master/console/` and sign in with your username (`admin`) and password (`admin`).
 
 #### Create the plugin client
 

--- a/app/_kong_plugins/datakit/examples/route-host-by-credential.yaml
+++ b/app/_kong_plugins/datakit/examples/route-host-by-credential.yaml
@@ -1,0 +1,76 @@
+title: Route requests to different targets based on the authenticated caller
+description: |
+  Map an authenticated credential to a host:port target and override the backend per request, bypassing load balancing.
+
+extended_description: |
+  Map an authenticated credential to a host:port target and override the backend per request, bypassing load balancing.
+  This example works together with the OpenID Connect plugin, which validates a bearer token and extracts a token claim (such as `client_id`) as a virtual credential.
+  Datakit then reads that credential and uses its value to select a `host:port` target.
+
+  Unlike routing to a named Upstream entity, writing to `kong.service.target` bypasses load balancing, health checks, and retries.
+  Use this approach for stable single-host backends where you don't need a pool.
+
+  This example contains the following nodes:
+  1. `GET_CREDENTIAL` reads the `kong.client.credential` object that the OpenID Connect plugin populated.
+  1. `PICK_TARGET` uses a jq map to look up the credential's `.id` field and return an object containing both the `host:port` address and the scheme. Unknown callers fall through to a default backend.
+  1. `EXTRACT_TARGET` extracts the `.target` field from the `PICK_TARGET` output.
+  1. `SET_TARGET` writes the extracted `host:port` string to `kong.service.target`, overriding the backend for this request.
+  1. `EXTRACT_SCHEME` extracts the `.scheme` field from the `PICK_TARGET` output.
+  1. `SET_SCHEME` writes the extracted scheme to `kong.service.request.scheme`, ensuring Kong uses the correct protocol when connecting.
+
+  For a complete tutorial, see [Route requests to different targets based on the authenticated caller](/how-to/configure-oidc-datakit-host-routing/).
+
+  {:.info}
+  > **Note:** The OpenID Connect plugin has a higher static priority than Datakit, so it always runs first in the `access` phase. No explicit plugin ordering configuration is required.
+
+weight: 894
+
+requirements:
+  - "You have configured the [OpenID Connect plugin](/plugins/openid-connect/) with `credential_claim` pointing to a token claim (such as `client_id`) and `consumer_optional: true`."
+
+config:
+  nodes:
+    - name: GET_CREDENTIAL
+      type: property
+      property: kong.client.credential
+
+    - name: PICK_TARGET
+      type: jq
+      input: GET_CREDENTIAL
+      jq: |
+        {
+          "caller-a": {"target": "backend-a.example:443", "scheme": "https"},
+          "caller-b": {"target": "backend-b.example:443", "scheme": "https"}
+        }[.id] // {"target": "default.example:443", "scheme": "https"}
+
+    - name: EXTRACT_TARGET
+      type: jq
+      input: PICK_TARGET
+      jq: .target
+
+    - name: SET_TARGET
+      type: property
+      property: kong.service.target
+      input: EXTRACT_TARGET
+
+    - name: EXTRACT_SCHEME
+      type: jq
+      input: PICK_TARGET
+      jq: .scheme
+
+    - name: SET_SCHEME
+      type: property
+      property: kong.service.request.scheme
+      input: EXTRACT_SCHEME
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform
+
+min_version:
+  gateway: '3.14'
+
+group: authentication

--- a/app/_kong_plugins/datakit/examples/route-upstream-by-credential.yaml
+++ b/app/_kong_plugins/datakit/examples/route-upstream-by-credential.yaml
@@ -1,0 +1,56 @@
+title: Route requests to different upstreams based on the authenticated caller
+description: |
+  Map an authenticated credential to a named Upstream entity and override the backend per request.
+
+extended_description: |
+  Map an authenticated credential to a named Upstream entity and override the backend per request.
+  This example works together with the OpenID Connect plugin, which validates a bearer token and extracts a token claim (such as `client_id`) as a virtual credential.
+  Datakit then reads that credential and uses its value to select an upstream.
+
+  This example contains the following nodes:
+  1. `GET_CREDENTIAL` reads the `kong.client.credential` object that the OpenID Connect plugin populated.
+  1. `PICK_UPSTREAM` uses a jq map to look up the credential's `.id` field and return the matching upstream name. Unknown callers fall through to `upstream-default`.
+  1. `SET_UPSTREAM` writes the resolved upstream name to `kong.service.upstream`, overriding the backend for this request.
+
+  For a complete tutorial, see [Route requests to different upstreams based on the authenticated caller](/how-to/configure-oidc-datakit-upstream-routing/).
+
+  {:.info}
+  > **Note:** The OpenID Connect plugin has a higher static priority than Datakit, so it always runs first in the `access` phase. No explicit plugin ordering configuration is required.
+
+weight: 895
+
+requirements:
+  - "You have configured the [OpenID Connect plugin](/plugins/openid-connect/) with `credential_claim` pointing to a token claim (such as `client_id`) and `consumer_optional: true`."
+  - "You have created named [Upstream](/gateway/entities/upstream/) entities for each caller and a fallback upstream."
+
+config:
+  nodes:
+    - name: GET_CREDENTIAL
+      type: property
+      property: kong.client.credential
+
+    - name: PICK_UPSTREAM
+      type: jq
+      input: GET_CREDENTIAL
+      jq: |
+        {
+          "caller-a": "upstream-a",
+          "caller-b": "upstream-b"
+        }[.id] // "upstream-default"
+
+    - name: SET_UPSTREAM
+      type: property
+      property: kong.service.upstream
+      input: PICK_UPSTREAM
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform
+
+min_version:
+  gateway: '3.14'
+
+group: authentication

--- a/app/_kong_plugins/datakit/index.md
+++ b/app/_kong_plugins/datakit/index.md
@@ -95,7 +95,11 @@ rows:
   - usecase: "[Authenticate Consumers using multiple JWT sources](/plugins/datakit/examples/authenticate-consumer-from-multiple-jwts/)"
     description: Authenticate a Consumer by verifying a JWT from one of two possible sources, each backed by a different JWKS.
   - usecase: "[Sign JWT with Consumer ID](/plugins/datakit/examples/sign-consumer-jwt/)"
-    description: Sign an outgoing JWT in a request header using the authenticated Consumer’s ID as the subject. 
+    description: Sign an outgoing JWT in a request header using the authenticated Consumer’s ID as the subject.
+  - usecase: "[Route requests to different upstreams based on the authenticated caller](/plugins/datakit/examples/route-upstream-by-credential/)"
+    description: Read a credential set by the OpenID Connect plugin and map its value to a named Upstream entity, routing different callers to different backends on a single Route.
+  - usecase: "[Route requests to different hosts based on the authenticated caller](/plugins/datakit/examples/route-host-by-credential/)"
+    description: Read a credential set by the OpenID Connect plugin and map its value directly to a `host:port` backend, bypassing Upstream entities and load balancing. Use this when each backend is a fixed address and you don't need health checks or retries.
 {% endtable %}
 <!--vale on-->
 
@@ -1384,6 +1388,10 @@ rows:
     type: "`object` with at least one of `id`, `username`, or `custom_id`"
 {% endtable %}
 <!--vale on-->
+
+For examples that read `kong.client.credential` and route different callers to different backends, see:
+* [Dynamically set upstream based on the authenticated caller](/how-to/configure-oidc-datakit-upstream-routing/) (using named Upstream entities)
+* [Dynamically set host based on the authenticated caller](/how-to/configure-oidc-datakit-host-routing/) (using direct `host:port` targets)
 
 The following properties support `get` and `set` operations:
 

--- a/app/_kong_plugins/openid-connect/index.md
+++ b/app/_kong_plugins/openid-connect/index.md
@@ -277,6 +277,8 @@ forwards the credentials passed by the client to the identity server's token end
 Set up client credentials grant auth:
 * [Plugin configuration example](/plugins/openid-connect/examples/client-credentials/)
 * [Client credentials grant tutorial with Keycloak](/how-to/configure-oidc-with-client-credentials/)
+* [Dynamically set upstream based on the authenticated caller with Datakit](/how-to/configure-oidc-datakit-upstream-routing/)
+* [Dynamically set host based on the authenticated caller with Datakit](/how-to/configure-oidc-datakit-host-routing/)
 
 #### Authorization code flow
 


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes #5548 

Two how-to guides (and parallel plugin examples) that use Datakit with OpenID Connect to route the client based on their auth token, either to a specific Upstream (which provides load balancing and health checking), or directly to a mapped host.

This doesn't use Kong Identity as Kong Identity isn't supported for Datakit _yet_. 
## Preview Links

/how-to/configure-oidc-datakit-host-routing/
/how-to/configure-oidc-datakit-upstream-routing/
/plugins/datakit/
/plugins/datakit/examples/route-upstream-by-credential/
/plugins/datakit/examples/route-host-by-credential/

