### PR TITLE
Feat(dcgw): managed cache TF purge

### DIFF
--- a/app/_how-tos/dedicated-cloud-gateways/flush-managed-cache.md
+++ b/app/_how-tos/dedicated-cloud-gateways/flush-managed-cache.md
@@ -1,0 +1,439 @@
+---
+title: Flush a Dedicated Cloud Gateway managed cache using Terraform
+description: 'Use Terraform to deploy a custom plugin that flushes a Dedicated Cloud Gateway AWS managed cache on demand.'
+content_type: how_to
+permalink: /dedicated-cloud-gateways/flush-managed-cache/
+breadcrumbs:
+  - /dedicated-cloud-gateways/
+products:
+  - gateway
+works_on:
+  - konnect
+tools:
+  - terraform
+min_version:
+  gateway: '3.13'
+tags:
+  - dedicated-cloud-gateways
+  - terraform
+  - aws
+  - caching
+  - custom-plugins
+automated_tests: false
+tldr:
+  q: How do I flush a Dedicated Cloud Gateway AWS managed cache using Terraform?
+  a: |
+    Deploy a `konnect_gateway_custom_plugin_streaming` custom plugin that authenticates to the managed cache via AWS STS and runs `FLUSHDB`, exposed through a `konnect_gateway_service` and `konnect_gateway_route`, then trigger a flush by calling the Terraform output URL.
+related_resources:
+  - text: Managed cache for Redis
+    url: /dedicated-cloud-gateways/managed-cache/
+  - text: Configure an AWS managed cache for a Dedicated Cloud Gateway control plane
+    url: /dedicated-cloud-gateways/aws-managed-cache-control-plane/
+prereqs:
+  show_works_on: false
+  inline:
+    - title: Terraform and the Konnect provider
+      include_content: prereqs/products/konnect-terraform
+      icon_url: /assets/icons/terraform.svg
+    - title: An AWS managed cache
+      include_content: prereqs/dcgw-aws-managed-cache
+      icon_url: /assets/icons/kogo-white.svg
+next_steps:
+  - text: Dedicated Cloud Gateways production readiness checklist
+    url: /dedicated-cloud-gateways/production-readiness/
+---
+
+An AWS [managed cache](/dedicated-cloud-gateways/managed-cache/) doesn't expose a built-in way to clear its contents on demand.
+This how-to deploys a custom Kong plugin that exposes a flush endpoint on your gateway.
+Calling the endpoint authenticates to the managed cache with AWS STS-derived credentials and runs `FLUSHDB`, so you (or your CI/CD pipeline) can flush the cache without engineering involvement.
+
+## Upload the custom plugin
+
+1. Create a `schema.lua` file that defines the plugin's configuration fields.
+
+    {% details %}
+    summary: "Expand to see the schema.lua command"
+    content: |
+      <!--vale off-->
+      ```bash
+      echo '
+      local typedefs = require "kong.db.schema.typedefs"
+
+      return {
+        name = "cache-flusher",
+        fields = {
+          { protocols = typedefs.protocols_http },
+          {
+            config = {
+              type = "record",
+              fields = {
+              { host = typedefs.host({ default = "127.0.0.1", referenceable = true }) },
+              { port = typedefs.port({ default = 6379, referenceable = true }) },
+              { username = { type = "string", referenceable = true } },
+              { ssl = { type = "boolean", default = true } },
+              { server_name = { type = "string", referenceable = true } },
+              { cloud_authentication = {
+                  type = "record",
+                  fields = {
+                    { auth_provider = { type = "string", referenceable = true } },
+                    { aws_region = { type = "string", referenceable = true } },
+                    { aws_assume_role_arn = { type = "string", referenceable = true } },
+                    { aws_cache_name = { type = "string", referenceable = true } },
+                  }
+              }},
+            }
+            },
+          },
+        },
+      }
+      ' > schema.lua
+      ```
+      <!--vale on-->
+    {% enddetails %}
+
+1. Create a `handler.lua` file that authenticates to the managed cache and runs the flush.
+
+    {% details %}
+    summary: "Expand to see the handler.lua command"
+    content: |
+      <!--vale off-->
+      ```bash
+      echo '
+      local AWS = require "resty.aws"
+      local redis = require "resty.redis"
+      local aws_config = require "resty.aws.config"
+
+      local AWS_DEFAULT_ROLE_SESSION_NAME = "KongElasticacheSession"
+      local AWS_global_config = aws_config.global
+      local aws = AWS({ region = AWS_global_config.region })
+
+      local plugin = {
+        PRIORITY = 1000,
+        VERSION  = "1.0.0",
+      }
+
+      local function get_aws_auth_token(conf, cloud_auth)
+          local cachename = cloud_auth.aws_cache_name
+          local name = conf.username
+          local region = cloud_auth.aws_region
+          local assume_role_arn = cloud_auth.aws_assume_role_arn
+
+          local credentials = aws.config.credentials
+
+          local sts, err = aws:STS({
+              region = region,
+              credentials = credentials,
+              stsRegionalEndpoints = AWS_global_config.sts_regional_endpoints,
+          })
+          if not sts then
+              return nil, err
+          end
+
+          local creds = aws:ChainableTemporaryCredentials {
+              params = {
+                  RoleArn = assume_role_arn,
+                  RoleSessionName = AWS_DEFAULT_ROLE_SESSION_NAME,
+              },
+              sts = sts,
+          }
+
+          local cache = aws:ElastiCache({ region = region })
+
+          local signer = cache:Signer {
+              cachename = cachename,
+              username = name,
+              is_serverless = false,
+              region = region,
+              credentials = creds,
+          }
+
+          local auth_token, token_err = signer:getAuthToken()
+          if token_err then
+              return nil, token_err
+          end
+
+          return auth_token
+      end
+
+      local function get_auth_token(conf)
+          local cloud_auth = conf.cloud_authentication
+          local provider = cloud_auth.auth_provider
+
+          if provider == "aws" then
+              return get_aws_auth_token(conf, cloud_auth)
+          end
+
+          return nil, "cloud provider '" .. tostring(provider) .. "' not implemented"
+      end
+
+      function plugin:access(conf)
+          kong.log.notice("[cache-flusher] starting cache flush")
+
+          -- Connect to Cache
+          kong.log.notice("[cache-flusher] connecting to Cache at ", conf.host, ":", conf.port)
+
+          local red = redis:new()
+          local ok, err = red:connect(conf.host, conf.port, {
+              ssl = conf.ssl,
+              ssl_verify = conf.ssl,
+              server_name = conf.server_name,
+          })
+          if not ok then
+              kong.log.err("[cache-flusher] failed to connect to Cache: ", err)
+              return kong.response.error(500, "cache flush failed: Cache connect error")
+          end
+
+          kong.log.notice("[cache-flusher] connected to Cache, obtaining auth token")
+
+          -- Authenticate with STS-derived token
+          local auth_token, token_err = get_auth_token(conf)
+          if not auth_token then
+              kong.log.err("[cache-flusher] failed to obtain auth token: ", token_err)
+              return kong.response.error(500, "cache flush failed: auth token error")
+          end
+
+          kong.log.notice("[cache-flusher] auth token obtained, authenticating with Cache")
+
+          local res, auth_err = red:auth(conf.username, auth_token)
+          if not res then
+              kong.log.err("[cache-flusher] failed to authenticate with Cache: ", auth_err)
+              return kong.response.error(500, "cache flush failed: Cache auth error")
+          end
+
+          kong.log.notice("[cache-flusher] authenticated, flushing Cache")
+
+          -- Flush Cache
+          local flush_res, flush_err = red:flushdb("ASYNC")
+          if not flush_res then
+              kong.log.err("[cache-flusher] failed to flush Cache: ", flush_err)
+              return kong.response.error(500, "cache flush failed: Cache flushdb error")
+          end
+
+          kong.log.notice("[cache-flusher] cache flush completed successfully")
+
+          return kong.response.exit(200, { message = "[cache-flusher] cache flushed" })
+      end
+
+      return plugin
+      ' > handler.lua
+      ```
+      <!--vale on-->
+    {% enddetails %}
+
+1. Declare the variables this how-to uses, and export the ones only you know:
+
+    <!--vale off-->
+    ```hcl
+    echo '
+    variable "control_plane_id" {
+      type = string
+    }
+
+    variable "flush_path" {
+      type    = string
+      default = "/konnect/managed-cache/flush"
+    }
+
+    variable "ip_allowlist" {
+      type    = list(string)
+      default = []
+    }
+
+    variable "auto_flush" {
+      type    = bool
+      default = false
+    }
+    ' > variables.tf
+    ```
+    <!--vale on-->
+
+    ```bash
+    export TF_VAR_control_plane_id="your-control-plane-id"
+    ```
+
+1. Define the custom plugin, the service and route that expose the flush endpoint, and the plugin instance:
+
+    <!--vale off-->
+    ```hcl
+    echo '
+    resource "konnect_gateway_custom_plugin_streaming" "cache_flusher" {
+      control_plane_id = var.control_plane_id
+      name             = "cache-flusher"
+      schema           = file("${path.module}/schema.lua")
+      handler          = file("${path.module}/handler.lua")
+    }
+
+    resource "konnect_gateway_service" "cache_flusher_service" {
+      control_plane_id = var.control_plane_id
+      name             = "managed-cache-flush-service"
+      host             = "127.0.0.1"
+      port             = 443
+      protocol         = "https"
+    }
+
+    resource "konnect_gateway_route" "cache_flusher_route" {
+      control_plane_id = var.control_plane_id
+      service = {
+        id = konnect_gateway_service.cache_flusher_service.id
+      }
+      paths = [var.flush_path]
+    }
+
+    resource "konnect_gateway_custom_plugin" "cache_flusher_instance" {
+      name             = "cache-flusher"
+      control_plane_id = var.control_plane_id
+      enabled          = true
+      service = {
+        id = konnect_gateway_service.cache_flusher_service.id
+      }
+      route = {
+        id = konnect_gateway_route.cache_flusher_route.id
+      }
+      config = {
+        "cloud_authentication" : {
+          "auth_provider" : "{vault://env/ADDON_MANAGED_CACHE_AUTH_PROVIDER}",
+          "aws_assume_role_arn" : "{vault://env/ADDON_MANAGED_CACHE_AWS_ASSUME_ROLE_ARN}",
+          "aws_cache_name" : "{vault://env/ADDON_MANAGED_CACHE_AWS_CACHE_NAME}",
+          "aws_region" : "{vault://env/ADDON_MANAGED_CACHE_AWS_REGION}"
+        },
+        "host" : "{vault://env/ADDON_MANAGED_CACHE_HOST}",
+        "port" : "{vault://env/ADDON_MANAGED_CACHE_PORT}",
+        "server_name" : "{vault://env/ADDON_MANAGED_CACHE_SERVER_NAME}",
+        "ssl" : true,
+        "username" : "{vault://env/ADDON_MANAGED_CACHE_USERNAME}"
+      }
+
+      depends_on = [konnect_gateway_custom_plugin_streaming.cache_flusher]
+    }
+    ' >> main.tf
+    ```
+    <!--vale on-->
+
+    The `{vault://env/ADDON_MANAGED_CACHE_*}` references are populated automatically by {{site.konnect_short_name}} once your managed cache add-on reaches a Ready state, so you don't need to configure any AWS IAM credentials yourself.
+
+1. Add an output for the flush URL:
+
+    <!--vale off-->
+    ```hcl
+    echo '
+    output "flush_proxy_url" {
+      value = "${local.proxy_url}${var.flush_path}"
+    }
+    ' > output.tf
+    ```
+    <!--vale on-->
+
+    <!--vale off-->
+    ```hcl
+    echo '
+    data "konnect_gateway_control_plane" "control-plane" {
+      filter = {
+        id = {
+          eq = var.control_plane_id
+        }
+      }
+    }
+
+    locals {
+      cp_endpoint = data.konnect_gateway_control_plane.control-plane.config.control_plane_endpoint
+      cp_short_id = regex("https://([^.]+)\\.", local.cp_endpoint)[0]
+      proxy_url   = "https://${local.cp_short_id}.gateways.konggateway.com"
+    }
+    ' > data.tf
+    ```
+    <!--vale on-->
+
+1. Apply the configuration:
+
+    ```bash
+    terraform apply -auto-approve
+    ```
+
+    ```text
+    Apply complete! Resources: 5 added, 0 changed, 0 destroyed.
+    ```
+    {:.no-copy-code}
+
+### Optional: restrict access and auto-flush on apply
+
+If you want to limit which IPs can trigger a flush, set `ip_allowlist` to a list of IPs or CIDRs, and add an `ip-restriction` plugin scoped to the flush route:
+
+<!--vale off-->
+```hcl
+echo '
+resource "konnect_gateway_plugin_ip_restriction" "ip-restriction-plugin" {
+  count = length(var.ip_allowlist) > 0 ? 1 : 0
+
+  config = {
+    allow = var.ip_allowlist
+
+    message = "NOT ALLOWED"
+    status  = 405
+  }
+
+  control_plane_id = var.control_plane_id
+  enabled          = true
+  service = {
+    id = konnect_gateway_service.cache_flusher_service.id
+  }
+  route = {
+    id = konnect_gateway_route.cache_flusher_route.id
+  }
+}
+' >> main.tf
+```
+<!--vale on-->
+
+Requests from IPs outside the allowlist receive a `405` response.
+
+If you want the cache to flush automatically every time you run `terraform apply`, set `auto_flush` to `true`:
+
+<!--vale off-->
+```hcl
+echo '
+resource "terraform_data" "flush_cache" {
+  count = var.auto_flush ? 1 : 0
+
+  triggers_replace = [timestamp()]
+
+  provisioner "local-exec" {
+    command = "sleep 10 && curl -sf ${local.proxy_url}${var.flush_path}"
+  }
+
+  depends_on = [
+    konnect_gateway_route.cache_flusher_route,
+    konnect_gateway_custom_plugin.cache_flusher_instance,
+    konnect_gateway_plugin_ip_restriction.ip-restriction-plugin,
+  ]
+}
+' >> main.tf
+```
+<!--vale on-->
+
+{:.warning}
+> When `auto_flush` is `true`, every `terraform apply` triggers a cache flush, not just the first one.
+> Subsequent applies also show the `terraform_data.flush_cache` resource being destroyed and recreated.
+> This is expected and can be safely ignored.
+
+## Validate
+
+Trigger a flush by calling the URL Terraform output in the previous step:
+
+```bash
+curl -sf "$(terraform output -raw flush_proxy_url)"
+```
+
+A successful flush returns:
+
+```json
+{"message": "[cache-flusher] cache flushed"}
+```
+{:.no-copy-code}
+
+## Teardown
+
+To remove the flush endpoint and all associated resources:
+
+```bash
+terraform destroy
+```

