### PR TITLE
fix(ai-gateway): Route Claude CLI traffic through AI Gateway and Hugging Face audit

### DIFF
--- a/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-huggingface.md
+++ b/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-huggingface.md
@@ -6,6 +6,12 @@ permalink: /ai-gateway/use-claude-code-with-ai-gateway-huggingface/
 related_resources:
   - text: "{{site.ai_gateway}}"
     url: /ai-gateway/
+  - text: Hugging Face provider
+    url: /ai-gateway/ai-providers/huggingface/
+  - text: AI Model Provider
+    url: /ai-gateway/entities/ai-model-provider/
+  - text: AI Model
+    url: /ai-gateway/entities/ai-model/
 
 description: Configure {{site.ai_gateway}} to proxy Claude CLI traffic to a Hugging Face model
 
@@ -45,74 +51,16 @@ tldr:
 
 ---
 
-## Create an AI Model Provider entity
+## Create an AI Model Provider, and AI Model, and an AI Policy
 
-Create an [AI Model Provider](/ai-gateway/entities/ai-model-provider/) entity to define your connection and store your authentication credentials:
-
-{% entity_examples %}
-ai_gateway_model_providers:
-  - ref: my-huggingface-account
-    ai_gateway: !lookup {id: !env AI_GATEWAY_ID}
-    name: my-huggingface-account
-    display_name: "Hugging Face"
-    type: huggingface
-    config:
-      auth:
-        type: basic
-        headers:
-          - name: Authorization
-            value: !secret {source: !env HUGGINGFACE_AUTH_HEADER}
-{% endentity_examples %}
-
-{:.info}
-> `ai-quickstart` references the {{site.ai_gateway}} created by the quickstart script in the prerequisites above, instead of creating a new one.
-
-The AI Model Provider uses the following settings:
-
-* `type: huggingface`: Specifies that this provider speaks Hugging Face's Messages API format.
-* `config.auth.headers[0].value: !secret {source: !env HUGGINGFACE_AUTH_HEADER}`: Loads the API key from your environment at apply time so it is not embedded in the config, and `kongctl` redacts it in plan and diff output.
-
-## Create an AI Policy entity
+Create an [AI Model Provider](/ai-gateway/entities/ai-model-provider/) entity to define your connection and store your authentication credentials.
 
 Create an [AI Policy](/ai-gateway/entities/ai-policy/) entity using [request transformer](/ai-gateway/policies/ai-request-transformer/) to remove extra fields that  Hugging Face's API does not support. 
-
-{% entity_examples %}
-ai_gateway_policies:
-  - ref: strip-claude-beta-info
-    ai_gateway: !lookup {id: !env AI_GATEWAY_ID}
-    name: strip-claude-beta-info
-    display_name: "Strip Claude beta info"
-    type: request-transformer-advanced
-    config:
-      remove:
-        headers:
-          - anthropic-beta
-        querystring:
-          - beta
-        body:
-          - output_config
-          - context_management
-          - mcp_servers
-          - container
-          - service_tier
-{% endentity_examples %}
-
-{:.info}
-> {{ site.claude_code }} beta features vary by version and may add other incompatible fields over time. If you still see a `400` error mentioning an unexpected field after applying this Policy, add that field to the appropriate `remove` list and re-apply.
-
-The AI Policy uses the following settings:
-
-* `type: request-transformer-advanced`: Modifies requests before {{site.ai_gateway}} forwards them upstream.
-*  `config.remove.headers`: Removes the `anthropic-beta` header.
-*  `config.remove.querystring`: Removes the `beta` query string parameter.
-*  `config.remove.body`: Removes the `output_config`, `context_management`, `mcp_servers`, `container`, and `service_tier`body fields.
-
-## Create an AI Model entity
 
 Create an [AI Model](/ai-gateway/entities/ai-model/) entity to declare which upstream models are available, configure how client requests are routed, and specify which AI Model Provider to use:
 
 {:.info}
