### PR TITLE
docs: fix duplicated words and incorrect policy name

### DIFF
--- a/app/_how-tos/insomnia/manage-secrets-in-insomnia-with-1password.md
+++ b/app/_how-tos/insomnia/manage-secrets-in-insomnia-with-1password.md
@@ -80,7 +80,7 @@ The 1Password plugin creates a custom [template tag](/insomnia/template-tags/) t
 1. Create a new request. For this example, we'll send a `POST` request to `http://httpbin.konghq.com/anything`.
 1. Open the **Body** tab, click **No Body** and select **Form Data**.
 1. Enter a parameter name, `secret` for example.
-1. Click the **value** field field, press `Control+Space` to display the available template tags, and select **1Password => Fetch Secret**.
+1. Click the **value** field, press `Control+Space` to display the available template tags, and select **1Password => Fetch Secret**.
 1. Click the template tag to configure it, and add the reference to the 1Password secret we created in the [prerequisites](#1password): `op://insomnia/test-secret/password`. The live preview should show `my-password`.
 1. Click **Done** to apply the configuration.
 

--- a/app/_how-tos/mesh/deploy-universal-self-managed.md
+++ b/app/_how-tos/mesh/deploy-universal-self-managed.md
@@ -199,7 +199,7 @@ mtls:
 EOF
 ```
 
-Once Mutual TLS has been enabled, {{site.mesh_product_name}} will **not allow** traffic to flow freely across our services unless we explicitly have a [Traffic Traffic Permission](/mesh/policies/meshtrafficpermission/) policy that describes what services can be consumed by other services.
+Once Mutual TLS has been enabled, {{site.mesh_product_name}} will **not allow** traffic to flow freely across our services unless we explicitly have a [TrafficPermission](/mesh/policies/meshtrafficpermission/) policy that describes what services can be consumed by other services.
 
 You can try to make requests to the demo application at [`127.0.0.1:5000/`](http://127.0.0.1:5000/) and you will notice that they will **not** work.
 

--- a/app/catalog/integrations/azure-api-management.md
+++ b/app/catalog/integrations/azure-api-management.md
@@ -72,7 +72,7 @@ columns:
     key: description
 rows:
   - entity: API
-    description: An Azure API Management API that relates to the {{site.konnect_catalog}} service. Only HTTP specs can be added via the the **API Specs** tab on a service. gRPC, WebSocket, and GraphQL specifications aren't supported.
+    description: An Azure API Management API that relates to the {{site.konnect_catalog}} service. Only HTTP specs can be added via the **API Specs** tab on a service. gRPC, WebSocket, and GraphQL specifications aren't supported.
 {% endtable %}
 <!--vale on-->
 

--- a/app/operator/reference/custom-resources.md
+++ b/app/operator/reference/custom-resources.md
@@ -2793,7 +2793,7 @@ broker 92 to 9092, broker 93 to 9093, broker 94 to 9094, and broker 100 to
 9100.<br /><br />In most cases users should use a single range `["9090-9094"] ` and
 `bootstrap_port: at_start` and connect with
 `<host>:9090` as bootstrap server.
-Being able to use multiple ranges is only useful when when dealing with
+Being able to use multiple ranges is only useful when dealing with
 gaps in broker ids.<br /><br />It is strongly discouraged to use port mapping in production.
 
 


### PR DESCRIPTION
## Summary
Fixes four small but genuine text errors found while reading the docs:

1. `app/catalog/integrations/azure-api-management.md` — duplicated word: "via **the the** API Specs tab"
2. `app/_how-tos/insomnia/manage-secrets-in-insomnia-with-1password.md` — duplicated word: "**value** field field, press..."
3. `app/_how-tos/mesh/deploy-universal-self-managed.md` — incorrect policy name: "Traffic Traffic Permission" → **TrafficPermission** (the actual Kong Mesh policy, link target unchanged)
4. `app/operator/reference/custom-resources.md` — duplicated word: "only useful when when dealing with"

## Verification
Each error confirmed present on current `main`; searched open PRs to ensure no duplicate fix. Docs-only changes — no code paths affected.
