### PR TITLE
chore(kongctl): install with the Homebrew formula

### DIFF
--- a/app/_data/homepage.yml
+++ b/app/_data/homepage.yml
@@ -20,7 +20,7 @@ agents_section:
     - tool: kongctl
       icon: /assets/icons/terminal.svg
       description: "Control Konnect resources from the terminal, declaratively or imperatively."
-      install: "brew install --cask kong/kongctl/kongctl"
+      install: "brew install --formula kong/kongctl/kongctl"
       command: "kongctl get control-planes"
       docs_url: /kongctl/
     - tool: inso
@@ -284,4 +284,3 @@ specs_section:
 
 whats_new:
   all_url: /changelogs/
-

--- a/app/_includes/tools/kongctl/install/osx.md
+++ b/app/_includes/tools/kongctl/install/osx.md
@@ -1,7 +1,8 @@
-Kong provides a [Homebrew](https://brew.sh) cask for kongctl. To install kongctl on macOS, run:
+Kong provides a [Homebrew](https://brew.sh) formula for kongctl. To install
+kongctl on macOS, run:
 
 ```bash
-brew install --cask kong/kongctl/kongctl
+brew install --formula kong/kongctl/kongctl
 ```
 
 Verify the installation:

--- a/app/kongctl/troubleshooting.md
+++ b/app/kongctl/troubleshooting.md
@@ -30,6 +30,22 @@ related_resources:
 
 This reference covers common issues and their solutions when using kongctl.
 
+## Homebrew installation
+
+### Switch from the cask to the formula
+
+If you previously installed kongctl using the Homebrew cask, uninstall it before
+installing the formula:
+
+```bash
+brew uninstall --cask kong/kongctl/kongctl
+brew install --formula kong/kongctl/kongctl
+kongctl version --full
+```
+
+Uninstalling the cask does not remove your kongctl configuration or stored
+credentials.
+
 ## Common issues
 
 ### "No changes detected" when changes exist


### PR DESCRIPTION
## Description

Recommend `brew install --formula kong/kongctl/kongctl` as the Homebrew
installation command in the kongctl macOS installation tab and homepage CLI
card. Keep introductory installation instructions focused on the formula.

Add cask-to-formula migration instructions to the existing kongctl
troubleshooting page, including uninstalling the cask first and verifying the
new installation. Configuration and stored credentials are preserved.

This documentation change does not deprecate the cask or change its support.
Any cask retirement schedule will be handled separately.

Related to Kong/kongctl#2009 and Kong/kongctl#2087. The formula installation
has already been manually verified on macOS; a new release is not required
to publish these installation instructions.

## Preview Links

- `/kongctl/?tab=macos#install-kongctl`
- `/` (kongctl CLI card)
- `/kongctl/troubleshooting/#switch-from-the-cask-to-the-formula`

## Validation

- Vale: zero errors, warnings, or suggestions in both changed Markdown files.
- Homepage YAML and troubleshooting frontmatter parse successfully.
- `git diff --check`: passed.
- Formula installation and cask-to-formula migration were manually verified
  on macOS during the Homebrew rollout.
- Full site build and Ruby tests were not run locally: required gems are
  missing (`bundle check`). CI validation remains required.

## Checklist

- [x] Installation and migration commands were manually tested on macOS.
- [x] Existing page metadata is preserved; no new pages were added.
- [x] No new documentation links or autogenerated instructions were added.
- [x] Style checks pass.
- [x] No product index changes are required.
