### PR TITLE
feat(gateway): Dynamic plugin expression fields

### DIFF
--- a/app/_gateway_entities/plugin.md
+++ b/app/_gateway_entities/plugin.md
@@ -249,7 +249,7 @@ condition: 'http.headers.x_block == "true"'
 ```
 
 For more information, see:
-* [Plugin expressions reference](/gateway/plugins/conditions/)
+* [Plugin conditional execution reference](/gateway/plugins/conditions/)
 * [CEL reference](/gateway/plugins/expressions/)
 * [How to: Configure conditional plugin execution in {{site.base_gateway}}](/gateway/configure-conditional-plugin-execution/)
 

--- a/app/_gateway_entities/plugin.md
+++ b/app/_gateway_entities/plugin.md
@@ -249,8 +249,25 @@ condition: 'http.headers.x_block == "true"'
 ```
 
 For more information, see:
-* [Plugin expressions reference](/gateway/plugins/expressions/)
+* [Plugin expressions reference](/gateway/plugins/conditions/)
+* [CEL reference](/gateway/plugins/expressions/)
 * [How to: Configure conditional plugin execution in {{site.base_gateway}}](/gateway/configure-conditional-plugin-execution/)
+
+## Dynamic configuration {% new_in 3.16 %}
+
+Some plugin config fields can be computed per request from a CEL expression. For example, you could read an attribute of the authenticated Consumer or Principal instead of always using a fixed value.
+
+Unlike a `condition`, which decides whether the whole plugin runs, this only changes the value of one specific field.
+
+Only specific fields on the following plugins support dynamic plugin config:
+* [ACL](/plugins/acl/#dynamic-allow-and-deny-rules)
+* [Rate Limiting](/plugins/rate-limiting/#dynamic-configuration-with-cel)
+* [Rate Limiting Advanced](/plugins/rate-limiting-advanced/#dynamic-configuration-with-cel)
+
+For more information, see:
+* [Dynamic plugin config with CEL](/gateway/plugins/expressible-fields/)
+* [CEL reference](/gateway/plugins/expressions/)
+* [How-to: Configure dynamic plugin config with CEL](/gateway/configure-dynamic-plugin-config-with-cel/)
 
 ## Cloning plugins {% new_in 3.15 %}
 
@@ -266,7 +283,7 @@ Cloned plugins are useful in many situations. For example:
 * Allowing different teams who want to use the same plugin logic to apply different business rules. 
 For example, a platform team may want to add a global IP deny list to a Gateway to enforce a global security policy, while an engineering team may also want to block IPs from a particular problematic customer on a single Route.
 * Running multiple instances of the [Datakit](/plugins/datakit/) plugin where different teams want to independently manage their own distinct flows on the same Gateway.
-* In conjunction with [conditional plugins](/gateway/plugins/expressions/), running different configurations of the plugin based on different environmental conditions.
+* In conjunction with [conditional plugins](/gateway/plugins/conditions/), running different configurations of the plugin based on different environmental conditions.
 
 ### Permissions required
 

--- a/app/_how-tos/gateway/configure-conditional-plugin-execution.md
+++ b/app/_how-tos/gateway/configure-conditional-plugin-execution.md
@@ -44,7 +44,7 @@ min_version:
     gateway: '3.15'
 
 related_resources:
-  - text: Plugin expressions reference
+  - text: Plugin conditional execution reference
     url: /gateway/plugins/conditions/
 
 faqs:

--- a/app/_how-tos/gateway/configure-conditional-plugin-execution.md
+++ b/app/_how-tos/gateway/configure-conditional-plugin-execution.md
@@ -45,7 +45,7 @@ min_version:
 
 related_resources:
   - text: Plugin expressions reference
-    url: /gateway/plugins/expressions/
+    url: /gateway/plugins/conditions/
 
 faqs:
   - q: Can I see the results of a condition check in the {{site.base_gateway}} logs?
@@ -69,7 +69,7 @@ faqs:
 
 ## Add a plugin with a condition
 
-Add the Request Termination plugin to your Route with a [`condition` expression](/gateway/plugins/expressions/). 
+Add the Request Termination plugin to your Route with a [`condition` expression](/gateway/plugins/conditions/). 
 In this example, the plugin only triggers when the request includes the header `x-block: true`, and blocks the request. 
 Requests without this header are proxied to the upstream service.
 {% entity_examples %}

--- a/app/_how-tos/gateway/configure-dynamic-plugin-config-with-cel.md
+++ b/app/_how-tos/gateway/configure-dynamic-plugin-config-with-cel.md
@@ -1,0 +1,258 @@
+---
+title: Configure dynamic plugin config with CEL in {{site.base_gateway}}
+permalink: /gateway/configure-dynamic-plugin-config-with-cel/
+content_type: how_to
+
+description: Learn how to set a Rate Limiting Advanced plugin's rate limit and rate limiting key per request, based on the authenticated Principal's metadata.
+products:
+    - gateway
+    - identity
+
+plugins:
+  - rate-limiting-advanced
+
+works_on:
+    - konnect
+
+entities:
+  - plugin
+  - service
+  - route
+  - principal
+
+tags:
+    - traffic-control
+    - authentication
+
+tools:
+    - konnect-api
+
+tldr:
+  q: How do I compute a plugin's config from a CEL expression instead of a fixed value?
+  a: |
+    To compute a plugin's config from a CEL expression instead of a fixed value, set a config field's parallel `expressions.FIELD` entry to a CEL expression, alongside the field's ordinary static `config.FIELD` value. 
+    {{site.base_gateway}} evaluates the expression per request. 
+    If it succeeds, its result overrides the field for that request; if it fails, {{site.base_gateway}} falls back to the static `config` value.
+
+    This guide computes Rate Limiting Advanced's `limit` and `custom_key` fields from a Principal's metadata, so each authenticated client gets their own rate limit and their own counter from a single plugin instance.
+
+faqs:
+  - q: What happens if a Principal is missing the metadata that an expression expects to find?
+    a: |
+      If the Principal is missing expected metadata, the expression fails to evaluate, and {{site.base_gateway}} falls back to the field's static `config` value for that request. 
+      {{site.base_gateway}} doesn't raise an error, and the plugin still runs normally.
+
+prereqs:
+  entities:
+    services:
+        - example-service
+    routes:
+        - example-route
+  inline:
+    - title: Kong Identity directory
+      include_content: prereqs/kong-identity-directory
+      icon_url: /assets/icons/identity.svg
+    - title: Konnect API
+      include_content: prereqs/konnect-api-for-curl
+
+cleanup:
+  inline:
+    - title: Clean up Konnect environment
+      include_content: cleanup/platform/konnect
+      icon_url: /assets/icons/gateway.svg
+    - title: Destroy the {{site.base_gateway}} container
+      include_content: cleanup/products/gateway
+      icon_url: /assets/icons/gateway.svg
+
+min_version:
+    gateway: '3.16'
+
+related_resources:
+  - text: Dynamic plugin config with CEL
+    url: /gateway/plugins/expressible-fields/
+  - text: CEL expressions for plugins
+    url: /gateway/plugins/expressions/
+  - text: Rate Limiting Advanced plugin
+    url: /plugins/rate-limiting-advanced/
+
+automated_tests: false
+---
+
+## Create a Principal
+
+{% include /how-tos/steps/principal.md %}
+
+Set `rate_limit` and `partner_id` metadata on the Principal so the plugin's expressions have something to read:
+
+<!--vale off-->
+{% konnect_api_request %}
+url: /v2/directories/$DIRECTORY_ID/principals/$PRINCIPAL_ID
+status_code: 200
+method: PUT
+body:
+  display_name: "example-principal"
+  description: "Example principal"
+  metadata:
+    rate_limit: 20
+    partner_id: acme-rockets
+{% endkonnect_api_request %}
+<!--vale on-->
+
+## Add key auth
+
+Add an API key credential to the Principal so clients can authenticate with {{site.base_gateway}} using key authentication.
+
+The following example sets a system-generated key (`v1`) and stores the key secret as `$KEY_SECRET`:
+
+<!--vale off-->
+{% konnect_api_request %}
+url: /v2/directories/$DIRECTORY_ID/principals/$PRINCIPAL_ID/api-keys
+status_code: 201
+method: POST
+body:
+  type: v1
+capture:
+  - variable: KEY_SECRET
+    jq: ".secret"
+{% endkonnect_api_request %}
+<!--vale on-->
+
+## Get the directory name
+
+{% include /how-tos/steps/get-directory-name.md %}
+
+## Configure the Key Auth plugin
+
+Enable the [Key Auth](/plugins/key-auth/) plugin so clients can authenticate with an API key, and resolve the authenticated Principal for later plugins to read:
+
+{% entity_examples %}
+entities:
+  plugins:
+  - name: key-auth
+    route: example-route
+    config:
+      identity_realms: []
+      principals:
+        enabled: true
+        directory: ${directory_name}
+variables:
+  directory_name:
+    value: $DIRECTORY_NAME
+formats:
+  - deck
+{% endentity_examples %}
+
+## Configure Rate Limiting Advanced with CEL expressions
+
+`limit` and `custom_key` are [expressible config fields](/gateway/plugins/expressible-fields/#expressible-config-fields) on Rate Limiting Advanced. They both have parallel entries under `expressions`, alongside their static `config` values. 
+Configure the plugin globally with:
+
+* `identifier: principal`, so the plugin keys and limits by the authenticated Principal.
+* A static `config.limit` and `config.custom_key`, used as the fallback whenever a request's expressions can't be evaluated.
+* `expressions.limit` and `expressions.custom_key`, reading the authenticated Principal's `rate_limit` and `partner_id` metadata.
+
+<!--vale off-->
+{% konnect_api_request %}
+url: /v2/control-planes/$CONTROL_PLANE_ID/core-entities/plugins/
+status_code: 201
+method: POST
+headers:
+  - 'Content-Type: application/json'
+body:
+  name: rate-limiting-advanced
+  config:
+    identifier: principal
+    custom_key: unknown-partner
+    limit:
+      - 10
+    window_size:
+      - 60
+    strategy: local
+  expressions:
+    custom_key: principal.metadata.partner_id
+    limit:
+      - principal.metadata.rate_limit
+{% endkonnect_api_request %}
+<!--vale on-->
+
+{% comment %}
+_to do: uncomment and replace API instructions once decK support is added_
+{% entity_examples %}
+entities:
+  plugins:
+    - name: rate-limiting-advanced
+      config:
+        identifier: principal
+        custom_key: unknown-partner
+        limit:
+          - 10
+        window_size:
+          - 60
+        strategy: local
+      expressions:
+        custom_key: principal.metadata.partner_id
+        limit:
+          - principal.metadata.rate_limit
+formats:
+  - deck
+{% endentity_examples %}
+{% endcomment %}
+
+## Validate
+
+Send a request with the API key stored in `$KEY_SECRET`:
+
+{% validation request-check %}
+url: /anything
+method: GET
+display_headers: true
+headers:
+  - "apikey: $KEY_SECRET"
+status_code: 200
+{% endvalidation %}
+
+Check the `RateLimit-Limit` response header:
+
+```
+RateLimit-Limit: 20
+```
+{:.no-copy-code}
+
+The limit is now `20` from `expressions.limit` instead of the static fallback value of `10` from `principal.metadata.rate_limit`. 
+
+To see the static fallback take over, remove the Principal's `rate_limit` metadata:
+
+<!--vale off-->
+{% konnect_api_request %}
+url: /v2/directories/$DIRECTORY_ID/principals/$PRINCIPAL_ID
+status_code: 200
+method: PUT
+body:
+  display_name: "example-principal"
+  description: "Example principal"
+  metadata:
+    partner_id: acme-rockets
+{% endkonnect_api_request %}
+<!--vale on-->
+
+{:.warning}
+> {{site.base_gateway}} caches a successfully authenticated Principal for the directory's configured `ttl_secs` (5 minutes at minimum, 10 minutes by default). Wait at least 5 minutes after the previous request before continuing, or the next request will still show the cached Principal's old metadata.
+
+After the `ttl` has elapsed (5-10 minutes), send another request:
+{% validation request-check %}
+url: /anything
+method: GET
+display_headers: true
+headers:
+  - "apikey: $KEY_SECRET"
+status_code: 200
+{% endvalidation %}
+
+With `rate_limit` no longer present on the Principal, `expressions.limit` fails to evaluate, and {{site.base_gateway}} falls back to the static `config.limit` value of `10`:
+
+```
+RateLimit-Limit: 10
+```
+{:.no-copy-code}
+
+

--- a/app/_how-tos/gateway/configure-dynamic-plugin-config-with-cel.md
+++ b/app/_how-tos/gateway/configure-dynamic-plugin-config-with-cel.md
@@ -79,7 +79,8 @@ automated_tests: false
 ---
 
 ## Create a Principal
-
+A plugin’s config can be computed per request from a [CEL expression](/gateway/plugins/expressions/), for example, reading an attribute of the authenticated Consumer or Principal, instead of always using a fixed value.
+In this guide, you'll create a [Principal](/identity/principals/) so that a custom limit can be applied to authenticated Principals.
 {% include /how-tos/steps/principal.md %}
 
 Set `rate_limit` and `partner_id` metadata on the Principal so the plugin's expressions have something to read:

--- a/app/_how-tos/gateway/stream-custom-plugins.md
+++ b/app/_how-tos/gateway/stream-custom-plugins.md
@@ -167,7 +167,7 @@ EOF
 ## Configure the plugins
 
 Now that both plugins are defined, apply them globally.
-Apply `replaceme` with a [condition](/gateway/plugins/expressions/) so it only runs when the request path doesn't contain `skip`:
+Apply `replaceme` with a [condition](/gateway/plugins/conditions/) so it only runs when the request path doesn't contain `skip`:
 
 {% entity_examples %}
 entities:

--- a/app/_includes/gateway/expressions/limitation-note.md
+++ b/app/_includes/gateway/expressions/limitation-note.md
@@ -1,2 +1,2 @@
 {:.info}
-> **Note**: This plugin **does not** support [conditional expressions](/gateway/plugins/conditions/).
+> **Note**: This plugin **does not** support [conditional execution through expressions](/gateway/plugins/conditions/).

--- a/app/_includes/gateway/expressions/limitation-note.md
+++ b/app/_includes/gateway/expressions/limitation-note.md
@@ -1,2 +1,2 @@
 {:.info}
-> **Note**: This plugin **does not** support [conditional expressions](/gateway/plugins/expressions/).
+> **Note**: This plugin **does not** support [conditional expressions](/gateway/plugins/conditions/).

--- a/app/_includes/gateway/expressions/migrate.md
+++ b/app/_includes/gateway/expressions/migrate.md
@@ -1,6 +1,6 @@
 The plugin expression language changed between 3.14 and 3.15.
 In {{site.base_gateway}} 3.14, the feature was in beta and used ATC (Abstract Tree Classifier) syntax for plugin conditions. 
-{{site.base_gateway}} 3.15 uses [CEL (Common Expression Language)](/gateway/plugins/expressions/), which isn't backwards-compatible.
+{{site.base_gateway}} 3.15 uses [CEL (Common Expression Language)](/gateway/plugins/conditions/), which isn't backwards-compatible.
 
 Any conditional expression that worked in 3.14 will need to be rewritten for 3.15.
 The main syntax changes are:

--- a/app/_includes/prereqs/kong-identity-directory.md
+++ b/app/_includes/prereqs/kong-identity-directory.md
@@ -1,4 +1,9 @@
 A directory is a regional collection of principals. 
+A {{site.konnect_short_name}} organization supports only one {{site.identity}} directory. Create a directory for the tutorial, or look up your existing one.
+
+{% navtabs 'directory' %}
+{% navtab "Create directory" %}
+
 Create a directory for this tutorial:
 
 <!--vale off-->
@@ -17,3 +22,22 @@ capture:
     jq: ".id"
 {% endkonnect_api_request %}
 <!--vale on-->
+
+{:.info}
+> If you run into 403 errors when trying to create a directory, the directory likely already exists. Look up your existing directory instead.
+
+{% endnavtab %}
+{% navtab "Look up directory" %}
+Look up an existing directory:
+<!--vale off-->
+{% konnect_api_request %}
+url: /v2/directories
+status_code: 200
+method: GET
+capture:
+  - variable: DIRECTORY_ID
+    jq: ".data[0].id"
+{% endkonnect_api_request %}
+<!--vale on-->
+{% endnavtab %}
+{% endnavtabs %}

--- a/app/_includes/prereqs/konnect-api-for-curl.md
+++ b/app/_includes/prereqs/konnect-api-for-curl.md
@@ -1,6 +1,15 @@
-To use the copy, paste, and run the instructions in this how-to, you must export the additional environmental variable `CONTROL_PLANE_ID`:
+To use the copy, paste, and run the instructions in this how-to, you need the ID of your control plane.
 
-```sh
-export CONTROL_PLANE_ID='YOUR CONTROL PLANE ID'
-```
-You can find your control plane UUID by navigating to the control plane in the {{site.konnect_short_name}} UI or by sending a `GET` request to the [`/control-planes` endpoint](/api/konnect/control-planes/#/operations/list-control-planes).
+Look it up using `DECK_KONNECT_CONTROL_PLANE_NAME`, exported in a previous prerequisite, or substitute the name of your own control plane:
+
+<!--vale off-->
+{% konnect_api_request %}
+url: /v2/control-planes?filter%5Bname%5D%5Beq%5D=$DECK_KONNECT_CONTROL_PLANE_NAME
+status_code: 200
+method: GET
+capture:
+  - variable: CONTROL_PLANE_ID
+    jq: ".data[0].id"
+{% endkonnect_api_request %}
+<!--vale on-->
+

--- a/app/_includes/prereqs/products/konnect.md
+++ b/app/_includes/prereqs/products/konnect.md
@@ -25,6 +25,7 @@ This is a Konnect tutorial and requires a Konnect personal access token.
    ```bash
    export DECK_KONNECT_TOKEN=$KONNECT_TOKEN
    export DECK_KONNECT_CONTROL_PLANE_NAME=quickstart
+   export DECK_KONNECT_ADDR=https://us.api.konghq.com
    export KONNECT_CONTROL_PLANE_URL=https://us.api.konghq.com
    export KONNECT_PROXY_URL='http://localhost:8000'
    ```

--- a/app/_indices/gateway.yaml
+++ b/app/_indices/gateway.yaml
@@ -29,6 +29,9 @@ sections:
       - path: /gateway/entities/plugin/
       - path: /gateway/plugins/plugin-ordering-legacy/
       - path: /gateway/plugins/plugin-ordering-priority-preserving/
+      - path: /gateway/plugins/conditions/
+      - path: /gateway/plugins/expressions/
+      - path: /gateway/plugins/expressible-fields/
       - path: /gateway/entities/upstream/
       - path: /gateway/entities/target/
       - path: /gateway/rate-limiting/

--- a/app/_kong_plugins/acl/examples/allow-when-principal-metadata.yaml
+++ b/app/_kong_plugins/acl/examples/allow-when-principal-metadata.yaml
@@ -1,0 +1,22 @@
+description: "Allow requests using a CEL expression that reads the authenticated Principal's metadata, instead of a static allow list."
+
+title: 'Allow by Principal metadata'
+
+weight: 800
+
+requirements:
+  - "[Authentication](/gateway/authentication/) configured with Kong Identity Principal support"
+
+config:
+  allow_when:
+    - "has(principal.metadata.tier) && principal.metadata.tier == \"partner\""
+
+min_version:
+  gateway: '3.16'
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform

--- a/app/_kong_plugins/acl/examples/allow-when-principal-metadata.yaml
+++ b/app/_kong_plugins/acl/examples/allow-when-principal-metadata.yaml
@@ -5,7 +5,7 @@ title: 'Allow by Principal metadata'
 weight: 800
 
 requirements:
-  - "[Authentication](/gateway/authentication/) configured with Kong Identity Principal support"
+  - "[Authentication](/gateway/authentication/) configured with {{site.identity}} [Principal](/identity/principals/) support"
 
 config:
   allow_when:

--- a/app/_kong_plugins/acl/examples/deny-when-principal-metadata.yaml
+++ b/app/_kong_plugins/acl/examples/deny-when-principal-metadata.yaml
@@ -5,7 +5,7 @@ title: 'Deny by Principal metadata'
 weight: 700
 
 requirements:
-  - "[Authentication](/gateway/authentication/) configured with Kong Identity Principal support"
+  - "[Authentication](/gateway/authentication/) configured with {{site.identity}} [Principal](/identity/principals/) support"
 
 config:
   deny_when:

--- a/app/_kong_plugins/acl/examples/deny-when-principal-metadata.yaml
+++ b/app/_kong_plugins/acl/examples/deny-when-principal-metadata.yaml
@@ -1,0 +1,22 @@
+description: "Deny requests using a CEL expression that reads the authenticated Principal's metadata, instead of a static deny list."
+
+title: 'Deny by Principal metadata'
+
+weight: 700
+
+requirements:
+  - "[Authentication](/gateway/authentication/) configured with Kong Identity Principal support"
+
+config:
+  deny_when:
+    - "has(principal.metadata.status) && principal.metadata.status == \"suspended\""
+
+min_version:
+  gateway: '3.16'
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform

--- a/app/_kong_plugins/acl/index.md
+++ b/app/_kong_plugins/acl/index.md
@@ -59,9 +59,9 @@ If `hide_groups_header` is set to `false` and a Consumer is validated, the plugi
 
 ## Dynamic allow and deny rules {% new_in 3.16 %}
 
-Instead of an allow or deny list of group names, you can use [`allow_when`](/plugins/acl/reference/#schema--config-allow-when) or [`deny_when`](/plugins/acl/reference/#schema--config-deny-when) to allow or deny requests based on a list of [CEL](https://cel.dev/) boolean expressions, evaluated against the same fields available to [plugin conditions](/gateway/plugins/expressions/) (for example, the authenticated Consumer, Principal, or HTTP request attributes).
+Instead of an allow or deny list of group names, you can use [`allow_when`](/plugins/acl/reference/#schema--config-allow-when) or [`deny_when`](/plugins/acl/reference/#schema--config-deny-when) to allow or deny requests based on a list of [CEL](https://cel.dev/) boolean expressions, evaluated against the same fields available to [plugin conditions](/gateway/plugins/conditions/) (for example, the authenticated Consumer, Principal, or HTTP request attributes).
 
-`allow`, `deny`, `allow_when`, and `deny_when` are mutually exclusive. Configure exactly one of them on a given ACL plugin instance.
+`allow`, `deny`, `allow_when`, and `deny_when` are mutually exclusive. Configure exactly one of them on a given ACL plugin instance:
 
 ```yaml
 config:

--- a/app/_kong_plugins/acl/index.md
+++ b/app/_kong_plugins/acl/index.md
@@ -12,6 +12,8 @@ related_resources:
     url: /how-to/use-acl-with-consumer-groups/
   - text: "{{site.base_gateway}} traffic control and routing"
     url: /gateway/traffic-control-and-routing/
+  - text: Dynamic plugin config with CEL
+    url: /gateway/plugins/expressible-fields/
 
 tags:
   - traffic-control
@@ -54,3 +56,28 @@ This plugin uses authenticated Consumers to identify who can and can't access th
 ## Upstream Consumer Groups header
 
 If `hide_groups_header` is set to `false` and a Consumer is validated, the plugin appends a `X-Consumer-Groups` header to the request before proxying it to the upstream service. The header contains a comma separated list of groups that belong to the Consumer, for example `admin, pro_user`. This allows you to identify the groups associated with the Consumer. 
+
+## Dynamic allow and deny rules {% new_in 3.16 %}
+
+Instead of an allow or deny list of group names, you can use [`allow_when`](/plugins/acl/reference/#schema--config-allow-when) or [`deny_when`](/plugins/acl/reference/#schema--config-deny-when) to allow or deny requests based on a list of [CEL](https://cel.dev/) boolean expressions, evaluated against the same fields available to [plugin conditions](/gateway/plugins/expressions/) (for example, the authenticated Consumer, Principal, or HTTP request attributes).
+
+`allow`, `deny`, `allow_when`, and `deny_when` are mutually exclusive. Configure exactly one of them on a given ACL plugin instance.
+
+```yaml
+config:
+  allow_when:
+    - "has(principal.metadata.tier) && principal.metadata.tier == \"partner\""
+```
+
+Each entry in `allow_when` or `deny_when` is evaluated in order, with OR semantics:
+
+* For `allow_when`, the request is allowed as soon as any expression matches. If none match, the request is denied with a `403` response, the same behavior as when no group in an `allow` list matches.
+* For `deny_when`, the request is denied with a `403` response as soon as any expression matches. If none match, the request is allowed, **unless** one or more expressions failed to compile or evaluate. In that case, the plugin fails closed and returns a `500` response, since treating an evaluation failure the same as "no match" could let through a request that should have been denied.
+
+When `allow_when` or `deny_when` is configured:
+* `hide_groups_header`, `include_consumer_groups`, and `always_use_authenticated_groups` are all ignored.
+* The `X-Consumer-Groups` header isn't sent to the upstream service, since there's no matched group list to report.
+
+For example plugin configurations, see [Allow by Principal metadata](/plugins/acl/examples/allow-when-principal-metadata/) and [Deny by Principal metadata](/plugins/acl/examples/deny-when-principal-metadata/).
+
+For general information on this class of CEL-driven plugin config, see [Dynamic plugin config with CEL](/gateway/plugins/expressible-fields/).

--- a/app/_kong_plugins/rate-limiting-advanced/examples/rate-limit-by-principal-metadata.yaml
+++ b/app/_kong_plugins/rate-limiting-advanced/examples/rate-limit-by-principal-metadata.yaml
@@ -1,0 +1,29 @@
+description: 'Rate limit by Principal, with the limit and rate limiting key both driven by CEL expressions reading the Principal''s metadata.'
+
+title: 'Rate limit by Principal metadata'
+
+weight: 800
+
+requirements:
+  - "[Authentication](/gateway/authentication/) configured with Kong Identity Principal support"
+
+config:
+  identifier: principal
+  custom_key: unknown-partner
+  limit:
+    - 10
+  window_size:
+    - 60
+
+expressions:
+  custom_key: principal.metadata.partner_id
+  limit:
+    - principal.metadata.rate_limit
+
+min_version:
+  gateway: '3.16'
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api

--- a/app/_kong_plugins/rate-limiting-advanced/index.md
+++ b/app/_kong_plugins/rate-limiting-advanced/index.md
@@ -224,7 +224,7 @@ For an example plugin configuration, see [Rate limit by consumer username](/plug
 
 ## Rate limit by Principal {% new_in 3.16 %}
 
-Set [`identifier`](/plugins/rate-limiting-advanced/reference/#schema--config-identifier) to `principal` to rate limit based on the authenticated [Kong Identity Principal](/identity/principals/) instead of the Consumer, credential, IP address, or other supported identifiers. `principal` is also a valid segment in [`compound_identifier`](/plugins/rate-limiting-advanced/reference/#schema--config-compound-identifier).
+Set [`identifier`](/plugins/rate-limiting-advanced/reference/#schema--config-identifier) to `principal` to rate limit based on the authenticated [{{site.identity}} Principal](/identity/principals/) instead of the Consumer, credential, IP address, or other supported identifiers. `principal` is also a valid segment in [`compound_identifier`](/plugins/rate-limiting-advanced/reference/#schema--config-compound-identifier).
 
 ```yaml
 config:

--- a/app/_kong_plugins/rate-limiting-advanced/index.md
+++ b/app/_kong_plugins/rate-limiting-advanced/index.md
@@ -18,6 +18,10 @@ related_resources:
     url: /how-to/multiple-rate-limits-window-sizes/
   - text: Rate Limiting plugin
     url: /plugins/rate-limiting/
+  - text: Dynamic plugin config with CEL
+    url: /gateway/plugins/expressible-fields/
+  - text: "How-to: Configure dynamic plugin config with CEL"
+    url: /gateway/configure-dynamic-plugin-config-with-cel/
 
 products:
     - gateway
@@ -217,6 +221,55 @@ This enables consistent rate limiting across distributed deployments that share 
 `counter_key` also applies when using [`compound_identifier`](/plugins/rate-limiting-advanced/reference/#schema--config-compound-identifier) with a Consumer segment, for example `["ip", "consumer"]`.
 
 For an example plugin configuration, see [Rate limit by consumer username](/plugins/rate-limiting-advanced/examples/rate-limit-counter-key/).
+
+## Rate limit by Principal {% new_in 3.16 %}
+
+Set [`identifier`](/plugins/rate-limiting-advanced/reference/#schema--config-identifier) to `principal` to rate limit based on the authenticated [Kong Identity Principal](/identity/principals/) instead of the Consumer, credential, IP address, or other supported identifiers. `principal` is also a valid segment in [`compound_identifier`](/plugins/rate-limiting-advanced/reference/#schema--config-compound-identifier).
+
+```yaml
+config:
+  identifier: principal
+  limit:
+    - 10
+  window_size:
+    - 60
+```
+
+`principal` requires an auth plugin that populates the Principal, such as Key Auth configured for Kong Identity Principal authentication.
+
+In [hybrid mode](/gateway/hybrid-mode/), if the control plane is running {{site.base_gateway}} 3.16 or later and a data plane is running an earlier version, {{site.base_gateway}} falls back to `identifier: ip` for that data plane, and drops `principal` from `compound_identifier` if it's set.
+
+[`custom_key`](/plugins/rate-limiting-advanced/reference/#schema--config-custom-key) overrides the computed rate limiting key with a literal string, regardless of `identifier` or `compound_identifier`. This is most useful in combination with [expressible config fields](#dynamic-configuration-with-cel), where `custom_key`'s value comes from a CEL expression instead of a fixed string.
+
+## Dynamic configuration with CEL {% new_in 3.16 %}
+
+`limit` and `custom_key` are [expressible config fields](/gateway/plugins/expressible-fields/#expressible-config-fields): instead of always using the static value in `config`, {{site.base_gateway}} can compute the field's value per request from a CEL expression, for example, reading an attribute of the authenticated Consumer or Principal. If the expression is unset, invalid, or fails to evaluate, {{site.base_gateway}} falls back to the field's static value in `config`.
+
+Because `limit` is an array field (one value per configured window), its expression is also an array, with one expression per element, in the same order:
+
+```yaml
+config:
+  identifier: principal
+  custom_key: unknown-partner    # static fallback
+  limit:
+    - 10                         # static fallback
+  window_size:
+    - 60
+expressions:
+  custom_key: principal.metadata.partner_id
+  limit:
+    - principal.metadata.rate_limit
+```
+
+{:.info}
+> **Note**: `window_size` is **not** expressible because it is unreliable.
+> For the `cluster` and `redis` strategies, window sizes are registered for cross-node counter synchronization once, from the static config, when the plugin is configured. 
+> A per-request expression-driven window size would never be picked up by that registration.
+
+See also:
+* For an example plugin configuration, see [Rate limit by Principal metadata](/plugins/rate-limiting-advanced/examples/rate-limit-by-principal-metadata/).
+* For a full walkthrough, see the how-to guide [Configure dynamic plugin config with CEL](/gateway/configure-dynamic-plugin-config-with-cel/).
+* For general information on expressible config fields, including limitations, see [Dynamic plugin config with CEL](/gateway/plugins/expressible-fields/).
 
 
 

--- a/app/_kong_plugins/rate-limiting/examples/rate-limit-by-principal-metadata.yaml
+++ b/app/_kong_plugins/rate-limiting/examples/rate-limit-by-principal-metadata.yaml
@@ -4,7 +4,7 @@ title: 'Rate limit by Principal metadata'
 weight: 800
 
 requirements:
-  - "[Authentication](/gateway/authentication/) configured with Kong Identity Principal support"
+  - "[Authentication](/gateway/authentication/) configured with {{site.identity}} [Principal](/identity/principals/) support"
 
 config:
   limit_by: principal

--- a/app/_kong_plugins/rate-limiting/examples/rate-limit-by-principal-metadata.yaml
+++ b/app/_kong_plugins/rate-limiting/examples/rate-limit-by-principal-metadata.yaml
@@ -1,0 +1,23 @@
+description: "Rate limit by Principal, with the limit and rate limiting key both driven by CEL expressions reading the Principal's metadata."
+title: 'Rate limit by Principal metadata'
+
+weight: 800
+
+requirements:
+  - "[Authentication](/gateway/authentication/) configured with Kong Identity Principal support"
+
+config:
+  limit_by: principal
+  custom_key: unknown-partner
+  second: 10
+expressions:
+  custom_key: principal.metadata.partner_id
+  second: principal.metadata.rate_limit
+
+min_version:
+  gateway: '3.16'
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api

--- a/app/_kong_plugins/rate-limiting/index.md
+++ b/app/_kong_plugins/rate-limiting/index.md
@@ -97,7 +97,7 @@ See [Rate Limiting in {{site.base_gateway}}](/gateway/rate-limiting/) to choose 
 
 ## Rate limit by Principal {% new_in 3.16 %}
 
-Set [`limit_by`](/plugins/rate-limiting/reference/#schema--config-limit-by) to `principal` to rate limit based on the authenticated [Kong Identity Principal](/identity/principals/) instead of the Consumer, credential, IP address, or other supported identifiers.
+Set [`limit_by`](/plugins/rate-limiting/reference/#schema--config-limit-by) to `principal` to rate limit based on the authenticated [{{site.identity}} Principal](/identity/principals/) instead of the Consumer, credential, IP address, or other supported identifiers.
 
 ```yaml
 config:
@@ -105,7 +105,7 @@ config:
   second: 10
 ```
 
-`principal` requires an auth plugin that populates the Principal, such as Key Auth configured for Kong Identity Principal authentication.
+`principal` requires an auth plugin that populates the Principal, such as Key Auth configured for {{site.identity}} Principal authentication.
 
 [`custom_key`](/plugins/rate-limiting/reference/#schema--config-custom-key) overrides the computed rate limiting key with a literal string, regardless of `limit_by`. This is most useful in combination with [expressible config fields](#dynamic-configuration-with-cel), where `custom_key`'s value comes from a CEL expression instead of a fixed string.
 

--- a/app/_kong_plugins/rate-limiting/index.md
+++ b/app/_kong_plugins/rate-limiting/index.md
@@ -27,6 +27,8 @@ related_resources:
     url: /how-to/throttle-apis-with-services-and-consumers/
   - text: Rate Limiting Advanced plugin
     url: /plugins/rate-limiting-advanced/
+  - text: Dynamic plugin config with CEL
+    url: /gateway/plugins/expressible-fields/
 
 products:
   - gateway
@@ -92,4 +94,39 @@ See [Rate Limiting in {{site.base_gateway}}](/gateway/rate-limiting/) to choose 
 ## Headers sent to the client
 
 {% include_cached /plugins/rate-limiting/headers.md name=page.name %}
+
+## Rate limit by Principal {% new_in 3.16 %}
+
+Set [`limit_by`](/plugins/rate-limiting/reference/#schema--config-limit-by) to `principal` to rate limit based on the authenticated [Kong Identity Principal](/identity/principals/) instead of the Consumer, credential, IP address, or other supported identifiers.
+
+```yaml
+config:
+  limit_by: principal
+  second: 10
+```
+
+`principal` requires an auth plugin that populates the Principal, such as Key Auth configured for Kong Identity Principal authentication.
+
+[`custom_key`](/plugins/rate-limiting/reference/#schema--config-custom-key) overrides the computed rate limiting key with a literal string, regardless of `limit_by`. This is most useful in combination with [expressible config fields](#dynamic-configuration-with-cel), where `custom_key`'s value comes from a CEL expression instead of a fixed string.
+
+## Dynamic configuration with CEL {% new_in 3.16 %}
+
+`custom_key` and each of `second`, `minute`, `hour`, `day`, `month`, and `year` are [expressible config fields](/gateway/plugins/expressible-fields/#expressible-config-fields): instead of always using the static value in `config`, {{site.base_gateway}} can compute the field's value per request from a CEL expression, for example, reading an attribute of the authenticated Consumer or Principal. 
+If the expression is unset, invalid, or fails to evaluate, {{site.base_gateway}} falls back to the field's static value in `config`.
+
+For example, you can set `custom_key` and `second` as expressions with a static fallback:
+
+```yaml
+config:
+  limit_by: principal
+  custom_key: unknown-partner    # static fallback
+  second: 10                     # static fallback
+expressions:
+  custom_key: principal.metadata.partner_id
+  second: principal.metadata.rate_limit
+```
+
+See also:
+* For an example plugin configuration, see [Rate limit by Principal metadata](/plugins/rate-limiting/examples/rate-limit-by-principal-metadata/).
+* For general information on expressible config fields, including limitations, see [Dynamic plugin config with CEL](/gateway/plugins/expressible-fields/).
 

--- a/app/_plugins/drops/config_example/base.rb
+++ b/app/_plugins/drops/config_example/base.rb
@@ -35,6 +35,14 @@ module Jekyll
           @config ||= example.fetch('config', {})
         end
 
+        def expressions
+          @expressions ||= example.fetch('expressions', {})
+        end
+
+        def condition
+          @condition ||= example['condition']
+        end
+
         def description
           @description ||= example.fetch('description')
         end

--- a/app/_plugins/drops/entity_example/presenters/deck.rb
+++ b/app/_plugins/drops/entity_example/presenters/deck.rb
@@ -65,6 +65,10 @@ module Jekyll
               plugin.merge!('tags' => @example_drop.tags) unless @example_drop.tags.empty?
               config_field = @example_drop.data.fetch('config', {})
               plugin.merge!('config' => config_field) unless config_field.empty?
+              expressions_field = @example_drop.data.fetch('expressions', {})
+              plugin.merge!('expressions' => expressions_field) unless expressions_field.empty?
+              condition_field = @example_drop.data['condition']
+              plugin.merge!('condition' => condition_field) unless condition_field.nil?
               plugin.merge!('ordering' => ordering) unless ordering.nil?
 
               plugin = Utils::VariableReplacer::DeckData.run(

--- a/app/_plugins/drops/plugin_config_example.rb
+++ b/app/_plugins/drops/plugin_config_example.rb
@@ -57,6 +57,8 @@ module Jekyll
 
       def build_data(target)
         data = { 'name' => plugin_slug, target => nil, 'config' => config }
+        data['expressions'] = expressions unless expressions.empty?
+        data['condition'] = condition unless condition.nil?
         data['tags'] = tags unless tags.empty?
         data
       end

--- a/app/custom-plugins/schema.lua.md
+++ b/app/custom-plugins/schema.lua.md
@@ -280,6 +280,60 @@ rows:
     description: A custom validation function written in Lua.
 {% endtable %}
 
+## Making a field expressible {% new_in 3.16 %}
+
+A `string`, `number`, `integer`, or `boolean` field, or an `array`/`map` whose elements or values are one of those scalar types, can be marked `expressible = true`:
+
+```lua
+{
+  limit = {
+    type = "number",
+    gt = 0,
+    expressible = true,
+  },
+},
+```
+
+This lets an operator pair the field with a [CEL expression](/gateway/plugins/expressible-fields/), evaluated per request, alongside the field's ordinary static `config` value. 
+{{site.base_gateway}} derives the paired `expressions.FIELD` entry from this attribute automatically. 
+You don't define it yourself, and you don't need any additional code in `handler.lua` to support it.
+
+`record` fields can't be marked expressible, and neither can an `array` or `map` of them. Kong rejects this when your plugin's schema loads.
+
+For the full mechanism, including how the static value acts as a fallback and how array fields work, see [Dynamic plugin config with CEL](/gateway/plugins/expressible-fields/).
+
+### Security guidance for expressible fields
+
+Marking a field expressible has security implications the framework doesn't check for you. Before adding `expressible = true` to a field, review the following considerations.
+
+#### Is the field's static value already safe as a fallback?
+
+{{site.base_gateway}} falls back to a field's static `config` value automatically whenever its expression fails to evaluate on a CEL error, a `null` result, or a type or constraint mismatch. 
+This fallback is unconditional. A plugin can't opt out of it.
+
+A client can trigger this fallback deliberately by sending a request shaped to make the expression error or produce the wrong type. 
+That means a field's static value is also its worst-case runtime value once the field is expressible.
+If a permissive static value would be unsafe, marking the field expressible makes that value reachable from ordinary request traffic, not just from an Admin API misconfiguration.
+
+Here are examples of a safe vs an unsafe approach:
+* **Safe approach**: [Rate Limiting Advanced](/plugins/rate-limiting-advanced/)'s `limit` field requires `gt = 0`, so a forced fallback always lands on the operator's own configured limit, never zero, negative, or unbounded.
+* **Unsafe approach**: A boolean gating field, for example `bypass_check` or `skip_verification`, where `false` is the safe default and `true` disables an enforcement step. If a forced fallback could land on `true`, a client could force that fallback and skip the check the field is meant to gate. Before marking a field like this expressible, make sure every failure path lands on the restrictive value, or don't mark it expressible at all.
+
+Before shipping, ask: if every expression on this field failed on every request, would you be comfortable with the resulting behavior as the field's permanent default? If not, fix the field's static semantics first.
+
+#### Are the exposed CEL variables safe to drive this field?
+
+An expressible field's expression can reference any of the available CEL variables, including request data such as `http.headers.*` and `http.queries.*`. 
+That data is controlled by the client by definition. A client can set it to anything, including a value chosen specifically to collide with, spoof, or evade another client's.
+
+This matters most for a field that keys, identifies, or scopes something for a specific client, such as a counter key, a quota bucket, or an identity binding. 
+If your field falls into that category, document which CEL variables are safe to reference and which aren't:
+
+* **Safe example**: Authenticated, identity-derived values, such as `principal.id` or `principal.metadata.*`. A client can't forge them without first compromising the authentication step itself.
+* **Unsafe example**: Raw request data, such as `http.headers.*` or `http.queries.*`, used as the sole input to anything identity-related. Any client can set it to any value, including another client's.
+
+This isn't a risk expressible fields introduce on their own. 
+Making a field expressible just lets an operator express an unsafe choice as a formula instead of a fixed value. Document the risk the same way you would for a static field, rather than assume the operator will guess right.
 
 ## Examples
 

--- a/app/gateway/plugins/conditions.md
+++ b/app/gateway/plugins/conditions.md
@@ -1,0 +1,178 @@
+---
+title: Conditional expressions for plugins
+
+description: Reference for the `condition` field, which lets a {{site.base_gateway}} plugin run only when a CEL expression matches the request.
+content_type: reference
+layout: reference
+
+products:
+  - gateway
+
+min_version:
+  gateway: '3.15'
+
+breadcrumbs:
+  - /gateway/
+  - /gateway/entities/
+  - /gateway/entities/plugin/
+
+faqs:
+  - q: Do conditions work with global plugins?
+    a: Yes, conditions can be used on global plugins that are not scoped to a Route, Service, Consumer, or Consumer Group.
+  - q: When should I use plugin conditions instead of Routes?
+    a: |
+      Routes with expression router conditions should be used instead of per-plugin conditions, since Route expressions are more performant than plugin conditions.
+      This is because:
+       * The `init` phase of plugins on excluded Routes won't execute.
+       * The plugin condition won't need to be evaluated.
+  - q: Can I match a plugin condition based on request content type (for example, JSON or XML)?
+    a: |
+      No, the condition expression language doesn't support this explicitly.
+      As an alternative, you can use a plugin such as [Datakit](/plugins/datakit/) or [Pre-Function](/plugins/pre-function/) to parse the body, extract the required value, and store it in [`kong.ctx.shared`](/gateway/plugins/expressions/#available-fields).
+      The plugin condition can then reference that `kong.ctx.shared` key.
+  - q: What happens if my condition expression has a runtime error?
+    a: |
+      If a condition expression fails at runtime, {{site.base_gateway}} logs the error at the ERROR level and returns a 500 status code to the client.
+      To prevent this, wrap your expression in a `default()` call: `default(<expression>, false)`.
+      This returns `false` (and skips the plugin) instead of a 500 if the expression errors.
+
+works_on:
+  - on-prem
+  - konnect
+
+related_resources:
+  - text: CEL expressions for plugins
+    url: /gateway/plugins/expressions/
+  - text: Expressions router
+    url: /gateway/routing/expressions/
+  - text: Configure conditional plugin execution
+    url: /gateway/configure-conditional-plugin-execution/
+  - text: Dynamic plugin config with CEL
+    url: /gateway/plugins/expressible-fields/
+  - text: Plugin entity
+    url: /gateway/entities/plugin/
+  - text: Plugin contexts
+    url: /gateway/entities/plugin/#plugin-contexts
+  - text: Plugin scopes
+    url: /gateway/entities/plugin/#scoping-plugins
+  - text: Plugin priority
+    url: /gateway/entities/plugin/#plugin-priority
+  - text: Conditional expressions for plugins in 3.14
+    url: /gateway/plugins/expressions-314/
+
+---
+
+Plugin conditions let you attach an optional `condition` expression to any plugin.
+When a request comes in, {{site.base_gateway}} evaluates the expression immediately before the plugin's `access` phase.
+If the expression evaluates to `true`, the plugin runs normally.
+If it evaluates to `false`, the plugin is skipped for that request.
+
+Conditions use [Common Expression Language (CEL)](https://cel.dev/), a lightweight expression language.
+
+Here are some common use cases for setting a condition on a plugin:
+
+* Skip a global plugin for specific Routes, hosts, or request paths without removing the plugin or duplicating it across individual Routes.
+* Enforce a plugin only for specific HTTP methods, headers, or query parameters.
+* Make one plugin's execution depend on context set by a higher-priority plugin.
+* Condition plugin behavior on the authenticated Consumer, matched Route, or target Gateway Service.
+
+## How it works
+
+When {{site.base_gateway}} receives a request, it matches the request to a Route and determines which plugins are in scope according to the [plugin scoping rules](/gateway/entities/plugin/#scoping-plugins).
+For each in-scope plugin that has a `condition` set, {{site.base_gateway}} evaluates the expression before that plugin's `access` phase runs.
+
+The following [plugin contexts](/gateway/entities/plugin/#plugin-contexts) always execute, regardless of the condition: `init_worker`, `configure`, `certificate`, and `rewrite`.
+If the condition evaluates to `false`, the plugin's `access` phase and all later phases are skipped.
+Because of this, values set during or after the response phase (for example, `kong.ctx.shared` values written in `header_filter` or `body_filter`) aren't available to condition expressions.
+
+Unlike plugin scopes, which are evaluated once at router time before any plugins run, conditions are evaluated per request, per plugin, immediately before each plugin executes.
+This means a higher-priority plugin can set values in `kong.ctx.shared` that a lower-priority plugin's condition can then read.
+
+If no condition is set, the plugin always executes.
+
+## Performance considerations
+
+[Plugin scopes](/gateway/entities/plugin/#scoping-plugins) are evaluated once at router time and are more efficient than conditions, which are evaluated per request for each conditioned plugin.
+Where possible, use plugin scopes to control plugin execution rather than conditions.
+
+When conditions are necessary, keep the following in mind:
+
+* A plugin's configuration is always loaded into memory, even if its condition evaluates to `false`.
+* Complex compound expressions with many fields are more expensive to evaluate than simple single-field expressions.
+* Conditions that reference `kong.ctx.shared` fields require a higher-priority plugin to set those values on every request, which adds its own overhead.
+
+## Limitations
+
+Plugin conditions are only supported in the HTTP subsystem.
+They can't be used with stream (TCP, TLS, UDP) Routes.
+
+The following plugins **do not** support conditions:
+* Pre-Function
+* Post-Function
+* WebSocket Size Limit
+* WebSocket Validator
+
+All other [{{site.base_gateway}} plugins](/plugins/) support conditions.
+
+Condition expressions have a maximum length of 1024 characters.
+
+## Condition expressions reference
+
+A condition expression is a string value assigned to the `condition` field of a plugin object. It follows the syntax, available fields, and types described in [CEL expressions for plugins](/gateway/plugins/expressions/).
+
+### Handling default values
+
+`default()` makes condition expressions safe at runtime.
+If the expression raises an evaluation error (for example, accessing a missing key in a map), `default()` returns the fallback value instead of causing a 500 error.
+
+`default()` must wrap the **entire** expression. It can't appear inline within a larger expression:
+
+```sh
+# Valid — wraps the entire expression
+default(kong.ctx.shared.my_flag == "enabled", false)
+
+# Not valid — default() can't be used inline
+kong.ctx.shared.my_flag == "enabled" && default(principal.id == "abc", false)
+```
+{:.no-copy-code}
+
+Use `default()` when your expression references fields that might not be set for every request, such as `kong.ctx.shared.*` or `principal.metadata.*`:
+
+```sh
+default(principal.metadata["Department"] == "finance", false)
+```
+
+## Debugging
+
+When {{site.base_gateway}} is running with debug logging enabled, a log line is emitted for each condition evaluation.
+
+When a condition is **not matched** and the plugin is skipped:
+
+```
+plugin condition not matched for plugin 'request-termination' (ID: 66a1adbb-0179-49af-a065-4d0bc6c28cd6): skipped
+```
+{:.no-copy-code}
+
+When a condition is **matched** and the plugin executes:
+
+```
+plugin condition matched for plugin 'request-termination' (ID: 66a1adbb-0179-49af-a065-4d0bc6c28cd6)
+```
+{:.no-copy-code}
+
+If a condition expression **fails at runtime**, the error is logged at the `ERROR` level and {{site.base_gateway}} returns a 500 to the client:
+
+```
+error evaluating plugin condition for plugin 'request-termination' (ID: 66a1adbb-0179-49af-a065-4d0bc6c28cd6): No such key: foo
+```
+{:.no-copy-code}
+
+To prevent runtime errors, wrap your expression in `default()`:
+
+```json
+"condition": "default(kong.ctx.shared.my_flag == \"enabled\", false)"
+```
+
+## Migration from 3.14 to 3.15
+
+{% include_cached /gateway/expressions/migrate.md %}

--- a/app/gateway/plugins/expressible-fields.md
+++ b/app/gateway/plugins/expressible-fields.md
@@ -1,0 +1,174 @@
+---
+title: Dynamic plugin config with CEL
+
+description: Reference for dynamically setting plugin config fields with CEL expressions in {{site.base_gateway}}.
+content_type: reference
+layout: reference
+
+products:
+  - gateway
+
+works_on:
+  - on-prem
+  - konnect
+
+min_version:
+  gateway: '3.16'
+
+breadcrumbs:
+  - /gateway/
+  - /gateway/entities/
+  - /gateway/entities/plugin/
+
+related_resources:
+  - text: CEL reference
+    url: /gateway/plugins/expressions/
+  - text: Plugin entity
+    url: /gateway/entities/plugin/
+  - text: ACL plugin
+    url: /plugins/acl/
+  - text: Rate Limiting plugin
+    url: /plugins/rate-limiting/
+  - text: Rate Limiting Advanced plugin
+    url: /plugins/rate-limiting-advanced/
+---
+
+A plugin's config can be computed per request from a [CEL expression](/gateway/plugins/expressions/), for example, reading an attribute of the authenticated Consumer or Principal, instead of always using a fixed value.
+
+{{site.base_gateway}} supports this through the following mechanisms:
+
+* **[Expressible config fields](#expressible-config-fields)**: A config field has a paired CEL expression field. If the expression evaluates successfully, {{site.base_gateway}} uses its result; otherwise, it falls back to the field's static value.
+* **[Direct CEL fields](#direct-cel-fields)**: A config field's value is a CEL expression. There's no separate static value to fall back to.
+
+Both are different from a plugin's [`condition`](/gateway/plugins/conditions/) field, which decides whether the whole plugin runs for a request. Expressible config fields and direct CEL fields don't skip the plugin; they only change the value of one specific field.
+
+The following plugins support expressions in fields:
+
+<!--vale off-->
+{% table %}
+columns:
+  - title: Plugin
+    key: plugin
+  - title: Mechanism
+    key: mechanism
+  - title: Fields
+    key: fields
+rows:
+  - plugin: "[ACL](/plugins/acl/)"
+    mechanism: Direct CEL fields
+    fields: "`allow_when`, `deny_when`"
+  - plugin: "[Rate Limiting](/plugins/rate-limiting/)"
+    mechanism: Expressible config fields
+    fields: "`custom_key`, `second`, `minute`, `hour`, `day`, `month`, `year`"
+  - plugin: "[Rate Limiting Advanced](/plugins/rate-limiting-advanced/)"
+    mechanism: Expressible config fields
+    fields: "`limit`, `custom_key`"
+{% endtable %}
+<!--vale on-->
+
+See each plugin's own documentation for how its fields are used.
+
+## Expressible config fields
+
+A plugin schema field marked as expressible has a matching field of the same name under a top-level `expressions` block, alongside `config`:
+
+```yaml
+plugins:
+  - name: rate-limiting-advanced
+    config:
+      limit:
+        - 10          # static fallback
+      window_size:
+        - 60
+    expressions:
+      limit:
+        - consumer.tags.exists(t, t == "vip") ? 1000 : 10
+```
+
+For each request, {{site.base_gateway}} evaluates the field's expression:
+
+* If the expression evaluates successfully and produces a value of the correct type for that field, {{site.base_gateway}} uses that value for the request.
+* If the expression is unset, invalid, or fails to evaluate (for example, because a referenced field is missing), {{site.base_gateway}} falls back to the field's static value in `config`.
+
+This fallback means an expressible field can never cause a request to fail. 
+If you want to use an expression for a field, make sure its sibling static `config.FIELD` value is also set.
+For example, to use `expressions.limit`, also set `config.limit`.
+
+Expressible fields use the same CEL field vocabulary, types, and null-handling rules as plugin conditions. 
+See the CEL expressions reference:
+* [Available fields](/gateway/plugins/expressions/#available-fields)
+* [Types](/gateway/plugins/expressions/#types)
+* [Null handling](/gateway/plugins/expressions/#null-handling)
+
+### Array fields
+
+If the underlying config field is an array, its expression is also an array, with one expression per element, in the same order. For example, the Rate Limiting Advanced plugin's `limit` field holds one value per configured window:
+
+```yaml
+config:
+  limit: [10, 100]
+  window_size: [60, 3600]
+expressions:
+  limit:
+    - consumer.tags.exists(t, t == "vip") ? 1000 : 10
+    - consumer.tags.exists(t, t == "vip") ? 10000 : 100
+```
+
+Leave an element as an empty string (`""`) to keep that position's static `config` value with no expression override:
+
+```yaml
+expressions:
+  limit:
+    - consumer.tags.exists(t, t == "vip") ? 1000 : 10
+    - ""
+```
+
+### Handling default values
+
+Unlike `condition`, an expressible field's expression can't be wrapped in `default()`. 
+The sibling `config` value is already the automatic fallback, so `default()` would be redundant. Accessing a missing key in a map field like `principal.metadata` also doesn't need a `has()` guard: if the key is absent, the expression fails to evaluate, and {{site.base_gateway}} falls back to the static `config` value, the same as for any other evaluation failure.
+
+```yaml
+expressions:
+  custom_key: principal.metadata.partner_id
+```
+
+Use `has()` only if you want the expression itself to compute a different fallback than the static `config` value when a key is missing:
+
+```yaml
+expressions:
+  custom_key: "has(principal.metadata.partner_id) ? principal.metadata.partner_id : \"unknown\""
+```
+
+## Direct CEL fields
+
+Some plugin config fields don't have a static equivalent to fall back to. 
+Instead, the field itself holds one or more CEL expressions, and there is no parallel static value.
+
+The [ACL](/plugins/acl/) plugin's `allow_when` and `deny_when` fields work this way: each field is an array of CEL boolean expressions, evaluated against the same request context as plugin conditions. 
+`allow_when` and `deny_when` are mutually exclusive with `allow` and `deny`. 
+Exactly one of `allow`, `deny`, `allow_when`, or `deny_when` must be set on a given ACL plugin instance.
+
+```yaml
+plugins:
+  - name: acl
+    config:
+      allow_when:
+        - "has(principal.metadata.tier) && principal.metadata.tier == \"partner\""
+```
+
+Because there's no static value to fall back to, a direct CEL field that fails to evaluate at runtime behaves according to that plugin's own documented error handling, rather than falling back to a static config value. 
+
+For example, in ACL, `allow_when` and `deny_when` are treated differently:
+* If an `allow_when` expression fails, the request is denied with a `403`, the same safe default as when no expression matches at all. 
+* If a `deny_when` expression fails, the plugin fails closed with a `500`, because silently treating that error as "no match" could let through a request that should have been denied. 
+
+See [Dynamic allow and deny rules](/plugins/acl/#dynamic-allow-and-deny-rules) in the ACL plugin documentation for details.
+
+## Limitations
+
+* Expressible fields and direct CEL fields are only supported in the HTTP subsystem. They can't be used with stream (TCP, TLS, UDP) Routes.
+* In [hybrid mode](/gateway/hybrid-mode/), if the control plane is running a version that supports expressible fields and a data plane is running an earlier version, {{site.base_gateway}} strips the plugin's `expressions` for that data plane, and the plugin behaves as if no expression were configured, falling back to its static `config` value.
+* Direct CEL fields don't have a static `config` value to fall back to, so this hybrid-mode compatibility works differently: {{site.base_gateway}} doesn't sync the plugin's config to a data plane that doesn't support the direct CEL field being used. For example, an older data plane won't receive an ACL plugin instance configured with `allow_when` or `deny_when` until it's upgraded.
+* Only fields the plugin's schema marks as expressible can have an `expressions` entry. The plugin's schema lists these fields under its `expressions` key. Setting `expressions` for any other field is rejected at configuration time.
+* An expressible field's expression must resolve to a type compatible with that field's own Kong type (for example, a `number` field requires a CEL `double`, `int`, `uint`, or `dyn` result).

--- a/app/gateway/plugins/expressible-fields.md
+++ b/app/gateway/plugins/expressible-fields.md
@@ -15,6 +15,16 @@ works_on:
 min_version:
   gateway: '3.16'
 
+faqs:
+  - q: Are all CEL variables equally safe to use in an expressible field?
+    a: |
+      No. A CEL expression can reference request data like `http.headers.*` and `http.queries.*`.
+      That data is controlled by the client, so a client can set it to any value, including one chosen to collide with, spoof, or evade another client's.
+
+      This matters most for a field that keys, identifies, or scopes something for a specific client, such as a counter key, a quota bucket, or an identity binding. 
+      For a sensitive field like this, we recommend authenticated identity-derived values, such as `principal.id` or `principal.metadata.*`. 
+      A client can't forge those values without first compromising the authentication step itself.
+
 breadcrumbs:
   - /gateway/
   - /gateway/entities/

--- a/app/gateway/plugins/expressible-fields.md
+++ b/app/gateway/plugins/expressible-fields.md
@@ -44,6 +44,8 @@ related_resources:
 ---
 
 A plugin's config can be computed per request from a [CEL expression](/gateway/plugins/expressions/), for example, reading an attribute of the authenticated Consumer or Principal, instead of always using a fixed value.
+This is useful when you want to change plugin behavior depending on a specific situation, such as for authenticated users. 
+For example, you can set different limits for Consumers tagged with `vip` versus Consumers that don't have that tag on the Rate Limiting Advanced plugin.
 
 {{site.base_gateway}} supports this through the following mechanisms:
 
@@ -178,7 +180,8 @@ See [Dynamic allow and deny rules](/plugins/acl/#dynamic-allow-and-deny-rules) i
 ## Limitations
 
 * Expressible fields and direct CEL fields are only supported in the HTTP subsystem. They can't be used with stream (TCP, TLS, UDP) Routes.
-* In [hybrid mode](/gateway/hybrid-mode/), if the control plane is running a version that supports expressible fields and a data plane is running an earlier version, {{site.base_gateway}} strips the plugin's `expressions` for that data plane, and the plugin behaves as if no expression were configured, falling back to its static `config` value.
-* Direct CEL fields don't have a static `config` value to fall back to, so this hybrid-mode compatibility works differently: {{site.base_gateway}} doesn't sync the plugin's config to a data plane that doesn't support the direct CEL field being used. For example, an older data plane won't receive an ACL plugin instance configured with `allow_when` or `deny_when` until it's upgraded.
+* In [hybrid mode](/gateway/hybrid-mode/), if the control plane is running {{site.base_gateway}} 3.16 or later and a data plane is running an earlier version, that data plane won't understand expressible fields or direct CEL fields. 
+  * For an expressible field, {{site.base_gateway}} strips the plugin's expressions for that data plane, and the plugin falls back to its static config value. 
+  * For a direct CEL field, there's no static value to fall back to, so {{site.base_gateway}} doesn't sync the plugin's config to that data plane at all. For example, an older data plane won't receive an ACL plugin instance configured with `allow_when` or `deny_when` until it's upgraded.
 * Only fields the plugin's schema marks as expressible can have an `expressions` entry. The plugin's schema lists these fields under its `expressions` key. Setting `expressions` for any other field is rejected at configuration time.
 * An expressible field's expression must resolve to a type compatible with that field's own Kong type (for example, a `number` field requires a CEL `double`, `int`, `uint`, or `dyn` result).

--- a/app/gateway/plugins/expressions-314.md
+++ b/app/gateway/plugins/expressions-314.md
@@ -38,7 +38,7 @@ works_on:
 related_resources:
   - text: Expressions router
     url: /gateway/routing/expressions/
-  - text: Conditional expressions for plugins in 3.15 and later
+  - text: Plugin conditional execution in 3.15 and later
     url: /gateway/plugins/conditions/
   - text: Configure conditional plugin execution
     url: /gateway/configure-conditional-plugin-execution/

--- a/app/gateway/plugins/expressions-314.md
+++ b/app/gateway/plugins/expressions-314.md
@@ -39,7 +39,7 @@ related_resources:
   - text: Expressions router
     url: /gateway/routing/expressions/
   - text: Conditional expressions for plugins in 3.15 and later
-    url: /gateway/plugins/expressions/
+    url: /gateway/plugins/conditions/
   - text: Configure conditional plugin execution
     url: /gateway/configure-conditional-plugin-execution/
   - text: Plugin entity
@@ -56,7 +56,7 @@ related_resources:
 {:.warning}
 > **This page documents the beta version of plugin conditions available in {{site.base_gateway}} 3.14, which used ATC expression syntax.**
 > In 3.15, plugin expressions are generally available, but the expression language changed significantly from 3.14 to 3.15.
-> If you are using {{site.base_gateway}} 3.15 or later, see the [plugin conditions reference](/gateway/plugins/expressions/) for the current CEL-based syntax.
+> If you are using {{site.base_gateway}} 3.15 or later, see the [plugin conditions reference](/gateway/plugins/conditions/) for the current CEL-based syntax.
 
 Plugin conditions allow you to attach an optional `condition` expression to any plugin.
 When a request comes in, {{site.base_gateway}} evaluates the expression immediately before the plugin's `access` phase.

--- a/app/gateway/plugins/expressions.md
+++ b/app/gateway/plugins/expressions.md
@@ -1,7 +1,7 @@
 ---
-title: Conditional expressions for plugins
+title: CEL expressions reference
 
-description: Reference for the CEL expression language used in {{site.base_gateway}} plugin conditions.
+description: Reference for the CEL expression language and fields available to plugin conditions and other CEL-driven plugin config in {{site.base_gateway}}.
 content_type: reference
 layout: reference
 
@@ -16,109 +16,28 @@ breadcrumbs:
   - /gateway/entities/
   - /gateway/entities/plugin/
 
-faqs:
-  - q: Do conditions work with global plugins?
-    a: Yes, conditions can be used on global plugins that are not scoped to a Route, Service, Consumer, or Consumer Group.
-  - q: When should I use plugin conditions instead of Routes?
-    a: |
-      Routes with expression router conditions should be used instead of per-plugin conditions, since Route expressions are more performant than plugin conditions.
-      This is because:
-       * The `init` phase of plugins on excluded Routes won't execute.
-       * The plugin condition won't need to be evaluated.
-  - q: Can I match a plugin condition based on request content type (for example, JSON or XML)?
-    a: |
-      No, the condition expression language doesn't support this explicitly.
-      As an alternative, you can use a plugin such as [Datakit](/plugins/datakit/) or [Pre-Function](/plugins/pre-function/) to parse the body, extract the required value, and store it in [`kong.ctx.shared`](/gateway/plugins/expressions/#kong-ctx-shared-fields).
-      The plugin condition can then reference that `kong.ctx.shared` key.
-  - q: What happens if my condition expression has a runtime error?
-    a: |
-      If a condition expression fails at runtime, {{site.base_gateway}} logs the error at the ERROR level and returns a 500 status code to the client.
-      To prevent this, wrap your expression in a `default()` call: `default(<expression>, false)`.
-      This returns `false` (and skips the plugin) instead of a 500 if the expression errors.
-
 works_on:
   - on-prem
   - konnect
 
 related_resources:
+  - text: Executing plugins based on conditions
+    url: /gateway/plugins/conditions/
+  - text: Dynamic plugin config with CEL
+    url: /gateway/plugins/expressible-fields/
   - text: Expressions router
     url: /gateway/routing/expressions/
-  - text: Configure conditional plugin execution
-    url: /gateway/configure-conditional-plugin-execution/
   - text: Plugin entity
     url: /gateway/entities/plugin/
-  - text: Plugin contexts
-    url: /gateway/entities/plugin/#plugin-contexts
-  - text: Plugin scopes
-    url: /gateway/entities/plugin/#scoping-plugins
-  - text: Plugin priority
-    url: /gateway/entities/plugin/#plugin-priority
-  - text: Conditional expressions for plugins in 3.14
-    url: /gateway/plugins/expressions-314/
-
 ---
 
-Plugin conditions let you attach an optional `condition` expression to any plugin.
-When a request comes in, {{site.base_gateway}} evaluates the expression immediately before the plugin's `access` phase.
-If the expression evaluates to `true`, the plugin runs normally.
-If it evaluates to `false`, the plugin is skipped for that request.
+[Common Expression Language (CEL)](https://cel.dev/) is a lightweight expression language used across {{site.base_gateway}}'s CEL-driven plugin config for [plugin conditions](/gateway/plugins/conditions/) and [dynamic plugin configuration fields](/gateway/plugins/expressible-fields/). 
 
-Conditions use [Common Expression Language (CEL)](https://cel.dev/), a lightweight expression language.
+This page is the shared reference for that language, its available fields, and its types. 
+See the linked pages for how each mechanism works.
 
-Here are some common use cases for setting a condition on a plugin:
+## Expression syntax
 
-* Skip a global plugin for specific Routes, hosts, or request paths without removing the plugin or duplicating it across individual Routes.
-* Enforce a plugin only for specific HTTP methods, headers, or query parameters.
-* Make one plugin's execution depend on context set by a higher-priority plugin.
-* Condition plugin behavior on the authenticated Consumer, matched Route, or target Gateway Service.
-
-## How it works
-
-When {{site.base_gateway}} receives a request, it matches the request to a Route and determines which plugins are in scope according to the [plugin scoping rules](/gateway/entities/plugin/#scoping-plugins).
-For each in-scope plugin that has a `condition` set, {{site.base_gateway}} evaluates the expression before that plugin's `access` phase runs.
-
-The following [plugin contexts](/gateway/entities/plugin/#plugin-contexts) always execute, regardless of the condition: `init_worker`, `configure`, `certificate`, and `rewrite`.
-If the condition evaluates to `false`, the plugin's `access` phase and all later phases are skipped.
-Because of this, values set during or after the response phase (for example, `kong.ctx.shared` values written in `header_filter` or `body_filter`) aren't available to condition expressions.
-
-Unlike plugin scopes, which are evaluated once at router time before any plugins run, conditions are evaluated per request, per plugin, immediately before each plugin executes.
-This means a higher-priority plugin can set values in `kong.ctx.shared` that a lower-priority plugin's condition can then read.
-
-If no condition is set, the plugin always executes.
-
-## Performance considerations
-
-[Plugin scopes](/gateway/entities/plugin/#scoping-plugins) are evaluated once at router time and are more efficient than conditions, which are evaluated per request for each conditioned plugin.
-Where possible, use plugin scopes to control plugin execution rather than conditions.
-
-When conditions are necessary, keep the following in mind:
-
-* A plugin's configuration is always loaded into memory, even if its condition evaluates to `false`.
-* Complex compound expressions with many fields are more expensive to evaluate than simple single-field expressions.
-* Conditions that reference `kong.ctx.shared` fields require a higher-priority plugin to set those values on every request, which adds its own overhead.
-
-## Limitations
-
-Plugin conditions are only supported in the HTTP subsystem.
-They can't be used with stream (TCP, TLS, UDP) Routes.
-
-The following plugins **do not** support conditions:
-* Pre-Function
-* Post-Function
-* WebSocket Size Limit
-* WebSocket Validator
-
-All other [{{site.base_gateway}} plugins](/plugins/) support conditions.
-
-Condition expressions have a maximum length of 1024 characters.
-
-## Plugin conditions reference
-
-This reference describes the CEL expression syntax and available fields for plugin conditions.
-
-### Expression syntax
-
-A condition expression is a string value assigned to the `condition` field of a plugin object.
 A predicate is the basic unit of an expression and compares a field against a value:
 
 ```sh
@@ -158,7 +77,7 @@ rows:
 {% endtable %}
 <!--vale on-->
 
-### Combining predicates
+## Combining predicates
 
 Multiple predicates can be combined using logical operators:
 
@@ -187,14 +106,14 @@ rows:
 {% endtable %}
 <!--vale on-->
 
-### Available fields
+## Available fields
 
-Plugin conditions support HTTP request fields, {{site.base_gateway}} context fields, and plugin state fields.
+Plugin conditions and other CEL-driven plugin config support HTTP request fields, {{site.base_gateway}} context fields, and plugin state fields.
 
 #### HTTP request fields
 
-These fields reflect the state of the incoming HTTP request at the time the condition is evaluated.
-Higher-priority plugins may have already modified these values (for example, by rewriting a header or query parameter) before the condition is evaluated.
+These fields reflect the state of the incoming HTTP request at the time the expression is evaluated.
+Higher-priority plugins may have already modified these values (for example, by rewriting a header or query parameter) before the expression is evaluated.
 
 <!--vale off-->
 {% table %}
@@ -296,7 +215,7 @@ rows:
 
 #### Gateway context fields
 
-The following fields are populated during plugin execution and reflect the Gateway context at the time the condition is evaluated.
+The following fields are populated during plugin execution and reflect the Gateway context at the time the expression is evaluated.
 
 <!--vale off-->
 {% table %}
@@ -400,12 +319,11 @@ rows:
 <!--vale on-->
 
 {:.info}
-> `consumer.*` and `consumer_group.*` fields are only populated after an authentication plugin (such as Key Auth or Basic Auth) has run.
-> Conditions referencing these fields must be on a plugin with a **lower priority** than the authentication plugin.
+> `consumer.*` and `consumer_group.*` fields are only populated after an authentication plugin (such as Key Auth or Basic Auth) has run. On a plugin condition, this means the condition must be on a plugin with a **lower priority** than the authentication plugin.
 
 #### Plugin state fields
 
-The following fields reflect the configured state of other plugins in the same Gateway workspace or control plane at the time the condition is evaluated.
+The following fields reflect the configured state of other plugins in the same Gateway workspace or control plane at the time the expression is evaluated.
 
 <!--vale off-->
 {% table %}
@@ -435,7 +353,7 @@ rows:
   - field: "`plugins.<plugin_name>.access_has_executed`"
     type: "`boolean`"
     description: |
-      * `true` if the plugin's `access` phase has already executed at the time this condition is evaluated.
+      * `true` if the plugin's `access` phase has already executed at the time this field is evaluated.
       * `false` if the plugin is matched but its `access` phase has not run yet.
       * `null` if the plugin isn't configured.
     example: |
@@ -443,7 +361,7 @@ rows:
 {% endtable %}
 <!--vale on-->
 
-### Null handling
+## Null handling
 
 How null values behave depends on the field type.
 
@@ -463,22 +381,16 @@ route.tags != null && "internal" in route.tags
 ```
 
 The `kong.ctx.shared` and `principal.metadata` fields are maps whose inner keys are not pre-populated by {{site.base_gateway}}.
-Accessing a missing key in these maps causes a runtime error (500).
+Accessing a missing key in these maps causes a runtime error.
 Before accessing a key, use `has()` to check for its existence:
 
 ```sh
 has(kong.ctx.shared.my_flag) && kong.ctx.shared.my_flag == "enabled"
 ```
 
-Alternatively, wrap the entire expression in `default()` to return a safe fallback if the key is missing:
+How that runtime error is handled once it occurs (for example, whether it can be caught with `default()`) depends on which CEL-driven mechanism the expression belongs to. See [Plugin conditions](/gateway/plugins/conditions/) and [Dynamic plugin config with CEL](/gateway/plugins/expressible-fields/) for each mechanism's own error handling.
 
-```sh
-default(kong.ctx.shared.my_flag == "enabled", false)
-```
-
-### Operators and functions
-
-The following operators and functions are supported in plugin condition expressions:
+## Operators and functions
 
 <!--vale off-->
 {% table %}
@@ -518,11 +430,8 @@ rows:
     description: "Additional CEL comprehension macros for working with lists."
   - type: "`default()`"
     description: |
-      Wraps an expression to return a fallback boolean value if the expression produces a runtime error.
-      Wraps an expression to return a fallback boolean value if the expression produces a runtime error.
-      Must wrap the **entire** expression, and cannot be used inline within a larger expression.
-      <br><br>
-      The second argument for this function accepts only boolean values (`true` or `false`).
+      Wraps an expression to return a fallback value if the expression produces a runtime error.
+      Whether `default()` is available depends on the CEL-driven mechanism. See [Plugin conditions](/gateway/plugins/conditions/#handling-default-values) and [Dynamic plugin config with CEL](/gateway/plugins/expressible-fields/) for each mechanism's own rules.
 {% endtable %}
 <!--vale on-->
 
@@ -532,9 +441,7 @@ rows:
 > Use explicit anchors (`^` and `$`) in the pattern to force full-string matching, if desired. 
 > For example, `http.path.matches("^/api/v[0-9]+$")` matches `/api/v1` but not `/other/api/v1`.
 
-### Types
-
-Plugins support the following CEL types:
+## Types
 
 <!--vale off-->
 {% table %}
@@ -566,60 +473,3 @@ rows:
     example: "`null`"
 {% endtable %}
 <!--vale on-->
-
-### Handling default values
-
-`default()` makes condition expressions safe at runtime.
-If the expression raises an evaluation error (for example, accessing a missing key in a map), `default()` returns the fallback value instead of causing a 500 error.
-
-`default()` must wrap the **entire** expression. It can't appear inline within a larger expression:
-
-```sh
-# Valid — wraps the entire expression
-default(kong.ctx.shared.my_flag == "enabled", false)
-
-# Not valid — default() can't be used inline
-kong.ctx.shared.my_flag == "enabled" && default(principal.id == "abc", false)
-```
-{:.no-copy-code}
-
-Use `default()` when your expression references fields that might not be set for every request, such as `kong.ctx.shared.*` or `principal.metadata.*`:
-
-```sh
-default(principal.metadata["Department"] == "finance", false)
-```
-
-## Debugging
-
-When {{site.base_gateway}} is running with debug logging enabled, a log line is emitted for each condition evaluation.
-
-When a condition is **not matched** and the plugin is skipped:
-
-```
-plugin condition not matched for plugin 'request-termination' (ID: 66a1adbb-0179-49af-a065-4d0bc6c28cd6): skipped
-```
-{:.no-copy-code}
-
-When a condition is **matched** and the plugin executes:
-
-```
-plugin condition matched for plugin 'request-termination' (ID: 66a1adbb-0179-49af-a065-4d0bc6c28cd6)
-```
-{:.no-copy-code}
-
-If a condition expression **fails at runtime**, the error is logged at the `ERROR` level and {{site.base_gateway}} returns a 500 to the client:
-
-```
-error evaluating plugin condition for plugin 'request-termination' (ID: 66a1adbb-0179-49af-a065-4d0bc6c28cd6): No such key: foo
-```
-{:.no-copy-code}
-
-To prevent runtime errors, wrap your expression in `default()`:
-
-```json
-"condition": "default(kong.ctx.shared.my_flag == \"enabled\", false)"
-```
-
-## Migration from 3.14 to 3.15
-
-{% include_cached /gateway/expressions/migrate.md %}

--- a/app/gateway/plugins/expressions.md
+++ b/app/gateway/plugins/expressions.md
@@ -21,7 +21,7 @@ works_on:
   - konnect
 
 related_resources:
-  - text: Executing plugins based on conditions
+  - text: Plugin conditional execution reference
     url: /gateway/plugins/conditions/
   - text: Dynamic plugin config with CEL
     url: /gateway/plugins/expressible-fields/

--- a/app/gateway/routing/expressions.md
+++ b/app/gateway/routing/expressions.md
@@ -18,7 +18,7 @@ related_resources:
     url: /gateway/routing/traditional/
   - text: Traffic control and routing
     url: /gateway/traffic-control-and-routing/
-  - text: Conditional plugin expressions
+  - text: Plugin conditional execution reference
     url: /gateway/plugins/conditions/
 
 min_version:

--- a/app/gateway/routing/expressions.md
+++ b/app/gateway/routing/expressions.md
@@ -19,7 +19,7 @@ related_resources:
   - text: Traffic control and routing
     url: /gateway/traffic-control-and-routing/
   - text: Conditional plugin expressions
-    url: /gateway/plugins/expressions/
+    url: /gateway/plugins/conditions/
 
 min_version:
   gateway: '3.0'
@@ -59,7 +59,7 @@ You can do the following with the expressions router:
 
 {:.info}
 > The plugin `condition` field also supports expressions, with some differences in options and considerations. 
-> See the [Conditional expressions for plugins reference](/gateway/plugins/expressions/) for more information.
+> See the [Conditional expressions for plugins reference](/gateway/plugins/conditions/) for more information.
 
 ## Enable the expressions router
 


### PR DESCRIPTION
## Description

Resolves #6820 + a bunch of related branching changes from the original Jira
* Expressional fields support in ACL, RL, and RLA plugins (updates to overviews and examples)
* New reference doc for this
  *  Split the existing CEL reference doc to just cover CEL and have a separate page for plugin conditions. Previously it was a mix of CEL ref + plugin conditions, but the CEL reference applies both to plugin conditions and plugin field expressions. 
* Rate limiting by Principal support in RL and RLA
* how-to guide for using expressions with Kong Identity

Reviewers: to make your lives easier, please note that two of the docs that look new/heavily edited are just being split out.
* app/gateway/plugins/expressions.md and app/gateway/plugins/conditions.md used to be one document. 
* app/gateway/plugins/expressions.md applies more broadly to conditions and expressional fields, so I split the content out.  _You don't need to copyedit app/gateway/plugins/conditions.md unless you really really want to, as nothing should have changed_.

You can test the how-to using the 3.16.0.0-rc.3 image in Konnect. Run the quickstart like this:

```
curl -Ls https://get.konghq.com/quickstart | KONNECT_DOMAIN=konghq.tech bash -s -- -k $KONNECT_TOKEN -i kong-gateway-dev  -t 3.16.0.0-rc.3 -a kong-316 --deck-output
```
And set DECK_KONNECT_ADDR to your region:

```
export DECK_KONNECT_ADDR='https://us.api.konghq.tech'
```

please ignore the failing check, that's still the entitlement enforcement plugin.
## Preview Links

References:

* Main doc: [Dynamic plugin config with CEL](https://deploy-preview-7172--kongdeveloper.netlify.app/gateway/plugins/expressible-fields/)
* Supporting doc (already existed, just slightly adjusted): [CEL reference](https://deploy-preview-7172--kongdeveloper.netlify.app/gateway/plugins/expressions/)
* Mentioned in the [plugin entity reference](https://deploy-preview-7172--kongdeveloper.netlify.app/gateway/entities/plugin/#dynamic-configuration)

Guide:
[How-to: Configure dynamic plugin config with CEL](https://deploy-preview-7172--kongdeveloper.netlify.app/gateway/configure-dynamic-plugin-config-with-cel/)

In the plugins:
[ACL overview](https://deploy-preview-7172--kongdeveloper.netlify.app/plugins/acl/#dynamic-allow-and-deny-rules) & [example 1](https://deploy-preview-7172--kongdeveloper.netlify.app/plugins/acl/examples/allow-when-principal-metadata/) [example 2](https://deploy-preview-7172--kongdeveloper.netlify.app/plugins/acl/examples/deny-when-principal-metadata/)
[Rate Limiting overview](https://deploy-preview-7172--kongdeveloper.netlify.app/plugins/rate-limiting/#dynamic-configuration-with-cel) & [example](https://deploy-preview-7172--kongdeveloper.netlify.app/plugins/rate-limiting/examples/rate-limit-by-principal-metadata/)
[Rate Limiting Advanced overview](https://deploy-preview-7172--kongdeveloper.netlify.app/plugins/rate-limiting-advanced/#dynamic-configuration-with-cel) & [example](https://deploy-preview-7172--kongdeveloper.netlify.app/plugins/rate-limiting-advanced/examples/rate-limit-by-principal-metadata/)

