### PR TITLE
chore(gateway): 3.4 Sunset (End of regular support)

### DIFF
--- a/app/_data/products/gateway.yml
+++ b/app/_data/products/gateway.yml
@@ -30,6 +30,7 @@ releases:
     ee-version: "3.4.3.29"
     ce-version: "3.4.2"
     eol: 2026-08-31
+    sunset: true
     lts: true
     distributions:
       - amazonlinux2:


### PR DESCRIPTION

## Description

Fixes #6825 

3.4 enters sunset support on August 31st.

## Preview Links
https://deploy-preview-7052--kongdeveloper.netlify.app/gateway/version-support-policy/#supported-versions - 3.4 should be gone from the tabs, and should only appear in the "older versions" table below.