--- a/app/_how-tos/dedicated-cloud-gateways/flush-managed-cache.md
+++ b/app/_how-tos/dedicated-cloud-gateways/flush-managed-cache.md
@@ -1,6 +1,6 @@
 ---
-title: Flush a Dedicated Cloud Gateway managed cache using Terraform
-description: 'Use Terraform to deploy a custom plugin that flushes a Dedicated Cloud Gateway AWS managed cache on demand.'
+title: Flush a public Dedicated Cloud Gateway managed cache using Terraform
+description: 'Use Terraform to deploy a custom plugin that flushes a public Dedicated Cloud Gateway AWS managed cache on demand.'
 content_type: how_to
 permalink: /dedicated-cloud-gateways/flush-managed-cache/
 breadcrumbs:
@@ -21,7 +21,7 @@ tags:
   - custom-plugins
 automated_tests: false
 tldr:
-  q: How do I flush a Dedicated Cloud Gateway AWS managed cache using Terraform?
+  q: How do I flush a public Dedicated Cloud Gateway AWS managed cache using Terraform?
   a: |
     Deploy a `konnect_gateway_custom_plugin_streaming` custom plugin that authenticates to the managed cache via AWS STS and runs `FLUSHDB`, exposed through a `konnect_gateway_service` and `konnect_gateway_route`, then trigger a flush by calling the Terraform output URL.
 related_resources:
