### PR TITLE
fix(metering-and-billing): Set ssl_verify explicitly in plugin snippets

### DIFF
--- a/app/_how-tos/ai-gateway/v1/meter-llm-traffic.md
+++ b/app/_how-tos/ai-gateway/v1/meter-llm-traffic.md
@@ -163,6 +163,7 @@ entities:
       config:
         ingest_endpoint: https://us.api.konghq.com/v3/openmeter/events
         api_token: ${AUTH_TOKEN}
+        ssl_verify: true
         meter_api_requests: false
         meter_ai_token_usage: true
         subject:

--- a/app/_how-tos/gateway/get-started-with-metering-and-billing.md
+++ b/app/_how-tos/gateway/get-started-with-metering-and-billing.md
@@ -192,6 +192,7 @@ entities:
       config:
         ingest_endpoint: https://us.api.konghq.com/v3/openmeter/events
         api_token: ${AUTH_TOKEN}
+        ssl_verify: true
         meter_api_requests: true
         meter_ai_token_usage: false
         subject:

--- a/app/_how-tos/gateway/meter-api-requests-by-consumer.md
+++ b/app/_how-tos/gateway/meter-api-requests-by-consumer.md
@@ -132,6 +132,7 @@ entities:
       config:
         ingest_endpoint: https://us.api.konghq.com/v3/openmeter/events
         api_token: ${AUTH_TOKEN}
+        ssl_verify: true
         meter_api_requests: true
         meter_ai_token_usage: false
         subject:

--- a/app/_kong_plugins/metering-and-billing/examples/filter-by-department.yaml
+++ b/app/_kong_plugins/metering-and-billing/examples/filter-by-department.yaml
@@ -20,6 +20,7 @@ requirements:
 config:
   ingest_endpoint: ${ingest-endpoint}
   api_token: ${auth-token}
+  ssl_verify: true
   meter_api_requests: true
   meter_ai_token_usage: false
   subject:

--- a/app/_kong_plugins/metering-and-billing/examples/meter-ai-tokens.yaml
+++ b/app/_kong_plugins/metering-and-billing/examples/meter-ai-tokens.yaml
@@ -18,6 +18,7 @@ requirements:
 config:
   ingest_endpoint: ${ingest-endpoint}
   api_token: ${auth-token}
+  ssl_verify: true
   meter_api_requests: false
   meter_ai_token_usage: true
   subject:

--- a/app/_kong_plugins/metering-and-billing/examples/meter-api-requests.yaml
+++ b/app/_kong_plugins/metering-and-billing/examples/meter-api-requests.yaml
@@ -18,6 +18,7 @@ requirements:
 config:
   ingest_endpoint: ${ingest-endpoint}
   api_token: ${auth-token}
+  ssl_verify: true
   meter_api_requests: true
   meter_ai_token_usage: false
   subject:

--- a/app/_kong_plugins/metering-and-billing/examples/meter-by-tenant-header.yaml
+++ b/app/_kong_plugins/metering-and-billing/examples/meter-by-tenant-header.yaml
@@ -19,6 +19,7 @@ requirements:
 config:
   ingest_endpoint: ${ingest-endpoint}
   api_token: ${auth-token}
+  ssl_verify: true
   meter_api_requests: true
   meter_ai_token_usage: false
   subject:


### PR DESCRIPTION
## Description

### What

Adds `ssl_verify: true` to every decK snippet that creates the Metering & Billing plugin: three how-to guides and the four plugin example pages.

### Why

Konnect serves the plugin schema with `ssl_verify` defaulting to `false`, so following the guides as written leaves TLS verification toward the ingest endpoint off. On a Data Plane that enforces `tls_certificate_verify`, the plugin's validator then rejects the entire configuration push, and the Data Plane silently keeps serving its previous configuration while Konnect reports success. The setup the guides describe never becomes active.

### How

One line added per snippet, placed directly after `api_token`. All affected pages are Gateway 3.14+, where the field exists.

Split into two commits so the examples change can be dropped on its own if reviewers prefer the example pages to stay minimal:

- `fix(metering-and-billing): set ssl_verify explicitly in how-to guides`
  - `app/_how-tos/gateway/meter-api-requests-by-consumer.md`
  - `app/_how-tos/gateway/get-started-with-metering-and-billing.md`
  - `app/_how-tos/ai-gateway/v1/meter-llm-traffic.md`
- `fix(metering-and-billing): set ssl_verify explicitly in plugin examples`
  - `app/_kong_plugins/metering-and-billing/examples/*.yaml` (4 files)

## Preview Links

## Checklist

- [ ] Tested how-to docs. If not, note why here.
- [x] All pages contain metadata.
- [x] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [x] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [x] Every page has a `description` entry in frontmatter.
- [x] Add new pages to the product documentation index (if applicable).