### PR TITLE
feat(ai-gateway): add Skills API capability for OpenAI and Anthropic

### DIFF
--- a/app/_ai_gateway_entities/ai-model.md
+++ b/app/_ai_gateway_entities/ai-model.md
@@ -129,7 +129,7 @@ An AI Model is a managed entity. {{site.ai_gateway}} owns its runtime configurat
 When you expose an AI Model, you choose which AI capabilities it provides through the [`capabilities`](#schema-aigateway-model-capabilities) field. The [`type`](#schema-aigateway-model-type) you select determines which capabilities are available:
 
 * **`model` type**: for synchronous request/response workloads. Available capabilities: `generate`, `agentic`, `embeddings`, `audio/speech`, `audio/transcription`, `audio/translation`, `image`, `video`, `realtime`, `rerank`.
-* **`api` type**: for asynchronous batch processing. Available capabilities: `batches`, `files`.
+* **`api` type**: for asynchronous batch processing. Available capabilities: `batches`, `files`, `skills`.
 
 Not every LLM service supports every capability. The set of capabilities you can declare on an AI Model depends on what the AI Model Provider in [`targets`](#schema-aigateway-model-targets) exposes. See [{{site.ai_gateway}} providers](/ai-gateway/ai-providers/) for per-provider details.
 
@@ -179,6 +179,9 @@ rows:
   - capability: "`files`"
     path: "`/files`"
     description: File uploads for long documents and structured input.
+  - capability: "`skills`"
+    path: "`/skills`"
+    description: Create, manage, and download reusable skill bundles hosted with the provider.
 {% endtable %}
 <!-- vale on -->
 
@@ -205,7 +208,7 @@ rows:
     capabilities: Translates between OpenAI request and response shapes and the upstream provider format.
   - format: "`anthropic`"
     provider: "[Anthropic](/ai-gateway/ai-providers/anthropic/#supported-native-llm-formats-for-anthropic)"
-    capabilities: Messages, batch processing.
+    capabilities: Messages, batch processing, skills management.
   - format: "`bedrock`"
     provider: "[Amazon Bedrock](/ai-gateway/ai-providers/bedrock/#supported-native-llm-formats-for-amazon-bedrock)"
     capabilities: Converse, RAG (RetrieveAndGenerate), reranking, async invocation.
@@ -412,6 +415,58 @@ data:
 {:.info}
 > Because [`config.route.model`](#schema-aigateway-model-config-route-model) is set here with `body_param: model`, requests through this AI Model must send `"model": "my-gpt-4o"` (the alias) in the request body instead of the upstream target name (`gpt-4o`). Sending the upstream target name instead of the alias fails.
 
+### Set up a Skills API model
+
+`skills` is an `api`-type capability (like `batches` and `files`), so it's declared on its own dedicated AI Model, separate from any `model`-type AI Model handling synchronous capabilities like `generate`.
+
+The Skills API only supports native format passthrough: an OpenAI target must use `formats: [{type: openai}]`, and an Anthropic target must use `formats: [{type: anthropic}]`. Mixing providers within a single Skills AI Model, or pairing a provider with the other's native format, is not supported.
+
+{:.info}
+> `targets[].name` is still required by the schema, but Skills requests don't select a model, so any placeholder value works.
+
+{% entity_example %}
+type: model
+data:
+  display_name: my-openai-skills
+  name: my-openai-skills
+  type: api
+  capabilities:
+    - skills
+  formats:
+    - type: openai
+  policies: []
+  targets:
+    - name: openai-skills
+      provider: my-openai-account
+      config:
+        type: openai
+  config:
+    route:
+      paths:
+        - /v1
+{% endentity_example %}
+
+{% entity_example %}
+type: model
+data:
+  display_name: my-anthropic-skills
+  name: my-anthropic-skills
+  type: api
+  capabilities:
+    - skills
+  formats:
+    - type: anthropic
+  policies: []
+  targets:
+    - name: anthropic-skills
+      provider: my-anthropic-account
+      config:
+        type: anthropic
+  config:
+    route:
+      paths:
+        - /v1
+{% endentity_example %}
 
 ## Schema
 

--- a/app/_ai_gateway_entities/ai-model.md
+++ b/app/_ai_gateway_entities/ai-model.md
@@ -415,11 +415,11 @@ data:
 {:.info}
 > Because [`config.route.model`](#schema-aigateway-model-config-route-model) is set here with `body_param: model`, requests through this AI Model must send `"model": "my-gpt-4o"` (the alias) in the request body instead of the upstream target name (`gpt-4o`). Sending the upstream target name instead of the alias fails.
 
-### Set up a Skills API model
+### Set up an AI Model with API capabilities
 
-`skills` is an `api`-type capability (like `batches` and `files`), so it's declared on its own dedicated AI Model, separate from any `model`-type AI Model handling synchronous capabilities like `generate`.
+You can also configure an AI Model entity with `api` type capabilities: `skills`, `batches`, and `files`. API capabilities are set on a dedicated AI Model, separate from any `model`-type AI Model handling synchronous capabilities like `generate`.
 
-The Skills API only supports native format passthrough: an OpenAI target must use `formats: [{type: openai}]`, and an Anthropic target must use `formats: [{type: anthropic}]`. Mixing providers within a single Skills AI Model, or pairing a provider with the other's native format, is not supported.
+The following example set's up an AI Model to provide the `skills` capability. The Skills API only supports native format passthrough: an OpenAI target must use `formats: [{type: openai}]`, and an Anthropic target must use `formats: [{type: anthropic}]`. Mixing providers within a single Skills AI Model, or pairing a provider with another's native format, is not supported.
 
 {:.info}
 > `targets[].name` is still required by the schema, but Skills requests don't select a model, so any placeholder value works.
@@ -440,28 +440,6 @@ data:
       provider: my-openai-account
       config:
         type: openai
-  config:
-    route:
-      paths:
-        - /v1
-{% endentity_example %}
-
-{% entity_example %}
-type: model
-data:
-  display_name: my-anthropic-skills
-  name: my-anthropic-skills
-  type: api
-  capabilities:
-    - skills
-  formats:
-    - type: anthropic
-  policies: []
-  targets:
-    - name: anthropic-skills
-      provider: my-anthropic-account
-      config:
-        type: anthropic
   config:
     route:
       paths:

--- a/app/_data/ai-gateway/v2/providers.yaml
+++ b/app/_data/ai-gateway/v2/providers.yaml
@@ -29,6 +29,11 @@ providers:
         min_version: '2.0'
         note:
           content: 'Batches processing for Bedrock is supported in the native format from SDK only'
+      skills:
+        supported: false
+        streaming: false
+        model_example: ''
+        min_version: ''
       files:
         supported: true
         streaming: false
@@ -121,6 +126,14 @@ providers:
         min_version: '2.0'
         note:
           content: 'Batches processing for Anthropic is supported in the native format from SDK only'
+      skills:
+        supported: true
+        streaming: false
+        upstream_path: '`/v1/skills`'
+        model_example: 'n/a'
+        min_version: '2.1'
+        note:
+          content: 'Only supports native format passthrough (anthropic-to-anthropic); no cross-provider translation.'
       embeddings:
         supported: false
         streaming: false
@@ -176,11 +189,13 @@ providers:
         supported_apis:
           - '/v1/messages'
           - '/v1/messages/batches'
+          - '/v1/skills'
     limitations:
       provider_specific:
         - 'Does not support embeddings'
       statistics_logging:
         - 'No statistics logging for completions'
+        - 'No statistics logging for skills'
 
   - name: Azure OpenAI
     url_patterns:
@@ -219,6 +234,11 @@ providers:
         upstream_path: '`/openai/batches`'
         model_example: 'n/a'
         min_version: '2.0'
+      skills:
+        supported: false
+        streaming: false
+        model_example: ''
+        min_version: ''
       agentic:
         supported: true
         streaming: false
@@ -306,6 +326,11 @@ providers:
         streaming: false
         model_example: ''
         min_version: ''
+      skills:
+        supported: false
+        streaming: false
+        model_example: ''
+        min_version: ''
       agentic:
         supported: false
         streaming: false
@@ -385,6 +410,11 @@ providers:
         model_example: ''
         min_version: ''
       batches:
+        supported: false
+        streaming: false
+        model_example: ''
+        min_version: ''
+      skills:
         supported: false
         streaming: false
         model_example: ''
@@ -472,6 +502,11 @@ providers:
         streaming: false
         model_example: ''
         min_version: ''
+      skills:
+        supported: false
+        streaming: false
+        model_example: ''
+        min_version: ''
       agentic:
         supported: false
         streaming: false
@@ -544,6 +579,11 @@ providers:
         min_version: '2.0'
         note:
           content: 'Batches processing for Gemini is supported in the native format from SDK only'
+      skills:
+        supported: false
+        streaming: false
+        model_example: ''
+        min_version: ''
       image:
         supported: true
         streaming: false
@@ -647,6 +687,11 @@ providers:
         upstream_path: 'Uses `batchPredictionJobs` API'
         model_example: 'n/a'
         min_version: '2.0'
+      skills:
+        supported: false
+        streaming: false
+        model_example: ''
+        min_version: ''
       image:
         supported: true
         streaming: false
@@ -753,6 +798,11 @@ providers:
         streaming: false
         model_example: ''
         min_version: ''
+      skills:
+        supported: false
+        streaming: false
+        model_example: ''
+        min_version: ''
       agentic:
         supported: false
         streaming: false
@@ -818,6 +868,11 @@ providers:
         model_example: ''
         min_version: ''
       batches:
+        supported: false
+        streaming: false
+        model_example: ''
+        min_version: ''
+      skills:
         supported: false
         streaming: false
         model_example: ''
@@ -901,6 +956,11 @@ providers:
         streaming: false
         model_example: ''
         min_version: ''
+      skills:
+        supported: false
+        streaming: false
+        model_example: ''
+        min_version: ''
       agentic:
         supported: false
         streaming: false
@@ -974,6 +1034,11 @@ providers:
         model_example: ''
         min_version: ''
       batches:
+        supported: false
+        streaming: false
+        model_example: ''
+        min_version: ''
+      skills:
         supported: false
         streaming: false
         model_example: ''
@@ -1057,6 +1122,14 @@ providers:
         upstream_path: '`/v1/batches`'
         model_example: 'n/a'
         min_version: '2.0'
+      skills:
+        supported: true
+        streaming: false
+        upstream_path: '`/v1/skills`'
+        model_example: 'n/a'
+        min_version: '2.1'
+        note:
+          content: 'Only supports native format passthrough (openai-to-openai); no cross-provider translation.'
       agentic:
         supported: true
         streaming: false
@@ -1111,7 +1184,7 @@ providers:
     limitations:
       provider_specific: []
       statistics_logging:
-        - 'No statistics logging for assistants, batch, or audio APIs'
+        - 'No statistics logging for assistants, batch, skills, or audio APIs'
 
   - name: vLLM
     url_patterns:
@@ -1140,6 +1213,11 @@ providers:
         model_example: ''
         min_version: ''
       batches:
+        supported: false
+        streaming: false
+        model_example: ''
+        min_version: ''
+      skills:
         supported: false
         streaming: false
         model_example: ''
@@ -1232,6 +1310,11 @@ providers:
         streaming: false
         model_example: ''
         min_version: ''
+      skills:
+        supported: false
+        streaming: false
+        model_example: ''
+        min_version: ''
       audio_speech:
         supported: false
         streaming: false
@@ -1293,6 +1376,11 @@ providers:
         model_example: ''
         min_version: ''
       batches:
+        supported: false
+        streaming: false
+        model_example: ''
+        min_version: ''
+      skills:
         supported: false
         streaming: false
         model_example: ''
@@ -1365,6 +1453,11 @@ providers:
         model_example: ''
         min_version: ''
       batches:
+        supported: false
+        streaming: false
+        model_example: ''
+        min_version: ''
+      skills:
         supported: false
         streaming: false
         model_example: ''
@@ -1444,6 +1537,11 @@ providers:
         streaming: false
         model_example: ''
         min_version: ''
+      skills:
+        supported: false
+        streaming: false
+        model_example: ''
+        min_version: ''
       agentic:
         supported: false
         streaming: false
@@ -1515,6 +1613,11 @@ providers:
         model_example: ''
         min_version: ''
       batches:
+        supported: false
+        streaming: false
+        model_example: ''
+        min_version: ''
+      skills:
         supported: false
         streaming: false
         model_example: ''
@@ -1591,6 +1694,11 @@ providers:
         model_example: ''
         min_version: ''
       batches:
+        supported: false
+        streaming: false
+        model_example: ''
+        min_version: ''
+      skills:
         supported: false
         streaming: false
         model_example: ''

--- a/app/_includes/components/entity_example/format/ui_ai.md
+++ b/app/_includes/components/entity_example/format/ui_ai.md
@@ -66,11 +66,11 @@ The following creates a new model. Suggested values are shown in backticks.
 1. Select an {{site.ai_gateway}}.
 1. Navigate to **Models**.
 1. Click **New model**.
-1. In **General information**, toggle **Enabled**, enter a **Display name** (for example: `{{ include.presenter.data['display_name'] }}`), and select a **Type**, either **Model** for generative and embeddings requests, or **API** for files and batch operations.
+1. In **General information**, toggle **Enabled**, enter a **Display name** (for example: `{{ include.presenter.data['display_name'] }}`), and select a **Type**, either **Model** for generative and embeddings requests, or **API** for files, batch, and skills operations.
 1. Optional. Enter a **Model alias** if you plan to route by request body instead of base path or hostname.
 1. In **Route**, enter a **Base path** to determine how the {{site.ai_gateway}} is accessed. Don't include capability-specific paths such as `/chat/completions`, those are set in the Capabilities section.
 1. In **Target models**, select a **Provider**. If you selected **Model** as the type, also select a **Target model**. Add additional targets to route requests across multiple providers.
-1. In **Capabilities**, select which AI capabilities this model supports. For **Model** type, options include Chat completions, Embeddings, Image generations, and others. For **API** type, options are Batches and Files.
+1. In **Capabilities**, select which AI capabilities this model supports. For **Model** type, options include Chat completions, Embeddings, Image generations, and others. For **API** type, options are Batches, Files, and Skills.
 1. Optional. In **Advanced configuration**, adjust settings such as max request body size, response streaming, and payload logging. The **Return model name header** option is available only for **Model** type.
 1. Click **Create**.
 {% when 'agent' %}

--- a/app/_includes/md/ai-gateway/v2/providers.md
+++ b/app/_includes/md/ai-gateway/v2/providers.md
@@ -40,6 +40,7 @@ You can proxy requests to {{ provider.name }} AI models through {{site.ai_gatewa
 {%- capture rerank_label -%}{% if page.output_format == 'markdown' %}Rerank{% else %}[Rerank](#rerank){% endif %}{%- endcapture -%}
 {%- capture batches_label -%}{% if page.output_format == 'markdown' %}Batches{% else %}[Batches](#batches){% endif %}{%- endcapture -%}
 {%- capture files_label -%}{% if page.output_format == 'markdown' %}Files{% else %}[Files](#files){% endif %}{%- endcapture -%}
+{%- capture skills_label -%}{% if page.output_format == 'markdown' %}Skills{% else %}[Skills](#skills){% endif %}{%- endcapture -%}
 
 ## Upstream paths
 
@@ -61,7 +62,7 @@ columns:
   - title: Upstream path or API
     key: upstream_path
 rows:
-{%- assign all_capability_keys = "generate,agentic,realtime,embeddings,image,audio_speech,audio_transcription,audio_translation,video,rerank,batches,files" | split: "," -%}
+{%- assign all_capability_keys = "generate,agentic,realtime,embeddings,image,audio_speech,audio_transcription,audio_translation,video,rerank,batches,files,skills" | split: "," -%}
 {% for cap in all_capability_keys %}
 {% assign cap_supported = false %}
 {% if provider.capabilities[cap].supported %}{% assign cap_supported = true %}{% endif %}
@@ -81,6 +82,7 @@ rows:
 {% when 'rerank' %}{% assign cap_label = rerank_label %}{% assign cap_path_template = "`/rerank`" %}{% assign cap_description = "Semantic reranking of documents" %}
 {% when 'batches' %}{% assign cap_label = batches_label %}{% assign cap_path_template = "`/batches`" %}{% assign cap_description = "Batch processing of requests" %}
 {% when 'files' %}{% assign cap_label = files_label %}{% assign cap_path_template = "`/files`" %}{% assign cap_description = "File management and storage" %}
+{% when 'skills' %}{% assign cap_label = skills_label %}{% assign cap_path_template = "`/skills`" %}{% assign cap_description = "Manage reusable skill bundles hosted with the provider" %}
 {% endcase %}
 {% if compare_provider %}
 {% if cap_supported and cap_supported_compare %}
@@ -137,6 +139,7 @@ rows:
 {%- assign realtime_note_num = 0 %}{% if provider.capabilities.realtime.note.content %}{% assign note_counter = note_counter | plus: 1 %}{% assign realtime_note_num = note_counter %}{% endif -%}
 {%- assign batches_note_num = 0 %}{% if provider.capabilities.batches.note.content %}{% assign note_counter = note_counter | plus: 1 %}{% assign batches_note_num = note_counter %}{% endif -%}
 {%- assign files_note_num = 0 %}{% if provider.capabilities.files.note.content %}{% assign note_counter = note_counter | plus: 1 %}{% assign files_note_num = note_counter %}{% endif -%}
+{%- assign skills_note_num = 0 %}{% if provider.capabilities.skills.note.content %}{% assign note_counter = note_counter | plus: 1 %}{% assign skills_note_num = note_counter %}{% endif -%}
 {%- assign rerank_note_num = 0 %}{% if provider.capabilities.rerank.note.content %}{% assign note_counter = note_counter | plus: 1 %}{% assign rerank_note_num = note_counter %}{% endif -%}
 {%- assign compare_generate_note_num = 0 %}{% if compare_provider.capabilities.generate.note.content %}{% assign note_counter = note_counter | plus: 1 %}{% assign compare_generate_note_num = note_counter %}{% endif -%}
 {%- assign compare_embeddings_note_num = 0 %}{% if compare_provider.capabilities.embeddings.note.content %}{% assign note_counter = note_counter | plus: 1 %}{% assign compare_embeddings_note_num = note_counter %}{% endif -%}
@@ -149,6 +152,7 @@ rows:
 {%- assign compare_realtime_note_num = 0 %}{% if compare_provider.capabilities.realtime.note.content %}{% assign note_counter = note_counter | plus: 1 %}{% assign compare_realtime_note_num = note_counter %}{% endif -%}
 {%- assign compare_batches_note_num = 0 %}{% if compare_provider.capabilities.batches.note.content %}{% assign note_counter = note_counter | plus: 1 %}{% assign compare_batches_note_num = note_counter %}{% endif -%}
 {%- assign compare_files_note_num = 0 %}{% if compare_provider.capabilities.files.note.content %}{% assign note_counter = note_counter | plus: 1 %}{% assign compare_files_note_num = note_counter %}{% endif -%}
+{%- assign compare_skills_note_num = 0 %}{% if compare_provider.capabilities.skills.note.content %}{% assign note_counter = note_counter | plus: 1 %}{% assign compare_skills_note_num = note_counter %}{% endif -%}
 {%- assign compare_rerank_note_num = 0 %}{% if compare_provider.capabilities.rerank.note.content %}{% assign note_counter = note_counter | plus: 1 %}{% assign compare_rerank_note_num = note_counter %}{% endif -%}
 {%- assign has_text = false -%}
 {%- assign has_embeddings = false -%}
@@ -159,6 +163,7 @@ rows:
 {%- assign has_realtime = false -%}
 {%- assign has_batches = false -%}
 {%- assign has_files = false -%}
+{%- assign has_skills = false -%}
 {%- assign has_rerank = false -%}
 {%- if provider.capabilities.generate.supported or compare_provider.capabilities.generate.supported %}{% assign has_text = true %}{% endif -%}
 {%- if provider.capabilities.embeddings.supported or compare_provider.capabilities.embeddings.supported %}{% assign has_embeddings = true %}{% endif -%}
@@ -169,6 +174,7 @@ rows:
 {%- if provider.capabilities.realtime.supported or compare_provider.capabilities.realtime.supported %}{% assign has_realtime = true %}{% endif -%}
 {%- if provider.capabilities.batches.supported or compare_provider.capabilities.batches.supported %}{% assign has_batches = true %}{% endif -%}
 {%- if provider.capabilities.files.supported or compare_provider.capabilities.files.supported %}{% assign has_files = true %}{% endif -%}
+{%- if provider.capabilities.skills.supported or compare_provider.capabilities.skills.supported %}{% assign has_skills = true %}{% endif -%}
 {%- if provider.capabilities.rerank.supported or compare_provider.capabilities.rerank.supported %}{% assign has_rerank = true %}{% endif -%}
 
 ## Supported capabilities
@@ -728,6 +734,63 @@ rows:
 {:.warning}
 > Batches are configured on a separate AI Model with [`type: "api"`](/ai-gateway/entities/ai-model/#schema-aigateway-model-type), distinct from regular models that handle synchronous capabilities like generate and embeddings.
 > Create a dedicated AI Model exclusively for batches and files, as each model must be either a regular model or an API model, not both.
+{%- endif -%}
+
+{% if has_skills %}
+
+### Skills
+
+Support for {{ provider.name }} skills management capabilities:
+
+{% table %}
+vertical_align: middle
+columns:
+  - title: Capability
+    key: capability
+{% if compare_provider %}
+  - title: Variant
+    key: variant
+{% endif %}
+  - title: Model example
+    key: model_example
+  - title: Path template
+    key: path_template
+  - title: Min version
+    key: min_version
+rows:
+{% if compare_provider %}
+{% if provider.capabilities.skills.supported and compare_provider.capabilities.skills.supported %}
+  - capability: "skills{% if skills_note_num != 0 %}<sup>{{ skills_note_num }}</sup>{% endif %}"
+    variant: "{{ include.variant_label }} & {{ include.compare_variant_label }}"
+    model_example: "{{ provider.capabilities.skills.model_example }}"
+    path_template: "`/skills`"
+    min_version: "{{ provider.capabilities.skills.min_version }}"
+{% elsif provider.capabilities.skills.supported %}
+  - capability: "skills{% if skills_note_num != 0 %}<sup>{{ skills_note_num }}</sup>{% endif %}"
+    variant: "{{ include.variant_label }} only"
+    model_example: "{{ provider.capabilities.skills.model_example }}"
+    path_template: "`/skills`"
+    min_version: "{{ provider.capabilities.skills.min_version }}"
+{% else %}
+  - capability: "skills{% if compare_skills_note_num != 0 %}<sup>{{ compare_skills_note_num }}</sup>{% endif %}"
+    variant: "{{ include.compare_variant_label }} only"
+    model_example: "{{ compare_provider.capabilities.skills.model_example }}"
+    path_template: "`/skills`"
+    min_version: "{{ compare_provider.capabilities.skills.min_version }}"
+{% endif %}
+{% elsif provider.capabilities.skills %}
+  - capability: "skills{% if skills_note_num != 0 %}<sup>{{ skills_note_num }}</sup>{% endif %}"
+    model_example: "{{ provider.capabilities.skills.model_example }}"
+    path_template: "`/skills`"
+    min_version: "{{ provider.capabilities.skills.min_version }}"
+{% endif %}
+{% endtable %}
+{% if provider.capabilities.skills.note.content %}<sup>{{ skills_note_num }}</sup> {% if compare_provider %}**{{ include.variant_label }}:** {% endif %}{{ provider.capabilities.skills.note.content }}{% endif %}
+{% if compare_provider.capabilities.skills.note.content %}<sup>{{ compare_skills_note_num }}</sup> **{{ include.compare_variant_label }}:** {{ compare_provider.capabilities.skills.note.content }}{% endif %}
+
+{:.warning}
+> Skills are configured on a separate AI Model with [`type: "api"`](/ai-gateway/entities/ai-model/#schema-aigateway-model-type), distinct from regular models that handle synchronous capabilities like generate and embeddings.
+> Create a dedicated AI Model exclusively for batches, files, and skills, as each model must be either a regular model or an API model, not both.
 {%- endif -%}
 
 {% if has_rerank %}


### PR DESCRIPTION
## Description
Documents the new llm/v1/skills route type (AG-907, aigw-2.1.0) as an api-type AI Model capability, alongside batches and files. Updates the provider capability tables, the AI Model entity reference, and the shared Konnect-UI walkthrough copy.

Fixes: #7134

## Preview Links


## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
