### PR TITLE
feat(ai-gateway): Migrate Kafka Consume

### DIFF
--- a/app/_ai_gateway_policies/kafka-consume/index.md
+++ b/app/_ai_gateway_policies/kafka-consume/index.md
@@ -21,7 +21,10 @@ related_resources:
 This Policy consumes messages from [Apache Kafka](https://kafka.apache.org/) topics and makes them available through HTTP endpoints.
 For more information, see [Kafka topics](https://kafka.apache.org/documentation/#intro_concepts_and_terms).
 
-{% include md/ai-gateway/v2/policies/kafka/consume-limitations.md %}
+{:.info}
+> This Policy has the following known limitations:
+> * Message compression is not supported.
+> * The message format is not customizable.
 
 {{site.ai_gateway}} also provides Kafka Policies for publishing messages:
 * [Kafka Log](/ai-gateway/policies/kafka-log/reference/)

--- a/app/_ai_gateway_policies/kafka-consume/index.md
+++ b/app/_ai_gateway_policies/kafka-consume/index.md
@@ -69,7 +69,7 @@ In `http-get` mode, send a `GET` request to the path with no query parameters. T
 
 Each entry in `records` carries the message `value`, `key`, `timestamp`, and `offset`. When [`config.message_deserializer`](./reference/#schema--config-message-deserializer) is `json`, `value` is a parsed object. When it's `noop`, `value` is the raw message as a string.
 
-Which records a request returns depends on [`config.auto_offset_reset`](./reference/#schema--config-auto-offset-reset): `latest` (default) returns only messages produced after the Policy started consuming, and `earliest` returns messages from the beginning of the topic.
+Which records a request returns depends on [`config.auto_offset_reset`](./reference/#schema--config-auto-offset-reset). When it's set to `latest` (default), it returns only messages produced after the Policy started consuming. `earliest` returns messages from the beginning of the topic.
 
 {:.info}
 > Responses aren't immediate. A request can take several seconds to return, even when records are already available on the topic.

--- a/app/_ai_gateway_policies/kafka-consume/index.md
+++ b/app/_ai_gateway_policies/kafka-consume/index.md
@@ -1,9 +1,124 @@
 ---
+description: 'Consume messages from Kafka topics and make them available through HTTP endpoints.'
 min_version:
   ai-gateway: '2.0'
 works_on:
   - konnect
 products:
   - ai-gateway
-content_type: plugin
+content_type: policy
+related_resources:
+  - text: AI Policy entity
+    url: /ai-gateway/entities/ai-policy/
+  - text: Kafka Log Policy
+    url: /ai-gateway/policies/kafka-log/reference/
+  - text: Kafka Upstream Policy
+    url: /ai-gateway/policies/kafka-upstream/reference/
+  - text: Confluent Consume Policy
+    url: /ai-gateway/policies/confluent-consume/reference/
 ---
+
+This Policy consumes messages from [Apache Kafka](https://kafka.apache.org/) topics and makes them available through HTTP endpoints.
+For more information, see [Kafka topics](https://kafka.apache.org/documentation/#intro_concepts_and_terms).
+
+{% include md/ai-gateway/v2/policies/kafka/consume-limitations.md %}
+
+{{site.ai_gateway}} also provides Kafka Policies for publishing messages:
+* [Kafka Log](/ai-gateway/policies/kafka-log/reference/)
+* [Kafka Upstream](/ai-gateway/policies/kafka-upstream/reference/)
+
+## Implementation details
+
+The Policy supports the following modes of operation, set with [`config.mode`](./reference/#schema--config-mode):
+* `http-get`: Consume messages via HTTP GET requests (default)
+* `server-sent-events`: Stream messages using [server-sent events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events)
+* `websocket`: Stream messages over a [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) connection
+
+### WebSocket mode
+
+{% include md/ai-gateway/v2/policies/kafka/websocket.md broker='Kafka' name='Kafka Consume' %}
+
+## Consume messages
+
+The Policy serves messages on the Route of the entity it's attached to. Reference it from the `policies` array on an [AI Model](/ai-gateway/entities/ai-model/), [AI Agent](/ai-gateway/entities/ai-agent/), or [AI MCP Server](/ai-gateway/entities/ai-mcp-server/) that defines `config.route`, then send requests to that path. A global Kafka Consume Policy runs on every {{site.ai_gateway}} Route, so requests only reach it where a Route already exists.
+
+In `http-get` mode, send a `GET` request to the path with no query parameters. The Policy returns the records available for every topic in [`config.topics`](./reference/#schema--config-topics), keyed by topic name and then by partition:
+
+```json
+{
+  "ai-events": {
+    "partitions": {
+      "0": {
+        "high_watermark": 1,
+        "last_stable_offset": 1,
+        "errcode": 0,
+        "records": [
+          {
+            "value": {"event": "prompt_received", "model": "gpt-4o"},
+            "key": "",
+            "timestamp": 1787305085262,
+            "offset": 0
+          }
+        ],
+        "aborted_transactions": {}
+      }
+    }
+  }
+}
+```
+
+Each entry in `records` carries the message `value`, `key`, `timestamp`, and `offset`. When [`config.message_deserializer`](./reference/#schema--config-message-deserializer) is `json`, `value` is a parsed object. When it's `noop`, `value` is the raw message as a string.
+
+Which records a request returns depends on [`config.auto_offset_reset`](./reference/#schema--config-auto-offset-reset): `latest` (default) returns only messages produced after the Policy started consuming, and `earliest` returns messages from the beginning of the topic.
+
+{:.info}
+> Responses aren't immediate. A request can take several seconds to return, even when records are already available on the topic.
+
+## Message delivery guarantees
+
+{% include md/ai-gateway/v2/policies/kafka/message-delivery.md %}
+
+## Schema registry support
+
+{% include_cached md/ai-gateway/v2/policies/kafka/schema-registry.md name='Kafka Consume' workflow='consumer' %}
+
+## Filter and transform messages
+
+You can use the [`config.message_by_lua_functions`](./reference/#schema--config-message-by-lua-functions) parameter to specify custom Lua code that will filter or transform Kafka messages.
+
+## Authentication
+
+{% include_cached md/ai-gateway/v2/policies/kafka/auth.md name='Kafka Consume' %}
+
+## Example
+
+The following example creates a Kafka Consume Policy that reads from two topics over HTTP GET, authenticating to the brokers with SASL/PLAIN. Reference it from the `policies` array on an entity that defines `config.route` to make it reachable, as described in [Consume messages](#consume-messages):
+
+{% entity_example %}
+type: policy
+data:
+  display_name: Kafka Consume
+  name: kafka-consume
+  type: kafka-consume
+  enabled: true
+  global: false
+  config:
+    bootstrap_servers:
+      - host: broker.internal
+        port: 9092
+    topics:
+      - name: ai-events
+      - name: ai-audit
+    mode: http-get
+    message_deserializer: json
+    auto_offset_reset: latest
+    authentication:
+      strategy: sasl
+      mechanism: PLAIN
+      user: kafka-user
+      password: kafka-password
+    security:
+      ssl: true
+formats:
+  - kongctl
+{% endentity_example %}

--- a/app/_ai_gateway_policies/kafka-log/index.md
+++ b/app/_ai_gateway_policies/kafka-log/index.md
@@ -1,9 +1,71 @@
 ---
+description: 'Publish logs to a Kafka topic.'
 min_version:
   ai-gateway: '2.0'
 works_on:
   - konnect
 products:
   - ai-gateway
-content_type: plugin
+content_type: policy
+related_resources:
+  - text: AI Policy entity
+    url: /ai-gateway/entities/ai-policy/
+  - text: Kafka Consume Policy
+    url: /ai-gateway/policies/kafka-consume/
+  - text: HTTP Log Policy
+    url: /ai-gateway/policies/http-log/
 ---
+
+Publish request and response logs to an [Apache Kafka](https://kafka.apache.org/) topic.
+For more information, see [Kafka topics](https://kafka.apache.org/documentation/#intro_concepts_and_terms).
+
+{{site.ai_gateway}} also provides a Kafka Policy for request transformations. See [Kafka Upstream](/ai-gateway/policies/kafka-upstream/reference/).
+
+This Policy uses the [lua-resty-kafka](https://github.com/kong/lua-resty-kafka) client.
+
+{:.info}
+> This Policy does not support message compression.
+
+## Log format
+
+{% include md/ai-gateway/v2/policies/log-format.md %}
+
+## Custom fields by Lua
+
+Use [`config.custom_fields_by_lua`](./reference/#schema--config-custom-fields-by-lua) to dynamically modify log fields with Lua code. The field accepts a map of log field names to Lua expressions. Set a field to `nil` to remove it from the log entry.
+
+## Schema registry support
+
+{% include_cached md/ai-gateway/v2/policies/kafka/schema-registry.md name='Kafka Log' workflow='producer' %}
+
+## Authentication
+
+{% include_cached md/ai-gateway/v2/policies/kafka/auth.md name='Kafka Log' %}
+
+## Example
+
+The following example creates a global Kafka Log Policy that publishes logs for all {{site.ai_gateway}} traffic to the `kong-log` topic, authenticating to the brokers with SASL/PLAIN:
+
+{% entity_example %}
+type: policy
+data:
+  display_name: Kafka Log
+  name: kafka-log
+  type: kafka-log
+  enabled: true
+  global: true
+  config:
+    bootstrap_servers:
+      - host: broker.internal
+        port: 9092
+    topic: kong-log
+    authentication:
+      strategy: sasl
+      mechanism: PLAIN
+      user: kafka-user
+      password: kafka-password
+    security:
+      ssl: true
+formats:
+  - kongctl
+{% endentity_example %}

--- a/app/_ai_gateway_policies/kafka-upstream/index.md
+++ b/app/_ai_gateway_policies/kafka-upstream/index.md
@@ -1,9 +1,81 @@
 ---
+description: 'Transform requests into Kafka messages in a Kafka topic.'
 min_version:
   ai-gateway: '2.0'
 works_on:
   - konnect
 products:
   - ai-gateway
-content_type: plugin
+content_type: policy
+related_resources:
+  - text: AI Policy entity
+    url: /ai-gateway/entities/ai-policy/
+  - text: Kafka Log Policy
+    url: /ai-gateway/policies/kafka-log/reference/
+  - text: Kafka Consume Policy
+    url: /ai-gateway/policies/kafka-consume/
 ---
+
+This Policy converts requests into [Apache Kafka](https://kafka.apache.org/) messages and publishes them to a specified Kafka topic.
+For more details, see [Kafka topics](https://kafka.apache.org/documentation/#intro_concepts_and_terms).
+
+{{site.ai_gateway}} also offers a separate [Kafka Log](/ai-gateway/policies/kafka-log/reference/) Policy for streaming logs to Kafka topics.
+
+{:.info}
+> This Policy does not support message compression.
+
+## Implementation details
+
+This Policy uses the [lua-resty-kafka](https://github.com/kong/lua-resty-kafka) client.
+
+Control which parts of the request are included in the message with [`config.forward_body`](./reference/#schema--config-forward-body) (enabled by default), [`config.forward_headers`](./reference/#schema--config-forward-headers), [`config.forward_method`](./reference/#schema--config-forward-method), and [`config.forward_uri`](./reference/#schema--config-forward-uri).
+
+When encoding request bodies, several things happen:
+
+* For requests with a content-type header of `application/x-www-form-urlencoded`, `multipart/form-data`,
+  or `application/json`, this Policy passes the raw request body in the `body` attribute, and tries
+  to return a parsed version of those arguments in `body_args`.
+  If this parsing fails, the Policy returns an error message and the message isn't sent.
+* If the `content-type` is not `text/plain`, `text/html`, `application/xml`, `text/xml`, or `application/soap+xml`,
+  then the body will be base64-encoded to ensure that the message can be sent as JSON. In that case,
+  the message has an extra attribute called `body_base64` set to `true`.
+
+## Schema registry support
+
+{% include_cached md/ai-gateway/v2/policies/kafka/schema-registry.md name='Kafka Upstream' workflow='producer' %}
+
+## Authentication
+
+{% include_cached md/ai-gateway/v2/policies/kafka/auth.md name='Kafka Upstream' %}
+
+## Example
+
+The following example creates a global Kafka Upstream Policy that publishes each request to the `kong-upstream` topic, authenticating to the brokers with SASL/PLAIN:
+
+{% entity_example %}
+type: policy
+data:
+  display_name: Kafka Upstream
+  name: kafka-upstream
+  type: kafka-upstream
+  enabled: true
+  global: true
+  config:
+    bootstrap_servers:
+      - host: broker.internal
+        port: 9092
+    topic: kong-upstream
+    forward_body: true
+    forward_headers: true
+    forward_method: true
+    forward_uri: true
+    authentication:
+      strategy: sasl
+      mechanism: PLAIN
+      user: kafka-user
+      password: kafka-password
+    security:
+      ssl: true
+formats:
+  - kongctl
+{% endentity_example %}

--- a/app/_includes/md/ai-gateway/v2/policies/kafka/auth.md
+++ b/app/_includes/md/ai-gateway/v2/policies/kafka/auth.md
@@ -1,0 +1,27 @@
+The {{ include.name }} Policy supports the following SASL authentication mechanisms for broker connections through [`config.authentication.mechanism`](./reference/#schema--config-authentication-mechanism):
+
+{% table %}
+columns:
+  - title: "Mechanism"
+    key: mechanism
+  - title: Description
+    key: description
+rows:
+  - mechanism: "`PLAIN`"
+    description: |
+      Authenticates using a username and password.
+      <br><br>
+      Set `authentication.strategy` to `sasl` and provide `authentication.user` and `authentication.password`.
+  - mechanism: "`SCRAM-SHA-256`"
+    description: |
+      Authenticates using a username and password with SCRAM-SHA-256 hashing.
+      <br><br>
+      Set `authentication.strategy` to `sasl` and provide `authentication.user` and `authentication.password`.
+  - mechanism: "`SCRAM-SHA-512`"
+    description: |
+      Authenticates using a username and password with SCRAM-SHA-512 hashing.
+      <br><br>
+      Set `authentication.strategy` to `sasl` and provide `authentication.user` and `authentication.password`.
+{% endtable %}
+
+Configure TLS for broker connections with [`config.security`](./reference/#schema--config-security).

--- a/app/_includes/md/ai-gateway/v2/policies/kafka/consume-limitations.md
+++ b/app/_includes/md/ai-gateway/v2/policies/kafka/consume-limitations.md
@@ -1,0 +1,4 @@
+{:.info}
+> **Note**: This Policy has the following known limitations:
+> * Message compression is not supported.
+> * The message format is not customizable.

--- a/app/_includes/md/ai-gateway/v2/policies/kafka/consume-limitations.md
+++ b/app/_includes/md/ai-gateway/v2/policies/kafka/consume-limitations.md
@@ -1,4 +1,0 @@
-{:.info}
-> **Note**: This Policy has the following known limitations:
-> * Message compression is not supported.
-> * The message format is not customizable.

--- a/app/_includes/md/ai-gateway/v2/policies/kafka/message-delivery.md
+++ b/app/_includes/md/ai-gateway/v2/policies/kafka/message-delivery.md
@@ -3,4 +3,4 @@ When running multiple data plane nodes, there is no thread-safe behavior between
 To minimize duplicate message delivery in a multi-node setup, consider:
 * Using a single data plane node for consuming messages from specific topics
 * Implementing idempotency handling in your consuming application
-* Monitoring consumer group offsets across your data plane nodes
+* Monitoring Consumer Group offsets across your data plane nodes

--- a/app/_includes/md/ai-gateway/v2/policies/kafka/message-delivery.md
+++ b/app/_includes/md/ai-gateway/v2/policies/kafka/message-delivery.md
@@ -1,0 +1,6 @@
+When running multiple data plane nodes, there is no thread-safe behavior between nodes. In high-load scenarios, you may observe the same message being delivered multiple times across different data plane nodes.
+
+To minimize duplicate message delivery in a multi-node setup, consider:
+* Using a single data plane node for consuming messages from specific topics
+* Implementing idempotency handling in your consuming application
+* Monitoring consumer group offsets across your data plane nodes

--- a/app/_includes/md/ai-gateway/v2/policies/kafka/schema-registry.md
+++ b/app/_includes/md/ai-gateway/v2/policies/kafka/schema-registry.md
@@ -1,0 +1,86 @@
+The {{ include.name }} Policy supports integration with Confluent Schema Registry for AVRO and JSON schemas.
+
+Schema registries provide a centralized repository for managing and validating schemas for data formats like AVRO and JSON.
+Integrating with a schema registry allows the Policy to validate and serialize/deserialize messages in a standardized format.
+
+Using a schema registry with {{site.ai_gateway}} provides several benefits:
+
+* **Data validation**: Ensures messages conform to a predefined schema before being processed.
+* **Schema evolution**: Manages schema changes and versioning.
+* **Interoperability**: Enables seamless communication between different services using standardized data formats.
+* **Reduced overhead**: Minimizes the need for custom validation logic in your applications.
+
+To learn more about Kong's supported schema registry, see:
+
+* [Confluent Schema Registry Documentation](https://docs.confluent.io/platform/current/schema-registry/index.html)
+* [AVRO Specification](https://avro.apache.org/docs/++version++/specification/)
+
+### How schema registry validation works
+
+{% if include.workflow == 'producer' %}
+
+When a producer Policy is configured with a schema registry, the following workflow occurs:
+
+<!--vale off-->
+{% mermaid %}
+sequenceDiagram
+autonumber
+    participant Client
+    participant Kong as {{ include.name }} Policy
+    participant Registry as Schema Registry
+    participant Kafka
+
+    activate Client
+    activate Kong
+    Client->>Kong: Send request
+    deactivate Client
+    activate Registry
+    Kong->>Registry: Fetch schema from registry
+    Registry-->>Kong: Return schema
+    deactivate Registry
+    Kong->>Kong: Validate message against schema
+    Kong->>Kong: Serialize using schema
+    activate Kafka
+    Kong->>Kafka: Forward to Kafka
+    deactivate Kong
+    deactivate Kafka
+{% endmermaid %}
+<!--vale on-->
+
+If validation fails, the request is rejected with an error message.
+
+{% elsif include.workflow == 'consumer' %}
+
+When a consumer Policy is configured with a schema registry, the following workflow occurs:
+
+<!--vale off-->
+{% mermaid %}
+sequenceDiagram
+autonumber
+    participant Kafka
+    participant Kong as {{ include.name }} Policy
+    participant Registry as Schema Registry
+    participant Client
+
+    activate Kafka
+    activate Kong
+    Kafka->>Kong: Send message
+    deactivate Kafka
+    Kong->>Kong: Extract schema ID
+    activate Registry
+    Kong->>Registry: Fetch schema from registry
+    Registry-->>Kong: Return schema
+    deactivate Registry
+    Kong->>Kong: Deserialize using schema
+    activate Client
+    Kong->>Client: Return response to client
+    deactivate Kong
+    deactivate Client
+{% endmermaid %}
+<!--vale on-->
+
+{% endif %}
+
+### Configure schema registry
+
+To configure Schema Registry with the {{ include.name }} Policy, use the [`config.schema_registry`](./reference/#schema--config-schema-registry) parameter for a Policy-wide registry, or [`config.topics[].schema_registry`](./reference/#schema--config-topics) to override it for an individual topic.

--- a/app/_includes/md/ai-gateway/v2/policies/kafka/schema-registry.md
+++ b/app/_includes/md/ai-gateway/v2/policies/kafka/schema-registry.md
@@ -1,4 +1,4 @@
-The {{ include.name }} Policy supports integration with Confluent Schema Registry for AVRO and JSON schemas.
+You can integrate the {{ include.name }} Policy with Confluent Schema Registry for AVRO and JSON schemas.
 
 Schema registries provide a centralized repository for managing and validating schemas for data formats like AVRO and JSON.
 Integrating with a schema registry allows the Policy to validate and serialize/deserialize messages in a standardized format.
@@ -51,7 +51,7 @@ If validation fails, the request is rejected with an error message.
 
 {% elsif include.workflow == 'consumer' %}
 
-When a consumer Policy is configured with a schema registry, the following workflow occurs:
+When a consume policy is configured with a schema registry, the following workflow occurs:
 
 <!--vale off-->
 {% mermaid %}

--- a/app/_includes/md/ai-gateway/v2/policies/kafka/websocket.md
+++ b/app/_includes/md/ai-gateway/v2/policies/kafka/websocket.md
@@ -1,0 +1,37 @@
+In `websocket` mode, the Policy maintains a bi-directional WebSocket connection with the client,
+allowing for continuous delivery of {{ include.broker }} messages to the client.
+
+Here's how it works:
+1. Establish a WebSocket connection to the endpoint where the {{ include.name }} Policy is enabled and mode is set to `websocket`.
+1. {{site.ai_gateway}} continuously streams messages as JSON text frames.
+1. Optionally, client sends acknowledgments (`client-acks`) for each message or batch to enable `at-least-once` delivery semantics.
+
+This approach provides real-time message flow without the limitations of HTTP polling.
+
+{% mermaid %}
+sequenceDiagram
+    participant Client
+    participant Kong as {{site.ai_gateway}}
+    participant Broker as Message Broker
+
+    Client->>Kong: Establish WebSocket connection
+    Kong->>Broker: Connect to broker
+
+    loop Continuous message delivery
+        Broker->>Kong: Broker message
+        Kong->>Client: Stream JSON text frame
+
+        opt If client-acks
+            Client->>Kong: Acknowledge message/batch
+        end
+    end
+
+{% endmermaid %}
+
+> _Figure 1: The diagram shows the bi-directional WebSocket flow where the {{ include.name }} Policy is running in `websocket` mode, and messages are streamed as JSON text frames._
+
+This mode provides parity with HTTP-based consumption, including support for:
+* Message keys
+* Topic filtering
+* {{ include.broker }} authentication and TLS
+* Auto or manual offset commits

--- a/app/_includes/md/ai-gateway/v2/policies/kafka/websocket.md
+++ b/app/_includes/md/ai-gateway/v2/policies/kafka/websocket.md
@@ -2,9 +2,9 @@ In `websocket` mode, the Policy maintains a bi-directional WebSocket connection 
 allowing for continuous delivery of {{ include.broker }} messages to the client.
 
 Here's how it works:
-1. Establish a WebSocket connection to the endpoint where the {{ include.name }} Policy is enabled and mode is set to `websocket`.
+1. The client establishes a WebSocket connection to the endpoint where the {{ include.name }} Policy is enabled with the mode set to `websocket`.
 1. {{site.ai_gateway}} continuously streams messages as JSON text frames.
-1. Optionally, client sends acknowledgments (`client-acks`) for each message or batch to enable `at-least-once` delivery semantics.
+1. Optionally, the client sends acknowledgments (`client-acks`) for each message or batch to enable `at-least-once` delivery semantics.
 
 This approach provides real-time message flow without the limitations of HTTP polling.
 


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes #6378 

## Testing instructions

There's a significant amount of setup needed to test this, here are the instructions: [kafka-consume-testing.md](https://github.com/user-attachments/files/31373986/kafka-consume-testing.md)

The policy config in this is slightly different from the one in the example to simplify the setup.

## Preview Links

https://deploy-preview-6769--kongdeveloper.netlify.app/ai-gateway/policies/kafka-consume/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
