### PR TITLE
chore(gateway): Update support matrix for 3.16

### DIFF
--- a/app/_data/products/gateway.yml
+++ b/app/_data/products/gateway.yml
@@ -1678,6 +1678,7 @@ releases:
           docker_support:
             arm: true
           default: true
+          eol: 2028-06-30
       - distroless:
           package: false
           docker: true
@@ -1720,6 +1721,7 @@ releases:
             fips2: true
             fips3: true
             arm: true
+          eol: 2027-05-31
       - ubuntu2404:
           package: true
           package_support:
@@ -1920,6 +1922,7 @@ releases:
             fips2: true
             fips3: false
             arm: true
+          eol: 2027-05-31
       - ubuntu2404:
           package: true
           package_support:
@@ -2119,6 +2122,7 @@ releases:
           docker_support:
             fips: true
             arm: true
+          eol: 2027-05-31
       - ubuntu2404:
           package: true
           package_support:

--- a/app/_data/products/gateway.yml
+++ b/app/_data/products/gateway.yml
@@ -2044,7 +2044,7 @@ releases:
   - release: "3.16"
     latest: true
     ee-version: "3.16.0.0"
-    eol: 2027-XX-XX
+    eol: 2027-09-10
     distributions:
       - amazonlinux2023:
           package: true
@@ -2056,16 +2056,6 @@ releases:
           docker_support:
             arm: true
           default: true
-      - debian11:
-          package: true
-          package_support:
-            fips: false
-            arm: true
-            graviton: true
-          docker: true
-          docker_support:
-            arm: true
-          eol: 2026-08-31
       - debian12:
           package: true
           package_support:
@@ -2076,12 +2066,21 @@ releases:
           docker_support:
             arm: true
           default: true
+      - debian13:
+          package: true
+          package_support:
+            fips: false
+            arm: true
+            graviton: true
+          docker: false
+          default: true
       - distroless:
           package: false
           docker: true
           docker_support:
             arm: true
-            fips: false
+            fips2: true
+            fips3: true
             graviton: true
           default: true
       - rhel8:
@@ -2101,6 +2100,14 @@ releases:
           docker_support:
             fips: true
             arm: true
+          default: true
+      - rhel10:
+          package: true
+          package_support:
+            graviton: false
+            arm: true
+            fips: true
+          docker: false
           default: true
       - ubuntu2204:
           package: true
@@ -2122,6 +2129,14 @@ releases:
           docker_support:
             fips: true
             arm: true
+          default: true
+      - ubuntu2604:
+          package: true
+          package_support:
+            arm: true
+            graviton: true
+            fips: true
+          docker: false
           default: true
     third_party_support:
       ai_providers:
@@ -2255,7 +2270,7 @@ release_dates:
   '3.15.0.5': 2026/08/24
   '3.13.0.10': 2026/08/20
   '3.15.0.4': 2026/08/20
-  '3.16.0.0': 2026/XX/XX
+  '3.16.0.0': 2026/09/10
   '3.14.0.13': 2026/08/19
   '3.12.0.11': 2026/08/18
   '3.15.0.3': 2026/08/10

--- a/app/_data/support/packages.yml
+++ b/app/_data/support/packages.yml
@@ -40,6 +40,11 @@ debian12:
   version: 12
   codename: bookworm
   docker_tag: debian
+debian13:
+  os: Debian
+  version: 13
+  codename: trixie
+  docker_tag: debian
 debian-stable:
   os: Debian
   version: stable
@@ -61,6 +66,11 @@ rhel9:
   version: 9.x
   codename: 9
   docker_tag: rhel
+rhel10:
+  os: RHEL
+  version: 10.x
+  codename: 10
+  docker_tag: rhel
 ubuntu1604:
   os: Ubuntu
   version: 16.04
@@ -80,4 +90,9 @@ ubuntu2404:
   os: Ubuntu
   version: 24.04
   codename: noble
+  docker_tag: ubuntu
+ubuntu2604:
+  os: Ubuntu
+  version: 26.04
+  codename: resolute
   docker_tag: ubuntu


### PR DESCRIPTION

## Description

Fixes #6720 
Fixes #6722 
Fixes #6976 

Updates to the support matrix for API Gateway:
* Support for RHEL 10, Debian 13, and Ubuntu 26.04
* Support for FIPS in distroless
* Removed support for Debian 11, it's reached EOL

## Preview Links
