### PR TITLE
Feat/add specs

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,0 +1,45 @@
+name: RSpec
+on:
+  pull_request:
+    types: [synchronize, opened, reopened]
+
+permissions:
+  contents: read
+
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+jobs:
+  rspec:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@84684c07c1965536eb4802c8daf1a77968df0cb1 # v1
+        with:
+          ruby-version: .ruby-version
+
+      - name: Ruby gem cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ${{ github.workspace }}/vendor/bundle
+          key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-
+
+      - name: Bundle Setup
+        run: bundle config path ${{ github.workspace }}/vendor/bundle
+
+      - name: Bundle Install
+        run: bundle install --jobs 4 --retry 3
+
+      - name: Run RSpec
+        run: bundle exec rspec

--- a/app/_how-tos/ai-gateway/v1/configure-hashicorp-vault-as-a-vault-for-llm-providers.md
+++ b/app/_how-tos/ai-gateway/v1/configure-hashicorp-vault-as-a-vault-for-llm-providers.md
@@ -1,5 +1,5 @@
 ---
-title: Configure dynamic authentication to LLM providers using HashiCorp vault
+title: Configure dynamic authentication to LLM providers using HashiCorp Vault
 permalink: /ai-gateway/v1/how-to/configure-hashicorp-vault-as-a-vault-for-llm-providers/
 description: "Use HashiCorp Vault to securely store and reference API keys for OpenAI, Mistral, and other LLM providers in {{site.ai_gateway}}."
 content_type: how_to
@@ -46,7 +46,7 @@ tags:
 tldr:
   q: How can I access HashiCorp Vault secrets in {{site.base_gateway}}?
   a: |
-    Store secrets using `vault kv put secret/openai key="Bearer OPENAI_API_KEY"` to HashiCorp Vault. Then configure a Vault entity in {{site.base_gateway}} with the host, token, and mount path. Inside the Gateway container, run `kong vault get {vault://hashicorp-vault/openai/key}` to confirm access. Next Use the `{vault://...}` syntax in a plugin field to [dynamically authenticate to LLM providers](/ai-gateway/v1/how-to/use-semantic-load-balancing-with-dynamic-vault-authentication/) such as OpenAI and Mistral.
+    Store secrets using `vault kv put secret/openai key="Bearer OPENAI_API_KEY"` to HashiCorp Vault. Then configure a Vault entity in {{site.base_gateway}} with the host, token, and mount path. Inside the Gateway container, run `kong vault get {vault://hashicorp-vault/openai/key}` to confirm access. Next, use the `{vault://...}` syntax in a plugin field to [dynamically authenticate to LLM providers](/ai-gateway/v1/how-to/use-semantic-load-balancing-with-dynamic-vault-authentication/) such as OpenAI and Mistral.
 
 tools:
     - deck
@@ -88,7 +88,7 @@ major_version:
 ## Create secrets in HashiCorp Vault
 
 LLM providers such as OpenAI and {{ site.mistral }} expect the `Authorization` header to be `Bearer <api-key>`. Store this full header value, including the `Bearer ` prefix, as the secret. This way, any plugin
-field that references the secret directly with `{vault://...}` sends a correctly formatted header, with no other configuration needed
+field that references the secret directly with `{vault://...}` sends a correctly formatted header, with no other configuration needed.
 
 Replace the placeholder with your OpenAI API key and run:
 
