### PR TITLE
fix(gateway): Bump supported pgsql version to 18

### DIFF
--- a/app/_data/products/gateway.yml
+++ b/app/_data/products/gateway.yml
@@ -1706,6 +1706,7 @@ releases:
       datastore:
         - postgres:
             versions:
+              - 18
               - 17
               - 16
               - 15
@@ -1895,6 +1896,7 @@ releases:
       datastore:
         - postgres:
             versions:
+              - 18
               - 17
               - 16
               - 15


### PR DESCRIPTION
Gateway supports pgsql 18+ since at least 3.14. See https://developer.konghq.com/gateway/configuration/#pg-oauth-auth and https://kongstrong.slack.com/archives/C03CTMSHP6C/p1787351675334309?thread_ts=1787315402.595769&cid=C03CTMSHP6C.

Preview:
/gateway/third-party-support/