### PR TITLE
feat(gateway): Simple json transformation for kafka producer plugins

### DIFF
--- a/.github/styles/base/Dictionary.txt
+++ b/.github/styles/base/Dictionary.txt
@@ -564,6 +564,7 @@ no_version
 node_quantifier
 Node.js
 nodeport
+nullable
 Nullsoft
 nunjucks
 Noname

--- a/app/_includes/plugins/confluent-kafka-consume/schema-registry.md
+++ b/app/_includes/plugins/confluent-kafka-consume/schema-registry.md
@@ -91,6 +91,47 @@ For sample configuration values, see:
 * [Schema registry with OAuth2 configuration example](./examples/schema-registry-oauth2/) {% new_in 3.12 %}
 {% endif %}
 
+{% if include.workflow == 'producer' %}
+### Accept plain JSON for Avro schemas {% new_in 3.16 %}
+
+By default, an Avro schema requires every union-typed value to be wrapped in a single-key object that names the union branch. 
+For example, a field declared as `["null", "string"]` must be sent as `{"string": "hello"}` or `{"null": null}`.
+This forces HTTP clients to understand Avro's wire encoding to call your API.
+
+Set `payload_encoding: simple_json` on the [`value_schema`](./reference/#schema--config-schema-registry-confluent-value-schema-payload-encoding) or the [`key_schema`](./reference/#schema--config-schema-registry-confluent-key-schema-payload-encoding) to let the {{include.name}} plugin accept plain JSON instead, and resolve union branches against the schema itself:
+
+{% table %}
+columns:
+  - title: Value
+    key: value
+  - title: Resolution
+    key: resolution
+rows:
+  - value: "`null`, or a nullable field is omitted"
+    resolution: "Encoded as the union's `null` branch."
+  - value: "A value matching exactly one non-null branch"
+    resolution: "Encoded as that branch."
+  - value: |
+      A value matching more than one non-null branch (for example a JSON number against `["int", "long"]` or `["float", "double"]`)
+    resolution: |
+      Encoded using the first matching branch, in the order the branches are declared in the schema. 
+      An integer that doesn't fit in a 32-bit signed range is always encoded as `long`, even if `int` is declared first.
+  - value: "A value that doesn't match any branch of the union"
+    resolution: "The request is rejected with an error that includes the JSON path and the branches that were considered."
+{% endtable %}
+
+This resolution applies at every level of the payload, including fields inside nested records, arrays, and maps. 
+Logical types (for example timestamps, decimals, or UUIDs) are passed through unchanged once their union is resolved.
+
+If a record field is omitted from the request body, the plugin falls back to the field's schema `default`, if one exists.
+Otherwise, the field must be nullable, or the plugin rejects the request as missing a required field.
+
+Because an Avro-tagged value like `{"string": "hello"}` already matches a single branch by name, `simple_json` accepts it as-is. 
+This lets you migrate clients from `avro_json` to `simple_json` one at a time, instead of all at once.
+
+For a sample configuration, see [Simple JSON encoding for Avro schemas](./examples/schema-registry-simple-json/).
+{% endif %}
+
 
 
 

--- a/app/_kong_plugins/confluent/examples/schema-registry-simple-json.yaml
+++ b/app/_kong_plugins/confluent/examples/schema-registry-simple-json.yaml
@@ -1,0 +1,60 @@
+description: 'Configure the Confluent plugin to accept plain JSON for an Avro schema with nullable fields, instead of Avro-encoded JSON with type-tagged unions.'
+
+title: 'Simple JSON encoding for Avro schemas'
+
+weight: 910
+
+min_version:
+  gateway: '3.16'
+
+requirements:
+  - "[Create a Kafka cluster in Confluent Cloud](https://docs.confluent.io/cloud/current/get-started/index.html#step-1-create-a-ak-cluster-in-ccloud)"
+  - "[Create a Kafka topic in the cluster](https://docs.confluent.io/cloud/current/get-started/index.html#step-2-create-a-ak-topic)"
+  - "Create an API key and secret in the cluster"
+  - "[Configure a Schema Registry](https://docs.confluent.io/platform/current/schema-registry/index.html) with an Avro schema that includes at least one nullable (union) field"
+
+variables:
+  topic:
+    description: 'The name of your Kafka topic.'
+    value: $KAFKA_TOPIC
+  host:
+    description: 'The bootstrap server host.'
+    value: $BOOTSTRAP_SERVER_HOST
+  registry_url:
+    description: "The URL of your Confluent Schema Registry instance. For example, `http://schema-registry:8081`."
+    value: $REGISTRY_URL
+  cluster_api_key:
+    value: $CONFLUENT_CLUSTER_API_KEY
+    description: Your Confluent cluster API key.
+  cluster_api_secret:
+    value: $CONFLUENT_CLUSTER_API_SECRET
+    description: Your Confluent cluster API key.
+
+config:
+  bootstrap_servers:
+  - host: ${host}
+    port: 9092
+  topic: ${topic}
+  schema_registry:
+    confluent:
+      url: ${registry_url}
+      authentication:
+        mode: basic
+        basic:
+          username: user
+          password: password
+      value_schema:
+        subject_name: kong-value
+        schema_version: latest
+        payload_encoding: simple_json
+  cluster_api_key: ${cluster_api_key}
+  cluster_api_secret: ${cluster_api_secret}
+  message_by_lua_functions:
+    - "return function(message) return message.body end"
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform

--- a/app/_kong_plugins/kafka-log/examples/schema-registry-simple-json.yaml
+++ b/app/_kong_plugins/kafka-log/examples/schema-registry-simple-json.yaml
@@ -1,0 +1,49 @@
+description: 'Configure the Kafka Log plugin to accept plain JSON for an Avro schema with nullable fields, instead of Avro-encoded JSON with type-tagged unions.'
+
+title: 'Simple JSON encoding for Avro schemas'
+
+weight: 910
+
+min_version:
+  gateway: '3.16'
+
+requirements:
+ - "[Kafka installed](https://kafka.apache.org/quickstart#quickstart_download) and running"
+ - "[Create a Kafka topic](https://kafka.apache.org/quickstart#quickstart_createtopic)"
+ - "[Schema Registry configured](https://docs.confluent.io/platform/current/schema-registry/index.html) with an Avro schema that includes at least one nullable (union) field"
+
+variables:
+  topic:
+    description: 'The name of your Kafka topic.'
+    value: $KAFKA_TOPIC
+  host:
+    description: 'The bootstrap server host.'
+    value: $BOOTSTRAP_SERVER_HOST
+  registry_url:
+    description: "The URL of your Confluent Schema Registry instance. For example, `http://schema-registry:8081`."
+    value: $REGISTRY_URL
+
+config:
+  bootstrap_servers:
+  - host: ${host}
+    port: 9092
+  topic: ${topic}
+  schema_registry:
+    confluent:
+      url: ${registry_url}
+      authentication:
+        mode: basic
+        basic:
+          username: user
+          password: password
+      value_schema:
+        subject_name: kong-logs-value
+        schema_version: latest
+        payload_encoding: simple_json
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform

--- a/app/_kong_plugins/kafka-upstream/examples/schema-registry-simple-json.yaml
+++ b/app/_kong_plugins/kafka-upstream/examples/schema-registry-simple-json.yaml
@@ -1,0 +1,52 @@
+description: 'Configure the Kafka Upstream plugin to accept plain JSON for an Avro schema with nullable fields, instead of Avro-encoded JSON with type-tagged unions.'
+
+title: 'Simple JSON encoding for Avro schemas'
+
+weight: 910
+
+min_version:
+  gateway: '3.16'
+
+requirements:
+ - "[Kafka installed](https://kafka.apache.org/quickstart#quickstart_download) and running"
+ - "[Create a Kafka topic](https://kafka.apache.org/quickstart#quickstart_createtopic)"
+ - "[Schema Registry configured](https://docs.confluent.io/platform/current/schema-registry/index.html) with an Avro schema that includes at least one nullable (union) field"
+
+variables:
+  topic:
+    description: 'The name of your Kafka topic.'
+    value: $KAFKA_TOPIC
+  host:
+    description: 'The bootstrap server host.'
+    value: $BOOTSTRAP_SERVER_HOST
+  registry_url:
+    description: "The URL of your Confluent Schema Registry instance. For example, `http://schema-registry:8081`."
+    value: $REGISTRY_URL
+
+config:
+  bootstrap_servers:
+  - host: ${host}
+    port: 9092
+  topic: ${topic}
+  schema_registry:
+    confluent:
+      url: ${registry_url}
+      authentication:
+        mode: basic
+        basic:
+          username: user
+          password: password
+      value_schema:
+        subject_name: kong-value
+        schema_version: latest
+        payload_encoding: simple_json
+  message_by_lua_functions:
+  - "return function(message) return message.body end"
+
+
+tools:
+  - deck
+  - admin-api
+  - konnect-api
+  - kic
+  - terraform


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes #6814 

Support for simple json payload encoding in Kafka producer plugins (Confluent, Kafka Log, Kafka Upstream). 
Adds plugin examples and an overview section that's reused on each.

## Preview Links

https://deploy-preview-7189--kongdeveloper.netlify.app/plugins/kafka-log/
https://deploy-preview-7189--kongdeveloper.netlify.app/plugins/kafka-upstream

https://deploy-preview-7189--kongdeveloper.netlify.app/plugins/confluent