### PR TITLE
feat(ai-gateway): Migrate Kafka Upstream

### DIFF
--- a/app/_ai_gateway_policies/kafka-upstream/index.md
+++ b/app/_ai_gateway_policies/kafka-upstream/index.md
@@ -1,9 +1,82 @@
 ---
+description: 'Transform requests into Kafka messages in a Kafka topic.'
 min_version:
   ai-gateway: '2.0'
 works_on:
   - konnect
 products:
   - ai-gateway
-content_type: plugin
+content_type: policy
+related_resources:
+  - text: AI Policy entity
+    url: /ai-gateway/entities/ai-policy/
+  - text: Kafka Log Policy
+    url: /ai-gateway/policies/kafka-log/reference/
+  - text: Kafka Consume Policy
+    url: /ai-gateway/policies/kafka-consume/
 ---
+
+This Policy converts requests into [Apache Kafka](https://kafka.apache.org/) messages and publishes them to a specified Kafka topic.
+For more details, see [Kafka topics](https://kafka.apache.org/documentation/#intro_concepts_and_terms).
+
+{{site.ai_gateway}} also offers a separate [Kafka Log](/ai-gateway/policies/kafka-log/reference/) Policy for streaming logs to Kafka topics.
+
+## Implementation details
+
+This Policy uses the [lua-resty-kafka](https://github.com/kong/lua-resty-kafka) client.
+
+Control which parts of the request are included in the message with [`config.forward_body`](./reference/#schema--config-forward-body) (enabled by default), [`config.forward_headers`](./reference/#schema--config-forward-headers), [`config.forward_method`](./reference/#schema--config-forward-method), and [`config.forward_uri`](./reference/#schema--config-forward-uri).
+
+When encoding request bodies, several things happen:
+
+* For requests with a content-type header of `application/x-www-form-urlencoded`, `multipart/form-data`,
+  or `application/json`, this Policy passes the raw request body in the `body` attribute, and tries
+  to return a parsed version of those arguments in `body_args`. If this parsing fails, an error message is
+  returned and the message is not sent.
+* If the `content-type` is not `text/plain`, `text/html`, `application/xml`, `text/xml`, or `application/soap+xml`,
+  then the body will be base64-encoded to ensure that the message can be sent as JSON. In such a case,
+  the message has an extra attribute called `body_base64` set to `true`.
+
+## Schema registry support
+
+{% include_cached md/ai-gateway/v2/policies/kafka/schema-registry.md name='Kafka Upstream' workflow='producer' %}
+
+## Known issues and limitations
+
+Message compression is not supported.
+
+## Authentication
+
+{% include_cached md/ai-gateway/v2/policies/kafka/auth.md name='Kafka Upstream' %}
+
+## Example
+
+The following example creates a global Kafka Upstream Policy that publishes each request to the `kong-upstream` topic, authenticating to the brokers with SASL/PLAIN:
+
+{% entity_example %}
+type: policy
+data:
+  display_name: Kafka Upstream
+  name: kafka-upstream
+  type: kafka-upstream
+  enabled: true
+  global: true
+  config:
+    bootstrap_servers:
+      - host: broker.internal
+        port: 9092
+    topic: kong-upstream
+    forward_body: true
+    forward_headers: true
+    forward_method: true
+    forward_uri: true
+    authentication:
+      strategy: sasl
+      mechanism: PLAIN
+      user: kafka-user
+      password: kafka-password
+    security:
+      ssl: true
+formats:
+  - kongctl
+{% endentity_example %}

--- a/app/_ai_gateway_policies/kafka-upstream/index.md
+++ b/app/_ai_gateway_policies/kafka-upstream/index.md
@@ -26,7 +26,19 @@ For more details, see [Kafka topics](https://kafka.apache.org/documentation/#int
 
 ## Implementation details
 
-{% include md/ai-gateway/v2/policies/kafka/implementation-details.md forward_fields=true %}
+This Policy uses the [lua-resty-kafka](https://github.com/kong/lua-resty-kafka) client.
+
+Control which parts of the request are included in the message with [`config.forward_body`](./reference/#schema--config-forward-body) (enabled by default), [`config.forward_headers`](./reference/#schema--config-forward-headers), [`config.forward_method`](./reference/#schema--config-forward-method), and [`config.forward_uri`](./reference/#schema--config-forward-uri).
+
+When encoding request bodies, several things happen:
+
+* For requests with a content-type header of `application/x-www-form-urlencoded`, `multipart/form-data`,
+  or `application/json`, this Policy passes the raw request body in the `body` attribute, and tries
+  to return a parsed version of those arguments in `body_args`.
+  If this parsing fails, the Policy returns an error message and the message isn't sent.
+* If the `content-type` is not `text/plain`, `text/html`, `application/xml`, `text/xml`, or `application/soap+xml`,
+  then the body will be base64-encoded to ensure that the message can be sent as JSON. In that case,
+  the message has an extra attribute called `body_base64` set to `true`.
 
 ## Schema registry support
 

--- a/app/_ai_gateway_policies/kafka-upstream/index.md
+++ b/app/_ai_gateway_policies/kafka-upstream/index.md
@@ -26,19 +26,7 @@ For more details, see [Kafka topics](https://kafka.apache.org/documentation/#int
 
 ## Implementation details
 
-This Policy uses the [lua-resty-kafka](https://github.com/kong/lua-resty-kafka) client.
-
-Control which parts of the request are included in the message with [`config.forward_body`](./reference/#schema--config-forward-body) (enabled by default), [`config.forward_headers`](./reference/#schema--config-forward-headers), [`config.forward_method`](./reference/#schema--config-forward-method), and [`config.forward_uri`](./reference/#schema--config-forward-uri).
-
-When encoding request bodies, several things happen:
-
-* For requests with a content-type header of `application/x-www-form-urlencoded`, `multipart/form-data`,
-  or `application/json`, this Policy passes the raw request body in the `body` attribute, and tries
-  to return a parsed version of those arguments in `body_args`. If this parsing fails, an error message is
-  returned and the message is not sent.
-* If the `content-type` is not `text/plain`, `text/html`, `application/xml`, `text/xml`, or `application/soap+xml`,
-  then the body will be base64-encoded to ensure that the message can be sent as JSON. In such a case,
-  the message has an extra attribute called `body_base64` set to `true`.
+{% include md/ai-gateway/v2/policies/kafka/implementation-details.md forward_fields=true %}
 
 ## Schema registry support
 

--- a/app/_ai_gateway_policies/kafka-upstream/index.md
+++ b/app/_ai_gateway_policies/kafka-upstream/index.md
@@ -21,6 +21,9 @@ For more details, see [Kafka topics](https://kafka.apache.org/documentation/#int
 
 {{site.ai_gateway}} also offers a separate [Kafka Log](/ai-gateway/policies/kafka-log/reference/) Policy for streaming logs to Kafka topics.
 
+{:.info}
+> This Policy does not support message compression.
+
 ## Implementation details
 
 This Policy uses the [lua-resty-kafka](https://github.com/kong/lua-resty-kafka) client.
@@ -40,10 +43,6 @@ When encoding request bodies, several things happen:
 ## Schema registry support
 
 {% include_cached md/ai-gateway/v2/policies/kafka/schema-registry.md name='Kafka Upstream' workflow='producer' %}
-
-## Known issues and limitations
-
-Message compression is not supported.
 
 ## Authentication
 


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes: #6380 

## Testing instructions

There's a significant amount of setup needed to test this, here are the instructions: [kafka-upstream-testing.md](https://github.com/user-attachments/files/31383037/kafka-upstream-testing.md)

The policy config in this is slightly different from the one in the example to simplify the setup.

## Preview Links

This PR is based on #6778 so there's no preview. You can run the site locally and go to /ai-gateway/policies/kafka-upstream/


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
