### PR TITLE
fix(aigw): Policy examples add `display_name`

### DIFF
--- a/app/_ai_gateway_policies/ai-prompt-guard/index.md
+++ b/app/_ai_gateway_policies/ai-prompt-guard/index.md
@@ -41,7 +41,9 @@ Configure the AI Prompt Guard Policy to detect hidden unicode characters that at
 {% entity_example %}
 type: policy
 data:
+  display_name: AI Prompt Guard - Hidden Unicode Detection
   name: ai-prompt-guard
+  type: ai-prompt-guard
   config:
     deny_patterns:
     - (\xE2\x80[\x8B-\x8D]|\xEF\xBB\xBF)
@@ -50,6 +52,7 @@ data:
     - \xF3\xA0\x80[\xA0-\xBF]|\xF3\xA0\x81[\x80-\xBF]
 formats:
   - konnect-api
+  - kongctl
 {% endentity_example %}
 
 In this example:

--- a/app/_ai_gateway_policies/ai-prompt-template/index.md
+++ b/app/_ai_gateway_policies/ai-prompt-template/index.md
@@ -23,21 +23,24 @@ When activated, the template restricts LLM usage to the predefined templates. Th
 {% entity_example %}
 type: policy
 data:
+  display_name: AI Prompt Template - Sample Template
   name: ai-prompt-template
+  type: ai-prompt-template
   config:
     templates:
-       name: sample-template
-       template: |-
-          {
-            "messages": [
-              {
-                "role": "user",
-                "content": "Explain to me what {% raw %}{{thing}}{% endraw %} is."
-              }
-            ]
-          }
+    - name: sample-template
+      template: |-
+        {
+          "messages": [
+            {
+              "role": "user",
+              "content": "Explain to me what {% raw %}{{thing}}{% endraw %} is."
+            }
+          ]
+        }
 formats:
   - konnect-api
+  - kongctl
 {% endentity_example %}
 
 