@@ -122,7 +122,7 @@ Both secrets will be stored under their respective paths (`secret/openai` and `s
 
 We'll use decK environment variables for the `host` and `token` in the {{site.base_gateway}} Vault configuration. This is because these values typically vary between environments.
 
-In this tutorial, we're using `host.docker.internal` as our host instead of the `localhost` variable that HashiCorp Vault uses by default. This is because if you used the quick-start script {{site.base_gateway}} is running in a Docker container and uses a different `localhost`.
+In this tutorial, we're using `host.docker.internal` as our host instead of the `localhost` variable that HashiCorp Vault uses by default. This is because if you used the quick-start script, {{site.base_gateway}} is running in a Docker container and uses a different `localhost`.
 
 Because we are running HashiCorp Vault in dev mode, we are using `root` for our `token` value.
 
@@ -180,4 +180,4 @@ secret: '{vault://hashicorp-vault/openai/key}'
 value: Bearer $DECK_OPENAI_API_KEY
 {% endvalidation %}
 
-If the vault was configured correctly, this command should return the value of the secrets for OpenAI and {{ site.mistral }}, prefixed with `Bearer `. You can use `{vault://hashicorp-vault/openai/key}` and `{vault://hashicorp-vault/mistral/key}` to reference the secret in any referenceable field. Because the stored value already includes the `Bearer ` prefix, use the bare `{vault://...}` reference as the field's value — Kong only resolves a vault reference when it is the field's entire value, not when it's embedded alongside other text.
+If the vault was configured correctly, this command should return the value of the secrets for OpenAI and {{ site.mistral }}, prefixed with `Bearer `. You can use `{vault://hashicorp-vault/openai/key}` and `{vault://hashicorp-vault/mistral/key}` to reference the secret in any referenceable field. Because the stored value already includes the `Bearer ` prefix, use the bare `{vault://...}` reference as the field's value. Kong only resolves a vault reference when it's the field's entire value, not when it's embedded alongside other text.

--- a/app/_how-tos/ai-gateway/v1/configure-hashicorp-vault-as-a-vault-for-llm-providers.md
+++ b/app/_how-tos/ai-gateway/v1/configure-hashicorp-vault-as-a-vault-for-llm-providers.md
@@ -46,7 +46,7 @@ tags:
 tldr:
   q: How can I access HashiCorp Vault secrets in {{site.base_gateway}}?
   a: |
-    Store secrets using `vault kv put secret/openai key="OPENAI_API_KEY"` to HashiCorp Vault. Then configure a Vault entity in {{site.base_gateway}} with the host, token, and mount path. Inside the Gateway container, run `kong vault get {vault://hashicorp-vault/openai/key}` to confirm access. Next Use the `{vault://...}` syntax in a plugin field to [dynamically authenticate to LLM providers](/ai-gateway/v1/how-to/use-semantic-load-balancing-with-dynamic-vault-authentication/) such as OpenAI and Mistral.
+    Store secrets using `vault kv put secret/openai key="Bearer OPENAI_API_KEY"` to HashiCorp Vault. Then configure a Vault entity in {{site.base_gateway}} with the host, token, and mount path. Inside the Gateway container, run `kong vault get {vault://hashicorp-vault/openai/key}` to confirm access. Next Use the `{vault://...}` syntax in a plugin field to [dynamically authenticate to LLM providers](/ai-gateway/v1/how-to/use-semantic-load-balancing-with-dynamic-vault-authentication/) such as OpenAI and Mistral.
 
 tools:
     - deck
@@ -87,6 +87,9 @@ major_version:
 
 ## Create secrets in HashiCorp Vault
 
+LLM providers such as OpenAI and {{ site.mistral }} expect the `Authorization` header to be `Bearer <api-key>`. Store this full header value, including the `Bearer ` prefix, as the secret. This way, any plugin
+field that references the secret directly with `{vault://...}` sends a correctly formatted header, with no other configuration needed
+
 Replace the placeholder with your OpenAI API key and run:
 
 {% validation custom-command %}
@@ -94,7 +97,7 @@ command: |
   curl -X POST http://localhost:8200/v1/secret/data/openai \
        -H "X-Vault-Token: $VAULT_TOKEN" \
        -H "Content-Type: application/json" \
-       --data '{"data": {"key": "'$DECK_OPENAI_API_KEY'" }}'
+       --data '{"data": {"key": "Bearer '$DECK_OPENAI_API_KEY'" }}'
 expected:
   return_code: 0
 render_output: false
@@ -107,13 +110,13 @@ command: |
   curl -X POST http://localhost:8200/v1/secret/data/mistral \
        -H "X-Vault-Token: $VAULT_TOKEN" \
        -H "Content-Type: application/json" \
-       --data '{"data": {"key": "'$DECK_MISTRAL_API_KEY'" }}'
+       --data '{"data": {"key": "Bearer '$DECK_MISTRAL_API_KEY'" }}'
 expected:
   return_code: 0
 render_output: false
 {% endvalidation %}
 
-Both secrets will be stored under their respective paths (`secret/openai` and `secret/mistral`) in the key field.
+Both secrets will be stored under their respective paths (`secret/openai` and `secret/mistral`) in the key field, with the `Bearer ` prefix included.
 
 ## Create decK environment variables
 
@@ -168,14 +171,13 @@ To validate that the secret was stored correctly in HashiCorp Vault, you can cal
 
 {% validation vault-secret %}
 secret: '{vault://hashicorp-vault/mistral/key}'
-value: $DECK_MISTRAL_API_KEY
+value: Bearer $DECK_MISTRAL_API_KEY
 {% endvalidation %}
 
 
 {% validation vault-secret %}
 secret: '{vault://hashicorp-vault/openai/key}'
-value: $DECK_OPENAI_API_KEY
+value: Bearer $DECK_OPENAI_API_KEY
 {% endvalidation %}
 
-
-If the vault was configured correctly, this command should return the value of the secrets for OpenAI and {{ site.mistral }}. You can use `{vault://hashicorp-vault/openai/key}` and `{vault://hashicorp-vault/mistral/key}` to reference the secret in any referenceable field.
+If the vault was configured correctly, this command should return the value of the secrets for OpenAI and {{ site.mistral }}, prefixed with `Bearer `. You can use `{vault://hashicorp-vault/openai/key}` and `{vault://hashicorp-vault/mistral/key}` to reference the secret in any referenceable field. Because the stored value already includes the `Bearer ` prefix, use the bare `{vault://...}` reference as the field's value — Kong only resolves a vault reference when it is the field's entire value, not when it's embedded alongside other text.

--- a/app/_how-tos/ai-gateway/v1/use-semantic-load-balancing-with-dynamic-vault-authentication.md
+++ b/app/_how-tos/ai-gateway/v1/use-semantic-load-balancing-with-dynamic-vault-authentication.md
@@ -140,7 +140,7 @@ entities:
         description: CATCHALL
 variables:
   redis_host:
-    value: $DECK_REDIS_HOST
+    value: $REDIS_HOST
 {% endentity_examples %}
 
 
@@ -155,12 +155,14 @@ These prompts are routed to **OpenAI GPT-3.5-Turbo**, since it performs well on 
 <!-- vale off -->
 {% validation request-check %}
 url: /anything
+method: POST
 headers:
 - 'Content-Type: application/json'
 body:
   messages:
     - role: user
       content: How can I build a REST API using Flask?
+status_code: 200
 {% endvalidation %}
 <!-- vale on -->
 
@@ -169,12 +171,14 @@ You can also try a question regarding debugging JavaScript code:
 <!-- vale off -->
 {% validation request-check %}
 url: /anything
+method: POST
 headers:
 - 'Content-Type: application/json'
 body:
   messages:
     - role: user
       content: How can you effectively debug asynchronous code in JavaScript to identify where a Promise or callback might be failing?
+status_code: 200
 {% endvalidation %}
 <!-- vale on -->
 
@@ -185,12 +189,14 @@ These prompts should match the **OpenAI GPT-4o** target, which is designated for
 <!-- vale off -->
 {% validation request-check %}
 url: /anything
+method: POST
 headers:
 - 'Content-Type: application/json'
 body:
   messages:
     - role: user
       content: What is the derivative of sin(x)?
+status_code: 200
 {% endvalidation %}
 <!-- vale on -->
 
@@ -199,12 +205,14 @@ You can also try asking a question related to theorems:
 <!-- vale off -->
 {% validation request-check %}
 url: /anything
+method: POST
 headers:
 - 'Content-Type: application/json'
 body:
   messages:
     - role: user
       content: Explain me Gödel`s incompleteness theorem.
+status_code: 200
 {% endvalidation %}
 <!-- vale on -->
 
@@ -215,12 +223,14 @@ These general-purpose or unmatched prompts are routed to **{{ site.mistral }} Ti
 <!-- vale off -->
 {% validation request-check %}
 url: /anything
+method: POST
 headers:
 - 'Content-Type: application/json'
 body:
   messages:
     - role: user
       content: What is Wulfila Bible?
+status_code: 200
 {% endvalidation %}
 <!-- vale on -->
 
@@ -229,11 +239,13 @@ You can also try another general question:
 <!-- vale off -->
 {% validation request-check %}
 url: /anything
+method: POST
 headers:
 - 'Content-Type: application/json'
 body:
   messages:
     - role: user
       content: Who was Edward Gibbon and what he is famous for?
+status_code: 200
 {% endvalidation %}
 <!-- vale on -->

--- a/app/_how-tos/gateway/configure-oidc-with-kong-oauth2.md
+++ b/app/_how-tos/gateway/configure-oidc-with-kong-oauth2.md
@@ -181,8 +181,9 @@ extract_body:
   - name: 'access_token'
     variable: ACCESS_TOKEN
 status_code: 200
-capture: ACCESS_TOKEN
-jq: ".access_token"
+capture:
+  - variable: ACCESS_TOKEN
+    jq: ".access_token"
 {% endvalidation%}
 <!-- vale on -->
 

--- a/app/_includes/how-tos/validations/qwen/snippet.md
+++ b/app/_includes/how-tos/validations/qwen/snippet.md
@@ -1,8 +1,4 @@
 ```sh
-{% if include.config.base_url -%}
-export OPENAI_BASE_URL={{include.config.base_url}}
-
-{% endif -%}
 {{include.config.base_command}}
 ```
 

--- a/app/_includes/how-tos/validations/request-check/snippet.md
+++ b/app/_includes/how-tos/validations/request-check/snippet.md
@@ -26,7 +26,7 @@
 {%- elsif capture_size > 1 -%}
 _response=$({{ curl_cmd }})
 {%- else -%}
-{{ curl_cmd }}{% if count > 1 %}
+{{ curl_cmd }}{% if count > 1 %} \
 ; done{% endif -%}
 {%- endif %}
 ```

--- a/app/_includes/how-tos/validations/unauthorized-check/index.html
+++ b/app/_includes/how-tos/validations/unauthorized-check/index.html
@@ -10,4 +10,4 @@
 </div>
 {% endif %}
 
-This request returns a `{{config.status_code}}` error with the message `{{config.message}}`.
+{% include how-tos/validations/unauthorized-check/message.md %}

--- a/app/_includes/how-tos/validations/unauthorized-check/index.md
+++ b/app/_includes/how-tos/validations/unauthorized-check/index.md
@@ -4,3 +4,5 @@
 {%- capture on_prem_snippet -%}{% include how-tos/validations/unauthorized-check/snippet.md url=config.on_prem_url headers=config.headers %}{%- endcapture -%}
 
 {% include works_on_wrapper.md on_prem_content=on_prem_snippet konnect_content=konnect_snippet %}
+
+{% include how-tos/validations/unauthorized-check/message.md %}

--- a/app/_includes/how-tos/validations/unauthorized-check/message.md
+++ b/app/_includes/how-tos/validations/unauthorized-check/message.md
@@ -1,0 +1,7 @@
+{%- if config.status_code and config.message -%}
+This request returns a `{{ config.status_code }}` error with the message `{{ config.message }}`.
+{%- elsif config.status_code -%}
+This request returns a `{{ config.status_code }}` error.
+{%- elsif config.message -%}
+This request returns an error with the message `{{ config.message }}`.
+{%- endif -%}

--- a/spec/app/_includes/how-tos/validations/claude-code/snippet_spec.rb
+++ b/spec/app/_includes/how-tos/validations/claude-code/snippet_spec.rb
@@ -1,0 +1,130 @@
+# frozen_string_literal: true
+
+# Config fixtures below are adapted from real {% validation claude-code %} blocks in
+# app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-*.md. Real docs only ever set
+# `base_url` alone or `base_url` + `disable_experimental_betas` together, so the "disable
+# only" and "neither" cases are synthetic, built directly from the snippet.md logic, to get
+# full branch coverage of the env_exports capture.
+RSpec.describe 'how-tos/validations/claude-code/snippet.md' do
+  let(:validations_config) do
+    [{ 'id' => 'claude-code', 'command' => 'claude', 'expected' => { 'return_code' => 0 } }]
+  end
+  let(:site_data) { { 'how-tos' => { 'config' => { 'validations' => validations_config } } } }
+  let(:site) { instance_double(Jekyll::Site, data: site_data) }
+
+  before { allow(Jekyll).to receive(:sites).and_return([site]) }
+
+  let(:config) { Jekyll::Drops::Validations::ClaudeCode.new(id: 'claude-code', yaml: yaml) }
+  let(:template) { '{% include how-tos/validations/claude-code/snippet.md config=config %}' }
+
+  subject(:rendered) { render_liquid(template, locals: { 'config' => config }) }
+  let(:code) { bash_code_block(rendered, lang: 'sh') }
+
+  shared_examples 'a valid shell command' do
+    it 'renders syntactically valid shell' do
+      validate_bash_syntax!(code)
+    end
+  end
+
+  context 'with base_url only (use-claude-code-with-ai-gateway-anthropic.md)' do
+    let(:yaml) do
+      {
+        'model' => 'my-claude',
+        'prompt' => 'Tell me about the Madrid Skylitzes manuscript.',
+        'base_url' => 'http://localhost:8000/'
+      }
+    end
+
+    include_examples 'a valid shell command'
+
+    it 'renders the base_url export and the base command, with no disable_experimental_betas export' do
+      expect(rendered).to eq(<<~'MD'.chomp)
+        ```sh
+        export ANTHROPIC_BASE_URL=http://localhost:8000/
+
+        claude --model "my-claude"
+        ```
+
+        And ask a question to confirm that requests reach AI Gateway.
+
+        ```text
+        Tell me about the Madrid Skylitzes manuscript.
+        ```
+      MD
+    end
+  end
+
+  context 'with base_url and disable_experimental_betas (use-claude-code-with-ai-gateway-bedrock.md)' do
+    let(:yaml) do
+      {
+        'model' => 'my-claude-bedrock',
+        'prompt' => 'Tell me about the Madrid Skylitzes manuscript.',
+        'base_url' => 'http://localhost:8000/',
+        'disable_experimental_betas' => true
+      }
+    end
+
+    include_examples 'a valid shell command'
+
+    it 'renders both env exports before the base command' do
+      expect(rendered).to eq(<<~'MD'.chomp)
+        ```sh
+        export CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1
+        export ANTHROPIC_BASE_URL=http://localhost:8000/
+
+        claude --model "my-claude-bedrock"
+        ```
+
+        And ask a question to confirm that requests reach AI Gateway.
+
+        ```text
+        Tell me about the Madrid Skylitzes manuscript.
+        ```
+      MD
+    end
+  end
+
+  context 'with disable_experimental_betas only, no base_url (synthetic)' do
+    let(:yaml) do
+      { 'model' => 'my-model', 'prompt' => 'Explain this error message.', 'disable_experimental_betas' => true }
+    end
+
+    include_examples 'a valid shell command'
+
+    it 'renders only the disable_experimental_betas export' do
+      expect(rendered).to eq(<<~'MD'.chomp)
+        ```sh
+        export CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1
+
+        claude --model "my-model"
+        ```
+
+        And ask a question to confirm that requests reach AI Gateway.
+
+        ```text
+        Explain this error message.
+        ```
+      MD
+    end
+  end
+
+  context 'with neither base_url nor disable_experimental_betas (synthetic)' do
+    let(:yaml) { { 'model' => 'my-model', 'prompt' => 'Explain this error message.' } }
+
+    include_examples 'a valid shell command'
+
+    it 'renders the base command with no env exports and no leading blank line' do
+      expect(rendered).to eq(<<~'MD'.chomp)
+        ```sh
+        claude --model "my-model"
+        ```
+
+        And ask a question to confirm that requests reach AI Gateway.
+
+        ```text
+        Explain this error message.
+        ```
+      MD
+    end
+  end
+end

--- a/spec/app/_includes/how-tos/validations/codex/snippet_spec.rb
+++ b/spec/app/_includes/how-tos/validations/codex/snippet_spec.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# The base case (no base_url) is adapted from the real {% validation codex %} block in
+# app/_how-tos/ai-gateway/use-codex-with-ai-gateway.md. That's the only real-doc usage of
+# this validation, and it never sets `base_url`, so the base_url branch is synthetic, built
+# directly from the snippet.md logic, to get full branch coverage.
+RSpec.describe 'how-tos/validations/codex/snippet.md' do
+  let(:validations_config) do
+    [{ 'id' => 'codex', 'command' => 'codex', 'expected' => { 'return_code' => 0 } }]
+  end
+  let(:site_data) { { 'how-tos' => { 'config' => { 'validations' => validations_config } } } }
+  let(:site) { instance_double(Jekyll::Site, data: site_data) }
+
+  before { allow(Jekyll).to receive(:sites).and_return([site]) }
+
+  let(:config) { Jekyll::Drops::Validations::Codex.new(id: 'codex', yaml: yaml) }
+  let(:template) { '{% include how-tos/validations/codex/snippet.md config=config %}' }
+
+  subject(:rendered) { render_liquid(template, locals: { 'config' => config }) }
+  let(:code) { bash_code_block(rendered, lang: 'sh') }
+
+  shared_examples 'a valid shell command' do
+    it 'renders syntactically valid shell' do
+      validate_bash_syntax!(code)
+    end
+  end
+
+  context 'with no base_url (use-codex-with-ai-gateway.md)' do
+    let(:yaml) { { 'model' => 'gpt-5.4', 'prompt' => 'Hello' } }
+
+    include_examples 'a valid shell command'
+
+    it 'renders the base command with no env export and no leading blank line' do
+      expect(rendered).to eq(<<~MD)
+        ```sh
+        codex --model "gpt-5.4"
+        ```
+
+        And ask a question to confirm that requests reach AI Gateway.
+
+        ```text
+        Hello
+        ```
+      MD
+    end
+  end
+
+  context 'with base_url (synthetic)' do
+    let(:yaml) { { 'model' => 'gpt-5.4', 'prompt' => 'Hello', 'base_url' => 'http://localhost:9000/codex' } }
+
+    include_examples 'a valid shell command'
+
+    it 'renders the OPENAI_BASE_URL export before the base command' do
+      expect(rendered).to eq(<<~MD)
+        ```sh
+        export OPENAI_BASE_URL=http://localhost:9000/codex
+
+        codex --model "gpt-5.4"
+        ```
+
+        And ask a question to confirm that requests reach AI Gateway.
+
+        ```text
+        Hello
+        ```
+      MD
+    end
+  end
+end

--- a/spec/app/_includes/how-tos/validations/custom-command/snippet_spec.rb
+++ b/spec/app/_includes/how-tos/validations/custom-command/snippet_spec.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+# Config fixtures below are adapted from real {% validation custom-command %} blocks in
+# app/_how-tos/**/*.md. Real docs only ever set `expected.return_code` (0 or non-zero) and
+# `render_output: false`; none use `expected.stdout` or `expected.stderr`, and none omit
+# `return_code` entirely, so those cases are synthetic, built directly from the snippet.md
+# logic, to get full branch coverage.
+RSpec.describe 'how-tos/validations/custom-command/snippet.md' do
+  let(:validations_config) do
+    [{ 'id' => 'custom-command', 'expected' => { 'return_code' => 0 } }]
+  end
+  let(:site_data) { { 'how-tos' => { 'config' => { 'validations' => validations_config } } } }
+  let(:site) { instance_double(Jekyll::Site, data: site_data) }
+
+  before { allow(Jekyll).to receive(:sites).and_return([site]) }
+
+  let(:config) { Jekyll::Drops::Validations::CustomCommand.new(id: 'custom-command', yaml: yaml) }
+  let(:template) { '{% include how-tos/validations/custom-command/snippet.md config=config %}' }
+
+  subject(:rendered) { render_liquid(template, locals: { 'config' => config }) }
+  let(:code) { bash_code_block(rendered) }
+
+  shared_examples 'a valid bash command' do
+    it 'renders syntactically valid bash for the command' do
+      validate_bash_syntax!(code)
+    end
+  end
+
+  context 'return_code 0, no render_output, no stdout/stderr ' \
+          '(encrypt-sensitive-data-in-kong-gateway-with-keyring.md)' do
+    let(:yaml) do
+      {
+        'command' => "openssl genrsa -out private.pem 2048\nopenssl rsa -in private.pem -pubout -out public.pem",
+        'expected' => { 'return_code' => 0 }
+      }
+    end
+
+    include_examples 'a valid bash command'
+
+    it 'renders the command then the success-worded return code check' do
+      expect(rendered).to eq(<<~'MD')
+        ```bash
+        openssl genrsa -out private.pem 2048
+        openssl rsa -in private.pem -pubout -out public.pem
+        ```
+
+
+        Check the return code of the command to make sure it completed successfully:
+        ```bash
+        if [[ $? -ne 0 ]]; then
+          echo "Did not receive the expected return code"
+        fi
+        ```
+
+      MD
+    end
+  end
+
+  context 'render_output: false (monitor-ai-agent-with-opentelemetry.md)' do
+    let(:yaml) do
+      {
+        'command' => 'docker logs otel-collector 2>&1 | grep -A 15 kong.a2a',
+        'expected' => { 'return_code' => 0 },
+        'render_output' => false
+      }
+    end
+
+    include_examples 'a valid bash command'
+
+    it 'renders only the command, with no return code check' do
+      expect(rendered).to eq(<<~'MD'.chomp)
+        ```bash
+        docker logs otel-collector 2>&1 | grep -A 15 kong.a2a
+        ```
+      MD
+    end
+  end
+
+  context 'return_code 1, no render_output (get-started-with-event-gateway.md)' do
+    let(:yaml) do
+      {
+        'command' => 'kafkactl -C kafkactl.yaml --context vc produce blocked-topic --value="test message"',
+        'expected' => { 'message' => 'Failed to produce message', 'return_code' => 1 }
+      }
+    end
+
+    include_examples 'a valid bash command'
+
+    it 'renders the return code check without the success wording' do
+      expect(rendered).to eq(<<~'MD')
+        ```bash
+        kafkactl -C kafkactl.yaml --context vc produce blocked-topic --value="test message"
+        ```
+
+
+        Check the return code of the command:
+        ```bash
+        if [[ $? -ne 1 ]]; then
+          echo "Did not receive the expected return code"
+        fi
+        ```
+
+      MD
+    end
+  end
+
+  context 'expected.stdout only (synthetic)' do
+    let(:yaml) { { 'command' => 'kong version', 'expected' => { 'stdout' => '3.9.0', 'return_code' => 0 } } }
+
+    include_examples 'a valid bash command'
+
+    it 'renders the stdout block before the return code check' do
+      expect(rendered).to eq(<<~'MD')
+        ```bash
+        kong version
+        ```You should see the following content on `stdout`:
+
+        ```bash
+        3.9.0
+        ```
+
+
+
+        Check the return code of the command to make sure it completed successfully:
+        ```bash
+        if [[ $? -ne 0 ]]; then
+          echo "Did not receive the expected return code"
+        fi
+        ```
+
+      MD
+    end
+  end
+
+  context 'expected.stdout and expected.stderr (synthetic)' do
+    let(:yaml) do
+      {
+        'command' => 'kong version --verbose',
+        'expected' => { 'stdout' => '3.9.0', 'stderr' => 'warning: deprecated flag', 'return_code' => 0 }
+      }
+    end
+
+    include_examples 'a valid bash command'
+
+    it 'renders stdout, then "also" worded stderr, then the return code check' do
+      expect(rendered).to eq(<<~'MD')
+        ```bash
+        kong version --verbose
+        ```You should see the following content on `stdout`:
+
+        ```bash
+        3.9.0
+        ```
+
+        You should also see the following content on `stderr`:
+
+        ```bash
+        warning: deprecated flag
+        ```
+
+
+        Check the return code of the command to make sure it completed successfully:
+        ```bash
+        if [[ $? -ne 0 ]]; then
+          echo "Did not receive the expected return code"
+        fi
+        ```
+
+      MD
+    end
+  end
+
+  context 'expected has no return_code at all (synthetic)' do
+    let(:yaml) { { 'command' => 'kong version', 'expected' => { 'stdout' => '3.9.0' } } }
+
+    include_examples 'a valid bash command'
+
+    it 'renders the "check the return code" line with no code block after it' do
+      expect(rendered).to eq(<<~'MD')
+        ```bash
+        kong version
+        ```You should see the following content on `stdout`:
+
+        ```bash
+        3.9.0
+        ```
+
+
+
+        Check the return code of the command:
+      MD
+    end
+  end
+end

--- a/spec/app/_includes/how-tos/validations/env-variables/snippet_spec.rb
+++ b/spec/app/_includes/how-tos/validations/env-variables/snippet_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+RSpec.describe 'how-tos/validations/env-variables/snippet.md' do
+  let(:template) { '{% include how-tos/validations/env-variables/snippet.md variables=variables %}' }
+
+  subject(:rendered) { render_liquid(template, locals: { 'variables' => variables }) }
+  let(:code) { bash_code_block(rendered) }
+
+  shared_examples 'a valid bash command' do
+    it 'renders syntactically valid bash' do
+      validate_bash_syntax!(code)
+    end
+  end
+
+  context 'a single variable (synthetic)' do
+    let(:variables) { { 'KONNECT_TOKEN' => 'kpat_xxx' } }
+
+    include_examples 'a valid bash command'
+
+    it 'renders one export line' do
+      expect(rendered).to eq(<<~'MD'.chomp)
+        ```bash
+        export KONNECT_TOKEN="kpat_xxx"
+        ```
+      MD
+    end
+  end
+
+  context 'multiple variables, in insertion order (synthetic)' do
+    let(:variables) { { 'KONNECT_TOKEN' => 'kpat_xxx', 'KONNECT_CONTROL_PLANE_ID' => 'abc-123' } }
+
+    include_examples 'a valid bash command'
+
+    it 'renders one export line per variable, in order' do
+      expect(rendered).to eq(<<~'MD'.chomp)
+        ```bash
+        export KONNECT_TOKEN="kpat_xxx"
+        export KONNECT_CONTROL_PLANE_ID="abc-123"
+        ```
+      MD
+    end
+  end
+
+  context 'zero variables (synthetic — see report: reachable via validate_yaml! when only ' \
+          '`section`/`indent` are set)' do
+    let(:variables) { {} }
+
+    it 'renders an empty bash fence with no export lines' do
+      expect(rendered).to eq(<<~'MD'.chomp)
+        ```bash
+        ```
+      MD
+    end
+  end
+end

--- a/spec/app/_includes/how-tos/validations/gemini/snippet_spec.rb
+++ b/spec/app/_includes/how-tos/validations/gemini/snippet_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+RSpec.describe 'how-tos/validations/gemini/snippet.md' do
+  let(:validations_config) do
+    [{ 'id' => 'gemini', 'command' => 'gemini', 'expected' => { 'return_code' => 0 } }]
+  end
+  let(:site_data) { { 'how-tos' => { 'config' => { 'validations' => validations_config } } } }
+  let(:site) { instance_double(Jekyll::Site, data: site_data) }
+
+  before { allow(Jekyll).to receive(:sites).and_return([site]) }
+
+  let(:config) { Jekyll::Drops::Validations::Gemini.new(id: 'gemini', yaml: yaml) }
+  let(:template) { '{% include how-tos/validations/gemini/snippet.md config=config %}' }
+
+  subject(:rendered) { render_liquid(template, locals: { 'config' => config }) }
+  let(:code) { bash_code_block(rendered, lang: 'sh') }
+
+  shared_examples 'a valid shell command' do
+    it 'renders syntactically valid shell' do
+      validate_bash_syntax!(code)
+    end
+  end
+
+  context 'with base_url' do
+    let(:yaml) do
+      { 'model' => 'my-gemini-model', 'base_url' => 'http://localhost:8000/gemini', 'prompt' => "Tell me about the prisoner's dilemma." }
+    end
+
+    include_examples 'a valid shell command'
+
+    it 'renders the GOOGLE_GEMINI_BASE_URL export before the base command' do
+      expect(rendered).to eq(<<~MD)
+        ```sh
+        export GOOGLE_GEMINI_BASE_URL=http://localhost:8000/gemini
+
+        gemini --model "my-gemini-model"
+        ```
+
+        And ask a question to confirm that requests reach AI Gateway.
+
+        ```text
+        Tell me about the prisoner's dilemma.
+        ```
+      MD
+    end
+  end
+
+  context 'with no base_url (synthetic)' do
+    let(:yaml) { { 'model' => 'my-gemini-model', 'prompt' => 'Hello' } }
+
+    include_examples 'a valid shell command'
+
+    it 'renders the base command with no env export and no leading blank line' do
+      expect(rendered).to eq(<<~MD)
+        ```sh
+        gemini --model "my-gemini-model"
+        ```
+
+        And ask a question to confirm that requests reach AI Gateway.
+
+        ```text
+        Hello
+        ```
+      MD
+    end
+  end
+end

--- a/spec/app/_includes/how-tos/validations/grpc-check/snippet_spec.rb
+++ b/spec/app/_includes/how-tos/validations/grpc-check/snippet_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+RSpec.describe 'how-tos/validations/grpc-check/snippet.md' do
+  let(:template) do
+    '{% include how-tos/validations/grpc-check/snippet.md url=config.url method=config.method ' \
+      'payload=config.payload response=config.response authority=config.authority port=config.port ' \
+      'plaintext=config.plaintext %}'
+  end
+
+  subject(:rendered) { render_liquid(template, locals: { 'config' => config }) }
+  let(:code) { bash_code_block(rendered) }
+
+  shared_examples 'a valid grpcurl command' do
+    it 'renders syntactically valid bash' do
+      validate_bash_syntax!(code)
+    end
+  end
+
+  context 'plaintext, with authority, port 80' do
+    let(:config) do
+      {
+        'url' => '$PROXY_IP',
+        'method' => 'hello.HelloService.SayHello',
+        'authority' => 'example.com',
+        'port' => 80,
+        'plaintext' => true,
+        'payload' => '{"greeting": "Kong"}',
+        'response' => "{\n  \"reply\": \"hello Kong\"\n}"
+      }
+    end
+
+    include_examples 'a valid grpcurl command'
+
+    it 'renders -plaintext with no -insecure flag' do
+      expect(rendered).to eq(<<~'MD'.chomp)
+        Use `grpcurl` to send a gRPC request through the proxy:
+
+        ```bash
+        grpcurl -d '{"greeting": "Kong"}' -plaintext -authority example.com $PROXY_IP:80 hello.HelloService.SayHello
+        ```
+
+        You should see the following response:
+
+        ```json
+        {
+          "reply": "hello Kong"
+        }
+        ```
+      MD
+    end
+  end
+
+  context 'no plaintext, with authority, port 443' do
+    let(:config) do
+      {
+        'url' => '$PROXY_IP',
+        'method' => 'hello.HelloService.SayHello',
+        'authority' => 'example.com',
+        'port' => 443,
+        'payload' => '{"greeting": "Kong"}',
+        'response' => "{\n  \"reply\": \"hello Kong\"\n}"
+      }
+    end
+
+    include_examples 'a valid grpcurl command'
+
+    it 'renders -insecure with no -plaintext flag' do
+      expect(rendered).to eq(<<~'MD'.chomp)
+        Use `grpcurl` to send a gRPC request through the proxy:
+
+        ```bash
+        grpcurl -d '{"greeting": "Kong"}' -authority example.com -insecure $PROXY_IP:443 hello.HelloService.SayHello
+        ```
+
+        You should see the following response:
+
+        ```json
+        {
+          "reply": "hello Kong"
+        }
+        ```
+      MD
+    end
+  end
+
+  context 'no authority (synthetic)' do
+    let(:config) do
+      {
+        'url' => '$PROXY_IP',
+        'method' => 'hello.HelloService.SayHello',
+        'port' => 443,
+        'payload' => '{"greeting": "Kong"}',
+        'response' => '{}'
+      }
+    end
+
+    include_examples 'a valid grpcurl command'
+
+    it 'omits the -authority flag' do
+      expect(rendered).to eq(<<~'MD'.chomp)
+        Use `grpcurl` to send a gRPC request through the proxy:
+
+        ```bash
+        grpcurl -d '{"greeting": "Kong"}' -insecure $PROXY_IP:443 hello.HelloService.SayHello
+        ```
+
+        You should see the following response:
+
+        ```json
+        {}
+        ```
+      MD
+    end
+  end
+end

--- a/spec/app/_includes/how-tos/validations/qwen/snippet_spec.rb
+++ b/spec/app/_includes/how-tos/validations/qwen/snippet_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.describe 'how-tos/validations/qwen/snippet.md' do
+  let(:validations_config) do
+    [{ 'id' => 'qwen', 'command' => 'qwen', 'expected' => { 'return_code' => 0 } }]
+  end
+  let(:site_data) { { 'how-tos' => { 'config' => { 'validations' => validations_config } } } }
+  let(:site) { instance_double(Jekyll::Site, data: site_data) }
+
+  before { allow(Jekyll).to receive(:sites).and_return([site]) }
+
+  let(:config) { Jekyll::Drops::Validations::Qwen.new(id: 'qwen', yaml: yaml) }
+  let(:template) { '{% include how-tos/validations/qwen/snippet.md config=config %}' }
+
+  subject(:rendered) { render_liquid(template, locals: { 'config' => config }) }
+  let(:code) { bash_code_block(rendered, lang: 'sh') }
+  let(:yaml) { { 'model' => 'my-qwen-dashscope', 'auth-type' => 'openai', 'prompt' => 'Explain the singleton pattern in Python.' } }
+
+  it 'renders syntactically valid shell' do
+    validate_bash_syntax!(code)
+  end
+
+  it 'renders the base command followed by the prompt' do
+    expect(rendered).to eq(<<~'MD'.chomp)
+      ```sh
+      qwen --model "my-qwen-dashscope" --auth-type "openai"
+      ```
+
+      And ask a question to confirm that requests reach AI Gateway.
+
+      ```text
+      Explain the singleton pattern in Python.
+      ```
+    MD
+  end
+end

--- a/spec/app/_includes/how-tos/validations/rate-limit-check/snippet_spec.rb
+++ b/spec/app/_includes/how-tos/validations/rate-limit-check/snippet_spec.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+# Config fixtures below are adapted from real {% validation rate-limit-check %} blocks in
+# app/_how-tos/ai-gateway/rate-limit-a2a-traffic.md,
+# app/_how-tos/gateway/multiple-rate-limits-window-sizes.md, and
+# app/_how-tos/kubernetes-ingress-controller/kic-get-started-proxy-caching.md and
+# kic-plugin-rate-limiting.md. No real doc combines multiple headers, `sleep`, or an
+# `output.expected` without `output.explanation`, so those contexts are synthetic, built
+# directly from snippet.md's conditionals, to get full branch coverage.
+RSpec.describe 'how-tos/validations/rate-limit-check/snippet.md' do
+  let(:template) do
+    '{% include how-tos/validations/rate-limit-check/snippet.md iterations=config.iterations ' \
+      'url=config.url headers=config.headers sleep=config.sleep grep=config.grep output=config.output %}'
+  end
+
+  subject(:rendered) { render_liquid(template, locals: { 'config' => config }) }
+  let(:code) { bash_code_block(rendered) }
+
+  shared_examples 'a valid bash command' do
+    it 'renders syntactically valid bash' do
+      validate_bash_syntax!(code)
+    end
+  end
+
+  context 'minimal, no headers/grep/sleep/output (multiple-rate-limits-window-sizes.md)' do
+    let(:config) { { 'iterations' => 11, 'url' => '/anything' } }
+
+    include_examples 'a valid bash command'
+
+    it 'renders the exact loop' do
+      expect(rendered).to eq(<<~MD)
+        ```bash
+        for _ in {1..11}; do
+        #{'  curl  -i /anything  '}
+          echo
+        done
+        ```
+
+      MD
+    end
+  end
+
+  context 'a single header, no grep (rate-limit-a2a-traffic.md)' do
+    let(:config) { { 'iterations' => 5, 'url' => '/a2a/.well-known/agent-card.json', 'headers' => ['apikey: a2a-secret-key-1'] } }
+
+    include_examples 'a valid bash command'
+
+    it 'renders the header on its own continuation line' do
+      expect(rendered).to eq(<<~MD)
+        ```bash
+        for _ in {1..5}; do
+          curl  -i /a2a/.well-known/agent-card.json \\
+        #{'       -H "apikey: a2a-secret-key-1" '}
+          echo
+        done
+        ```
+
+      MD
+    end
+  end
+
+  context 'grep without headers (kic-plugin-rate-limiting.md)' do
+    let(:config) { { 'iterations' => 10, 'url' => '/echo', 'grep' => '(< RateLimit-Remaining)' } }
+
+    include_examples 'a valid bash command'
+
+    it 'switches to -sv and pipes into grep' do
+      expect(rendered).to eq(<<~'MD')
+        ```bash
+        for _ in {1..10}; do
+          curl  -sv /echo  2>&1 | grep -E "(< RateLimit-Remaining)"
+          echo
+        done
+        ```
+
+      MD
+    end
+  end
+
+  context 'a header with grep and a full output block (kic-get-started-proxy-caching.md)' do
+    let(:config) do
+      {
+        'iterations' => 6,
+        'url' => '/echo',
+        'headers' => ['apikey:example-key'],
+        'grep' => '(Status|< HTTP)',
+        'output' => {
+          'explanation' => 'The first request results in `X-Cache-Status: Miss`.',
+          'expected' => [
+            { 'value' => ['< HTTP/1.1 200 OK', '< X-Cache-Status: Miss'] },
+            { 'value' => ['< HTTP/1.1 429 Too Many Requests'] }
+          ]
+        }
+      }
+    end
+
+    include_examples 'a valid bash command'
+
+    it 'renders the header, the grep pipe, and the explanation with expected output' do
+      expect(rendered).to eq(<<~'MD')
+        ```bash
+        for _ in {1..6}; do
+          curl  -sv /echo \
+               -H "apikey:example-key" 2>&1 | grep -E "(Status|< HTTP)"
+          echo
+        done
+        ```
+
+        <br />
+        The first request results in `X-Cache-Status: Miss`.
+        <br />
+
+
+        ```text
+        < HTTP/1.1 200 OK
+        < X-Cache-Status: Miss
+
+        < HTTP/1.1 429 Too Many Requests
+        ```
+        {:.no-copy-code}
+      MD
+    end
+  end
+
+  context 'an explanation with no expected output (kic-plugin-rate-limiting.md)' do
+    let(:config) do
+      {
+        'iterations' => 6,
+        'url' => '/echo',
+        'output' => {
+          'explanation' => 'The `RateLimit-Remaining` header indicates how many requests are remaining.'
+        }
+      }
+    end
+
+    include_examples 'a valid bash command'
+
+    it 'renders the explanation with no trailing text block' do
+      expect(rendered).to eq(<<~MD)
+        ```bash
+        for _ in {1..6}; do
+        #{'  curl  -i /echo  '}
+          echo
+        done
+        ```
+
+        <br />
+        The `RateLimit-Remaining` header indicates how many requests are remaining.
+        <br />
+
+      MD
+    end
+  end
+
+  context 'multiple headers, exercising the forloop.last continuation (synthetic)' do
+    let(:config) { { 'iterations' => 3, 'url' => '/anything', 'headers' => ['Accept: application/json', 'apikey: test-key'] } }
+
+    include_examples 'a valid bash command'
+
+    it 'chains the header lines with backslash continuations except the last' do
+      expect(rendered).to eq(<<~MD)
+        ```bash
+        for _ in {1..3}; do
+          curl  -i /anything \\
+               -H "Accept: application/json"\\
+        #{'       -H "apikey: test-key" '}
+          echo
+        done
+        ```
+
+      MD
+    end
+  end
+
+  context 'a sleep between requests (synthetic)' do
+    let(:config) { { 'iterations' => 3, 'url' => '/anything', 'sleep' => 2 } }
+
+    include_examples 'a valid bash command'
+
+    it 'renders a sleep line before the loop ends' do
+      expect(rendered).to eq(<<~MD)
+        ```bash
+        for _ in {1..3}; do
+        #{'  curl  -i /anything  '}
+          echo
+          sleep 2
+        done
+        ```
+
+      MD
+    end
+  end
+
+  context 'output.expected with no explanation (synthetic)' do
+    let(:config) do
+      {
+        'iterations' => 2,
+        'url' => '/anything',
+        'output' => { 'expected' => [{ 'value' => ['< HTTP/1.1 429 Too Many Requests'] }] }
+      }
+    end
+
+    include_examples 'a valid bash command'
+
+    it 'renders the expected text block with no explanation or <br /> tags' do
+      expect(rendered).to eq(<<~MD)
+        ```bash
+        for _ in {1..2}; do
+        #{'  curl  -i /anything  '}
+          echo
+        done
+        ```
+
+
+        ```text
+        < HTTP/1.1 429 Too Many Requests
+        ```
+        {:.no-copy-code}
+      MD
+    end
+  end
+end

--- a/spec/app/_includes/how-tos/validations/request-check/snippet_spec.rb
+++ b/spec/app/_includes/how-tos/validations/request-check/snippet_spec.rb
@@ -1,12 +1,14 @@
 # frozen_string_literal: true
 
 # Config fixtures below are adapted from real {% validation request-check %} blocks in
-# app/_how-tos/ai-gateway/*.md, to make sure the curl commands we generate for real docs
-# are syntactically valid bash.
+# app/_how-tos/**/*.md, to make sure the curl commands we generate for real docs
+# are syntactically valid bash. A few (mtls, form_data, body_cmd, output, expected_headers)
+# have zero real-doc usage anywhere in the repo, so those fixtures are synthetic, built
+# directly from the snippet.md logic, to get full branch coverage.
 RSpec.describe 'how-tos/validations/request-check/snippet.md' do
   let(:template) do
     <<~LIQUID
-      {% include how-tos/validations/request-check/snippet.md url=config.url method=config.method headers=config.headers body=config.body body_file=config.body_file form_url_encoded_data=config.form_url_encoded_data display_headers=config.display_headers message=config.message capture=config.capture %}
+      {% include how-tos/validations/request-check/snippet.md url=config.url method=config.method headers=config.headers body=config.body body_file=config.body_file body_cmd=config.body_cmd form_data=config.form_data form_url_encoded_data=config.form_url_encoded_data display_headers=config.display_headers message=config.message capture=config.capture count=config.count user=config.user cookie_jar=config.cookie_jar cookie=config.cookie insecure=config.insecure sleep=config.sleep mtls=config.mtls output=config.output expected_headers=config.expected_headers %}
     LIQUID
   end
 
@@ -261,6 +263,340 @@ RSpec.describe 'how-tos/validations/request-check/snippet.md' do
     it 'renders the expected response text outside the curl command' do
       expect(rendered).to include('You should see the following response:')
       expect(rendered).to include('prompt pattern is blocked.')
+    end
+  end
+
+  context 'user and cookie_jar (configure-oidc-with-session-auth.md)' do
+    let(:config) do
+      {
+        'url' => '/anything',
+        'method' => 'GET',
+        'user' => 'alex:doe',
+        'display_headers' => true,
+        'cookie_jar' => 'example-user'
+      }
+    end
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        curl -i -X GET "/anything" \
+             --no-progress-meter --fail-with-body  \
+             -u alex:doe \
+             --cookie-jar example-user
+      BASH
+    end
+  end
+
+  context 'a cookie (configure-oidc-with-session-auth.md)' do
+    let(:config) do
+      {
+        'url' => '/anything',
+        'method' => 'GET',
+        'display_headers' => true,
+        'cookie' => 'example-user'
+      }
+    end
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        curl -i -X GET "/anything" \
+             --no-progress-meter --fail-with-body  \
+             --cookie example-user
+      BASH
+    end
+  end
+
+  context 'insecure with a JSON body (enable-oauth2-authentication-with-kong-gateway.md)' do
+    let(:config) do
+      {
+        'url' => 'https://localhost:8443/anything/oauth2/token',
+        'method' => 'POST',
+        'headers' => ['Content-Type: application/json'],
+        'insecure' => true,
+        'body' => { 'client_id' => '$CLIENT_ID', 'client_secret' => '$CLIENT_SECRET', 'grant_type' => 'client_credentials' }
+      }
+    end
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        curl -k -X POST "https://localhost:8443/anything/oauth2/token" \
+             --no-progress-meter --fail-with-body  \
+             -H "Content-Type: application/json" \
+             --json '{
+               "client_id": "'$CLIENT_ID'",
+               "client_secret": "'$CLIENT_SECRET'",
+               "grant_type": "client_credentials"
+             }'
+      BASH
+    end
+  end
+
+  context 'a body with an array of scalars (validate-incoming-json-request-bodies.md)' do
+    let(:config) do
+      {
+        'url' => '/anything',
+        'method' => 'POST',
+        'headers' => ['Content-Type: application/json'],
+        'display_headers' => true,
+        'body' => { 'name' => 'Jason', 'age' => 20, 'gender' => 'male', 'parents' => ['Joseph', 'Viva'] }
+      }
+    end
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        curl -i -X POST "/anything" \
+             --no-progress-meter --fail-with-body  \
+             -H "Content-Type: application/json" \
+             --json '{
+               "name": "Jason",
+               "age": 20,
+               "gender": "male",
+               "parents": [
+                 "Joseph",
+                 "Viva"
+               ]
+             }'
+      BASH
+    end
+  end
+
+  context 'a request loop with no other params (collect-metrics-with-datadog-and-prometheus-plugin.md)' do
+    let(:config) { { 'url' => '/anything', 'count' => 10 } }
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        for _  in {1..10}; do
+        curl "/anything" \
+             --no-progress-meter --fail-with-body  \
+        ; done
+      BASH
+    end
+  end
+
+  context 'insecure with a jq capture (configure-oidc-with-kong-oauth2.md)' do
+    let(:config) do
+      {
+        'url' => 'https://localhost:8443/anything/oauth2/token',
+        'method' => 'POST',
+        'headers' => ['Content-Type: application/json'],
+        'insecure' => true,
+        'body' => { 'client_id' => 'client', 'client_secret' => 'secret', 'grant_type' => 'client_credentials' },
+        'capture' => [{ 'variable' => 'ACCESS_TOKEN', 'jq' => '.access_token' }]
+      }
+    end
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        ACCESS_TOKEN=$(curl -k -X POST "https://localhost:8443/anything/oauth2/token" \
+             --no-progress-meter --fail-with-body  \
+             -H "Content-Type: application/json" \
+             --json '{
+               "client_id": "client",
+               "client_secret": "secret",
+               "grant_type": "client_credentials"
+             }' | jq -r ".access_token"
+        )
+      BASH
+    end
+  end
+
+  context 'sleep before the request (kic-service-healthchecks.md)' do
+    let(:config) do
+      {
+        'url' => '$PROXY_IP/httpbin/status/200',
+        'display_headers' => true,
+        'sleep' => 15
+      }
+    end
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        sleep 15 && curl -i "$PROXY_IP/httpbin/status/200" \
+             --no-progress-meter --fail-with-body 
+      BASH
+    end
+  end
+
+  context 'a second real count-loop case, no continuation (kic-service-healthchecks.md)' do
+    let(:config) do
+      {
+        'url' => '$PROXY_IP/httpbin/status/500',
+        'display_headers' => true,
+        'count' => 2
+      }
+    end
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        for _  in {1..2}; do
+        curl -i "$PROXY_IP/httpbin/status/500" \
+             --no-progress-meter --fail-with-body  \
+        ; done
+      BASH
+    end
+  end
+
+  context 'a message with no other params (filter-requests-based-on-header-names.md)' do
+    let(:config) do
+      {
+        'url' => '/anything',
+        'display_headers' => true,
+        'message' => 'Invalid Credentials'
+      }
+    end
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        curl -i "/anything" \
+             --no-progress-meter --fail-with-body 
+      BASH
+    end
+
+    it 'renders the expected response text outside the curl command' do
+      expect(rendered).to include('You should see the following response:')
+      expect(rendered).to include('Invalid Credentials')
+    end
+  end
+
+  context 'more than one capture, exercising the capture_size > 1 branch (synthetic — no real doc uses 2+ captures)' do
+    let(:config) do
+      {
+        'url' => '/oauth/token',
+        'method' => 'POST',
+        'headers' => ['Content-Type: application/json'],
+        'body' => { 'client_id' => 'client', 'client_secret' => 'secret', 'grant_type' => 'client_credentials' },
+        'capture' => [
+          { 'variable' => 'ACCESS_TOKEN', 'jq' => '.access_token' },
+          { 'variable' => 'EXPIRES_IN', 'jq' => '.expires_in' }
+        ]
+      }
+    end
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command, wrapped in a shared _response variable' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        _response=$(curl -X POST "/oauth/token" \
+             --no-progress-meter --fail-with-body  \
+             -H "Content-Type: application/json" \
+             --json '{
+               "client_id": "client",
+               "client_secret": "secret",
+               "grant_type": "client_credentials"
+             }')
+      BASH
+    end
+
+    it 'renders a separate export block for each capture' do
+      expect(rendered).to include('Export the env variables:')
+      expect(rendered).to include('export ACCESS_TOKEN=$(echo "$_response" | jq -r ".access_token")')
+      expect(rendered).to include('export EXPIRES_IN=$(echo "$_response" | jq -r ".expires_in")')
+    end
+  end
+
+  context 'mtls (synthetic — no real doc uses mtls)' do
+    let(:config) { { 'url' => 'https://secure.example.com/orders', 'method' => 'GET', 'mtls' => true } }
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        curl -X GET -k --key key.pem --cert cert.pem "https://secure.example.com/orders" \
+             --no-progress-meter --fail-with-body 
+      BASH
+    end
+  end
+
+  context 'form_data, a multipart upload (synthetic — no real doc uses form_data)' do
+    let(:config) do
+      {
+        'url' => '/upload',
+        'method' => 'POST',
+        'form_data' => { 'file' => '@photo.png', 'description' => 'profile picture' }
+      }
+    end
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        curl -X POST "/upload" \
+             --no-progress-meter --fail-with-body  \
+             -F file="@photo.png" \
+             -F description="profile picture" 
+      BASH
+    end
+  end
+
+  context 'body_cmd, a shell command substitution as the body (synthetic — no real doc uses body_cmd)' do
+    let(:config) do
+      {
+        'url' => '/anything',
+        'method' => 'POST',
+        'headers' => ['Content-Type: application/json'],
+        'body_cmd' => '$(cat payload.json)'
+      }
+    end
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        curl -X POST "/anything" \
+             --no-progress-meter --fail-with-body  \
+             -H "Content-Type: application/json" \
+             --json "$(cat payload.json)"
+      BASH
+    end
+  end
+
+  context 'output, saving the response to a file (synthetic — no real doc uses output)' do
+    let(:config) { { 'url' => '/anything', 'method' => 'GET', 'output' => 'response.json' } }
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        curl -X GET "/anything" \
+             -o response.json --no-progress-meter --fail-with-body 
+      BASH
+    end
+  end
+
+  context 'expected_headers, a pluralized list (synthetic — no real doc uses expected_headers)' do
+    let(:config) do
+      {
+        'url' => '/anything',
+        'method' => 'GET',
+        'display_headers' => true,
+        'expected_headers' => ['X-RateLimit-Remaining: 99', 'X-RateLimit-Limit: 100']
+      }
+    end
+
+    include_examples 'a valid curl command'
+
+    it 'renders the expected headers outside the curl command, pluralized' do
+      expect(rendered).to include('You should see the following headers:')
+      expect(rendered).to include('X-RateLimit-Remaining: 99')
+      expect(rendered).to include('X-RateLimit-Limit: 100')
     end
   end
 end

