### PR TITLE
feat(gateway): Redis client support for oauth as auth provider

### DIFF
--- a/app/_includes/plugins/redis/enterprise.md
+++ b/app/_includes/plugins/redis/enterprise.md
@@ -25,7 +25,8 @@ You need:
 
 To configure cloud authentication with Redis, add the following parameters to your plugin configuration:
 
-{% if include.name == 'Rate Limiting Advanced' or include.name == 'GraphQL Proxy Cache Advanced' or include.name == 'GraphQL Rate Limiting Advanced' or include.name == 'Proxy Caching Advanced' or include.name == 'Service Protection' %}
+{% case include.redis_group %}
+{% when "strategy" %}
 ```yaml
 config:
   strategy: redis
@@ -41,7 +42,7 @@ config:
       aws_access_key_id: $AWS_ACCESS_KEY_ID
       aws_secret_access_key: $AWS_ACCESS_SECRET_KEY
 ```
-{% elsif include.name == 'AI Proxy Advanced' or include.name == 'AI RAG Injector' or include.name == 'AI Semantic Cache' or include.name == 'AI Semantic Prompt Guard' or include.name == 'AI Semantic Response Guard' %}
+{% when "vectordb" %}
 ```yaml
 config:
   vectordb:
@@ -58,8 +59,7 @@ config:
         aws_access_key_id: $AWS_ACCESS_KEY_ID
         aws_secret_access_key: $AWS_ACCESS_SECRET_KEY
 ```
-
-{% elsif include.name == 'OpenID Connect' %}
+{% when "oidc" %}
 ```yaml
 config:
   cluster_cache_strategy: redis
@@ -75,7 +75,7 @@ config:
       aws_access_key_id: $AWS_ACCESS_KEY_ID
       aws_secret_access_key: $AWS_ACCESS_SECRET_KEY
 ```
-{% elsif include.name == 'Datakit' %}
+{% when "datakit" %}
 ```yaml
 config:
   resources:
@@ -93,7 +93,7 @@ config:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_ACCESS_SECRET_KEY
 ```
-{% elsif include.name == 'Request Callout' or include.name == 'Upstream OAuth' %}
+{% when "cache" %}
 ```yaml
 config:
   cache:
@@ -110,7 +110,7 @@ config:
         aws_access_key_id: $AWS_ACCESS_KEY_ID
         aws_secret_access_key: $AWS_ACCESS_SECRET_KEY
 ```
-{% elsif include.name == 'SAML' %}
+{% when "session_storage" %}
 ```yaml
 config:
   session_storage: redis
@@ -126,24 +126,7 @@ config:
       aws_access_key_id: $AWS_ACCESS_KEY_ID
       aws_secret_access_key: $AWS_ACCESS_SECRET_KEY
 ```
-{% else %}
-```yaml
-config:
-  storage: redis
-  storage_config:
-    redis:
-      host: $INSTANCE_ADDRESS
-      username: $INSTANCE_USERNAME
-      port: 6379
-      cloud_authentication:
-        auth_provider: aws
-        aws_cache_name: $AWS_CACHE_NAME
-        aws_is_serverless: false
-        aws_region: $AWS_REGION
-        aws_access_key_id: $AWS_ACCESS_KEY_ID
-        aws_secret_access_key: $AWS_ACCESS_SECRET_KEY
-```
-{% endif %}
+{% endcase %}
 
 Replace the following with your actual values:
 * `$INSTANCE_ADDRESS`: The ElastiCache instance address.
@@ -179,7 +162,8 @@ You need:
 
 To configure cloud authentication with Redis, add the following parameters to your plugin configuration:
 
-{% if include.name == 'Rate Limiting Advanced' %}
+{% case include.redis_group %}
+{% when "strategy" %}
 ```yaml
 config:
   strategy: redis
@@ -193,11 +177,11 @@ config:
       auth_provider: aws
       aws_cache_name: $AWS_CACHE_NAME
       aws_is_serverless: false
-      aws_region: $AWS_REGION 
+      aws_region: $AWS_REGION
       aws_access_key_id: $AWS_ACCESS_KEY_ID
-      aws_secret_access_key: $AWS_ACCESS_SECRET_KEY 
+      aws_secret_access_key: $AWS_ACCESS_SECRET_KEY
 ```
-{% elsif include.name == 'AI Proxy Advanced' or include.name == 'AI RAG Injector'  or include.name == 'AI Semantic Cache' or include.name == 'AI Semantic Prompt Guard' or include.name == 'AI Semantic Response Guard' %}
+{% when "vectordb" %}
 ```yaml
 config:
   vectordb:
@@ -212,12 +196,11 @@ config:
         auth_provider: aws
         aws_cache_name: $AWS_CACHE_NAME
         aws_is_serverless: false
-        aws_region: $AWS_REGION 
+        aws_region: $AWS_REGION
         aws_access_key_id: $AWS_ACCESS_KEY_ID
-        aws_secret_access_key: $AWS_ACCESS_SECRET_KEY 
+        aws_secret_access_key: $AWS_ACCESS_SECRET_KEY
 ```
