### PR TITLE
fix(aigw): kongctl examples

### DIFF
--- a/app/_data/entity_examples/config.yml
+++ b/app/_data/entity_examples/config.yml
@@ -48,8 +48,8 @@ event_gateway_variables: &event_gateway_variables
 
 ai_gateway_variables: &ai_gateway_variables
   ai_gateway:
-    placeholder: 'ai-gateway-name'
-    description: "The `name` of your AI Gateway."
+    placeholder: 'AI_GATEWAY_ID'
+    description: "The `id` of your AI Gateway."
 
 formats:
   deck:

--- a/app/_includes/components/entity_example/format/kongctl.md
+++ b/app/_includes/components/entity_example/format/kongctl.md
@@ -18,7 +18,6 @@ The following example creates a new `{{ include.presenter.data['type'] }}` polic
 {% endif %}
 {% if include.render_context or include.presenter.product == 'ai-gateway' %}
 {% if include.presenter.product == 'event-gateway' %}{% assign product = 'event_gateways' %}{% elsif include.presenter.product == 'ai-gateway'%}{% assign product = 'ai_gateways' %}{% endif %}
-Add this snippet to a kongctl declarative configuration file, and then [manage it with kongctl](/kongctl/declarative/#declarative-commands):
 {% endif %}
 
 {% include components/entity_example/format/snippets/kongctl.md presenter=include.presenter %}

--- a/app/_includes/components/entity_examples_kongctl.html
+++ b/app/_includes/components/entity_examples_kongctl.html
@@ -1,5 +1,5 @@
 ```yaml
-kongctl apply -f - --auto-approve --pat "$KONNECT_TOKEN" <<EOF
+kongctl apply -f - --auto-approve --pat "$KONNECT_TOKEN" << 'EOF'
 {{ entity_examples.kongctl_data }}
 EOF
 ```

--- a/app/_plugins/drops/entity_example/utils/variable_replacer.rb
+++ b/app/_plugins/drops/entity_example/utils/variable_replacer.rb
@@ -123,7 +123,7 @@ module Jekyll
               yaml
                 .gsub(SECRET_SENTINEL_PATTERN, '!secret {source: !env \1}')
                 .gsub(SENTINEL_PATTERN, '!env \1')
-                .gsub(AI_GATEWAY_LOOKUP_SENTINEL, '!lookup name:ai-gateway-name')
+                .gsub(AI_GATEWAY_LOOKUP_SENTINEL, '!lookup {id: !env AI_GATEWAY_ID}')
             end
 
             def initialize(variables: {})

--- a/spec/app/_includes/components/entity_example/format/snippets/kongctl_spec.rb
+++ b/spec/app/_includes/components/entity_example/format/snippets/kongctl_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe 'components/entity_example/format/snippets/kongctl.md' do
         ```yaml
         ai_gateway_models:
           - ref: my-gpt-4o
-            ai_gateway: !lookup name:ai-gateway-name
+            ai_gateway: !lookup {id: !env AI_GATEWAY_ID}
             display_name: my-gpt-4o
             name: my-gpt-4o
             type: model
@@ -110,7 +110,7 @@ RSpec.describe 'components/entity_example/format/snippets/kongctl.md' do
         ```yaml
         ai_gateway_model_providers:
           - ref: my-openai-account
-            ai_gateway: !lookup name:ai-gateway-name
+            ai_gateway: !lookup {id: !env AI_GATEWAY_ID}
             display_name: OpenAI Production
             name: my-openai-account
             type: openai
@@ -155,7 +155,7 @@ RSpec.describe 'components/entity_example/format/snippets/kongctl.md' do
         ```yaml
         ai_gateway_model_providers:
           - ref: my-openai-account
-            ai_gateway: !lookup name:ai-gateway-name
+            ai_gateway: !lookup {id: !env AI_GATEWAY_ID}
             display_name: OpenAI Production
             name: my-openai-account
             type: openai

--- a/spec/app/_plugins/drops/entity_example/presenters/kongctl_spec.rb
+++ b/spec/app/_plugins/drops/entity_example/presenters/kongctl_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Jekyll::Drops::EntityExample::Presenters::Kongctl::Base do
     {
       'kongctl' => {
         'ai_gateway_variables' => {
-          'ai_gateway' => { 'placeholder' => 'ai-gateway-name' }
+          'ai_gateway' => { 'placeholder' => 'AI_GATEWAY_ID' }
         },
         'event_gateway_variables' => {
           'event_gateway' => { 'placeholder' => 'event-gateway-name' }


### PR DESCRIPTION

## Description

Fixes a few kongctl example issues:
* quotes `'EOF'` to get around weird character escape issues
* uses an `id` lookup instead of `name`, same as our how-tos
* removes the generated kongctl codeblock preamble to avoid having multiple preambles when people write their own
## Preview Links