--- a/spec/app/_includes/how-tos/validations/request-check/snippet_spec.rb
+++ b/spec/app/_includes/how-tos/validations/request-check/snippet_spec.rb
@@ -1,0 +1,266 @@
+# frozen_string_literal: true
+
+# Config fixtures below are adapted from real {% validation request-check %} blocks in
+# app/_how-tos/ai-gateway/*.md, to make sure the curl commands we generate for real docs
+# are syntactically valid bash.
+RSpec.describe 'how-tos/validations/request-check/snippet.md' do
+  let(:template) do
+    <<~LIQUID
+      {% include how-tos/validations/request-check/snippet.md url=config.url method=config.method headers=config.headers body=config.body body_file=config.body_file form_url_encoded_data=config.form_url_encoded_data display_headers=config.display_headers message=config.message capture=config.capture %}
+    LIQUID
+  end
+
+  subject(:rendered) { render_liquid(template, locals: { 'config' => config }) }
+
+  let(:code) { bash_code_block(rendered) }
+
+  shared_examples 'a valid curl command' do
+    it 'renders syntactically valid bash' do
+      validate_bash_syntax!(code)
+    end
+  end
+
+  context 'minimal url only (get-started-with-ai-agent.md)' do
+    let(:config) { { 'url' => '/a2a/.well-known/agent-card.json' } }
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        curl "/a2a/.well-known/agent-card.json" \
+             --no-progress-meter --fail-with-body 
+      BASH
+    end
+  end
+
+  context 'headers and a JSON body (get-started-with-ai-gateway.md)' do
+    let(:config) do
+      {
+        'url' => '/v1/chat/completions',
+        'method' => 'POST',
+        'headers' => ['Accept: application/json', 'Content-Type: application/json', 'Authorization: Bearer $OPENAI_API_KEY'],
+        'body' => { 'messages' => [{ 'role' => 'user', 'content' => 'Say this is a test!' }], 'model' => 'my-gpt-4o' }
+      }
+    end
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        curl -X POST "/v1/chat/completions" \
+             --no-progress-meter --fail-with-body  \
+             -H "Accept: application/json"\
+             -H "Content-Type: application/json"\
+             -H "Authorization: Bearer $OPENAI_API_KEY" \
+             --json '{
+               "messages": [
+                 {
+                   "role": "user",
+                   "content": "Say this is a test!"
+                 }
+               ],
+               "model": "my-gpt-4o"
+             }'
+      BASH
+    end
+  end
+
+  context 'a header only, with display_headers (rate-limit-a2a-traffic.md)' do
+    let(:config) do
+      {
+        'url' => '/a2a/.well-known/agent-card.json',
+        'method' => 'GET',
+        'display_headers' => true,
+        'headers' => ['apikey: a2a-secret-key-1']
+      }
+    end
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        curl -i -X GET "/a2a/.well-known/agent-card.json" \
+             --no-progress-meter --fail-with-body  \
+             -H "apikey: a2a-secret-key-1"
+      BASH
+    end
+  end
+
+  context 'a body_file reference (limit-a2a-body-size.md)' do
+    let(:config) do
+      {
+        'url' => '/a2a',
+        'method' => 'POST',
+        'headers' => ['Content-Type: application/json'],
+        'body_file' => '@large_payload.json'
+      }
+    end
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        curl -X POST "/a2a" \
+             --no-progress-meter --fail-with-body  \
+             -H "Content-Type: application/json" \
+             -F file="@large_payload.json"
+      BASH
+    end
+  end
+
+  context 'form_url_encoded_data with a jq capture (enforce-tiered-ai-budgets-with-kong-identity.md)' do
+    let(:config) do
+      {
+        'url' => '/oauth/token',
+        'method' => 'POST',
+        'headers' => ['Content-Type: application/x-www-form-urlencoded'],
+        'form_url_encoded_data' => {
+          'grant_type' => 'client_credentials',
+          'client_id' => '$CAROL_CLIENT_ID',
+          'client_secret' => '$CAROL_CLIENT_SECRET',
+          'scope' => 'budgets-access'
+        },
+        'capture' => [{ 'variable' => 'CAROL_ACCESS_TOKEN', 'jq' => '.access_token' }]
+      }
+    end
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        CAROL_ACCESS_TOKEN=$(curl -X POST "/oauth/token" \
+             --no-progress-meter --fail-with-body  \
+             -H "Content-Type: application/x-www-form-urlencoded" \
+             -d "grant_type=client_credentials" \
+             -d "client_id=$CAROL_CLIENT_ID" \
+             -d "client_secret=$CAROL_CLIENT_SECRET" \
+             -d "scope=budgets-access"  | jq -r ".access_token"
+        )
+      BASH
+    end
+  end
+
+  context 'a nested JSON body with a command capture (get-started-with-mcp-server.md)' do
+    let(:config) do
+      {
+        'url' => '/weather/',
+        'method' => 'POST',
+        'headers' => ['Content-Type: application/json', 'Accept: application/json, text/event-stream'],
+        'display_headers' => true,
+        'body' => {
+          'jsonrpc' => '2.0',
+          'id' => 1,
+          'method' => 'initialize',
+          'params' => {
+            'protocolVersion' => '2025-06-18',
+            'capabilities' => {},
+            'clientInfo' => { 'name' => 'weather-mcp-test', 'version' => '1.0.0' }
+          }
+        },
+        'capture' => [{ 'variable' => 'SESSION_ID', 'command' => "grep -i '^mcp-session-id:' | tr -d '\\r' | cut -d' ' -f2" }]
+      }
+    end
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        SESSION_ID=$(curl -i -X POST "/weather/" \
+             --no-progress-meter --fail-with-body  \
+             -H "Content-Type: application/json"\
+             -H "Accept: application/json, text/event-stream" \
+             --json '{
+               "jsonrpc": "2.0",
+               "id": 1,
+               "method": "initialize",
+               "params": {
+                 "protocolVersion": "2025-06-18",
+                 "capabilities": {},
+                 "clientInfo": {
+                   "name": "weather-mcp-test",
+                   "version": "1.0.0"
+                 }
+               }
+             }' | grep -i '^mcp-session-id:' | tr -d '\r' | cut -d' ' -f2
+        )
+      BASH
+    end
+  end
+
+  context 'a deeply nested JSON body with an array (get-started-with-ai-agent.md)' do
+    let(:config) do
+      {
+        'url' => '/a2a/',
+        'method' => 'POST',
+        'headers' => ['Content-Type: application/json'],
+        'body' => {
+          'jsonrpc' => '2.0',
+          'id' => '1',
+          'method' => 'message/send',
+          'params' => {
+            'message' => {
+              'kind' => 'message',
+              'messageId' => 'msg-001',
+              'role' => 'user',
+              'parts' => [{ 'kind' => 'text', 'text' => 'What flights are available on route KA-123?' }]
+            }
+          }
+        }
+      }
+    end
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        curl -X POST "/a2a/" \
+             --no-progress-meter --fail-with-body  \
+             -H "Content-Type: application/json" \
+             --json '{
+               "jsonrpc": "2.0",
+               "id": "1",
+               "method": "message/send",
+               "params": {
+                 "message": {
+                   "kind": "message",
+                   "messageId": "msg-001",
+                   "role": "user",
+                   "parts": [
+                     {
+                       "kind": "text",
+                       "text": "What flights are available on route KA-123?"
+                     }
+                   ]
+                 }
+               }
+             }'
+      BASH
+    end
+  end
+
+  context 'an expected message (use-ai-prompt-guard-policy.md)' do
+    let(:config) do
+      {
+        'url' => '/chat/completions',
+        'method' => 'POST',
+        'headers' => ['Content-Type: application/json'],
+        'message' => 'prompt pattern is blocked.'
+      }
+    end
+
+    include_examples 'a valid curl command'
+
+    it 'renders the exact curl command' do
+      expect(code).to eq(<<~'BASH'.chomp)
+        curl -X POST "/chat/completions" \
+             --no-progress-meter --fail-with-body  \
+             -H "Content-Type: application/json"
+      BASH
+    end
+
+    it 'renders the expected response text outside the curl command' do
+      expect(rendered).to include('You should see the following response:')
+      expect(rendered).to include('prompt pattern is blocked.')
+    end
+  end
+end

