### PR TITLE
fix(otel): Remove Shared Logging table section

### DIFF
--- a/app/_includes/plugins/logging/custom-lua-limitations.md
+++ b/app/_includes/plugins/logging/custom-lua-limitations.md
@@ -1,0 +1,7 @@
+Lua code runs in a restricted sandbox environment, whose behavior is governed
+by the `untrusted_lua` [configuration properties](/gateway/configuration/).
+
+{% include /plugins/sandbox.md %}
+
+Further, as code runs in the context of the log phase, only [PDK](/gateway/pdk/reference/) methods
+that can run in said phase can be used.

--- a/app/_includes/plugins/logging/custom-lua-plugin-precedence.md
+++ b/app/_includes/plugins/logging/custom-lua-plugin-precedence.md
@@ -1,0 +1,22 @@
+{% assign custom_fields_by_lua = include.custom_fields_by_lua %}
+{% assign custom_fields_by_lua_name = include.custom_fields_by_lua_name %}
+{% assign custom_fields_by_lua_slug = include.custom_fields_by_lua_slug %}
+
+All logging plugins use the same table for logging.
+If you set `{{custom_fields_by_lua_name}}` in one plugin, all logging plugins that execute after that plugin will also use the same configuration.
+For example, if you configure fields via `{{custom_fields_by_lua_name}}` in File Log, those same fields will appear in [Syslog](/plugins/syslog/), since {{page.name}} executes first.
+
+* If you want all logging plugins to use the same configuration, we recommend using the [Pre-function](/plugins/pre-function/) plugin to call [kong.log.set_serialize_value](/gateway/pdk/reference/kong.log/#kong-log-set-serialize-value-key-value-options) so that the function is applied predictably and is easier to manage.
+
+* If you **don't** want all logging plugins to use the same configuration, you need to manually disable the relevant fields in each plugin.
+
+   For example, if you configure a field in File Log that you don't want appearing in Syslog, set that field to `return nil` in the File Log plugin:
+
+   ```sh
+   curl -i -X POST http://localhost:8001/plugins/ \
+   ...
+     --data config.name={{include.slug}} \
+    --data {{custom_fields_by_lua}}.my_file_log_field="return nil"
+   ```
+
+See the [plugin execution order reference](/gateway/entities/plugin/#plugin-contexts) for more details on plugin ordering.

--- a/app/_includes/plugins/logging/custom-lua-special-characters.md
+++ b/app/_includes/plugins/logging/custom-lua-special-characters.md
@@ -1,0 +1,20 @@
+{% assign custom_fields_by_lua = include.custom_fields_by_lua %}
+{% assign custom_fields_by_lua_name = include.custom_fields_by_lua_name %}
+{% assign custom_fields_by_lua_slug = include.custom_fields_by_lua_slug %}
+
+Dot characters (`.`) in the field key create nested fields. You can use a backslash `\` to escape a dot if you want to keep it in the field name.
+
+For example, if you configure a field with both a regular dot and an escaped dot:
+
+```sh
+curl -i -X POST http://localhost:8001/plugins/ \
+...
+  --data config.name={{include.slug}} \
+  --data {{custom_fields_by_lua}}.[my_entry.log\.field]="return foo"
+```
+The field will look like this in the log:
+```sh
+"my_entry": {
+  "log.field": "foo"
+}
+```

--- a/app/_includes/plugins/logging/log-custom-fields-by-lua.md
+++ b/app/_includes/plugins/logging/log-custom-fields-by-lua.md
@@ -3,7 +3,7 @@
 {% assign custom_fields_by_lua_slug = include.custom_fields_by_lua_slug %}
 
 The [`{{custom_fields_by_lua_name}}`](./reference/#schema--{{custom_fields_by_lua_slug}}) configuration allows for the dynamic modification of
-log fields using Lua code. Below is a snippet of an example configuration that
+log fields using Lua code. For example, here is a snippet of an example configuration that
 removes the `route` field from the logs:
 
 ```sh
@@ -19,73 +19,3 @@ curl -i -X POST http://localhost:8001/plugins \
   --data config.name={{include.slug}} \
   --data {{custom_fields_by_lua}}.header="return kong.request.get_header('h1')"
 ```
-
-### Array indices {% new_in 3.15 %}
-
-Array indices should be enclosed within square brackets. For example:
-
-```sh
-curl -i -X POST http://localhost:8001/plugins \
-  --header 'Accept: application/json' \
-  --header 'Content-Type: application/json' \
-  --data '{
-  "name": "{{include.slug}}",
-  "config": {
-    "{{custom_fields_by_lua_name}}": {
-      "foo[1].bar[2].woo": "return 456"
-    }
-  }
-}'
-```
-
-Array indices only support positive integers.
-
-### Special characters {% unless page.name =="Solace Log"%}{% new_in 3.10 %}{% endunless %}
-
-Dot characters (`.`) in the field key create nested fields. You can use a backslash `\` to escape a dot if you want to keep it in the field name.
-
-For example, if you configure a field with both a regular dot and an escaped dot:
-
-```sh
-curl -i -X POST http://localhost:8001/plugins/ \
-...
-  --data config.name={{page.name}} \
-  --data {{custom_fields_by_lua}}.[my_entry.log\.field]="return foo"
-```
-The field will look like this in the log:
-```sh
-"my_entry": {
-  "log.field": "foo"
-}
-```
-
-### Plugin precedence and managing fields
-
-All logging plugins use the same table for logging.
-If you set `{{custom_fields_by_lua_name}}` in one plugin, all logging plugins that execute after that plugin will also use the same configuration.
-For example, if you configure fields via `{{custom_fields_by_lua_name}}` in File Log, those same fields will appear in [Syslog](/plugins/syslog/), since {{page.name}} executes first.
-
-* If you want all logging plugins to use the same configuration, we recommend using the [Pre-function](/plugins/pre-function/) plugin to call [kong.log.set_serialize_value](/gateway/pdk/reference/kong.log/#kong-log-set-serialize-value-key-value-options) so that the function is applied predictably and is easier to manage.
-
-* If you **don't** want all logging plugins to use the same configuration, you need to manually disable the relevant fields in each plugin.
-
-   For example, if you configure a field in File Log that you don't want appearing in Syslog, set that field to `return nil` in the File Log plugin:
-
-   ```sh
-   curl -i -X POST http://localhost:8001/plugins/ \
-   ...
-     --data config.name={{include.slug}} \
-    --data {{custom_fields_by_lua}}.my_file_log_field="return nil"
-   ```
-
-See the [plugin execution order reference](/gateway/entities/plugin/#plugin-contexts) for more details on plugin ordering.
-
-### Limitations
-
-Lua code runs in a restricted sandbox environment, whose behavior is governed
-by the `untrusted_lua` [configuration properties](/gateway/configuration/).
-
-{% include /plugins/sandbox.md %}
-
-Further, as code runs in the context of the log phase, only [PDK](/gateway/pdk/reference/) methods
-that can run in said phase can be used.

--- a/app/_includes/plugins/logging/lua-custom-array-indices.md
+++ b/app/_includes/plugins/logging/lua-custom-array-indices.md
@@ -1,0 +1,21 @@
+{% assign custom_fields_by_lua = include.custom_fields_by_lua %}
+{% assign custom_fields_by_lua_name = include.custom_fields_by_lua_name %}
+{% assign custom_fields_by_lua_slug = include.custom_fields_by_lua_slug %}
+
+Array indices should be enclosed within square brackets. For example:
+
+```sh
+curl -i -X POST http://localhost:8001/plugins \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "name": "{{include.slug}}",
+  "config": {
+    "{{custom_fields_by_lua_name}}": {
+      "foo[1].bar[2].woo": "return 456"
+    }
+  }
+}'
+```
+
+Array indices only support positive integers.

--- a/app/_kong_plugins/file-log/index.md
+++ b/app/_kong_plugins/file-log/index.md
@@ -73,3 +73,34 @@ custom_fields_by_lua_slug='config-custom-fields-by-lua'
 custom_fields_by_lua_name='custom_fields_by_lua' 
 name=page.name 
 slug=page.slug %}
+
+### Array indices {% new_in 3.15 %}
+
+{% include /plugins/logging/lua-custom-array-indices.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name 
+slug=page.slug %}
+
+### Special characters {% new_in 3.10 %}
+
+{% include /plugins/logging/custom-lua-special-characters.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name 
+slug=page.slug %}
+
+### Plugin precedence and managing fields
+
+{% include /plugins/logging/custom-lua-plugin-precedence.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name 
+slug=page.slug %}
+
+### Limitations
+
+{% include /plugins/logging/custom-lua-limitations.md %}

--- a/app/_kong_plugins/http-log/index.md
+++ b/app/_kong_plugins/http-log/index.md
@@ -99,6 +99,37 @@ custom_fields_by_lua_name='custom_fields_by_lua'
 name=page.name 
 slug=page.slug %}
 
+### Array indices {% new_in 3.15 %}
+
+{% include /plugins/logging/lua-custom-array-indices.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name 
+slug=page.slug %}
+
+### Special characters {% new_in 3.10 %}
+
+{% include /plugins/logging/custom-lua-special-characters.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name 
+slug=page.slug %}
+
+### Plugin precedence and managing fields
+
+{% include /plugins/logging/custom-lua-plugin-precedence.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name 
+slug=page.slug %}
+
+### Limitations
+
+{% include /plugins/logging/custom-lua-limitations.md %}
+
 ## mTLS support {% new_in 3.15 %}
 
 The HTTP Log plugin supports mutual TLS (mTLS) when connecting to a log server.

--- a/app/_kong_plugins/kafka-log/index.md
+++ b/app/_kong_plugins/kafka-log/index.md
@@ -79,6 +79,37 @@ custom_fields_by_lua_name='custom_fields_by_lua'
 name=page.name 
 slug=page.slug %}
 
+### Array indices {% new_in 3.15 %}
+
+{% include /plugins/logging/lua-custom-array-indices.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name 
+slug=page.slug %}
+
+### Special characters {% new_in 3.10 %}
+
+{% include /plugins/logging/custom-lua-special-characters.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name 
+slug=page.slug %}
+
+### Plugin precedence and managing fields
+
+{% include /plugins/logging/custom-lua-plugin-precedence.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name 
+slug=page.slug %}
+
+### Limitations
+
+{% include /plugins/logging/custom-lua-limitations.md %}
+
 ## Schema registry support {% new_in 3.11 %}
 
 {% include_cached /plugins/confluent-kafka-consume/schema-registry.md name=page.name slug=page.slug workflow='producer' %}

--- a/app/_kong_plugins/loggly/index.md
+++ b/app/_kong_plugins/loggly/index.md
@@ -61,3 +61,34 @@ custom_fields_by_lua_slug='config-custom-fields-by-lua'
 custom_fields_by_lua_name='custom_fields_by_lua' 
 name=page.name 
 slug=page.slug %}
+
+### Array indices {% new_in 3.15 %}
+
+{% include /plugins/logging/lua-custom-array-indices.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name 
+slug=page.slug %}
+
+### Special characters {% new_in 3.10 %}
+
+{% include /plugins/logging/custom-lua-special-characters.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name 
+slug=page.slug %}
+
+### Plugin precedence and managing fields
+
+{% include /plugins/logging/custom-lua-plugin-precedence.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name 
+slug=page.slug %}
+
+### Limitations
+
+{% include /plugins/logging/custom-lua-limitations.md %}

--- a/app/_kong_plugins/opentelemetry/index.md
+++ b/app/_kong_plugins/opentelemetry/index.md
@@ -334,23 +334,12 @@ for each different header format, as in the following example:
 
 ## Custom attributes by Lua {% new_in 3.14 %}
 
-The [`custom_attributes_by_lua`](./reference/#schema--config-access-logs-custom-attributes-by-lua) configuration allows for the dynamic modification of
-log fields using Lua code. Below is a snippet of an example configuration that
-removes the `route` field from the logs:
-
-```sh
-curl -i -X POST http://localhost:8001/plugins \
-  --data config.name=opentelemetry \
-  --data config.access_logs.custom_attributes_by_lua.route="return nil"
-```
-
-Similarly, new fields can be added:
-
-```sh
-curl -i -X POST http://localhost:8001/plugins \
-  --data config.name=opentelemetry \
-  --data config.access_logs.custom_attributes_by_lua.header="return kong.request.get_header('h1')"
-```
+{% include /plugins/logging/log-custom-fields-by-lua.md
+custom_fields_by_lua='config.access_logs.custom_attributes_by_lua'
+custom_fields_by_lua_slug='config-access-logs-custom-attributes-by-lua'
+custom_fields_by_lua_name='custom_attributes_by_lua'
+name=page.name
+slug=page.slug %}
 
 ### Array indices {% new_in 3.15 %}
 
@@ -363,8 +352,10 @@ curl -i -X POST http://localhost:8001/plugins \
   --data '{
   "name": "opentelemetry",
   "config": {
-    "custom_attributes_by_lua": {
-      "foo[1].bar[2].woo": "return 456"
+    "access_logs": {
+      "custom_attributes_by_lua": {
+        "foo[1].bar[2].woo": "return 456"
+      }
     }
   }
 }'
@@ -374,35 +365,19 @@ Array indices only support positive integers.
 
 ### Special characters {% new_in 3.10 %}
 
-Dot characters (`.`) in the field key create nested fields. You can use a backslash `\` to escape a dot if you want to keep it in the field name.
-
-For example, if you configure a field with both a regular dot and an escaped dot:
-
-```sh
-curl -i -X POST http://localhost:8001/plugins/ \
-...
-  --data config.name=OpenTelemetry \
-  --data config.access_logs.custom_attributes_by_lua.[my_entry.log\.field]="return foo"
-```
-The field will look like this in the log:
-```sh
-"my_entry": {
-  "log.field": "foo"
-}
-```
+{% include /plugins/logging/custom-lua-special-characters.md 
+custom_fields_by_lua='config.access_logs.custom_attributes_by_lua'
+custom_fields_by_lua_slug='config-access-logs-custom-attributes-by-lua'
+custom_fields_by_lua_name='custom_attributes_by_lua'
+name=page.name
+slug=page.slug %}
 
 {:.warning}
 > The OpenTelemetry plugin doesn't use the same table for logging as the other logging plugins. This is because it uses `config.access_logs.custom_attributes_by_lua` instead of `config.custom_fields_by_lua`.
 
 ### Limitations
 
-Lua code runs in a restricted sandbox environment, whose behavior is governed
-by the `untrusted_lua` [configuration properties](/gateway/configuration/).
-
-{% include /plugins/sandbox.md %}
-
-Further, as code runs in the context of the log phase, only [PDK](/gateway/pdk/reference/) methods
-that can run in said phase can be used.
+{% include /plugins/logging/custom-lua-limitations.md %}
 
 ## Troubleshooting
 

--- a/app/_kong_plugins/opentelemetry/index.md
+++ b/app/_kong_plugins/opentelemetry/index.md
@@ -334,12 +334,75 @@ for each different header format, as in the following example:
 
 ## Custom attributes by Lua {% new_in 3.14 %}
 
-{% include /plugins/logging/log-custom-fields-by-lua.md
-custom_fields_by_lua='config.access_logs.custom_attributes_by_lua'
-custom_fields_by_lua_slug='config-access-logs-custom-attributes-by-lua'
-custom_fields_by_lua_name='custom_attributes_by_lua'
-name=page.name
-slug=page.slug %}
+The [`custom_attributes_by_lua`](./reference/#schema--config-access-logs-custom-attributes-by-lua) configuration allows for the dynamic modification of
+log fields using Lua code. Below is a snippet of an example configuration that
+removes the `route` field from the logs:
+
+```sh
+curl -i -X POST http://localhost:8001/plugins \
+  --data config.name=opentelemetry \
+  --data config.access_logs.custom_attributes_by_lua.route="return nil"
+```
+
+Similarly, new fields can be added:
+
+```sh
+curl -i -X POST http://localhost:8001/plugins \
+  --data config.name=opentelemetry \
+  --data config.access_logs.custom_attributes_by_lua.header="return kong.request.get_header('h1')"
+```
+
+### Array indices {% new_in 3.15 %}
+
+Array indices should be enclosed within square brackets. For example:
+
+```sh
+curl -i -X POST http://localhost:8001/plugins \
+  --header 'Accept: application/json' \
+  --header 'Content-Type: application/json' \
+  --data '{
+  "name": "opentelemetry",
+  "config": {
+    "custom_attributes_by_lua": {
+      "foo[1].bar[2].woo": "return 456"
+    }
+  }
+}'
+```
+
+Array indices only support positive integers.
+
+### Special characters {% new_in 3.10 %}
+
+Dot characters (`.`) in the field key create nested fields. You can use a backslash `\` to escape a dot if you want to keep it in the field name.
+
+For example, if you configure a field with both a regular dot and an escaped dot:
+
+```sh
+curl -i -X POST http://localhost:8001/plugins/ \
+...
+  --data config.name=OpenTelemetry \
+  --data config.access_logs.custom_attributes_by_lua.[my_entry.log\.field]="return foo"
+```
+The field will look like this in the log:
+```sh
+"my_entry": {
+  "log.field": "foo"
+}
+```
+
+{:.warning}
+> The OpenTelemetry plugin doesn't use the same table for logging as the other logging plugins. This is because it uses `config.access_logs.custom_attributes_by_lua` instead of `config.custom_fields_by_lua`.
+
+### Limitations
+
+Lua code runs in a restricted sandbox environment, whose behavior is governed
+by the `untrusted_lua` [configuration properties](/gateway/configuration/).
+
+{% include /plugins/sandbox.md %}
+
+Further, as code runs in the context of the log phase, only [PDK](/gateway/pdk/reference/) methods
+that can run in said phase can be used.
 
 ## Troubleshooting
 

--- a/app/_kong_plugins/solace-log/index.md
+++ b/app/_kong_plugins/solace-log/index.md
@@ -85,6 +85,37 @@ custom_fields_by_lua_name='custom_fields_by_lua'
 name=page.name
 slug=page.slug %}
 
+### Array indices {% new_in 3.15 %}
+
+{% include /plugins/logging/lua-custom-array-indices.md 
+custom_fields_by_lua='config.message.custom_fields_by_lua'
+custom_fields_by_lua_slug='config-message-custom-fields-by-lua'
+custom_fields_by_lua_name='custom_fields_by_lua'
+name=page.name
+slug=page.slug %}
+
+### Special characters
+
+{% include /plugins/logging/custom-lua-special-characters.md
+custom_fields_by_lua='config.message.custom_fields_by_lua'
+custom_fields_by_lua_slug='config-message-custom-fields-by-lua'
+custom_fields_by_lua_name='custom_fields_by_lua'
+name=page.name
+slug=page.slug %}
+
+### Plugin precedence and managing fields
+
+{% include /plugins/logging/custom-lua-plugin-precedence.md
+custom_fields_by_lua='config.message.custom_fields_by_lua'
+custom_fields_by_lua_slug='config-message-custom-fields-by-lua'
+custom_fields_by_lua_name='custom_fields_by_lua'
+name=page.name
+slug=page.slug %}
+
+### Limitations
+
+{% include /plugins/logging/custom-lua-limitations.md %}
+
 ## Authentication
 
 {% include_cached /plugins/solace/auth.md slug=page.slug name=page.name %}

--- a/app/_kong_plugins/syslog/index.md
+++ b/app/_kong_plugins/syslog/index.md
@@ -77,6 +77,37 @@ custom_fields_by_lua_name='custom_fields_by_lua'
 name=page.name 
 slug=page.slug %}
 
+### Array indices {% new_in 3.15 %}
+
+{% include /plugins/logging/lua-custom-array-indices.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name 
+slug=page.slug %}
+
+### Special characters {% new_in 3.10 %}
+
+{% include /plugins/logging/custom-lua-special-characters.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name 
+slug=page.slug %}
+
+### Plugin precedence and managing fields
+
+{% include /plugins/logging/custom-lua-plugin-precedence.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name 
+slug=page.slug %}
+
+### Limitations
+
+{% include /plugins/logging/custom-lua-limitations.md %}
+
 ## Forwarding logs to a remote network host
 
 {{site.base_gateway}} system logs can be forwarded to a Syslog server by changing the {{site.base_gateway}} configuration:

--- a/app/_kong_plugins/tcp-log/index.md
+++ b/app/_kong_plugins/tcp-log/index.md
@@ -60,3 +60,34 @@ custom_fields_by_lua_slug='config-custom-fields-by-lua'
 custom_fields_by_lua_name='custom_fields_by_lua' 
 name=page.name 
 slug=page.slug %}
+
+### Array indices {% new_in 3.15 %}
+
+{% include /plugins/logging/lua-custom-array-indices.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name 
+slug=page.slug %}
+
+### Special characters {% new_in 3.10 %}
+
+{% include /plugins/logging/custom-lua-special-characters.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name 
+slug=page.slug %}
+
+### Plugin precedence and managing fields
+
+{% include /plugins/logging/custom-lua-plugin-precedence.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name 
+slug=page.slug %}
+
+### Limitations
+
+{% include /plugins/logging/custom-lua-limitations.md %}

--- a/app/_kong_plugins/udp-log/index.md
+++ b/app/_kong_plugins/udp-log/index.md
@@ -60,3 +60,31 @@ custom_fields_by_lua='config.custom_fields_by_lua'
 custom_fields_by_lua_slug='config-custom-fields-by-lua' 
 custom_fields_by_lua_name='custom_fields_by_lua' 
 name=page.name slug=page.slug %}
+
+### Array indices {% new_in 3.15 %}
+
+{% include /plugins/logging/lua-custom-array-indices.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name slug=page.slug %}
+
+### Special characters {% new_in 3.10 %}
+
+{% include /plugins/logging/custom-lua-special-characters.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name slug=page.slug %}
+
+### Plugin precedence and managing fields
+
+{% include /plugins/logging/custom-lua-plugin-precedence.md 
+custom_fields_by_lua='config.custom_fields_by_lua' 
+custom_fields_by_lua_slug='config-custom-fields-by-lua' 
+custom_fields_by_lua_name='custom_fields_by_lua' 
+name=page.name slug=page.slug %}
+
+### Limitations
+
+{% include /plugins/logging/custom-lua-limitations.md %}


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes https://kongstrong.slack.com/archives/C046SPHV6AH/p1787686060733119

Found this when I was migrating/auditing the OTEL AI Policy. Because OTEL (plugin and policy) don't use the custom lua field param as the other logging policies/plugins, it doesn't share the same logging table. I chose to break the include out and remove the shared logging table paragraph, but let me know if this wasn't the best choice.

## Preview Links
- https://deploy-preview-7201--kongdeveloper.netlify.app/plugins/opentelemetry/#custom-attributes-by-lua
- https://deploy-preview-7201--kongdeveloper.netlify.app/plugins/file-log/#custom-fields-by-lua
- https://deploy-preview-7201--kongdeveloper.netlify.app/plugins/http-log/#custom-fields-by-lua
- https://deploy-preview-7201--kongdeveloper.netlify.app/plugins/kafka-log/#custom-fields-by-lua
- https://deploy-preview-7201--kongdeveloper.netlify.app/plugins/loggly/#custom-fields-by-lua
- https://deploy-preview-7201--kongdeveloper.netlify.app/plugins/solace-log/#custom-fields-by-lua
- https://deploy-preview-7201--kongdeveloper.netlify.app/plugins/syslog/#custom-fields-by-lua
- https://deploy-preview-7201--kongdeveloper.netlify.app/plugins/tcp-log/#custom-fields-by-lua
- https://deploy-preview-7201--kongdeveloper.netlify.app/plugins/udp-log/#custom-fields-by-lua

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