-
-{% elsif include.name == 'OpenID Connect' %}
+{% when "oidc" %}
 ```yaml
 config:
   cluster_cache_strategy: redis
@@ -235,7 +218,7 @@ config:
       aws_access_key_id: $AWS_ACCESS_KEY_ID
       aws_secret_access_key: $AWS_ACCESS_SECRET_KEY
 ```
-{% elsif include.name == 'Datakit' %}
+{% when "datakit" %}
 ```yaml
 config:
   resources:
@@ -255,7 +238,7 @@ config:
           aws_access_key_id: $AWS_ACCESS_KEY_ID
           aws_secret_access_key: $AWS_ACCESS_SECRET_KEY
 ```
-{% elsif include.name == 'Request Callout' or include.name == 'Upstream OAuth' %}
+{% when "cache" %}
 ```yaml
 config:
   cache:
@@ -274,7 +257,7 @@ config:
         aws_access_key_id: $AWS_ACCESS_KEY_ID
         aws_secret_access_key: $AWS_ACCESS_SECRET_KEY
 ```
-{% elsif include.name == 'SAML' %}
+{% when "session_storage" %}
 ```yaml
 config:
   session_storage: redis
@@ -292,26 +275,7 @@ config:
       aws_access_key_id: $AWS_ACCESS_KEY_ID
       aws_secret_access_key: $AWS_ACCESS_SECRET_KEY
 ```
-{% else %}
-```yaml
-config:
-  storage: redis
-  storage_config:
-    redis:
-      cluster_nodes:
-      - ip: $CLUSTER_ADDRESS
-        port: 6379
-      username: $CLUSTER_USERNAME
-      port: 6379
-      cloud_authentication:
-        auth_provider: aws
-        aws_cache_name: $AWS_CACHE_NAME
-        aws_is_serverless: false
-        aws_region: $AWS_REGION
-        aws_access_key_id: $AWS_ACCESS_KEY_ID
-        aws_secret_access_key: $AWS_ACCESS_SECRET_KEY
-```
-{% endif %}
+{% endcase %}
 
 Replace the following with your actual values:
 * `$CLUSTER_ADDRESS`: The ElastiCache cluster address.
@@ -329,7 +293,8 @@ You need:
 
 To configure cloud authentication with Redis, add the following parameters to your plugin configuration:
 
-{% if include.name == 'Rate Limiting Advanced' %}
+{% case include.redis_group %}
+{% when "strategy" %}
 ```yaml
 config:
   strategy: redis
@@ -343,7 +308,7 @@ config:
       azure_client_secret: $AZURE_CLIENT_SECRET
       azure_tenant_id: $AZURE_TENANT_ID
 ```
-{% elsif include.name == 'AI Proxy Advanced' or include.name == 'AI RAG Injector'  or include.name == 'AI Semantic Cache' or include.name == 'AI Semantic Prompt Guard' or include.name == 'AI Semantic Response Guard' %}
+{% when "vectordb" %}
 ```yaml
 config:
   vectordb:
@@ -358,8 +323,7 @@ config:
         azure_client_secret: $AZURE_CLIENT_SECRET
         azure_tenant_id: $AZURE_TENANT_ID
 ```
-
-{% elsif include.name == 'OpenID Connect' %}
+{% when "oidc" %}
 ```yaml
 config:
   cluster_cache_strategy: redis
@@ -373,7 +337,7 @@ config:
       azure_client_secret: $AZURE_CLIENT_SECRET
       azure_tenant_id: $AZURE_TENANT_ID
 ```
-{% elsif include.name == 'Datakit' %}
+{% when "datakit" %}
 ```yaml
 config:
   resources:
@@ -389,7 +353,7 @@ config:
           azure_client_secret: $AZURE_CLIENT_SECRET
           azure_tenant_id: $AZURE_TENANT_ID
 ```
-{% elsif include.name == 'Request Callout' or include.name == 'Upstream OAuth' %}
+{% when "cache" %}
 ```yaml
 config:
   cache:
@@ -404,7 +368,7 @@ config:
         azure_client_secret: $AZURE_CLIENT_SECRET
         azure_tenant_id: $AZURE_TENANT_ID
 ```
-{% elsif include.name == 'SAML' %}
+{% when "session_storage" %}
 ```yaml
 config:
   session_storage: redis
@@ -418,22 +382,7 @@ config:
       azure_client_secret: $AZURE_CLIENT_SECRET
       azure_tenant_id: $AZURE_TENANT_ID
 ```
-{% else %}
-```yaml
-config:
-  storage: redis
-  storage_config:
-    redis:
-      host: $INSTANCE_ADDRESS
-      username: $INSTANCE_USERNAME
-      port: 10000
-      cloud_authentication:
-        auth_provider: azure
-        azure_client_id: $AZURE_CLIENT_ID
-        azure_client_secret: $AZURE_CLIENT_SECRET
-        azure_tenant_id: $AZURE_TENANT_ID
-```
-{% endif %}
+{% endcase %}
 
 Replace the following with your actual values:
 * `$INSTANCE_ADDRESS`: The Azure Managed Redis instance address.
@@ -451,7 +400,8 @@ You need:
 
 To configure cloud authentication with Redis, add the following parameters to your plugin configuration:
 