--- a/spec/app/_includes/how-tos/validations/unauthorized-check/snippet_spec.rb
+++ b/spec/app/_includes/how-tos/validations/unauthorized-check/snippet_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe 'how-tos/validations/unauthorized-check/snippet.md' do
+  let(:template) { '{% include how-tos/validations/unauthorized-check/snippet.md url=config.url headers=config.headers %}' }
+
+  subject(:rendered) { render_liquid(template, locals: { 'config' => config }) }
+  let(:code) { bash_code_block(rendered) }
+
+  shared_examples 'a valid bash command' do
+    it 'renders syntactically valid bash' do
+      validate_bash_syntax!(code)
+    end
+  end
+
+  context 'no headers' do
+    let(:config) { { 'url' => '/anything' } }
+
+    include_examples 'a valid bash command'
+
+    it 'renders the exact curl command' do
+      expect(rendered).to eq(<<~MD)
+        ```bash
+        #{'curl -i /anything '}
+        ```
+      MD
+    end
+  end
+
+  context 'a single header' do
+    let(:config) { { 'url' => '/anything', 'headers' => ['apikey:another_key'] } }
+
+    include_examples 'a valid bash command'
+
+    it 'renders the header on its own continuation line' do
+      expect(rendered).to eq(<<~MD)
+        ```bash
+        curl -i /anything \\
+             -H "apikey:another_key"
+        ```
+      MD
+    end
+  end
+
+  context 'multiple headers, exercising the forloop.last continuation (synthetic)' do
+    let(:config) { { 'url' => '/anything', 'headers' => ['Accept: application/json', 'apikey: test-key'] } }
+
+    include_examples 'a valid bash command'
+
+    it 'chains the header lines with backslash continuations except the last' do
+      expect(rendered).to eq(<<~MD)
+        ```bash
+        curl -i /anything \\
+             -H "Accept: application/json"\\
+             -H "apikey: test-key"
+        ```
+      MD
+    end
+  end
+end

--- a/spec/app/_includes/how-tos/validations/vault-secret/snippet_spec.rb
+++ b/spec/app/_includes/how-tos/validations/vault-secret/snippet_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.describe 'how-tos/validations/vault-secret/snippet.md' do
+  let(:template) do
+    '{% include how-tos/validations/vault-secret/snippet.md container=container secret=secret command=command %}'
+  end
+
+  subject(:rendered) do
+    render_liquid(template, locals: { 'container' => container, 'secret' => secret, 'command' => command })
+  end
+
+  let(:code) { bash_code_block(rendered) }
+
+  shared_examples 'a valid bash command' do
+    it 'renders syntactically valid bash' do
+      validate_bash_syntax!(code)
+    end
+  end
+
+  context 'no command override' do
+    let(:container) { 'kong-quickstart-gateway' }
+    let(:secret) { '{vault://hashicorp-vault/customer/acme/name}' }
+    let(:command) { '' }
+
+    include_examples 'a valid bash command'
+
+    it 'wraps kong vault get in a docker exec against the container' do
+      expect(rendered).to eq(<<~'MD'.chomp)
+        ```bash
+        docker exec kong-quickstart-gateway kong vault get {vault://hashicorp-vault/customer/acme/name}
+        ```
+      MD
+    end
+  end
+
+  context 'a command override' do
+    let(:container) { 'kong-gateway' }
+    let(:secret) { '{vault://aws-vault/my-aws-secret/token}' }
+    let(:command) { 'kubectl exec -n kong -it deployment/kong-gateway -c proxy --' }
+
+    include_examples 'a valid bash command'
+
+    it 'uses the given command in place of docker exec, ignoring container' do
+      expect(rendered).to eq(<<~'MD'.chomp)
+        ```bash
+        kubectl exec -n kong -it deployment/kong-gateway -c proxy -- kong vault get {vault://aws-vault/my-aws-secret/token}
+        ```
+      MD
+    end
+  end
+end

