### PR TITLE
fix: update examples for deck on prep ai gateway support for runtime 2.0.2

### DIFF
--- a/app/ai-gateway/configure-on-prem.md
+++ b/app/ai-gateway/configure-on-prem.md
@@ -227,7 +227,7 @@ models:
           - /ai
         model:
           body_param: model
-          values: ["@openai/gpt-5.2"]
+          values: ["gpt-5.2"]
     targets:
       - name: gpt-5.2
         provider: openai-prod
@@ -256,8 +256,7 @@ _info:
   select_tags:
   - 'managed_by:deck-ai'
 ai_models:
-- alias: '@openai/gpt-5.2'
-  name: gpt-5-2
+- name: gpt-5-2
 plugins:
 - config:
     body_path: model
@@ -279,7 +278,7 @@ plugins:
          log_payloads: false
          log_statistics: true
       model:
-        model_alias: '@openai/gpt-5.2'
+        model_alias: 'gpt-5.2'
         name: gpt-5.2
         options:
           max_tokens: 1024
@@ -360,6 +359,7 @@ services:
     - /demo-mcp
     plugins:
     - config:
+        acl_attribute_type: consumer
         include_consumer_groups: true
         logging:
           log_audits: false
@@ -457,7 +457,7 @@ models:
           - /ai
         model:
           body_param: model
-          values: ["@openai/gpt-5.2"]
+          values: ["gpt-5.2"]
     policies:
       - ai-gw-prompt-guard
     targets:
@@ -493,7 +493,7 @@ Converting it generates the same Service, Route, `ai-model-selector`, and `ai-pr
 - config:
     deny_patterns:
     - .*(W|w)ar.*
-  model: gpt-5-2
+  model: gpt-5.2
   name: ai-prompt-guard
   route: openai-chat
 ```


### PR DESCRIPTION
## Description
Updating the config examples for `deck ai` commands.

This mostly includes removing `model.alias` and aligning it with `name`.

Verified by running the `deck ai` commands against the examples in deck.

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
