### PR TITLE
fix(dev): PAGE_PATHS to skip plugin/policies generators locally

### DIFF
--- a/app/_plugins/generators/ai_gateway_policy/generator.rb
+++ b/app/_plugins/generators/ai_gateway_policy/generator.rb
@@ -40,6 +40,10 @@ module Jekyll
 
         site.pages << api_reference
       end
+
+      def skip_locally?
+        @build_filter.excludes_prefix?('/ai-gateway/')
+      end
     end
   end
 end

--- a/app/_plugins/generators/event_gateway_policy/generator.rb
+++ b/app/_plugins/generators/event_gateway_policy/generator.rb
@@ -20,6 +20,10 @@ module Jekyll
       def skip?
         site.config.dig('skip', 'event_gateway_policy')
       end
+
+      def skip_locally?
+        @build_filter.excludes_prefix?('/event-gateway/')
+      end
     end
   end
 end

--- a/app/_plugins/generators/mesh_policy/generator.rb
+++ b/app/_plugins/generators/mesh_policy/generator.rb
@@ -20,6 +20,10 @@ module Jekyll
       def skip?
         site.config.dig('skip', 'mesh_policy')
       end
+
+      def skip_locally?
+        @build_filter.excludes_prefix?('/mesh/')
+      end
     end
   end
 end

--- a/app/_plugins/generators/plugins/generator.rb
+++ b/app/_plugins/generators/plugins/generator.rb
@@ -19,8 +19,6 @@ module Jekyll
       end
 
       def run
-        return if skip_locally?
-
         Dir.glob(File.join(site.source, "#{PLUGINS_FOLDER}/*/")).each do |folder|
           slug = folder.gsub("#{site.source}/#{PLUGINS_FOLDER}/", '').chomp('/')
 
@@ -30,6 +28,9 @@ module Jekyll
 
       def generate_pages(plugin)
         generate_overview_page(plugin)
+
+        return if skip_locally?
+
         generate_changelog_page(plugin)
 
         return if site.config.dig('skip', 'plugins')
@@ -46,7 +47,7 @@ module Jekyll
                    .to_jekyll_page
 
         site.data['kong_plugins'][plugin.slug] = overview
-        site.pages << overview
+        site.pages << overview unless skip_locally?
       end
 
       def generate_reference_page(plugin)

--- a/app/_plugins/generators/policies/generator.rb
+++ b/app/_plugins/generators/policies/generator.rb
@@ -15,11 +15,15 @@ module Jekyll
 
       attr_reader :site
 
-      def initialize(site)
+      def initialize(site, build_filter: Jekyll::BuildFilter.current)
         @site = site
+        @build_filter = build_filter
       end
 
+
       def run
+        return if skip_locally?
+
         Dir.glob(File.join(site.source, "#{self.class.policies_folder}/*/")).each do |folder|
           slug = folder.gsub("#{site.source}/#{self.class.policies_folder}/", '').chomp('/')
 


### PR DESCRIPTION
## Description

Fix `PAGE_PATHS` so  it skips plugin/policies generators locally depending on the provided paths

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