-> `formats: [type: anthropic]` accepts requests in Anthropic format even though the upstream is Hugging Face:
+> `formats: [type: anthropic]` accepts requests in Anthropic format even though the upstream is Hugging Face.
 
 {% entity_examples %}
 ai_gateway_model_providers:
@@ -173,11 +121,26 @@ ai_gateway_models:
       - generate
 {% endentity_examples %}
 
+The AI Model Provider uses the following settings:
+
+* `type: huggingface`: Specifies that this provider speaks Hugging Face's Messages API format.
+* `config.auth.headers[0].value: !secret {source: !env HUGGINGFACE_AUTH_HEADER}`: Loads the API key from your environment at apply time so it is not embedded in the config, and `kongctl` redacts it in plan and diff output.
+
+The AI Policy uses the following settings:
+
+* `type: request-transformer-advanced`: Modifies requests before {{site.ai_gateway}} forwards them upstream.
+*  `config.remove.headers`: Removes the `anthropic-beta` header.
+*  `config.remove.querystring`: Removes the `beta` query string parameter.
+*  `config.remove.body`: Removes the `output_config`, `context_management`, `mcp_servers`, `container`, `service_tier`, and `reasoning_effort` body fields.
+
+   {:.info}
+   > {{ site.claude_code }} beta features vary by version and may add other incompatible fields over time. If you still see a `400` error mentioning an unexpected field after applying this Policy, add that field to the appropriate `remove` list and re-apply.
+
 The AI Model uses the following settings:
 
 * `name`/`display_name: my-huggingface`: The identifier you pass to `claude --model`. {{ site.claude_code }} uses this, not the upstream target name, to select the model.
 * `formats: [type: anthropic]`: Declares that this model accepts requests in Anthropic-compatible format, matching what {{ site.claude_code }} sends natively.
-* `config.route.paths: [/]`: Configures the base path where this model's routes are accessible.
+* `config.route.paths: [/]`: Configures the base path where this model's Routes are accessible.
 * `capabilities: [generate]`: Enables text generation. For a model using the `anthropic` format, `generate` creates a `/messages` endpoint matching Anthropic's native Messages API, so combined with your base path, clients send requests to `/v1/messages`.
 * `policies`: Attaches the `strip-claude-beta-info` policy created in the previous step, so its header and body transformations apply to every request sent through this model.
 

--- a/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-huggingface.md
+++ b/app/_how-tos/ai-gateway/use-claude-code-with-ai-gateway-huggingface.md
@@ -53,11 +53,11 @@ tldr:
 
 ## Create an AI Model Provider, and AI Model, and an AI Policy
 
-Create an [AI Model Provider](/ai-gateway/entities/ai-model-provider/) entity to define your connection and store your authentication credentials.
+Create an AI Model Provider, and AI Model, and an AI Policy with all of your configuration
 
-Create an [AI Policy](/ai-gateway/entities/ai-policy/) entity using [request transformer](/ai-gateway/policies/ai-request-transformer/) to remove extra fields that  Hugging Face's API does not support. 
-
-Create an [AI Model](/ai-gateway/entities/ai-model/) entity to declare which upstream models are available, configure how client requests are routed, and specify which AI Model Provider to use:
+* The [AI Model Provider](/ai-gateway/entities/ai-model-provider/) entity defines your connection and stores your authentication credentials.
+* The [AI Request Transformer Policy](/ai-gateway/policies/ai-request-transformer/) removes extra fields that Hugging Face's API does not support. 
+* The [AI Model](/ai-gateway/entities/ai-model/) entity declares which upstream models are available, configures how client requests are routed, and specifies which AI Model Provider to use.
 
 {:.info}
 > `formats: [type: anthropic]` accepts requests in Anthropic format even though the upstream is Hugging Face.


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes #6894 

## Preview Links

https://deploy-preview-7038--kongdeveloper.netlify.app/ai-gateway/use-claude-code-with-ai-gateway-huggingface/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
