### PR TITLE
fix(gateway): Custom plugin streaming prerequisite

### DIFF
--- a/app/custom-plugins/streaming-plugins.md
+++ b/app/custom-plugins/streaming-plugins.md
@@ -67,6 +67,13 @@ To create streaming plugins, you must have the following permissions:
 
 ## How do I add a streamed plugin?
 
+### Prerequisites
+
+* [`custom_plugin_streaming_enabled`](/gateway/configuration/#custom-plugin-streaming-enabled) is set to `on` in `kong.conf` or as an environment variable.
+If running in {{site.konnect_short_name}}, launch your data plane with this setting.
+
+### Stream a custom plugin
+
 {% navtabs 'streaming' %}
 {% navtab "Admin API" %}
 


### PR DESCRIPTION
<!-- ## PR Title

Use the format `feat/fix/chore(Product): Title`, for example:
- `feat(mesh): Add transparent proxy upgrade guide`
- `fix(gateway): Correct decK example in rate limiting how-to`
- `chore(ai-gateway): Bump plugin schema`
- `chore(platform): Fix issue template`
- `release: Kong Gateway 3.14`
-->

## Description

Fixes https://kongstrong.slack.com/archives/C02KEASTTRC/p1789007080885519?thread_ts=1784728902.676849&cid=C02KEASTTRC.

The streaming plugin reference was missing the `custom_plugin_streaming_enabled` setting required for streaming plugins to work. 

Note: The setting is already in the how-to, so that doesn't need updating: https://developer.konghq.com/how-to/stream-custom-plugins/#kong-konnect


## Preview Links

https://deploy-preview-7214--kongdeveloper.netlify.app/custom-plugins/streaming-plugins/#how-do-i-add-a-streamed-plugin