### PR TITLE
fix(gateway): Add info about temp creds for AWS for CP outage

### DIFF
--- a/app/gateway/cp-outage.md
+++ b/app/gateway/cp-outage.md
@@ -102,8 +102,14 @@ In this setup, you need to designate one backup node.
 The backup node must have read and write access to the S3 bucket, and the Data Plane nodes that are provisioned must have read access to the same S3 bucket.
 The backup node is responsible for communicating the state of the {{site.base_gateway}} `kong.conf` configuration file from the Control Plane to the S3 bucket.
 
-Nodes are initialized with fallback configs via environment variables, including `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_DEFAULT_REGION`. 
-If you're associating this with an IAM role and if the backup node doesn't reside on the AWS platform, you may also need to use the `AWS_SESSION_TOKEN` environment variable. 
+Nodes are initialized with fallback configs via environment variables, including `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_DEFAULT_REGION`.
+Instead of static credentials, a node deployed on AWS compute can use temporary credentials from an assumed IAM role. 
+The role is fetched automatically based on where the node runs: 
+* On EC2, from an [instance profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html).
+* On ECS, from a [container credential provider](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html).
+* On EKS, from [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+
+When using temporary credentials from an assumed role, also set the `AWS_SESSION_TOKEN` environment variable alongside `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. This is also required if you're associating this with an IAM role and the backup node doesn't reside on the AWS platform.
 
 
 {:.warning}


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes https://kongstrong.slack.com/archives/CDSTDSG9J/p1789042740477709
(info here: https://github.com/Kong/kong-ee/pull/22205/changes)

## Preview Links
/gateway/cp-outage/#amazon-s3-storage

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
