### PR TITLE
fix(ai-gateway): correct public Docker image name for AI PII Sanitizer

### DIFF
--- a/app/_kong_plugins/ai-sanitizer/index.md
+++ b/app/_kong_plugins/ai-sanitizer/index.md
@@ -134,13 +134,13 @@ Kong provides several AI PII Anonymizer service Docker images in a private repos
 To pull an image:
 
 ```bash
-docker pull kong/ai-pii-service:tagname
+docker pull kong/ai-pii-service:TAG
 ```
 
-Replace `IMAGE-NAME` and `TAG` with the appropriate image and version, such as:
+Replace `TAG` with the appropriate version and language code, such as:
 
 ```bash
-docker pull kong/ai-pii/service:v0.2.2-en
+docker pull kong/ai-pii-service:v0.2.2-en
 ```
 
 #### AI PII service Dockerfile usage
@@ -148,7 +148,7 @@ docker pull kong/ai-pii/service:v0.2.2-en
 To use an image in a `Dockerfile`, reference it as follows:
 
 ```dockerfile
-FROM kong/ai-pii/ai-pii-service:v0.2.2-en
+FROM kong/ai-pii-service:v0.2.2-en
 ```
 
 ### Available language tags


### PR DESCRIPTION
## Description

The Gateway plugin page still uses leftover Cloudsmith path fragments after the public Docker Hub move in #6753.

- `docker pull kong/ai-pii/service:v0.2.2-en` → `kong/ai-pii-service:v0.2.2-en`
- `FROM kong/ai-pii/ai-pii-service:v0.2.2-en` → `kong/ai-pii-service:v0.2.2-en`

This matches Docker Hub (`kong/ai-pii-service:v0.2.2-en`) and the AI Gateway 2.0 policy page.

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. Plugin reference page only; image names aligned with the existing policy page.
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).