### PR TITLE
feat(gateway): FIPS 140-3 support in 3.16

### DIFF
--- a/app/_data/products/gateway.yml
+++ b/app/_data/products/gateway.yml
@@ -2053,7 +2053,8 @@ releases:
       - amazonlinux2023:
           package: true
           package_support:
-            fips: false
+            fips2: false
+            fips3: false
             arm: true
             graviton: true
           docker: true
@@ -2063,7 +2064,8 @@ releases:
       - debian12:
           package: true
           package_support:
-            fips: false
+            fips2: false
+            fips3: false
             arm: true
             graviton: true
           docker: true
@@ -2073,7 +2075,8 @@ releases:
       - debian13:
           package: true
           package_support:
-            fips: false
+            fips2: false
+            fips3: false
             arm: true
             graviton: true
           docker: false
@@ -2092,14 +2095,16 @@ releases:
           package_support:
             arm: false
             graviton: false
-            fips: true
+            fips2: true
+            fips3: true
           docker: false
       - rhel9:
           package: true
           package_support:
             graviton: false
             arm: true
-            fips: true
+            fips2: true
+            fips3: true
           docker: true
           docker_support:
             fips: true
@@ -2110,7 +2115,8 @@ releases:
           package_support:
             graviton: false
             arm: true
-            fips: true
+            fips2: true
+            fips3: true
           docker: false
           default: true
       - ubuntu2204:
@@ -2118,7 +2124,8 @@ releases:
           package_support:
             arm: true
             graviton: true
-            fips: true
+            fips2: true
+            fips3: true
           docker: true
           docker_support:
             fips: true
@@ -2129,10 +2136,12 @@ releases:
           package_support:
             arm: true
             graviton: true
-            fips: true
+            fips2: true
+            fips3: true
           docker: true
           docker_support:
-            fips: true
+            fips2: true
+            fips3: true
             arm: true
           default: true
       - ubuntu2604:
@@ -2140,7 +2149,8 @@ releases:
           package_support:
             arm: true
             graviton: true
-            fips: true
+            fips2: true
+            fips3: true
           docker: false
           default: true
     third_party_support:

--- a/app/gateway/fips-support.md
+++ b/app/gateway/fips-support.md
@@ -139,7 +139,7 @@ rows:
     The FIPS 140-3 package name and download URL use a `-fips-140-3` suffix. For links to the correct package for your distribution, see the [{{site.base_gateway}} install page](/gateway/install/), or see the FIPS 140-3 packages on [Docker Hub](https://hub.docker.com/r/kong/kong-gateway/tags?name=fips-140-3).
 
     {:.info}
-    > **Note:** Currently, the FIPS 140-3 package is only available on {{site.base_gateway}} 3.14 LTS.
+    > **Note:** Currently, the FIPS 140-3 package is only available on {{site.base_gateway}} 3.14 LTS and 3.16.
 
 2. Confirm `fips = on` in `kong.conf` or set `KONG_FIPS=on` as an environment variable.
 3. Restart {{site.base_gateway}}.


### PR DESCRIPTION

## Description

Set FIPS 140-3 as supported in 3.16.

## Preview Links
https://deploy-preview-7177--kongdeveloper.netlify.app/gateway/version-support-policy/
