### PR TITLE
fix(kic): update broken Gateway API spec links

### DIFF
--- a/app/_how-tos/kubernetes-ingress-controller/kic-redirect-to-https.md
+++ b/app/_how-tos/kubernetes-ingress-controller/kic-redirect-to-https.md
@@ -115,7 +115,7 @@ kubectl annotate -n kong ingress echo konghq.com/https-redirect-status-code="301
 {{ the_code | indent: 4 }}
 
 {:.info}
-> **Note**: {{ site.kic_product_name }} _does not_ use a [HTTPRequestRedirectFilter](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.HTTPRequestRedirectFilter) to configure the redirect. Using the filter to redirect HTTP to HTTPS requires a separate `HTTPRoute` to handle redirected HTTPS traffic, which doesn't align well with {{site.base_gateway}}'s single Route redirect model.
+> **Note**: {{ site.kic_product_name }} _does not_ use a [HTTPRequestRedirectFilter](https://gateway-api.sigs.k8s.io/reference/api-types/gateway/#gateway.networking.k8s.io/v1.HTTPRequestRedirectFilter) to configure the redirect. Using the filter to redirect HTTP to HTTPS requires a separate `HTTPRoute` to handle redirected HTTPS traffic, which doesn't align well with {{site.base_gateway}}'s single Route redirect model.
 > 
 > Work to support the standard filter-based configuration is ongoing. Until then, the annotations allow you to configure HTTPS-only `HTTPRoutes`.
 

--- a/app/kubernetes-ingress-controller/class-annotations.md
+++ b/app/kubernetes-ingress-controller/class-annotations.md
@@ -40,7 +40,7 @@ If the `IngressClass` used by {{site.kic_product_name}} (specified in flag `--in
 
 ## GatewayClass
 
-{{ site.kic_product_name }} reconciles any resources attached to a [`GatewayClass`](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io/v1.GatewayClass) that has a `spec.controllerName` of `konghq.com/kic-gateway-controller`. 
+{{ site.kic_product_name }} reconciles any resources attached to a [`GatewayClass`](https://gateway-api.sigs.k8s.io/reference/api-types/gateway/#gateway.networking.k8s.io/v1.GatewayClass) that has a `spec.controllerName` of `konghq.com/kic-gateway-controller`. 
 
 Gateway API resources are attached to a `Gateway` object using the `spec.parentRefs` field, and the `Gateway` references a `GatewayClass` using the `spec.gatewayClassName` field.
 

--- a/app/kubernetes-ingress-controller/faq/upgrading-ingress-controller.md
+++ b/app/kubernetes-ingress-controller/faq/upgrading-ingress-controller.md
@@ -274,7 +274,7 @@ DB-less configurations in the Helm chart now use the `expressions` [`router_flav
 Use of the new routing engine should not change route matching outside of cases where route precedence did not match the [Gateway API specification][gateway-api-precedence]. The new engine does have different performance characteristics than the old engine, but should improve matching and configuration update speed for most configurations.
 
 [expression-kong-conf]: https://github.com/Kong/kong/blob/3.4.2/kong.conf.default#L1589-L1621
-[gateway-api-precedence]: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPRouteRule
+[gateway-api-precedence]: https://gateway-api.sigs.k8s.io/reference/api-types/gateway/#gateway.networking.k8s.io%2fv1.HTTPRouteRule
 
 #### Logging changes
 

--- a/app/kubernetes-ingress-controller/reference/host-manipulation.md
+++ b/app/kubernetes-ingress-controller/reference/host-manipulation.md
@@ -88,7 +88,7 @@ URL: /?details=true
 
 #### Using Gateway API {% new_in 3.2 %}
 
-You can set the Host header explicitly when using Gateway API's HTTPRoute with [`URLRewrite`](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPURLRewriteFilter) 
+You can set the Host header explicitly when using Gateway API's HTTPRoute with [`URLRewrite`](https://gateway-api.sigs.k8s.io/reference/api-types/gateway/#gateway.networking.k8s.io%2fv1.HTTPURLRewriteFilter) 
 filter's `hostname` field. You only need to add a `URLRewrite` filter to your HTTPRoute rule.
 
 ```yaml

--- a/app/kubernetes-ingress-controller/reference/path-manipulation.md
+++ b/app/kubernetes-ingress-controller/reference/path-manipulation.md
@@ -128,7 +128,7 @@ filters:
 
 Alternatively, you can add the `URLRewrite` filter with `path.replacePrefixMatch` to your `HTTPRoute` rule to rewrite the path prefix.
 
-See the [URLRewrite filter documentation](https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1.HTTPPathModifier)
+See the [URLRewrite filter documentation](https://gateway-api.sigs.k8s.io/reference/api-types/gateway/#gateway.networking.k8s.io%2fv1.HTTPPathModifier)
 for more information.
 
 ```yaml


### PR DESCRIPTION
## Summary
The Gateway API reference site moved its spec reference from `/reference/spec/` to `/reference/api-types/gateway/`. Five links in the KIC documentation still pointed at the old path and return **404**:

- `app/kubernetes-ingress-controller/class-annotations.md` — `GatewayClass`
- `app/kubernetes-ingress-controller/faq/upgrading-ingress-controller.md` — `HTTPRouteRule`
- `app/kubernetes-ingress-controller/reference/host-manipulation.md` — `URLRewrite`
- `app/kubernetes-ingress-controller/reference/path-manipulation.md` — `HTTPPathModifier`
- `app/_how-tos/kubernetes-ingress-controller/kic-redirect-to-https.md` — `HTTPRequestRedirectFilter`

## Verification
Each old URL returns 404; each updated URL (including the fragment anchor) was checked and returns 200.