-{% if include.name == 'Rate Limiting Advanced' %}
+{% case include.redis_group %}
+{% when "strategy" %}
 ```yaml
 config:
   strategy: redis
@@ -467,7 +417,7 @@ config:
       azure_client_secret: $AZURE_CLIENT_SECRET
       azure_tenant_id: $AZURE_TENANT_ID
 ```
-{% elsif include.name == 'AI Proxy Advanced' or include.name == 'AI RAG Injector'  or include.name == 'AI Semantic Cache' or include.name == 'AI Semantic Prompt Guard' or include.name == 'AI Semantic Response Guard' %}
+{% when "vectordb" %}
 ```yaml
 config:
   vectordb:
@@ -484,8 +434,7 @@ config:
         azure_client_secret: $AZURE_CLIENT_SECRET
         azure_tenant_id: $AZURE_TENANT_ID
 ```
-
-{% elsif include.name == 'OpenID Connect' %}
+{% when "oidc" %}
 ```yaml
 config:
   cluster_cache_strategy: redis
@@ -501,7 +450,7 @@ config:
       azure_client_secret: $AZURE_CLIENT_SECRET
       azure_tenant_id: $AZURE_TENANT_ID
 ```
-{% elsif include.name == 'Datakit' %}
+{% when "datakit" %}
 ```yaml
 config:
   resources:
@@ -519,7 +468,7 @@ config:
           azure_client_secret: $AZURE_CLIENT_SECRET
           azure_tenant_id: $AZURE_TENANT_ID
 ```
-{% elsif include.name == 'Request Callout' or include.name == 'Upstream OAuth' %}
+{% when "cache" %}
 ```yaml
 config:
   cache:
@@ -536,7 +485,7 @@ config:
         azure_client_secret: $AZURE_CLIENT_SECRET
         azure_tenant_id: $AZURE_TENANT_ID
 ```
-{% elsif include.name == 'SAML' %}
+{% when "session_storage" %}
 ```yaml
 config:
   session_storage: redis
@@ -552,24 +501,7 @@ config:
       azure_client_secret: $AZURE_CLIENT_SECRET
       azure_tenant_id: $AZURE_TENANT_ID
 ```
-{% else %}
-```yaml
-config:
-  storage: redis
-  storage_config:
-    redis:
-      cluster_nodes:
-      - ip: $CLUSTER_ADDRESS
-        port: 10000
-      username: $CLUSTER_USERNAME
-      port: 10000
-      cloud_authentication:
-        auth_provider: azure
-        azure_client_id: $AZURE_CLIENT_ID
-        azure_client_secret: $AZURE_CLIENT_SECRET
-        azure_tenant_id: $AZURE_TENANT_ID
-```
-{% endif %}
+{% endcase %}
 
 Replace the following with your actual values:
 * `$CLUSTER_ADDRESS`: The Azure Managed Redis cluster address.
@@ -589,7 +521,8 @@ You need:
 
 To configure cloud authentication with Redis, add the following parameters to your plugin configuration:
 
-{% if include.name == 'Rate Limiting Advanced' %}
+{% case include.redis_group %}
+{% when "strategy" %}
 ```yaml
 config:
   strategy: redis
@@ -600,7 +533,7 @@ config:
       auth_provider: gcp
       gcp_service_account_json: $GCP_SERVICE_ACCOUNT
 ```
-{% elsif include.name == 'AI Proxy Advanced' or include.name == 'AI RAG Injector' or include.name == 'AI Semantic Cache' or include.name == 'AI Semantic Prompt Guard' or include.name == 'AI Semantic Response Guard' %}
+{% when "vectordb" %}
 ```yaml
 config:
   vectordb:
@@ -612,8 +545,7 @@ config:
         auth_provider: gcp
         gcp_service_account_json: $GCP_SERVICE_ACCOUNT
 ```
-
-{% elsif include.name == 'OpenID Connect' %}
+{% when "oidc" %}
 ```yaml
 config:
   cluster_cache_strategy: redis
@@ -624,7 +556,7 @@ config:
       auth_provider: gcp
       gcp_service_account_json: $GCP_SERVICE_ACCOUNT
 ```
-{% elsif include.name == 'Datakit' %}
+{% when "datakit" %}
 ```yaml
 config:
   resources:
@@ -637,7 +569,7 @@ config:
           auth_provider: gcp
           gcp_service_account_json: $GCP_SERVICE_ACCOUNT
 ```
-{% elsif include.name == 'Request Callout' or include.name == 'Upstream OAuth' %}
+{% when "cache" %}
 ```yaml
 config:
   cache:
@@ -649,7 +581,7 @@ config:
         auth_provider: gcp
         gcp_service_account_json: $GCP_SERVICE_ACCOUNT
 ```
-{% elsif include.name == 'SAML' %}
+{% when "session_storage" %}
 ```yaml
 config:
   session_storage: redis
@@ -660,19 +592,7 @@ config:
       auth_provider: gcp
       gcp_service_account_json: $GCP_SERVICE_ACCOUNT
 ```