--- a/app/_ai_gateway_policies/ai-rate-limiting-advanced/index.md
+++ b/app/_ai_gateway_policies/ai-rate-limiting-advanced/index.md
@@ -44,6 +44,8 @@ The [`config.policies`](./reference/#schema--config-policies) field allows you t
 {% entity_example %}
 type: policy
 data:
+  display_name: AI Rate Limiting Advanced - Consumer and Model
+  type: ai-rate-limiting-advanced
   name: ai-rate-limiting-advanced
   config:
     policies:
@@ -63,6 +65,7 @@ data:
           window_size: 3600
 formats:
   - kongctl
+  - konnect-api
 {% endentity_example %}
 
 In this example, the limits will apply only to requests made by the specified AI Consumer to the `gpt-4o` model.
@@ -105,6 +108,7 @@ rows:
 {% entity_example %}
 type: policy
 data:
+  display_name: AI Rate Limiting Advanced - Calendar Window
   name: ai-rate-limiting-advanced
   type: ai-rate-limiting-advanced
   config:
@@ -122,6 +126,7 @@ data:
           tokens_count_strategy: total_tokens
 formats:
   - kongctl
+  - konnect-api
 {% endentity_example %}
 
 This policy grants the `premium` AI Consumer Group 2,000,000 tokens per calendar month, resetting at local midnight on the 1st in `America/New_York`.

--- a/app/_ai_gateway_policies/opentelemetry/index.md
+++ b/app/_ai_gateway_policies/opentelemetry/index.md
@@ -130,13 +130,27 @@ The OpenTelemetry AI Policy is built on top of the {{site.ai_gateway}} tracing P
    span:finish()
    ```
 
-2. Apply the Lua code with the [Post-function Policy](/ai-gateway/policies/post-function/) using a cURL file upload:
+2. Load the file into an environment variable:
 
    ```bash
-   curl -i -X POST http://localhost:8001/plugins \
-     -F "name=post-function" \
-     -F "config.access[1]=@custom-span.lua"
+   export CUSTOM_SPAN_LUA=$(cat custom-span.lua)
    ```
+
+3. Apply the Lua code with the [Post-function Policy](/ai-gateway/policies/post-function/):
+
+   {% entity_example %}
+   type: policy
+   data:
+     display_name: Post Function - Custom Span
+     name: post-function
+     type: post-function
+     config:
+       access:
+       - $CUSTOM_SPAN_LUA
+   formats:
+     - konnect-api
+     - kongctl
+   {% endentity_example %}
 
 ## Logging
 
@@ -204,12 +218,88 @@ The value of this field is an object that can contain different formats of the c
 
 ## Custom attributes by Lua
 
-{% include /md/ai-gateway/v2/policies/log-custom-fields-by-lua.md
-custom_fields_by_lua='config.access_logs.custom_attributes_by_lua'
-custom_fields_by_lua_slug='config-access-logs-custom-attributes-by-lua'
-custom_fields_by_lua_name='custom_attributes_by_lua'
-name=page.name
-slug=page.slug %}
+The [`config.access_logs.custom_attributes_by_lua`](./reference/#schema--config-access-logs-custom-attributes-by-lua) configuration lets you dynamically modify access log fields using Lua code. This field is only valid when [`config.access_logs.endpoint`](./reference/#schema--config-access-logs-endpoint) is also set. The following example configuration removes the `route` field from the access logs:
+
+{% entity_example %}
+type: policy
+data:
+  display_name: OpenTelemetry - Remove Field
+  name: opentelemetry
+  type: opentelemetry
+  config:
+    access_logs:
+      endpoint: http://my-access-log-endpoint:9999/
+      custom_attributes_by_lua:
+        route: "return nil"
+formats:
+  - konnect-api
+  - kongctl
+{% endentity_example %}
+
+New fields can be added the same way:
+
+{% entity_example %}
+type: policy
+data:
+  display_name: OpenTelemetry - Add Field
+  name: opentelemetry
+  type: opentelemetry
+  config:
+    access_logs:
+      endpoint: http://my-access-log-endpoint:9999/
+      custom_attributes_by_lua:
+        header: "return kong.request.get_header('h1')"
+formats:
+  - konnect-api
+  - kongctl
+{% endentity_example %}
+
+Dot characters (`.`) in the field key create nested fields. Use a backslash `\` to escape a dot if you want to keep it as part of a flat field name instead of nesting it. For example, `[my_entry.log\.field]` produces a `my_entry` object with a single `log.field` key, instead of nesting into `log` and `field`.
+
+### Targeting {{site.ai_gateway}} fields
+
+{{site.ai_gateway}} logs the outcome of an LLM request under a nested `ai` object, for example `ai.proxy.meta`, `ai.proxy.usage`, and, when payload logging is enabled, `ai.proxy.payload.request` and `ai.proxy.payload.response`. Because `custom_attributes_by_lua` keys are split into nested table accesses the same way, you can use the same unescaped, dotted-key syntax to remove or override those fields.
+
+For example, to stop logging LLM request and response payloads:
+
+{% entity_example %}
+type: policy
+data:
+  display_name: OpenTelemetry - Disable Payload Logging
+  name: opentelemetry
+  type: opentelemetry
+  config:
+    access_logs:
+      endpoint: http://my-access-log-endpoint:9999/
+      custom_attributes_by_lua:
+        "ai.proxy.payload.request": "return nil"
+formats:
+  - konnect-api
+  - kongctl
+{% endentity_example %}
+
+{:.info}
+> **Note:** Escaping the dots (for example, `ai\.proxy\.payload\.request`) targets a literal flat key instead of the nested `ai.proxy.payload.request` field, so it won't match. Use unescaped dots to target {{site.ai_gateway}} fields.
+
+Because the OpenTelemetry Policy applies `custom_attributes_by_lua` in its own log phase, which runs after {{site.ai_gateway}} sets the `ai.*` fields on the request, it can override or remove any `ai.*` field. The reverse isn't possible, since {{site.ai_gateway}} can't run after the Policy's log phase to override a field the Policy already set.
+
+{% comment %}
+### Policy precedence and managing fields
+
+All logging Policies use the same table for logging. If you set `config.custom_fields_by_lua` (or, for this Policy, `config.access_logs.custom_attributes_by_lua`) in one Policy, all logging Policies that run after it also use that configuration. For example, if you configure fields in the File Log Policy, those same fields appear in the Syslog Policy too, since File Log executes first.
+
+{:.info}
+> **Note:** This has been verified for the flat `config.custom_fields_by_lua` field shared across File Log, Syslog, and the other logging Policies. Whether the OpenTelemetry Policy's `config.access_logs.custom_attributes_by_lua` participates in that same shared table hasn't been independently confirmed; test this if you're relying on it.
+
+* If you want all logging Policies to use the same configuration, use the [Pre-function](/ai-gateway/policies/pre-function/) Policy to call `kong.log.set_serialize_value` so the function is applied predictably and is easier to manage.
+* If you don't want all logging Policies to share the same configuration, disable the relevant field in each Policy explicitly. For example, if you configure a field in the File Log Policy that you don't want appearing in the Syslog Policy, set that field to `return nil` in the File Log Policy's `custom_fields_by_lua` configuration.
+{% endcomment %}
+
+### Limitations
+
+Lua code runs in a restricted sandbox environment, whose behavior is governed by the `untrusted_lua` configuration.
+
+As this code runs in the log phase, only [PDK](/gateway/pdk/reference/) methods that can run in that phase can be used.
 
 ## Troubleshooting
 

--- a/app/_ai_gateway_policies/opentelemetry/index.md
+++ b/app/_ai_gateway_policies/opentelemetry/index.md
@@ -283,17 +283,8 @@ formats:
 
 Because the OpenTelemetry Policy applies `custom_attributes_by_lua` in its own log phase, which runs after {{site.ai_gateway}} sets the `ai.*` fields on the request, it can override or remove any `ai.*` field. The reverse isn't possible, since {{site.ai_gateway}} can't run after the Policy's log phase to override a field the Policy already set.
 
-{% comment %}
-### Policy precedence and managing fields
-
-All logging Policies use the same table for logging. If you set `config.custom_fields_by_lua` (or, for this Policy, `config.access_logs.custom_attributes_by_lua`) in one Policy, all logging Policies that run after it also use that configuration. For example, if you configure fields in the File Log Policy, those same fields appear in the Syslog Policy too, since File Log executes first.
-
-{:.info}
-> **Note:** This has been verified for the flat `config.custom_fields_by_lua` field shared across File Log, Syslog, and the other logging Policies. Whether the OpenTelemetry Policy's `config.access_logs.custom_attributes_by_lua` participates in that same shared table hasn't been independently confirmed; test this if you're relying on it.
-
-* If you want all logging Policies to use the same configuration, use the [Pre-function](/ai-gateway/policies/pre-function/) Policy to call `kong.log.set_serialize_value` so the function is applied predictably and is easier to manage.
-* If you don't want all logging Policies to share the same configuration, disable the relevant field in each Policy explicitly. For example, if you configure a field in the File Log Policy that you don't want appearing in the Syslog Policy, set that field to `return nil` in the File Log Policy's `custom_fields_by_lua` configuration.
-{% endcomment %}
+{:.warning}
+> The OpenTelemetry Policy doesn't use the same table for logging as the other logging Policies. This is because it uses `config.access_logs.custom_attributes_by_lua` instead of `config.custom_fields_by_lua`.
 
 ### Limitations
 

--- a/app/_ai_gateway_policies/opentelemetry/index.md
+++ b/app/_ai_gateway_policies/opentelemetry/index.md
@@ -201,7 +201,7 @@ The module records a structured log entry, which is reported via the OpenTelemet
 
 ## Queuing
 
-{% include_cached /md/ai-gateway/v2/policies/queues.md name=page.name %}
+{% include_cached /md/ai-gateway/v2/policies/queues.md name=page.name slug=page.slug %}
 
 ## Trace IDs in serialized logs
 

--- a/app/_includes/md/ai-gateway/v2/policies/log-custom-fields-by-lua.md
+++ b/app/_includes/md/ai-gateway/v2/policies/log-custom-fields-by-lua.md
@@ -5,6 +5,7 @@ The [`config.custom_fields_by_lua`](/ai-gateway/policies/{{include.slug}}/refere
 {% entity_example %}
 type: policy
 data:
+  display_name: "{{include.name}} - Remove Field"
   name: {{include.slug}}
   type: {{include.slug}}
   config:
@@ -21,6 +22,7 @@ New fields can be added the same way:
 {% entity_example %}
 type: policy
 data:
+  display_name: "{{include.name}} - Add Field"
   name: {{include.slug}}
   type: {{include.slug}}
   config:
@@ -43,6 +45,7 @@ For example, to stop logging LLM request and response payloads:
 {% entity_example %}
 type: policy
 data:
+  display_name: "{{include.name}} - Disable Payload Logging"
   name: {{include.slug}}
   type: {{include.slug}}
   config:

--- a/app/_includes/md/ai-gateway/v2/policies/passing-lua-code.md
+++ b/app/_includes/md/ai-gateway/v2/policies/passing-lua-code.md
@@ -3,6 +3,7 @@
 {% entity_example %}
 type: policy
 data:
+  display_name: "{{include.name}} - Inline Script"
   name: {{include.slug}}
   type: {{include.slug}}
   config:
@@ -10,7 +11,6 @@ data:
     - |
       kong.log.info("hello world")
 formats:
-  - konnect-api
   - kongctl
 {% endentity_example %}
 
@@ -25,12 +25,12 @@ Then reference the environment variable in your {{include.name}} Policy configur
 {% entity_example %}
 type: policy
 data:
+  display_name: "{{include.name}} - Script From File"
   name: {{include.slug}}
   type: {{include.slug}}
   config:
     access:
     - $FUNCTION_LUA
 formats:
-  - konnect-api
   - kongctl
 {% endentity_example %}


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes #6810 

## Preview Links

As I was testing these, I ran into several more errors unreleated to display_name, so I fixed those as well.
I've tested all the changed examples with 1.13.0 kongctl and Konnect API.

- /ai-gateway/policies/opentelemetry/#custom-attributes-by-lua (ripped this one out of the include because there were too many differences after fixing them, also I commented out a section that was in the original include because it's unclear if they use the same logging table now, I've asked [here](https://kongstrong.slack.com/archives/C0BEBVDL5TL/p1787684477697219))
- /ai-gateway/policies/loggly/#custom-fields-by-lua
- /ai-gateway/policies/file-log/#custom-fields-by-lua
- /ai-gateway/policies/http-log/#custom-fields-by-lua
- /ai-gateway/policies/pre-function/
- /ai-gateway/policies/ai-rate-limiting-advanced/
- /ai-gateway/policies/ai-prompt-template/ (another one that had an error outside of the scope of display_name that I've fixed)
- /ai-gateway/policies/ai-prompt-guard/


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