@@ -41,13 +41,26 @@ prereqs:
 next_steps:
   - text: Dedicated Cloud Gateways production readiness checklist
     url: /dedicated-cloud-gateways/production-readiness/
+cleanup:
+  inline:
+    - title: Remove the flush endpoint
+      content: |
+        To remove the flush endpoint and all associated resources:
+
+        ```bash
+        terraform destroy
+        ```
 ---
 
-An AWS [managed cache](/dedicated-cloud-gateways/managed-cache/) doesn't expose a built-in way to clear its contents on demand.
+{:.warning}
+> This how-to is for Dedicated Cloud Gateways with a [**public** network](/dedicated-cloud-gateways/public-network/) since it uses the control plane endpoint to flush the cache.
+
+## Upload the custom plugin
+
 This how-to deploys a custom Kong plugin that exposes a flush endpoint on your gateway.
 Calling the endpoint authenticates to the managed cache with AWS STS-derived credentials and runs `FLUSHDB`, so you (or your CI/CD pipeline) can flush the cache without engineering involvement.
 
-## Upload the custom plugin
+First, create and configure the custom plugin:
 
 1. Create a `schema.lua` file that defines the plugin's configuration fields.
 
@@ -156,7 +169,7 @@ Calling the endpoint authenticates to the managed cache with AWS STS-derived cre
               return get_aws_auth_token(conf, cloud_auth)
           end
 
