### PR TITLE
fix(changelog): 3.14.0.14 and make generator more robust

### DIFF
--- a/app/_data/changelogs/gateway.json
+++ b/app/_data/changelogs/gateway.json
@@ -25971,11 +25971,6 @@
         "scope": "Core"
       },
       {
-        "message": "**openid-connect**: KONG_FIPS=on no longer generates default EdDSA JWKS keys. Use an RSA-PSS or NIST-curve ECDSA key instead.",
-        "type": "feature",
-        "scope": "Plugin"
-      },
-      {
         "message": "The FIPS-140-3 artifacts serve an explicit TLS 1.2 cipher list: four ECDHE\nsuites with AES-GCM. The FIPS-140-2 artifacts keep the OpenSSL FIPS alias,\nwhich also admits static RSA key transport and SSLv3-era suites. To serve a\ndifferent list, set `ssl_cipher_suite = custom` and `ssl_ciphers`.",
         "type": "feature",
         "scope": "Core"
@@ -26139,6 +26134,11 @@
         "message": "Reduced config update latency on hybrid data planes by notifying the stream subsystem before applying the update in the HTTP subsystem, so both rebuild in parallel.",
         "type": "performance",
         "scope": "Core"
+      },
+      {
+        "message": "**openid-connect**: KONG_FIPS=on no longer generates default EdDSA JWKS keys. Use an RSA-PSS or NIST-curve ECDSA key instead. \n\nIf you migrate from the FIPS package to the FIPS-140-3 package, this change breaks existing EdDSA-based configurations.",
+        "type": "feature",
+        "scope": "Plugin"
       }
     ],
     "kong-manager-ee": [

--- a/tools/changelog-generator/md-to-yml.js
+++ b/tools/changelog-generator/md-to-yml.js
@@ -167,7 +167,6 @@ function parseChangelog(md) {
     }
 
     if (!current) continue;
-    if (line === '') { flush(); continue; }
     if (isRefLine(line)) continue;
     current.lines.push(line);
   }


### PR DESCRIPTION
## Description


Don't flush changelog entry on blank lines.
Blank lines inside a bullet's body (a paragraph break or a nested sub-list) were treated as entry boundaries, silently truncating the entry. Entries only actually end at the next `-` bullet or the next heading, both of which already call flush() on their own, so this check was redundant in the case it was meant for and harmful in the case it wasn't.

This fixes an issue where bad changelog entries get written, by including stray paragraphs into the previous bullet point

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
