### PR TITLE
fix(portal): access and approvals nav changes

### DIFF
--- a/app/_how-tos/dev-portal/kong-identity-dcr.md
+++ b/app/_how-tos/dev-portal/kong-identity-dcr.md
@@ -76,7 +76,7 @@ prereqs:
         1. Click **Create account**.
         1. If you haven't set developers to auto approval in Dev Portal, in the {{site.konnect_short_name}} sidebar, expand **Dev Portal** and click **Portals**.
         1. Click **Test {{site.identity}} DCR**.
-        1. Select the **Access and approvals** tab.
+        1. Select the **Developers** tab.
         1. Click your test developer.
         1. From the **Actions** dropdown menu, select "Approve". 
       icon_url: /assets/icons/dev-portal.svg

--- a/app/_how-tos/dev-portal/recover-dev-portal-audit-logs.md
+++ b/app/_how-tos/dev-portal/recover-dev-portal-audit-logs.md
@@ -54,7 +54,7 @@ prereqs:
         1. Click **New portal** to [create a Dev Portal](https://cloud.konghq.com/portals/create).
         1. Click your Dev Portal URL at the top of the Dev Portal overview.
         1. Click **Sign up** to [register a test developer account with your Dev Portal](/dev-portal/developer-signup/#1-register-or-sign-in).
-        1. If your settings require developer or application approval, you can manage approvals by navigating to **Access and approvals** in the {{site.konnect_short_name}} sidebar.
+        1. If your settings require developer or application approval, you can manage approvals by navigating to the **Developers** or **Applications** tab in your {{site.dev_portal}} overview in {{site.konnect_short_name}}.
       icon_url: /assets/icons/dev-portal.svg
     - title: SumoLogic SIEM provider
       include_content: /prereqs/sumologic-siem-for-konnect-ui

--- a/app/dev-portal/developer-rbac.md
+++ b/app/dev-portal/developer-rbac.md
@@ -67,7 +67,7 @@ resource "konnect_portal_team" "my_portalteam" {
 
 ## Manage developer RBAC
 
-You can manage developers, application registrations, and teams from the **Access and approvals** tab in your Dev Portal.
+You can manage developers, application registrations, and teams from the **Developers** and **Applications** tabs in your Dev Portal.
 
 To assign roles to developers, you need to create a team and add them to it:
 {% navtabs "assign-roles" %}
@@ -75,7 +75,7 @@ To assign roles to developers, you need to create a team and add them to it:
 1. In the {{site.konnect_short_name}} sidebar, expand **Dev Portal**.
 1. Click **Portals**.
 1. Click your Dev Portal.
-1. Click the **Access and approvals** tab.
+1. Click the **Developers** tab.
 1. Click the **Teams** tab.
 1. Click **New Team**.
 1. Enter a team name in the **Team** field.
@@ -101,8 +101,8 @@ To assign roles to developers, you need to create a team and add them to it:
       They can also transfer ownership of existing applications to their teams. 
       For more information on the developer experience, see [Dev Portal developer sign-up](/dev-portal/developer-signup/).
 1. To transfer application ownership to either a developer or team, do the following:
-   1. Click **Access and approvals** in the sidebar.
-   1. Click the **App registrations** tab.
+   1. Click the **Applications** tab.
+   1. Click the **API registrations** tab.
    1. Click the application you want to transfer ownership of.
    1. From the **Actions** dropdown menu, select "Transfer ownership".
 

--- a/app/dev-portal/self-service.md
+++ b/app/dev-portal/self-service.md
@@ -51,7 +51,7 @@ To enable developer self-service, do the following:
 
    For private {{site.dev_portal}}s, user authentication is enabled by default, and the default application auth strategy is key authentication.
 1. Configure an [application authentication strategy](/dev-portal/auth-strategies/) by navigating to **Settings > Security**.
-1. Optional: Enable [application sharing](#share-applications-with-a-team) for developer teams by navigating to your {{site.dev_portal}} in {{site.konnect_short_name}} and going to **Access and approvals > Teams**. Click the team, go to **Settings** and enable **Allow team to own applications**.
+1. Optional: Enable [application sharing](#share-applications-with-a-team) for developer teams by navigating to your {{site.dev_portal}} in {{site.konnect_short_name}} and clicking the **Developers > Teams** tabs. Click the team, go to **Settings** and enable **Allow team to own applications**.
 1. Link an [API to a Gateway Service](/catalog/apis/#gateway-service-link).
 
    This is required to enforce auth strategies.
@@ -106,7 +106,7 @@ To automatically create and manage {{site.dev_portal}} applications using Dynami
 
 You can choose to auto approve developers and applications or require admin approval for developers and applications by navigating to **Settings** and the **Security** tab in your {{site.dev_portal}} settings.
 
-If your settings require developer or application approval, you can manage approvals by navigating to **Access and approvals** in the sidebar. You need the [API Registration Approver and Portal Viewer role](/konnect-platform/teams-and-roles/#dev-portal) assigned to the Teams that control the APIs to approve these.
+If your settings require developer or application approval, you can manage approvals by navigating to the **Developers** or **Applications** tab in your {{site.dev_portal}} overview in {{site.konnect_short_name}}. You need the [API Registration Approver and Portal Viewer role](/konnect-platform/teams-and-roles/#dev-portal) assigned to the Teams that control the APIs to approve these.
 Additionally, you can add developers to teams by clicking on the settings menu next to the name of the developer.
 
 Once approved, developers can create applications and view APIs, and the application can generate credentials to use the APIs.
@@ -231,7 +231,7 @@ Important considerations:
   Similarly, you can only register APIs to team-owned applications if everyone in the team has access to the API.
   This is true even if an individual team member has broader access through other teams.
 
-To enable team application sharing, navigate to your {{site.dev_portal}} in {{site.konnect_short_name}} and click **Access and approvals > Teams**. Click the relevant team, go to **Settings**, and enable **Allow team to own applications**.
+To enable team application sharing, navigate to your {{site.dev_portal}} in {{site.konnect_short_name}} and click the **Developers > Teams** tabs. Click the relevant team, go to **Settings**, and enable **Allow team to own applications**.
 To transfer ownership of an application to either a developer or team, navigate to the app and from the **Actions** dropdown menu, select "Transfer ownership".
 
 For more information about how to configure {{site.dev_portal}} developer teams, see [{{site.dev_portal}} RBAC](/dev-portal/developer-rbac/).
@@ -425,8 +425,8 @@ To link the form to an API:
 #### View collected form data
 
 Submitted form answers appear alongside the developer or application registration they belong to:
-* Developer registration answers are available on the developer's detail page under **Access and approvals > Developers** in {{site.konnect_short_name}}, and through the `additional_data` property on the [`/portals/{portalId}/developers`](/api/konnect/portal-management/v3/#/operations/list-portal-developers) and [`/portals/{portalId}/developers/{developerId}`](/api/konnect/portal-management/v3/#/operations/get-developer) endpoints.
-* API registration answers are available on the registration's detail page under **Access and approvals > App Registrations**, and through the `additional_data` property on the [`/portals/{portalId}/application-registrations`](/api/konnect/portal-management/v3/#/operations/list-registrations) endpoint.
+* Developer registration answers are available on the developer's detail page under the **Developers** tab in {{site.konnect_short_name}}, and through the `additional_data` property on the [`/portals/{portalId}/developers`](/api/konnect/portal-management/v3/#/operations/list-portal-developers) and [`/portals/{portalId}/developers/{developerId}`](/api/konnect/portal-management/v3/#/operations/get-developer) endpoints.
+* API registration answers are available on the registration's detail page under **Applications > API Registrations** tabs, and through the `additional_data` property on the [`/portals/{portalId}/application-registrations`](/api/konnect/portal-management/v3/#/operations/list-registrations) endpoint.
 
 {{site.dev_portal}} doesn't have a webhook for new registrations or form submissions, so if you want to react to new submissions automatically, poll these endpoints on an interval instead. 
 For example, you could filter on `status=pending` and track the last submission you've already processed.
@@ -569,8 +569,8 @@ body:
 {% navtab "UI" %}
 1. In the {{site.konnect_short_name}} sidebar, click **Dev Portal > Portals**.
 1. Click your {{site.dev_portal}}.
-1. Click the **Access and approvals** tab.
-1. Click the **App Registrations** tab.
+1. Click the **Applications** tab.
+1. Click the **API registrations** tab.
 1. Click the application you want to link a Consumer to.
 1. In the **App Registrations** section, click the action menu icon for the registration.
 1. Click **Link Consumer**.

--- a/app/dev-portal/v2-migration.md
+++ b/app/dev-portal/v2-migration.md
@@ -52,6 +52,6 @@ To migrate from Dev Portal classic (v2) to the new Dev Portal (v3), do the follo
    1. Decrease your domain TTL in advance to reduce the transition time. Some minimal downtime will be required to move custom domains.
    1. Delete your custom domain from v2 Dev Portal.
    1. Add the custom domain to the v3 Dev Portal.
-1. If you've enabled developer RBAC, manually assign developers to teams and roles by navigating to your v3 Dev Portal in {{site.konnect_short_name}}, clicking **Access and approvals** in the sidebar, and click the **Teams** tab.
+1. If you've enabled developer RBAC, manually assign developers to teams and roles by navigating to your v3 Dev Portal in {{site.konnect_short_name}}, clicking the **Developers > Teams** tabs.
    {:.warning}
    > For self-hosted Dev Portals, contact Kong Support by navigating to the **?** icon on the top right menu and clicking **Create support case** or from the [Kong Support portal](https://support.konghq.com).


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes https://kongstrong.slack.com/archives/CAW1MAFLZ/p1788441885086789?thread_ts=1788432808.121279&cid=CAW1MAFLZ

When custom forms was released, they also changed the **Access and approvals** tab that used to be there and split it into **Developers** and **Applications** tabs.

## Preview Links
- /how-to/kong-identity-dcr/
- /how-to/recover-dev-portal-audit-logs/
- /dev-portal/developer-rbac/
- /dev-portal/self-service/
- /dev-portal/v2-migration/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