-          return nil, "cloud provider '" .. tostring(provider) .. "' not implemented"
+          return nil, "cloud provider " .. tostring(provider) .. " not implemented"
       end
 
       function plugin:access(conf)
@@ -242,34 +255,43 @@ Calling the endpoint authenticates to the managed cache with AWS STS-derived cre
     }
     ' > variables.tf
     ```
+    {:.collapsible.wrap}
     <!--vale on-->
+
+    If you created your control plane as part of the prereqs, get its ID directly from Terraform state:
+
+    ```bash
+    export TF_VAR_control_plane_id=$(terraform output -raw control_plane_id)
+    ```
+
+    Otherwise, export the ID of your existing control plane:
 
     ```bash
     export TF_VAR_control_plane_id="your-control-plane-id"
     ```
 
 1. Look up the {{site.konnect_short_name}} proxy hostname for your control plane, and export it as a Terraform variable:
-    
-    THIS IS WRONG BUT I'M ASKING HOW TO PROPERLY FIND THIS PROXY URL
-    <!--vale off-->
-    {% konnect_api_request %}
-    url: /v2/cloud-gateways/configurations?filter%5Bcontrol_plane_id%5D%5Beq%5D=$TF_VAR_control_plane_id
-    method: GET
-    region: global
-    status_code: 200
-    extract_body:
-        - name: 'dataplane_groups[0].hostnames[0]'
-          variable: PROXY_HOSTNAME
-    capture:
-      - variable: PROXY_HOSTNAME
-        jq: ".data[0].dataplane_groups[0].hostnames[0]"
-    {% endkonnect_api_request %}
-    <!--vale on-->
 
+{% capture control_plane_details %}
+<!--vale off-->
+{% konnect_api_request %}
+url: /v2/control-planes/$TF_VAR_control_plane_id
+method: GET
+region: us
+status_code: 200
+capture:
+  - variable: CONTROL_PLANE_DETAILS
+{% endkonnect_api_request %}
+<!--vale on-->
+{% endcapture %}
+{{ control_plane_details | indent: 3 }}
 
-    ```bash
-    export TF_VAR_proxy_hostname="$PROXY_HOSTNAME"
-    ```
+1. Export the proxy hostname: 
+
+   ```bash
+   PROXY_HOSTNAME=$(echo $CONTROL_PLANE_DETAILS | jq -r '.config.control_plane_endpoint | sub("https://";"") | split(".")[0]')
+   export TF_VAR_proxy_hostname="${PROXY_HOSTNAME}.gateways.konggateway.com"
+   ```
 
 1. Define the custom plugin, the Gateway Service and Route that expose the flush endpoint, and the plugin instance:
 
@@ -327,6 +349,7 @@ Calling the endpoint authenticates to the managed cache with AWS STS-derived cre
     }
     ' >> main.tf
     ```
+    {:.collapsible.wrap}
     <!--vale on-->
 
     The `{vault://env/ADDON_MANAGED_CACHE_*}` references are populated automatically by {{site.konnect_short_name}} once your managed cache add-on reaches a Ready state, so you don't need to configure any AWS IAM credentials yourself.