-{% else %}
-```yaml
-config:
-  storage: redis
-  storage_config:
-    redis:
-      host: $INSTANCE_ADDRESS
-      port: 6379
-      cloud_authentication:
-        auth_provider: gcp
-        gcp_service_account_json: $GCP_SERVICE_ACCOUNT
-```
-{% endif %}
+{% endcase %}
 
 Replace the following with your actual values:
 * `$INSTANCE_ADDRESS`: The Memorystore instance address.
@@ -688,7 +608,8 @@ You need:
 
 To configure cloud authentication with Redis, add the following parameters to your plugin configuration:
 
-{% if include.name == 'Rate Limiting Advanced' %}
+{% case include.redis_group %}
+{% when "strategy" %}
 ```yaml
 config:
   strategy: redis
@@ -701,7 +622,7 @@ config:
       auth_provider: gcp
       gcp_service_account_json: $GCP_SERVICE_ACCOUNT
 ```
-{% elsif include.name == 'AI Proxy Advanced' or include.name == 'AI RAG Injector' or include.name == 'AI Semantic Cache' or include.name == 'AI Semantic Prompt Guard' or include.name == 'AI Semantic Response Guard' %}
+{% when "vectordb" %}
 ```yaml
 config:
   vectordb:
@@ -715,8 +636,7 @@ config:
         auth_provider: gcp
         gcp_service_account_json: $GCP_SERVICE_ACCOUNT
 ```
-
-{% elsif include.name == 'OpenID Connect' %}
+{% when "oidc" %}
 ```yaml
 config:
   cluster_cache_strategy: redis
@@ -729,7 +649,7 @@ config:
       auth_provider: gcp
       gcp_service_account_json: $GCP_SERVICE_ACCOUNT
 ```
-{% elsif include.name == 'Datakit' %}
+{% when "datakit" %}
 ```yaml
 config:
   resources:
@@ -744,7 +664,7 @@ config:
           auth_provider: gcp
           gcp_service_account_json: $GCP_SERVICE_ACCOUNT
 ```
-{% elsif include.name == 'Request Callout' or include.name == 'Upstream OAuth' %}
+{% when "cache" %}
 ```yaml
 config:
   cache:
@@ -758,7 +678,7 @@ config:
         auth_provider: gcp
         gcp_service_account_json: $GCP_SERVICE_ACCOUNT
 ```
-{% elsif include.name == 'SAML' %}
+{% when "session_storage" %}
 ```yaml
 config:
   session_storage: redis
@@ -771,24 +691,128 @@ config:
       auth_provider: gcp
       gcp_service_account_json: $GCP_SERVICE_ACCOUNT
 ```
-{% else %}
-```yaml
-config:
-  storage: redis
-  storage_config:
-    redis:
-      cluster_nodes:
-      - ip: $CLUSTER_ADDRESS
-        port: 6379
-      port: 6379
-      cloud_authentication:
-        auth_provider: gcp
-        gcp_service_account_json: $GCP_SERVICE_ACCOUNT
-```
-{% endif %}
+{% endcase %}
 
 Replace the following with your actual values:
 * `$CLUSTER_ADDRESS`: The Memorystore cluster address.
 * `$GCP_SERVICE_ACCOUNT`: The GCP service account JSON.
