### PR TITLE
fix(aigw): Audit request size limiting policy

### DIFF
--- a/app/_ai_gateway_policies/request-size-limiting/index.md
+++ b/app/_ai_gateway_policies/request-size-limiting/index.md
@@ -24,7 +24,7 @@ Because prompt payloads are client-controlled and can be large, capping request 
 
 ## Example
 
-The following example creates a global Request Size Limiting Policy that rejects any request body larger than 256 kilobytes.
+The following example creates a global Request Size Limiting Policy that rejects any request body larger than 256 kilobytes:
 
 {% entity_example %}
 type: policy
@@ -39,4 +39,5 @@ data:
     size_unit: kilobytes
 formats:
   - kongctl
+  - konnect-api
 {% endentity_example %}


### PR DESCRIPTION
Added `konnect-api` as an example tab. Both it and kongctl are supported; without it, can't tell what the kongctl format is supposed to be.

Fixes https://github.com/Kong/developer.konghq.com/issues/6875