@@ -349,66 +372,99 @@ Calling the endpoint authenticates to the managed cache with AWS STS-derived cre
     terraform apply -auto-approve
     ```
 
+    You'll get a response like the following:
     ```text
     Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
     ```
     {:.no-copy-code}
 
-### Optional: restrict access and auto-flush on apply
+### Optional: Restrict access and auto-flush on apply
 
-If you want to limit which IPs can trigger a flush, set `ip_allowlist` to a list of IPs or CIDRs, and add an `ip-restriction` plugin scoped to the flush route:
+Use the following sections to further configure the managed cache flush behavior.
 
-<!--vale off-->
-```hcl
-echo '
-resource "konnect_gateway_plugin_ip_restriction" "ip-restriction-plugin" {
-  count = length(var.ip_allowlist) > 0 ? 1 : 0
+#### Limit IPs that can trigger a flush
 
-  config = {
-    allow = var.ip_allowlist
+If you want to limit which IPs can trigger a flush, set `ip_allowlist` to a list of IPs or CIDRs, and add an [`ip-restriction` plugin](/plugins/ip-restriction/) scoped to the flush route.
 
-    message = "NOT ALLOWED"
-    status  = 405
-  }
+1. Configure the IP Restriction plugin:
 
-  control_plane_id = var.control_plane_id
-  enabled          = true
-  service = {
-    id = konnect_gateway_service.cache_flusher_service.id
-  }
-  route = {
-    id = konnect_gateway_route.cache_flusher_route.id
-  }
-}
-' >> main.tf
-```
-<!--vale on-->
+   <!--vale off-->
+   ```hcl
+   echo '
+   resource "konnect_gateway_plugin_ip_restriction" "ip-restriction-plugin" {
+     count = length(var.ip_allowlist) > 0 ? 1 : 0
+
+     config = {
+       allow = var.ip_allowlist
+
+       message = "NOT ALLOWED"
+       status  = 405
+     }
+
+     control_plane_id = var.control_plane_id
+     enabled          = true
+     service = {
+       id = konnect_gateway_service.cache_flusher_service.id
+     }
+     route = {
+       id = konnect_gateway_route.cache_flusher_route.id
+     }
+   }
+   ' >> main.tf
+   ```
+   {:.collapsible.wrap}
+   <!--vale on-->
+
+1. Export the IPs you want to allow list:
+
+   ```bash
+   export TF_VAR_ip_allowlist='["203.0.113.0/24"]'
+   ```
+
+1. Apply the Terraform configuration:
+   ```bash
+   terraform apply -auto-approve
+   ```
 
 Requests from IPs outside the allowlist receive a `405` response.
 
-If you want the cache to flush automatically every time you run `terraform apply`, set `auto_flush` to `true`:
+#### Automatically flush on `terraform apply`
 
-<!--vale off-->
-```hcl
-echo '
-resource "terraform_data" "flush_cache" {
-  count = var.auto_flush ? 1 : 0
+1. If you want the cache to flush automatically every time you run `terraform apply`, set `auto_flush` to `true`:
 
-  triggers_replace = [timestamp()]
+   <!--vale off-->
+   ```hcl
+   echo '
+   resource "terraform_data" "flush_cache" {
+     count = var.auto_flush ? 1 : 0
 
-  provisioner "local-exec" {
-    command = "sleep 10 && curl -sf https://${var.proxy_hostname}${var.flush_path}"
-  }
+     triggers_replace = [timestamp()]
 
-  depends_on = [
-    konnect_gateway_route.cache_flusher_route,
-    konnect_gateway_custom_plugin.cache_flusher_instance,
-    konnect_gateway_plugin_ip_restriction.ip-restriction-plugin,
-  ]
-}
-' >> main.tf
-```
-<!--vale on-->
+     provisioner "local-exec" {
+       command = "sleep 10 && curl -sf https://${var.proxy_hostname}${var.flush_path}"
+     }
+
+     depends_on = [
+       konnect_gateway_route.cache_flusher_route,
+       konnect_gateway_custom_plugin.cache_flusher_instance,
+       konnect_gateway_plugin_ip_restriction.ip-restriction-plugin,
+     ]
+   }
+   ' >> main.tf
+   ```
+   {:.collapsible.wrap}
+   <!--vale on-->
+
+1. Export the auto flush behavior:
+
+   ```bash
+   export TF_VAR_auto_flush=true
+   ```
+
+1. Apply the Terraform configuration:
+   ```bash
+   terraform apply -auto-approve
+   ```
 
 {:.warning}
 > When `auto_flush` is `true`, every `terraform apply` triggers a cache flush, not just the first one.
@@ -429,11 +485,3 @@ A successful flush returns:
 {"message": "[cache-flusher] cache flushed"}
 ```
 {:.no-copy-code}
-
-## Teardown
-
-To remove the flush endpoint and all associated resources:
-
-```bash
-terraform destroy
-```

--- a/app/_how-tos/dedicated-cloud-gateways/flush-managed-cache.md
+++ b/app/_how-tos/dedicated-cloud-gateways/flush-managed-cache.md
@@ -51,11 +51,7 @@ Calling the endpoint authenticates to the managed cache with AWS STS-derived cre
 
 1. Create a `schema.lua` file that defines the plugin's configuration fields.
 
-    {% details %}
-    summary: "Expand to see the schema.lua command"
-    content: |
-      <!--vale off-->
-      ```bash
+      ```hcl
       echo '
       local typedefs = require "kong.db.schema.typedefs"
 
@@ -88,16 +84,13 @@ Calling the endpoint authenticates to the managed cache with AWS STS-derived cre
       }
       ' > schema.lua
       ```
+      {:.collapsible.wrap}
       <!--vale on-->
-    {% enddetails %}
 
 1. Create a `handler.lua` file that authenticates to the managed cache and runs the flush.
 
-    {% details %}
-    summary: "Expand to see the handler.lua command"
-    content: |
       <!--vale off-->
-      ```bash
+      ```hcl
       echo '
       local AWS = require "resty.aws"
       local redis = require "resty.redis"
@@ -217,8 +210,8 @@ Calling the endpoint authenticates to the managed cache with AWS STS-derived cre
       return plugin
       ' > handler.lua
       ```
