### PR TITLE
feat(gateway): Distroless in Gateway 3.12

### DIFF
--- a/app/_data/products/gateway.yml
+++ b/app/_data/products/gateway.yml
@@ -1179,6 +1179,14 @@ releases:
           docker_support:
             arm: true
           default: true
+      - distroless:
+          package: false
+          docker: true
+          docker_support:
+            arm: true
+            fips: false
+            graviton: true
+          default: true
       - rhel8:
           package: true
           package_support:

--- a/app/_how-tos/gateway/install-gateway-distroless.md
+++ b/app/_how-tos/gateway/install-gateway-distroless.md
@@ -23,7 +23,7 @@ works_on:
   - on-prem
   - konnect
 min_version:
-  gateway: '3.13'
+  gateway: '3.12'
 
 tldr:
   q: How do I run {{site.base_gateway}} using the distroless image?


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Mark distroless image as supported in 3.12 (came out in latest patch).

## Preview Links

https://deploy-preview-6700--kongdeveloper.netlify.app/gateway/version-support-policy/ - 3.12 tab