--- a/spec/app/_plugins/blocks/env_variables_spec.rb
+++ b/spec/app/_plugins/blocks/env_variables_spec.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+RSpec.describe Jekyll::EnvVariables do
+  let(:how_tos_config) { { 'validations' => [] } }
+  let(:site_data) { { 'how-tos' => { 'config' => how_tos_config } } }
+  let(:site) { instance_double(Jekyll::Site, data: site_data) }
+
+  before { allow(Jekyll).to receive(:sites).and_return([site]) }
+
+  let(:page) do
+    { 'output_format' => 'html', 'path' => 'test.md', 'products' => products, 'works_on' => works_on }
+  end
+  let(:products) { ['gateway'] }
+  let(:template) do
+    <<~LIQUID
+      {% env_variables %}
+      KONNECT_TOKEN: kpat_xxx
+      {% endenv_variables %}
+    LIQUID
+  end
+
+  subject(:rendered) { render_liquid(template, page: page) }
+
+  let(:html) { Capybara::Node::Simple.new(rendered) }
+
+  describe 'html output' do
+    context 'works_on: konnect' do
+      let(:works_on) { %w[konnect] }
+
+      it 'renders a konnect content div with the markdown attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][data-test-step]')
+      end
+    end
+
+    context 'works_on: konnect and on-prem' do
+      let(:works_on) { %w[konnect on-prem] }
+
+      it 'renders both content divs with the markdown attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][markdown="1"]')
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][markdown="1"]')
+      end
+    end
+
+    context 'when section is prereqs' do
+      let(:works_on) { %w[konnect] }
+      let(:template) do
+        <<~LIQUID
+          {% env_variables %}
+          KONNECT_TOKEN: kpat_xxx
+          section: prereqs
+          {% endenv_variables %}
+        LIQUID
+      end
+
+      it 'renders a data-test-prereq attribute instead of data-test-step' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][data-test-prereq]')
+        expect(html).not_to have_css('div[data-deployment-topology="konnect"][data-test-step]')
+      end
+    end
+
+    context 'with no supported product listed (real {% validation %} block would reject this)' do
+      let(:works_on) { %w[konnect] }
+      let(:products) { ['not-a-real-product'] }
+
+      it 'still renders, since Jekyll::EnvVariables performs no product-type check' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"]')
+      end
+    end
+  end
+
+  describe 'markdown output_format' do
+    let(:page) do
+      { 'output_format' => 'markdown', 'path' => 'test.md', 'products' => products, 'works_on' => works_on }
+    end
+
+    context 'works_on: konnect and on-prem, default section' do
+      let(:works_on) { %w[konnect on-prem] }
+
+      it 'renders a deployment topology heading for each, konnect before on-prem' do
+        expect(rendered.index('Konnect deployments')).to be < rendered.index('On-prem deployments')
+      end
+    end
+
+    context 'works_on: konnect and on-prem, section: prereqs' do
+      let(:works_on) { %w[konnect on-prem] }
+      let(:template) do
+        <<~LIQUID
+          {% env_variables %}
+          DECK_IDENTIFIER: SAML-application-identifier
+          section: prereqs
+          {% endenv_variables %}
+        LIQUID
+      end
+
+      it 'renders each heading at a hardcoded level 4, not the level ClosestHeading would pick' do
+        expect(rendered).to include("\n#### Konnect deployments\n")
+        expect(rendered).to include("\n#### On-prem deployments\n")
+      end
+    end
+
+    context 'indent combined with section: prereqs' do
+      let(:works_on) { %w[konnect] }
+      let(:template) do
+        <<~LIQUID
+          {% env_variables %}
+          DECK_NGROK_HOST: YOUR-FORWARDING-URL/anything
+          indent: 3
+          section: prereqs
+          {% endenv_variables %}
+        LIQUID
+      end
+
+      it 'applies the requested indent exactly once, unlike {% validation env-variables %}' do
+        content_line = rendered.lines.find { |l| l.include?('export DECK_NGROK_HOST') }
+        expect(content_line).to eq("   export DECK_NGROK_HOST=\"YOUR-FORWARDING-URL/anything\"\n")
+      end
+    end
+  end
+
+  describe 'yaml validation' do
+    let(:works_on) { %w[konnect] }
+
+    context 'an empty mapping' do
+      let(:template) do
+        <<~LIQUID
+          {% env_variables %}
+          {}
+          {% endenv_variables %}
+        LIQUID
+      end
+
+      it 'raises an error, worded for {% validation %} even though this is {% env_variables %}' do
+        expect { rendered }.to raise_error(ArgumentError, 'Missing variables in {% validation env-variables %}.')
+      end
+    end
+
+    context 'malformed yaml' do
+      let(:template) do
+        <<~LIQUID
+          {% env_variables %}
+          KEY: 'unterminated
+          {% endenv_variables %}
+        LIQUID
+      end
+
+      it 'raises an error worded for {% env_variables %}' do
+        expect { rendered }.to raise_error(ArgumentError, /the following \{% env_variables %\} block contains a malformed yaml/)
+      end
+    end
+  end
+end

--- a/spec/app/_plugins/blocks/validations/claude_code_spec.rb
+++ b/spec/app/_plugins/blocks/validations/claude_code_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+RSpec.describe Jekyll::Validation do
+  let(:validations_config) do
+    [{ 'id' => 'claude-code', 'command' => 'claude', 'expected' => { 'return_code' => 0 } }]
+  end
+  let(:how_tos_config) { { 'validations' => validations_config } }
+  let(:site_data) { { 'how-tos' => { 'config' => how_tos_config } } }
+  let(:site) { instance_double(Jekyll::Site, data: site_data) }
+
+  before { allow(Jekyll).to receive(:sites).and_return([site]) }
+
+  let(:page) { { 'output_format' => 'html', 'path' => 'test.md', 'products' => ['ai-gateway'] } }
+  let(:template) do
+    <<~LIQUID
+      {% validation claude-code %}
+      prompt: Tell me about the Madrid Skylitzes manuscript.
+      model: my-claude
+      base_url: http://localhost:8000/
+      {% endvalidation %}
+    LIQUID
+  end
+
+  subject(:rendered) { render_liquid(template, page: page) }
+
+  let(:html) { Capybara::Node::Simple.new(rendered) }
+
+  describe 'html output' do
+    it 'renders a content div with the markdown attribute' do
+      expect(html).to have_css('div.content[markdown="1"]')
+    end
+
+    it 'renders a data-test-step attribute' do
+      expect(html).to have_css('div.content[data-test-step]')
+    end
+  end
+
+  context 'when model or prompt is missing' do
+    let(:template) do
+      <<~LIQUID
+        {% validation claude-code %}
+        model: my-claude
+        {% endvalidation %}
+      LIQUID
+    end
+
+    it 'raises an error' do
+      expect { rendered }.to raise_error(ArgumentError, 'Missing `prompt` in {% validation claude-code %}.')
+    end
+  end
+
+  describe 'template source' do
+    subject(:template_source) { File.read('app/_includes/how-tos/validations/claude-code/index.html') }
+
+    it 'renders the snippet include' do
+      expect(template_source).to include('{% include how-tos/validations/claude-code/snippet.md config=config %}')
+    end
+
+    context 'markdown template' do
+      subject(:template_source) { File.read('app/_includes/how-tos/validations/claude-code/index.md') }
+
+      it 'renders the snippet include' do
+        expect(template_source).to include('{% include how-tos/validations/claude-code/snippet.md config=config %}')
+      end
+    end
+  end
+end

--- a/spec/app/_plugins/blocks/validations/codex_spec.rb
+++ b/spec/app/_plugins/blocks/validations/codex_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+RSpec.describe Jekyll::Validation do
+  let(:validations_config) do
+    [{ 'id' => 'codex', 'command' => 'codex', 'expected' => { 'return_code' => 0 } }]
+  end
+  let(:how_tos_config) { { 'validations' => validations_config } }
+  let(:site_data) { { 'how-tos' => { 'config' => how_tos_config } } }
+  let(:site) { instance_double(Jekyll::Site, data: site_data) }
+
+  before { allow(Jekyll).to receive(:sites).and_return([site]) }
+
+  let(:page) { { 'output_format' => 'html', 'path' => 'test.md', 'products' => ['ai-gateway'] } }
+  let(:template) do
+    <<~LIQUID
+      {% validation codex %}
+      model: gpt-5.4
+      prompt: Hello
+      {% endvalidation %}
+    LIQUID
+  end
+
+  subject(:rendered) { render_liquid(template, page: page) }
+
+  let(:html) { Capybara::Node::Simple.new(rendered) }
+
+  describe 'html output' do
+    it 'renders a content div with the markdown attribute' do
+      expect(html).to have_css('div.content[markdown="1"]')
+    end
+
+    it 'renders a data-test-step attribute' do
+      expect(html).to have_css('div.content[data-test-step]')
+    end
+  end
+
+  context 'when model or prompt is missing' do
+    let(:template) do
+      <<~LIQUID
+        {% validation codex %}
+        model: gpt-5.4
+        {% endvalidation %}
+      LIQUID
+    end
+
+    it 'raises an error' do
+      expect { rendered }.to raise_error(ArgumentError, 'Missing `prompt` in {% validation codex %}.')
+    end
+  end
+
+  describe 'template source' do
+    subject(:template_source) { File.read('app/_includes/how-tos/validations/codex/index.html') }
+
+    it 'renders the snippet include' do
+      expect(template_source).to include('{% include how-tos/validations/codex/snippet.md config=config %}')
+    end
+
+    context 'markdown template' do
+      subject(:template_source) { File.read('app/_includes/how-tos/validations/codex/index.md') }
+
+      it 'renders the snippet include' do
+        expect(template_source).to include('{% include how-tos/validations/codex/snippet.md config=config %}')
+      end
+    end
+  end
+end

--- a/spec/app/_plugins/blocks/validations/custom_command_spec.rb
+++ b/spec/app/_plugins/blocks/validations/custom_command_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+RSpec.describe Jekyll::Validation do
+  let(:validations_config) do
+    [{ 'id' => 'custom-command', 'expected' => { 'return_code' => 0 } }]
+  end
+  let(:how_tos_config) { { 'validations' => validations_config } }
+  let(:site_data) { { 'how-tos' => { 'config' => how_tos_config } } }
+  let(:site) { instance_double(Jekyll::Site, data: site_data) }
+
+  before { allow(Jekyll).to receive(:sites).and_return([site]) }
+
+  let(:page) { { 'output_format' => 'html', 'path' => 'test.md', 'products' => ['ai-gateway'] } }
+  let(:template) do
+    <<~LIQUID
+      {% validation custom-command %}
+      command: kong version
+      expected:
+        return_code: 0
+      {% endvalidation %}
+    LIQUID
+  end
+
+  subject(:rendered) { render_liquid(template, page: page) }
+
+  let(:html) { Capybara::Node::Simple.new(rendered) }
+
+  describe 'html output' do
+    it 'renders a content div with the markdown attribute' do
+      expect(html).to have_css('div.content[markdown="1"]')
+    end
+
+    it 'renders a data-test-step attribute' do
+      expect(html).to have_css('div.content[data-test-step]')
+    end
+
+    it 'does not render a data-test-prereq attribute' do
+      expect(html).not_to have_css('div.content[data-test-prereq]')
+    end
+
+    context 'when section is prereqs' do
+      let(:template) do
+        <<~LIQUID
+          {% validation custom-command %}
+          command: kong version
+          expected:
+            return_code: 0
+          section: prereqs
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'renders a data-test-prereq attribute instead of data-test-step' do
+        expect(html).to have_css('div.content[data-test-prereq="block"]')
+        expect(html).not_to have_css('div.content[data-test-step]')
+      end
+    end
+  end
+
+  context 'when command or expected is missing' do
+    let(:template) do
+      <<~LIQUID
+        {% validation custom-command %}
+        command: kong version
+        {% endvalidation %}
+      LIQUID
+    end
+
+    it 'raises an error' do
+      expect { rendered }.to raise_error(ArgumentError, 'Missing `expected` in {% validation custom-command %}.')
+    end
+  end
+
+  describe 'template source' do
+    subject(:template_source) { File.read('app/_includes/how-tos/validations/custom-command/index.html') }
+
+    it 'renders the snippet include' do
+      expect(template_source).to include(
+        '{% include how-tos/validations/custom-command/snippet.md config=config %}'
+      )
+    end
+
+    context 'markdown template' do
+      subject(:template_source) { File.read('app/_includes/how-tos/validations/custom-command/index.md') }
+
+      it 'renders the snippet include' do
+        expect(template_source).to include(
+          '{% include how-tos/validations/custom-command/snippet.md config=config %}'
+        )
+      end
+    end
+  end
+end

--- a/spec/app/_plugins/blocks/validations/env_variables_spec.rb
+++ b/spec/app/_plugins/blocks/validations/env_variables_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+RSpec.describe Jekyll::Validation do
+  let(:how_tos_config) { { 'validations' => [] } }
+  let(:site_data) { { 'how-tos' => { 'config' => how_tos_config } } }
+  let(:site) { instance_double(Jekyll::Site, data: site_data) }
+
+  before { allow(Jekyll).to receive(:sites).and_return([site]) }
+
+  let(:page) do
+    { 'output_format' => 'html', 'path' => 'test.md', 'products' => ['gateway'], 'works_on' => works_on }
+  end
+  let(:template) do
+    <<~LIQUID
+      {% validation env-variables %}
+      KONNECT_TOKEN: kpat_xxx
+      {% endvalidation %}
+    LIQUID
+  end
+
+  subject(:rendered) { render_liquid(template, page: page) }
+
+  let(:html) { Capybara::Node::Simple.new(rendered) }
+
+  describe 'html output' do
+    context 'works_on: konnect' do
+      let(:works_on) { %w[konnect] }
+
+      it 'renders a konnect content div with the markdown attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][data-test-step]')
+      end
+
+      it 'does not render an on-prem content div' do
+        expect(html).not_to have_css('div[data-deployment-topology="on-prem"]')
+      end
+    end
+
+    context 'works_on: on-prem' do
+      let(:works_on) { %w[on-prem] }
+
+      it 'renders an on-prem content div with the markdown attribute' do
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute' do
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][data-test-step]')
+      end
+
+      it 'does not render a konnect content div' do
+        expect(html).not_to have_css('div[data-deployment-topology="konnect"]')
+      end
+    end
+
+    context 'works_on: konnect and on-prem' do
+      let(:works_on) { %w[konnect on-prem] }
+
+      it 'renders both content divs with the markdown attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][markdown="1"]')
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute on both content divs' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][data-test-step]')
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][data-test-step]')
+      end
+    end
+
+    context 'when section is prereqs' do
+      let(:works_on) { %w[konnect] }
+      let(:template) do
+        <<~LIQUID
+          {% validation env-variables %}
+          KONNECT_TOKEN: kpat_xxx
+          section: prereqs
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'renders a data-test-prereq attribute instead of data-test-step' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][data-test-prereq]')
+        expect(html).not_to have_css('div[data-deployment-topology="konnect"][data-test-step]')
+      end
+    end
+  end
+
+  describe 'markdown output_format' do
+    let(:page) do
+      { 'output_format' => 'markdown', 'path' => 'test.md', 'products' => ['gateway'], 'works_on' => works_on }
+    end
+
+    context 'works_on: konnect' do
+      let(:works_on) { %w[konnect] }
+
+      it 'renders the export line' do
+        expect(rendered).to include('export KONNECT_TOKEN="kpat_xxx"')
+      end
+
+      it 'does not render a deployment topology heading' do
+        expect(rendered).not_to include('### Konnect deployments')
+      end
+    end
+
+    context 'works_on: konnect and on-prem' do
+      let(:works_on) { %w[konnect on-prem] }
+
+      it 'renders the export line for both topologies' do
+        expect(rendered.scan('export KONNECT_TOKEN="kpat_xxx"').size).to eq(2)
+      end
+
+      it 'renders a deployment topology heading for each, konnect before on-prem' do
+        expect(rendered.index('### Konnect deployments')).to be < rendered.index('### On-prem deployments')
+      end
+    end
+  end
+
+  describe 'yaml validation' do
+    let(:works_on) { %w[konnect] }
+
+    context 'an empty mapping (see report: a fully blank body raises NoMethodError instead, since ' \
+             'YAML.load("") is nil, not {})' do
+      let(:template) do
+        <<~LIQUID
+          {% validation env-variables %}
+          {}
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'raises an error' do
+        expect { rendered }.to raise_error(ArgumentError, 'Missing variables in {% validation env-variables %}.')
+      end
+    end
+  end
+
+  describe '`indent:` stacks with the generic {% validation %} indent (see report — likely unintended)' do
+    let(:works_on) { %w[konnect] }
+    let(:template) do
+      <<~LIQUID
+        {% validation env-variables %}
+        KONNECT_TOKEN: kpat_xxx
+        indent: 3
+        {% endvalidation %}
+      LIQUID
+    end
+
+    it 'indents content by double the requested amount, because index.html applies `indent` ' \
+       'itself and Jekyll::Validation#render applies it again on top' do
+      content_line = rendered.lines.find { |l| l.include?('export KONNECT_TOKEN') }
+      expect(content_line).to start_with(' ' * 6)
+    end
+  end
+
+  describe 'template source' do
+    subject(:template_source) { File.read('app/_includes/how-tos/validations/env-variables/index.html') }
+
+    it 'renders the snippet include' do
+      expect(template_source).to include(
+        '{% include how-tos/validations/env-variables/snippet.md variables=config.variables %}'
+      )
+    end
+
+    context 'markdown template' do
+      subject(:template_source) { File.read('app/_includes/how-tos/validations/env-variables/index.md') }
+
+      it 'renders the snippet include' do
+        expect(template_source).to include(
+          '{% include how-tos/validations/env-variables/snippet.md variables=config.variables %}'
+        )
+      end
+    end
+  end
+end