+{% endnavtab %}
+{% navtab "OAuth 2.0" %}
+
+You need:
+* An OAuth 2.0 token endpoint that issues access tokens for the `client_credentials` or `password` grant type
+* A [Redis deployment](https://redis.io/tutorials/authentication-token-storage-with-redis/) that accepts the issued access token as a bearer credential, either natively or through an OAuth-aware proxy (such as Envoy) placed in front of it
+
+To configure OAuth 2.0 authentication with Redis, add the following parameters to your plugin configuration:
+
+{% case include.redis_group %}
+{% when "strategy" %}
+```yaml
+config:
+  strategy: redis
+  redis:
+    host: $INSTANCE_ADDRESS
+    port: 6379
+    cloud_authentication:
+      auth_provider: oauth
+      oauth:
+        token_endpoint: $OAUTH_TOKEN_ENDPOINT
+        grant_type: client_credentials
+        client_id: $OAUTH_CLIENT_ID
+        client_secret: $OAUTH_CLIENT_SECRET
+```
+{% when "vectordb" %}
+```yaml
+config:
+  vectordb:
+    strategy: redis
+    redis:
+      host: $INSTANCE_ADDRESS
+      port: 6379
+      cloud_authentication:
+        auth_provider: oauth
+        oauth:
+          token_endpoint: $OAUTH_TOKEN_ENDPOINT
+          grant_type: client_credentials
+          client_id: $OAUTH_CLIENT_ID
+          client_secret: $OAUTH_CLIENT_SECRET
+```
+{% when "oidc" %}
+```yaml
+config:
+  cluster_cache_strategy: redis
+  cluster_cache_redis:
+    host: $INSTANCE_ADDRESS
+    port: 6379
+    cloud_authentication:
+      auth_provider: oauth
+      oauth:
+        token_endpoint: $OAUTH_TOKEN_ENDPOINT
+        grant_type: client_credentials
+        client_id: $OAUTH_CLIENT_ID
+        client_secret: $OAUTH_CLIENT_SECRET
+```
+{% when "datakit" %}
+```yaml
+config:
+  resources:
+    cache:
+      strategy: redis
+      redis:
+        host: $INSTANCE_ADDRESS
+        port: 6379
+        cloud_authentication:
+          auth_provider: oauth
+          oauth:
+            token_endpoint: $OAUTH_TOKEN_ENDPOINT
+            grant_type: client_credentials
+            client_id: $OAUTH_CLIENT_ID
+            client_secret: $OAUTH_CLIENT_SECRET
+```
+{% when "cache" %}
+```yaml
+config:
+  cache:
+    strategy: redis
+    redis:
+      host: $INSTANCE_ADDRESS
+      port: 6379
+      cloud_authentication:
+        auth_provider: oauth
+        oauth:
+          token_endpoint: $OAUTH_TOKEN_ENDPOINT
+          grant_type: client_credentials
+          client_id: $OAUTH_CLIENT_ID
+          client_secret: $OAUTH_CLIENT_SECRET
+```
+{% when "session_storage" %}
+```yaml
+config:
+  session_storage: redis
+  redis:
+    host: $INSTANCE_ADDRESS
+    port: 6379
+    cloud_authentication:
+      auth_provider: oauth
+      oauth:
+        token_endpoint: $OAUTH_TOKEN_ENDPOINT
+        grant_type: client_credentials
+        client_id: $OAUTH_CLIENT_ID
+        client_secret: $OAUTH_CLIENT_SECRET
+```
+{% endcase %}
+
+Replace the following with your actual values:
+* `$INSTANCE_ADDRESS`: The Redis instance or proxy address.
+* `$OAUTH_TOKEN_ENDPOINT`: The OAuth 2.0 token endpoint URL used to request access tokens.
+* `$OAUTH_CLIENT_ID`: Your OAuth 2.0 client ID.
+* `$OAUTH_CLIENT_SECRET`: Your OAuth 2.0 client secret.
+
+{{site.base_gateway}} caches the acquired token for the duration of its validity and refreshes it asynchronously before it expires. 
+To use the `password` grant type instead, set `oauth.grant_type` to `password` and also provide `oauth.username` and `oauth.password`.
+
+If your Redis deployment uses ACL-based authentication and needs a username sent alongside the token, also set one of:
+* `oauth.redis_username`: a static username to send with `AUTH <username> <token>`.
+* `oauth.redis_username_claim`: the name of a claim in the access token (for example, `oid` for Microsoft Entra ID) to derive the username from.
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/_includes/plugins/redis/oss.md
+++ b/app/_includes/plugins/redis/oss.md
@@ -25,7 +25,8 @@ You need:
 
 To configure cloud authentication with Redis, add the following parameters to your plugin configuration:
 
-{% if include.name == 'Basic Auth' %}
+{% case include.redis_group %}
+{% when "brute_force_protection" %}
 ```yaml
 config:
   brute_force_protection:
@@ -42,7 +43,7 @@ config:
         aws_access_key_id: $AWS_ACCESS_KEY_ID
         aws_secret_access_key: $AWS_ACCESS_SECRET_KEY
 ```
-{% elsif include.name == 'Rate Limiting' or include.name == 'Response Rate Limiting' %}
+{% when "policy" %}
 ```yaml
 config:
   policy: redis
@@ -58,7 +59,7 @@ config:
       aws_access_key_id: $AWS_ACCESS_KEY_ID
       aws_secret_access_key: $AWS_ACCESS_SECRET_KEY
 ```
-{% else %}
+{% when "storage_config" %}
 ```yaml
 config:
   storage: redis
@@ -75,7 +76,7 @@ config:
         aws_access_key_id: $AWS_ACCESS_KEY_ID
         aws_secret_access_key: $AWS_ACCESS_SECRET_KEY
 ```
-{% endif %}
+{% endcase %}
 
 Replace the following with your actual values:
 * `$INSTANCE_ADDRESS`: The ElastiCache instance address.
@@ -93,7 +94,8 @@ You need:
 
 To configure cloud authentication with Redis, add the following parameters to your plugin configuration:
 
-{% if include.name == 'Basic Auth' %}
+{% case include.redis_group %}
+{% when "brute_force_protection" %}
 ```yaml
 config:
   brute_force_protection:
@@ -108,7 +110,7 @@ config:
         azure_client_secret: $AZURE_CLIENT_SECRET
         azure_tenant_id: $AZURE_TENANT_ID
 ```
-{% elsif include.name == 'Rate Limiting' or include.name == 'Response Rate Limiting' %}
+{% when "policy" %}
 ```yaml
 config:
   policy: redis
@@ -122,7 +124,7 @@ config:
       azure_client_secret: $AZURE_CLIENT_SECRET
       azure_tenant_id: $AZURE_TENANT_ID
 ```
-{% else %}
+{% when "storage_config" %}
 ```yaml
 config:
   storage: redis
@@ -137,7 +139,7 @@ config:
         azure_client_secret: $AZURE_CLIENT_SECRET
         azure_tenant_id: $AZURE_TENANT_ID
 ```
-{% endif %}
+{% endcase %}
 
 Replace the following with your actual values:
 * `$INSTANCE_ADDRESS`: The Azure Managed Redis instance address.
@@ -157,7 +159,8 @@ You need:
 
 To configure cloud authentication with Redis, add the following parameters to your plugin configuration:
 
-{% if include.name == 'Basic Auth' %}
+{% case include.redis_group %}
+{% when "brute_force_protection" %}
 ```yaml
 config:
   brute_force_protection:
@@ -169,7 +172,7 @@ config:
         auth_provider: gcp
         gcp_service_account_json: $GCP_SERVICE_ACCOUNT
 ```
-{% elsif include.name == 'Rate Limiting' or include.name == 'Response Rate Limiting' %}
+{% when "policy" %}
 ```yaml
 config:
   policy: redis
@@ -180,7 +183,7 @@ config:
       auth_provider: gcp
       gcp_service_account_json: $GCP_SERVICE_ACCOUNT
 ```
-{% else %}
+{% when "storage_config" %}
 ```yaml
 config:
   storage: redis
@@ -192,10 +195,82 @@ config:
         auth_provider: gcp
         gcp_service_account_json: $GCP_SERVICE_ACCOUNT
 ```
-{% endif %}
+{% endcase %}
 
 Replace the following with your actual values:
 * `$INSTANCE_ADDRESS`: The Memorystore instance address.
 * `$GCP_SERVICE_ACCOUNT`: (Optional) The GCP service account JSON.
+{% endnavtab %}
+{% navtab "OAuth 2.0" %}
+
+You need:
+* An OAuth 2.0 token endpoint that issues access tokens for the `client_credentials` or `password` grant type
+* A [Redis deployment](https://redis.io/tutorials/authentication-token-storage-with-redis/) that accepts the issued access token as a bearer credential, either natively or through an OAuth-aware proxy (such as Envoy) placed in front of it
+
+To configure OAuth 2.0 authentication with Redis, add the following parameters to your plugin configuration:
+
+{% case include.redis_group %}
+{% when "brute_force_protection" %}
+```yaml
+config:
+  brute_force_protection:
+    strategy: redis
+    redis:
+      host: $INSTANCE_ADDRESS
+      port: 6379
+      cloud_authentication:
+        auth_provider: oauth
+        oauth:
+          token_endpoint: $OAUTH_TOKEN_ENDPOINT
+          grant_type: client_credentials
+          client_id: $OAUTH_CLIENT_ID
+          client_secret: $OAUTH_CLIENT_SECRET
+```
+{% when "policy" %}
+```yaml
+config:
+  policy: redis
+  redis:
+    host: $INSTANCE_ADDRESS
+    port: 6379
+    cloud_authentication:
+      auth_provider: oauth
+      oauth:
+        token_endpoint: $OAUTH_TOKEN_ENDPOINT
+        grant_type: client_credentials
+        client_id: $OAUTH_CLIENT_ID
+        client_secret: $OAUTH_CLIENT_SECRET
+```
+{% when "storage_config" %}
+```yaml
+config:
+  storage: redis
+  storage_config:
+    redis:
+      host: $INSTANCE_ADDRESS
+      port: 6379
+      cloud_authentication:
+        auth_provider: oauth
+        oauth:
+          token_endpoint: $OAUTH_TOKEN_ENDPOINT
+          grant_type: client_credentials
+          client_id: $OAUTH_CLIENT_ID
+          client_secret: $OAUTH_CLIENT_SECRET
+```
+{% endcase %}
+
+Replace the following with your actual values:
+* `$INSTANCE_ADDRESS`: The Redis instance or proxy address.
+* `$OAUTH_TOKEN_ENDPOINT`: The OAuth 2.0 token endpoint URL used to request access tokens.
+* `$OAUTH_CLIENT_ID`: Your OAuth 2.0 client ID.
+* `$OAUTH_CLIENT_SECRET`: Your OAuth 2.0 client secret.
+
+{{site.base_gateway}} caches the acquired token for the duration of its validity and refreshes it asynchronously before it expires. 
+To use the `password` grant type instead, set `oauth.grant_type` to `password` and also provide `oauth.username` and `oauth.password`.
+
+If your Redis deployment uses ACL-based authentication and needs a username sent alongside the token, also set one of:
+* `oauth.redis_username`: A static username to send with `AUTH <username> <token>`.
+* `oauth.redis_username_claim`: The name of a claim in the access token (for example, `oid` for Microsoft Entra ID) to derive the username from.
+
 {% endnavtab %}
 {% endnavtabs %}

--- a/app/_includes/plugins/redis/redis-cloud-auth.md
+++ b/app/_includes/plugins/redis/redis-cloud-auth.md
@@ -1,11 +1,12 @@
-If your plugin uses a Redis datastore, you can authenticate to it with a cloud Redis provider. 
+If your plugin uses a Redis datastore, you can authenticate to it with a cloud Redis provider, or with an OAuth 2.0 token endpoint. 
 This allows you to seamlessly rotate credentials without relying on static passwords. 
 
 The following providers are supported:
 * AWS ElastiCache
 * Azure Managed Redis
 * {{ site.google_cloud }} Memorystore (with or without Valkey)
+* OAuth 2.0 {% new_in 3.16 %}, using the `client_credentials` or `password` grant type
 
 {% if include.tier == 'enterprise' %}
-Each provider also supports an instance and cluster configuration.
+Each cloud provider also supports an instance and cluster configuration.
 {% endif %}

--- a/app/_kong_plugins/acme/index.md
+++ b/app/_kong_plugins/acme/index.md
@@ -226,4 +226,4 @@ If you're using [ZeroSSL](https://zerossl.com/), the provider's external account
 
 {% include_cached /plugins/redis/redis-cloud-auth.md tier=page.tier %}
 
-{% include_cached /plugins/redis/oss.md name=page.name heading_level=2 %}
+{% include_cached /plugins/redis/oss.md name=page.name heading_level=2 redis_group="storage_config" %}

--- a/app/_kong_plugins/ai-proxy-advanced/index.md
+++ b/app/_kong_plugins/ai-proxy-advanced/index.md
@@ -198,4 +198,4 @@ For setup instructions, see [AI plugin Partials](/gateway/entities/partial/#ai-p
 
 {% include_cached /plugins/redis/redis-cloud-auth.md tier=page.tier %}
 
-{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=3 %}
+{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=3 redis_group="vectordb" %}

--- a/app/_kong_plugins/ai-rag-injector/index.md
+++ b/app/_kong_plugins/ai-rag-injector/index.md
@@ -260,7 +260,7 @@ Rather than guessing from memory, the LLM paired with the RAG pipeline now has t
 
 {% include_cached /plugins/redis/redis-cloud-auth.md tier=page.tier %}
 
-{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=3 %}
+{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=3 redis_group="vectordb" %}
 
 ## Access control and metadata filtering {% new_in 3.13 %}
 

--- a/app/_kong_plugins/ai-rate-limiting-advanced/index.md
+++ b/app/_kong_plugins/ai-rate-limiting-advanced/index.md
@@ -78,7 +78,7 @@ See [Rate Limiting in {{site.base_gateway}}](/gateway/rate-limiting/) to choose 
 
 {% include_cached /plugins/redis/redis-cloud-auth.md tier=page.tier %}
 
-{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=3 %}
+{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=3 redis_group="strategy" %}
 
 ### Fallback from Redis
 

--- a/app/_kong_plugins/ai-semantic-cache/index.md
+++ b/app/_kong_plugins/ai-semantic-cache/index.md
@@ -184,4 +184,4 @@ The plugin respects cache control headers to determine if requests and responses
 
 {% include_cached /plugins/redis/redis-cloud-auth.md tier=page.tier %}
 
-{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=3 %}
+{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=3 redis_group="vectordb" %}

--- a/app/_kong_plugins/ai-semantic-prompt-guard/index.md
+++ b/app/_kong_plugins/ai-semantic-prompt-guard/index.md
@@ -107,4 +107,4 @@ The matching behavior is as follows:
 
 {% include_cached /plugins/redis/redis-cloud-auth.md tier=page.tier %}
 
-{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=3 %}
+{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=3 redis_group="vectordb" %}

--- a/app/_kong_plugins/ai-semantic-response-guard/index.md
+++ b/app/_kong_plugins/ai-semantic-response-guard/index.md
@@ -102,4 +102,4 @@ To enforce these rules, the plugin:
 
 {% include_cached /plugins/redis/redis-cloud-auth.md tier=page.tier %}
 
-{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=3 %}
+{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=3 redis_group="vectordb" %}

--- a/app/_kong_plugins/basic-auth/index.md
+++ b/app/_kong_plugins/basic-auth/index.md
@@ -121,4 +121,4 @@ Keep the following limitations in mind when you configure brute force protection
 
 {% include_cached /plugins/redis/redis-cloud-auth.md tier=page.tier %}
 
-{% include_cached /plugins/redis/oss.md name=page.name heading_level=2 %}
+{% include_cached /plugins/redis/oss.md name=page.name heading_level=2 redis_group="brute_force_protection" %}

--- a/app/_kong_plugins/datakit/index.md
+++ b/app/_kong_plugins/datakit/index.md
@@ -1838,7 +1838,7 @@ The [`cache` node](#cache-node) requires a `resources.cache` resource definition
 
 {% include_cached /plugins/redis/redis-cloud-auth.md tier=page.tier %}
 
-{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=4 %}
+{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=4 redis_group="datakit" %}
 
 ### Vault resource {% new_in 3.12 %}
 

--- a/app/_kong_plugins/graphql-proxy-cache-advanced/index.md
+++ b/app/_kong_plugins/graphql-proxy-cache-advanced/index.md
@@ -87,4 +87,4 @@ key = md5(UUID | headers | body)
 
 {% include_cached /plugins/redis/redis-cloud-auth.md tier=page.tier %}
 
-{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=2 %}
+{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=2 redis_group="strategy" %}

--- a/app/_kong_plugins/graphql-rate-limiting-advanced/index.md
+++ b/app/_kong_plugins/graphql-rate-limiting-advanced/index.md
@@ -72,7 +72,7 @@ This is different from the cost strategy ([`config.cost_strategy`](/plugins/grap
 
 {% include_cached /plugins/redis/redis-cloud-auth.md tier=page.tier %}
 
-{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=3 %}
+{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=3 redis_group="strategy" %}
 
 ## Introspection endpoint
 

--- a/app/_kong_plugins/openid-connect/index.md
+++ b/app/_kong_plugins/openid-connect/index.md
@@ -735,7 +735,7 @@ curl -X GET "http://localhost:8000?client_id=2"
 
 {% include_cached /plugins/redis/redis-cloud-auth.md tier=page.tier %}
 
-{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=2 %}
+{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=2 redis_group="oidc" %}
 
 ## Debugging the OIDC plugin
 

--- a/app/_kong_plugins/proxy-cache-advanced/index.md
+++ b/app/_kong_plugins/proxy-cache-advanced/index.md
@@ -104,4 +104,4 @@ This plugin extends the [Proxy Cache plugin](/plugins/proxy-cache/) with Redis, 
 
 {% include_cached /plugins/redis/redis-cloud-auth.md tier=page.tier %}
 
-{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=2 %}
+{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=2 redis_group="strategy" %}

--- a/app/_kong_plugins/rate-limiting-advanced/index.md
+++ b/app/_kong_plugins/rate-limiting-advanced/index.md
@@ -168,7 +168,7 @@ Otherwise the field will be regenerated automatically with every update.
 
 {% include_cached /plugins/redis/redis-cloud-auth.md tier=page.tier %}
 
-{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=3 %}
+{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=3 redis_group="strategy" %}
 
 ### Fallback from Redis
 

--- a/app/_kong_plugins/rate-limiting/index.md
+++ b/app/_kong_plugins/rate-limiting/index.md
@@ -83,7 +83,7 @@ See [Rate Limiting in {{site.base_gateway}}](/gateway/rate-limiting/) to choose 
 
 {% include_cached /plugins/redis/redis-cloud-auth.md tier=page.tier %}
 
-{% include_cached /plugins/redis/oss.md name=page.name heading_level=3 %}
+{% include_cached /plugins/redis/oss.md name=page.name heading_level=3 redis_group="policy" %}
 
 ## Limit by IP address
 

--- a/app/_kong_plugins/request-callout/index.md
+++ b/app/_kong_plugins/request-callout/index.md
@@ -159,4 +159,4 @@ cache key.
 
 {% include_cached /plugins/redis/redis-cloud-auth.md tier=page.tier %}
 
-{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=3 %}
+{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=3 redis_group="cache" %}

--- a/app/_kong_plugins/response-ratelimiting/index.md
+++ b/app/_kong_plugins/response-ratelimiting/index.md
@@ -70,7 +70,7 @@ Otherwise, the Consumer is used if an authentication plugin has been configured.
 
 {% include_cached /plugins/redis/redis-cloud-auth.md tier=page.tier %}
 
-{% include_cached /plugins/redis/oss.md name=page.name heading_level=3 %}
+{% include_cached /plugins/redis/oss.md name=page.name heading_level=3 redis_group="policy" %}
 
 ## Limit by IP address
 

--- a/app/_kong_plugins/saml/index.md
+++ b/app/_kong_plugins/saml/index.md
@@ -137,7 +137,7 @@ to be configured in the plugin.
 
 {% include_cached /plugins/redis/redis-cloud-auth.md tier=page.tier %}
 
-{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=2 %}
+{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=2 redis_group="session_storage" %}
 
 ## Troubleshooting the SAML plugin
 

--- a/app/_kong_plugins/service-protection/index.md
+++ b/app/_kong_plugins/service-protection/index.md
@@ -64,4 +64,4 @@ If you want to apply global rate limits or apply rate limits to Routes and Consu
 
 {% include_cached /plugins/redis/redis-cloud-auth.md tier=page.tier %}
 
-{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=2 %}
+{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=2 redis_group="strategy" %}

--- a/app/_kong_plugins/upstream-oauth/index.md
+++ b/app/_kong_plugins/upstream-oauth/index.md
@@ -117,4 +117,4 @@ The plugin supports the following caching [strategies](/plugins/upstream-oauth/r
 
 {% include_cached /plugins/redis/redis-cloud-auth.md tier=page.tier %}
 
-{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=3 %}
+{% include_cached /plugins/redis/enterprise.md name=page.name heading_level=3 redis_group="cache" %}


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes #6790 

Adding a new section in the redis cloud provider auth includes for OAuth 2.0. This appears in 20 plugins.

Also did a minor refactor of the if/else statements to make them easier to keep track of. This also fixes:
* AI Rate Limiting Advanced was missing from any group, even though it has the include
* GraphQL Proxy Cache Advanced, GraphQL Rate Limiting Advanced, Proxy Caching Advanced, Service Protection were grouped incorrectly

Note that while the original ticket only mentions Proxy Cache, this change actually affects all plugins that support cloud auth through redis partials.

## Preview Links
Many. Check some examples like https://deploy-preview-7204--kongdeveloper.netlify.app/plugins/ai-rag-injector/#using-cloud-authentication-with-redis