### PR TITLE
Feat(aigw) acl policy

### DIFF
--- a/app/_ai_gateway_policies/acl/index.md
+++ b/app/_ai_gateway_policies/acl/index.md
@@ -15,17 +15,23 @@ categories:
 search_aliases:
   - access control list
 related_resources:
-  - text: Enforce tiered AI budgets on AI Models with {{site.identity}}
-    url: /ai-gateway/enforce-tiered-ai-budgets-with-kong-identity/
+  - text: AI Auth Strategies
+    url: /ai-gateway/entities/ai-auth-strategy/
   - text: AI Consumer
     url: /ai-gateway/entities/ai-consumer/
   - text: AI Consumer Group
     url: /ai-gateway/entities/ai-consumer-group/
+faqs:
+  - q: What are the differences between an ACL AI Policy and the `access.acl` field?
+    a: |
+      The ACL AI Policy allows you to set `always_use_authenticated_groups` and `include_consumer_groups` which are `false` by default. When setting `access.acl` fields on an entity these are always `true`.
 ---
 
-The ACL (access control list) policy allows you to restrict [AI Consumers](/ai-gateway/entities/ai-consumer/) or [AI Consumer Groups](/ai-gateway/entities/ai-consumer-group/) access to {{site.ai_gateway}} entities. You do this by configuring **either** an allow list or a deny list with AI Consumer or AI Consumer Group names. 
+The ACL (access control list) policy allows you to restrict [AI Consumers](/ai-gateway/entities/ai-consumer/) or [AI Consumer Groups](/ai-gateway/entities/ai-consumer-group/) access to {{site.ai_gateway}} entities. This is the same capability provided by `access.acls` for AI Models, AI MCP Servers, and AI Agents. However, the policy provides additional configuration options.
 
-This policy requires that Consumers are authenticated and you should set up [AI Auth Strategies](/ai-gateway/entities/ai-auth-strategy/) before enabling this policy.
+You can configure **either** an allow list or a deny list with AI Consumers, AI Consumer Groups or authenticated groups (discovered by an [AI Auth Strategy](https://developer.konghq.com/ai-gateway/entities/ai-auth-strategy/#oidc-token-authentication) running in `openid-connect` mode).
+
+The ACL policy requires that AI Consumers are authenticated and you should set up [AI Auth Strategies](/ai-gateway/entities/ai-auth-strategy/) before enabling this policy.
 
 ## Upstream Consumer Groups header
 

--- a/app/_ai_gateway_policies/acl/index.md
+++ b/app/_ai_gateway_policies/acl/index.md
@@ -7,6 +7,13 @@ products:
   - ai-gateway
 content_type: plugin
 description: Control which AI Consumers and AI Consumer Groups can access entities
+tags:
+  - traffic-control
+  - authorization
+categories:
+  - traffic-control
+search_aliases:
+  - access control list
 related_resources:
   - text: Enforce tiered AI budgets on AI Models with {{site.identity}}
     url: /ai-gateway/enforce-tiered-ai-budgets-with-kong-identity/

--- a/app/_ai_gateway_policies/acl/index.md
+++ b/app/_ai_gateway_policies/acl/index.md
@@ -6,4 +6,7 @@ works_on:
 products:
   - ai-gateway
 content_type: plugin
+description: Control which AI Consumers and AI Consumer Groups can access entities
 ---
+
+The ACL (access control list) policy allows you to restrict AI Consumer access to {{site.ai_gateway}} entities. You do this by configuring **either** an allow list or a deny list with certain [AI Consumers](/ai-gateway/entities/ai-consumer/) or [AI Consumer Groups](/ai-gateway/entities/ai-consumer-group/).

--- a/app/_ai_gateway_policies/acl/index.md
+++ b/app/_ai_gateway_policies/acl/index.md
@@ -17,10 +17,8 @@ search_aliases:
 related_resources:
   - text: Enforce tiered AI budgets on AI Models with {{site.identity}}
     url: /ai-gateway/enforce-tiered-ai-budgets-with-kong-identity/
-related_resources:
   - text: AI Consumer
     url: /ai-gateway/entities/ai-consumer/
-related_resources:
   - text: AI Consumer Group
     url: /ai-gateway/entities/ai-consumer-group/
 ---

--- a/app/_ai_gateway_policies/acl/index.md
+++ b/app/_ai_gateway_policies/acl/index.md
@@ -7,6 +7,21 @@ products:
   - ai-gateway
 content_type: plugin
 description: Control which AI Consumers and AI Consumer Groups can access entities
+related_resources:
+  - text: Enforce tiered AI budgets on AI Models with {{site.identity}}
+    url: /ai-gateway/enforce-tiered-ai-budgets-with-kong-identity/
+related_resources:
+  - text: AI Consumer
+    url: /ai-gateway/entities/ai-consumer/
+related_resources:
+  - text: AI Consumer Group
+    url: /ai-gateway/entities/ai-consumer-group/
 ---
 
-The ACL (access control list) policy allows you to restrict AI Consumer access to {{site.ai_gateway}} entities. You do this by configuring **either** an allow list or a deny list with certain [AI Consumers](/ai-gateway/entities/ai-consumer/) or [AI Consumer Groups](/ai-gateway/entities/ai-consumer-group/).
+The ACL (access control list) policy allows you to restrict [AI Consumers](/ai-gateway/entities/ai-consumer/) or [AI Consumer Groups](/ai-gateway/entities/ai-consumer-group/) access to {{site.ai_gateway}} entities. You do this by configuring **either** an allow list or a deny list with AI Consumer or AI Consumer Group names. 
+
+This policy requires that Consumers are authenticated and you should set up [AI Auth Strategies](/ai-gateway/entities/ai-auth-strategy/) before enabling this policy.
+
+## Upstream Consumer Groups header
+
+If `hide_groups_header` is set to `false` and an AI Consumer is validated, {{site.ai_gateway}} appends a `X-Consumer-Groups` header to the request before proxying it to the upstream service. The header contains a comma separated list of groups that belong to the AI Consumer, for example `admin, pro_user`. This allows you to identify the groups associated with the AI Consumer. 


### PR DESCRIPTION
## Description

Migrates the ACL policy overview, highlights that this is the same as defining access.acls on other entities but with more config options.

Fixes https://github.com/Kong/developer.konghq.com/issues/6346 

Example config:

```
kongctl apply -f - --auto-approve --pat "$KONNECT_TOKEN" << 'EOF'
ai_gateway_policies:
  - ref: acl
    ai_gateway: !lookup {id: !env AI_GATEWAY_ID}
    name: acl
    display_name: "My ACL Policy"
    type: acl
    enabled: true
    global: true
    config:
      include_consumer_groups: true
      allow: []
      deny: [suspended]
EOF
``` 

You can substitute this for the `access.acls` fields in https://developer.konghq.com/ai-gateway/enforce-tiered-ai-budgets-with-kong-identity/ 

## Preview Links

https://deploy-preview-7207--kongdeveloper.netlify.app/ai-gateway/policies/acl/

## Checklist 

- [ ] Tested how-to docs. If not, note why here. 
- [ ] All pages contain metadata.
- [ ] Any new docs link to existing docs.
- [ ] All autogenerated instructions render correctly (API, decK, Konnect, Kong Manager).
- [ ] Style guide (capitalized gateway entities, placeholder URLs) implemented correctly.
- [ ] Every page has a `description` entry in frontmatter.
- [ ] Add new pages to the product documentation index (if applicable).
