### PR TITLE
feat(gateway): Dynamic log levels for data planes

### DIFF
--- a/app/gateway/logs.md
+++ b/app/gateway/logs.md
@@ -74,11 +74,11 @@ You can change log levels dynamically, without restarting {{site.base_gateway}},
 A dynamic log level change is never persisted to `kong.conf`.
 If a node restarts while an override is active, it reverts to the log level set in `kong.conf`, and the `ttl` doesn't carry over.
 
-Alternatively, you can configure log levels using the `log_level` parameter in the [`kong.conf` file](/gateway/configuration/), but this requires you to [restart {{site.base_gateway}}](/how-to/restart-kong-gateway-container/).
+Alternatively, you can configure log levels using the `log_level` parameter in the [`kong.conf` file](/gateway/configuration/), which will persist. However, this requires you to [restart {{site.base_gateway}}](/how-to/restart-kong-gateway-container/).
 
 ### Dynamic log levels for control planes and traditional clusters
 
-You can view and manage log levels dynamically in traditional mode and for control planes in hybrid mode using the following settings and endpoints:
+Use the following settings and endpoints for log levels in traditional mode and hybrid mode control planes:
 
 {% navtabs "control plane log level" %}
 {% navtab "Self-managed" %}
@@ -196,7 +196,7 @@ The data plane applies the new log level and automatically reverts to the previo
 
 Data plane nodes on older {{site.base_gateway}} versions that don't support dynamic log levels report a status of `unsupported` instead of `applied`, both in `GET` and `POST` responses.
 
