### PR TITLE
fix(support): Title and tldr formatting

### DIFF
--- a/app/_support/error-require-resty-http-not-allowed-within-sandbox.md
+++ b/app/_support/error-require-resty-http-not-allowed-within-sandbox.md
@@ -1,5 +1,5 @@
 ---
-title: 'Error: require "resty.http" not allowed within sandbox'
+title: "Error: require 'resty.http' not allowed within sandbox"
 content_type: support
 description: Plugins that execute arbitrary Lua code run in a sandbox that blocks require of certain modules; allow the module or disable the sandbox to resolve it.
 products:
@@ -8,7 +8,8 @@ works_on:
   - on-prem
   - konnect
 tldr:
-  q: "Why do I get \"require 'resty.http' not allowed within sandbox\" when using a plugin that runs Lua code?"
+  q: |
+    Why do I get the error `require 'resty.http' not allowed within sandbox` when using a plugin that runs Lua code?
   a: |
     The plugin runs in a sandbox that blocks `require` of certain modules.
     Add the module to `untrusted_lua_sandbox_requires` (preferred), or set `untrusted_lua` to `on` to disable the sandbox entirely (use with caution).


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

When a title has double quotes in it, Algolia doesn't render anything after the first `"`. Double quotes can only surround a title. See https://developer.konghq.com/support/?page=3

Also fixing the missing backtick formatting in the tldr.

<img width="1327" height="453" alt="Screenshot 2026-09-03 at 1 10 16 PM" src="https://github.com/user-attachments/assets/0f254981-0444-4df6-b786-6bc7d99ce792" />

Note that you won't be able to preview the title fix; it'll only show up after a re-index.
## Preview Links

/support/error-nginx-kong-lua-9-expected-near-customformat-when-using-a-custom-log-format/