+      {:.collapsible.wrap}
       <!--vale on-->
-    {% enddetails %}
 
 1. Declare the variables this how-to uses, and export the ones only you know:
 
@@ -243,6 +236,10 @@ Calling the endpoint authenticates to the managed cache with AWS STS-derived cre
       type    = bool
       default = false
     }
+
+    variable "proxy_hostname" {
+      type = string
+    }
     ' > variables.tf
     ```
     <!--vale on-->
@@ -251,7 +248,30 @@ Calling the endpoint authenticates to the managed cache with AWS STS-derived cre
     export TF_VAR_control_plane_id="your-control-plane-id"
     ```
 
-1. Define the custom plugin, the service and route that expose the flush endpoint, and the plugin instance:
+1. Look up the {{site.konnect_short_name}} proxy hostname for your control plane, and export it as a Terraform variable:
+    
+    THIS IS WRONG BUT I'M ASKING HOW TO PROPERLY FIND THIS PROXY URL
+    <!--vale off-->
+    {% konnect_api_request %}
+    url: /v2/cloud-gateways/configurations?filter%5Bcontrol_plane_id%5D%5Beq%5D=$TF_VAR_control_plane_id
+    method: GET
+    region: global
+    status_code: 200
+    extract_body:
+        - name: 'dataplane_groups[0].hostnames[0]'
+          variable: PROXY_HOSTNAME
+    capture:
+      - variable: PROXY_HOSTNAME
+        jq: ".data[0].dataplane_groups[0].hostnames[0]"
+    {% endkonnect_api_request %}
+    <!--vale on-->
+
+
+    ```bash
+    export TF_VAR_proxy_hostname="$PROXY_HOSTNAME"
+    ```
+
+1. Define the custom plugin, the Gateway Service and Route that expose the flush endpoint, and the plugin instance:
 
     <!--vale off-->
     ```hcl
@@ -317,29 +337,9 @@ Calling the endpoint authenticates to the managed cache with AWS STS-derived cre
     ```hcl
     echo '
     output "flush_proxy_url" {
-      value = "${local.proxy_url}${var.flush_path}"
+      value = "https://${var.proxy_hostname}${var.flush_path}"
     }
     ' > output.tf
-    ```
-    <!--vale on-->
-
-    <!--vale off-->
-    ```hcl
-    echo '
-    data "konnect_gateway_control_plane" "control-plane" {
-      filter = {
-        id = {
-          eq = var.control_plane_id
-        }
-      }
-    }
-
-    locals {
-      cp_endpoint = data.konnect_gateway_control_plane.control-plane.config.control_plane_endpoint
-      cp_short_id = regex("https://([^.]+)\\.", local.cp_endpoint)[0]
-      proxy_url   = "https://${local.cp_short_id}.gateways.konggateway.com"
-    }
-    ' > data.tf
     ```
     <!--vale on-->
 
@@ -350,7 +350,7 @@ Calling the endpoint authenticates to the managed cache with AWS STS-derived cre
     ```
 
     ```text
-    Apply complete! Resources: 5 added, 0 changed, 0 destroyed.
+    Apply complete! Resources: 4 added, 0 changed, 0 destroyed.
     ```
     {:.no-copy-code}
 