--- a/spec/app/_plugins/blocks/validations/gemini_spec.rb
+++ b/spec/app/_plugins/blocks/validations/gemini_spec.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+RSpec.describe Jekyll::Validation do
+  let(:validations_config) do
+    [{ 'id' => 'gemini', 'command' => 'gemini', 'expected' => { 'return_code' => 0 } }]
+  end
+  let(:how_tos_config) { { 'validations' => validations_config } }
+  let(:site_data) { { 'how-tos' => { 'config' => how_tos_config } } }
+  let(:site) { instance_double(Jekyll::Site, data: site_data) }
+
+  before { allow(Jekyll).to receive(:sites).and_return([site]) }
+
+  let(:page) { { 'output_format' => 'html', 'path' => 'test.md', 'products' => ['ai-gateway'] } }
+  let(:template) do
+    <<~LIQUID
+      {% validation gemini %}
+      model: my-gemini-model
+      prompt: Explain the singleton pattern in Python.
+      {% endvalidation %}
+    LIQUID
+  end
+
+  subject(:rendered) { render_liquid(template, page: page) }
+
+  let(:html) { Capybara::Node::Simple.new(rendered) }
+
+  describe 'html output' do
+    it 'renders a content div with the markdown attribute' do
+      expect(html).to have_css('div.content[markdown="1"]')
+    end
+
+    it 'renders a data-test-step attribute' do
+      expect(html).to have_css('div.content[data-test-step]')
+    end
+  end
+
+  describe 'yaml validation' do
+    context 'when prompt is missing' do
+      let(:template) do
+        <<~LIQUID
+          {% validation gemini %}
+          model: my-gemini-model
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'raises an error' do
+        expect { rendered }.to raise_error(ArgumentError, 'Missing `prompt` in {% validation gemini %}.')
+      end
+    end
+
+    context 'when model is missing' do
+      let(:template) do
+        <<~LIQUID
+          {% validation gemini %}
+          prompt: Explain the singleton pattern in Python.
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'raises an error' do
+        expect { rendered }.to raise_error(ArgumentError, 'Missing `model` in {% validation gemini %}.')
+      end
+    end
+  end
+
+  describe 'template source' do
+    subject(:template_source) { File.read('app/_includes/how-tos/validations/gemini/index.html') }
+
+    it 'renders the snippet include' do
+      expect(template_source).to include('{% include how-tos/validations/gemini/snippet.md config=config %}')
+    end
+
+    context 'markdown template' do
+      subject(:template_source) { File.read('app/_includes/how-tos/validations/gemini/index.md') }
+
+      it 'renders the snippet include' do
+        expect(template_source).to include('{% include how-tos/validations/gemini/snippet.md config=config %}')
+      end
+    end
+  end
+end

--- a/spec/app/_plugins/blocks/validations/grpc_check_spec.rb
+++ b/spec/app/_plugins/blocks/validations/grpc_check_spec.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+RSpec.describe Jekyll::Validation do
+  let(:how_tos_config) do
+    {
+      'url_origin' => {
+        'konnect' => 'https://konnect.example.com',
+        'on_prem' => 'https://on-prem.example.com'
+      },
+      'validations' => []
+    }
+  end
+  let(:site_data) { { 'how-tos' => { 'config' => how_tos_config } } }
+  let(:site) { instance_double(Jekyll::Site, data: site_data) }
+
+  before { allow(Jekyll).to receive(:sites).and_return([site]) }
+
+  let(:page) do
+    { 'output_format' => 'html', 'path' => 'test.md', 'products' => ['kic'], 'works_on' => works_on }
+  end
+  let(:template) do
+    <<~LIQUID
+      {% validation grpc-check %}
+      method: hello.HelloService.SayHello
+      port: 443
+      {% endvalidation %}
+    LIQUID
+  end
+
+  subject(:rendered) { render_liquid(template, page: page) }
+
+  let(:html) { Capybara::Node::Simple.new(rendered) }
+
+  describe 'html output' do
+    context 'works_on: konnect' do
+      let(:works_on) { %w[konnect] }
+
+      it 'renders a konnect content div with the markdown attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][data-test-step]')
+      end
+
+      it 'renders the flex layout classes' do
+        expect(html).to have_css('div.flex.flex-col.gap-3[data-deployment-topology="konnect"]')
+      end
+
+      it 'does not render an on-prem content div' do
+        expect(html).not_to have_css('div[data-deployment-topology="on-prem"]')
+      end
+
+      it 'resolves the konnect url from how_tos_config, with no path suffix' do
+        expect(rendered).to include('https://konnect.example.com:443')
+      end
+    end
+
+    context 'works_on: on-prem' do
+      let(:works_on) { %w[on-prem] }
+
+      it 'renders an on-prem content div with the markdown attribute' do
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute' do
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][data-test-step]')
+      end
+
+      it 'does not render a konnect content div' do
+        expect(html).not_to have_css('div[data-deployment-topology="konnect"]')
+      end
+    end
+
+    context 'works_on: konnect and on-prem' do
+      let(:works_on) { %w[konnect on-prem] }
+
+      it 'renders both content divs with the markdown attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][markdown="1"]')
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute on both content divs' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][data-test-step]')
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][data-test-step]')
+      end
+    end
+
+    context 'overriding konnect_url/on_prem_url' do
+      let(:works_on) { %w[konnect on-prem] }
+      let(:template) do
+        <<~LIQUID
+          {% validation grpc-check %}
+          method: hello.HelloService.SayHello
+          port: 443
+          konnect_url: $PROXY_IP
+          on_prem_url: $PROXY_IP
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'uses the overridden host for both topologies, ignoring url_origin' do
+        expect(rendered).to include('$PROXY_IP:443')
+        expect(rendered).not_to include('https://konnect.example.com')
+        expect(rendered).not_to include('https://on-prem.example.com')
+      end
+    end
+  end
+
+  describe 'markdown output_format' do
+    let(:page) do
+      { 'output_format' => 'markdown', 'path' => 'test.md', 'products' => ['kic'], 'works_on' => works_on }
+    end
+
+    context 'works_on: konnect' do
+      let(:works_on) { %w[konnect] }
+
+      it 'renders the konnect snippet' do
+        expect(rendered).to include('https://konnect.example.com:443')
+      end
+
+      it 'does not render a deployment topology heading' do
+        expect(rendered).not_to include('### Konnect deployments')
+      end
+    end
+
+    context 'works_on: konnect and on-prem' do
+      let(:works_on) { %w[konnect on-prem] }
+
+      it 'renders both snippets' do
+        expect(rendered).to include('https://konnect.example.com:443')
+        expect(rendered).to include('https://on-prem.example.com:443')
+      end
+
+      it 'renders a deployment topology heading for each, konnect before on-prem' do
+        expect(rendered.index('### Konnect deployments')).to be < rendered.index('### On-prem deployments')
+      end
+    end
+  end
+
+  describe 'yaml validation' do
+    let(:works_on) { %w[konnect] }
+
+    context 'missing method' do
+      let(:template) do
+        <<~LIQUID
+          {% validation grpc-check %}
+          port: 443
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'raises an error' do
+        expect { rendered }.to raise_error(ArgumentError, 'Missing `method` in {% validation grpc-check %}.')
+      end
+    end
+  end
+
+  describe 'template source' do
+    subject(:template_source) { File.read('app/_includes/how-tos/validations/grpc-check/index.html') }
+
+    it 'renders the snippet include for konnect' do
+      expect(template_source).to include('{% include how-tos/validations/grpc-check/snippet.md url=config.konnect_url')
+    end
+
+    it 'renders the snippet include for on-prem' do
+      expect(template_source).to include('{% include how-tos/validations/grpc-check/snippet.md url=config.on_prem_url')
+    end
+
+    context 'markdown template' do
+      subject(:template_source) { File.read('app/_includes/how-tos/validations/grpc-check/index.md') }
+
+      it 'renders the snippet include for konnect' do
+        expect(template_source).to include('{% include how-tos/validations/grpc-check/snippet.md url=config.konnect_url')
+      end
+
+      it 'renders the snippet include for on-prem' do
+        expect(template_source).to include('{% include how-tos/validations/grpc-check/snippet.md url=config.on_prem_url')
+      end
+    end
+  end
+end

--- a/spec/app/_plugins/blocks/validations/qwen_spec.rb
+++ b/spec/app/_plugins/blocks/validations/qwen_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+RSpec.describe Jekyll::Validation do
+  let(:validations_config) do
+    [{ 'id' => 'qwen', 'command' => 'qwen', 'expected' => { 'return_code' => 0 } }]
+  end
+  let(:how_tos_config) { { 'validations' => validations_config } }
+  let(:site_data) { { 'how-tos' => { 'config' => how_tos_config } } }
+  let(:site) { instance_double(Jekyll::Site, data: site_data) }
+
+  before { allow(Jekyll).to receive(:sites).and_return([site]) }
+
+  let(:page) { { 'output_format' => 'html', 'path' => 'test.md', 'products' => ['ai-gateway'] } }
+  let(:template) do
+    <<~LIQUID
+      {% validation qwen %}
+      model: my-qwen-dashscope
+      auth-type: openai
+      prompt: Explain the singleton pattern in Python.
+      {% endvalidation %}
+    LIQUID
+  end
+
+  subject(:rendered) { render_liquid(template, page: page) }
+
+  let(:html) { Capybara::Node::Simple.new(rendered) }
+
+  describe 'html output' do
+    it 'renders a content div with the markdown attribute' do
+      expect(html).to have_css('div.content[markdown="1"]')
+    end
+
+    it 'renders a data-test-step attribute' do
+      expect(html).to have_css('div.content[data-test-step]')
+    end
+  end
+
+  describe 'yaml validation' do
+    context 'when prompt is missing' do
+      let(:template) do
+        <<~LIQUID
+          {% validation qwen %}
+          model: my-qwen-dashscope
+          auth-type: openai
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'raises an error' do
+        expect { rendered }.to raise_error(ArgumentError, 'Missing `prompt` in {% validation qwen %}.')
+      end
+    end
+
+    context 'when model is missing' do
+      let(:template) do
+        <<~LIQUID
+          {% validation qwen %}
+          auth-type: openai
+          prompt: Explain the singleton pattern in Python.
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'raises an error' do
+        expect { rendered }.to raise_error(ArgumentError, 'Missing `model` in {% validation qwen %}.')
+      end
+    end
+
+    context 'when auth-type is missing' do
+      let(:template) do
+        <<~LIQUID
+          {% validation qwen %}
+          model: my-qwen-dashscope
+          prompt: Explain the singleton pattern in Python.
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'raises an error' do
+        expect { rendered }.to raise_error(ArgumentError, 'Missing `auth-type` in {% validation qwen %}.')
+      end
+    end
+  end
+
+  describe 'template source' do
+    subject(:template_source) { File.read('app/_includes/how-tos/validations/qwen/index.html') }
+
+    it 'renders the snippet include' do
+      expect(template_source).to include('{% include how-tos/validations/qwen/snippet.md config=config %}')
+    end
+
+    context 'markdown template' do
+      subject(:template_source) { File.read('app/_includes/how-tos/validations/qwen/index.md') }
+
+      it 'renders the snippet include' do
+        expect(template_source).to include('{% include how-tos/validations/qwen/snippet.md config=config %}')
+      end
+    end
+  end
+end

--- a/spec/app/_plugins/blocks/validations/rate_limit_check_spec.rb
+++ b/spec/app/_plugins/blocks/validations/rate_limit_check_spec.rb
@@ -1,0 +1,240 @@
+# frozen_string_literal: true
+
+RSpec.describe Jekyll::Validation do
+  let(:how_tos_config) do
+    {
+      'url_origin' => {
+        'konnect' => 'https://konnect.example.com',
+        'on_prem' => 'https://on-prem.example.com'
+      },
+      'validations' => []
+    }
+  end
+  let(:site_data) { { 'how-tos' => { 'config' => how_tos_config } } }
+  let(:site) { instance_double(Jekyll::Site, data: site_data) }
+
+  before { allow(Jekyll).to receive(:sites).and_return([site]) }
+
+  let(:page) do
+    { 'output_format' => 'html', 'path' => 'test.md', 'products' => ['gateway'], 'works_on' => works_on }
+  end
+  let(:template) do
+    <<~LIQUID
+      {% validation rate-limit-check %}
+      iterations: 6
+      url: /anything
+      {% endvalidation %}
+    LIQUID
+  end
+
+  subject(:rendered) { render_liquid(template, page: page) }
+
+  let(:html) { Capybara::Node::Simple.new(rendered) }
+
+  describe 'html output' do
+    context 'works_on: konnect' do
+      let(:works_on) { %w[konnect] }
+
+      it 'renders a konnect content div with the markdown attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][data-test-step]')
+      end
+
+      it 'does not render an on-prem content div' do
+        expect(html).not_to have_css('div[data-deployment-topology="on-prem"]')
+      end
+    end
+
+    context 'works_on: on-prem' do
+      let(:works_on) { %w[on-prem] }
+
+      it 'renders an on-prem content div with the markdown attribute' do
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute' do
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][data-test-step]')
+      end
+
+      it 'does not render a konnect content div' do
+        expect(html).not_to have_css('div[data-deployment-topology="konnect"]')
+      end
+    end
+
+    context 'works_on: konnect and on-prem' do
+      let(:works_on) { %w[konnect on-prem] }
+
+      it 'renders both content divs with the markdown attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][markdown="1"]')
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute on both content divs' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][data-test-step]')
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][data-test-step]')
+      end
+    end
+
+    context 'with a message and status_code' do
+      let(:works_on) { %w[konnect] }
+      let(:template) do
+        <<~LIQUID
+          {% validation rate-limit-check %}
+          iterations: 6
+          url: /anything
+          status_code: 429
+          message: Too Many Requests
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'renders the status code and message outside the content divs' do
+        expect(rendered).to include('you should get a `429` response with the message `Too Many Requests`')
+      end
+    end
+
+    context 'with no message' do
+      let(:works_on) { %w[konnect] }
+
+      it 'does not render the status code and message text' do
+        expect(rendered).not_to include('you should get a')
+      end
+    end
+  end
+
+  describe 'markdown output_format' do
+    let(:page) do
+      { 'output_format' => 'markdown', 'path' => 'test.md', 'products' => ['gateway'], 'works_on' => works_on }
+    end
+
+    context 'works_on: konnect' do
+      let(:works_on) { %w[konnect] }
+
+      it 'renders the konnect snippet' do
+        expect(rendered).to include('https://konnect.example.com/anything')
+      end
+
+      it 'does not render a deployment topology heading' do
+        expect(rendered).not_to include('### Konnect deployments')
+      end
+    end
+
+    context 'works_on: on-prem' do
+      let(:works_on) { %w[on-prem] }
+
+      it 'renders the on-prem snippet' do
+        expect(rendered).to include('https://on-prem.example.com/anything')
+      end
+
+      it 'does not render a deployment topology heading' do
+        expect(rendered).not_to include('### On-prem deployments')
+      end
+    end
+
+    context 'works_on: konnect and on-prem' do
+      let(:works_on) { %w[konnect on-prem] }
+
+      it 'renders both snippets' do
+        expect(rendered).to include('https://konnect.example.com/anything')
+        expect(rendered).to include('https://on-prem.example.com/anything')
+      end
+
+      it 'renders a deployment topology heading for each, konnect before on-prem' do
+        expect(rendered.index('### Konnect deployments')).to be < rendered.index('### On-prem deployments')
+      end
+    end
+  end
+
+  describe 'yaml validation' do
+    let(:works_on) { %w[konnect] }
+
+    context 'missing iterations' do
+      let(:template) do
+        <<~LIQUID
+          {% validation rate-limit-check %}
+          url: /anything
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'raises an error' do
+        expect { rendered }.to raise_error(ArgumentError, 'Missing `iterations` in {% validation rate-limit-check %}.')
+      end
+    end
+
+    context 'grep specified with no output at all' do
+      let(:template) do
+        <<~LIQUID
+          {% validation rate-limit-check %}
+          iterations: 6
+          url: /anything
+          grep: "HTTP"
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'raises an error' do
+        expect { rendered }.to raise_error(ArgumentError, 'output.expected must be provided if `grep` is specified')
+      end
+    end
+
+    context 'grep specified with output.explanation but no output.expected' do
+      let(:template) do
+        <<~LIQUID
+          {% validation rate-limit-check %}
+          iterations: 6
+          url: /anything
+          grep: "HTTP"
+          output:
+            explanation: "some text"
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'raises an error' do
+        expect { rendered }.to raise_error(ArgumentError, 'output.expected must be provided if `grep` is specified')
+      end
+    end
+
+    context 'missing url' do
+      let(:template) do
+        <<~LIQUID
+          {% validation rate-limit-check %}
+          iterations: 6
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'raises an error' do
+        expect { rendered }.to raise_error(ArgumentError, 'Missing `url` in {% validation rate-limit-check %}.')
+      end
+    end
+  end
+
+  describe 'template source' do
+    subject(:template_source) { File.read('app/_includes/how-tos/validations/rate-limit-check/index.html') }
+
+    it 'renders the snippet include for konnect' do
+      expect(template_source).to include('{% include how-tos/validations/rate-limit-check/snippet.md iterations=config.iterations url=config.konnect_url')
+    end
+
+    it 'renders the snippet include for on-prem' do
+      expect(template_source).to include('{% include how-tos/validations/rate-limit-check/snippet.md iterations=config.iterations url=config.on_prem_url')
+    end
+
+    context 'markdown template' do
+      subject(:template_source) { File.read('app/_includes/how-tos/validations/rate-limit-check/index.md') }
+
+      it 'renders the snippet include for konnect' do
+        expect(template_source).to include('{% include how-tos/validations/rate-limit-check/snippet.md iterations=config.iterations url=config.konnect_url')
+      end
+
+      it 'renders the snippet include for on-prem' do
+        expect(template_source).to include('{% include how-tos/validations/rate-limit-check/snippet.md iterations=config.iterations url=config.on_prem_url')
+      end
+    end
+  end
+end

