### PR TITLE
fix(changelog-generator): fix plugin changelog generator

### DIFF
--- a/.github/workflows/generate-gateway-plugins-changelogs.yml
+++ b/.github/workflows/generate-gateway-plugins-changelogs.yml
@@ -89,7 +89,7 @@ jobs:
         if: ${{ inputs.version != '' }}
         run: |
           cd tools/changelog-generator
-          node run.js --path='./tmp' --version='${{ inputs.version }}'
+          node run.js --version='${{ inputs.version }}'
 
       - name: Update release date in gateway.yml
         run: |

--- a/tools/changelog-generator/README.md
+++ b/tools/changelog-generator/README.md
@@ -39,9 +39,9 @@ Reads `<kong-ee>/changelog/3.10.0.2/3.10.0.2.md`, writes YAML files to `./tmp/ga
 ### 2. Generate temp files for specific versions
 
 ```bash
-node run.js --path='./tmp/gateway' --version='3.10.0.2'
+node run.js --version='3.10.0.2'
 # or explicitly:
-node run.js --path='./tmp/gateway' --version='3.10.0.2' --product=gateway
+node run.js --version='3.10.0.2' --product=gateway
 ```
 
 Creates `./tmp/gateway/3.10.0.2.json`. Omit `--version` to process all versions found under `./tmp/gateway/changelog/`.
@@ -72,7 +72,7 @@ Reads `./tmp/gateway/*`, `./missing_changelogs/*`, and `./missing_entries/`, wri
 
 1. Make sure your local `kong-ee` is up to date and on the right branch.
 1. `node md-to-yml.js --path='../../../kong-ee' --version='<version>'`
-1. `node run.js --path='./tmp/gateway' --version='<version>'`
+1. `node run.js --version='<version>'`
 1. Update `app/_data/products/gateway.yml` with the new version and release date.
 1. `node changelog.js`
 
@@ -90,7 +90,7 @@ Reads `<ai-gateway>/changelog/aigw-1.2.3/aigw-1.2.3.md`, writes YAML files to `.
 ### 2. Generate temp files for specific versions
 
 ```bash
-node run.js --path='./tmp/ai-gateway' --version='1.2.3' --product=ai-gateway
+node run.js --version='1.2.3' --product=ai-gateway
 ```
 
 Creates `./tmp/ai-gateway/1.2.3.json`. Omit `--version` to process all versions found under `./tmp/ai-gateway/changelog/`.
@@ -116,6 +116,6 @@ Reads `./tmp/ai-gateway/*`, writes to `app/_changelogs/ai-gateway.json`.
 
 1. Make sure your local `ai-gateway` repo is up to date and on the right branch.
 1. `node md-to-yml.js --path='../../../ai-gateway' --version='<version>' --product=ai-gateway`
-1. `node run.js --path='./tmp/ai-gateway' --version='<version>' --product=ai-gateway`
+1. `node run.js --version='<version>' --product=ai-gateway`
 1. Update `app/_data/products/ai-gateway.yml` with the new version and release date.
 1. `node changelog.js --product=ai-gateway`

--- a/tools/changelog-generator/run.js
+++ b/tools/changelog-generator/run.js
@@ -78,17 +78,14 @@ function fetchVersions(path) {
       process.exit(1);
     }
 
-    if (!args.path) {
-      console.error("Missing argument --path, relative path to the tmp changelog folder.");
-      process.exit(1);
-    }
+    const folderPath = `./tmp/${product}`;
 
     if (args.version) {
-      generateChangelogsByVersion(args.path, args.version, product);
+      generateChangelogsByVersion(folderPath, args.version, product);
     } else {
-      const versions = fetchVersions(args.path);
+      const versions = fetchVersions(folderPath);
       versions.forEach((version) => {
-        generateChangelogsByVersion(args.path, version, product);
+        generateChangelogsByVersion(folderPath, version, product);
       });
     }
   } catch (error) {


### PR DESCRIPTION
## Description

Fixes plugin changelog generator.
Remove `--path` from run.js, default to`./tmp/<product>/`

Fixes #issue

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
