### PR TITLE
feat(gateway): OTEL principal metric attributes

### DIFF
--- a/app/_data/plugins/otel-metrics.yaml
+++ b/app/_data/plugins/otel-metrics.yaml
@@ -7,6 +7,8 @@ metrics:
       - kong.service.name
       - kong.route.name
       - kong.auth.consumer.name
+      - kong.auth.principal.id
+      - kong.auth.principal.display_name
       - kong.response.source
       - kong.workspace.name
       - http.request.method
@@ -43,6 +45,8 @@ metrics:
       - kong.service.name
       - kong.route.name
       - kong.auth.consumer.name
+      - kong.auth.principal.id
+      - kong.auth.principal.display_name
       - kong.workspace.name
   - name: http.server.response.size
     description: Total size of the HTTP response sent back to the client in bytes.
@@ -52,6 +56,8 @@ metrics:
       - kong.service.name
       - kong.route.name
       - kong.auth.consumer.name
+      - kong.auth.principal.id
+      - kong.auth.principal.display_name
       - kong.workspace.name
   - name: stream.server.session.count
     min_version: "3.16"
@@ -684,6 +690,8 @@ attributes:
   kong.service.name: Name of the Gateway Service.
   kong.route.name: Name of the Route.
   kong.auth.consumer.name: Name of the authenticated Consumer.
+  kong.auth.principal.id: "ID of the authenticated [Principal](/identity/principals/). Only set when {{site.identity}} has authenticated a Principal for the request."
+  kong.auth.principal.display_name: "Display name of the authenticated [Principal](/identity/principals/). Only set when a display name has been defined for the Principal."
   kong.response.source: |
     Origin of the current response. Possible values:
       - `upstream` if the response originated by successfully contacting the upstream service

--- a/app/_kong_plugins/opentelemetry/examples/metrics-principal-attributes.yaml
+++ b/app/_kong_plugins/opentelemetry/examples/metrics-principal-attributes.yaml
@@ -1,0 +1,37 @@
+description: Add authenticated Principal attributes to the OTEL plugin's request count and bandwidth metrics.
+extended_description: |
+  Add authenticated Principal attributes to the OTEL plugin's request count and bandwidth metrics by enabling `enable_principal_attribute`.
+
+  In the example:
+  * `enable_request_metrics` adds request count metrics.
+  * `enable_bandwidth_metrics` adds request and response size metrics.
+  * `enable_principal_attribute` adds authenticated Principal attributes to the enabled metrics.
+
+  When a request carries an authenticated [Principal](/identity/principals/) managed by {{site.identity}}, 
+  the plugin exports `http.server.request.count`, `http.server.request.size`, and `http.server.response.size` with the `kong.auth.principal.id` and `kong.auth.principal.display_name` attributes.
+
+title: 'Add Principal attributes to metrics'
+
+requirements:
+  - "An OpenTelemetry backend"
+  - "An authentication plugin configured with [Principals](/identity/principals/) enabled, such as [Key Auth](/plugins/key-auth/examples/principals/) or [Basic Auth](/plugins/basic-auth/examples/principal/)"
+
+weight: 880
+
+min_version:
+  gateway: '3.16'
+
+config:
+  metrics:
+    endpoint: http://localhost:4318/v1/metrics
+    push_interval: 10
+    enable_request_metrics: true
+    enable_bandwidth_metrics: true
+    enable_principal_attribute: true
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform

--- a/app/_kong_plugins/opentelemetry/index.md
+++ b/app/_kong_plugins/opentelemetry/index.md
@@ -86,6 +86,10 @@ rows:
   - use_case: "[Enable the OTEL plugin for metrics](./examples/metrics/)"
     description: Configure the OpenTelemetry plugin to send metrics.
 
+  - use_case: |
+      [Add Principal attributes to metrics](./examples/metrics-principal-attributes/) {% new_in 3.16 %}
+    description: Attach the authenticated Principal's ID and display name to request count and bandwidth metrics.
+
   - use_case: "[Enable the OTEL plugin for API transactional logs](./examples/transactional-logs/)"
     description: Configure the OpenTelemetry plugin to send API transactional logs.
 
@@ -132,6 +136,39 @@ In {{site.base_gateway}}, metrics are natively supported by the OpenTelemetry pl
 * For all available metrics, see the [OpenTelemetry metrics reference](/gateway/otel-metrics/).
 * For AI metrics and required setup prerequisites, see the [Gen AI OpenTelemetry metrics reference](/ai-gateway/ai-otel-metrics/).
 * For a step-by-step setup using an OpenTelemetry Collector, see [Collect metrics, logs, and traces with the OpenTelemetry plugin](/how-to/collect-metrics-logs-and-traces-with-opentelemetry/).
+
+### Identifying requests in metrics
+
+You can attach the client's identity as attributes to the `http.server.request.count`, `http.server.request.size`, and `http.server.response.size` metrics. 
+These attributes can capture the [Consumer](/gateway/entities/consumer/) and the [Principal](/identity/principals/). You can enable both at the same time.
+
+Enable these identity attributes alongside `enable_request_metrics` or `enable_bandwidth_metrics`, which produce the metrics themselves.
+
+<!--vale off-->
+{% table %}
+columns:
+  - title: Metric attribute
+    key: attribute
+  - title: Config
+    key: config
+  - title: Description
+    key: description
+rows:
+  - attribute: "`kong.auth.consumer.name`"
+    config: "[`enable_consumer_attribute`](./reference/#schema--config-metrics-enable-consumer-attribute)"
+    description: Name of the authenticated Consumer.
+  - attribute: "`kong.auth.principal.id`"
+    config: |
+      [`enable_principal_attribute`](./reference/#schema--config-metrics-enable-principal-attribute) {% new_in 3.16 %}
+    description: ID of the authenticated Principal managed by {{site.identity}}.
+  - attribute: "`kong.auth.principal.display_name`"
+    config: |
+      [`enable_principal_attribute`](./reference/#schema--config-metrics-enable-principal-attribute) {% new_in 3.16 %}
+    description: Display name of the authenticated Principal managed by {{site.identity}}.
+{% endtable %}
+<!--vale on-->
+
+If the request has no authenticated Consumer or Principal, the corresponding attribute is left empty on the exported metrics.
 
 ### Metrics with {{site.base_gateway}} 3.12 or earlier
 


### PR DESCRIPTION
## Description

Fixes #6816 

Adds a section on identifying the client in requests to the OTEL plugin, and a plugin example. No how-to guide as it's a one-field change that just customizes a particular metric.

## Preview Links
https://deploy-preview-7188--kongdeveloper.netlify.app/plugins/opentelemetry/