-Reading the current log level is available to any Control Plane Viewer.
+Reading the current log level is available to any Control Plane Viewer. You can also use the [Debugger](/observability/debugger/#reading-traces-and-logs) to do this directly from the {{site.konnect_short_name}} UI.
 Creating or changing a dynamic log level operation is a privileged action and requires Control Plane Admin permissions or higher.
 
 ## Find specific client requests in logs

--- a/app/gateway/logs.md
+++ b/app/gateway/logs.md
@@ -68,35 +68,135 @@ rows:
 {% endtable %}
 <!--vale on-->
 
-## Configure log levels
+## Configure log levels dynamically
 
-You can change log levels dynamically, without restarting {{site.base_gateway}}, using the Admin API. Alternatively, you can configure log levels using the `log_level` parameter in the [`kong.conf` file](/gateway/configuration/), but this requires you to [restart {{site.base_gateway}}](/how-to/restart-kong-gateway-container/).
+You can change log levels dynamically, without restarting {{site.base_gateway}}, using the Admin API or the {{site.konnect_short_name}} API.
+A dynamic log level change is never persisted to `kong.conf`.
+If a node restarts while an override is active, it reverts to the log level set in `kong.conf`, and the `ttl` doesn't carry over.
+
+Alternatively, you can configure log levels using the `log_level` parameter in the [`kong.conf` file](/gateway/configuration/), but this requires you to [restart {{site.base_gateway}}](/how-to/restart-kong-gateway-container/).
+
+### Dynamic log levels for control planes and traditional clusters
+
+You can view and manage log levels dynamically in traditional mode and for control planes in hybrid mode using the following settings and endpoints:
+
+{% navtabs "control plane log level" %}
+{% navtab "Self-managed" %}
 
 <!--vale off-->
 {% table %}
 columns:
   - title: Use case
     key: usecase
-  - title: How to configure
+  - title: Setting or endpoint
     key: config
 rows:
-  - usecase: "View current log level<sup>1</sup>"
-    config: "[`/debug/node/log-level`](/api/gateway/admin-ee/#/operations/get-debug-node-log-level)"
+  - usecase: "View current log level"
+    config: |
+      [`GET /debug/node/log-level`](/api/gateway/admin-ee/#/operations/get-debug-node-log-level)
   - usecase: "Modify the log level for an individual {{site.base_gateway}} node"
-    config: "[`/debug/node/log-level/{logLevel}`](/api/gateway/admin-ee/#/operations/get-debug-node-log-level-log_level)"
+    config: "[`POST /debug/node/log-level/{logLevel}`](/api/gateway/admin-ee/#/operations/get-debug-node-log-level-log_level)"
   - usecase: "Change the log level of the {{site.base_gateway}} cluster"
-    config: "[`/debug/cluster/log-level/{loglevel}`](/api/gateway/admin-ee/#/operations/update-debug-cluster-log-level)"
+    config: "[`/POST debug/cluster/log-level/{loglevel}`](/api/gateway/admin-ee/#/operations/update-debug-cluster-log-level)"
   - usecase: "Keep the log level of new nodes added to the cluster in sync with other nodes in the cluster"
     config: |
       Change the [`log_level`](/gateway/configuration/#log-level) entry in `kong.conf` to `KONG_LOG_LEVEL`, and start every new node with the `KONG_LOG_LEVEL` env variable set.
-  - usecase: "Change the log level of all Control Plane {{site.base_gateway}} nodes"
-    config: "[`/debug/cluster/control-planes-nodes/log-level/{loglevel}`](/api/gateway/admin-ee/#/operations/create-debug-cluster-control-planes-nodes-log-level)"
+  - usecase: "Change the log level of all control plane {{site.base_gateway}} nodes"
+    config: "[`POST /debug/cluster/control-planes-nodes/log-level/{loglevel}`](/api/gateway/admin-ee/#/operations/create-debug-cluster-control-planes-nodes-log-level)"
 {% endtable %}
 <!--vale on-->
 
-{:.info}
-> <sup>1</sup>: You can't change the log level of the Data Plane or DB-less nodes.
+{% endnavtab %}
+{% navtab "{{site.konnect_short_name}}" %}
 
+In {{site.konnect_short_name}}, you can only view the control plane log level. You can't adjust it dynamically.
+
+<!--vale off-->
+{% table %}
+columns:
+  - title: Use case
+    key: usecase
+  - title: Setting or endpoint
+    key: config
+rows:
+  - usecase: "View current log level {% new_in 3.16 %}"
+    config: |
+      `GET /control-planes/{controlPlaneId}/nodes`: View the `log_level` field in the response
+{% endtable %}
+<!--vale on-->
+
+{% endnavtab %}
+{% endnavtabs %}
+
+### Dynamic log levels for data plane nodes {% new_in 3.16 %} 
+
+In hybrid mode, you can temporarily change the log level of data plane nodes from the control plane.
+This is a runtime-only, on-demand override for debugging. It doesn't persist, and it isn't a substitute for permanent configuration in `kong.conf`.
+
+{:.info}
+> **Note**: Dynamic log levels are supported for data plane nodes running in hybrid mode. DB-less deployments are not supported.
+
+{% navtabs "dynamic log level endpoints" %}
+{% navtab "Self-managed" %}
+
+<!--vale off-->
+{% table %}
+columns:
+  - title: Use case
+    key: usecase
+  - title: Setting or endpoint
+    key: config
+rows:
+  - usecase: "Modify the log level for one or more data plane nodes"
+    config: "`POST /debug/cluster/data-planes/log-level-operations`"
+  - usecase: "List dynamic log level operations"
+    config: "`GET /debug/cluster/data-planes/log-level-operations`"
+  - usecase: "Get the status of a dynamic log level operation"
+    config: "`GET /debug/cluster/data-planes/log-level-operations/{id}`"
+  - usecase: "List the per-node results of a dynamic log level operation"
+    config: "`GET /debug/cluster/data-planes/log-level-operations/{id}/results`"
+  - usecase: "Get the result for one data plane node in an operation"
+    config: "`GET /debug/cluster/data-planes/log-level-operations/{id}/results/{node_id}`"
+{% endtable %}
+<!--vale on-->
+
+{% endnavtab %}
+{% navtab "{{site.konnect_short_name}}" %}
+
+<!--vale off-->
+{% table %}
+columns:
+  - title: Use case
+    key: usecase
+  - title: Setting or endpoint
+    key: config
+rows:
+  - usecase: "Modify the log level for one or more data plane nodes"
+    config: "`POST /control-planes/{controlPlaneId}/nodes/log-level-operations`"
+  - usecase: "List dynamic log level operations"
+    config: "`GET /control-planes/{controlPlaneId}/nodes/log-level-operations`"
+  - usecase: "Get the status of a dynamic log level operation"
+    config: "`GET /control-planes/{controlPlaneId}/nodes/log-level-operations/{operationId}`"
+  - usecase: "List the per-node results of a dynamic log level operation"
+    config: "`GET /control-planes/{controlPlaneId}/nodes/log-level-operations/{operationId}/results`"
+  - usecase: "Get the result for one data plane node in an operation"
+    config: "`GET /control-planes/{controlPlaneId}/nodes/log-level-operations/{operationId}/results/{nodeId}`"
+{% endtable %}
+<!--vale on-->
+
+{% endnavtab %}
+{% endnavtabs %}
+
+When you create an operation, you specify a `log_level`, a target (`all` data plane nodes, or a list of `node_ids`), and an optional `ttl` in seconds. 
+The data plane applies the new log level and automatically reverts to the previous level when the `ttl` expires.
+
+{:.info}
+> **Note**: The `ttl` must be an integer between 10 and 3600 seconds. If you don't set one, it defaults to 600 seconds (10 minutes). The 10 second minimum exists because data planes poll the control plane for updates every 5 seconds, so the `ttl` needs to cover at least two poll intervals for the node to reliably apply the change before it expires.
+
+Data plane nodes on older {{site.base_gateway}} versions that don't support dynamic log levels report a status of `unsupported` instead of `applied`, both in `GET` and `POST` responses.
+
+Reading the current log level is available to any Control Plane Viewer.
+Creating or changing a dynamic log level operation is a privileged action and requires Control Plane Admin permissions or higher.
 
 ## Find specific client requests in logs
 

--- a/app/gateway/logs.md
+++ b/app/gateway/logs.md
@@ -94,14 +94,14 @@ rows:
   - usecase: "View current log level"
     config: |
       [`GET /debug/node/log-level`](/api/gateway/admin-ee/#/operations/get-debug-node-log-level)
-  - usecase: "Modify the log level for an individual {{site.base_gateway}} node"
+  - usecase: "Modify the log level for an individual {{site.base_gateway}} node."
     config: "[`POST /debug/node/log-level/{logLevel}`](/api/gateway/admin-ee/#/operations/get-debug-node-log-level-log_level)"
-  - usecase: "Change the log level of the {{site.base_gateway}} cluster"
+  - usecase: "Change the log level of the {{site.base_gateway}} cluster."
     config: "[`/POST debug/cluster/log-level/{loglevel}`](/api/gateway/admin-ee/#/operations/update-debug-cluster-log-level)"
-  - usecase: "Keep the log level of new nodes added to the cluster in sync with other nodes in the cluster"
+  - usecase: "Keep the log level of new nodes added to the cluster in sync with other nodes in the cluster."
     config: |
       Change the [`log_level`](/gateway/configuration/#log-level) entry in `kong.conf` to `KONG_LOG_LEVEL`, and start every new node with the `KONG_LOG_LEVEL` env variable set.
-  - usecase: "Change the log level of all control plane {{site.base_gateway}} nodes"
+  - usecase: "Change the log level of all control plane {{site.base_gateway}} nodes."
     config: "[`POST /debug/cluster/control-planes-nodes/log-level/{loglevel}`](/api/gateway/admin-ee/#/operations/create-debug-cluster-control-planes-nodes-log-level)"
 {% endtable %}
 <!--vale on-->
@@ -119,9 +119,10 @@ columns:
   - title: Setting or endpoint
     key: config
 rows:
-  - usecase: "View current log level {% new_in 3.16 %}"
+  - usecase: |
+      View current log level {% new_in 3.16 %}
     config: |
-      `GET /control-planes/{controlPlaneId}/nodes`: View the `log_level` field in the response
+      `GET /control-planes/{controlPlaneId}/nodes`: View the `log_level` field in the response.
 {% endtable %}
 <!--vale on-->
 
@@ -147,15 +148,15 @@ columns:
   - title: Setting or endpoint
     key: config
 rows:
-  - usecase: "Modify the log level for one or more data plane nodes"
+  - usecase: "Modify the log level for one or more data plane nodes."
     config: "`POST /debug/cluster/data-planes/log-level-operations`"
-  - usecase: "List dynamic log level operations"
+  - usecase: "List dynamic log level operations."
     config: "`GET /debug/cluster/data-planes/log-level-operations`"
-  - usecase: "Get the status of a dynamic log level operation"
+  - usecase: "Get the status of a dynamic log level operation."
     config: "`GET /debug/cluster/data-planes/log-level-operations/{id}`"
-  - usecase: "List the per-node results of a dynamic log level operation"
+  - usecase: "List the per-node results of a dynamic log level operation."
     config: "`GET /debug/cluster/data-planes/log-level-operations/{id}/results`"
-  - usecase: "Get the result for one data plane node in an operation"
+  - usecase: "Get the result for one data plane node in an operation."
     config: "`GET /debug/cluster/data-planes/log-level-operations/{id}/results/{node_id}`"
 {% endtable %}
 <!--vale on-->
@@ -171,15 +172,15 @@ columns:
   - title: Setting or endpoint
     key: config
 rows:
-  - usecase: "Modify the log level for one or more data plane nodes"
+  - usecase: "Modify the log level for one or more data plane nodes."
     config: "`POST /control-planes/{controlPlaneId}/nodes/log-level-operations`"
-  - usecase: "List dynamic log level operations"
+  - usecase: "List dynamic log level operations."
     config: "`GET /control-planes/{controlPlaneId}/nodes/log-level-operations`"
-  - usecase: "Get the status of a dynamic log level operation"
+  - usecase: "Get the status of a dynamic log level operation."
     config: "`GET /control-planes/{controlPlaneId}/nodes/log-level-operations/{operationId}`"
-  - usecase: "List the per-node results of a dynamic log level operation"
+  - usecase: "List the per-node results of a dynamic log level operation."
     config: "`GET /control-planes/{controlPlaneId}/nodes/log-level-operations/{operationId}/results`"
-  - usecase: "Get the result for one data plane node in an operation"
+  - usecase: "Get the result for one data plane node in an operation."
     config: "`GET /control-planes/{controlPlaneId}/nodes/log-level-operations/{operationId}/results/{nodeId}`"
 {% endtable %}
 <!--vale on-->


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes #6791 
Adds a section to the logging doc about setting dynamic log levels on DPs.

Reviewers: 
* There are no links to the APIs, as they're all currently `x-internal`. We will add links when the spec is made public.
* Note that while the original issue also includes DB-less, dynamic node levels for DB-less mode are out of scope for 3.16.

## Preview Links

/gateway/logs/