--- a/spec/app/_plugins/blocks/validations/request_check_spec.rb
+++ b/spec/app/_plugins/blocks/validations/request_check_spec.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+RSpec.describe Jekyll::Validation do
+  let(:how_tos_config) do
+    {
+      'url_origin' => {
+        'konnect' => 'https://konnect.example.com',
+        'on_prem' => 'https://on-prem.example.com'
+      },
+      'validations' => []
+    }
+  end
+  let(:site_data) { { 'how-tos' => { 'config' => how_tos_config } } }
+  let(:site) { instance_double(Jekyll::Site, data: site_data) }
+
+  before { allow(Jekyll).to receive(:sites).and_return([site]) }
+
+  let(:page) do
+    { 'output_format' => 'html', 'path' => 'test.md', 'products' => ['gateway'], 'works_on' => works_on }
+  end
+  let(:template) do
+    <<~LIQUID
+      {% validation request-check %}
+      url: /mock/anything
+      method: GET
+      status_code: 200
+      {% endvalidation %}
+    LIQUID
+  end
+
+  subject(:rendered) { render_liquid(template, page: page) }
+
+  let(:html) { Capybara::Node::Simple.new(rendered) }
+
+  describe 'html output' do
+    context 'works_on: konnect' do
+      let(:works_on) { %w[konnect] }
+
+      it 'renders a konnect content div with the markdown attribute' do
+        expect(html).to have_css('div.content[data-deployment-topology="konnect"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute' do
+        expect(html).to have_css('div.content[data-deployment-topology="konnect"][data-test-step]')
+      end
+
+      context 'when config.skip is true' do
+        let(:template) do
+          <<~LIQUID
+            {% validation request-check %}
+            url: /mock/anything
+            method: GET
+            status_code: 200
+            skip: true
+            {% endvalidation %}
+          LIQUID
+        end
+
+        it 'does not render a data-test-step attribute' do
+          expect(html).not_to have_css('div.content[data-deployment-topology="konnect"][data-test-step]')
+        end
+      end
+
+    end
+
+    context 'works_on: on-prem' do
+      let(:works_on) { %w[on-prem] }
+
+      it 'renders an on-prem content div with the markdown attribute' do
+        expect(html).to have_css('div.content[data-deployment-topology="on-prem"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute' do
+        expect(html).to have_css('div.content[data-deployment-topology="on-prem"][data-test-step]')
+      end
+
+      context 'when config.skip is true' do
+        let(:template) do
+          <<~LIQUID
+            {% validation request-check %}
+            url: /mock/anything
+            method: GET
+            status_code: 200
+            skip: true
+            {% endvalidation %}
+          LIQUID
+        end
+
+        it 'does not render a data-test-step attribute' do
+          expect(html).not_to have_css('div.content[data-deployment-topology="on-prem"][data-test-step]')
+        end
+      end
+    end
+
+    context 'works_on: konnect and on-prem' do
+      let(:works_on) { %w[konnect on-prem] }
+
+      it 'renders both content divs with the markdown attribute' do
+        expect(html).to have_css('div.content[data-deployment-topology="konnect"][markdown="1"]')
+        expect(html).to have_css('div.content[data-deployment-topology="on-prem"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute on both content divs' do
+        expect(html).to have_css('div.content[data-deployment-topology="konnect"][data-test-step]')
+        expect(html).to have_css('div.content[data-deployment-topology="on-prem"][data-test-step]')
+      end
+
+      context 'when config.skip is true' do
+        let(:template) do
+          <<~LIQUID
+            {% validation request-check %}
+            url: /mock/anything
+            method: GET
+            status_code: 200
+            skip: true
+            {% endvalidation %}
+          LIQUID
+        end
+
+        it 'does not render a data-test-step attribute on either content div' do
+          expect(html).not_to have_css('div.content[data-deployment-topology="konnect"][data-test-step]')
+          expect(html).not_to have_css('div.content[data-deployment-topology="on-prem"][data-test-step]')
+        end
+      end
+    end
+  end
+
+  describe 'markdown output_format' do
+    let(:page) do
+      { 'output_format' => 'markdown', 'path' => 'test.md', 'products' => ['gateway'], 'works_on' => works_on }
+    end
+
+    context 'works_on: konnect' do
+      let(:works_on) { %w[konnect] }
+
+      it 'renders the konnect snippet' do
+        expect(rendered).to include('https://konnect.example.com/mock/anything')
+      end
+
+      it 'does not render a deployment topology heading' do
+        expect(rendered).not_to include('### Konnect deployments')
+      end
+    end
+
+    context 'works_on: on-prem' do
+      let(:works_on) { %w[on-prem] }
+
+      it 'renders the on-prem snippet' do
+        expect(rendered).to include('https://on-prem.example.com/mock/anything')
+      end
+
+      it 'does not render a deployment topology heading' do
+        expect(rendered).not_to include('### On-prem deployments')
+      end
+    end
+
+    context 'works_on: konnect and on-prem' do
+      let(:works_on) { %w[konnect on-prem] }
+
+      it 'renders both snippets' do
+        expect(rendered).to include('https://konnect.example.com/mock/anything')
+        expect(rendered).to include('https://on-prem.example.com/mock/anything')
+      end
+
+      it 'renders a deployment topology heading for each, konnect before on-prem' do
+        expect(rendered.index('### Konnect deployments')).to be < rendered.index('### On-prem deployments')
+      end
+    end
+  end
+
+  describe 'template source' do
+    subject(:template_source) { File.read('app/_includes/how-tos/validations/request-check/index.html') }
+
+    it 'renders the snippet include for konnect' do
+      expect(template_source).to include('{% include how-tos/validations/request-check/snippet.md url=config.konnect_url')
+    end
+
+    it 'renders the snippet include for on-prem' do
+      expect(template_source).to include('{% include how-tos/validations/request-check/snippet.md url=config.on_prem_url')
+    end
+
+    context 'markdown template' do
+      subject(:template_source) { File.read('app/_includes/how-tos/validations/request-check/index.md') }
+
+      it 'renders the snippet include for konnect' do
+        expect(template_source).to include('{% include how-tos/validations/request-check/snippet.md url=config.konnect_url')
+      end
+
+      it 'renders the snippet include for on-prem' do
+        expect(template_source).to include('{% include how-tos/validations/request-check/snippet.md url=config.on_prem_url')
+      end
+    end
+  end
+end

--- a/spec/app/_plugins/blocks/validations/traffic_generator_spec.rb
+++ b/spec/app/_plugins/blocks/validations/traffic_generator_spec.rb
@@ -1,0 +1,226 @@
+# frozen_string_literal: true
+
+RSpec.describe Jekyll::Validation do
+  let(:how_tos_config) do
+    {
+      'url_origin' => {
+        'konnect' => 'https://konnect.example.com',
+        'on_prem' => 'https://on-prem.example.com'
+      },
+      'validations' => []
+    }
+  end
+  let(:site_data) { { 'how-tos' => { 'config' => how_tos_config } } }
+  let(:site) { instance_double(Jekyll::Site, data: site_data) }
+
+  before { allow(Jekyll).to receive(:sites).and_return([site]) }
+
+  let(:page) do
+    { 'output_format' => 'html', 'path' => 'test.md', 'products' => ['gateway'], 'works_on' => works_on }
+  end
+  let(:template) do
+    <<~LIQUID
+      {% validation traffic-generator %}
+      iterations: 6
+      url: /anything
+      headers:
+        - 'apikey:jsmith-key'
+      status_code: 200
+      {% endvalidation %}
+    LIQUID
+  end
+
+  subject(:rendered) { render_liquid(template, page: page) }
+
+  let(:html) { Capybara::Node::Simple.new(rendered) }
+
+  describe 'html output' do
+    context 'works_on: konnect' do
+      let(:works_on) { %w[konnect] }
+
+      it 'renders a konnect content div with the markdown attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][data-test-step]')
+      end
+
+      it 'does not render an on-prem content div' do
+        expect(html).not_to have_css('div[data-deployment-topology="on-prem"]')
+      end
+
+      it 'delegates to request-check/snippet.md, looping `iterations` times via `count`' do
+        expect(rendered).to include('for _  in {1..6}; do')
+        expect(rendered).to include('-H "apikey:jsmith-key"')
+      end
+    end
+
+    context 'works_on: on-prem' do
+      let(:works_on) { %w[on-prem] }
+
+      it 'renders an on-prem content div with the markdown attribute' do
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute' do
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][data-test-step]')
+      end
+
+      it 'does not render a konnect content div' do
+        expect(html).not_to have_css('div[data-deployment-topology="konnect"]')
+      end
+    end
+
+    context 'works_on: konnect and on-prem' do
+      let(:works_on) { %w[konnect on-prem] }
+
+      it 'renders both content divs with the markdown attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][markdown="1"]')
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute on both content divs' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][data-test-step]')
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][data-test-step]')
+      end
+    end
+
+    context 'with a method, body, and inline_sleep' do
+      let(:works_on) { %w[konnect] }
+      let(:template) do
+        <<~LIQUID
+          {% validation traffic-generator %}
+          iterations: 5
+          url: /anything
+          method: POST
+          status_code: 200
+          body:
+            messages:
+              - role: user
+                content: Who was Jozef Mackiewicz?
+          inline_sleep: 3
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'passes method/body/inline_sleep through to the delegated curl command' do
+        expect(rendered).to include('-X POST')
+        expect(rendered).to include('"content": "Who was Jozef Mackiewicz?"')
+      end
+    end
+  end
+
+  describe 'markdown output_format' do
+    let(:page) do
+      { 'output_format' => 'markdown', 'path' => 'test.md', 'products' => ['gateway'], 'works_on' => works_on }
+    end
+
+    context 'works_on: konnect' do
+      let(:works_on) { %w[konnect] }
+
+      it 'renders the konnect snippet' do
+        expect(rendered).to include('https://konnect.example.com/anything')
+      end
+
+      it 'does not render a deployment topology heading' do
+        expect(rendered).not_to include('### Konnect deployments')
+      end
+    end
+
+    context 'works_on: konnect and on-prem' do
+      let(:works_on) { %w[konnect on-prem] }
+
+      it 'renders both snippets' do
+        expect(rendered).to include('https://konnect.example.com/anything')
+        expect(rendered).to include('https://on-prem.example.com/anything')
+      end
+
+      it 'renders a deployment topology heading for each, konnect before on-prem' do
+        expect(rendered.index('### Konnect deployments')).to be < rendered.index('### On-prem deployments')
+      end
+    end
+  end
+
+  describe 'yaml validation' do
+    let(:works_on) { %w[konnect] }
+
+    context 'missing iterations' do
+      let(:template) do
+        <<~LIQUID
+          {% validation traffic-generator %}
+          url: /anything
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'raises an error' do
+        expect { rendered }.to raise_error(ArgumentError, 'Missing `iterations` in {% validation traffic-generator %}.')
+      end
+    end
+
+    context 'grep specified with no output.expected (synthetic — no real doc uses grep here)' do
+      let(:template) do
+        <<~LIQUID
+          {% validation traffic-generator %}
+          iterations: 6
+          url: /anything
+          grep: "HTTP"
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'raises an error' do
+        expect { rendered }.to raise_error(ArgumentError, 'output.expected must be provided if `grep` is specified')
+      end
+    end
+
+    context 'missing url' do
+      let(:template) do
+        <<~LIQUID
+          {% validation traffic-generator %}
+          iterations: 6
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'raises an error' do
+        expect { rendered }.to raise_error(ArgumentError, 'Missing `url` in {% validation traffic-generator %}.')
+      end
+    end
+  end
+
+  describe 'template source' do
+    subject(:template_source) { File.read('app/_includes/how-tos/validations/traffic-generator/index.html') }
+
+    it 'delegates to request-check/snippet.md for konnect, mapping iterations to count' do
+      expect(template_source).to include(
+        '{% include how-tos/validations/request-check/snippet.md url=config.konnect_url'
+      )
+      expect(template_source).to include('count=config.iterations')
+    end
+
+    it 'delegates to request-check/snippet.md for on-prem, mapping iterations to count' do
+      expect(template_source).to include(
+        '{% include how-tos/validations/request-check/snippet.md url=config.on_prem_url'
+      )
+    end
+
+    context 'markdown template' do
+      subject(:template_source) { File.read('app/_includes/how-tos/validations/traffic-generator/index.md') }
+
+      it 'delegates to request-check/snippet.md for konnect, mapping iterations to count' do
+        expect(template_source).to include(
+          '{% include how-tos/validations/request-check/snippet.md url=config.konnect_url'
+        )
+        expect(template_source).to include('count=config.iterations')
+      end
+
+      it 'delegates to request-check/snippet.md for on-prem, mapping iterations to count' do
+        expect(template_source).to include(
+          '{% include how-tos/validations/request-check/snippet.md url=config.on_prem_url'
+        )
+      end
+    end
+  end
+end

