### PR TITLE
fix(logging-plugins): remove deprecated queue settings

### DIFF
--- a/app/_kong_plugins/datadog/examples/request-count.yaml
+++ b/app/_kong_plugins/datadog/examples/request-count.yaml
@@ -13,8 +13,6 @@ requirements:
 config:
   host: 127.0.0.1
   port: 8125
-  flush_timeout: 2
-  retry_count: 10
   metrics:
     - name: request_count
       stat_type: counter

--- a/app/_kong_plugins/http-log/examples/custom-headers.yaml
+++ b/app/_kong_plugins/http-log/examples/custom-headers.yaml
@@ -23,7 +23,6 @@ config:
     Authorization: "Bearer ${token}"
   method: POST
   timeout: 3000
-  retry_count: 1
 
 tools:
   - deck

--- a/app/_kong_plugins/http-log/examples/http-log-with-splunk.yaml
+++ b/app/_kong_plugins/http-log/examples/http-log-with-splunk.yaml
@@ -31,7 +31,6 @@ config:
   http_endpoint: "https://example.splunkcloud.com:8088/services/collector/raw"
   method: POST
   timeout: 3000
-  retry_count: 1
 
 tools:
   - deck

--- a/app/_kong_plugins/http-log/index.md
+++ b/app/_kong_plugins/http-log/index.md
@@ -73,6 +73,13 @@ It also supports stream data (TCP, TLS, and UDP).
 
 {% include_cached /plugins/queues.md name=page.name %}
 
+{:.warning}
+> [`config.retry_count`](./reference/#schema--config-retry-count) is deprecated and has no effect in {{site.base_gateway}} 3.3 or later.
+> It will be removed in 4.0. Configure
+> [`config.queue.initial_retry_delay`](./reference/#schema--config-queue-initial-retry-delay),
+> [`config.queue.max_retry_delay`](./reference/#schema--config-queue-max-retry-delay), and
+> [`config.queue.max_retry_time`](./reference/#schema--config-queue-max-retry-time) instead.
+
 ### Shared queues in HTTP Log plugin instances
 
 In contrast to other plugins that use queues, all HTTP Log plugin instances that have the same values for the following parameters share one queue:

--- a/app/_kong_plugins/statsd/examples/log-on-status-range.yaml
+++ b/app/_kong_plugins/statsd/examples/log-on-status-range.yaml
@@ -15,8 +15,6 @@ config:
   allow_status_codes:
   - 200-205
   - 400-499
-  flush_timeout: 2
-  retry_count: 10
 
 
 variables:


### PR DESCRIPTION
## Description

Kong Gateway 3.3 replaced the legacy queue configuration used by HTTP Log, Datadog, and StatsD. The `config.retry_count` field no longer controls retries, but current examples still use legacy queue settings.

This PR adds the missing deprecation guidance to the HTTP Log documentation reported in FTI-5915. It also removes the same legacy defaults from related plugin examples.

- Add an HTTP Log warning with links to the supported queue retry settings.
- Remove `retry_count` from two HTTP Log examples.
- Remove `retry_count` and `flush_timeout` from the Datadog and StatsD examples.
- Keep the legacy schema fields unchanged for backward compatibility until Kong Gateway 4.0.
- Keep the historical changelog unchanged.

[FTI-5915](https://konghq.atlassian.net/browse/FTI-5915)

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).


[FTI-5915]: https://konghq.atlassian.net/browse/FTI-5915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