### PR TITLE
Fix: mcp conversion 2 0 series

### DIFF
--- a/app/_how-tos/ai-gateway/map-api-to-mcp-tools.md
+++ b/app/_how-tos/ai-gateway/map-api-to-mcp-tools.md
@@ -7,10 +7,10 @@ related_resources:
   - text: AI MCP Server entity
     url: /ai-gateway/entities/ai-mcp-server/
 
-description: Learn how to create an MCP Server entity in {{site.ai_gateway}} to convert any RESTful API into MCP tools, including setting up a mock Node.js server for testing.
+description: Learn how to create an MCP Server entity in {{site.ai_gateway}} to convert any RESTful API into MCP tools.
+
 products:
   - ai-gateway
-
 
 series:
   id: mcp-conversion-2-0
@@ -44,68 +44,33 @@ prereqs:
   konnect:
     - name: KONG_TRACING_INSTRUMENTATIONS
     - name: KONG_TRACING_SAMPLING_RATE
-  inline:
-    - title: OpenAI API key
-      content: |
-        This tutorial uses OpenAI:
-
-        1. [Create an OpenAI account](https://auth.openai.com/create-account).
-        1. [Get an API key](https://platform.openai.com/api-keys).
-      icon_url: /assets/icons/openai.svg
-    - title: ChatWise desktop application
-      content: |
-        Download and install [ChatWise](https://chatwise.app/) for your OS.
-
-        After installation:
-        1. Launch the app.
-        1. Navigate to the app's settings.
-        1. Click **Providers** in the sidebar.
-        1. In the Providers sidebar, click **OpenAI**.
-        1. In the **API Key** field, enter your OpenAI API key.
-
-cleanup:
-  inline:
-    - title: Clean up {{site.ai_gateway}} resources
-      include_content: cleanup/products/ai-gateway
-
 ---
-## Install mock API Server
 
-Before creating an [MCP Server](/ai-gateway/entities/ai-mcp-server/) entity, you’ll need an upstream HTTP API to expose. For this tutorial, we’ll use a simple mock API built with Express. This allows you to test the entity without relying on an external service. This mock API simulates a small marketplace system with a fixed set of users and their associated orders. Each user has between two and five sample orders, which the API exposes through `/marketplace/users` and `/marketplace/{userId}/orders` endpoints.
+## Run a sample API to expose
 
-Running these commands will download the mock API script and install any required dependencies automatically:
-
-```sh
-curl -s -o api.js "https://gist.githubusercontent.com/subnetmarco/5ddb23876f9ce7165df17f9216f75cce/raw/a44a947d69e6f597465050cc595b6abf4db2fbea/api.js"
-npm install express
-node api.js
-```
-
-Validate the API is running:
+Before creating an [MCP Server](/ai-gateway/entities/ai-mcp-server/) entity, you’ll need an upstream HTTP API to expose. For this tutorial, use the [Swagger Petstore](https://github.com/swagger-api/swagger-petstore) sample API running in Docker. This allows you to test the entity without relying on an external service. The Petstore API comes preloaded with 10 pets across the `available`, `pending`, and `sold` statuses, which the API exposes through the `/pet/findByStatus` and `/pet/{petId}` endpoints.
 
 ```sh
-curl -X GET http://localhost:3000
+docker run -d \
+  --name swagger-petstore \
+  -p 8080:8080 \
+  swaggerapi/petstore3:latest
 ```
+{:data-test-step="block"}
 
-This request confirms that the mock server is up and responding. Later, the MCP Server entity will convert this API's endpoints into MCP tool definitions. You should see the following response from the server:
-
-```text
-{"name":"Sample Users API"}%
-```
-{:.no-copy-code}
+The MCP Server entity will convert this API's endpoints into MCP tool definitions.
 
 ## Create an MCP Server entity
 
-With the mock API server running, create an [MCP Server](/ai-gateway/entities/ai-mcp-server/) entity configured as a `conversion-listener` to expose its endpoints as MCP tools.
-The following example maps the mock API operations to MCP tool definitions that the client can invoke.
+With the Petstore API running, create an [MCP Server](/ai-gateway/entities/ai-mcp-server/) entity configured as a `conversion-listener` to expose the endpoints `/pet/findByStatus` and `/pet/{petId}` as MCP tools.
+The following example maps the Petstore API operations to MCP tool definitions that the client can invoke.
 
-```sh
-kongctl apply -f - --auto-approve --pat "$KONNECT_TOKEN" <<EOF
+{% entity_examples %}
 ai_gateway_mcp_servers:
-  - ref: marketplace-mcp
+  - ref: petstore-mcp
     ai_gateway: !lookup {id: $AI_GATEWAY_ID}
-    name: marketplace-mcp
-    display_name: "Marketplace API"
+    name: petstore-mcp
+    display_name: "Petstore API"
     type: conversion-listener
     enabled: true
     policies: []
@@ -116,112 +81,137 @@ ai_gateway_mcp_servers:
       default_tool_acls:
         deny: []
     config:
-      url: http://host.docker.internal:3000
+      url: http://host.docker.internal:8080/api/v3
       route:
         paths:
-          - /marketplace
+          - /petstore
       logging:
         payloads: false
-        statistics: true
       server:
         timeout: 60000
     tools:
-      - name: get-users
-        description: Get users
+      - name: get-pets-by-status
+        description: Find pets by status
         method: GET
-        path: /marketplace/users
+        path: /petstore/pet/findByStatus
         parameters:
-          - name: id
+          - name: status
             in: query
-            required: false
-            schema:
-              type: string
-            description: Optional user ID
-      - name: get-orders-for-user
-        description: Get orders for a user
-        method: GET
-        path: /marketplace/orders
-        parameters:
-          - description: User ID to filter orders
-            in: query
-            name: userid
             required: true
             schema:
               type: string
-EOF
-```
+              enum:
+                - available
+                - pending
+                - sold
+            description: Status value to filter pets by
+      - name: get-pet-by-id
+        description: Get a pet by ID
+        method: GET
+        path: /petstore/pet/{petId}
+        parameters:
+          - description: ID of the pet to retrieve
+            in: path
+            name: petId
+            required: true
+            schema:
+              type: integer
+{% endentity_examples %}
 
-1. In the ChatWise app, navigate to settings.
-1. Click **MCP** in the sidebar.
-1. Click the **+** button.
-1. Select "HTTP Server (http)".
-1. In the **Name** field, enter `marketplace-mcp`.
-1. In the **URL** field, enter `http://localhost:8000/marketplace`.
-1. Click **Verify (View Tools)** to confirm the connection. You should see the following tools listed:
-   - `get-users`
-   - `get-orders-for-user`
-1. Close the settings window.
+Two details of this configuration are worth calling out:
+
+- **Route stripping**: `route.paths` (`/petstore`) is the prefix clients must hit for the {{site.ai_gateway}} to match this entity, so every tool's `path` includes it. Before forwarding upstream, the gateway strips that prefix and appends what's left (for example, `/pet/findByStatus`) to `config.url`.
+- **Parameters**: {{site.ai_gateway}} builds each tool's input schema from its `parameters` list, prefixing every parameter name with its `in` location: `path_<name>` for path parameters, `query_<name>` for query parameters.
+
+## Verify that the endpoints are avaiable as tools
+
+Use [MCP Inspector CLI](https://modelcontextprotocol.io/docs/tools/inspector#cli) to verify that the MCP server exposes `get-pet-by-id` and `get-pets-by-status` as tools:
+
+<!--vale off-->
+{% validation custom-command %}
+command: |
+  npx -y @modelcontextprotocol/inspector@0.22.0 --cli \
+    http://localhost:8000/petstore \
+    --transport http --method tools/list |  jq -r '.tools[].name'
+expected:
+  return_code: 0
+render_output: false
+message: |
+  get-pet-by-id
+  get-pets-by-status
+{% endvalidation %}
+<!--vale on-->
+
+You should see the following output:
+
+```text
+get-pet-by-id
+get-pets-by-status
+```
+{:.no-copy-code}
 
 ## Validate the configuration
 
-1. In ChatWise, start a new chat.
-1. Click the overflow (**...**) menu next to the chat input, then click the **hammer icon** to enable MCP tools. The icon turns blue when enabled.
-1. From the hammer dropdown menu, enable your MCP server.
-1. Enter the following in the ChatWise chat:
+Let's call the `get-pets-by-status` tool to see which pets are available:
+
+<!--vale off-->
+{% validation custom-command %}
+command: |
+  npx -y @modelcontextprotocol/inspector@0.22.0 --cli \
+    http://localhost:8000/petstore \
+    --transport http --method tools/call \
+    --tool-name get-pets-by-status \
+    --tool-arg query_status=available | jq -r '.content[0].text' | jq -c '.[]'
+expected:
+  return_code: 0
+render_output: false
+message: |
+  {"id":1,"category":{"id":2,"name":"Cats"},"name":"Cat 1","photoUrls":["url1","url2"],"tags":[{"id":1,"name":"tag1"},{"id":2,"name":"tag2"}],"status":"available"}
+  {"id":2,"category":{"id":2,"name":"Cats"},"name":"Cat 2","photoUrls":["url1","url2"],"tags":[{"id":1,"name":"tag2"},{"id":2,"name":"tag3"}],"status":"available"}
+  {"id":4,"category":{"id":1,"name":"Dogs"},"name":"Dog 1","photoUrls":["url1","url2"],"tags":[{"id":1,"name":"tag1"},{"id":2,"name":"tag2"}],"status":"available"}
+  {"id":7,"category":{"id":4,"name":"Lions"},"name":"Lion 1","photoUrls":["url1","url2"],"tags":[{"id":1,"name":"tag1"},{"id":2,"name":"tag2"}],"status":"available"}
+  {"id":8,"category":{"id":4,"name":"Lions"},"name":"Lion 2","photoUrls":["url1","url2"],"tags":[{"id":1,"name":"tag2"},{"id":2,"name":"tag3"}],"status":"available"}
+  {"id":9,"category":{"id":4,"name":"Lions"},"name":"Lion 3","photoUrls":["url1","url2"],"tags":[{"id":1,"name":"tag3"},{"id":2,"name":"tag4"}],"status":"available"}
+  {"id":10,"category":{"id":3,"name":"Rabbits"},"name":"Rabbit 1","photoUrls":["url1","url2"],"tags":[{"id":1,"name":"tag3"},{"id":2,"name":"tag4"}],"status":"available"}
+{% endvalidation %}
+<!--vale on-->
+
+You should see the following output:
 
 ```text
-What users do you see in the marketplace API?
-```
-
-ChatWise prompts you to approve the `get-users` tool call before it runs. Approve it:
-
-```
-I'll query the marketplace service for the list of users
-> Called get-users
+{"id":1,"category":{"id":2,"name":"Cats"},"name":"Cat 1","photoUrls":["url1","url2"],"tags":[{"id":1,"name":"tag1"},{"id":2,"name":"tag2"}],"status":"available"}
+{"id":2,"category":{"id":2,"name":"Cats"},"name":"Cat 2","photoUrls":["url1","url2"],"tags":[{"id":1,"name":"tag2"},{"id":2,"name":"tag3"}],"status":"available"}
+{"id":4,"category":{"id":1,"name":"Dogs"},"name":"Dog 1","photoUrls":["url1","url2"],"tags":[{"id":1,"name":"tag1"},{"id":2,"name":"tag2"}],"status":"available"}
+{"id":7,"category":{"id":4,"name":"Lions"},"name":"Lion 1","photoUrls":["url1","url2"],"tags":[{"id":1,"name":"tag1"},{"id":2,"name":"tag2"}],"status":"available"}
+{"id":8,"category":{"id":4,"name":"Lions"},"name":"Lion 2","photoUrls":["url1","url2"],"tags":[{"id":1,"name":"tag2"},{"id":2,"name":"tag3"}],"status":"available"}
+{"id":9,"category":{"id":4,"name":"Lions"},"name":"Lion 3","photoUrls":["url1","url2"],"tags":[{"id":1,"name":"tag3"},{"id":2,"name":"tag4"}],"status":"available"}
+{"id":10,"category":{"id":3,"name":"Rabbits"},"name":"Rabbit 1","photoUrls":["url1","url2"],"tags":[{"id":1,"name":"tag3"},{"id":2,"name":"tag4"}],"status":"available"}
 ```
 {:.no-copy-code}
 
-When the agent finishes reasoning, you should see the following output:
+Now, we can check the details of `Lion 1` - `id:7` - by calling the `get-pet-by-id` tool:
+
+<!--vale off-->
+{% validation custom-command %}
+command: |
+  npx -y @modelcontextprotocol/inspector@0.22.0 --cli \
+    http://localhost:8000/petstore \
+    --transport http --method tools/call \
+    --tool-name get-pet-by-id \
+    --tool-arg path_petId=7 | jq -r '.content[0].text' | jq -c '.'
+expected:
+  return_code: 0
+message: |
+  {"id":7,"category":{"id":4,"name":"Lions"},"name":"Lion 1","photoUrls":["url1","url2"],"tags":[{"id":1,"name":"tag1"},{"id":2,"name":"tag2"}],"status":"available"}
+render_output: false
+{% endvalidation %}
+<!--vale on-->
+
+You should see the following response:
 
 ```text
-Let me check what users are available in the API:
-I can see 10 users in the API:
-1. Alice Johnson (ID: a1b2c3d4)
-2. Bob Smith (ID: e5f6g7h8)
-3. Charlie Lee (ID: i9j0k1l2)
-4. Diana Evans (ID: m3n4o5p6)
-5. Ethan Brown (ID: q7r8s9t0)
-6. Fiona Clark (ID: u1v2w3x4)
-7. George Harris (ID: y5z6a7b8)
-8. Hannah Lewis (ID: c9d0e1f2)
-9. Ian Walker (ID: g3h4i5j6)
-10. Julia Turner (ID: k7l8m9n0)
+{"id":7,"category":{"id":4,"name":"Lions"},"name":"Lion 1","photoUrls":["url1","url2"],"tags":[{"id":1,"name":"tag1"},{"id":2,"name":"tag2"}],"status":"available"}
 ```
 {:.no-copy-code}
 
-Now, we can check what Alice Johnson ordered by entering the following message in the ChatWise chat:
-
-```text
-What has Alice Johnson ordered?
-```
-
-ChatWise calls two tools exposed by the MCP Server entity in sequence: `get-users` to find Alice's ID, then `get-orders-for-user` to fetch her orders. Approve each tool call when prompted:
-
-```text
-I'll look up the list of users to find Alice's user ID. Then I'll fetch her orders.
-
-> called get-users
-> called get-orders-for-user
-```
-{:.no-copy-code}
-
-When the agent finishes reasoning, you should see the following response:
-
-```text
-Sugar (50kg)
-Cleaning Supplies Pack
-Canned Tomatoes (100 cans)
-```
-{:.no-copy-code}
-
-You can validate this result against the [API exposed in the previous step](https://gist.githubusercontent.com/subnetmarco/5ddb23876f9ce7165df17f9216f75cce/raw/a44a947d69e6f597465050cc595b6abf4db2fbea/api.js).
+You can validate this result against the [Swagger Petstore API source](https://github.com/swagger-api/swagger-petstore).

--- a/app/_how-tos/ai-gateway/map-api-to-mcp-tools.md
+++ b/app/_how-tos/ai-gateway/map-api-to-mcp-tools.md
@@ -48,7 +48,7 @@ prereqs:
 
 ## Run a sample API to expose
 
-Before creating an [MCP Server](/ai-gateway/entities/ai-mcp-server/) entity, you’ll need an upstream HTTP API to expose. For this tutorial, use the [Swagger Petstore](https://github.com/swagger-api/swagger-petstore) sample API running in Docker. This allows you to test the entity without relying on an external service. The Petstore API comes preloaded with 10 pets across the `available`, `pending`, and `sold` statuses, which the API exposes through the `/pet/findByStatus` and `/pet/{petId}` endpoints.
+Before creating an [MCP Server](/ai-gateway/entities/ai-mcp-server/) entity, you’ll need an upstream HTTP API to expose. For this tutorial, use the [Swagger Petstore](https://github.com/swagger-api/swagger-petstore) sample API running in Docker. This allows you to test the entity without relying on an external service. The Petstore API comes pre-loaded with 10 pets across the `available`, `pending`, and `sold` statuses, which the API exposes through the `/pet/findByStatus` and `/pet/{petId}` endpoints.
 
 ```sh
 docker run -d \
@@ -123,7 +123,7 @@ Two details of this configuration are worth calling out:
 - **Route stripping**: `route.paths` (`/petstore`) is the prefix clients must hit for the {{site.ai_gateway}} to match this entity, so every tool's `path` includes it. Before forwarding upstream, the gateway strips that prefix and appends what's left (for example, `/pet/findByStatus`) to `config.url`.
 - **Parameters**: {{site.ai_gateway}} builds each tool's input schema from its `parameters` list, prefixing every parameter name with its `in` location: `path_<name>` for path parameters, `query_<name>` for query parameters.
 
-## Verify that the endpoints are avaiable as tools
+## Verify that the endpoints are available as tools
 
 Use [MCP Inspector CLI](https://modelcontextprotocol.io/docs/tools/inspector#cli) to verify that the MCP server exposes `get-pet-by-id` and `get-pets-by-status` as tools:
 

--- a/app/_how-tos/ai-gateway/monitor-mcp-traffic-with-otel.md
+++ b/app/_how-tos/ai-gateway/monitor-mcp-traffic-with-otel.md
@@ -63,18 +63,26 @@ cleanup:
         docker rm -f otel-collector
         ```
         {: data-test-cleanup="block" }
+      icon_url: /assets/icons/opentelemetry.svg
+    - title: Stop Petstore API
+      content: |
+        ```sh
+        docker rm -f swagger-petstore
+        ```
+        {: data-test-cleanup="block" }
+      icon_url: '/assets/icons/code.svg'
     - title: Clean up {{site.ai_gateway}} resources
       include_content: cleanup/products/ai-gateway
-
+      icon_url: '/assets/icons/ai-gateway.svg'
 ---
+
 ## Attach an OpenTelemetry Policy to the MCP Server entity
 
-By default, an AI Policy applies to every resource on your {{site.ai_gateway}}. Setting `global` to `false` changes that: the `otel-mcp` Policy now only takes effect on entities that explicitly list it, instead of applying to all entities.
+By default, an AI Policy applies to every resource on your {{site.ai_gateway}}. Setting `global` to `false` changes that: the `otel-mcp` Policy  only takes effect on entities that explicitly list it, instead of applying to all entities.
 
-The `marketplace-mcp` entity does this by referencing `otel-mcp` in its `policies` list. As a result, every request that goes through `marketplace-mcp` is measured and exported as metrics to the collector you started earlier. The `service.name` value under `resource_attributes` is a label attached to that exported data, so if you're running multiple {{site.ai_gateway}}s or services into the same collector, you can tell which one a given metric came from.
+The `petstore-mcp` entity does this by referencing `otel-mcp` in its `policies` list. As a result, every request that goes through `petstore-mcp` is measured and exported as metrics to the collector you started earlier. The `service.name` value under `resource_attributes` is a label attached to that exported data, so if you're running multiple {{site.ai_gateway}}s or services into the same collector, you can tell which one a given metric came from.
 
-```sh
-kongctl apply -f - --auto-approve --pat "$KONNECT_TOKEN" <<EOF
+{% entity_examples %}
 ai_gateway_policies:
   - ref: otel-mcp
     ai_gateway: !lookup {id: $AI_GATEWAY_ID}
@@ -92,10 +100,10 @@ ai_gateway_policies:
         service.name: kong-mcp
 
 ai_gateway_mcp_servers:
-  - ref: marketplace-mcp
+  - ref: petstore-mcp
     ai_gateway: !lookup {id: $AI_GATEWAY_ID}
-    name: marketplace-mcp
-    display_name: "Marketplace API"
+    name: petstore-mcp
+    display_name: "Petstore API"
     type: conversion-listener
     enabled: true
     policies:
@@ -107,72 +115,81 @@ ai_gateway_mcp_servers:
       default_tool_acls:
         deny: []
     config:
-      url: http://host.docker.internal:3000
+      url: http://host.docker.internal:8080/api/v3
       route:
         paths:
-          - /marketplace
+          - /petstore
       logging:
-        payloads: true
-        statistics: true
+        payloads: false
       server:
         timeout: 60000
     tools:
-      - name: get-users
-        description: Get users
+      - name: get-pets-by-status
+        description: Find pets by status
         method: GET
-        path: /marketplace/users
+        path: /petstore/pet/findByStatus
         parameters:
-          - name: id
+          - name: status
             in: query
-            required: false
-            schema:
-              type: string
-            description: Optional user ID
-      - name: get-orders-for-user
-        description: Get orders for a user
-        method: GET
-        path: /marketplace/orders
-        parameters:
-          - description: User ID to filter orders
-            in: query
-            name: userid
             required: true
             schema:
               type: string
-EOF
-```
-{:.collapsible}
+              enum:
+                - available
+                - pending
+                - sold
+            description: Status value to filter pets by
+      - name: get-pet-by-id
+        description: Get a pet by ID
+        method: GET
+        path: /petstore/pet/{petId}
+        parameters:
+          - description: ID of the pet to retrieve
+            in: path
+            name: petId
+            required: true
+            schema:
+              type: integer
+{% endentity_examples %}
 
 ## Generate MCP traffic
 
-Using the `marketplace-mcp` connection you already set up in ChatWise:
+Now, we can check the details of `Dog 1` - `id:4` - by calling the `get-pet-by-id` tool:
 
-1. Start a new chat.
-1. Click the **hammer icon** to enable MCP tools, and enable `marketplace-mcp` from the dropdown.
-1. Enter the following in the ChatWise chat:
+<!--vale off-->
+{% validation custom-command %}
+command: |
+  npx -y @modelcontextprotocol/inspector@0.22.0 --cli \
+    http://localhost:8000/petstore \
+    --transport http --method tools/call \
+    --tool-name get-pet-by-id \
+    --tool-arg path_petId=4 | jq -r '.content[0].text' | jq -c '.'
+expected:
+  return_code: 0
+message: |
+  {"id":4,"category":{"id":1,"name":"Dogs"},"name":"Dog 1","photoUrls":["url1","url2"],"tags":[{"id":1,"name":"tag1"},{"id":2,"name":"tag2"}],"status":"available"}
+render_output: false
+{% endvalidation %}
+<!--vale on-->
 
-   ```text
-   What did Fiona Clark order?
-   ```
+You should see the following response:
 
-  When the agent finishes reasoning, you should see a response like the following:
-
-  ```text
-  Fiona Clark ordered the following items:
-
-  Laundry Detergent (10L)
-  Trash Bags (100 ct)
-  Disinfectant Spray (5 bottles)
-  ```
-  {:.no-copy-code}
+```text
+{"id":4,"category":{"id":1,"name":"Dogs"},"name":"Dog 1","photoUrls":["url1","url2"],"tags":[{"id":1,"name":"tag1"},{"id":2,"name":"tag2"}],"status":"available"}
+```
+{:.no-copy-code}
 
 ## Validate metrics
 
 Check the collector's logs for `kong.gen_ai.mcp` to find the emitted metrics:
 
-```sh
-docker logs otel-collector 2>&1 | grep -A 15 kong.gen_ai.mcp
-```
+{% validation custom-command %}
+command: |
+  docker logs otel-collector 2>&1 | grep -A 15 kong.gen_ai.mcp
+expected:
+  return_code: 0
+render_output: false
+{% endvalidation %}
 
 You should see data like the following:
 
@@ -187,10 +204,10 @@ Descriptor:
 HistogramDataPoints #0
 Data point attributes:
      -> kong.workspace.name: Str(default)
-     -> kong.route.name: Str(marketplace-mcp-route)
+     -> kong.route.name: Str(petstore-mcp-route)
      -> mcp.method.name: Str(tools/call)
-     -> gen_ai.tool.name: Str(get-orders-for-user)
-     -> kong.service.name: Str(marketplace-mcp)
+     -> gen_ai.tool.name: Str(get-pet-by-id)
+     -> kong.service.name: Str(petstore-mcp)
 Count: 1
 Sum: 2175.000000
 
@@ -205,10 +222,10 @@ HistogramDataPoints #3
 Data point attributes:
      -> gen_ai.operation.name: Str(execute_tool)
      -> kong.workspace.name: Str(default)
-     -> kong.route.name: Str(marketplace-mcp-route)
+     -> kong.route.name: Str(petstore-mcp-route)
      -> mcp.method.name: Str(tools/call)
-     -> gen_ai.tool.name: Str(get-orders-for-user)
-     -> kong.service.name: Str(marketplace-mcp)
+     -> gen_ai.tool.name: Str(get-pet-by-id)
+     -> kong.service.name: Str(petstore-mcp)
 Count: 1
 Sum: 0.037000
 ```

--- a/app/_how-tos/ai-gateway/monitor-mcp-traffic-with-otel.md
+++ b/app/_how-tos/ai-gateway/monitor-mcp-traffic-with-otel.md
@@ -183,6 +183,10 @@ You should see the following response:
 
 Check the collector's logs for `kong.gen_ai.mcp` to find the emitted metrics:
 
+{:.info}
+> Allow a few seconds for the collector to export metrics after traffic generation.
+
+
 {% validation custom-command %}
 command: |
   docker logs otel-collector 2>&1 | grep -A 15 kong.gen_ai.mcp

--- a/tools/automated-tests/instructions/validations.js
+++ b/tools/automated-tests/instructions/validations.js
@@ -273,7 +273,9 @@ async function executeRequest(
           shouldRetry = true;
         } else {
           await setEnvVariable(container, header.variable, extractedValue);
-          console.log(`extracted value: ${extractedValue}`);
+          if (config.debug) {
+            console.log(`extracted value: ${extractedValue}`);
+          }
         }
       }
     }


### PR DESCRIPTION
## Description

Simplify mcp conversion 2 0 series, and adapt it so we can test it as part of our suite

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