--- a/spec/app/_plugins/blocks/validations/unauthorized_check_spec.rb
+++ b/spec/app/_plugins/blocks/validations/unauthorized_check_spec.rb
@@ -1,0 +1,246 @@
+# frozen_string_literal: true
+
+RSpec.describe Jekyll::Validation do
+  let(:how_tos_config) do
+    {
+      'url_origin' => {
+        'konnect' => 'https://konnect.example.com',
+        'on_prem' => 'https://on-prem.example.com'
+      },
+      'validations' => []
+    }
+  end
+  let(:site_data) { { 'how-tos' => { 'config' => how_tos_config } } }
+  let(:site) { instance_double(Jekyll::Site, data: site_data) }
+
+  before { allow(Jekyll).to receive(:sites).and_return([site]) }
+
+  let(:page) do
+    { 'output_format' => 'html', 'path' => 'test.md', 'products' => ['gateway'], 'works_on' => works_on }
+  end
+  let(:template) do
+    <<~LIQUID
+      {% validation unauthorized-check %}
+      url: /anything
+      {% endvalidation %}
+    LIQUID
+  end
+
+  subject(:rendered) { render_liquid(template, page: page) }
+
+  let(:html) { Capybara::Node::Simple.new(rendered) }
+
+  describe 'html output' do
+    context 'works_on: konnect' do
+      let(:works_on) { %w[konnect] }
+
+      it 'renders a konnect content div with the markdown attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][data-test-step]')
+      end
+
+      it 'does not render an on-prem content div' do
+        expect(html).not_to have_css('div[data-deployment-topology="on-prem"]')
+      end
+    end
+
+    context 'works_on: on-prem' do
+      let(:works_on) { %w[on-prem] }
+
+      it 'renders an on-prem content div with the markdown attribute' do
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute' do
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][data-test-step]')
+      end
+
+      it 'does not render a konnect content div' do
+        expect(html).not_to have_css('div[data-deployment-topology="konnect"]')
+      end
+    end
+
+    context 'works_on: konnect and on-prem' do
+      let(:works_on) { %w[konnect on-prem] }
+
+      it 'renders both content divs with the markdown attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][markdown="1"]')
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute on both content divs' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][data-test-step]')
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][data-test-step]')
+      end
+    end
+
+    context 'indent' do
+      let(:works_on) { %w[konnect] }
+      let(:template) do
+        <<~LIQUID
+          {% validation unauthorized-check %}
+          url: /echo
+          konnect_url: $PROXY_IP
+          indent: 3
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'applies the requested indent exactly once, since index.html does not indent itself' do
+        content_line = rendered.lines.find { |l| l.include?('curl -i') }
+        expect(content_line).to eq("   curl -i $PROXY_IP/echo \n")
+      end
+    end
+  end
+
+  describe 'markdown output_format' do
+    let(:page) do
+      { 'output_format' => 'markdown', 'path' => 'test.md', 'products' => ['gateway'], 'works_on' => works_on }
+    end
+
+    context 'works_on: konnect' do
+      let(:works_on) { %w[konnect] }
+
+      it 'renders the konnect snippet' do
+        expect(rendered).to include('https://konnect.example.com/anything')
+      end
+
+      it 'does not render a deployment topology heading' do
+        expect(rendered).not_to include('### Konnect deployments')
+      end
+    end
+
+    context 'works_on: konnect and on-prem' do
+      let(:works_on) { %w[konnect on-prem] }
+
+      it 'renders both snippets' do
+        expect(rendered).to include('https://konnect.example.com/anything')
+        expect(rendered).to include('https://on-prem.example.com/anything')
+      end
+
+      it 'renders a deployment topology heading for each, konnect before on-prem' do
+        expect(rendered.index('### Konnect deployments')).to be < rendered.index('### On-prem deployments')
+      end
+    end
+
+    context 'with a message and status_code' do
+      let(:works_on) { %w[konnect] }
+      let(:template) do
+        <<~LIQUID
+          {% validation unauthorized-check %}
+          url: /anything
+          status_code: 403
+          message: 'Forbidden'
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'renders the same sentence as html, since message.md is format-agnostic' do
+        expect(rendered).to include('This request returns a `403` error with the message `Forbidden`.')
+      end
+    end
+  end
+
+  describe 'the "This request returns..." message (message.md, tested once since it does not ' \
+           'depend on output_format)' do
+    let(:works_on) { %w[konnect] }
+
+    context 'status_code and message both set' do
+      let(:template) do
+        <<~LIQUID
+          {% validation unauthorized-check %}
+          url: /anything
+          status_code: 403
+          message: 'Forbidden'
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'renders the full sentence' do
+        expect(rendered).to include('This request returns a `403` error with the message `Forbidden`.')
+      end
+    end
+
+    context 'status_code only' do
+      let(:template) do
+        <<~LIQUID
+          {% validation unauthorized-check %}
+          url: /anything
+          status_code: 401
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'renders a sentence with only the status code' do
+        expect(rendered).to include('This request returns a `401` error.')
+        expect(rendered).not_to include('with the message')
+      end
+    end
+
+    context 'message only' do
+      let(:template) do
+        <<~LIQUID
+          {% validation unauthorized-check %}
+          url: /anything
+          message: No API key found in request
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'renders a sentence with only the message' do
+        expect(rendered).to include('This request returns an error with the message `No API key found in request`.')
+      end
+    end
+
+    context 'neither set' do
+      it 'renders no message sentence at all' do
+        expect(rendered).not_to include('This request returns')
+      end
+    end
+  end
+
+  describe 'yaml validation' do
+    let(:works_on) { %w[konnect] }
+
+    context 'missing url' do
+      let(:template) do
+        <<~LIQUID
+          {% validation unauthorized-check %}
+          status_code: 401
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'raises an error' do
+        expect { rendered }.to raise_error(ArgumentError, 'Missing `url` in {% validation unauthorized-check %}.')
+      end
+    end
+  end
+
+  describe 'template source' do
+    subject(:template_source) { File.read('app/_includes/how-tos/validations/unauthorized-check/index.html') }
+
+    it 'renders the snippet include for konnect' do
+      expect(template_source).to include('{% include how-tos/validations/unauthorized-check/snippet.md url=config.konnect_url')
+    end
+
+    it 'renders the snippet include for on-prem' do
+      expect(template_source).to include('{% include how-tos/validations/unauthorized-check/snippet.md url=config.on_prem_url')
+    end
+
+    context 'markdown template' do
+      subject(:template_source) { File.read('app/_includes/how-tos/validations/unauthorized-check/index.md') }
+
+      it 'renders the snippet include for konnect' do
+        expect(template_source).to include('{% include how-tos/validations/unauthorized-check/snippet.md url=config.konnect_url')
+      end
+
+      it 'renders the snippet include for on-prem' do
+        expect(template_source).to include('{% include how-tos/validations/unauthorized-check/snippet.md url=config.on_prem_url')
+      end
+    end
+  end
+end

--- a/spec/app/_plugins/blocks/validations/vault_secret_spec.rb
+++ b/spec/app/_plugins/blocks/validations/vault_secret_spec.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+RSpec.describe Jekyll::Validation do
+  let(:how_tos_config) do
+    {
+      'container' => {
+        'konnect' => '$KONNECT_DP_CONTAINER',
+        'on_prem' => 'kong-quickstart-gateway'
+      },
+      'validations' => []
+    }
+  end
+  let(:site_data) { { 'how-tos' => { 'config' => how_tos_config } } }
+  let(:site) { instance_double(Jekyll::Site, data: site_data) }
+
+  before { allow(Jekyll).to receive(:sites).and_return([site]) }
+
+  let(:page) do
+    { 'output_format' => 'html', 'path' => 'test.md', 'products' => ['gateway'], 'works_on' => works_on }
+  end
+  let(:template) do
+    <<~LIQUID
+      {% validation vault-secret %}
+      secret: '{vault://hashicorp-vault/customer/acme/name}'
+      value: 'ACME Inc.'
+      {% endvalidation %}
+    LIQUID
+  end
+
+  subject(:rendered) { render_liquid(template, page: page) }
+
+  let(:html) { Capybara::Node::Simple.new(rendered) }
+
+  describe 'html output' do
+    context 'works_on: konnect' do
+      let(:works_on) { %w[konnect] }
+
+      it 'renders a konnect content div with the markdown attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][data-test-step]')
+      end
+
+      it 'does not render an on-prem content div' do
+        expect(html).not_to have_css('div[data-deployment-topology="on-prem"]')
+      end
+
+      it 'uses the konnect container' do
+        expect(rendered).to include('docker exec $KONNECT_DP_CONTAINER')
+      end
+    end
+
+    context 'works_on: on-prem' do
+      let(:works_on) { %w[on-prem] }
+
+      it 'renders an on-prem content div with the markdown attribute' do
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute' do
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][data-test-step]')
+      end
+
+      it 'does not render a konnect content div' do
+        expect(html).not_to have_css('div[data-deployment-topology="konnect"]')
+      end
+
+      it 'uses the on-prem container' do
+        expect(rendered).to include('docker exec kong-quickstart-gateway')
+      end
+    end
+
+    context 'works_on: konnect and on-prem' do
+      let(:works_on) { %w[konnect on-prem] }
+
+      it 'renders both content divs with the markdown attribute' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][markdown="1"]')
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][markdown="1"]')
+      end
+
+      it 'renders a data-test-step attribute on both content divs' do
+        expect(html).to have_css('div[data-deployment-topology="konnect"][data-test-step]')
+        expect(html).to have_css('div[data-deployment-topology="on-prem"][data-test-step]')
+      end
+    end
+
+    context 'with a command override' do
+      let(:works_on) { %w[konnect] }
+      let(:template) do
+        <<~LIQUID
+          {% validation vault-secret %}
+          secret: '{vault://aws-vault/my-aws-secret/token}'
+          value: 'secret'
+          command: kubectl exec -n kong -it deployment/kong-gateway -c proxy --
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'uses the given command instead of the konnect container' do
+        expect(rendered).to include('kubectl exec -n kong -it deployment/kong-gateway -c proxy -- kong vault get')
+        expect(rendered).not_to include('docker exec')
+      end
+    end
+  end
+
+  describe 'markdown output_format' do
+    let(:page) do
+      { 'output_format' => 'markdown', 'path' => 'test.md', 'products' => ['gateway'], 'works_on' => works_on }
+    end
+
+    context 'works_on: konnect' do
+      let(:works_on) { %w[konnect] }
+
+      it 'renders the konnect snippet' do
+        expect(rendered).to include('docker exec $KONNECT_DP_CONTAINER')
+      end
+
+      it 'does not render a deployment topology heading' do
+        expect(rendered).not_to include('### Konnect deployments')
+      end
+    end
+
+    context 'works_on: konnect and on-prem' do
+      let(:works_on) { %w[konnect on-prem] }
+
+      it 'renders both snippets' do
+        expect(rendered).to include('docker exec $KONNECT_DP_CONTAINER')
+        expect(rendered).to include('docker exec kong-quickstart-gateway')
+      end
+
+      it 'renders a deployment topology heading for each, konnect before on-prem' do
+        expect(rendered.index('### Konnect deployments')).to be < rendered.index('### On-prem deployments')
+      end
+    end
+  end
+
+  describe 'yaml validation' do
+    let(:works_on) { %w[konnect] }
+
+    context 'missing secret' do
+      let(:template) do
+        <<~LIQUID
+          {% validation vault-secret %}
+          value: 'ACME Inc.'
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'raises an error' do
+        expect { rendered }.to raise_error(ArgumentError, 'Missing `secret` in {% validation vault-secret %}.')
+      end
+    end
+
+    context 'missing value' do
+      let(:template) do
+        <<~LIQUID
+          {% validation vault-secret %}
+          secret: '{vault://hashicorp-vault/customer/acme/name}'
+          {% endvalidation %}
+        LIQUID
+      end
+
+      it 'raises an error' do
+        expect { rendered }.to raise_error(ArgumentError, 'Missing `value` in {% validation vault-secret %}.')
+      end
+    end
+  end
+
+  describe 'template source' do
+    subject(:template_source) { File.read('app/_includes/how-tos/validations/vault-secret/index.html') }
+
+    it 'renders the snippet include for konnect' do
+      expect(template_source).to include('{% include how-tos/validations/vault-secret/snippet.md container=config.container.konnect')
+    end
+
+    it 'renders the snippet include for on-prem' do
+      expect(template_source).to include('{% include how-tos/validations/vault-secret/snippet.md container=config.container.on_prem')
+    end
+
+    context 'markdown template' do
+      subject(:template_source) { File.read('app/_includes/how-tos/validations/vault-secret/index.md') }
+
+      it 'renders the snippet include for konnect' do
+        expect(template_source).to include('{% include how-tos/validations/vault-secret/snippet.md container=config.container.konnect')
+      end
+
+      it 'renders the snippet include for on-prem' do
+        expect(template_source).to include('{% include how-tos/validations/vault-secret/snippet.md container=config.container.on_prem')
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,4 +33,6 @@ RSpec.configure do |config|
   config.filter_run_when_matching :focus
   config.order = :random
   config.warnings = true
+
+  config.before(:suite) { JekyllSite.instance }
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,8 @@ require 'liquid'
 require 'capybara'
 
 Dir[File.join(PROJECT_ROOT, 'app/_plugins/**/*.rb')].sort.each do |f|
+  next if f.end_with?('app/_plugins/blocks/kuma-specific/kuma.rb')
+
   require f
 end
 

--- a/spec/support/liquid_context.rb
+++ b/spec/support/liquid_context.rb
@@ -4,7 +4,7 @@ def build_liquid_context(page: {}, locals: {})
   liquid_page = { 'path' => 'test/page.md', 'output_format' => 'html' }.merge(page)
 
   Liquid::Context.new(
-    [{ 'page' => liquid_page }.merge(locals)],
+    [{ 'page' => liquid_page }.merge(locals), JekyllSite.instance.site_payload],
     {},
     { site: JekyllSite.instance, page: liquid_page },
     true

--- a/spec/support/shell_syntax.rb
+++ b/spec/support/shell_syntax.rb
@@ -2,8 +2,8 @@
 
 require 'open3'
 
-def bash_code_block(rendered)
-  rendered[/```bash\n(.*?)\n```/m, 1]
+def bash_code_block(rendered, lang: 'bash')
+  rendered[/```#{lang}\n(.*?)\n```/m, 1]
 end
 
 def validate_bash_syntax!(script)

--- a/spec/support/shell_syntax.rb
+++ b/spec/support/shell_syntax.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'open3'
+
+def bash_code_block(rendered)
+  rendered[/```bash\n(.*?)\n```/m, 1]
+end
+
+def validate_bash_syntax!(script)
+  _stdout, stderr, status = Open3.capture3('bash', '-n', stdin_data: script)
+  return if status.success?
+
+  raise "Invalid bash syntax:\n#{script}\n\n#{stderr}"
+end

--- a/tools/automated-tests/config/expected_failures.yaml
+++ b/tools/automated-tests/config/expected_failures.yaml
@@ -41,10 +41,11 @@ input/instructions/ai-gateway/v1/how-to/set-up-ai-proxy-with-vertex-ai/on-prem/g
 input/instructions/ai-gateway/v1/how-to/set-up-ai-proxy-with-gemini/on-prem/gateway.yaml: "Expected: request http://localhost:8000/anything to have status code 200, got: 400."
 input/instructions/ai-gateway/v1/how-to/set-up-ai-proxy-advanced-with-gemini/on-prem/gateway.yaml: "Expected: request http://localhost:8000/anything to have status code 200, got: 400."
 input/instructions/ai-gateway/v1/how-to/use-ai-custom-guardrail-with-mistral/on-prem/gateway.yaml: "Expected: request http://localhost:8000/anything to have status code 400, got: 500."
-input/instructions/ai-gateway/v1/how-to/set-up-ai-proxy-with-ollama-qwen/on-prem/gateway.yaml: "Expected: request http://localhost:8000/anything to have status code 200, got: 503."
-input/instructions/ai-gateway/v1/how-to/set-up-ai-proxy-advanced-with-ollama-qwen/on-prem/gateway.yaml: "Expected: request http://localhost:8000/anything to have status code 200, got: 503."
+input/instructions/ai-gateway/v1/how-to/set-up-ai-proxy-with-ollama-qwen/on-prem/gateway.yaml: "Expected: request http://localhost:8000/anything to have status code 200, got: 502."
+input/instructions/ai-gateway/v1/how-to/set-up-ai-proxy-advanced-with-ollama-qwen/on-prem/gateway.yaml: "Expected: request http://localhost:8000/anything to have status code 200, got: 502."
 input/instructions/ai-gateway/v1/how-to/set-up-ai-proxy-with-databricks/on-prem/gateway.yaml: "Expected: request http://localhost:8000/anything to have status code 200, got: 503."
 input/instructions/ai-gateway/v1/how-to/set-up-ai-proxy-advanced-with-databricks/on-prem/gateway.yaml: "Expected: request http://localhost:8000/anything to have status code 200, got: 503."
 input/instructions/ai-gateway/v1/how-to/set-up-ai-proxy-with-deepseek/on-prem/gateway.yaml: "Expected: request http://localhost:8000/anything to have status code 200, got: 401."
 input/instructions/ai-gateway/v1/how-to/set-up-ai-proxy-advanced-with-deepseek/on-prem/gateway.yaml: "Expected: request http://localhost:8000/anything to have status code 200, got: 401."
 input/instructions/ai-gateway/v1/how-to/route-requests-by-model-alias/on-prem/gateway.yaml: "Expected: request http://localhost:8000/anything to have status code 200, got: 401."
+input/instructions/ai-gateway/v1/how-to/configure-hashicorp-vault-as-a-vault-for-llm-providers/on-prem/gateway.yaml: 'Expected: request http://localhost:8000/anything to have status code 200, got: 500.'


### PR DESCRIPTION
## Description

Add rspec coverage to some validation blocks and a gh action that runs the specs

fixes app/_how-tos/ai-gateway/v1/configure-hashicorp-vault-as-a-vault-for-llm-providers.md series

## Preview Links

/ai-gateway/v1/how-to/configure-hashicorp-vault-as-a-vault-for-llm-providers/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