@@ -397,7 +397,7 @@ resource "terraform_data" "flush_cache" {
   triggers_replace = [timestamp()]
 
   provisioner "local-exec" {
-    command = "sleep 10 && curl -sf ${local.proxy_url}${var.flush_path}"
+    command = "sleep 10 && curl -sf https://${var.proxy_hostname}${var.flush_path}"
   }
 
   depends_on = [

--- a/app/_how-tos/dedicated-cloud-gateways/flush-managed-cache.md
+++ b/app/_how-tos/dedicated-cloud-gateways/flush-managed-cache.md
@@ -114,7 +114,7 @@ First, create and configure the custom plugin:
       local aws = AWS({ region = AWS_global_config.region })
 
       local plugin = {
-        PRIORITY = 1000,
+        PRIORITY = 980,
         VERSION  = "1.0.0",
       }
 

--- a/app/_how-tos/dedicated-cloud-gateways/flush-managed-cache.md
+++ b/app/_how-tos/dedicated-cloud-gateways/flush-managed-cache.md
@@ -50,6 +50,12 @@ cleanup:
         ```bash
         terraform destroy
         ```
+faqs:
+  - q: How do I flush a managed cache for a private Dedicated Cloud Gateway?
+    a: |
+      This how-to is scoped to Dedicated Cloud Gateways with a public network, because the flush endpoint is reached through the control plane endpoint. A private network Dedicated Cloud Gateway doesn't have a control plane endpoint to route through.
+
+      Instead, reach the flush endpoint through the FQDN assigned to the private IP address of your Dedicated Cloud Gateway, for example through a CDN or nodes placed in front of the data planes, or over your internal/private network. As long as a client can reach that FQDN, the rest of this how-to (the custom plugin, Terraform resources, and flush call) applies the same way.
 ---
 
 {:.warning}
@@ -378,7 +384,7 @@ capture:
     ```
     {:.no-copy-code}
 
-### Optional: Restrict access and auto-flush on apply
+### Strongly recommended: Restrict access and auto-flush on apply
 
 Use the following sections to further configure the managed cache flush behavior.
 

--- a/app/_includes/prereqs/dcgw-aws-managed-cache.md
+++ b/app/_includes/prereqs/dcgw-aws-managed-cache.md
@@ -1,0 +1,39 @@
+This tutorial requires an AWS managed cache already attached to a Ready Dedicated Cloud Gateway control plane.
+
+If you don't have one configured yet, create one with Terraform:
+
+<!--vale off-->
+```hcl
+echo '
+resource "konnect_gateway_control_plane" "test_cp" {
+  name         = "CGW Control Plane"
+  cloud_gateway = true
+}
+
+resource "konnect_cloud_gateway_addon" "managed_cache" {
+  name = "managed-cache"
+  owner = {
+    control_plane = {
+      control_plane_id  = konnect_gateway_control_plane.test_cp.id
+      control_plane_geo = "us"
+    }
+  }
+  config = {
+    managed_cache = {
+      capacity_config = {
+        tiered = {
+          tier = "micro"
+        }
+      }
+    }
+  }
+}
+' >> main.tf
+```
+<!--vale on-->
+
+```bash
+terraform apply -auto-approve
+```
+
+For sizing recommendations, a control plane group setup, or the full walkthrough, see [Configure an AWS managed cache for a Dedicated Cloud Gateway control plane](/dedicated-cloud-gateways/aws-managed-cache-control-plane/) or [Configure an AWS managed cache for a Dedicated Cloud Gateway control plane group](/dedicated-cloud-gateways/aws-managed-cache-control-plane-group/).

--- a/app/_includes/prereqs/dcgw-aws-managed-cache.md
+++ b/app/_includes/prereqs/dcgw-aws-managed-cache.md
@@ -1,13 +1,85 @@
-This tutorial requires an AWS managed cache already attached to a Ready Dedicated Cloud Gateway control plane.
+This tutorial requires an AWS managed cache attached to a ready public Dedicated Cloud Gateway control plane with a live data plane.
 
-If you don't have one configured yet, create one with Terraform:
+If you don't have one configured yet, create one with Terraform.
+
+You need to retrieve the provider account ID. 
+First, make a GET request to the {{site.konnect_short_name}} Cloud Gateways API using the `/provider-accounts` endpoint:
+
+<!--vale off-->
+{% konnect_api_request %}
+url: /v2/cloud-gateways/provider-accounts?filter%5Bprovider%5D%5Beq%5D=aws
+status_code: 200
+region: global
+method: GET
+headers:
+  - 'Accept: application/json'
+  - 'Content-Type: application/json'
+{% endkonnect_api_request %}
+<!--vale on-->
+
+Export the `id` from the output as a Terraform variable:
+
+```bash
+export TF_VAR_provider_id='YOUR_PROVIDER_ACCOUNT_ID'
+```
+
+{:.danger}
+> Use the `id` from the output, **not** `provider_account_id`.
+
+The supported region, availability zones, and CIDR blocks depend on your provider account. List the values that AWS supports from the availability endpoint:
+
+```sh
+curl -s -H "Authorization: Bearer $KONNECT_TOKEN" \
+  https://global.api.konghq.com/v2/cloud-gateways/availability.json | \
+  jq '.providers[] | select(.provider == "aws") | .regions[] | {region, availability_zones, cidr_blocks}'
+```
+
+Use a supported `region`, its `availability_zones`, and a CIDR subnet inside one of the supported `cidr_blocks` in the following configuration, which creates the public network, the control plane, a live data plane on that network, and the managed cache:
 
 <!--vale off-->
 ```hcl
 echo '
+variable "provider_id" {
+  type = string
+}
+
+resource "konnect_cloud_gateway_network" "my_cloudgatewaynetwork" {
+  name   = "Terraform Network"
+  region = "us-east-2"
+  availability_zones = [
+    "use2-az1",
+    "use2-az2",
+    "use2-az3"
+  ]
+
+  cidr_block      = "10.0.0.0/16"
+
+  cloud_gateway_provider_account_id = var.provider_id
+}
+
 resource "konnect_gateway_control_plane" "test_cp" {
   name         = "CGW Control Plane"
   cloud_gateway = true
+}
+
+resource "konnect_cloud_gateway_configuration" "test_cp_configuration" {
+  control_plane_id  = konnect_gateway_control_plane.test_cp.id
+  control_plane_geo = "us"
+  api_access        = "public"
+  version           = "3.15"
+  dataplane_groups = [
+    {
+      provider                  = "aws"
+      region                    = "us-east-2"
+      cloud_gateway_network_id  = konnect_cloud_gateway_network.my_cloudgatewaynetwork.id
+      autoscale = {
+        configuration_data_plane_group_autoscale_autopilot = {
+          kind     = "autopilot"
+          base_rps = 10
+        }
+      }
+    }
+  ]
 }
 
 resource "konnect_cloud_gateway_addon" "managed_cache" {
@@ -28,12 +100,20 @@ resource "konnect_cloud_gateway_addon" "managed_cache" {
     }
   }
 }
+
+output "control_plane_id" {
+  value = konnect_gateway_control_plane.test_cp.id
+}
 ' >> main.tf
 ```
 <!--vale on-->
 
-```bash
+Create the resources using Terraform:
+```sh
 terraform apply -auto-approve
 ```
 
-For sizing recommendations, a control plane group setup, or the full walkthrough, see [Configure an AWS managed cache for a Dedicated Cloud Gateway control plane](/dedicated-cloud-gateways/aws-managed-cache-control-plane/) or [Configure an AWS managed cache for a Dedicated Cloud Gateway control plane group](/dedicated-cloud-gateways/aws-managed-cache-control-plane-group/).
+{:.warning}
+> **Important:** It can take 30-40 minutes for your network to initialize, and about 15 minutes after that for the managed cache to become ready. You **must** wait for both the network and the managed cache to show as `Ready` before continuing.
+
+For sizing recommendations or a full walkthrough, see [Configure an AWS managed cache for a Dedicated Cloud Gateway control plane](/dedicated-cloud-gateways/aws-managed-cache-control-plane/) or [Configure an AWS managed cache for a Dedicated Cloud Gateway control plane group](/dedicated-cloud-gateways/aws-managed-cache-control-plane-group/).

--- a/app/dedicated-cloud-gateways/managed-cache.md
+++ b/app/dedicated-cloud-gateways/managed-cache.md
@@ -20,11 +20,15 @@ related_resources:
     url: /dedicated-cloud-gateways/aws-managed-cache-control-plane/
   - text: Configure an Azure managed cache for a Dedicated Cloud Gateway control plane
     url: /dedicated-cloud-gateways/azure-managed-cache-control-plane/
+  - text: Flush a Dedicated Cloud Gateway managed cache using Terraform
+    url: /dedicated-cloud-gateways/flush-managed-cache/
 next_steps:
   - text: Configure an AWS managed cache for a Dedicated Cloud Gateway control plane
     url: /dedicated-cloud-gateways/aws-managed-cache-control-plane/
   - text: Configure an Azure managed cache for a Dedicated Cloud Gateway control plane
     url: /dedicated-cloud-gateways/azure-managed-cache-control-plane/
+  - text: Flush a Dedicated Cloud Gateway managed cache using Terraform
+    url: /dedicated-cloud-gateways/flush-managed-cache/
   - text: Dedicated Cloud Gateways production readiness checklist
     url: /dedicated-cloud-gateways/production-readiness/
 tags:
@@ -38,6 +42,7 @@ tags:
 > * [Configure an AWS managed cache for a Dedicated Cloud Gateway control plane group](/dedicated-cloud-gateways/aws-managed-cache-control-plane-group/)
 > * [Configure an Azure managed cache for a Dedicated Cloud Gateway control plane](/dedicated-cloud-gateways/azure-managed-cache-control-plane/)
 > * [Configure an Azure managed cache for a Dedicated Cloud Gateway control plane group](/dedicated-cloud-gateways/azure-managed-cache-control-plane-group/)
+> * [Flush a Dedicated Cloud Gateway managed cache using Terraform](/dedicated-cloud-gateways/flush-managed-cache/)
 
 {% include_cached /sections/managed-cache-intro.md %}
 
@@ -109,7 +114,6 @@ rows:
       `micro` fails at 10,000 RPS.
       <br>
       `small` handles a 1,000 RPS baseline cleanly.
-
   - profile: Standard enterprise
     entities: "≤1,000 × ≤100 × 3 windows"
     rps: "≤10,000"
@@ -122,7 +126,6 @@ rows:
     instance: "`xlarge`"
     sync: "0.5–1.0"
     notes: Large tiers are overwhelmed at a 0.1 sync rate with this entity count. The `xlarge` tier provides headroom.
-
   - profile: High-scale enterprise
     entities: "≤5,000 × ≤3,000 × 3 windows"
     rps: "≤20,000"
@@ -443,6 +446,11 @@ body:
       tier: small
 {% endkonnect_api_request %}
 <!--vale on-->
+
+## Flush a managed cache
+
+A managed cache doesn't expose a built-in way to clear its contents on demand.
+To flush a managed cache, see [Flush a Dedicated Cloud Gateway managed cache using Terraform](/dedicated-cloud-gateways/flush-managed-cache/), which deploys a custom plugin that exposes a flush endpoint on your gateway.
 
 ## Use a Dedicated Cloud Gateway managed cache in a custom plugin
 


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes #6461 

## Preview Links
https://deploy-preview-7136--kongdeveloper.netlify.app/dedicated-cloud-gateways/flush-managed-cache/

Testing info:
You can use the CP I've already set up (in the .com instance, called `CGW Control Plane`).
So ignore the [managed cache prereq](https://deploy-preview-7136--kongdeveloper.netlify.app/dedicated-cloud-gateways/flush-managed-cache/#an-aws-managed-cache) and you'll export this when you get to this step:
`export TF_VAR_control_plane_id="CP UUID HERE"`

To test the [optional settings](https://deploy-preview-7136--kongdeveloper.netlify.app/dedicated-cloud-gateways/flush-managed-cache/#optional-restrict-access-and-auto-flush-on-apply), I recommend:

- test once without any of these enabled
- enable the [IP restriction plugin](https://deploy-preview-7136--kongdeveloper.netlify.app/dedicated-cloud-gateways/flush-managed-cache/#limit-ips-that-can-trigger-a-flush) and test once with this
- Disable the IP restriction plugin in the UI, then test with the [flush on TF apply](https://deploy-preview-7136--kongdeveloper.netlify.app/dedicated-cloud-gateways/flush-managed-cache/#automatically-flush-on-terraform-apply)

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
